### PR TITLE
feat(she-1.2): port crypto and agent config service layer

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Shipwright reference agent — autonomous task runner: pick → build → ship PR → forward metrics",
   "scripts": {
+    "postinstall": "prisma generate --schema=prisma/schema.prisma",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "db:generate": "prisma generate --schema=prisma/schema.prisma",

--- a/agent/src/agent-cron-jobs.integration.test.ts
+++ b/agent/src/agent-cron-jobs.integration.test.ts
@@ -1,0 +1,300 @@
+/**
+ * agent/src/agent-cron-jobs.integration.test.ts
+ * Integration tests for AgentCronJobService against a real SQLite DB.
+ *
+ * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { AgentCronJobService } from "./agent-cron-jobs.ts";
+import { NotFoundError, UnprocessableEntityError } from "./errors.ts";
+
+const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    // TEST_DB is guaranteed set — the describe block is skipped otherwise.
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+async function createAgent(
+  prisma: PrismaClient,
+  name = "Test Agent",
+): Promise<string> {
+  const agent = await prisma.agent.create({ data: { name } });
+  return agent.id;
+}
+
+describeOrSkip("AgentCronJobService (integration)", () => {
+  let prisma: PrismaClient;
+  let service: AgentCronJobService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    await prisma.agentToken.deleteMany();
+    await prisma.agentCronJob.deleteMany();
+    await prisma.agentTool.deleteMany();
+    await prisma.agentEnv.deleteMany();
+    await prisma.agent.deleteMany();
+    service = new AgentCronJobService(prisma);
+  });
+
+  // ─── create ─────────────────────────────────────────────────────────────────
+
+  it("create() creates a cron job with channel target", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Good morning",
+      channel: "C123456",
+    });
+    expect(job.agentId).toBe(agentId);
+    expect(job.schedule).toBe("0 9 * * *");
+    expect(job.channel).toBe("C123456");
+    expect(job.user).toBeNull();
+    expect(job.silent).toBe(false);
+    expect(job.enabled).toBe(true);
+  });
+
+  it("create() creates a cron job with user target", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "*/5 * * * *",
+      prompt: "Check status",
+      user: "U123456",
+    });
+    expect(job.user).toBe("U123456");
+    expect(job.channel).toBeNull();
+  });
+
+  it("create() creates a silent cron job with no channel/user", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 * * * *",
+      prompt: "Silent task",
+      silent: true,
+    });
+    expect(job.silent).toBe(true);
+    expect(job.channel).toBeNull();
+    expect(job.user).toBeNull();
+  });
+
+  it("create() throws UnprocessableEntityError for invalid cron expression", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(
+      service.create(agentId, {
+        schedule: "not-a-cron",
+        prompt: "Bad cron",
+        channel: "C123",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  it("create() throws UnprocessableEntityError when both channel and user are set", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(
+      service.create(agentId, {
+        schedule: "0 9 * * *",
+        prompt: "Ambiguous target",
+        channel: "C123456",
+        user: "U123456",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  it("create() throws UnprocessableEntityError when neither channel nor user set and not silent", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(
+      service.create(agentId, {
+        schedule: "0 9 * * *",
+        prompt: "No target",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  // ─── list / get ─────────────────────────────────────────────────────────────
+
+  it("list() returns all cron jobs for an agent", async () => {
+    const agentId = await createAgent(prisma);
+    await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Job 1",
+      channel: "C1",
+    });
+    await service.create(agentId, {
+      schedule: "0 10 * * *",
+      prompt: "Job 2",
+      channel: "C2",
+    });
+    const jobs = await service.list(agentId);
+    expect(jobs).toHaveLength(2);
+  });
+
+  it("get() returns a specific cron job", async () => {
+    const agentId = await createAgent(prisma);
+    const created = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Specific",
+      channel: "C1",
+    });
+    const fetched = await service.get(agentId, created.id);
+    expect(fetched.id).toBe(created.id);
+  });
+
+  it("get() throws NotFoundError for unknown cronId", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(service.get(agentId, "nonexistent")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("get() throws NotFoundError when cronId belongs to a different agent", async () => {
+    const agentId1 = await createAgent(prisma, "Agent 1");
+    const agentId2 = await createAgent(prisma, "Agent 2");
+    const job = await service.create(agentId1, {
+      schedule: "0 9 * * *",
+      prompt: "Owned by agent1",
+      channel: "C1",
+    });
+    await expect(service.get(agentId2, job.id)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  // ─── listEnabled ────────────────────────────────────────────────────────────
+
+  it("listEnabled() returns only enabled jobs across all agents", async () => {
+    const agentId = await createAgent(prisma);
+    await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Enabled",
+      channel: "C1",
+      enabled: true,
+    });
+    await service.create(agentId, {
+      schedule: "0 10 * * *",
+      prompt: "Disabled",
+      channel: "C2",
+      enabled: false,
+    });
+    const enabled = await service.listEnabled();
+    expect(enabled.every((j) => j.enabled)).toBe(true);
+    expect(enabled).toHaveLength(1);
+  });
+
+  // ─── update ─────────────────────────────────────────────────────────────────
+
+  it("update() changes schedule and prompt", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Original",
+      channel: "C1",
+    });
+    const updated = await service.update(agentId, job.id, {
+      schedule: "0 10 * * *",
+      prompt: "Updated",
+      channel: "C1",
+    });
+    expect(updated.schedule).toBe("0 10 * * *");
+    expect(updated.prompt).toBe("Updated");
+  });
+
+  it("update() throws UnprocessableEntityError when both channel and user are set", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Original",
+      channel: "C1",
+    });
+    await expect(
+      service.update(agentId, job.id, {
+        schedule: "0 9 * * *",
+        prompt: "Updated",
+        channel: "C1",
+        user: "U1",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  it("update() throws UnprocessableEntityError for invalid cron expression", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Original",
+      channel: "C1",
+    });
+    await expect(
+      service.update(agentId, job.id, {
+        schedule: "bad",
+        prompt: "Updated",
+        channel: "C1",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  // ─── delete ─────────────────────────────────────────────────────────────────
+
+  it("delete() removes the cron job", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Delete me",
+      channel: "C1",
+    });
+    await service.delete(agentId, job.id);
+    const jobs = await service.list(agentId);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("delete() throws NotFoundError for unknown cronId", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(service.delete(agentId, "nonexistent")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  // ─── setEnabled ─────────────────────────────────────────────────────────────
+
+  it("setEnabled() toggles a cron job", async () => {
+    const agentId = await createAgent(prisma);
+    const job = await service.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Toggle",
+      channel: "C1",
+      enabled: true,
+    });
+    const disabled = await service.setEnabled(agentId, job.id, false);
+    expect(disabled.enabled).toBe(false);
+    const reenabled = await service.setEnabled(agentId, job.id, true);
+    expect(reenabled.enabled).toBe(true);
+  });
+
+  // ─── reconcileSystemCrons ───────────────────────────────────────────────────
+
+  it("reconcileSystemCrons() creates system crons for a new agent", async () => {
+    const agentId = await createAgent(prisma);
+    const result = await service.reconcileSystemCrons(agentId);
+    expect(result.created).toBeGreaterThan(0);
+    expect(result.updated).toBe(0);
+    expect(result.deleted).toBe(0);
+
+    const jobs = await service.list(agentId);
+    const systemJobs = jobs.filter((j) => j.system);
+    expect(systemJobs.length).toBe(result.created);
+  });
+
+  it("reconcileSystemCrons() updates existing system crons", async () => {
+    const agentId = await createAgent(prisma);
+    // First reconcile seeds all system crons
+    await service.reconcileSystemCrons(agentId);
+    // Second reconcile should update them (not create new ones)
+    const result = await service.reconcileSystemCrons(agentId);
+    expect(result.updated).toBeGreaterThan(0);
+    expect(result.created).toBe(0);
+  });
+});

--- a/agent/src/agent-cron-jobs.ts
+++ b/agent/src/agent-cron-jobs.ts
@@ -1,0 +1,341 @@
+/**
+ * agent/src/agent-cron-jobs.ts
+ * AgentCronJobService — CRUD for scheduled prompts per agent.
+ *
+ * Cron expression validation uses an inline 5-field regex check.
+ * Delivery target must be either a Slack channel ID or a Slack user ID (DM)
+ * — not both, and not neither (unless silent=true).
+ */
+
+import { NotFoundError, UnprocessableEntityError } from "./errors.ts";
+import { SYSTEM_CRONS } from "./system-crons.ts";
+import type { AgentCronJob, PrismaClient } from "../prisma/client/index.js";
+
+export type { AgentCronJob };
+
+export interface CreateAgentCronJobInput {
+  schedule: string;
+  prompt: string;
+  channel?: string | null;
+  user?: string | null;
+  silent?: boolean;
+  enabled?: boolean;
+  preCheck?: string | null;
+  name?: string | null;
+  system?: boolean;
+}
+
+/**
+ * Validates a cron expression.
+ * Accepts standard 5-field cron: minute hour day-of-month month day-of-week.
+ * Each field may contain digits, *, /, -, and comma.
+ */
+function isValidCron(schedule: string): boolean {
+  const fields = schedule.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  const fieldPattern = /^(\*|[0-9]+([-,][0-9]+)*)(\/[0-9]+)?$|^\*\/[0-9]+$/;
+  return fields.every((f) => fieldPattern.test(f));
+}
+
+export class AgentCronJobService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * List all cron jobs for a given agent.
+   */
+  async list(agentId: string): Promise<AgentCronJob[]> {
+    return this.prisma.agentCronJob.findMany({
+      where: { agentId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  async get(agentId: string, cronId: string): Promise<AgentCronJob> {
+    const job = await this.prisma.agentCronJob.findUnique({
+      where: { id: cronId },
+    });
+    if (!job || job.agentId !== agentId) {
+      throw new NotFoundError(`cron job ${cronId} not found`);
+    }
+    return job;
+  }
+
+  /**
+   * List all enabled cron jobs across all agents.
+   * Used by the runtime sync loop on startup and every 60s.
+   */
+  async listEnabled(): Promise<AgentCronJob[]> {
+    return this.prisma.agentCronJob.findMany({
+      where: { enabled: true },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
+   * Create a new cron job for the given agent.
+   * Validates:
+   *   - schedule is a valid 5-field cron expression
+   *   - channel and user are mutually exclusive (422 if both set)
+   *   - at least one of channel or user is set (unless silent=true)
+   * Throws UnprocessableEntityError for invalid inputs.
+   */
+  async create(
+    agentId: string,
+    input: CreateAgentCronJobInput,
+  ): Promise<AgentCronJob> {
+    if (!isValidCron(input.schedule)) {
+      throw new UnprocessableEntityError(
+        `invalid cron expression: "${input.schedule}"`,
+      );
+    }
+
+    const channel = input.channel ?? null;
+    const user = input.user ?? null;
+    const silent = input.silent ?? false;
+
+    // Channel and user are mutually exclusive — setting both is ambiguous.
+    if (channel && user) {
+      throw new UnprocessableEntityError(
+        "channel and user are mutually exclusive — set one or the other, not both",
+      );
+    }
+
+    // Silent crons run without posting to Slack, so they don't need a target.
+    // Non-silent crons MUST post somewhere.
+    if (!silent && !channel && !user) {
+      throw new UnprocessableEntityError(
+        "at least one of channel or user must be set (unless silent=true)",
+      );
+    }
+
+    return this.prisma.agentCronJob.create({
+      data: {
+        agentId,
+        schedule: input.schedule,
+        prompt: input.prompt,
+        channel,
+        user,
+        silent,
+        enabled: input.enabled ?? true,
+        preCheck: input.preCheck ?? null,
+        name: input.name ?? null,
+        system: input.system ?? false,
+      },
+    });
+  }
+
+  /**
+   * Delete a cron job. Verifies agentId ownership before deleting.
+   * Throws NotFoundError if the cronId doesn't exist or belongs to a different agent.
+   */
+  async delete(agentId: string, cronId: string): Promise<void> {
+    const existing = await this.prisma.agentCronJob.findUnique({
+      where: { id: cronId },
+    });
+
+    if (!existing || existing.agentId !== agentId) {
+      throw new NotFoundError(`cron job ${cronId} not found`);
+    }
+
+    await this.prisma.agentCronJob.delete({ where: { id: cronId } });
+  }
+
+  /**
+   * Update a cron job's schedule, prompt, channel, user, silent, and preCheck.
+   * Applies the same validation as create():
+   *   - schedule must be a valid cron expression
+   *   - channel and user are mutually exclusive (422 if both set)
+   *   - at least one of channel or user must be set (unless silent=true)
+   * Throws NotFoundError if the cronId doesn't exist or belongs to a different agent.
+   * Throws UnprocessableEntityError for invalid inputs.
+   */
+  async update(
+    agentId: string,
+    cronId: string,
+    input: {
+      schedule: string;
+      prompt: string;
+      channel?: string | null;
+      user?: string | null;
+      silent?: boolean;
+      preCheck?: string | null;
+    },
+  ): Promise<AgentCronJob> {
+    await this.get(agentId, cronId);
+
+    if (!isValidCron(input.schedule)) {
+      throw new UnprocessableEntityError(
+        `invalid cron expression: "${input.schedule}"`,
+      );
+    }
+
+    const channel = input.channel ?? null;
+    const user = input.user ?? null;
+    const silent = input.silent ?? false;
+
+    if (channel && user) {
+      throw new UnprocessableEntityError(
+        "channel and user are mutually exclusive — set one or the other, not both",
+      );
+    }
+
+    if (!silent && !channel && !user) {
+      throw new UnprocessableEntityError(
+        "at least one of channel or user must be set",
+      );
+    }
+
+    return this.prisma.agentCronJob.update({
+      where: { id: cronId },
+      data: {
+        schedule: input.schedule,
+        prompt: input.prompt,
+        channel,
+        user,
+        silent,
+        ...(input.preCheck !== undefined && { preCheck: input.preCheck }),
+      },
+    });
+  }
+
+  /**
+   * Update only the preCheck field of a cron job.
+   * Pass null to clear the preCheck script.
+   * Throws NotFoundError if the cronId doesn't exist or belongs to a different agent.
+   */
+  async updatePreCheck(
+    agentId: string,
+    cronId: string,
+    preCheck: string | null,
+  ): Promise<AgentCronJob> {
+    await this.get(agentId, cronId);
+    return this.prisma.agentCronJob.update({
+      where: { id: cronId },
+      data: { preCheck },
+    });
+  }
+
+  /**
+   * Update only the delivery-target fields of a cron job (channel, user, silent).
+   * Does not touch schedule or prompt.
+   * Throws NotFoundError if the cronId doesn't exist or belongs to a different agent.
+   */
+  async updateDelivery(
+    agentId: string,
+    cronId: string,
+    input: {
+      channel?: string | null;
+      user?: string | null;
+      silent?: boolean;
+    },
+  ): Promise<AgentCronJob> {
+    await this.get(agentId, cronId);
+
+    return this.prisma.agentCronJob.update({
+      where: { id: cronId },
+      data: {
+        ...(input.channel !== undefined && { channel: input.channel }),
+        ...(input.user !== undefined && { user: input.user }),
+        ...(input.silent !== undefined && { silent: input.silent }),
+      },
+    });
+  }
+
+  /**
+   * Enable or disable a cron job.
+   * Throws NotFoundError if the cronId doesn't exist or belongs to a different agent.
+   */
+  async setEnabled(
+    agentId: string,
+    cronId: string,
+    enabled: boolean,
+  ): Promise<AgentCronJob> {
+    const existing = await this.prisma.agentCronJob.findUnique({
+      where: { id: cronId },
+    });
+
+    if (!existing || existing.agentId !== agentId) {
+      throw new NotFoundError(`cron job ${cronId} not found`);
+    }
+
+    return this.prisma.agentCronJob.update({
+      where: { id: cronId },
+      data: { enabled },
+    });
+  }
+
+  /**
+   * Reconcile system crons for the given agent.
+   *
+   * For each entry in SYSTEM_CRONS:
+   *   - If an existing system cron with matching name exists: delete it and
+   *     recreate it with current SYSTEM_CRONS definition, preserving the
+   *     existing enabled state.
+   *   - If no matching cron exists: create it with SYSTEM_CRONS default enabled.
+   *
+   * Orphan pass: delete any cron with system=true whose name is no longer in SYSTEM_CRONS.
+   *
+   * Returns a summary { created, updated, deleted }.
+   */
+  async reconcileSystemCrons(
+    agentId: string,
+  ): Promise<{ created: number; updated: number; deleted: number }> {
+    // Fetch all existing system crons for this agent
+    const existingSystemCrons = await this.prisma.agentCronJob.findMany({
+      where: { agentId, system: true },
+    });
+
+    // Build a map of name → existing cron
+    const existingByName = new Map<string, AgentCronJob>();
+    for (const cron of existingSystemCrons) {
+      if (cron.name) {
+        existingByName.set(cron.name, cron);
+      }
+    }
+
+    // Build set of valid SYSTEM_CRONS names for orphan detection
+    const systemCronNames = new Set(SYSTEM_CRONS.map((c) => c.name));
+
+    let created = 0;
+    let updated = 0;
+    let deleted = 0;
+
+    // Reconcile each SYSTEM_CRON entry
+    for (const systemCron of SYSTEM_CRONS) {
+      const existing = existingByName.get(systemCron.name);
+      const enabled = existing ? existing.enabled : systemCron.enabled;
+
+      if (existing) {
+        await this.prisma.agentCronJob.delete({ where: { id: existing.id } });
+        updated++;
+      } else {
+        created++;
+      }
+
+      await this.prisma.agentCronJob.create({
+        data: {
+          agentId,
+          name: systemCron.name,
+          system: true,
+          schedule: systemCron.schedule,
+          prompt: systemCron.prompt,
+          silent: systemCron.silent ?? false,
+          preCheck: systemCron.preCheck ?? null,
+          channel: null,
+          user: null,
+          enabled,
+        },
+      });
+    }
+
+    // Orphan pass: delete any system cron whose name is not in SYSTEM_CRONS.
+    for (const cron of existingSystemCrons) {
+      if (!cron.name || !systemCronNames.has(cron.name)) {
+        await this.prisma.agentCronJob.delete({ where: { id: cron.id } });
+        deleted++;
+      }
+    }
+
+    return { created, updated, deleted };
+  }
+}

--- a/agent/src/agent-cron-jobs.ts
+++ b/agent/src/agent-cron-jobs.ts
@@ -37,6 +37,23 @@ function isValidCron(schedule: string): boolean {
   return fields.every((f) => fieldPattern.test(f));
 }
 
+function validateDeliveryTarget(
+  channel: string | null,
+  user: string | null,
+  silent: boolean,
+): void {
+  if (channel && user) {
+    throw new UnprocessableEntityError(
+      "channel and user are mutually exclusive — set one or the other, not both",
+    );
+  }
+  if (!silent && !channel && !user) {
+    throw new UnprocessableEntityError(
+      "at least one of channel or user must be set (unless silent=true)",
+    );
+  }
+}
+
 export class AgentCronJobService {
   constructor(private prisma: PrismaClient) {}
 
@@ -93,20 +110,7 @@ export class AgentCronJobService {
     const user = input.user ?? null;
     const silent = input.silent ?? false;
 
-    // Channel and user are mutually exclusive — setting both is ambiguous.
-    if (channel && user) {
-      throw new UnprocessableEntityError(
-        "channel and user are mutually exclusive — set one or the other, not both",
-      );
-    }
-
-    // Silent crons run without posting to Slack, so they don't need a target.
-    // Non-silent crons MUST post somewhere.
-    if (!silent && !channel && !user) {
-      throw new UnprocessableEntityError(
-        "at least one of channel or user must be set (unless silent=true)",
-      );
-    }
+    validateDeliveryTarget(channel, user, silent);
 
     return this.prisma.agentCronJob.create({
       data: {
@@ -173,17 +177,7 @@ export class AgentCronJobService {
     const user = input.user ?? null;
     const silent = input.silent ?? false;
 
-    if (channel && user) {
-      throw new UnprocessableEntityError(
-        "channel and user are mutually exclusive — set one or the other, not both",
-      );
-    }
-
-    if (!silent && !channel && !user) {
-      throw new UnprocessableEntityError(
-        "at least one of channel or user must be set",
-      );
-    }
+    validateDeliveryTarget(channel, user, silent);
 
     return this.prisma.agentCronJob.update({
       where: { id: cronId },
@@ -250,13 +244,7 @@ export class AgentCronJobService {
     cronId: string,
     enabled: boolean,
   ): Promise<AgentCronJob> {
-    const existing = await this.prisma.agentCronJob.findUnique({
-      where: { id: cronId },
-    });
-
-    if (!existing || existing.agentId !== agentId) {
-      throw new NotFoundError(`cron job ${cronId} not found`);
-    }
+    await this.get(agentId, cronId);
 
     return this.prisma.agentCronJob.update({
       where: { id: cronId },

--- a/agent/src/agent-envs.integration.test.ts
+++ b/agent/src/agent-envs.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * agent/src/agent-envs.integration.test.ts
+ * Integration tests for AgentEnvService against a real SQLite DB.
+ *
+ * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { AgentEnvService } from "./agent-envs.ts";
+import { identityCrypto } from "./token-crypto.ts";
+import { UnprocessableEntityError } from "./errors.ts";
+
+const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    // TEST_DB is guaranteed set — the describe block is skipped otherwise.
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+async function createAgent(
+  prisma: PrismaClient,
+  name = "Test Agent",
+): Promise<string> {
+  const agent = await prisma.agent.create({ data: { name } });
+  return agent.id;
+}
+
+describeOrSkip("AgentEnvService (integration)", () => {
+  let prisma: PrismaClient;
+  let service: AgentEnvService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    // Clean all tables in FK dependency order
+    await prisma.agentToken.deleteMany();
+    await prisma.agentCronJob.deleteMany();
+    await prisma.agentTool.deleteMany();
+    await prisma.agentEnv.deleteMany();
+    await prisma.agent.deleteMany();
+    service = new AgentEnvService(prisma, identityCrypto);
+  });
+
+  it("upsert() writes values and getByAgentId() returns them", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { FOO: "bar", BAZ: "qux" });
+    const result = await service.getByAgentId(agentId);
+    expect(result).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("upsert() replaces all existing vars (delete + insert)", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { FOO: "bar", OLD: "value" });
+    await service.upsert(agentId, { FOO: "new", FRESH: "yes" });
+    const result = await service.getByAgentId(agentId);
+    expect(result).toEqual({ FOO: "new", FRESH: "yes" });
+    expect(result).not.toHaveProperty("OLD");
+  });
+
+  it("upsert() encrypts values (round-trip with real crypto)", async () => {
+    // Use a real crypto instead of identity to verify encrypt→decrypt round-trip
+    const { makeTokenCrypto } = await import("./token-crypto.ts");
+    const realKey =
+      "0000000000000000000000000000000000000000000000000000000000000001";
+    const origKey = process.env.SHIPWRIGHT_ENCRYPTION_KEY;
+    process.env.SHIPWRIGHT_ENCRYPTION_KEY = realKey;
+    const realCrypto = makeTokenCrypto();
+
+    try {
+      const encService = new AgentEnvService(prisma, realCrypto);
+      const agentId = await createAgent(prisma);
+      await encService.upsert(agentId, { SECRET: "my-api-key" });
+
+      // Raw DB value should be encrypted (not plain text)
+      const raw = await prisma.agentEnv.findFirst({
+        where: { agentId, key: "SECRET" },
+      });
+      expect(raw?.value).not.toBe("my-api-key");
+      expect(raw?.value).toContain(":"); // iv:ciphertext:authTag format
+
+      // But getByAgentId should return decrypted
+      const result = await encService.getByAgentId(agentId);
+      expect(result?.SECRET).toBe("my-api-key");
+    } finally {
+      process.env.SHIPWRIGHT_ENCRYPTION_KEY =
+        origKey === undefined ? undefined : origKey;
+    }
+  });
+
+  it("upsert() throws UnprocessableEntityError for unknown agent", async () => {
+    await expect(
+      service.upsert("nonexistent-id", { FOO: "bar" }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  it("patch() upserts specific keys without touching others", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { A: "1", B: "2" });
+    await service.patch(agentId, { B: "updated", C: "new" });
+    const result = await service.getByAgentId(agentId);
+    expect(result).toEqual({ A: "1", B: "updated", C: "new" });
+  });
+
+  it("patch() throws UnprocessableEntityError for unknown agent", async () => {
+    await expect(
+      service.patch("nonexistent-id", { FOO: "bar" }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityError);
+  });
+
+  it("getByAgentId() returns null when no env vars set", async () => {
+    const agentId = await createAgent(prisma);
+    const result = await service.getByAgentId(agentId);
+    expect(result).toBeNull();
+  });
+
+  it("getConfigBundle() returns env and agentId and allowedTools", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { SLACK_BOT_TOKEN: "xoxb-test" });
+
+    const bundle = await service.getConfigBundle(agentId);
+    expect(bundle).not.toBeNull();
+    expect(bundle?.env.SLACK_BOT_TOKEN).toBe("xoxb-test");
+    expect(bundle?.agentId).toBe(agentId);
+    expect(Array.isArray(bundle?.allowedTools)).toBe(true);
+  });
+
+  it("getConfigBundle() returns null when no env vars", async () => {
+    const agentId = await createAgent(prisma);
+    const bundle = await service.getConfigBundle(agentId);
+    expect(bundle).toBeNull();
+  });
+
+  it("getConfigBundle() includes enabled tools in allowedTools", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { FOO: "bar" });
+    await prisma.agentTool.create({
+      data: { agentId, pattern: "Read", enabled: true },
+    });
+    await prisma.agentTool.create({
+      data: { agentId, pattern: "Bash", enabled: false },
+    });
+
+    const bundle = await service.getConfigBundle(agentId);
+    expect(bundle?.allowedTools).toContain("Read");
+    expect(bundle?.allowedTools).not.toContain("Bash");
+  });
+
+  it("deleteKey() removes a specific env var", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { A: "1", B: "2" });
+    await service.deleteKey(agentId, "A");
+    const result = await service.getByAgentId(agentId);
+    expect(result).toEqual({ B: "2" });
+  });
+
+  it("deleteKey() no-ops for a key that doesn't exist", async () => {
+    const agentId = await createAgent(prisma);
+    await service.upsert(agentId, { B: "2" });
+    await expect(service.deleteKey(agentId, "MISSING")).resolves.toBeUndefined();
+  });
+
+  it("listAll() returns entries for all agents", async () => {
+    const id1 = await createAgent(prisma, "Agent 1");
+    const id2 = await createAgent(prisma, "Agent 2");
+    await service.upsert(id1, { KEY: "val1" });
+    await service.upsert(id2, { KEY: "val2" });
+
+    const all = await service.listAll();
+    expect(all).toHaveLength(2);
+    const entry1 = all.find((e) => e.agentId === id1);
+    const entry2 = all.find((e) => e.agentId === id2);
+    expect(entry1?.env.KEY).toBe("val1");
+    expect(entry2?.env.KEY).toBe("val2");
+  });
+});

--- a/agent/src/agent-envs.ts
+++ b/agent/src/agent-envs.ts
@@ -1,0 +1,176 @@
+/**
+ * agent/src/agent-envs.ts
+ * AgentEnvService — generic env var store for deployed agents.
+ *
+ * Keys are env var names (e.g. SLACK_BOT_TOKEN). Values are encrypted at rest
+ * using SHIPWRIGHT_ENCRYPTION_KEY (AES-256-GCM).
+ */
+
+import { type Clock, SystemClock } from "./clock.ts";
+import { ApiError, UnprocessableEntityError } from "./errors.ts";
+import type { PrismaClient } from "../prisma/client/index.js";
+import type { TokenCrypto } from "./token-crypto.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AgentEnvBundle {
+  /** All stored env vars (decrypted). */
+  env: Record<string, string>;
+  agentId: string;
+  /** Enabled tool patterns for this agent. */
+  allowedTools: string[];
+}
+
+export interface AgentEnvEntry {
+  agentId: string;
+  env: Record<string, string>;
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export class AgentEnvService {
+  constructor(
+    private prisma: PrismaClient,
+    private crypto: TokenCrypto,
+    private clock: Clock = SystemClock(),
+  ) {}
+
+  /**
+   * Replace all env vars for the given agent (delete existing + insert new).
+   * Validates that agentId references an existing Agent.
+   */
+  async upsert(agentId: string, env: Record<string, string>): Promise<void> {
+    const agent = await this.prisma.agent.findUnique({ where: { id: agentId } });
+    if (!agent) {
+      throw new UnprocessableEntityError("agent not found");
+    }
+
+    const now = this.clock.now();
+    const rows = Object.entries(env).map(([key, value]) => ({
+      agentId,
+      key,
+      value: this.crypto.encrypt(value),
+      updatedAt: now,
+    }));
+
+    await this.prisma.$transaction([
+      this.prisma.agentEnv.deleteMany({ where: { agentId } }),
+      ...rows.map((row) =>
+        this.prisma.agentEnv.create({
+          data: {
+            agentId: row.agentId,
+            key: row.key,
+            value: row.value,
+            updatedAt: row.updatedAt,
+          },
+        }),
+      ),
+    ]);
+  }
+
+  /**
+   * Upsert specific keys for the given agent without touching other keys.
+   * Validates that agentId references an existing Agent.
+   */
+  async patch(agentId: string, env: Record<string, string>): Promise<void> {
+    const agent = await this.prisma.agent.findUnique({ where: { id: agentId } });
+    if (!agent) {
+      throw new UnprocessableEntityError("agent not found");
+    }
+
+    const now = this.clock.now();
+    await this.prisma.$transaction(
+      Object.entries(env).map(([key, value]) =>
+        this.prisma.agentEnv.upsert({
+          where: { agentId_key: { agentId, key } },
+          create: {
+            agentId,
+            key,
+            value: this.crypto.encrypt(value),
+            updatedAt: now,
+          },
+          update: { value: this.crypto.encrypt(value), updatedAt: now },
+        }),
+      ),
+    );
+  }
+
+  /**
+   * Get all env vars for an agent (decrypted).
+   * Returns null if the agent has no env vars set.
+   */
+  async getByAgentId(agentId: string): Promise<Record<string, string> | null> {
+    const rows = await this.prisma.agentEnv.findMany({ where: { agentId } });
+    if (rows.length === 0) return null;
+    return this.decryptRows(rows);
+  }
+
+  /**
+   * Returns the full env bundle for an agent — stored env vars (decrypted) plus
+   * allowed tools.
+   *
+   * Returns null if the agent has no env vars set.
+   * Throws 500 if decryption fails.
+   */
+  async getConfigBundle(agentId: string): Promise<AgentEnvBundle | null> {
+    const rows = await this.prisma.agentEnv.findMany({ where: { agentId } });
+    if (rows.length === 0) return null;
+
+    let env: Record<string, string>;
+    try {
+      env = this.decryptRows(rows);
+    } catch (err) {
+      console.error("[shipwright agent] failed to decrypt agent env vars", err);
+      throw new ApiError(500, "failed to decrypt agent env vars");
+    }
+
+    const tools = await this.prisma.agentTool.findMany({
+      where: { agentId, enabled: true },
+    });
+
+    return {
+      env,
+      agentId,
+      allowedTools: tools.map((t) => t.pattern),
+    };
+  }
+
+  /**
+   * Delete a single env var key for the given agent.
+   * No-ops if the key does not exist.
+   */
+  async deleteKey(agentId: string, key: string): Promise<void> {
+    await this.prisma.agentEnv.deleteMany({ where: { agentId, key } });
+  }
+
+  /**
+   * List all agents with their decrypted env vars. Used by the interceptor to
+   * build its routing table on startup.
+   */
+  async listAll(): Promise<AgentEnvEntry[]> {
+    const rows = await this.prisma.agentEnv.findMany();
+
+    // Group by agentId
+    const byAgent = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const existing = byAgent.get(row.agentId) ?? [];
+      existing.push(row);
+      byAgent.set(row.agentId, existing);
+    }
+
+    return Array.from(byAgent.entries()).map(([agentId, agentRows]) => ({
+      agentId,
+      env: this.decryptRows(agentRows),
+    }));
+  }
+
+  private decryptRows(
+    rows: Array<{ key: string; value: string }>,
+  ): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (const row of rows) {
+      env[row.key] = this.crypto.decrypt(row.value);
+    }
+    return env;
+  }
+}

--- a/agent/src/agent-envs.ts
+++ b/agent/src/agent-envs.ts
@@ -131,7 +131,7 @@ export class AgentEnvService {
     return {
       env,
       agentId,
-      allowedTools: tools.map((t) => t.pattern),
+      allowedTools: tools.map((t: { pattern: string }) => t.pattern),
     };
   }
 

--- a/agent/src/agent-envs.ts
+++ b/agent/src/agent-envs.ts
@@ -144,8 +144,7 @@ export class AgentEnvService {
   }
 
   /**
-   * List all agents with their decrypted env vars. Used by the interceptor to
-   * build its routing table on startup.
+   * List all agents with their decrypted env vars.
    */
   async listAll(): Promise<AgentEnvEntry[]> {
     const rows = await this.prisma.agentEnv.findMany();

--- a/agent/src/agent-tokens.integration.test.ts
+++ b/agent/src/agent-tokens.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * agent/src/agent-tokens.integration.test.ts
+ * Integration tests for AgentTokenService against a real SQLite DB.
+ *
+ * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { AgentTokenService } from "./agent-tokens.ts";
+import { UnprocessableEntityError } from "./errors.ts";
+
+const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    // TEST_DB is guaranteed set — the describe block is skipped otherwise.
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+async function createAgent(
+  prisma: PrismaClient,
+  name = "Test Agent",
+): Promise<string> {
+  const agent = await prisma.agent.create({ data: { name } });
+  return agent.id;
+}
+
+describeOrSkip("AgentTokenService (integration)", () => {
+  let prisma: PrismaClient;
+  let service: AgentTokenService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    await prisma.agentToken.deleteMany();
+    await prisma.agentCronJob.deleteMany();
+    await prisma.agentTool.deleteMany();
+    await prisma.agentEnv.deleteMany();
+    await prisma.agent.deleteMany();
+    service = new AgentTokenService(prisma);
+  });
+
+  // ─── create ─────────────────────────────────────────────────────────────────
+
+  it("create() returns a token record and a raw token", async () => {
+    const agentId = await createAgent(prisma);
+    const { token, rawToken } = await service.create(agentId);
+    expect(token.agentId).toBe(agentId);
+    expect(typeof rawToken).toBe("string");
+    expect(rawToken).toHaveLength(64); // 32 bytes = 64 hex chars
+    expect(token.revokedAt).toBeNull();
+  });
+
+  it("create() stores only the SHA-256 hash (not raw token)", async () => {
+    const agentId = await createAgent(prisma);
+    const { token, rawToken } = await service.create(agentId);
+    // The stored token should NOT be the raw token
+    expect(token.token).not.toBe(rawToken);
+    // But should be a valid 64-char hex SHA-256 hash
+    expect(token.token).toHaveLength(64);
+  });
+
+  it("create() accepts an optional label", async () => {
+    const agentId = await createAgent(prisma);
+    const { token } = await service.create(agentId, "My CI Token");
+    expect(token.label).toBe("My CI Token");
+  });
+
+  it("create() throws UnprocessableEntityError for unknown agentId", async () => {
+    await expect(service.create("nonexistent-id")).rejects.toBeInstanceOf(
+      UnprocessableEntityError,
+    );
+  });
+
+  // ─── validate ───────────────────────────────────────────────────────────────
+
+  it("validate() returns agentId for a valid token", async () => {
+    const agentId = await createAgent(prisma);
+    const { rawToken } = await service.create(agentId);
+    const result = await service.validate(rawToken);
+    expect(result).not.toBeNull();
+    expect(result?.agentId).toBe(agentId);
+  });
+
+  it("validate() returns null for unknown token", async () => {
+    const result = await service.validate("0".repeat(64));
+    expect(result).toBeNull();
+  });
+
+  it("validate() returns null for a revoked token", async () => {
+    const agentId = await createAgent(prisma);
+    const { token, rawToken } = await service.create(agentId);
+    await service.revoke(token.id);
+    const result = await service.validate(rawToken);
+    expect(result).toBeNull();
+  });
+
+  // ─── revoke ─────────────────────────────────────────────────────────────────
+
+  it("revoke() sets revokedAt on the token", async () => {
+    const agentId = await createAgent(prisma);
+    const { token } = await service.create(agentId);
+    const revoked = await service.revoke(token.id);
+    expect(revoked).not.toBeNull();
+    expect(revoked?.revokedAt).not.toBeNull();
+  });
+
+  it("revoke() returns null for unknown tokenId (P2025)", async () => {
+    const result = await service.revoke("nonexistent-id");
+    expect(result).toBeNull();
+  });
+
+  // ─── listForAgent ────────────────────────────────────────────────────────────
+
+  it("listForAgent() returns all tokens for an agent", async () => {
+    const agentId = await createAgent(prisma);
+    await service.create(agentId, "Token 1");
+    await service.create(agentId, "Token 2");
+    const tokens = await service.listForAgent(agentId);
+    expect(tokens).toHaveLength(2);
+  });
+
+  it("listForAgent() does not return tokens from other agents", async () => {
+    const agentId1 = await createAgent(prisma, "Agent 1");
+    const agentId2 = await createAgent(prisma, "Agent 2");
+    await service.create(agentId1);
+    const tokens = await service.listForAgent(agentId2);
+    expect(tokens).toHaveLength(0);
+  });
+
+  // ─── getById ────────────────────────────────────────────────────────────────
+
+  it("getById() returns a token by ID", async () => {
+    const agentId = await createAgent(prisma);
+    const { token } = await service.create(agentId);
+    const fetched = await service.getById(token.id);
+    expect(fetched?.id).toBe(token.id);
+  });
+
+  it("getById() returns null for unknown tokenId", async () => {
+    const result = await service.getById("nonexistent");
+    expect(result).toBeNull();
+  });
+});

--- a/agent/src/agent-tokens.ts
+++ b/agent/src/agent-tokens.ts
@@ -1,0 +1,110 @@
+/**
+ * agent/src/agent-tokens.ts
+ * AgentTokenService — scoped API tokens for agent authentication.
+ *
+ * The raw token (64-char hex) is returned once at creation; only the SHA-256
+ * hash is stored. Token validation is O(1) via the unique index on `token`.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { type Clock, SystemClock } from "./clock.ts";
+import { UnprocessableEntityError } from "./errors.ts";
+import type { AgentToken, PrismaClient } from "../prisma/client/index.js";
+
+export type { AgentToken };
+
+export interface AgentTokenValidated {
+  agentId: string;
+}
+
+function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+function generateRawToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export class AgentTokenService {
+  constructor(
+    private prisma: PrismaClient,
+    private clock: Clock = SystemClock(),
+  ) {}
+
+  /**
+   * Create a new token for an agent.
+   * Returns the token record plus the raw token — only opportunity to read it.
+   * Throws UnprocessableEntityError if agentId doesn't reference an existing Agent.
+   */
+  async create(
+    agentId: string,
+    label?: string,
+  ): Promise<{ token: AgentToken; rawToken: string }> {
+    const agent = await this.prisma.agent.findUnique({ where: { id: agentId } });
+    if (!agent) {
+      throw new UnprocessableEntityError("agentId not found");
+    }
+
+    const rawToken = generateRawToken();
+    const hashed = hashToken(rawToken);
+
+    const token = await this.prisma.agentToken.create({
+      data: { agentId, token: hashed, label },
+    });
+
+    return { token, rawToken };
+  }
+
+  /**
+   * Validate a raw token. Returns { agentId } if valid and not revoked,
+   * or null if the token is unknown or revoked.
+   */
+  async validate(raw: string): Promise<AgentTokenValidated | null> {
+    const hashed = hashToken(raw);
+    const record = await this.prisma.agentToken.findUnique({
+      where: { token: hashed },
+    });
+    if (!record || record.revokedAt !== null) return null;
+    return { agentId: record.agentId };
+  }
+
+  /**
+   * Revoke a token by ID. Returns the updated record, or null if not found (P2025).
+   * Re-throws all other errors so real failures aren't silently swallowed.
+   */
+  async revoke(tokenId: string): Promise<AgentToken | null> {
+    try {
+      return await this.prisma.agentToken.update({
+        where: { id: tokenId },
+        data: { revokedAt: this.clock.now() },
+      });
+    } catch (err: unknown) {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code: string }).code === "P2025"
+      ) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * List tokens for a given agent (without the hashed token value).
+   */
+  async listForAgent(agentId: string): Promise<AgentToken[]> {
+    return this.prisma.agentToken.findMany({
+      where: { agentId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
+   * Get a single token by ID. Used for ownership checks before mutating.
+   */
+  async getById(tokenId: string): Promise<AgentToken | null> {
+    return this.prisma.agentToken.findUnique({ where: { id: tokenId } });
+  }
+}

--- a/agent/src/agent-tools.integration.test.ts
+++ b/agent/src/agent-tools.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * agent/src/agent-tools.integration.test.ts
+ * Integration tests for AgentToolService against a real SQLite DB.
+ *
+ * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { AgentToolService } from "./agent-tools.ts";
+import { NotFoundError } from "./errors.ts";
+
+const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    // TEST_DB is guaranteed set — the describe block is skipped otherwise.
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+async function createAgent(
+  prisma: PrismaClient,
+  name = "Test Agent",
+): Promise<string> {
+  const agent = await prisma.agent.create({ data: { name } });
+  return agent.id;
+}
+
+describeOrSkip("AgentToolService (integration)", () => {
+  let prisma: PrismaClient;
+  let service: AgentToolService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    await prisma.agentToken.deleteMany();
+    await prisma.agentCronJob.deleteMany();
+    await prisma.agentTool.deleteMany();
+    await prisma.agentEnv.deleteMany();
+    await prisma.agent.deleteMany();
+    service = new AgentToolService(prisma);
+  });
+
+  it("add() creates a new tool pattern", async () => {
+    const agentId = await createAgent(prisma);
+    const tool = await service.add(agentId, "Read");
+    expect(tool.agentId).toBe(agentId);
+    expect(tool.pattern).toBe("Read");
+    expect(tool.enabled).toBe(true);
+  });
+
+  it("add() re-enables a disabled pattern (upsert behavior)", async () => {
+    const agentId = await createAgent(prisma);
+    const tool = await service.add(agentId, "Write");
+    await service.toggle(agentId, tool.id, false);
+    // Re-add should re-enable it
+    const reenabled = await service.add(agentId, "Write");
+    expect(reenabled.enabled).toBe(true);
+  });
+
+  it("list() returns all tools for an agent ordered by createdAt", async () => {
+    const agentId = await createAgent(prisma);
+    await service.add(agentId, "Read");
+    await service.add(agentId, "Write");
+    await service.add(agentId, "Bash");
+    const tools = await service.list(agentId);
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.pattern)).toEqual(["Read", "Write", "Bash"]);
+  });
+
+  it("remove() deletes a tool pattern", async () => {
+    const agentId = await createAgent(prisma);
+    const tool = await service.add(agentId, "Bash");
+    await service.remove(agentId, tool.id);
+    const tools = await service.list(agentId);
+    expect(tools).toHaveLength(0);
+  });
+
+  it("remove() throws NotFoundError for unknown toolId", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(service.remove(agentId, "nonexistent")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("remove() throws NotFoundError when toolId belongs to a different agent", async () => {
+    const agentId1 = await createAgent(prisma, "Agent 1");
+    const agentId2 = await createAgent(prisma, "Agent 2");
+    const tool = await service.add(agentId1, "Read");
+    await expect(service.remove(agentId2, tool.id)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("toggle() enables and disables a tool", async () => {
+    const agentId = await createAgent(prisma);
+    const tool = await service.add(agentId, "Write");
+    const disabled = await service.toggle(agentId, tool.id, false);
+    expect(disabled.enabled).toBe(false);
+    const enabled = await service.toggle(agentId, tool.id, true);
+    expect(enabled.enabled).toBe(true);
+  });
+
+  it("toggle() throws NotFoundError for unknown toolId", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(
+      service.toggle(agentId, "nonexistent", true),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("updatePattern() changes the pattern string", async () => {
+    const agentId = await createAgent(prisma);
+    const tool = await service.add(agentId, "OldPattern");
+    const updated = await service.updatePattern(agentId, tool.id, "NewPattern");
+    expect(updated.pattern).toBe("NewPattern");
+  });
+
+  it("updatePattern() throws NotFoundError for unknown toolId", async () => {
+    const agentId = await createAgent(prisma);
+    await expect(
+      service.updatePattern(agentId, "nonexistent", "Read"),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/agent/src/agent-tools.ts
+++ b/agent/src/agent-tools.ts
@@ -1,0 +1,102 @@
+/**
+ * agent/src/agent-tools.ts
+ * AgentToolService — CRUD for allowed tool patterns per agent.
+ *
+ * Each pattern grants an agent permission to use a specific tool (e.g. "Read",
+ * "Bash", "Write"). The unique constraint on [agentId, pattern] prevents
+ * duplicates; add() uses upsert so it re-enables a previously disabled pattern.
+ */
+
+import { NotFoundError } from "./errors.ts";
+import type { AgentTool, PrismaClient } from "../prisma/client/index.js";
+
+export type { AgentTool };
+
+export class AgentToolService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * List all tool patterns for a given agent, ordered by createdAt.
+   */
+  async list(agentId: string): Promise<AgentTool[]> {
+    return this.prisma.agentTool.findMany({
+      where: { agentId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
+   * Add a tool pattern for the given agent.
+   * Uses upsert so re-adding a disabled pattern re-enables it.
+   */
+  async add(agentId: string, pattern: string): Promise<AgentTool> {
+    return this.prisma.agentTool.upsert({
+      where: { agentId_pattern: { agentId, pattern } },
+      create: { agentId, pattern, enabled: true },
+      update: { enabled: true },
+    });
+  }
+
+  /**
+   * Delete a tool pattern. Verifies agentId ownership before deleting.
+   * Throws NotFoundError if the toolId doesn't exist or belongs to a different agent.
+   */
+  async remove(agentId: string, toolId: string): Promise<void> {
+    const existing = await this.prisma.agentTool.findUnique({
+      where: { id: toolId },
+    });
+
+    if (!existing || existing.agentId !== agentId) {
+      throw new NotFoundError(`tool ${toolId} not found`);
+    }
+
+    await this.prisma.agentTool.delete({ where: { id: toolId } });
+  }
+
+  /**
+   * Enable or disable a tool pattern.
+   * Throws NotFoundError if the toolId doesn't exist or belongs to a different agent.
+   */
+  async toggle(
+    agentId: string,
+    toolId: string,
+    enabled: boolean,
+  ): Promise<AgentTool> {
+    const existing = await this.prisma.agentTool.findUnique({
+      where: { id: toolId },
+    });
+
+    if (!existing || existing.agentId !== agentId) {
+      throw new NotFoundError(`tool ${toolId} not found`);
+    }
+
+    return this.prisma.agentTool.update({
+      where: { id: toolId },
+      data: { enabled },
+    });
+  }
+
+  /**
+   * Update the pattern string for a tool.
+   * Verifies agentId ownership before updating.
+   * Throws NotFoundError if the toolId doesn't exist or belongs to a different agent.
+   */
+  async updatePattern(
+    agentId: string,
+    toolId: string,
+    pattern: string,
+  ): Promise<AgentTool> {
+    const existing = await this.prisma.agentTool.findUnique({
+      where: { id: toolId },
+    });
+
+    if (!existing || existing.agentId !== agentId) {
+      throw new NotFoundError(`tool ${toolId} not found`);
+    }
+
+    return this.prisma.agentTool.update({
+      where: { id: toolId },
+      data: { pattern },
+    });
+  }
+}

--- a/agent/src/clock.ts
+++ b/agent/src/clock.ts
@@ -1,0 +1,47 @@
+/**
+ * agent/src/clock.ts
+ * Clock interface and production implementation for injectable time.
+ *
+ * Any code that needs the current time should accept a `Clock` via dependency
+ * injection rather than calling `new Date()` or `Date.now()` directly.
+ * This makes time-dependent logic trivially testable and deterministic.
+ */
+
+// ─── Interface ────────────────────────────────────────────────────────────────
+
+export interface Clock {
+  /** Returns the current time as a Date. */
+  now(): Date;
+}
+
+// ─── SystemClock ──────────────────────────────────────────────────────────────
+
+/**
+ * Production clock — delegates to the real system time.
+ *
+ * @example
+ * const clock = SystemClock();
+ * clock.now(); // → current wall-clock time
+ */
+export function SystemClock(): Clock {
+  return {
+    now(): Date {
+      return new Date();
+    },
+  };
+}
+
+/**
+ * Fixed-time clock for deterministic testing.
+ *
+ * @example
+ * const clock = FixedClock(new Date("2024-01-01T00:00:00Z"));
+ * clock.now(); // → always 2024-01-01T00:00:00.000Z
+ */
+export function FixedClock(date: Date): Clock {
+  return {
+    now(): Date {
+      return date;
+    },
+  };
+}

--- a/agent/src/crypto.ts
+++ b/agent/src/crypto.ts
@@ -1,0 +1,73 @@
+/**
+ * agent/src/crypto.ts
+ * AES-256-GCM encryption for at-rest value storage.
+ *
+ * Encrypted format: `iv:ciphertext:authTag` — all hex-encoded, colon-separated.
+ *
+ * Key must be a 32-byte value expressed as a 64-character hex string
+ * (e.g. SHIPWRIGHT_ENCRYPTION_KEY env var).
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12; // 96-bit IV — recommended for GCM
+
+/**
+ * Encrypts a plaintext string with AES-256-GCM.
+ *
+ * @param plaintext - The string to encrypt.
+ * @param keyHex   - 64-char hex string representing a 32-byte key.
+ * @returns Hex-encoded `iv:ciphertext:authTag`.
+ */
+export function encrypt(plaintext: string, keyHex: string): string {
+  const key = Buffer.from(keyHex, "hex");
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+
+  const authTag = cipher.getAuthTag();
+
+  return [
+    iv.toString("hex"),
+    ciphertext.toString("hex"),
+    authTag.toString("hex"),
+  ].join(":");
+}
+
+/**
+ * Decrypts a value produced by `encrypt()`.
+ *
+ * @param encrypted - Hex-encoded `iv:ciphertext:authTag` string.
+ * @param keyHex    - 64-char hex string representing a 32-byte key.
+ * @returns The original plaintext string.
+ * @throws If the format is invalid, the key is wrong, or the auth tag fails.
+ */
+export function decrypt(encrypted: string, keyHex: string): string {
+  const parts = encrypted.split(":");
+  if (parts.length !== 3) {
+    throw new Error(
+      `Invalid encrypted format: expected "iv:ciphertext:authTag", got ${parts.length} part(s)`,
+    );
+  }
+
+  const [ivHex, ciphertextHex, authTagHex] = parts as [string, string, string];
+  const key = Buffer.from(keyHex, "hex");
+  const iv = Buffer.from(ivHex, "hex");
+  const ciphertext = Buffer.from(ciphertextHex, "hex");
+  const authTag = Buffer.from(authTagHex, "hex");
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString("utf8");
+}

--- a/agent/src/errors.ts
+++ b/agent/src/errors.ts
@@ -1,0 +1,61 @@
+/**
+ * agent/src/errors.ts
+ * Typed HTTP error classes for use across agent service handlers.
+ * Handlers throw these; error middleware maps them to HTTP responses.
+ */
+
+// ─── Base class ───────────────────────────────────────────────────────────────
+
+export class ApiError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+// ─── HTTP error subclasses ────────────────────────────────────────────────────
+
+export class NotFoundError extends ApiError {
+  constructor(message = "Not found") {
+    super(404, message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ConflictError extends ApiError {
+  constructor(message = "Conflict") {
+    super(409, message);
+    this.name = "ConflictError";
+  }
+}
+
+export class BadRequestError extends ApiError {
+  constructor(message = "Bad request") {
+    super(400, message);
+    this.name = "BadRequestError";
+  }
+}
+
+export class ForbiddenError extends ApiError {
+  constructor(message = "Forbidden") {
+    super(403, message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class UnprocessableEntityError extends ApiError {
+  constructor(message = "Unprocessable entity") {
+    super(422, message);
+    this.name = "UnprocessableEntityError";
+  }
+}
+
+export class BadGatewayError extends ApiError {
+  constructor(message = "Bad gateway") {
+    super(502, message);
+    this.name = "BadGatewayError";
+  }
+}

--- a/agent/src/system-crons.ts
+++ b/agent/src/system-crons.ts
@@ -1,0 +1,97 @@
+/**
+ * agent/src/system-crons.ts
+ * Default cron jobs seeded for a new agent.
+ *
+ * When a preCheck script is set, its stdout becomes the actual prompt sent to
+ * Claude — the stored prompt field is only used as a fallback when the preCheck
+ * script is not found in the plugin cache. Keep both in sync.
+ */
+
+export interface SystemCron {
+  name: string;
+  schedule: string;
+  prompt: string;
+  silent?: boolean;
+  preCheck?: string;
+  enabled: boolean;
+}
+
+export const SYSTEM_CRONS: readonly SystemCron[] = [
+  {
+    name: "shipwright-dev-task",
+    schedule: "*/30 * * * *",
+    prompt: "/shipwright:dev-task",
+    silent: true,
+    preCheck: "shipwright:check-dev-task.ts",
+    enabled: true,
+  },
+  {
+    name: "shipwright-patch",
+    schedule: "*/30 * * * *",
+    prompt: "/shipwright:patch",
+    silent: true,
+    preCheck: "shipwright:check-patch.ts",
+    enabled: false,
+  },
+  {
+    name: "shipwright-review-patch",
+    schedule: "*/30 * * * *",
+    prompt: "/shipwright:review-patch",
+    silent: true,
+    preCheck: "shipwright:check-review-patch.ts",
+    enabled: true,
+  },
+  {
+    name: "shipwright-review",
+    schedule: "*/30 * * * *",
+    prompt: "/shipwright:review",
+    silent: true,
+    preCheck: "shipwright:check-review.ts",
+    enabled: false,
+  },
+  {
+    name: "shipwright-deploy",
+    schedule: "*/30 * * * *",
+    prompt: "/shipwright:deploy",
+    silent: true,
+    preCheck: "shipwright:check-deploy.ts",
+    enabled: false,
+  },
+  {
+    name: "shipwright-test-readiness",
+    schedule: "0 6 * * *",
+    prompt: "/shipwright:test-readiness --full --publish",
+    silent: true,
+    enabled: false,
+  },
+  {
+    name: "shipwright-docs-freshness",
+    schedule: "0 7 * * *",
+    prompt: "/shipwright:research-docs --auto",
+    silent: true,
+    preCheck: "shipwright:check-docs-freshness.ts",
+    enabled: false,
+  },
+  {
+    name: "learn-dream",
+    schedule: "0 3 * * *",
+    prompt: "/learn-dream --since 1d --review",
+    silent: true,
+    enabled: false,
+  },
+  {
+    name: "dependabot-triage",
+    schedule: "0 8 * * *",
+    prompt: "/dependabot-review:triage-dependabot-prs",
+    silent: true,
+    enabled: false,
+  },
+  {
+    name: "entropy-patrol-maintenance",
+    schedule: "0 4 * * 1",
+    prompt:
+      '/entropy-patrol:entropy-scan\n/entropy-patrol:entropy-fix\nAfter the fix run completes, write state/entropy-patrol-last-run.json: {"lastRun": "<ISO timestamp>"}. Use [silent] if no pr_worthy findings are found.',
+    silent: true,
+    enabled: false,
+  },
+] as const;

--- a/agent/src/token-crypto.ts
+++ b/agent/src/token-crypto.ts
@@ -1,0 +1,52 @@
+/**
+ * agent/src/token-crypto.ts
+ * Token encryption/decryption interface and factory for agent credential storage.
+ *
+ * Centralises all token crypto so every storage path encrypts and decrypts
+ * automatically — callers work with plain text.
+ *
+ * Key: SHIPWRIGHT_ENCRYPTION_KEY — 64-char hex string (32 bytes for AES-256-GCM).
+ * If unset: identity functions (plain text stored, no encryption).
+ * If wrong format: encrypt() throws loudly at write time (better than silent failure).
+ *
+ * Legacy plain-text values: decrypt() catches parse errors and returns the stored
+ * value as-is, so existing rows continue to work after the key is added.
+ */
+
+import { decrypt, encrypt } from "./crypto.ts";
+
+export interface TokenCrypto {
+  encrypt(token: string): string;
+  decrypt(token: string): string;
+}
+
+/** Identity implementation — no encryption. Used as default in tests and when key is unset. */
+export const identityCrypto: TokenCrypto = {
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+};
+
+/**
+ * Creates a TokenCrypto backed by AES-256-GCM using SHIPWRIGHT_ENCRYPTION_KEY.
+ * Falls back to identity (plain text) if the env var is not set.
+ */
+export function makeTokenCrypto(): TokenCrypto {
+  const key = process.env.SHIPWRIGHT_ENCRYPTION_KEY;
+  if (!key) {
+    console.warn(
+      "[shipwright agent] SHIPWRIGHT_ENCRYPTION_KEY not set — tokens stored in plain text",
+    );
+    return identityCrypto;
+  }
+  return {
+    encrypt: (token) => encrypt(token, key),
+    decrypt: (encrypted) => {
+      try {
+        return decrypt(encrypted, key);
+      } catch {
+        // Legacy plain-text value — return as-is so existing rows keep working.
+        return encrypted;
+      }
+    },
+  };
+}

--- a/agent/src/token-crypto.unit.test.ts
+++ b/agent/src/token-crypto.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * agent/src/token-crypto.unit.test.ts
+ * Unit tests for the crypto round-trip (AES-256-GCM).
+ * Pure logic — no I/O, no DB, no network.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { encrypt, decrypt } from "./crypto.ts";
+import { makeTokenCrypto, identityCrypto } from "./token-crypto.ts";
+
+// ─── Test key ─────────────────────────────────────────────────────────────────
+// A known 64-char hex key (32 bytes) for deterministic tests.
+const TEST_KEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+// ─── crypto.ts: encrypt / decrypt ─────────────────────────────────────────────
+
+describe("encrypt / decrypt (AES-256-GCM)", () => {
+  it("round-trips a plain ASCII string", () => {
+    const plaintext = "hello world";
+    const encrypted = encrypt(plaintext, TEST_KEY);
+    expect(decrypt(encrypted, TEST_KEY)).toBe(plaintext);
+  });
+
+  it("round-trips an empty string", () => {
+    const plaintext = "";
+    const encrypted = encrypt(plaintext, TEST_KEY);
+    expect(decrypt(encrypted, TEST_KEY)).toBe(plaintext);
+  });
+
+  it("round-trips a unicode string", () => {
+    const plaintext = "こんにちは世界 🌍 — café résumé naïve";
+    const encrypted = encrypt(plaintext, TEST_KEY);
+    expect(decrypt(encrypted, TEST_KEY)).toBe(plaintext);
+  });
+
+  it("round-trips a 4096-byte value", () => {
+    const plaintext = "x".repeat(4096);
+    const encrypted = encrypt(plaintext, TEST_KEY);
+    expect(decrypt(encrypted, TEST_KEY)).toBe(plaintext);
+  });
+
+  it("produces a different ciphertext on each call (random IV)", () => {
+    const plaintext = "same input";
+    const enc1 = encrypt(plaintext, TEST_KEY);
+    const enc2 = encrypt(plaintext, TEST_KEY);
+    expect(enc1).not.toBe(enc2);
+  });
+
+  it("encrypted format is iv:ciphertext:authTag (3 colon-separated parts)", () => {
+    const encrypted = encrypt("test", TEST_KEY);
+    const parts = encrypted.split(":");
+    expect(parts.length).toBe(3);
+    // IV is 12 bytes = 24 hex chars
+    expect(parts[0]).toHaveLength(24);
+    // Auth tag is 16 bytes = 32 hex chars
+    expect(parts[2]).toHaveLength(32);
+  });
+
+  it("throws on invalid encrypted format (wrong part count)", () => {
+    expect(() => decrypt("notvalid", TEST_KEY)).toThrow("Invalid encrypted format");
+  });
+
+  it("throws when auth tag is wrong (tampered ciphertext)", () => {
+    const encrypted = encrypt("secret", TEST_KEY);
+    const parts = encrypted.split(":");
+    // Flip one char in the ciphertext
+    parts[1] = parts[1]
+      ? parts[1].slice(0, -2) + (parts[1].slice(-2) === "ff" ? "00" : "ff")
+      : "00";
+    const tampered = parts.join(":");
+    expect(() => decrypt(tampered, TEST_KEY)).toThrow();
+  });
+});
+
+// ─── makeTokenCrypto ───────────────────────────────────────────────────────────
+
+describe("makeTokenCrypto", () => {
+  const originalKey = process.env.SHIPWRIGHT_ENCRYPTION_KEY;
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      process.env.SHIPWRIGHT_ENCRYPTION_KEY = undefined;
+    } else {
+      process.env.SHIPWRIGHT_ENCRYPTION_KEY = originalKey;
+    }
+  });
+
+  it("returns identityCrypto when SHIPWRIGHT_ENCRYPTION_KEY is not set", () => {
+    process.env.SHIPWRIGHT_ENCRYPTION_KEY = undefined;
+    const crypto = makeTokenCrypto();
+    const token = "my-secret-token";
+    expect(crypto.encrypt(token)).toBe(token);
+    expect(crypto.decrypt(token)).toBe(token);
+  });
+
+  it("encrypts and decrypts when key is set", () => {
+    process.env.SHIPWRIGHT_ENCRYPTION_KEY = TEST_KEY;
+    const crypto = makeTokenCrypto();
+    const token = "my-secret-token";
+    const encrypted = crypto.encrypt(token);
+    expect(encrypted).not.toBe(token);
+    expect(crypto.decrypt(encrypted)).toBe(token);
+  });
+
+  it("decrypt falls back to returning plain text for legacy unencrypted tokens", () => {
+    process.env.SHIPWRIGHT_ENCRYPTION_KEY = TEST_KEY;
+    const crypto = makeTokenCrypto();
+    const legacyToken = "plain-text-stored-before-encryption";
+    // decrypt should not throw — returns the value as-is
+    expect(crypto.decrypt(legacyToken)).toBe(legacyToken);
+  });
+});
+
+// ─── identityCrypto ────────────────────────────────────────────────────────────
+
+describe("identityCrypto", () => {
+  it("encrypt returns input unchanged", () => {
+    expect(identityCrypto.encrypt("hello")).toBe("hello");
+  });
+
+  it("decrypt returns input unchanged", () => {
+    expect(identityCrypto.decrypt("hello")).toBe("hello");
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,12 @@
   "workspaces": {
     "": {
       "name": "shipwright-monorepo",
+      "dependencies": {
+        "@prisma/client": "^6.19.2",
+      },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "prisma": "^6.19.2",
         "typescript": "^5.7.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "prisma": "^6.19.2",
     "typescript": "^5.7.3"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.19.2"
   }
 }


### PR DESCRIPTION
## Summary

- Ports AES-256-GCM `crypto.ts` and `token-crypto.ts` (using `SHIPWRIGHT_ENCRYPTION_KEY`) from vitals-os into `agent/src/`
- Ports `AgentEnvService`, `AgentCronJobService`, `AgentToolService`, and `AgentTokenService` adapted for the standalone `Agent` model (no User/Engagement dependency)
- Adds `errors.ts`, `clock.ts`, and `system-crons.ts` shared utilities to `agent/src/`
- Adds `AgentCronJobService` mutual exclusion validation: 422 if both `channel` and `user` are set

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | encrypt → decrypt round-trip for empty string, unicode, 4096-byte value | ✅ MET |
| 2 | AgentEnvService.upsert() writes encrypted, getBundle() returns decrypted | ✅ MET |
| 3 | AgentCronJobService channel/user mutual exclusion (422 if both set) | ✅ MET |
| 4 | Integration tests against DATABASE_URL_AGENT_TEST, real Prisma, no mocks | ✅ MET |
| 5 | token-crypto.unit.test.ts + 4x *.integration.test.ts; no existing tests retired | ✅ MET |

## Test Plan

- [x] 68 new tests: 12 unit (crypto) + 56 integration (4 services × ~14 each)
- [x] All 625 tests pass (no regressions)
- [x] `bunx biome lint .` — no issues
- [x] `bun run --filter='*' typecheck` — all packages pass

Generated with [Claude Code](https://claude.com/claude-code)
