### PR TITLE
feat(SW-1.1): repo scaffold — bun workspaces, Taskfile, biome config

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,39 @@
+version: "3"
+
+tasks:
+  setup:
+    desc: Install all dependencies
+    cmds:
+      - bun install
+
+  lint:
+    desc: Run linter across all packages
+    cmds:
+      - bunx biome lint .
+
+  format:
+    desc: Run formatter across all packages
+    cmds:
+      - bunx biome format --write .
+
+  typecheck:
+    desc: Type-check all packages
+    cmds:
+      - bun run --filter="*" typecheck
+
+  test:
+    desc: Run all tests
+    cmds:
+      - bun test
+
+  ci:
+    desc: Run all CI checks (lint → typecheck → test)
+    cmds:
+      - task: lint
+      - task: typecheck
+      - task: test
+
+  secret-scan:
+    desc: Scan for accidentally committed secrets
+    cmds:
+      - echo "Secret scan placeholder — gitleaks/detect-secrets to be wired in SW-1.7"

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@shipwright/agent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shipwright reference agent — autonomous task runner: pick → build → ship PR → forward metrics",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder — reference agent implementation added in Phase C (SW-3.x)
+export {};

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "files": {
+    "ignore": ["node_modules", "dist", "build", "coverage"]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       "name": "@shipwright/plugin",
       "version": "0.1.0",
       "devDependencies": {
+        "bun-types": "*",
         "typescript": "*",
       },
     },
@@ -56,6 +57,12 @@
 
     "@shipwright/plugin": ["@shipwright/plugin@workspace:plugins/shipwright"],
 
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,61 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "shipwright-monorepo",
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "typescript": "^5.7.3",
+      },
+    },
+    "agent": {
+      "name": "@shipwright/agent",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "*",
+      },
+    },
+    "metrics": {
+      "name": "@shipwright/metrics",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "*",
+      },
+    },
+    "plugins/shipwright": {
+      "name": "@shipwright/plugin",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "*",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@shipwright/agent": ["@shipwright/agent@workspace:agent"],
+
+    "@shipwright/metrics": ["@shipwright/metrics@workspace:metrics"],
+
+    "@shipwright/plugin": ["@shipwright/plugin@workspace:plugins/shipwright"],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+  }
+}

--- a/metrics/package.json
+++ b/metrics/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@shipwright/metrics",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shipwright metrics dashboard — stateless Hono service with PostHog-backed endpoints",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/metrics/src/index.ts
+++ b/metrics/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder — metrics dashboard implementation added in Phase B (SW-2.x)
+export {};

--- a/metrics/tsconfig.json
+++ b/metrics/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "shipwright-monorepo",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": [
+    "plugins/shipwright",
+    "metrics",
+    "agent"
+  ],
+  "scripts": {
+    "test": "bun test",
+    "lint": "bunx biome lint .",
+    "format": "bunx biome format --write .",
+    "typecheck": "bun run --filter='*' typecheck"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "typescript": "^5.7.3"
+  }
+}

--- a/plugins/shipwright/package.json
+++ b/plugins/shipwright/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "bun-types": "*",
     "typescript": "*"
   }
 }

