### PR TITLE
feat(SW-2.2): re-land env-first secrets + POSTHOG fail-fast onto main

### DIFF
--- a/metrics/src/lib/env.ts
+++ b/metrics/src/lib/env.ts
@@ -25,3 +25,19 @@ export function loadEnv(
     if (key && !process.env[key]) process.env[key] = val;
   }
 }
+
+/**
+ * Fail-fast guard for required environment variables.
+ * Throws with a clear error listing ALL missing vars so the operator knows exactly
+ * what to set before the service can start.
+ *
+ * @param required - list of env var names that must be non-empty strings
+ * @throws Error if any required vars are missing or empty
+ */
+export function validateRequiredEnv(required: string[]): void {
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length === 0) return;
+  throw new Error(
+    `Missing required environment variables: ${missing.join(", ")}\nSet them in your .env file or environment before starting the service.`,
+  );
+}

--- a/metrics/src/lib/env.unit.test.ts
+++ b/metrics/src/lib/env.unit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * metrics/src/lib/env.unit.test.ts
+ * Unit tests for validateRequiredEnv — fail-fast on missing environment variables.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { validateRequiredEnv } from "./env.ts";
+
+describe("validateRequiredEnv", () => {
+  const TEST_VAR_A = "METRICS_TEST_REQUIRED_VAR_A";
+  const TEST_VAR_B = "METRICS_TEST_REQUIRED_VAR_B";
+
+  beforeEach(() => {
+    delete process.env[TEST_VAR_A];
+    delete process.env[TEST_VAR_B];
+  });
+
+  afterEach(() => {
+    delete process.env[TEST_VAR_A];
+    delete process.env[TEST_VAR_B];
+  });
+
+  it("does nothing when all required vars are set", () => {
+    process.env[TEST_VAR_A] = "value-a";
+    process.env[TEST_VAR_B] = "value-b";
+    expect(() => validateRequiredEnv([TEST_VAR_A, TEST_VAR_B])).not.toThrow();
+  });
+
+  it("does nothing when the required list is empty", () => {
+    expect(() => validateRequiredEnv([])).not.toThrow();
+  });
+
+  it("throws when a single required var is missing", () => {
+    expect(() => validateRequiredEnv([TEST_VAR_A])).toThrow();
+  });
+
+  it("error message includes the missing var name", () => {
+    expect(() => validateRequiredEnv([TEST_VAR_A])).toThrow(TEST_VAR_A);
+  });
+
+  it("throws listing ALL missing vars, not just the first", () => {
+    let message = "";
+    try {
+      validateRequiredEnv([TEST_VAR_A, TEST_VAR_B]);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain(TEST_VAR_A);
+    expect(message).toContain(TEST_VAR_B);
+  });
+
+  it("does not throw when only some vars are missing if all provided are set", () => {
+    process.env[TEST_VAR_A] = "set";
+    expect(() => validateRequiredEnv([TEST_VAR_A])).not.toThrow();
+  });
+
+  it("throws when one of two vars is missing", () => {
+    process.env[TEST_VAR_A] = "value-a";
+    // TEST_VAR_B is not set
+    let message = "";
+    try {
+      validateRequiredEnv([TEST_VAR_A, TEST_VAR_B]);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain(TEST_VAR_B);
+    expect(message).not.toContain(TEST_VAR_A);
+  });
+
+  it("error message tells the operator what to do", () => {
+    let message = "";
+    try {
+      validateRequiredEnv([TEST_VAR_A]);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    // Should mention setting env vars or .env file
+    expect(message.toLowerCase()).toMatch(/env|environment/);
+  });
+});

--- a/metrics/src/secrets.integration.test.ts
+++ b/metrics/src/secrets.integration.test.ts
@@ -194,10 +194,10 @@ describe("createSecretsClient", () => {
 
   describe("createSecretsClient — real GCP client factory", () => {
     it("creates a real SecretManagerServiceClient when no factory is provided", async () => {
-      // Exercises the require('@google-cloud/secret-manager') path (lines 58-63).
-      // No factory = the lazy-init branch runs. In CI there are no GCP credentials,
-      // so accessSecretVersion() throws — the env var fallback catches it, proving
-      // the real client was constructed and the require() path was exercised.
+      // Exercises the require('@google-cloud/secret-manager') lazy-init path.
+      // With env-first resolution, an env var set before getSecret() is returned
+      // immediately without hitting GCP — this confirms the client construction
+      // path is importable and the factory can be omitted.
       const envKey = "METRICS_GCP_CLIENT_PATH_TEST";
       process.env[envKey] = "real-client-fallback";
       let val: string;
@@ -212,22 +212,29 @@ describe("createSecretsClient", () => {
   });
 
   describe("createSecretsClient — defaults", () => {
-    it("uses GCP_PROJECT_ID env var (or empty string) as default GCP project", async () => {
+    it("uses the gcpProjectId argument for GCP secret path construction", async () => {
+      // When env var is NOT set, GCP is tried using the provided gcpProjectId.
+      const envKey = "METRICS_DEFAULT_PROJECT_SECRET_TEST";
+      delete process.env[envKey]; // ensure env var absent so GCP is tried
+
       let capturedName = "";
-      const client = createSecretsClient(undefined, () => ({
+      const client = createSecretsClient("my-gcp-project", () => ({
         async accessSecretVersion(req) {
           capturedName = req.name;
-          return [{ payload: { data: "value" } }, {}, {}];
+          return [{ payload: { data: "gcp-value" } }, {}, {}];
         },
       }));
 
-      await client.getSecret("posthog-personal-api-key");
+      await client.getSecret(envKey);
       expect(capturedName).toBe(
-        "projects//secrets/posthog-personal-api-key/versions/latest",
+        `projects/my-gcp-project/secrets/${envKey}/versions/latest`,
       );
     });
 
     it("builds correct secret path from project and secret name", async () => {
+      const envKey = "METRICS_PATH_TEST_SECRET";
+      delete process.env[envKey]; // absent from env so GCP is tried
+
       let capturedName = "";
       const client = createSecretsClient("my-project-123", () => ({
         async accessSecretVersion(req) {
@@ -236,10 +243,55 @@ describe("createSecretsClient", () => {
         },
       }));
 
-      await client.getSecret("my-api-key");
+      await client.getSecret(envKey);
       expect(capturedName).toBe(
-        "projects/my-project-123/secrets/my-api-key/versions/latest",
+        `projects/my-project-123/secrets/${envKey}/versions/latest`,
       );
+    });
+  });
+
+  describe("getSecret — env-first resolution", () => {
+    it("returns env var value without calling GCP when env var is set", async () => {
+      const envKey = "METRICS_ENV_FIRST_TEST_SECRET";
+      const originalValue = process.env[envKey];
+      process.env[envKey] = "env-value";
+
+      try {
+        let gcpCalled = false;
+        const client = createSecretsClient(TEST_PROJECT, () => ({
+          async accessSecretVersion(_req) {
+            gcpCalled = true;
+            throw new Error("GCP should not have been called");
+          },
+        }));
+
+        const value = await client.getSecret(envKey);
+        expect(value).toBe("env-value");
+        expect(gcpCalled).toBe(false);
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = originalValue;
+        }
+      }
+    });
+
+    it("tries GCP when env var is absent", async () => {
+      const envKey = "METRICS_GCP_FALLBACK_TEST_SECRET";
+      delete process.env[envKey];
+
+      let gcpCalled = false;
+      const client = createSecretsClient(TEST_PROJECT, () => ({
+        async accessSecretVersion(_req) {
+          gcpCalled = true;
+          return [{ payload: { data: "gcp-secret-value" } }, {}, {}];
+        },
+      }));
+
+      const value = await client.getSecret(envKey);
+      expect(value).toBe("gcp-secret-value");
+      expect(gcpCalled).toBe(true);
     });
   });
 });

--- a/metrics/src/secrets.ts
+++ b/metrics/src/secrets.ts
@@ -1,7 +1,11 @@
 /**
  * metrics/src/secrets.ts
- * GCP Secret Manager client with env var fallback for local dev.
+ * Secrets client: env var first, GCP Secret Manager optional fallback.
  * Uses dependency injection for the SecretManager client (testable without real GCP).
+ *
+ * Resolution order:
+ *   1. process.env[name]  — plain env var, works without GCP credentials
+ *   2. GCP Secret Manager — optional, only tried when env var is absent
  */
 
 const GCP_PROJECT_ID = process.env.GCP_PROJECT_ID ?? "";
@@ -34,8 +38,8 @@ export class SecretNotFoundError extends Error {
 }
 
 /**
- * Creates a secrets client that resolves secrets from GCP Secret Manager,
- * falling back to environment variables when GCP is unavailable (local dev).
+ * Creates a secrets client that resolves secrets env-first, with GCP Secret Manager
+ * as an optional fallback when the env var is absent.
  *
  * @param gcpProjectId - GCP project ID (defaults to process.env.GCP_PROJECT_ID)
  * @param clientFactory - Optional factory for the GCP SecretManager client (DI for tests)
@@ -66,10 +70,17 @@ export function createSecretsClient(
 
   /**
    * Resolves a secret by name.
-   * Order: GCP Secret Manager → process.env[name] → throw SecretNotFoundError
+   * Order: process.env[name] → GCP Secret Manager → throw SecretNotFoundError
+   *
+   * Env var wins — supports plain POSTHOG_PERSONAL_API_KEY without GCP credentials.
+   * GCP Secret Manager is optional: only tried when env var is absent.
    */
   async function getSecret(name: string): Promise<string> {
-    // Try GCP Secret Manager first
+    // Env var wins — no GCP credentials required for plain env usage
+    const envValue = process.env[name];
+    if (envValue !== undefined) return envValue;
+
+    // GCP Secret Manager — optional, only used when env var is absent
     try {
       const client = getClient();
       const secretName = `projects/${gcpProjectId}/secrets/${name}/versions/latest`;
@@ -84,13 +95,7 @@ export function createSecretsClient(
       // Buffer / Uint8Array
       return Buffer.from(data).toString("utf8");
     } catch (err) {
-      // Fall back to env var if GCP is unavailable (local dev, missing credentials, etc.)
-      // Re-throw if it's our own error (secret explicitly missing from GCP)
       if (err instanceof SecretNotFoundError) throw err;
-
-      const envValue = process.env[name];
-      if (envValue !== undefined) return envValue;
-
       throw new SecretNotFoundError(
         name,
         err instanceof Error ? err : undefined,

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -10,10 +10,11 @@
 
 import { HttpAccountsClient } from "./lib/accounts-client.ts";
 import { parseApiKeys } from "./lib/api-auth.ts";
-import { loadEnv } from "./lib/env.ts";
+import { loadEnv, validateRequiredEnv } from "./lib/env.ts";
 import { createMetricsApp } from "./api.ts";
 
 loadEnv();
+validateRequiredEnv(["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"]);
 
 const port = Number(process.env.METRICS_API_PORT ?? 3460);
 const accountsClient = new HttpAccountsClient(

--- a/metrics/src/validate-hogql.ts
+++ b/metrics/src/validate-hogql.ts
@@ -10,8 +10,8 @@
  * Usage:
  *   POSTHOG_PERSONAL_API_KEY=phx_... POSTHOG_PROJECT_ID=<your-project-id> bun run validate:hogql
  *
- * In CI: set POSTHOG_PERSONAL_API_KEY as a CI secret. POSTHOG_PROJECT_ID defaults
- * to "" if unset.
+ * In CI: set POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID as CI secrets.
+ * Both are required — the script exits immediately if either is missing.
  */
 
 import { createPostHogClient } from "./posthog-client.ts";
@@ -121,12 +121,22 @@ if (!apiKey) {
   process.exit(1);
 }
 
-const projectId = process.env.POSTHOG_PROJECT_ID ?? "";
+const projectId = process.env.POSTHOG_PROJECT_ID;
+
+if (!projectId) {
+  console.error(
+    "ERROR: POSTHOG_PROJECT_ID is not set.\n" +
+      "Set the PostHog project ID for HogQL validation:\n" +
+      "  POSTHOG_PERSONAL_API_KEY=phx_... POSTHOG_PROJECT_ID=<your-project-id> bun run validate:hogql",
+  );
+  process.exit(1);
+}
+
 const client = createPostHogClient({ personalApiKey: apiKey, projectId });
 
 const builders = allBuilders();
 console.log(
-  `Validating ${builders.length} HogQL queries via PostHog HogQLMetadata (project ${projectId || "<your-project-id>"})...`,
+  `Validating ${builders.length} HogQL queries via PostHog HogQLMetadata (project ${projectId})...`,
 );
 
 let failures = 0;


### PR DESCRIPTION
Re-lands the SW-2.2 work that merged into the wrong base. PR #39 was stacked on `feat/sw-2-1-port-metrics-closure`; that base reached `main` via a different squash (#30), leaving #39 merged into an orphaned branch so its changes never hit `main`. This applies #39's exact diff (squash `c95405e`) onto current `main`.

- `secrets.ts`: resolution reordered to **env-first** (env var wins; GCP Secret Manager optional fallback)
- `env.ts`: new `validateRequiredEnv()` fail-fast guard
- `server.ts`: fail-fast on missing `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` at startup
- `validate-hogql.ts`: `POSTHOG_PROJECT_ID` now required (exits if missing) instead of defaulting to `""`
- adds `env.unit.test.ts`; updates `secrets.integration.test.ts`

Cherry-pick applied cleanly to main; metrics suite 540 pass / 0 fail; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
