### PR TITLE
docs: add CONTRIBUTING.md, SECURITY.md, and release badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Shipwright
+
+Thanks for your interest in contributing. Shipwright is an MIT-licensed project destined to be public — keep all contributions free of proprietary or confidential material (see the scrub rules in [CLAUDE.md](./CLAUDE.md)).
+
+## Coding conventions
+
+Follow the conventions in [CLAUDE.md](./CLAUDE.md). The short version:
+
+- **Tests land with the code** — same PR, correct layer (unit / integration / smoke / e2e). No "add tests later" tasks.
+- **Test isolation** — no `mock.module()`, no `global.fetch` / `global.*` overrides.
+- **Plugin stays repo-agnostic** — no new coupling to any external platform.
+- Lint, typecheck, and tests must pass locally before opening a PR:
+  ```
+  bunx biome lint .
+  bun run --filter='*' typecheck
+  bun test
+  ```
+
+## Commit style
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add deploy rollback command
+fix: handle missing task status label
+docs: update CLAUDE.md conventions
+chore: bump biome to 1.9
+```
+
+The type prefix drives `release-please` — it decides what goes in the changelog and whether to bump patch / minor / major. Keep messages accurate.
+
+## Release flow
+
+Releases are fully automated via `release-please`:
+
+- **Never hand-edit `CHANGELOG.md` or version fields** (`package.json`, etc.). `release-please` owns those files and will overwrite manual edits.
+- When enough merged commits accumulate, `release-please` opens an auto-generated release PR that bumps the version and updates the changelog.
+- A maintainer reviews and merges that PR — squash-merge is recommended to keep the release commit clean.
+- Merging the release PR triggers the publish workflow (tag + GitHub Release).
+
+In short: land your feature PRs with good Conventional Commit messages, and the release machinery takes care of itself.
+
+## Pull requests
+
+- Branch from `main`; follow the naming convention in CLAUDE.md (`feat/sw-x-y-slug`).
+- Keep PRs focused — one task, one PR.
+- The CI gate (lint → typecheck → test → secret scan) is merge-blocking. All checks must be green.
+
+## Still to come
+
+`CODE_OF_CONDUCT.md` and issue / PR templates are deferred to public launch.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Shipwright
 
+[![Release](https://img.shields.io/github/v/release/app-vitals/shipwright?sort=semver)](https://github.com/app-vitals/shipwright/releases)
+
 **A Claude Code plugin toolchain for the full delivery loop — spec → plan → execute → review → deploy.** Plus a metrics dashboard and a reference agent for running it autonomously.
 
 > 🚧 **Early development.** Shipwright is being built out in this standalone repository and isn't ready for general installation yet. Follow progress in the [issues](https://github.com/app-vitals/shipwright/issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest 0.x | Yes |
+| Older releases | No |
+
+Only the most recent release on the `0.x` line receives security fixes.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities via [GitHub private security advisories](https://github.com/app-vitals/shipwright/security/advisories/new). You'll receive a response within 7 days acknowledging receipt. We'll coordinate a fix and a disclosure timeline with you before any public announcement.
+
+## Scope
+
+Shipwright is a CLI plugin toolchain. Security issues in scope include:
+
+- Code execution or privilege escalation via plugin commands or task execution.
+- Credential or secret exposure through logging, error output, or generated artifacts.
+- Unsafe handling of repository content that could be exploited by a malicious repo.
+- Dependency vulnerabilities with a credible exploit path in Shipwright's use of that dependency.
+
+Out of scope: issues in the underlying Claude Code platform, GitHub, or Anthropic's APIs — report those to the respective vendors.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` documenting coding conventions, Conventional Commits, tests-land-with-code rule, and the release-please flow (never hand-edit CHANGELOG/version fields; maintainer merges auto-generated release PR; squash-merge recommended)
- Add `SECURITY.md` with GitHub private security advisory reporting policy and supported-versions = "latest 0.x"
- Add shields.io release badge to README near the top (renders "no releases" until v0.1.0 lands, then auto-populates)

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | CONTRIBUTING.md exists with release-please flow + CLAUDE.md + Conventional Commits + tests-land-with-code | ✅ MET |
| 2 | SECURITY.md exists with private advisory policy, generic contact, latest 0.x support | ✅ MET |
| 3 | README shows shields.io release badge near top | ✅ MET |
| 4 | No automated tests added/retired (documentation only) | ✅ MET |
| 5 | Scrub gate clean — no secrets, client names, internal IDs, or local paths | ✅ MET |

## Test Plan

- [x] Documentation-only PR — no code changed, no test suite changes
- [x] Scrub gate: files contain only `app-vitals/shipwright`, `github.com`, `shields.io`, and generic tooling references
- [x] Lint (`bunx biome lint .`) passes — 13 files checked, no issues
- [x] `bun test` — 8 tests pass
- [x] Visual check: CONTRIBUTING.md, SECURITY.md, and README badge all render correctly in GitHub markdown

Generated with [Claude Code](https://claude.com/claude-code)
