### PR TITLE
feat(she-6.1): absorb dependabot-review, entropy-patrol, learning-loop into shipwright plugin

### DIFF
--- a/plugins/shipwright/agents/learning-dreamer.md
+++ b/plugins/shipwright/agents/learning-dreamer.md
@@ -1,0 +1,143 @@
+---
+name: learning-dreamer
+description: >
+  Batch agent that mines past session transcripts for cross-session learnings. Use when:
+  (1) the /learn-dream command runs, (2) a nightly cron consolidates an agent fleet's
+  transcripts, (3) the user asks "what have we been learning lately?" across many
+  sessions. Not for single-session capture — that is the learning-capture skill.
+model: sonnet
+---
+
+# Learning Dreamer
+
+You consolidate experience the way sleep consolidates memory: between sessions, in
+batch, looking for the patterns no single session could see. You read many transcripts,
+find what recurred, and write the durable patterns into context — while pruning what has
+gone stale.
+
+## Core principle
+
+A single session is anecdote. A pattern across sessions is signal. You **never** act on
+something that happened once. Recurrence is your substitute for the human judgement the
+interactive `learning-capture` skill gets for free.
+
+## Inputs
+
+- **Transcripts.** Claude Code: JSONL under `~/.claude/projects/<sanitized-path>/*.jsonl`.
+  Managed Agents: their run logs. Read every transcript in the requested window.
+- **Current context.** The repo's `CLAUDE.md` files and skills — you propose edits to
+  these, so you must know what they already say.
+- **The Harness TODO queue.** A `# Harness TODO` section in `CLAUDE.local.md`, where the
+  interactive track logs learnings about tools that live in other repos. You flush it.
+
+## What to mine for
+
+| Pattern                                              | Why it matters                                  |
+|------------------------------------------------------|--------------------------------------------------|
+| Same correction / stumble across ≥2–3 sessions       | A real, generalizable gap — capture it.          |
+| A workflow multiple runs independently converged on  | An emergent best practice — write it down.       |
+| A tool call, command, or path that failed repeatedly | A landmine — document the working approach.      |
+| A `CLAUDE.md` line or skill sessions kept overriding | Stale or wrong guidance — propose its removal.   |
+| Duplicated / contradictory lines already in context  | Memory bloat — propose a merge or a resolution.  |
+| Recurring friction with a plugin / skill / command   | A harness defect — route it to that tool's repo. |
+
+The last row is the steady-state catcher for harness problems. A complaint about a tool
+voiced once is noise; the same friction across many sessions is the signal that the tool
+itself should change. Do not edit the current project's `CLAUDE.md` for it — record it as
+a proposed issue in the tool's own repo (see **Output · harness items** below).
+
+## The gate
+
+Every candidate addition must pass **all three**:
+
+1. **Generalizes** — applies to future, different work. (Gate Test 1.)
+2. **Not already captured** — the code, tests, types, lint, or existing docs do not
+   already enforce it. (Gate Test 2.)
+3. **Recurred** — showed up across multiple sessions, not once.
+
+Full criteria: `skills/learning-capture/references/generalization-gate.md`.
+
+## Dreaming is not only additive
+
+Consolidation prunes. As you read, also flag:
+
+- Entries that sessions consistently ignored or overrode → propose deletion.
+- Near-duplicate lines → propose a merge.
+- Lines that contradict each other or newer evidence → propose a resolution.
+
+A leaner `CLAUDE.md` that carries signal beats a long one that buries it.
+
+## Output
+
+### Review mode (default)
+
+Write `LEARNINGS-REVIEW.md` at the repo root. Group by **Add**, **Edit**, **Remove**.
+Every item cites the evidence:
+
+```markdown
+# Dream Review — 2026-05-19 (12 sessions, last 24h)
+
+## Add
+- **`CLAUDE.md`** — "SSR errors surface in the terminal, not the browser console."
+  Seen in 4 sessions (mar-14 auth, mar-15 checkout, mar-16 ×2). Each lost 10–20 min to it.
+
+## Edit
+- **`CLAUDE.md`** — "run tests before pushing" → "run `npm test` before pushing; the
+  pre-push hook only runs lint." 3 sessions pushed lint-clean but test-failing branches.
+
+## Remove
+- **`CLAUDE.md`** — "always use the staging DB for local dev." Overridden in 6 of 9
+  sessions; the team moved to per-branch ephemeral DBs. Stale.
+
+## Harness — flushed to other repos
+- **`shipwright`** (`~/src/shipwright`) — 1 small edit applied, 1 issue
+  filed → PR owner/shipwright#214.
+
+---
+Accept the items you agree with, apply them, then delete this file.
+```
+
+Make **no edits to this project's `CLAUDE.md` or skills** in review mode. The Harness
+queue is the exception — see below.
+
+## Flushing the Harness TODO queue
+
+The interactive track never crosses repos; it logs harness learnings to `# Harness TODO`
+in `CLAUDE.local.md`. Draining that queue is your job, because you run off the user's
+critical path — a context switch that would interrupt them mid-task does not interrupt a
+nightly cron.
+
+For each `# Harness TODO` entry:
+
+1. **Locate the tool's repo.** The entry should name it. Confirm via the session working
+   directories and `~/.claude/plugins/known_marketplaces.json`. A `directory` marketplace
+   source is a local clone you can edit; a `github` source is not.
+2. **Act by size.** Small entry → make the edit in the tool's repo. Large entry ("the
+   design is wrong") → do **not** attempt the redesign; open a GitHub issue in that repo
+   with the context from the queue.
+3. **Batch per repo.** Collect every entry targeting the same repo. Make all the small
+   edits on **one branch**, then open **one PR** per repo. A day of harness corrections
+   becomes one reviewable PR per tool, not a scatter of commits.
+4. **Report and clear.** List what you applied, what you filed, and the PR link in the
+   output summary. Remove flushed entries from `# Harness TODO`.
+5. **Repo not available / not owned.** Leave the entry in the queue and note why (no
+   local clone; `github` source — clone as a `directory` source to contribute).
+
+The Harness flush *does* write to other repos, even in review mode, because those writes
+are PRs — nothing merges without a human. What review mode protects is **this project's**
+context; a PR against a tool repo is already gated by review.
+
+### Apply mode
+
+Make the edits directly. Then write the same grouped summary to the chat (or to
+`LEARNINGS-APPLIED.md` if running headless) so every change is reviewable in the diff.
+Only ever use apply mode when `CLAUDE.md` is under version control.
+
+## Anti-patterns
+
+- **Acting on one session.** If it happened once, leave it. Note it for next run if you
+  want, but do not write it.
+- **Capturing the task.** A session fixed a bug; the fix is in the code. Do not write a
+  `CLAUDE.md` line restating the bug.
+- **Hoarding.** Adding ten weak lines is worse than adding one strong one. Be ruthless.
+- **Silent edits.** Every applied change must show up in a diff and in your summary.

--- a/plugins/shipwright/commands/entropy-fix.md
+++ b/plugins/shipwright/commands/entropy-fix.md
@@ -1,0 +1,6 @@
+---
+name: entropy-fix
+description: Read entropy-report.md and open targeted refactoring PRs for pr_worthy violations. One PR per golden principle. Requires /entropy-scan to have been run first. Flags: --dry-run (preview PRs without creating them), --rule {id} (fix one specific rule only).
+---
+
+Invoke the `entropy-fix` skill.

--- a/plugins/shipwright/commands/entropy-scan.md
+++ b/plugins/shipwright/commands/entropy-scan.md
@@ -1,0 +1,15 @@
+---
+name: entropy-scan
+description: Scan codebase for golden principle violations. Report only — no code changes. Flags: --init (create starter config), --summary (print summary only, skip report file), --trend (print trend from quality log, skip scan).
+---
+
+# /entropy-scan
+
+Scan the codebase against your golden principles and generate `entropy-report.md`. Report only — no code changes.
+
+**Flags:**
+- `--init` — copy the default `golden-principles.yaml` to `.claude/entropy-patrol/` so you can customize rules for this project, then stop
+- `--summary` — print a category summary to stdout without writing the full report file (useful for quick checks or CI)
+- `--trend` — print a trend summary from `.entropy-patrol/quality-log.jsonl`; skip scan. Combine with `--window N` to limit history (default: 30)
+
+Invoke the entropy-scan skill.

--- a/plugins/shipwright/commands/learn-dream.md
+++ b/plugins/shipwright/commands/learn-dream.md
@@ -1,0 +1,90 @@
+---
+name: learn-dream
+description: Extract cross-session learnings from past session transcripts in batch
+argument-hint: "[--since <when>] [--apply | --review]"
+---
+
+# /learn-dream — Batch Learning from Session Transcripts
+
+The interactive `learning-capture` skill needs a human in the loop — it reacts to a
+correction as it happens. Autonomous agents (Managed Agents, background/cron agents) have
+no human to react to. `/learn-dream` is how *they* learn: a batch job that reads past
+session transcripts, finds patterns no single session could see, and writes the durable
+ones into context.
+
+This is the "dreaming" pattern — consolidation that happens *between* sessions, not
+during them. Run it manually, or wire it to a nightly cron (see **Scheduling** below).
+
+## Usage
+
+```
+/learn-dream                      # last 24h, review mode (default)
+/learn-dream --since 7d            # last 7 days
+/learn-dream --apply               # write learnings directly, no review
+/learn-dream --review              # write a LEARNINGS-REVIEW.md for a human (default)
+```
+
+## Process
+
+Delegate the heavy reading to the `learning-dreamer` agent. It:
+
+1. **Collects transcripts.** Claude Code stores session transcripts as JSONL under
+   `~/.claude/projects/<sanitized-project-path>/*.jsonl`. Managed Agents expose their own
+   run logs. Gather every transcript in the window for this project.
+
+2. **Mines cross-session patterns.** It is looking for signal that *only aggregation
+   reveals* — never acting on a single session:
+   - A correction or stumble that **recurred across multiple sessions**.
+   - A workflow several runs **independently converged on**.
+   - A tool call, command, or path that **failed repeatedly** the same way.
+   - An existing `CLAUDE.md` line or skill that sessions **kept overriding** — a sign it
+     is wrong or stale.
+
+3. **Applies the gate, with recurrence.** Every candidate must pass both tests in
+   `skills/learning-capture/references/generalization-gate.md` — *and* must have recurred
+   across sessions. One occurrence is problem-specific noise; recurrence is the
+   substitute for the human judgement the interactive skill relies on.
+
+4. **Consolidates memory.** Dreaming is not only additive. The agent also prunes stale
+   entries, merges duplicates, and resolves contradictions in `CLAUDE.md` and skills —
+   keeping the context lean is as valuable as adding to it.
+
+5. **Flushes the Harness TODO queue.** The interactive track never crosses repos — when
+   it spots a learning about a plugin or skill, it logs a `# Harness TODO` in
+   `CLAUDE.local.md` instead of context-switching. The dream job is where that queue gets
+   drained. For each entry, the agent locates the tool's local repo, makes the **small**
+   edits, opens an issue for the **large** ones, and bundles everything per repo into
+   **one PR** — so a day of harness corrections becomes one PR per tool, reviewed when
+   you choose, instead of N interruptions while you worked. See
+   `agents/learning-dreamer.md`.
+
+6. **Writes the output**, per mode:
+   - `--review` (default): writes `LEARNINGS-REVIEW.md` at the repo root — proposed
+     additions, edits, and deletions, each with the sessions that justify it. A human
+     accepts or rejects, then deletes the file. Nothing touches `CLAUDE.md` unattended.
+   - `--apply`: makes the edits directly and reports a summary. Use this only once a
+     team trusts the dream job — and only with `CLAUDE.md` under version control, so
+     every dreamed change is reviewable in the diff and revertable.
+
+## Scheduling
+
+Wire it to run overnight so learnings are waiting in the morning:
+
+```bash
+# crontab — nightly at 3am, review mode
+0 3 * * * cd /path/to/repo && claude -p "/learn-dream --since 1d --review"
+```
+
+Start in `--review` mode. Move to `--apply` only after a few weeks of review output has
+shown the dream job's judgement is sound.
+
+## Why this is a separate track
+
+Interactive capture and dreaming are two tracks of one loop, not competitors:
+
+- **Interactive** — human present, reacts in real time, one good correction is enough.
+- **Dreaming** — no human, runs in batch, needs recurrence to trust a pattern.
+
+A team with both autonomous agents and humans at the keyboard runs both. A human
+correcting Claude at 2pm and a dream job consolidating the fleet's transcripts at 3am
+feed the same `CLAUDE.md`.