--- a/plugins/shipwright/package.json
+++ b/plugins/shipwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@shipwright/plugin",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shipwright Claude Code plugin — spec → plan → execute → review → deploy",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/plugins/shipwright/test/workspace.test.ts
+++ b/plugins/shipwright/test/workspace.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Workspace resolution smoke test.
+ *
+ * Verifies that the bun workspaces monorepo is correctly structured:
+ * all three workspace packages exist with valid package.json files,
+ * and the root package.json declares all workspaces.
+ *
+ * There is no business logic yet — this test exists to assert that
+ * `task setup`, `task test`, etc. succeed on a clean checkout.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// The monorepo root is three levels up from this test file:
+// plugins/shipwright/test/workspace.test.ts → root
+const root = resolve(import.meta.dir, "../../..");
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  workspaces?: string[];
+  [key: string]: unknown;
+}
+
+interface TsConfig {
+  compilerOptions?: {
+    strict?: boolean;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+interface BiomeConfig {
+  linter?: {
+    enabled?: boolean;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+function readJson<T = Record<string, unknown>>(rel: string): T {
+  const abs = resolve(root, rel);
+  if (!existsSync(abs)) {
+    throw new Error(`Missing file: ${rel}`);
+  }
+  return JSON.parse(readFileSync(abs, "utf8")) as T;
+}
+
+describe("bun workspaces scaffold", () => {
+  it("root package.json declares all three workspace packages", () => {
+    const pkg = readJson<PackageJson>("package.json");
+    const workspaces = pkg.workspaces;
+    expect(Array.isArray(workspaces)).toBe(true);
+    expect(workspaces).toContain("plugins/shipwright");
+    expect(workspaces).toContain("metrics");
+    expect(workspaces).toContain("agent");
+  });
+
+  it("plugins/shipwright has a valid package.json with a name", () => {
+    const pkg = readJson<PackageJson>("plugins/shipwright/package.json");
+    expect(typeof pkg.name).toBe("string");
+    expect((pkg.name as string).length).toBeGreaterThan(0);
+  });
+
+  it("metrics has a valid package.json with a name", () => {
+    const pkg = readJson<PackageJson>("metrics/package.json");
+    expect(typeof pkg.name).toBe("string");
+    expect((pkg.name as string).length).toBeGreaterThan(0);
+  });
+
+  it("agent has a valid package.json with a name", () => {
+    const pkg = readJson<PackageJson>("agent/package.json");
+    expect(typeof pkg.name).toBe("string");
+    expect((pkg.name as string).length).toBeGreaterThan(0);
+  });
+
+  it("each workspace package has a version field", () => {
+    for (const ws of ["plugins/shipwright", "metrics", "agent"]) {
+      const pkg = readJson<PackageJson>(`${ws}/package.json`);
+      expect(typeof pkg.version).toBe("string");
+    }
+  });
+
+  it("MIT LICENSE exists at repo root", () => {
+    const licensePath = resolve(root, "LICENSE");
+    expect(existsSync(licensePath)).toBe(true);
+    const content = readFileSync(licensePath, "utf8");
+    expect(content).toContain("MIT License");
+  });
+
+  it("root tsconfig.json exists and enables strict mode", () => {
+    const cfg = readJson<TsConfig>("tsconfig.json");
+    const opts = cfg.compilerOptions;
+    expect(opts).toBeDefined();
+    expect(opts?.strict).toBe(true);
+  });
+
+  it("root biome.json exists and has linter enabled", () => {
+    const cfg = readJson<BiomeConfig>("biome.json");
+    const linter = cfg.linter;
+    expect(linter).toBeDefined();
+    expect(linter?.enabled).toBe(true);
+  });
+});

--- a/plugins/shipwright/tsconfig.json
+++ b/plugins/shipwright/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/shipwright/tsconfig.json
+++ b/plugins/shipwright/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["bun-types"]
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Bootstraps the bun workspaces monorepo skeleton with three placeholder packages: `@shipwright/plugin`, `@shipwright/metrics`, `@shipwright/agent`
- Adds root `Taskfile.yml` with `setup`, `lint`, `typecheck`, `test`, `ci`, and `secret-scan` targets delegating to bun/bunx commands
- Adds root `tsconfig.json` (strict ES2022), `biome.json` (linter + formatter), and `bun.lock`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `task setup`, `task lint`, `task typecheck` run on clean checkout | ✅ MET |
| 2 | bun workspaces resolve all three packages | ✅ MET |
| 3 | MIT LICENSE exists at repo root | ✅ MET |
| 4 | Workspace-resolution smoke check | ✅ MET |

## Test Plan
- [x] `bun test` — 8 smoke tests pass (workspace structure, LICENSE, tsconfig, biome)
- [x] `bunx biome lint .` — clean (13 files, no fixes applied)
- [x] `bun run --filter="*" typecheck` — all 3 packages exit 0
- [x] `bun install` — lockfile resolves all workspace packages cleanly

Closes #2

Generated with [Claude Code](https://claude.com/claude-code)
