### PR TITLE
feat: publish v0.1.0 release + verify automated release loop (REL-1.2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,5 @@
 # Always LF for shell scripts (avoid CRLF breakage on Windows checkouts)
 *.sh text eol=lf
 
-# Binary / generated lockfiles — don't diff or merge as text
-bun.lockb binary
+# Lockfile — treat as text (bun.lock is the text-format lockfile used by Bun v1.1+)
+bun.lock text -diff merge=ours


### PR DESCRIPTION
## Summary

- Tags `v0.1.0` at the REL-1.1 merge commit (169e230) and publishes the GitHub Release with notes matching the seeded `[0.1.0]` CHANGELOG section
- Includes a genuine `fix:` commit (`.gitattributes` correction for `bun.lock` text format) to trigger the release-please automated loop after merge
- All version files (`version.txt`, `.release-please-manifest.json`, four `package.json` fields) confirmed at `0.1.0`

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `v0.1.0` tag exists; GitHub Release is non-draft with notes matching `[0.1.0]` CHANGELOG | ✅ MET |
| 2 | All four `package.json` versions, `version.txt`, and `.release-please-manifest.json` = `0.1.0` | ✅ MET |
| 3 | Steady-state proof: merging this PR triggers release-please `chore(main): release 0.1.1` PR | ⬜ POST-MERGE (verify via `gh pr list --label autorelease:pending`) |
| 4 | No test files added/retired; verification is operational assertions only | ✅ MET |

## Test Plan

- [x] `git tag --list` shows `v0.1.0`
- [x] `gh release view v0.1.0` shows `isDraft: false`, published 2026-06-07, body matches CHANGELOG
- [x] All version fields confirmed `0.1.0`
- [x] `bun test` — 8 pass, 0 fail
- [x] `bunx biome lint` — 15 files, no issues
- [ ] Post-merge: confirm release-please opens `chore(main): release 0.1.1` PR

Generated with [Claude Code](https://claude.com/claude-code)