--- a/plugins/shipwright/commands/learn.md
+++ b/plugins/shipwright/commands/learn.md
@@ -1,0 +1,62 @@
+---
+name: learn
+description: Capture a durable learning and write it to its permanent home
+argument-hint: "[insight]"
+---
+
+# /learn — Capture a Learning
+
+Capture a learning and put it in its permanent home **now** — `CLAUDE.md`, the relevant
+skill, or (for installed plugins) the right place per the routing rules. No staging file,
+no separate promote step. Git is the audit trail.
+
+## Usage
+
+```
+/learn use uv instead of pip
+/learn always run the suite before committing
+/learn SSR errors surface in the terminal, not the browser console
+/learn
+```
+
+## Process
+
+1. **Get the insight.**
+   - With an argument: that is the insight.
+   - Without an argument: look at the recent conversation, propose the one or two
+     strongest candidate learnings, and ask the user which to capture (this is the only
+     question the command asks — picking the insight, not approving the edit).
+
+2. **Run the generalization gate.** Apply both tests from
+   `skills/learning-capture/references/generalization-gate.md`:
+   - Does it generalize beyond the change just made?
+   - Is it already captured by the code, a test, a type, lint, CI, or existing docs?
+
+   If it fails the gate, say so plainly and stop — do not write a watered-down version:
+
+   ```
+   Not capturing that — the change you just made already enforces it (the new
+   handler is the pattern future handlers will copy). The code is the memory here.
+   ```
+
+3. **Route it** using the table in the `learning-capture` skill. Project `CLAUDE.md`,
+   package `CLAUDE.md`, `~/.claude/CLAUDE.md` / `CLAUDE.local.md` for personal, a skill,
+   or — for installed plugins — the plugin source (local marketplace) or a local override
+   plus a PR note (remote marketplace).
+
+4. **Check for duplicates.** Grep the target file. If a near-duplicate exists, edit it in
+   place. If the new learning contradicts an old one, replace the old one.
+
+5. **Make the edit and confirm in one line:**
+
+   ```
+   Noted in CLAUDE.md: use `uv`, not `pip`, for Python package management.
+   ```
+
+## Notes
+
+- `/learn` is an explicit opt-in, so it does not ask permission for the edit — only,
+  when run bare, which candidate insight to capture.
+- The gate still applies to `/learn`. Running the command does not force a bad learning
+  through; if it fails the gate, the command declines and explains why.
+- For learnings across many past sessions rather than this one, use `/learn-dream`.

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: entropy-fix
+description: Read entropy-report.md, fix pr_worthy violations, and open targeted PRs. One PR per concern. Requires entropy-scan to have run first.
+---
+
+# Entropy Fix
+
+Read the latest `entropy-report.md` and open focused, human-reviewable PRs for `pr_worthy` violations. Each PR fixes one rule — no bundled concerns, max 3 files changed per PR.
+
+**Prerequisites:** Run `/entropy-scan` first to produce `entropy-report.md`.
+
+---
+
+## Setup: Parse Arguments
+
+Before starting, check for flags:
+
+- `--dry-run` — print what PRs would be opened without creating branches, making changes, or creating PRs
+- `--rule {id}` — fix only violations of a specific rule ID (e.g., `--rule dead_exports`)
+- `--queue` — instead of opening PRs, push findings as tasks to the task store (via shipwright task_store.ts). Enables automated deferred fixing.
+
+---
+
+## Step 1: Verify entropy-report.md Exists
+
+1. Look for `entropy-report.md` in the project root.
+2. If it does not exist, print:
+   ```
+   No entropy-report.md found. Run /entropy-scan first to generate a report.
+   ```
+   Then stop.
+3. Read the report.
+
+---
+
+## Step 2: Load Golden Principles
+
+Load the same golden principles config that the scan used:
+
+1. Check `.claude/entropy-patrol/golden-principles.yaml` in the project root. If it exists, load it.
+2. Otherwise, load the plugin default: `skills/entropy-scan/golden-principles.yaml`.
+3. Build a map of `rule_id → rule` for quick lookup (needed for `pr_worthy` status and PR body generation).
+
+---
+
+## Step 3: Filter and Group Findings
+
+1. Parse the report's `## Findings` section. Collect all unchecked (`- [ ]`) findings.
+2. Filter to only findings whose rule has `pr_worthy: true` in the golden principles config.
+3. If `--rule` flag was passed, further filter to only that rule's findings. If no findings match that rule ID, print: "No unchecked findings for rule `{rule_id}`. Nothing to fix." and stop.
+4. Group findings by `rule_id`. One PR will be opened per group.
+5. Sort groups: high-severity rules first, then medium, then low.
+6. If no `pr_worthy` unchecked findings exist, print:
+   ```
+   No pr_worthy findings to fix. All violations are either:
+   - Already checked off (fixed)
+   - In categories marked pr_worthy: false (fix manually)
+   Run /entropy-scan to refresh the report.
+   ```
+   Then stop.
+
+---
+
+## Step 4: Dry-Run Output (if --dry-run, without --queue)
+
+If `--dry-run` was passed **and `--queue` was NOT passed**, print a preview and stop:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTROPY FIX — DRY RUN
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Would open {N} PRs:
+
+  1. fix/entropy-{rule-id}-{short-description}
+     Rule: {rule.description} ({severity})
+     Findings: {count} instances
+     Files affected: {list of unique file paths}
+
+  2. ...
+
+No branches created. No files changed. No PRs opened.
+Re-run without --dry-run to execute.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Stop after printing.
+
+---
+
+## Step 4b: Queue + Dry-Run Preview (if --queue AND --dry-run)
+
+If both `--queue` and `--dry-run` were passed, print a preview and stop:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTROPY FIX — QUEUE DRY RUN
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Would queue {N} tasks:
+
+  1. entropy-{rule-id}-{YYYY-Www}
+     Rule: {rule.description} ({severity})
+     Findings: {count} instances
+     Files: {list of unique file paths}
+
+  2. ...
+
+No tasks written to task store.
+Re-run with --queue (without --dry-run) to queue tasks.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Stop after printing.
+
+---
+
+## Step 5: Cap Check
+
+If there are more than 10 rule groups to fix, note:
+
+```
+Found {N} rules with pr_worthy findings. Capping at 10 PRs per run.
+Fixing highest-severity rules first. Re-run after merging to continue.
+```
+
+Process only the first 10 groups (sorted by severity).
+
+---
+
+## Step 6: Queue Tasks (if --queue)
+
+If `--queue` was passed, run this workflow instead of Steps 6a-6e.
+
+### 6q.1 Locate task_store.ts
+
+```bash
+TASK_STORE_DIR=$(find ~/.claude/plugins/cache -maxdepth 6 -name "task_store.ts" -path "*/shipwright/*" | sort -V | tail -1 | xargs dirname 2>/dev/null)
+```
+
+If `TASK_STORE_DIR` is empty, print:
+```
+task_store.ts not found — is the shipwright plugin installed?
+Cannot queue tasks without the task store. Use /entropy-fix without --queue to open PRs directly.
+```
+Then stop.
+
+### 6q.2 Dedup Check
+
+Run:
+```bash
+bun "$TASK_STORE_DIR/task_store.ts" query --status pending
+bun "$TASK_STORE_DIR/task_store.ts" query --status in_progress
+```
+
+Parse both JSON arrays. From the combined results, collect tasks where:
+- `source == "shipwright"`, OR
+- `title` starts with `"Entropy fix:"`
+
+Extract the rule IDs from existing tasks by parsing the `id` field (format: `entropy-{rule-id}-{YYYY-Www}`) or from the `branch` field (format: `fix/entropy-{rule-id}-...`). Build a set of "already active" rule IDs.
+
+For each rule group: if its `rule_id` is in the "already active" set, skip it. Print: `Skipping {rule_id} — task already active`.
+
+### 6q.3 Build Task JSON
+
+For each remaining rule group, build a task object:
+
+```json
+{
+  "id": "entropy-{rule-id}-{YYYY-Www}",
+  "title": "Entropy fix: {rule.description}",
+  "source": "shipwright",
+  "repo": "<detected from git remote get-url origin — strip https://github.com/ prefix>",
+  "branch": "fix/entropy-{rule-id}-{short-description}",
+  "layer": "Shared",
+  "status": "pending",
+  "addedAt": "<current ISO timestamp>",
+  "description": "<findings summary — see below>"
+}
+```
+
+The `description` field must give dev-task enough context to fix without re-reading entropy-report.md:
+```
+Entropy patrol finding: {rule.id} — {rule.description} ({rule.severity})
+
+Findings ({count} total):
+- {file_path}:{line} — {finding_description}
+{Include ALL findings. If there are more than 20, include the first 20 and append: "(+N more — re-run /entropy-fix to see all)"}
+
+Fix guidance: {rule.detection_hint or remediation guidance from the golden principles config}
+
+Rule: {rule.id} | Severity: {rule.severity} | Category: {rule.category}
+```
+
+The `{YYYY-Www}` suffix in the task ID uses ISO week format. Compute from the current date:
+- Year: 4-digit year
+- `W`: literal `W`
+- Week number: 2-digit zero-padded ISO week number (01–53)
+- Example: `entropy-dead_exports-2026-W23`
+
+`short-description`: lowercase, hyphens, max 5 words from rule.description.
+
+### 6q.4 Write and Append
+
+1. Write all task objects to `/tmp/entropy-tasks-{unix-timestamp}.json` as a JSON array
+2. Run: `bun "$TASK_STORE_DIR/task_store.ts" append --file /tmp/entropy-tasks-{unix-timestamp}.json`
+3. Delete the temp file after appending
+
+### 6q.5 Print Summary
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTROPY FIX — QUEUED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  QUEUED   {N} tasks
+  SKIPPED  {N} rule groups (already active)
+
+Tasks queued:
+  entropy-{rule-id}-{YYYY-Www} — {rule.description}
+  ...
+
+{If any skipped:}
+Skipped (already active):
+  {rule_id} — task already in queue or in progress
+
+Run /shipwright:dev-task to execute.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Stop after printing. Do NOT run Steps 6a-6e (branch creation, PR opening) in queue mode.
+
+---
+
+## Step 6 (PR Mode): Fix Each Group
+
+If `--queue` was NOT passed, run the PR workflow for each group (one rule at a time, sequentially — never parallel):
+
+### 6a. Confirmation Gate for High-Severity Destructive Fixes
+
+If the rule severity is `high` AND any finding involves deleting code (not just adding tests, moving functions, or renaming — specifically removing existing logic), print:
+
+```
+⚠️  HIGH-SEVERITY DESTRUCTIVE FIX
+Rule: {rule.id} — {rule.description}
+Findings:
+  - {file}:{line} — {description}
+  ...
+
+This fix involves removing existing code. Confirm to proceed? (yes/no)
+```
+
+Wait for confirmation. If the answer is not `yes`, skip this group and note it in the final summary.
+
+### 6b. Branch Check
+
+Check if branch `fix/entropy-{rule-id}-{short-description}` already exists (locally or remotely):
+- Construct short-description: lowercase, hyphens, max 5 words from rule.description
+- If branch exists, skip this group. Print: "Branch `fix/entropy-{rule-id}-...` already exists — skipping. Merge or delete it first."
+
+### 6c. Create Branch and Make Fixes
+
+1. Create branch from base: `git checkout main && git checkout -b fix/entropy-{rule-id}-{short-description}`
+2. For each finding in this group:
+   - Apply the fix described by the rule's `detection_hint` remediation guidance
+   - Keep changes focused: only fix what the finding describes. Do not refactor surrounding code.
+   - Blast radius cap: if this group has more than 3 unique files to modify, fix the 3 highest-severity or most clearly scoped findings and note the rest as "deferred — re-run after merge"
+3. Commit: `fix(entropy): resolve {rule.id} — {finding_count} instance(s)`
+
+### 6d. Open PR
+
+Run:
+```
+gh pr create \
+  --title "fix(entropy): {rule.description} ({finding_count} instance(s))" \
+  --body "..." \
+  --base main
+```
+
+PR body format:
+```markdown
+## Entropy Fix: {rule.description}
+
+**Golden Principle:** `{rule.id}` ({rule.severity})
+**Findings fixed:** {count}
+
+### What was changed
+{bullet list: `file_path:line` — one-line description of change}
+
+### Why this matters
+{rule.description — explain the principle being enforced and why drift here costs the team}
+
+### Review notes
+{Any caveats: "N instances auto-fixed; M flagged as needs-human-review and left as comments"}
+{If blast radius cap applied: "N additional findings deferred — re-run /entropy-fix after merge"}
+
+---
+_Generated by [shipwright](https://github.com/app-vitals/shipwright). Review carefully before merging._
+```
+
+### 6e. Update entropy-report.md
+
+After the PR is opened successfully, go back to the base branch and update `entropy-report.md`:
+- Check off the fixed findings: change `- [ ]` to `- [x]` for each finding that was addressed in this PR
+- Add a note below each checked finding: `_(fixed in PR #{pr_number})_`
+
+### 6f. Log PR Result
+
+Record the result for the final summary (success, skip, or failure with reason).
+
+---
+
+## Step 7: Return to Base Branch
+
+After processing all groups, run `git checkout {original-branch}` to return to where you started.
+
+---
+
+## Step 8: Print Final Summary
+
+> **Note:** In `--queue` mode, execution stops at Step 6q.5 and this Step 8 summary is not printed. The queue summary is the final output.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTROPY FIX COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  OPENED    {N} PRs
+  SKIPPED   {N} groups (branch exists or no-confirm)
+  FAILED    {N} PRs (see below)
+
+PRs opened:
+  #{pr_number} — {rule.id}: {title}
+  ...
+
+{If any failures:}
+Failures (fix manually):
+  {rule.id} — {reason}
+
+{If any deferred findings:}
+Deferred findings (run /entropy-fix again after merging open PRs):
+  {rule.id} — {N} remaining findings
+
+entropy-report.md updated with fixed findings checked off.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Error Handling
+
+- **`gh pr create` fails**: Log the failure, continue to the next group. Do not abort the run.
+- **Branch creation fails** (e.g., git conflict): Log and skip this group. Include in final summary under failures.
+- **Fix attempt produces no diff**: Don't commit an empty change. Skip and note: "No diff produced for {rule.id} — may already be fixed. Check entropy-report.md."
+- **More than 10 groups**: Cap at 10 as described in Step 5. Always process highest-severity first.
+
+---
+
+## Constraints (Do Not Violate)
+
+- **One PR per rule** — never bundle multiple rule violations into one PR.
+- **3-file blast radius cap** — never modify more than 3 files in a single PR.
+- **No auto-merge** — PRs always require human review before merge.
+- **No cascade** — only fix what's in the current `entropy-report.md`. Do not re-scan during a fix run.
+- **Sequential branches** — create branches one at a time. Parallel branch creation causes git conflicts.
+- **No golden-principles.yaml changes** — the fix skill enforces rules, it does not modify them.
+- **Confirmation required for high-severity destructive ops** — never skip this gate.

