### PR TITLE
ci: add Conventional-Commit PR-title lint workflow

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,35 @@
+name: pr-title-lint
+
+# Enforces Conventional-Commit PR titles so that, with squash-merge, the squashed
+# commit subject (= PR title) is deterministic input for release-please's changelog.
+# See CONTRIBUTING.md for the commit/PR-title convention.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    name: Conventional-Commit PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed Conventional-Commit types — kept in sync with the
+          # changelog-sections in release-please-config.json (REL-1.1).
+          types: |
+            feat
+            fix
+            perf
+            revert
+            docs
+            refactor
+            test
+            build
+            ci
+            chore


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-title-lint.yml` — a lightweight check (`amannn/action-semantic-pull-request@v5`) enforcing Conventional-Commit PR titles.
- Allowed types are kept in sync with release-please's `changelog-sections` (feat / fix / perf / revert / docs / refactor / test / build / ci / chore).
- With squash-merge, the squashed commit subject (= PR title) becomes deterministic input for release-please's changelog (REL-1.1). No husky/local hooks.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Runs on `pull_request` [opened, edited, synchronize]; `permissions: pull-requests: read`; uses `amannn/action-semantic-pull-request@v5` with the 10 allowed types | ✅ MET |
| 2 | Non-conforming title fails / conforming passes | ✅ MET — this PR's own `pr-title-lint` run validates a conforming `ci:` title passes; the action fails any title outside the configured types by design |
| 3 | No automated test layer applies (CI workflow YAML); none added/retired | ✅ MET |

## Test Plan
- Local CI parity green in worktree: `biome lint` (13 files, 0 issues), `typecheck` (3 packages, exit 0), `bun test` (8 pass / 0 fail).
- This PR is its own integration test: the new `pr-title-lint` workflow runs on this `pull_request` and must pass with the Conventional-Commit title `ci: ...`.
- [x] Pre-commit checks passing

Task: REL-1.4 · session `release-infra` · tracks #27

Generated with [Claude Code](https://claude.com/claude-code)
