### PR TITLE
ci: bootstrap GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.x"
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    name: lint / typecheck / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Install dependencies
+        run: task setup
+
+      - name: Lint
+        run: task lint
+
+      - name: Typecheck
+        run: task typecheck
+
+      - name: Test
+        run: task test


### PR DESCRIPTION
Adds a minimal `ci.yml` that runs `task ci` (lint → typecheck → test) on every PR and push to main.

Unblocks the deploy cron — `check-deploy.ts` requires a passing CI run before merging. Full gate set (secret-scan, task-store doctor, e2e) lands in SW-1.7 once the Phase A code is ported.

No code changes — workflow only.