--- a/plugins/shipwright/skills/entropy-scan/SKILL.md
+++ b/plugins/shipwright/skills/entropy-scan/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: entropy-scan
+description: Scan codebase for golden principle deviations. Report only — no code changes.
+---
+
+# Entropy Scan
+
+Scan the codebase for golden principle violations and write a structured report. This skill makes **no code changes** — it reads and reports only. Use `/entropy-fix` to act on the findings.
+
+---
+
+## Setup: Parse Arguments
+
+Before starting, check if any flags were passed:
+
+- `--init` — copy the default golden principles config to the project and exit (no scan)
+- `--summary` — print category counts to stdout; skip writing `entropy-report.md` or `quality-log.jsonl`
+- `--trend` — read `.entropy-patrol/quality-log.jsonl` and print a trend summary; skip the scan entirely
+
+---
+
+## Step 0: Handle `--trend` Flag
+
+If the `--trend` flag was passed:
+
+1. Look for `.entropy-patrol/quality-log.jsonl` in the project root.
+2. If it does not exist, print:
+   ```
+   No scan history found. Run /entropy-scan a few times to build trend data.
+   ```
+   Then stop.
+3. Read the file. Parse each line as JSON; skip malformed lines silently.
+4. If fewer than 2 valid entries, print:
+   ```
+   Not enough scan history for trends (need at least 2 runs).
+   Current entry count: {N}. Run /entropy-scan again to build history.
+   ```
+   Then stop.
+5. Load the most recent `--window N` entries (default: 30). If `--window` is not specified, use 30.
+6. Print a trend summary:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTROPY TREND ({first_date} → {last_date}, {N} scans)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+OVERALL
+  {first_scan_total} violations → {last_scan_total} violations  ({delta, e.g. "▼ 10" or "▲ 3" or "— no change"})
+
+BY SEVERITY
+  High    {first} → {last}  ({direction})
+  Medium  {first} → {last}  ({direction})
+  Low     {first} → {last}  ({direction})
+
+BY RULE (most changed first)
+  {rule_id}       {first} → {last}  ({direction})  {most improved label if applicable}
+  ...
+
+MOST IMPROVED:   {rule_id} (▼ {N} violations)
+MOST WORSENING:  {rule_id} (▲ {N} violations)   {or "none — all rules stable or improving"}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+7. Stop — do not run a scan.
+
+---
+
+## Step 1: Handle `--init` Flag
+
+If the `--init` flag was passed:
+
+1. Check if `.claude/entropy-patrol/golden-principles.yaml` already exists in the project root.
+   - If it exists, print: "Config already exists at `.claude/entropy-patrol/golden-principles.yaml`. Edit it to customize rules for this project." and stop.
+2. If it does not exist, create the directory and copy the default config:
+   - Source: `skills/entropy-scan/golden-principles.yaml` (relative to this skill file — the plugin's own default config)
+   - Destination: `.claude/entropy-patrol/golden-principles.yaml` in the project root
+3. Print: "Created `.claude/entropy-patrol/golden-principles.yaml`. Edit it to customize rules for this project. Re-run `/entropy-scan` to start scanning."
+4. Stop — do not run the scan.
+
+---
+
+## Step 2: Load Golden Principles
+
+1. Check for a project-level override: `.claude/entropy-patrol/golden-principles.yaml` in the project root.
+2. If it exists, load it. Print: "Using project config: `.claude/entropy-patrol/golden-principles.yaml`"
+3. If it does not exist, load the plugin default: `skills/entropy-scan/golden-principles.yaml` (relative to this skill file). Print: "No project config found. Using default golden principles. Run `/entropy-scan --init` to customize."
+4. If neither file exists, print: "No golden principles found. Run `/entropy-scan --init` to get started." and stop.
+5. Parse the YAML. Read the `rules` list and the `todo_max_age_days` global config (default: 90).
+6. Filter out any rules where `disabled: true`. Print the count of active rules.
+
+---
+
+## Step 3: Run the Scan
+
+For each active rule (in order: security first, then high → medium → low severity within each category), run the detection described in the rule's `detection_hint`. Use Read, Grep, and Glob tools to gather evidence.
+
+**Important:**
+- Work category by category, not rule by rule — this reduces redundant file reads
+- For each finding, record: `file_path`, `line_number` (if applicable), `rule_id`, `severity`, `description` (one line describing the specific issue), `estimated_fix_effort` (trivial / small / medium)
+- Stick to the `detection_hint` — do not expand scope or make judgment calls beyond what the hint describes
+- If a rule scan turns up nothing, that is a valid result ("no violations")
+- Cap the scan: if any single category scan takes more than 20 sequential tool calls, record a note: "Scan capped — partial results for this category" and move on
+
+**Order of categories:**
+1. `security` (highest stakes — always first)
+2. `missing_tests`
+3. `dead_code`
+4. `todo_debt`
+5. `inconsistent_patterns`
+6. `documentation_gaps`
+
+Within each category, process high-severity rules before medium before low.
+
+---
+
+## Step 4: Write the Report
+
+If `--summary` flag was passed, skip to Step 5.
+
+Write `entropy-report.md` to the project root (overwrite if it exists). Format:
+
+```markdown
+# Entropy Report
+
+**Generated:** {YYYY-MM-DD HH:MM} {timezone}
+**Config:** {project override path | "plugin default"}
+**Rules scanned:** {count active rules} / {count total rules}
+
+## Summary
+
+| Category | High | Medium | Low | Total |
+|----------|------|--------|-----|-------|
+| security | N | N | N | N |
+| missing_tests | N | N | N | N |
+| dead_code | N | N | N | N |
+| todo_debt | N | N | N | N |
+| inconsistent_patterns | N | N | N | N |
+| documentation_gaps | N | N | N | N |
+| **Total** | **N** | **N** | **N** | **N** |
+
+---
+
+## Findings
+
+### {category name}
+
+#### {rule.id} — {rule.description} `{severity}`
+
+{If no findings: "No violations found."}
+
+{If findings exist, list as checkboxes:}
+- [ ] `{file_path}:{line_number}` — {one-line description of the specific issue} _{estimated_fix_effort}_
+
+{Repeat for each finding in this rule}
+
+---
+
+{Repeat section for each category that has findings}
+
+## No Violations
+
+{List any categories or rules with zero findings here, as a quick confirmation they were checked.}
+
+---
+_Run `/entropy-fix` to open PRs for `pr_worthy: true` violations._
+_Run `/entropy-scan --init` to create a project-level config for rule customization._
+```
+
+Rules:
+- Findings are sorted high → medium → low within each category section
+- Each finding is a checkbox (`- [ ]`) so `/entropy-fix` can track which ones have been addressed
+- Include line numbers when available: `- [ ] \`{file_path}:{line_number}\` — {description} _{effort}_`
+- For file-level findings (no line number): `- [ ] \`{file_path}\` — {description} _{effort}_`
+- The "No Violations" section at the bottom lists all active rules where nothing was found — this confirms the rule ran and passed. Disabled rules do not appear anywhere in the report.
+
+---
+
+## Step 5: Print Summary
+
+Whether or not `--summary` was passed, always print a summary to stdout after the scan (or instead of writing the report, if `--summary` was passed):
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTROPY SCAN COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  HIGH     {N} findings
+  MEDIUM   {N} findings
+  LOW      {N} findings
+  ─────────────────────
+  TOTAL    {N} findings across {N} rules
+
+TOP ISSUES
+──────────
+{List up to 3 highest-severity findings, one line each:}
+  {severity} · {rule_id} · {file_path} — {description}
+
+{If any high-severity findings exist:}
+  ⚠️  Run /entropy-fix to open PRs for pr_worthy violations.
+
+{If zero findings:}
+  ✓ No violations found. Codebase is clean against active rules.
+
+{If --summary flag: no report written.}
+{Otherwise:}
+  Report written to: entropy-report.md
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Step 6: Append to Quality Log
+
+If `--summary` flag was NOT passed (i.e., a full scan with report write):
+
+1. Build the log entry:
+   ```json
+   {
+     "timestamp": "<current UTC ISO-8601>",
+     "commitSha": "<short git sha from `git rev-parse --short HEAD`; omit field if git unavailable>",
+     "totalViolations": <total findings count>,
+     "bySeverity": {
+       "high": <count>,
+       "medium": <count>,
+       "low": <count>
+     },
+     "byRule": {
+       "<rule_id>": <count>
+       // Only include rules with at least 1 finding
+     },
+     "reportPath": "entropy-report.md"
+   }
+   ```
+2. Create `.entropy-patrol/` directory in the project root if it doesn't exist.
+3. Append the JSON entry (as a single line) to `.entropy-patrol/quality-log.jsonl`.
+   - Append only — never overwrite or truncate existing entries.
+4. Print: `Quality log updated: .entropy-patrol/quality-log.jsonl`
+
+Schema reference: `skills/entropy-scan/references/quality-log-schema.md`
+
+---
+
+## Constraints (Do Not Violate)
+
+- **No code changes.** This skill reads and reports only. The only files written are `entropy-report.md` and `.entropy-patrol/quality-log.jsonl`.
+- **No git operations.** Do not commit, branch, or stage anything.
+- **No PR creation.** That belongs to `/entropy-fix`.
+- **No network calls.** All detection is local file inspection.
+- **Respect `disabled: true`.** Never scan a disabled rule — not even "just to check."
+- **One scan, one report.** Each run fully overwrites `entropy-report.md`. Previous results are not preserved.
+- **Quality log is append-only.** Never overwrite or truncate `.entropy-patrol/quality-log.jsonl`. Appends only.
+- **`--summary` skips log.** When `--summary` is passed, no log entry is written (no report = no log entry).

--- a/plugins/shipwright/skills/entropy-scan/golden-principles.yaml
+++ b/plugins/shipwright/skills/entropy-scan/golden-principles.yaml
@@ -1,0 +1,203 @@
+# Golden Principles — Default Ruleset
+# =====================================
+# These are the default code health rules for entropy-patrol.
+#
+# To customize for your project, copy this file to:
+#   .claude/entropy-patrol/golden-principles.yaml
+# Local config takes priority over this default. See references/customization.md.
+#
+# Top-level fields:
+#   version:            Schema version (currently "1.0")
+#   rules:              List of rule definitions (see per-rule fields below)
+#   todo_max_age_days:  Age threshold for stale_todo rule (default 90)
+#
+# Each rule has these fields:
+#   id:             Unique identifier (snake_case, e.g. dead_exports)
+#   category:       One of: dead_code | missing_tests | inconsistent_patterns | todo_debt | documentation_gaps | security
+#   severity:       low | medium | high
+#   description:    One-line description of what this rule catches
+#   detection_hint: Natural language instruction for the scanning agent — specific enough to act on
+#   pr_worthy:      true = /entropy-fix will open a PR to fix it; false = report only
+#   disabled:       true = skip this rule entirely (omit field or set false to enable)
+#
+# Age threshold for todo_debt rules is configured via:
+#   todo_max_age_days: 90  (default, at the bottom of this file)
+
+version: "1.0"
+
+rules:
+
+  # ---------------------------------------------------------------------------
+  # DEAD CODE
+  # ---------------------------------------------------------------------------
+
+  - id: dead_exports
+    category: dead_code
+    severity: medium
+    description: Exported functions, types, or constants that are never imported anywhere in the codebase
+    detection_hint: |
+      For each TypeScript/JavaScript source file, list all exported symbols (export function, export const,
+      export type, export class, export interface). Then search the entire codebase for import statements
+      that reference each symbol. Flag any export that has zero import sites. Skip index.ts re-export
+      files and test files. Report: file path, export name, export type.
+    pr_worthy: true
+
+  - id: commented_out_blocks
+    category: dead_code
+    severity: low
+    description: Large blocks of commented-out code (5+ consecutive commented lines) that should be deleted or restored
+    detection_hint: |
+      Scan source files for runs of 5 or more consecutive commented-out lines (// or #). Exclude
+      JSDoc/TSDoc blocks (/** ... */), license headers, and section dividers (--- or ===).
+      Flag the file, start line, and approximate line count. Blocks in test files are lower priority.
+    pr_worthy: false
+
+  - id: unreferenced_files
+    category: dead_code
+    severity: medium
+    description: Source files that are never imported or required by any other file and have no entry-point marker
+    detection_hint: |
+      List all .ts/.js source files (excluding *.test.ts, *.spec.ts, index.ts files, and CLI entry points
+      listed in package.json bin/scripts). For each file, check if it appears in any import statement
+      in the codebase. Flag files with zero import sites. These are candidates for deletion.
+    pr_worthy: false
+
+  # ---------------------------------------------------------------------------
+  # MISSING TESTS
+  # ---------------------------------------------------------------------------
+
+  - id: missing_test_file
+    category: missing_tests
+    severity: high
+    description: Source files in src/ that have no corresponding .test.ts file
+    detection_hint: |
+      For each .ts file under src/ (excluding *.test.ts, *.spec.ts, index.ts, and type-only files
+      that export only interfaces/types), check if a corresponding .test.ts file exists in the same
+      directory or a __tests__/ subdirectory. Flag every source file with no test coverage file.
+      Report: file path, file size (lines), approximate complexity (does it export functions?).
+    pr_worthy: false
+
+  - id: empty_test_file
+    category: missing_tests
+    severity: medium
+    description: Test files that exist but contain no actual test cases (describe/it/test blocks)
+    detection_hint: |
+      Scan all *.test.ts and *.spec.ts files. Flag any file that contains no test() or it() or
+      describe() calls with actual test bodies. Stub files with only imports and empty describes count
+      as empty. Report the file path and what it currently contains.
+    pr_worthy: false
+
+  # ---------------------------------------------------------------------------
+  # INCONSISTENT PATTERNS
+  # ---------------------------------------------------------------------------
+
+  - id: duplicated_utility
+    category: inconsistent_patterns
+    severity: medium
+    description: Hand-rolled utility functions that duplicate functionality already in a shared lib
+    detection_hint: |
+      Look for local implementations of: argument parsing (parseArgs, getArg, required),
+      Prisma client instantiation (new PrismaClient()), JSON read/write helpers, logger/log wrapper,
+      environment variable loading, MCP JSON-RPC send/ok/err helpers, date formatting.
+      For each local copy found, check if a canonical implementation exists in lib/ or a shared module.
+      Flag any local copy that duplicates a shared lib function. Report: file, function name, shared lib path.
+    pr_worthy: true
+
+  - id: inconsistent_error_handling
+    category: inconsistent_patterns
+    severity: low
+    description: Inconsistent error handling — some paths throw, some return null, some log and continue
+    detection_hint: |
+      For a given module, identify the dominant error-handling pattern (throw vs. return null/undefined
+      vs. return { error } vs. console.error + continue). Flag functions in the same module that use
+      a different pattern without an obvious reason. Don't flag intentional boundary differences
+      (e.g., CLI entry points that catch and log vs. library functions that throw).
+    pr_worthy: false
+
+  # ---------------------------------------------------------------------------
+  # TODO DEBT
+  # ---------------------------------------------------------------------------
+
+  - id: todo_fixme_hack
+    category: todo_debt
+    severity: medium
+    description: TODO, FIXME, or HACK comments in source code
+    detection_hint: |
+      Search all source files for comments containing TODO, FIXME, HACK, or XXX (case-insensitive).
+      For each match, report: file, line number, comment text, and whether git blame shows the comment
+      is older than todo_max_age_days. Prioritize comments in frequently-modified files. Exclude
+      test files (lower signal there). HACK comments are higher severity than TODOs.
+    pr_worthy: false
+
+  - id: stale_todo
+    category: todo_debt
+    severity: high
+    description: TODO/FIXME comments that have been in the codebase longer than the configured age threshold
+    detection_hint: |
+      For each TODO/FIXME/HACK found, use git log -S"<comment text>" --follow -- <file> to find when
+      that line was introduced. Flag comments older than todo_max_age_days as stale. These are
+      tech debt that has been consciously deferred past any reasonable window. Report: file, line,
+      comment, age in days, original author.
+    pr_worthy: false
+
+  # ---------------------------------------------------------------------------
+  # DOCUMENTATION GAPS
+  # ---------------------------------------------------------------------------
+
+  - id: undocumented_exports
+    category: documentation_gaps
+    severity: low
+    description: Exported functions and classes with no JSDoc comment
+    detection_hint: |
+      For each exported function, class, or interface in TypeScript source files, check if there is a
+      JSDoc comment (/** ... */) immediately preceding it. Flag exports with no JSDoc. Skip very
+      short utility functions (< 5 lines body) and test files. Prioritize: public API modules,
+      functions with complex signatures (3+ params), and functions that have caused bugs before
+      (check CLAUDE.md or commit messages for hints).
+    pr_worthy: false
+
+  - id: missing_readme_section
+    category: documentation_gaps
+    severity: low
+    description: Module directories (packages, services) that have no README.md or have a README missing key sections
+    detection_hint: |
+      For each top-level directory under src/ that contains TypeScript source files, check if a
+      README.md exists. Also check the README has at minimum: a title line (# ...) and at least one
+      of: a "What it does" section, a "Usage" section, or a CLI usage example. Flag missing README
+      files and READMEs with only a title. Report: directory, what's missing.
+    pr_worthy: false
+
+  # ---------------------------------------------------------------------------
+  # SECURITY
+  # ---------------------------------------------------------------------------
+
+  - id: ungated_outbound
+    category: security
+    severity: high
+    description: Outbound HTTP POST/PUT, email sends, or webhook calls without an explicit human-approval gate
+    detection_hint: |
+      Search source files for: fetch() with POST/PUT/PATCH/DELETE methods, axios.post/put/patch/delete,
+      nodemailer.sendMail, sendgrid/resend send calls, Slack WebClient.chat.postMessage,
+      exec/spawn calls that invoke curl or wget with POST flags. For each match, verify there is an
+      explicit human-approval gate nearby (a confirm prompt, a dry-run flag check, a --commit flag,
+      or a human-in-the-loop note). Flag any call that can fire without human confirmation.
+      This is the highest-priority check — a false negative here can send real emails to real clients.
+    pr_worthy: true
+
+  - id: hardcoded_secrets
+    category: security
+    severity: high
+    description: Hardcoded API keys, tokens, passwords, or credentials in source files
+    detection_hint: |
+      Search source files for string literals that look like secrets: patterns matching
+      sk-[a-zA-Z0-9]{20,}, Bearer [a-zA-Z0-9+/]{20,}, password\s*=\s*["'][^"']{8,},
+      api_key\s*=\s*["'][^"']{10,}, token\s*=\s*["'][^"']{10,}. Also flag any direct assignment
+      of environment variable names as string values (e.g., const token = "ghp_...").
+      Skip test files that use obviously fake values (e.g., "test-token", "fake-key").
+    pr_worthy: true
+
+# ---------------------------------------------------------------------------
+# Global config
+# ---------------------------------------------------------------------------
+
+todo_max_age_days: 90

--- a/plugins/shipwright/skills/entropy-scan/references/customization.md
+++ b/plugins/shipwright/skills/entropy-scan/references/customization.md
@@ -1,0 +1,93 @@
+# Customizing Golden Principles
+
+entropy-patrol ships with a default ruleset (`skills/entropy-scan/golden-principles.yaml`). You can customize it per project without modifying the plugin.
+
+---
+
+## Override path
+
+Create a file at:
+
+```
+.claude/entropy-patrol/golden-principles.yaml
+```
+
+**Priority order** (highest to lowest):
+1. `.claude/entropy-patrol/golden-principles.yaml` — project-local overrides
+2. `<plugin-dir>/skills/entropy-scan/golden-principles.yaml` — plugin defaults
+
+When a local config exists, it is used **in its entirety** — individual rules from the default config are not merged in. Start by copying the default and editing from there.
+
+---
+
+## Common customizations
+
+### Disable a rule you don't need
+
+```yaml
+rules:
+  - id: commented_out_blocks
+    disabled: true
+    # ... rest of fields recommended so the rule is ready to re-enable
+```
+
+Or omit it entirely — rules not present in your local config don't run.
+
+> **Note:** Local config replaces the default entirely — there is no merging. Any rule you omit from your local copy will not run, even if it exists in the plugin defaults.
+
+### Change severity
+
+```yaml
+rules:
+  - id: missing_test_file
+    category: missing_tests
+    severity: medium   # downgrade from high if your team is actively adding tests
+    description: Source files in src/ that have no corresponding .test.ts file
+    detection_hint: |
+      ...
+    pr_worthy: false
+```
+
+### Add a project-specific rule
+
+```yaml
+rules:
+  - id: no_console_log_in_prod
+    category: inconsistent_patterns
+    severity: medium
+    description: console.log calls in non-test source files (use the logger module instead)
+    detection_hint: |
+      Search all .ts files under src/ (excluding *.test.ts) for console.log(), console.warn(),
+      console.error() calls. Flag any that are not inside a conditional block gated on
+      NODE_ENV === 'development' or process.env.DEBUG. Report: file, line number, call text.
+      The project uses a shared logger module at lib/logger.ts — all logging should go through it.
+    pr_worthy: true
+```
+
+### Adjust the TODO age threshold
+
+```yaml
+todo_max_age_days: 60   # flag TODOs older than 60 days instead of the default 90
+```
+
+---
+
+## When to use local config vs. plugin defaults
+
+**Use local config when:**
+- Your project has language-specific patterns (Python, Go, etc.)
+- You want stricter enforcement on specific categories
+- A default rule generates too much noise for your codebase
+- You have project-specific conventions (e.g., a required license header)
+
+**Use plugin defaults when:**
+- You're onboarding a new project and want a starting point
+- The defaults match your team's norms
+
+---
+
+## Initializing local config
+
+Run `/entropy-scan --init` to copy the default ruleset to `.claude/entropy-patrol/golden-principles.yaml`.
+
+Then edit the file to match your project's norms.

--- a/plugins/shipwright/skills/entropy-scan/references/quality-log-schema.md
+++ b/plugins/shipwright/skills/entropy-scan/references/quality-log-schema.md
@@ -1,0 +1,82 @@
+# Quality Log Schema
+
+entropy-patrol appends a log entry to `.entropy-patrol/quality-log.jsonl` after each scan. This file is the trend record — commit it to your repo so drift history is preserved in git.
+
+---
+
+## Format
+
+JSONL — one JSON object per line, append-only. Never rewrite or truncate the file.
+
+## Entry Schema
+
+```json
+{
+  "timestamp": "2026-03-28T21:15:00.000Z",
+  "commitSha": "abc1234",
+  "totalViolations": 12,
+  "bySeverity": {
+    "high": 2,
+    "medium": 6,
+    "low": 4
+  },
+  "byRule": {
+    "dead_exports": 3,
+    "todo_fixme_hack": 5,
+    "missing_test_file": 4
+  },
+  "reportPath": "entropy-report.md"
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | ISO-8601 string | UTC timestamp when the scan completed |
+| `commitSha` | string | Short git SHA at time of scan. Omit if git is not available. |
+| `totalViolations` | number | Total findings across all rules |
+| `bySeverity` | object | Violation counts grouped by severity level (`high`, `medium`, `low`) |
+| `byRule` | object | Violation counts grouped by rule ID. Only includes rules with at least 1 finding. |
+| `reportPath` | string | Path to the report file written by this scan run (relative to project root) |
+
+---
+
+## Example: Three consecutive scans
+
+```jsonl
+{"timestamp":"2026-03-26T08:00:00.000Z","commitSha":"a1b2c3d","totalViolations":18,"bySeverity":{"high":3,"medium":9,"low":6},"byRule":{"dead_exports":5,"todo_fixme_hack":8,"missing_test_file":5},"reportPath":"entropy-report.md"}
+{"timestamp":"2026-03-27T08:00:00.000Z","commitSha":"e4f5a6b","totalViolations":12,"bySeverity":{"high":1,"medium":7,"low":4},"byRule":{"dead_exports":2,"todo_fixme_hack":6,"missing_test_file":4},"reportPath":"entropy-report.md"}
+{"timestamp":"2026-03-28T08:00:00.000Z","commitSha":"c7d8e9f","totalViolations":8,"bySeverity":{"high":0,"medium":5,"low":3},"byRule":{"todo_fixme_hack":4,"missing_test_file":4},"reportPath":"entropy-report.md"}
+```
+
+Reading this log: violations dropped from 18 → 12 → 8 across three days. `dead_exports` was cleaned up entirely. `todo_fixme_hack` improved but still has 4 open. No high-severity findings remain.
+
+---
+
+## Storage
+
+- **Location:** `.entropy-patrol/quality-log.jsonl` in the project root
+- **Commit it:** The log should be checked into your repo so trend history is preserved across environments
+- **Don't gitignore it:** Treat it like a changelog — it's part of the project record
+- **Skip it in one-off scans:** If you're doing a temporary scan and don't want to pollute the log, use `/entropy-scan --summary` (no report or log written)
+
+---
+
+## Trend Queries
+
+The log is designed for lightweight querying:
+
+- **Last N entries:** `tail -n N .entropy-patrol/quality-log.jsonl | jq`
+- **Total violations over time:** `jq .totalViolations .entropy-patrol/quality-log.jsonl`
+- **High-severity trend:** `jq '.bySeverity.high' .entropy-patrol/quality-log.jsonl`
+
+Or use `/entropy-scan --trend` to get a formatted summary (see SKILL.md Step 0).
+
+---
+
+## Resilience
+
+- One malformed line does not break the log — trend reads skip lines that fail to parse
+- Appends are atomic (append to file, no rewrite) — safe to run concurrently
+- Missing `commitSha` is valid — occurs in non-git directories

--- a/plugins/shipwright/skills/entropy-scan/references/schema.md
+++ b/plugins/shipwright/skills/entropy-scan/references/schema.md
@@ -1,0 +1,159 @@
+# Golden Principles Schema Reference
+
+This document describes the YAML format for entropy-patrol rule definitions.
+
+## File structure
+
+```yaml
+version: "1.0"
+
+rules:
+  - id: <rule_id>
+    category: <category>
+    severity: <severity>
+    description: <one-line description>
+    detection_hint: |
+      <multi-line instruction for the scanning agent>
+    pr_worthy: <true|false>
+    disabled: <true|false>   # optional; omit to enable
+
+todo_max_age_days: 90        # global config for stale_todo threshold
+```
+
+---
+
+## Field reference
+
+### `id` (required)
+
+Unique string identifier for the rule. Use `snake_case`. Must be unique across all rules in the file.
+
+```yaml
+id: dead_exports
+```
+
+---
+
+### `category` (required)
+
+Logical grouping for the rule. Used to organize the entropy report and filter rules by type.
+
+| Category | What it covers |
+|----------|---------------|
+| `dead_code` | Unused exports, unreferenced files, commented-out blocks |
+| `missing_tests` | Source files without test coverage |
+| `inconsistent_patterns` | Duplicated utilities, inconsistent error handling |
+| `todo_debt` | TODO/FIXME/HACK comments |
+| `documentation_gaps` | Missing JSDoc, missing README sections |
+| `security` | Ungated outbound calls, hardcoded secrets |
+
+You may define custom category strings for project-specific rules (e.g., `performance`, `accessibility`).
+
+---
+
+### `severity` (required)
+
+How urgently the issue should be addressed.
+
+| Value | When to use |
+|-------|------------|
+| `high` | Correctness or security risk; fix before next release |
+| `medium` | Technical debt that will compound; fix this sprint |
+| `low` | Cosmetic or low-impact; fix when convenient |
+
+---
+
+### `description` (required)
+
+One-line human-readable description of what the rule detects. Appears in the entropy report summary.
+
+```yaml
+description: Exported functions that are never imported anywhere in the codebase
+```
+
+---
+
+### `detection_hint` (required)
+
+Natural language instruction for the scanning Claude agent. This is the most important field — it determines scan quality. Write it like a task brief:
+
+- Be specific enough that the agent can execute it without guessing
+- Name the exact patterns, file paths, or AST constructs to look for
+- Include what to exclude (test files, index.ts re-exports, etc.)
+- Describe what to report (file path, line number, symbol name)
+- Don't be so prescriptive that it breaks on minor project variations
+
+**Example — good:**
+```yaml
+detection_hint: |
+  For each .ts file under src/ (excluding *.test.ts and index.ts), check if a
+  corresponding .test.ts file exists in the same directory. Flag every source
+  file with no test coverage. Report: file path and line count.
+```
+
+**Example — too vague:**
+```yaml
+detection_hint: Check if tests exist.
+```
+
+**Example — too prescriptive:**
+```yaml
+detection_hint: Run `jest --coverage` and parse the JSON output for files with 0% coverage.
+```
+
+---
+
+### `pr_worthy` (required)
+
+Whether `/entropy-fix` should open a pull request to address issues found by this rule.
+
+```yaml
+pr_worthy: true   # /entropy-fix will open a PR (max 3 files per PR)
+pr_worthy: false  # /entropy-scan reports it; /entropy-fix skips it
+```
+
+Use `false` for rules where:
+- The fix requires human judgment (e.g., whether a dead file should be deleted or revived)
+- The fix is high-risk (e.g., deleting a file)
+- The rule surfaces information rather than an actionable change
+
+---
+
+### `disabled` (optional)
+
+Set to `true` to skip a rule without deleting it. Useful for disabling a default rule that doesn't apply to your project.
+
+```yaml
+disabled: true
+```
+
+Omit this field (or set to `false`) to enable the rule.
+
+---
+
+## Complete example rule
+
+```yaml
+- id: missing_test_file
+  category: missing_tests
+  severity: high
+  description: Source files in src/ that have no corresponding .test.ts file
+  detection_hint: |
+    For each .ts file under src/ (excluding *.test.ts, *.spec.ts, index.ts, and
+    type-only files that export only interfaces/types), check if a corresponding
+    .test.ts file exists in the same directory or a __tests__/ subdirectory.
+    Flag every source file with no test coverage file.
+    Report: file path, file size (lines), approximate complexity (does it export functions?).
+  pr_worthy: false
+```
+
+---
+
+## Global config fields
+
+These appear at the top level of the YAML file (not inside `rules`).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `todo_max_age_days` | `90` | Age threshold for `stale_todo` rule (in days) |
+| `version` | `"1.0"` | Schema version — used for future migration |

--- a/plugins/shipwright/skills/learning-capture/SKILL.md
+++ b/plugins/shipwright/skills/learning-capture/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: learning-capture
+description: >
+  Capture a durable learning by editing context directly. Triggers when the user
+  corrects Claude in a generalizable way ("use X instead of Y", "always X", "never Y",
+  "I prefer X", "from now on X"), states a reusable preference, or asks to "remember this"
+  / "save this". Also triggers on the /learn command. Does NOT trigger on one-off,
+  problem-specific corrections — see the generalization gate before acting.
+---
+
+# Learning Capture
+
+When the user teaches you something durable, put it in its permanent home **now** —
+edit `CLAUDE.md` or the relevant skill in the same turn. Git is the audit trail. There
+is no staging file and no separate promotion step.
+
+This skill replaces the old capture → stage → promote flow. That flow added three
+interruptions and trusted the model less than it deserves. The model is trusted to make
+the edit; the user reviews it the same way they review any other change — in the diff.
+
+## The one rule: pass the gate first
+
+Before editing anything, run the **generalization gate**. Capture a learning **only if
+both** are true:
+
+1. **It generalizes.** It will apply to *future, different* work — not just the change
+   you both just made. A correction scoped to "this function", "this file", "this PR",
+   or "in this case" is not a learning. It is just doing the task.
+
+2. **It is not already captured by the code.** If the change you just committed already
+   embodies the rule — the code does it the right way now, a test enforces it, a type
+   makes the wrong version impossible, a lint rule will catch it — then **the code is the
+   memory.** A `CLAUDE.md` line that restates what the diff already shows is noise and
+   will rot. Skip it.
+
+If you are unsure whether something generalizes, it probably does not. See
+`references/generalization-gate.md` for the full criteria, signal patterns, and worked
+examples. **When in doubt, do not capture.** A missed learning costs nothing; a noisy
+`CLAUDE.md` costs every future session.
+
+## What passes the gate (capture these)
+
+- A correction the user frames as a standing rule: "always", "never", "from now on",
+  "in general", "as a rule", "going forward".
+- A preference that will shape unrelated future work: tooling, style, workflow.
+- A non-obvious discovery that took real effort and will recur — a misleading error, an
+  undocumented behavior, a workaround — *and* that the code itself does not now make
+  self-evident.
+- Anything the user explicitly says to remember.
+
+## What fails the gate (do not capture)
+
+- A correction that the committed change now embodies. The diff is the record.
+- A fix scoped to one symbol, file, or ticket — "in this case", "just here", "for now".
+- A restatement of something already in `CLAUDE.md`, a skill, the linter, or the types.
+- A vague preference ("do it better") with no actionable content.
+- A question, a hypothetical, or a quote from docs being discussed.
+
+## How to capture: edit the home directly
+
+When a learning passes the gate, pick its home, edit the file, and tell the user in one
+line. Do not ask permission for the edit itself — the user opted in by correcting you, or
+by running `/learn`. They can undo it with git like any other change.
+
+### Routing — two questions: what scope, what form
+
+Dropping the staging tier did not drop the *judgement* the old promote step made. That
+judgement still matters — it just happens inline now. It is two questions.
+
+**Question 1 — what scope?** Pick the **narrowest scope that still covers everywhere the
+learning is true.** Too narrow and a future session misses it; too broad and you pollute
+unrelated work.
+
+| Scope | Home | True for... |
+|-------|------|-------------|
+| **Package** | `./packages/<x>/CLAUDE.md` (nearest) | one part of one repo |
+| **Project · team** | `./CLAUDE.md` (committed) | this repo, everyone on it |
+| **Project · personal** | `./CLAUDE.local.md` (gitignored) | this repo, just you |
+| **User** | `~/.claude/CLAUDE.md` | every repo you work in, just you |
+| **Plugin / org** | a skill or file in a plugin — *in the plugin's own repo* | reusable across people and repos |
+| **Agent workspace** | `workspace/LEARNINGS.md` | persistent-agent workspaces where a LEARNINGS file is the session memory store |
+
+The team-vs-personal split at the project level is the one to get right: if a teammate
+would benefit, it is `CLAUDE.md`; if it is your taste alone, it is `CLAUDE.local.md`.
+Ask the user if it is genuinely unclear.
+
+The **Plugin / org** row is the tricky one: a plugin's home is its *own repo*, usually a
+sibling of the project you are in, not a file under it. See **The home is often another
+repo** below before routing one of these.
+
+**Question 2 — instruction or skill?** A one-line rule is an *instruction* — it goes in a
+`CLAUDE.md` at the scope above. A multi-step procedure or reusable workflow is a *skill*.
+A skill is itself scoped: `./.claude/skills/` (project), `~/.claude/skills/` (user), or a
+plugin (org). Same ladder, different form.
+
+Keep `CLAUDE.md` edits to **one concise line per concept** — it is part of every prompt.
+For a skill, add the guidance to the right section and keep the SKILL.md focused.
+
+### Confirm in one line
+
+After editing, say what you did and where, so it shows in the transcript:
+
+```
+Noted in CLAUDE.md: use `uv`, not `pip`, for Python package management.
+```
+
+That is the whole interaction. No preview, no "stage this?", no follow-up command.
+
+## The home is often another repo — and you do not go there now
+
+A learning is frequently *not* about the project you are working in. It is about a piece
+of your **harness** — a plugin, a skill pack, your marketplace, your `~/.claude` setup —
+and that harness lives in its own repo, a sibling of the project you are in.
+
+Two things are true at once:
+
+1. The learning belongs in the **tool's repo**, not this project's `CLAUDE.md`. Writing
+   it here buries it where nobody who maintains the tool will see it.
+2. Reaching across to another repo mid-session — opening it, editing it, branching,
+   committing, opening a PR — while you are in the middle of something else, *is* the
+   kind of disruption v0.2 exists to remove. It is the staging-tier problem wearing a
+   different coat.
+
+**So the interactive track does not cross repos.** It does the minimal, in-flow thing:
+records a precise `# Harness TODO` in `CLAUDE.local.md`. The cross-repo edit and the PR
+are batched onto the dream job, which runs when you are *not* in flow.
+
+### Record a Harness TODO
+
+Append to a `# Harness TODO` section in the current project's `CLAUDE.local.md`. Do the
+useful detection now — you just record it instead of acting on it:
+
+- Identify the tool and its repo. Check the session's **working directories** and
+  `~/.claude/plugins/known_marketplaces.json` (a `directory` source is a local clone; a
+  `github` source is a cache that cannot be edited).
+- Write the entry so the dream job can flush it without re-investigating: name the repo
+  path, the file, the change, and one line of why.
+
+```markdown
+# Harness TODO
+
+- **shipwright** (`~/src/shipwright`, local) — `skills/learning-capture/SKILL.md`:
+  the gate should call out type-system enforcement explicitly. Small edit.
+- **shipwright** (`~/src/shipwright`, local) — the staging model is wrong;
+  needs a redesign. Large: file as an issue, not an edit.
+```
+
+Then confirm in one line and keep working:
+
+```
+Logged a Harness TODO for the shipwright plugin. The dream job will pick it up.
+```
+
+### The dream job flushes the queue
+
+`/learn-dream` reads `# Harness TODO`, locates each local repo, makes the **small** edits,
+opens an issue for the **large** ones, and bundles everything per repo into **one PR** —
+not one interruption per correction. For a `github`-source plugin with no local clone, it
+leaves a note: to fix upstream, clone the marketplace as a local `directory` source.
+
+If you do not run a nightly dream job, run `/learn-dream` on demand to flush the queue.
+
+This is where the old "promote" judgement still lives — code you do not own needs a PR,
+and a tool you own but is not in front of you needs carrying to its repo — but the
+*carrying* is now batched and off your critical path.
+
+## Duplicates and contradictions
+
+Before adding a line, grep the target file. If a similar line exists, **edit it in place**
+rather than appending a near-duplicate. If the new learning contradicts an old one, the
+new one wins — replace it, do not stack both.
+
+## Autonomous agents do not use this skill
+
+This skill assumes a human is present and just corrected you. Managed agents and
+background agents run headless — there is no correction to react to in real time. Their
+learnings are captured in batch by the **dream job** (`/learn-dream`), which reads
+session transcripts on a schedule. See `commands/learn-dream.md`.

--- a/plugins/shipwright/skills/learning-capture/references/generalization-gate.md
+++ b/plugins/shipwright/skills/learning-capture/references/generalization-gate.md
@@ -1,0 +1,104 @@
+# The Generalization Gate
+
+The gate decides whether a correction is a *learning* (durable, worth context) or just
+*the task* (already handled by doing the work). Most corrections are the task. Capturing
+the task as a learning is the single biggest failure mode of a learning system: it fills
+`CLAUDE.md` with one-off trivia until the file is too long to carry signal.
+
+A correction passes the gate **only if both tests pass**.
+
+---
+
+## Test 1 — Does it generalize?
+
+Ask: *will this apply to future work that is different from what we just did?*
+
+The learning has to be true beyond the specific symbol, file, ticket, or bug in front of
+you. If you cannot restate it without naming the thing you just changed, it does not
+generalize.
+
+| Generalizes (a learning)                          | Does not generalize (just the task)                     |
+|----------------------------------------------------|---------------------------------------------------------|
+| "Use `uv`, not `pip`, for Python deps."            | "Use `uv` to install the deps for *this* script."       |
+| "Always run the suite before committing."          | "Run the suite now before you commit *this* PR."         |
+| "API handlers go in `handlers/`, not `routes/`."   | "Move `getUser` into `handlers/`."                       |
+| "We pin dependency versions exactly."              | "Pin `lodash` to 4.17.21."                              |
+
+**Signal words that suggest it generalizes** — capture-leaning:
+"always", "never", "from now on", "going forward", "in general", "as a rule",
+"we / our team", "every time", "by default", "remember this".
+
+**Signal words that suggest it does not** — skip-leaning:
+"just this once", "for now", "temporarily", "in this case", "only here", "this one",
+"for this PR".
+
+When the signal is ambiguous, default to **does not generalize**.
+
+---
+
+## Test 2 — Is it already captured by the code?
+
+Ask: *after the change we just made, would a fresh agent reading the repo already do the
+right thing?*
+
+If yes, the code is the memory. Writing it into `CLAUDE.md` too is duplication — and
+worse, a duplicate that drifts: the code evolves, the prose does not, and now they
+disagree.
+
+The change you just made already captures the rule if:
+
+- **The code now does it the right way** and that pattern is visible where future work
+  will look. (The next handler will be copied from the one you just fixed.)
+- **A test enforces it.** A failing test is a louder, more durable instruction than a
+  `CLAUDE.md` line.
+- **The type system makes the wrong version impossible.**
+- **A lint rule, formatter, or CI gate will catch the violation** automatically.
+- **It is already written down** — in `CLAUDE.md`, a skill, a `docs/` file, `REVIEW.md`.
+
+A correction passes Test 2 only when the knowledge would otherwise be **lost** — when
+nothing in the repo would stop a future agent from making the same mistake.
+
+| Already captured — skip                                          | Not captured — eligible                                       |
+|-------------------------------------------------------------------|---------------------------------------------------------------|
+| You renamed the column; the migration is the record.             | "Two-release migration policy: drop code refs in N, column in N+1." |
+| You fixed the import; the file now shows the right import.        | "SSR errors surface in the terminal, not the browser console."|
+| You added the missing `await`; lint rule `no-floating-promises` covers it. | "Treasury Prime webhooks are fire-and-forget — reconcile, don't trust." |
+
+The right column survives Test 2 because it is *policy* or *non-obvious system behavior*
+that no single diff teaches.
+
+---
+
+## What is worth capturing, once both tests pass
+
+In rough order of value:
+
+1. **Standing corrections** — the user states a rule, not a fix. Highest signal.
+2. **Non-obvious system behavior** — misleading errors, undocumented quirks, infra gotchas
+   a future agent would burn an hour rediscovering.
+3. **Policies and conventions** — decisions that constrain future work and are not
+   mechanically enforced yet.
+4. **Tooling and workflow preferences** — which tool, which command, which order.
+
+## What is never worth capturing
+
+- The task itself, restated as a rule.
+- One-off corrections scoped to a single symbol/file/ticket.
+- Anything a test, type, linter, or CI gate now enforces.
+- Anything already written in `CLAUDE.md`, a skill, or `docs/`.
+- Vague preferences with no action ("be more careful", "do it better").
+- Questions, hypotheticals, and quotes from docs under discussion.
+
+---
+
+## The frequency dimension (for the dream job)
+
+A human correcting you in real time *is* the signal — one explicit "always do X" is
+enough, because a human judged it worth saying. The interactive `learning-capture` skill
+relies on that judgement.
+
+The **dream job** has no human in the loop, so it substitutes **recurrence** for
+judgement: a pattern is only a learning if it shows up across **multiple sessions**. One
+agent making one correction once is probably problem-specific noise. The same correction
+surfacing in three sessions is a real, generalizable pattern. The dream job applies
+Tests 1 and 2 *and* requires cross-session recurrence before it writes anything.

--- a/plugins/shipwright/skills/triage-dependabot-pr/SKILL.md
+++ b/plugins/shipwright/skills/triage-dependabot-pr/SKILL.md
@@ -14,7 +14,7 @@ If `--repo` not in arguments:
 gh repo view --json nameWithOwner -q '.nameWithOwner'
 ```
 
-Set REPO (e.g. `app-vitals/vitals-os`) and REPO_SLUG (replace `/` with `_`, e.g. `app-vitals_vitals-os`).
+Set REPO (e.g. `my-org/my-repo`) and REPO_SLUG (replace `/` with `_`, e.g. `my-org_my-repo`).
 
 ## 2. Fetch PR context
 

--- a/plugins/shipwright/skills/triage-dependabot-pr/SKILL.md
+++ b/plugins/shipwright/skills/triage-dependabot-pr/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: triage-dependabot-pr
+description: Analyze a single Dependabot PR — fetch metadata and diff, classify risk (merge/review/hold), stage a patrol-style comment to `state/dependabot-reviews/`, and update `state/dependabot-reviews.json`. Use when asked to triage one specific Dependabot PR. Does not post to GitHub. Arguments — `<pr-number>` (required), `--repo owner/repo` (optional; detected from cwd if omitted).
+---
+
+# Triage a Dependabot PR
+
+Parse the invocation arguments: first token is the PR number. Optional `--repo owner/repo` specifies the repo — if not provided, detect from current directory.
+
+## 1. Resolve repo
+
+If `--repo` not in arguments:
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+
+Set REPO (e.g. `app-vitals/vitals-os`) and REPO_SLUG (replace `/` with `_`, e.g. `app-vitals_vitals-os`).
+
+## 2. Fetch PR context
+
+```bash
+gh pr view $PR --repo $REPO --json number,title,body,author,headRefName,baseRefName,files,url
+gh api "repos/$REPO/actions/runs?branch=$(gh pr view $PR --repo $REPO --json headRefName -q '.headRefName')&per_page=5" \
+  --jq '.workflow_runs[] | {name, status, conclusion}' 2>/dev/null || true
+```
+
+Extract:
+- `title` — e.g. "Bump axios from 1.6.0 to 1.7.0"
+- `body` — Dependabot's description
+- `headRefName` — branch name
+- `files` — changed files
+- CI check statuses (from Actions API — PATs do not have Checks API access)
+
+## 3. Fetch the diff
+
+```bash
+gh pr diff $PR --repo $REPO
+```
+
+Look at the actual version bumps — what changed and how many semver levels.
+
+## 4. Analyze risk
+
+**Recommendation options:**
+- `merge` — safe patch/minor update, no breaking changes, low risk
+- `review` — significant bump, possible breaking changes, or security-relevant
+- `hold` — known breaking change, deprecated package, or requires code changes first
+
+**Flags to assess:**
+- `breakingChange` — major version bump (X.0.0 → Y.0.0), or body explicitly mentions breaking changes
+- `securityRelevant` — CVE mentioned in body, or security-focused package (e.g. `helmet`, `bcrypt`, `jsonwebtoken`)
+- `productionImpact` — package is in `dependencies` (not `devDependencies`)
+
+**Heuristics:**
+- Patch bump (x.y.Z → x.y.Z+1) → almost always `merge` unless security-flagged
+- Minor bump (x.Y.z → x.Y+1.z) → usually `merge`, check for deprecation warnings in body
+- Major bump (X.y.z → X+1.y.z) → usually `review` or `hold`; read the body carefully
+- CVE in body → `review` minimum; flag `securityRelevant`
+- `devDependencies` only → lower production risk; usually `merge` or `review`
+
+## 5. Format the comment
+
+```
+### {icon} Patrol: {label}
+
+**{summary}**
+
+{flags}
+
+{reasoning}
+
+<sub>🏔️ [shipwright](https://github.com/app-vitals/shipwright) · claude-sonnet-4-6</sub><!-- shipwright -->
+```
+
+Where:
+- `{icon}`: ✅ for merge, ⚠️ for review, 🛑 for hold
+- `{label}`: "Safe to merge" / "Needs review" / "Hold — action required"
+- `{summary}`: one sentence, e.g. "Bumps axios from 1.6.0 to 1.7.0 — minor release, no breaking changes."
+- `{flags}`: space-separated, only include applicable: `🔴 Breaking change`, `🔒 Security relevant`, `🏭 Production impact`
+- `{reasoning}`: 2-3 sentences explaining the recommendation
+
+## 6. Write staged file
+
+```bash
+mkdir -p state/dependabot-reviews
+```
+
+Write the formatted comment to `state/dependabot-reviews/DEP_REVIEW_{REPO_SLUG}_{PR}.md`.
+
+## 7. Update state file
+
+Read `state/dependabot-reviews.json` (create `[]` if missing).
+
+Find the entry matching `pr == $PR && repo == $REPO_NAME` (just the repo name, not org). If not found, create a new entry.
+
+Set/update:
+```json
+{
+  "pr": <number>,
+  "repo": "<repo-name>",
+  "org": "<org-name>",
+  "title": "<pr title>",
+  "branch": "<headRefName>",
+  "firstSeen": "<now if new, else preserve existing>",
+  "lastTriagedAt": "<now>",
+  "recommendation": "<merge|review|hold>",
+  "stagedFile": "state/dependabot-reviews/DEP_REVIEW_{REPO_SLUG}_{PR}.md",
+  "status": "staged",
+  "postedAt": null,
+  "mergedAt": null
+}
+```
+
+Write back to `state/dependabot-reviews.json`.
+
+## 8. Report
+
+Output the formatted comment inline so it's immediately readable, then:
+
+```
+---
+Staged → state/dependabot-reviews/DEP_REVIEW_{REPO_SLUG}_{PR}.md
+Recommendation: {merge|review|hold}
+```
+
+Do NOT post the comment to GitHub.

--- a/plugins/shipwright/skills/triage-dependabot-prs/SKILL.md
+++ b/plugins/shipwright/skills/triage-dependabot-prs/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: triage-dependabot-prs
+description: Scan all repos in `repos/` for open Dependabot PRs, triage new ones, and stage patrol-style comments for review. Use when asked to triage, scan, or review open Dependabot PRs across multiple repos. Does not post to GitHub — staged comments are reviewed conversationally before posting.
+---
+
+# Triage All Dependabot PRs
+
+Scan every repo in `repos/` for open Dependabot PRs, triage new ones, and stage comments for review.
+
+## 1. Load state
+
+Read `state/dependabot-reviews.json`. Create `[]` if missing.
+
+## 2. Sync closed and merged PRs
+
+For each entry with `status` of `staged` or `posted`:
+
+```bash
+gh pr view {pr} --repo {org}/{repo} --json state -q '.state'
+```
+
+- `MERGED` → set `status: "merged"`, `mergedAt: <now>`
+- `CLOSED` → set `status: "closed"`
+
+## 3. Discover open Dependabot PRs
+
+For each directory in `repos/`:
+
+```bash
+# Get owner/repo for this directory
+git -C repos/{dirname} remote get-url origin
+# Parse owner/repo from the URL (strip .git suffix, handle both https and ssh formats)
+
+# List open Dependabot PRs
+gh pr list --repo {owner}/{repo} --author "app/dependabot" --state open --json number,title,headRefName
+```
+
+For each open PR not already present in state with a non-terminal status (`pending`, `staged`, `posted`):
+- Add a new entry: `{ pr, repo, org, title, branch, status: "pending", firstSeen: <now>, lastTriagedAt: null, recommendation: null, stagedFile: null, postedAt: null, mergedAt: null }`
+
+## 4. Triage pending PRs
+
+For each entry with `status: "pending"`:
+
+Invoke the `triage-dependabot-pr` skill with `{pr} --repo {org}/{repo}`.
+
+The skill writes the staged comment file and updates the state entry to `staged`. Collect the recommendation from the skill output.
+
+Process serially — merging one PR can affect others.
+
+## 5. Save state
+
+Write the updated `state/dependabot-reviews.json`.
+
+## 6. Report
+
+Output a summary table of all active entries (skip `merged` and `closed`):
+
+```
+## Dependabot Triage Summary
+
+| Repo | PR | Title | Recommendation | Status |
+|------|-----|-------|---------------|--------|
+| vitals-os | #42 | Bump axios 1.6→1.7 | ✅ merge | staged |
+| vitals-os | #41 | Bump webpack 4→5 | 🛑 hold | staged |
+
+New this run: N staged
+Already staged: M
+Merged/closed: P
+```
+
+If nothing to do: "No pending Dependabot PRs. All up to date."
+
+Staged reviews are ready for conversational walkthrough — run through them with the agent to review and post.
+
+## Notes
+
+- Process PRs serially — don't parallelize, as merging one PR can create conflicts in others.
+- If a PR has merge conflicts, note it in the summary — it may need a rebase first (`gh pr comment <number> --body "@dependabot rebase" --repo {owner}/{repo}`).
+- Use `gh` CLI for all GitHub interactions. Respect the current `GH_TOKEN` / `gh auth` context.

--- a/plugins/shipwright/skills/triage-dependabot-prs/SKILL.md
+++ b/plugins/shipwright/skills/triage-dependabot-prs/SKILL.md
@@ -61,8 +61,8 @@ Output a summary table of all active entries (skip `merged` and `closed`):
 
 | Repo | PR | Title | Recommendation | Status |
 |------|-----|-------|---------------|--------|
-| vitals-os | #42 | Bump axios 1.6→1.7 | ✅ merge | staged |
-| vitals-os | #41 | Bump webpack 4→5 | 🛑 hold | staged |
+| my-repo | #42 | Bump axios 1.6→1.7 | ✅ merge | staged |
+| my-repo | #41 | Bump webpack 4→5 | 🛑 hold | staged |
 
 New this run: N staged
 Already staged: M

--- a/plugins/shipwright/test/plugin-absorption.test.ts
+++ b/plugins/shipwright/test/plugin-absorption.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Plugin absorption tests — SHE-6.1
+ *
+ * Verifies that content from dependabot-review, entropy-patrol, and
+ * learning-loop has been absorbed into the shipwright plugin. Checks:
+ *   - All required skill directories exist with SKILL.md
+ *   - All required commands exist
+ *   - agents/learning-dreamer.md exists
+ *   - entropy-scan support files (golden-principles.yaml, references/) exist
+ *   - learning-capture references/generalization-gate.md exists
+ *   - No files contain old plugin-prefix invocation refs
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/test/ → plugins/shipwright/ → plugins/ → root
+const pluginRoot = resolve(import.meta.dir, "..");
+
+function pluginPath(...parts: string[]): string {
+  return join(pluginRoot, ...parts);
+}
+
+// Collect all .md and .yaml files under pluginRoot/skills, commands, agents
+function collectFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFiles(full));
+    } else if (entry.isFile()) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// ── Skills ────────────────────────────────────────────────────────────────────
+
+describe("absorbed skills — directories and SKILL.md", () => {
+  const requiredSkills = [
+    "triage-dependabot-pr",
+    "triage-dependabot-prs",
+    "entropy-fix",
+    "entropy-scan",
+    "learning-capture",
+  ];
+
+  for (const skill of requiredSkills) {
+    it(`skills/${skill}/ directory exists`, () => {
+      expect(existsSync(pluginPath("skills", skill))).toBe(true);
+    });
+
+    it(`skills/${skill}/SKILL.md exists`, () => {
+      expect(existsSync(pluginPath("skills", skill, "SKILL.md"))).toBe(true);
+    });
+  }
+});
+
+// ── Commands ──────────────────────────────────────────────────────────────────
+
+describe("absorbed commands", () => {
+  const requiredCommands = [
+    "entropy-fix.md",
+    "entropy-scan.md",
+    "learn-dream.md",
+    "learn.md",
+  ];
+
+  for (const cmd of requiredCommands) {
+    it(`commands/${cmd} exists`, () => {
+      expect(existsSync(pluginPath("commands", cmd))).toBe(true);
+    });
+  }
+});
+
+// ── Agents ────────────────────────────────────────────────────────────────────
+
+describe("absorbed agents", () => {
+  it("agents/learning-dreamer.md exists", () => {
+    expect(existsSync(pluginPath("agents", "learning-dreamer.md"))).toBe(true);
+  });
+});
+
+// ── entropy-scan support files ────────────────────────────────────────────────
+
+describe("entropy-scan support files", () => {
+  it("skills/entropy-scan/golden-principles.yaml exists", () => {
+    expect(
+      existsSync(
+        pluginPath("skills", "entropy-scan", "golden-principles.yaml"),
+      ),
+    ).toBe(true);
+  });
+
+  const requiredRefs = [
+    "customization.md",
+    "quality-log-schema.md",
+    "schema.md",
+  ];
+
+  for (const ref of requiredRefs) {
+    it(`skills/entropy-scan/references/${ref} exists`, () => {
+      expect(
+        existsSync(pluginPath("skills", "entropy-scan", "references", ref)),
+      ).toBe(true);
+    });
+  }
+});
+
+// ── learning-capture support files ───────────────────────────────────────────
+
+describe("learning-capture support files", () => {
+  it("skills/learning-capture/references/generalization-gate.md exists", () => {
+    expect(
+      existsSync(
+        pluginPath(
+          "skills",
+          "learning-capture",
+          "references",
+          "generalization-gate.md",
+        ),
+      ),
+    ).toBe(true);
+  });
+});
+
+// ── No old plugin-prefix invocation refs ─────────────────────────────────────
+
+describe("no old plugin-prefix invocation references", () => {
+  const oldPrefixes = [
+    "entropy-patrol:entropy-scan",
+    "entropy-patrol:entropy-fix",
+    "/entropy-patrol:entropy-scan",
+    "/entropy-patrol:entropy-fix",
+    "dependabot-review:triage-dependabot-prs",
+    "dependabot-review:triage-dependabot-pr",
+    "learning-loop:learning-capture",
+  ];
+
+  // Scan all .md and .yaml files under skills/, commands/, agents/
+  const dirsToScan = ["skills", "commands", "agents"].map((d) => pluginPath(d));
+
+  let allFiles: string[] = [];
+  for (const dir of dirsToScan) {
+    allFiles = allFiles.concat(collectFiles(dir));
+  }
+
+  for (const prefix of oldPrefixes) {
+    it(`no file contains old ref: "${prefix}"`, () => {
+      const violations: string[] = [];
+      for (const file of allFiles) {
+        const content = readFileSync(file, "utf8");
+        if (content.includes(prefix)) {
+          violations.push(file.replace(`${pluginRoot}/`, ""));
+        }
+      }
+      expect(violations).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Absorbs `dependabot-review`, `entropy-patrol`, and `learning-loop` plugin content into the `shipwright` plugin — 5 skills, 4 commands, 1 agent
- Updates all internal cross-references from old plugin prefixes (`entropy-patrol:`, `dependabot-review:`, `learning-loop:`) to `shipwright:`
- Retains support files: `entropy-scan/golden-principles.yaml`, `entropy-scan/references/` (3 docs), `learning-capture/references/generalization-gate.md`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `skills/` contains triage-dependabot-pr, triage-dependabot-prs, entropy-fix, entropy-scan, learning-capture (each with SKILL.md) | MET |
| 2 | `commands/` contains entropy-fix.md, entropy-scan.md, learn-dream.md, learn.md | MET |
| 3 | `agents/learning-dreamer.md` present | MET |
| 4 | No old plugin-prefix references in copied files | MET |
| 5 | `entropy-scan` retains golden-principles.yaml + references/ | MET |
| 6 | `learning-capture` retains references/generalization-gate.md | MET |
| 7 | Tests pass (27/27 absorption tests, 649 total) | MET |

## Test Plan
- [x] 27 new plugin-absorption tests verify all skills, commands, agents, and absence of old plugin refs
- [x] Full suite: 649 pass, 0 fail
- [x] Coverage: 96.75% lines (plugins/shipwright)
- [x] Biome lint clean

Generated with [Claude Code](https://claude.com/claude-code)
