### PR TITLE
docs: add CONTRIBUTING.md, SECURITY.md, and release badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Shipwright
+
+Thanks for your interest. This document covers the conventions, workflow, and release process for contributors.
+
+## Code of conduct
+
+Be respectful and constructive. Full code of conduct will land at public launch.
+
+## Conventions
+
+### Commit style — Conventional Commits
+
+All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/) spec:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`.
+
+Breaking changes: append `!` after the type/scope or add a `BREAKING CHANGE:` footer.
+
+### Tests land with the code
+
+Tests are required in the same PR as the feature or fix — no "add tests later" tasks. Land the code and its tests together, at the correct layer:
+
+- **unit** — pure logic, no I/O.
+- **integration** — real dependency behavior via recorded fixtures / injected doubles.
+- **smoke** — HTTP endpoints exercised in-process (no real socket).
+- **e2e** — full browser flows via Playwright.
+
+See [`CLAUDE.md`](./CLAUDE.md) for the full conventions, test isolation rules, and layer boundaries.
+
+### Code conventions
+
+Follow the guidance in [`CLAUDE.md`](./CLAUDE.md): no new platform coupling, local-first by default, MIT license across all artifacts.
+
+## Development workflow
+
+1. Find a `status:pending` issue with all dependencies marked `status:done`.
+2. Branch from the `branch` field in the issue's YAML block (pattern: `feat/sw-x-y-slug`). Never work directly on `main`.
+3. Build, test, and open a PR — all in one go.
+4. Request review; address findings via follow-up commits on the same branch.
+
+## Release process
+
+Releases are managed by **release-please**. The bot watches `main` and opens a release PR whenever there are releasable commits. That PR auto-updates `CHANGELOG.md` and version fields based on the commit history.
+
+**Never hand-edit `CHANGELOG.md` or any version field.** Let release-please own those files — manual edits will be overwritten or will break the automation.
+
+When the release PR is ready:
+- A maintainer reviews and merges it.
+- **Squash-merge is recommended** to keep the release commit clean.
+- Merging the release PR triggers the publish workflow and creates the GitHub release tag.
+
+## Submitting a pull request
+
+- Keep PRs focused — one concern per PR.
+- Squash noisy fixup commits before asking for review.
+- Confirm CI is green before requesting a review.
+- This repository is destined to be public and MIT-licensed — do not include proprietary or confidential material.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Shipwright
 
+[![release](https://img.shields.io/github/v/release/app-vitals/shipwright?sort=semver&label=release)](https://github.com/app-vitals/shipwright/releases)
+
 **A Claude Code plugin toolchain for the full delivery loop — spec → plan → execute → review → deploy.** Plus a metrics dashboard and a reference agent for running it autonomously.
 
 > 🚧 **Early development.** Shipwright is being built out in this standalone repository and isn't ready for general installation yet. Follow progress in the [issues](https://github.com/app-vitals/shipwright/issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest `0.x` release receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| latest 0.x | Yes |
+| older 0.x | No |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities via **GitHub private security advisories**:
+
+1. Go to [https://github.com/app-vitals/shipwright/security/advisories/new](https://github.com/app-vitals/shipwright/security/advisories/new)
+2. Describe the vulnerability, steps to reproduce, and potential impact.
+3. A maintainer will acknowledge the report within 7 days and work with you on a fix and coordinated disclosure.


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` documenting the release-please flow, Conventional Commits, tests-land-with-code rule, and references to `CLAUDE.md` conventions
- Adds `SECURITY.md` with GitHub private security advisory reporting policy and supported-versions (`latest 0.x`)
- Adds shields.io release badge to `README.md` near the top

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | CONTRIBUTING.md with release-please flow, no hand-editing CHANGELOG/version, squash-merge recommended, CLAUDE.md + Conventional Commits + tests-land-with-code | MET |
| 2 | SECURITY.md with GitHub advisory policy, generic contact, latest 0.x supported | MET |
| 3 | README shields.io release badge near top | MET |
| 4 | No automated tests added/retired (docs-only task) | MET |
| 5 | Scrub gate clean | MET |

## Test Plan
- [x] No automated test layer — docs-only task per AC #4
- [x] Scrub gate: no secrets, internal identifiers, or local paths in new/changed files
- [x] Biome lint passes (`bunx biome lint .`)
- [x] Visual check: CONTRIBUTING.md, SECURITY.md, and README badge render correctly

Generated with [Claude Code](https://claude.com/claude-code)
