### PR TITLE
feat(she-4.1): port core agent modules from vitals-os

### DIFF
--- a/agent/src/admin-api.ts
+++ b/agent/src/admin-api.ts
@@ -154,6 +154,13 @@ export function createAdminApp(deps: AdminDeps): Hono {
     return c.json({ crons });
   });
 
+  // POST /admin/api/agents/:id/crons/reconcile — static path must precede /:cronId routes
+  app.post("/admin/api/agents/:id/crons/reconcile", async (c) => {
+    const agentId = c.req.param("id");
+    const result = await agentCronJobService.reconcileSystemCrons(agentId);
+    return c.json(result);
+  });
+
   app.patch("/admin/api/agents/:id/crons/:cronId", async (c) => {
     const agentId = c.req.param("id");
     const cronId = c.req.param("cronId");
@@ -178,13 +185,6 @@ export function createAdminApp(deps: AdminDeps): Hono {
     const cronId = c.req.param("cronId");
     await agentCronJobService.delete(agentId, cronId);
     return new Response(null, { status: 204 });
-  });
-
-  // POST /admin/api/agents/:id/crons/reconcile — reconcile system crons
-  app.post("/admin/api/agents/:id/crons/reconcile", async (c) => {
-    const agentId = c.req.param("id");
-    const result = await agentCronJobService.reconcileSystemCrons(agentId);
-    return c.json(result);
   });
 
   // Tool routes

--- a/agent/src/agent-cron-jobs.ts
+++ b/agent/src/agent-cron-jobs.ts
@@ -288,41 +288,45 @@ export class AgentCronJobService {
     let updated = 0;
     let deleted = 0;
 
-    // Reconcile each SYSTEM_CRON entry
-    for (const systemCron of SYSTEM_CRONS) {
-      const existing = existingByName.get(systemCron.name);
-      const enabled = existing ? existing.enabled : systemCron.enabled;
+    // Wrap all mutations in a transaction so a crash mid-loop cannot leave
+    // the agent missing required system crons (e.g. shipwright-dev-task).
+    await this.prisma.$transaction(async (tx) => {
+      // Reconcile each SYSTEM_CRON entry
+      for (const systemCron of SYSTEM_CRONS) {
+        const existing = existingByName.get(systemCron.name);
+        const enabled = existing ? existing.enabled : systemCron.enabled;
 
-      if (existing) {
-        await this.prisma.agentCronJob.delete({ where: { id: existing.id } });
-        updated++;
-      } else {
-        created++;
+        if (existing) {
+          await tx.agentCronJob.delete({ where: { id: existing.id } });
+          updated++;
+        } else {
+          created++;
+        }
+
+        await tx.agentCronJob.create({
+          data: {
+            agentId,
+            name: systemCron.name,
+            system: true,
+            schedule: systemCron.schedule,
+            prompt: systemCron.prompt,
+            silent: systemCron.silent ?? false,
+            preCheck: systemCron.preCheck ?? null,
+            channel: null,
+            user: null,
+            enabled,
+          },
+        });
       }
 
-      await this.prisma.agentCronJob.create({
-        data: {
-          agentId,
-          name: systemCron.name,
-          system: true,
-          schedule: systemCron.schedule,
-          prompt: systemCron.prompt,
-          silent: systemCron.silent ?? false,
-          preCheck: systemCron.preCheck ?? null,
-          channel: null,
-          user: null,
-          enabled,
-        },
-      });
-    }
-
-    // Orphan pass: delete any system cron whose name is not in SYSTEM_CRONS.
-    for (const cron of existingSystemCrons) {
-      if (!cron.name || !systemCronNames.has(cron.name)) {
-        await this.prisma.agentCronJob.delete({ where: { id: cron.id } });
-        deleted++;
+      // Orphan pass: delete any system cron whose name is not in SYSTEM_CRONS.
+      for (const cron of existingSystemCrons) {
+        if (!cron.name || !systemCronNames.has(cron.name)) {
+          await tx.agentCronJob.delete({ where: { id: cron.id } });
+          deleted++;
+        }
       }
-    }
+    });
 
     return { created, updated, deleted };
   }

--- a/agent/src/analytics.ts
+++ b/agent/src/analytics.ts
@@ -1,0 +1,257 @@
+/**
+ * Agent usage analytics — lightweight event tracking for observability.
+ *
+ * Tracks: sessions started, messages handled, errors, response times.
+ * File-backed JSON store with daily rollover. Designed for agent-native
+ * querying (CLI, cron reports, health endpoint extension).
+ *
+ * Zero external dependencies. No database required.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface AnalyticsEvent {
+  type:
+    | "message"
+    | "mention"
+    | "cron"
+    | "error"
+    | "session_start"
+    | "session_fallback";
+  timestamp: number; // epoch ms
+  sessionKey?: string;
+  durationMs?: number;
+  error?: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+interface DailyStats {
+  date: string; // YYYY-MM-DD
+  events: AnalyticsEvent[];
+}
+
+export interface AnalyticsSummary {
+  date: string;
+  totalEvents: number;
+  messages: number;
+  mentions: number;
+  cronJobs: number;
+  errors: number;
+  sessionStarts: number;
+  sessionFallbacks: number;
+  avgResponseMs: number | null;
+  p95ResponseMs: number | null;
+  uniqueSessions: number;
+}
+
+interface WeeklyRollup {
+  startDate: string; // YYYY-MM-DD (inclusive)
+  endDate: string; // YYYY-MM-DD (inclusive)
+  totalMessages: number;
+  totalMentions: number;
+  totalCronJobs: number;
+  totalErrors: number;
+  totalInputTokens: number | null;
+  totalOutputTokens: number | null;
+  uniqueUsers: number;
+  uniqueSessions: number;
+  activeDays: number; // days with >= 1 message or mention
+  avgResponseMs: number | null;
+  errorRate: number | null; // errors / (messages + mentions), null if 0 interactions
+  topDay: string | null; // YYYY-MM-DD with highest message count
+}
+
+function todayString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function dateRange(startDate: string, endDate: string): string[] {
+  const result: string[] = [];
+  const start = new Date(`${startDate}T00:00:00Z`);
+  const end = new Date(`${endDate}T00:00:00Z`);
+  if (start > end) return result;
+  const cur = new Date(start);
+  while (cur <= end) {
+    result.push(cur.toISOString().slice(0, 10));
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return result;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+export function createAnalyticsStore(dir: string) {
+  // Ensure directory exists
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  function filePath(date: string): string {
+    return join(dir, `${date}.json`);
+  }
+
+  function loadDay(date: string): DailyStats {
+    const fp = filePath(date);
+    try {
+      return JSON.parse(readFileSync(fp, "utf8")) as DailyStats;
+    } catch {
+      return { date, events: [] };
+    }
+  }
+
+  function saveDay(stats: DailyStats): void {
+    const fp = filePath(stats.date);
+    writeFileSync(fp, JSON.stringify(stats, null, 2));
+  }
+
+  function track(event: Omit<AnalyticsEvent, "timestamp">): void {
+    const date = todayString();
+    const stats = loadDay(date);
+    stats.events.push({ ...event, timestamp: Date.now() });
+    saveDay(stats);
+  }
+
+  function summarize(date: string = todayString()): AnalyticsSummary {
+    const stats = loadDay(date);
+    const events = stats.events;
+
+    const durations = events
+      .filter(
+        (e): e is AnalyticsEvent & { durationMs: number } =>
+          e.durationMs !== undefined,
+      )
+      .map((e) => e.durationMs)
+      .sort((a, b) => a - b);
+
+    const sessions = new Set(
+      events.filter((e) => e.sessionKey).map((e) => e.sessionKey),
+    );
+
+    return {
+      date,
+      totalEvents: events.length,
+      messages: events.filter((e) => e.type === "message").length,
+      mentions: events.filter((e) => e.type === "mention").length,
+      cronJobs: events.filter((e) => e.type === "cron").length,
+      errors: events.filter((e) => e.type === "error").length,
+      sessionStarts: events.filter((e) => e.type === "session_start").length,
+      sessionFallbacks: events.filter((e) => e.type === "session_fallback")
+        .length,
+      avgResponseMs:
+        durations.length > 0
+          ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length)
+          : null,
+      p95ResponseMs: durations.length > 0 ? percentile(durations, 95) : null,
+      uniqueSessions: sessions.size,
+    };
+  }
+
+  function summarizeRange(
+    startDate: string,
+    endDate: string,
+  ): AnalyticsSummary[] {
+    return dateRange(startDate, endDate).map((date) => summarize(date));
+  }
+
+  function rollupWeek(endDate: string = todayString()): WeeklyRollup {
+    const start = new Date(`${endDate}T00:00:00Z`);
+    start.setUTCDate(start.getUTCDate() - 6);
+    const startDate = start.toISOString().slice(0, 10);
+
+    const days = summarizeRange(startDate, endDate);
+
+    let totalMessages = 0;
+    let totalMentions = 0;
+    let totalCronJobs = 0;
+    let totalErrors = 0;
+    let totalInputTokens: number | null = null;
+    let totalOutputTokens: number | null = null;
+    const uniqueSessionsSet = new Set<string>();
+    const uniqueUsersSet = new Set<string>();
+    let activeDays = 0;
+    let totalDurationMs = 0;
+    let durationCount = 0;
+    let topDay: string | null = null;
+    let topDayCount = 0;
+
+    for (const day of days) {
+      totalMessages += day.messages;
+      totalMentions += day.mentions;
+      totalCronJobs += day.cronJobs;
+      totalErrors += day.errors;
+
+      // Token aggregation: sum defined values; null only if all days null
+      if (
+        (day as AnalyticsSummary & { totalInputTokens?: number | null })
+          .totalInputTokens != null
+      ) {
+        totalInputTokens =
+          (totalInputTokens ?? 0) +
+          ((day as AnalyticsSummary & { totalInputTokens?: number | null })
+            .totalInputTokens as number);
+      }
+      if (
+        (day as AnalyticsSummary & { totalOutputTokens?: number | null })
+          .totalOutputTokens != null
+      ) {
+        totalOutputTokens =
+          (totalOutputTokens ?? 0) +
+          ((day as AnalyticsSummary & { totalOutputTokens?: number | null })
+            .totalOutputTokens as number);
+      }
+
+      if (day.messages + day.mentions >= 1) activeDays++;
+
+      if (day.avgResponseMs !== null) {
+        // Reconstruct total duration from avg (best approximation without per-event data)
+        const interactions = day.messages + day.mentions;
+        if (interactions > 0) {
+          totalDurationMs += day.avgResponseMs * interactions;
+          durationCount += interactions;
+        }
+      }
+
+      if (day.messages > topDayCount) {
+        topDayCount = day.messages;
+        topDay = day.date;
+      }
+
+      // Collect sessions and users from raw daily data
+      const raw = loadDay(day.date);
+      for (const e of raw.events) {
+        if (e.sessionKey) uniqueSessionsSet.add(e.sessionKey);
+        const u = (e as AnalyticsEvent & { userId?: string }).userId;
+        if (u) uniqueUsersSet.add(u);
+      }
+    }
+
+    const interactions = totalMessages + totalMentions;
+    const avgResponseMs =
+      durationCount > 0 ? Math.round(totalDurationMs / durationCount) : null;
+    const errorRate = interactions > 0 ? totalErrors / interactions : null;
+
+    return {
+      startDate,
+      endDate,
+      totalMessages,
+      totalMentions,
+      totalCronJobs,
+      totalErrors,
+      totalInputTokens,
+      totalOutputTokens,
+      uniqueUsers: uniqueUsersSet.size,
+      uniqueSessions: uniqueSessionsSet.size,
+      activeDays,
+      avgResponseMs,
+      errorRate,
+      topDay: topDayCount > 0 ? topDay : null,
+    };
+  }
+
+  return { track, summarize, summarizeRange, rollupWeek, loadDay };
+}

--- a/agent/src/analytics.ts
+++ b/agent/src/analytics.ts
@@ -9,7 +9,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+import { type Clock, SystemClock } from "./clock.ts";
 
 export interface AnalyticsEvent {
   type:
@@ -62,8 +63,8 @@ interface WeeklyRollup {
   topDay: string | null; // YYYY-MM-DD with highest message count
 }
 
-function todayString(): string {
-  return new Date().toISOString().slice(0, 10);
+function todayString(clock: Clock): string {
+  return clock.now().toISOString().slice(0, 10);
 }
 
 function dateRange(startDate: string, endDate: string): string[] {
@@ -85,7 +86,7 @@ function percentile(sorted: number[], p: number): number {
   return sorted[Math.max(0, idx)];
 }
 
-export function createAnalyticsStore(dir: string) {
+export function createAnalyticsStore(dir: string, clock: Clock = SystemClock()) {
   // Ensure directory exists
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -110,13 +111,13 @@ export function createAnalyticsStore(dir: string) {
   }
 
   function track(event: Omit<AnalyticsEvent, "timestamp">): void {
-    const date = todayString();
+    const date = todayString(clock);
     const stats = loadDay(date);
-    stats.events.push({ ...event, timestamp: Date.now() });
+    stats.events.push({ ...event, timestamp: clock.now().getTime() });
     saveDay(stats);
   }
 
-  function summarize(date: string = todayString()): AnalyticsSummary {
+  function summarize(date: string = todayString(clock)): AnalyticsSummary {
     const stats = loadDay(date);
     const events = stats.events;
 
@@ -158,7 +159,7 @@ export function createAnalyticsStore(dir: string) {
     return dateRange(startDate, endDate).map((date) => summarize(date));
   }
 
-  function rollupWeek(endDate: string = todayString()): WeeklyRollup {
+  function rollupWeek(endDate: string = todayString(clock)): WeeklyRollup {
     const start = new Date(`${endDate}T00:00:00Z`);
     start.setUTCDate(start.getUTCDate() - 6);
     const startDate = start.toISOString().slice(0, 10);

--- a/agent/src/claude.ts
+++ b/agent/src/claude.ts
@@ -1,0 +1,277 @@
+import type { AnalyticsEvent } from "./analytics.ts";
+
+type Tracker = (event: Omit<AnalyticsEvent, "timestamp">) => void;
+const noopTracker: Tracker = () => {};
+
+export interface LiveClaudeConfig {
+  model: string;
+  fallbackModel?: string;
+  effortLevel?: string;
+  allowedTools: string[];
+}
+
+/**
+ * Live Claude configuration — reads from process.env directly.
+ * Updated at runtime by setLiveClaudeConfig (e.g. from agent config polling).
+ */
+export const liveClaudeConfig: LiveClaudeConfig = {
+  model: process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6",
+  fallbackModel: process.env.ANTHROPIC_FALLBACK_MODEL,
+  effortLevel: process.env.ANTHROPIC_EFFORT_LEVEL,
+  allowedTools: process.env.AGENT_ALLOWED_TOOLS
+    ? JSON.parse(process.env.AGENT_ALLOWED_TOOLS)
+    : [],
+};
+
+export function setLiveClaudeConfig(patch: Partial<LiveClaudeConfig>): void {
+  Object.assign(liveClaudeConfig, patch);
+}
+
+export interface TokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+}
+
+interface ClaudeJsonOutput {
+  result: string;
+  session_id: string;
+  is_error: boolean;
+  api_error_status?: number;
+  usage?: TokenUsage;
+}
+
+export class ClaudeRunError extends Error {
+  constructor(
+    message: string,
+    readonly apiErrorStatus: number | undefined,
+    readonly resultMessage: string,
+    readonly sessionId: string | undefined,
+  ) {
+    super(message);
+    this.name = "ClaudeRunError";
+  }
+}
+
+export class ClaudeTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Claude session timed out after ${timeoutMs / 1000}s`);
+    this.name = "ClaudeTimeoutError";
+  }
+}
+
+interface ClaudeSessionStore {
+  get: (key: string) => string | undefined;
+  set: (key: string, id: string) => void;
+}
+
+/**
+ * Create a claude CLI runner.
+ *
+ * Default parameter values:
+ *  - workspace: process.cwd() — caller should inject the real workspace path
+ *  - sessions: no-op store — caller should inject a real createFileSessionStore instance
+ *  - model: undefined — falls back to liveClaudeConfig.model
+ */
+export function createRunClaude(
+  spawner: typeof Bun.spawn = Bun.spawn,
+  sessions: ClaudeSessionStore = { get: () => undefined, set: () => {} },
+  model: string | undefined = undefined,
+  workspace: string = process.cwd(),
+  tracker: Tracker = noopTracker,
+  extraAllowedTools: string[] | undefined = undefined,
+  fallbackModel: string | undefined = undefined,
+  effortLevel: string | undefined = undefined,
+  timeoutMs: number = 30 * 60 * 1000,
+): (
+  message: string,
+  sessionKey?: string,
+) => Promise<{ result: string; sessionId?: string; usage?: TokenUsage }> {
+  // Per-session queue: ensures messages on the same thread run serially
+  const sessionQueues = new Map<string, Promise<unknown>>();
+
+  function _enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = sessionQueues.get(key) ?? Promise.resolve();
+    const next = prev
+      .then(
+        () => fn(),
+        () => fn(),
+      )
+      .finally(() => {
+        if (sessionQueues.get(key) === next) sessionQueues.delete(key);
+      });
+    sessionQueues.set(key, next);
+    return next as Promise<T>;
+  }
+
+  function _buildArgs(
+    message: string,
+    resumeSessionId: string | undefined,
+  ): string[] {
+    const resolvedModel = model ?? liveClaudeConfig.model;
+    const resolvedFallbackModel =
+      fallbackModel ?? liveClaudeConfig.fallbackModel;
+    const resolvedEffortLevel = effortLevel ?? liveClaudeConfig.effortLevel;
+    const resolvedExtraAllowedTools =
+      extraAllowedTools ?? liveClaudeConfig.allowedTools;
+
+    const args = [
+      "-p",
+      "--output-format",
+      "json",
+      "--permission-mode",
+      "acceptEdits",
+      "--allowedTools",
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash",
+      "WebSearch",
+      "WebFetch",
+      "Skill",
+      "Agent",
+      "TodoWrite",
+      ...resolvedExtraAllowedTools,
+      "--model",
+      resolvedModel,
+      ...(resolvedFallbackModel
+        ? ["--fallback-model", resolvedFallbackModel]
+        : []),
+      ...(resolvedEffortLevel ? ["--effort", resolvedEffortLevel] : []),
+    ];
+
+    if (resumeSessionId) {
+      args.push("-r", resumeSessionId);
+    }
+
+    args.push(message);
+    return args;
+  }
+
+  function _tryParseJson(stdout: string): ClaudeJsonOutput | undefined {
+    try {
+      return JSON.parse(stdout) as ClaudeJsonOutput;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function _spawn(
+    args: string[],
+  ): Promise<{ result: string; sessionId?: string; usage?: TokenUsage }> {
+    const proc = spawner(["claude", ...args], {
+      cwd: workspace,
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, timeoutMs);
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]).finally(() => clearTimeout(timer));
+
+    if (timedOut) {
+      throw new ClaudeTimeoutError(timeoutMs);
+    }
+
+    const structured = _tryParseJson(stdout);
+    if (exitCode !== 0) {
+      if (structured?.is_error) {
+        throw new ClaudeRunError(
+          `claude exited ${exitCode}: api_error_status=${structured.api_error_status ?? "unknown"} ${structured.result}`,
+          structured.api_error_status,
+          structured.result,
+          structured.session_id,
+        );
+      }
+      throw new Error(
+        `claude exited ${exitCode}: ${stderr.trim() || stdout.trim()}`,
+      );
+    }
+
+    if (!structured) {
+      throw new Error(
+        `claude returned non-JSON stdout: ${stdout.slice(0, 200)}`,
+      );
+    }
+    if (structured.is_error) {
+      throw new ClaudeRunError(
+        `claude error: ${structured.result}`,
+        structured.api_error_status,
+        structured.result,
+        structured.session_id,
+      );
+    }
+
+    return {
+      result: structured.result,
+      sessionId: structured.session_id,
+      usage: structured.usage,
+    };
+  }
+
+  async function _runClaude(
+    message: string,
+    sessionKey: string | undefined,
+  ): Promise<{ result: string; sessionId?: string; usage?: TokenUsage }> {
+    const existingSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
+
+    if (sessionKey && !existingSessionId) {
+      tracker({ type: "session_start", sessionKey });
+    }
+
+    const args = _buildArgs(message, existingSessionId);
+
+    try {
+      const output = await _spawn(args);
+      if (sessionKey && output.sessionId) {
+        sessions.set(sessionKey, output.sessionId);
+      }
+      return output;
+    } catch (err) {
+      // Stale session fallback: if resume failed, clear the dead session
+      // and retry fresh so the user gets a response instead of an error.
+      // Do NOT catch ClaudeTimeoutError — that means the session hung and
+      // we should surface the error rather than silently spawning a second
+      // process that would also hang.
+      if (existingSessionId && !(err instanceof ClaudeTimeoutError)) {
+        const fallbackStart = Date.now();
+        if (sessionKey && "clear" in sessions) {
+          (sessions as { clear: (key: string) => void }).clear(sessionKey);
+        }
+        const freshArgs = _buildArgs(message, undefined);
+        const output = await _spawn(freshArgs);
+        tracker({
+          type: "session_fallback",
+          sessionKey,
+          durationMs: Date.now() - fallbackStart,
+        });
+        if (sessionKey && output.sessionId) {
+          sessions.set(sessionKey, output.sessionId);
+        }
+        return output;
+      }
+      throw err;
+    }
+  }
+
+  return async function runClaude(
+    message: string,
+    sessionKey?: string,
+  ): Promise<{ result: string; sessionId?: string; usage?: TokenUsage }> {
+    if (sessionKey)
+      return _enqueue(sessionKey, () => _runClaude(message, sessionKey));
+    return _runClaude(message, undefined);
+  };
+}

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -1,0 +1,40 @@
+import { join } from "node:path";
+
+function optional(key: string): string | undefined {
+  return process.env[key];
+}
+
+function buildConfig(agentHome: string) {
+  return {
+    claude: {
+      model: optional("ANTHROPIC_MODEL") ?? "claude-sonnet-4-6",
+      fallbackModel: optional("ANTHROPIC_FALLBACK_MODEL"),
+      effortLevel: optional("ANTHROPIC_EFFORT_LEVEL"),
+      anthropicApiKey: optional("ANTHROPIC_API_KEY"),
+      oauthToken: optional("CLAUDE_CODE_OAUTH_TOKEN"),
+    },
+    shipwright: {
+      apiUrl: optional("SHIPWRIGHT_API_URL"),
+      apiKey: optional("SHIPWRIGHT_INTERNAL_API_KEY"),
+      agentId: optional("SHIPWRIGHT_AGENT_ID"),
+    },
+    paths: {
+      home: agentHome,
+      workspace: join(agentHome, "workspace"),
+      sessions: join(agentHome, "sessions.json"),
+    },
+  } as const;
+}
+
+/**
+ * Creates config from a given agent home directory.
+ * Reads env vars at call time — no module-level side effects.
+ *
+ * AGENT_HOME defaults to ~/.shipwright-agent/ at the call site (index.ts).
+ * Not defaulted here to avoid module-level env reads.
+ */
+export function createConfig(agentHome: string) {
+  return {
+    config: buildConfig(agentHome),
+  };
+}

--- a/agent/src/config.unit.test.ts
+++ b/agent/src/config.unit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for agent/src/config.ts
+ *
+ * Strategy: call createConfig(agentHome) factory directly with a temp dir.
+ * No mock.module() needed — the factory reads env vars at call time.
+ * Uses SHIPWRIGHT_* env vars (not VITALS_OS_*).
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createConfig } from "./config.ts";
+
+const AGENT_HOME = join(
+  tmpdir(),
+  `shipwright-agent-config-test-${process.pid}`,
+);
+mkdirSync(AGENT_HOME, { recursive: true });
+
+// Set env vars before calling createConfig
+process.env.ANTHROPIC_MODEL = "claude-opus-4-6";
+process.env.SHIPWRIGHT_API_URL = "https://api.shipwright.app";
+process.env.SHIPWRIGHT_INTERNAL_API_KEY = "key-123";
+process.env.SHIPWRIGHT_AGENT_ID = "agent-xyz";
+
+const { config } = createConfig(AGENT_HOME);
+
+afterAll(() => {
+  rmSync(AGENT_HOME, { recursive: true, force: true });
+});
+
+// ─── config.claude ────────────────────────────────────────────────────────────
+
+describe("config.claude", () => {
+  test("model from ANTHROPIC_MODEL env var", () => {
+    expect(config.claude.model).toBe("claude-opus-4-6");
+  });
+
+  test("fallbackModel from ANTHROPIC_FALLBACK_MODEL env var", () => {
+    process.env.ANTHROPIC_FALLBACK_MODEL = "claude-sonnet-4-6";
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.fallbackModel).toBe("claude-sonnet-4-6");
+    process.env.ANTHROPIC_FALLBACK_MODEL = undefined;
+  });
+
+  test("fallbackModel is undefined when ANTHROPIC_FALLBACK_MODEL not set", () => {
+    process.env.ANTHROPIC_FALLBACK_MODEL = undefined;
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.fallbackModel).toBeUndefined();
+  });
+
+  test("effortLevel from ANTHROPIC_EFFORT_LEVEL env var", () => {
+    process.env.ANTHROPIC_EFFORT_LEVEL = "xhigh";
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.effortLevel).toBe("xhigh");
+    process.env.ANTHROPIC_EFFORT_LEVEL = undefined;
+  });
+
+  test("effortLevel is undefined when ANTHROPIC_EFFORT_LEVEL not set", () => {
+    process.env.ANTHROPIC_EFFORT_LEVEL = undefined;
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.effortLevel).toBeUndefined();
+  });
+
+  test("anthropicApiKey from ANTHROPIC_API_KEY env var", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-key";
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.anthropicApiKey).toBe("sk-ant-test-key");
+    process.env.ANTHROPIC_API_KEY = undefined;
+  });
+
+  test("anthropicApiKey is undefined when ANTHROPIC_API_KEY not set", () => {
+    process.env.ANTHROPIC_API_KEY = undefined;
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.anthropicApiKey).toBeUndefined();
+  });
+
+  test("model defaults to claude-sonnet-4-6 when ANTHROPIC_MODEL not set", () => {
+    const saved = process.env.ANTHROPIC_MODEL;
+    process.env.ANTHROPIC_MODEL = undefined;
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.model).toBe("claude-sonnet-4-6");
+    process.env.ANTHROPIC_MODEL = saved;
+  });
+});
+
+// ─── config.shipwright ────────────────────────────────────────────────────────
+
+describe("config.shipwright", () => {
+  test("apiUrl from SHIPWRIGHT_API_URL", () => {
+    expect(config.shipwright.apiUrl).toBe("https://api.shipwright.app");
+  });
+
+  test("apiKey from SHIPWRIGHT_INTERNAL_API_KEY", () => {
+    expect(config.shipwright.apiKey).toBe("key-123");
+  });
+
+  test("agentId from SHIPWRIGHT_AGENT_ID", () => {
+    expect(config.shipwright.agentId).toBe("agent-xyz");
+  });
+
+  test("apiUrl is undefined when SHIPWRIGHT_API_URL not set", () => {
+    const saved = process.env.SHIPWRIGHT_API_URL;
+    process.env.SHIPWRIGHT_API_URL = undefined;
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.shipwright.apiUrl).toBeUndefined();
+    process.env.SHIPWRIGHT_API_URL = saved;
+  });
+});
+
+// ─── config.paths ─────────────────────────────────────────────────────────────
+
+describe("config.paths", () => {
+  test("home is agentHome", () => {
+    expect(config.paths.home).toBe(AGENT_HOME);
+  });
+
+  test("workspace is inside agentHome", () => {
+    expect(config.paths.workspace).toContain(AGENT_HOME);
+    expect(config.paths.workspace).toContain("workspace");
+  });
+
+  test("sessions is agentHome/sessions.json", () => {
+    expect(config.paths.sessions).toBe(join(AGENT_HOME, "sessions.json"));
+  });
+});

--- a/agent/src/format.ts
+++ b/agent/src/format.ts
@@ -11,12 +11,15 @@ export function markdownToSlack(text: string): string {
       .replace(TABLE_REGEX, (match) => {
         return `\`\`\`\n${match.trimEnd()}\n\`\`\``;
       })
+      // Italic (but not bold) — must run before heading/bold so the
+      // lookbehind/lookahead can distinguish *italic* from **bold** in
+      // the original markdown input. After the bold pass, **bold** becomes
+      // *bold* and the regex would incorrectly convert it to _bold_ (italic).
+      .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "_$1_")
       // Headings → bold
       .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
       // Bold
       .replace(/\*\*(.+?)\*\*/g, "*$1*")
-      // Italic (but not bold)
-      .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "_$1_")
       // Inline code
       .replace(/`([^`]+)`/g, "`$1`")
       // Links

--- a/agent/src/format.ts
+++ b/agent/src/format.ts
@@ -1,0 +1,111 @@
+// Markdown → Slack mrkdwn converter
+// Converts GitHub-flavored markdown to Slack format
+
+const TABLE_REGEX =
+  /(\|[^\n]+\|\n)([ \t]*\|[ \t]*[-:]+[ \t]*(?:\|[ \t]*[-:]+[ \t]*)*\|[ \t]*\n)((?:[ \t]*\|[^\n]+\|\n?)*)/gm;
+
+export function markdownToSlack(text: string): string {
+  return (
+    text
+      // Tables → code blocks (fallback for non-block contexts)
+      .replace(TABLE_REGEX, (match) => {
+        return `\`\`\`\n${match.trimEnd()}\n\`\`\``;
+      })
+      // Headings → bold
+      .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
+      // Bold
+      .replace(/\*\*(.+?)\*\*/g, "*$1*")
+      // Italic (but not bold)
+      .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "_$1_")
+      // Inline code
+      .replace(/`([^`]+)`/g, "`$1`")
+      // Links
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>")
+      // Horizontal rules
+      .replace(/^---+$/gm, "─────────────────────")
+      .trim()
+  );
+}
+
+const SECTION_TEXT_LIMIT = 3000;
+
+type RawTextCell = { type: "raw_text"; text: string };
+type TableBlock = {
+  type: "table";
+  column_settings: Array<{ align: "left" | "center" | "right" }>;
+  rows: RawTextCell[][];
+};
+type SectionBlock = { type: "section"; text: { type: "mrkdwn"; text: string } };
+type SlackBlock = TableBlock | SectionBlock;
+
+function pushSectionBlocks(blocks: SlackBlock[], mrkdwn: string): void {
+  if (!mrkdwn) return;
+  for (let i = 0; i < mrkdwn.length; i += SECTION_TEXT_LIMIT) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: mrkdwn.slice(i, i + SECTION_TEXT_LIMIT) },
+    });
+  }
+}
+
+function parseTableRows(tableStr: string): string[][] {
+  const lines = tableStr.trim().split("\n").filter(Boolean);
+  const parseRow = (line: string) =>
+    line
+      .split("|")
+      .slice(1, -1)
+      .map((c) => c.trim());
+  // lines[0] = header, lines[1] = separator, lines[2+] = data rows
+  return [parseRow(lines[0]), ...lines.slice(2).map(parseRow)];
+}
+
+/**
+ * Converts markdown to Slack Block Kit blocks when tables are present.
+ * Returns null when no tables are found (fall back to markdownToSlack).
+ */
+export function markdownToBlocks(
+  text: string,
+): { text: string; blocks: SlackBlock[] } | null {
+  const regex = new RegExp(TABLE_REGEX.source, TABLE_REGEX.flags);
+  if (!regex.test(text)) return null;
+
+  regex.lastIndex = 0;
+  const blocks: SlackBlock[] = [];
+  let lastIndex = 0;
+
+  for (let match = regex.exec(text); match !== null; match = regex.exec(text)) {
+    const before = text.slice(lastIndex, match.index).trim();
+    if (before) {
+      pushSectionBlocks(blocks, markdownToSlack(before));
+    }
+
+    const rows = parseTableRows(match[0]);
+    const columnCount = rows[0]?.length ?? 0;
+    blocks.push({
+      type: "table",
+      column_settings: Array.from({ length: columnCount }, () => ({
+        align: "left" as const,
+      })),
+      rows: rows.map((row) =>
+        // Slack's table block rejects a cell whose text is empty ("must be more
+        // than 0 characters"), which a blank corner/header cell produces and
+        // fails the whole message with invalid_blocks. Coerce empties to a
+        // non-breaking space: a real character (passes validation) that still
+        // renders blank.
+        row.map((cell) => ({
+          type: "raw_text" as const,
+          text: cell || " ",
+        })),
+      ),
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  const after = text.slice(lastIndex).trim();
+  if (after) {
+    pushSectionBlocks(blocks, markdownToSlack(after));
+  }
+
+  return { text: markdownToSlack(text), blocks };
+}

--- a/agent/src/format.unit.test.ts
+++ b/agent/src/format.unit.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for agent/src/format.ts
+ * markdownToSlack: pure function, no mocking needed.
+ *
+ * Note on conversion order:
+ * The pipeline is: tables → headings(*) → bold(*) → italic(*→_) → code → links → hr
+ * Headings and **bold** are first wrapped in *, then the italic pass converts *x* → _x_.
+ * So headings and bold both render as _italic_ style in Slack (Slack italic = bold in some clients).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { markdownToBlocks, markdownToSlack } from "./format.ts";
+
+describe("markdownToSlack", () => {
+  // ─── Headings (become _italic_ due to conversion order) ───────────────────
+
+  test("converts h1 heading — wraps in underscores (italic)", () => {
+    expect(markdownToSlack("# Hello World")).toBe("_Hello World_");
+  });
+
+  test("converts h2 heading — wraps in underscores", () => {
+    expect(markdownToSlack("## Section Title")).toBe("_Section Title_");
+  });
+
+  test("converts h6 heading — wraps in underscores", () => {
+    expect(markdownToSlack("###### Deep Heading")).toBe("_Deep Heading_");
+  });
+
+  // ─── Bold (also becomes _italic_ due to conversion order) ─────────────────
+
+  test("converts **bold** — becomes _underscored_ in Slack", () => {
+    expect(markdownToSlack("This is **bold** text")).toBe(
+      "This is _bold_ text",
+    );
+  });
+
+  test("handles multiple **bold** spans", () => {
+    expect(markdownToSlack("**first** and **second**")).toBe(
+      "_first_ and _second_",
+    );
+  });
+
+  // ─── Italic ────────────────────────────────────────────────────────────────
+
+  test("converts *italic* to _italic_", () => {
+    expect(markdownToSlack("This is *italic* text")).toBe(
+      "This is _italic_ text",
+    );
+  });
+
+  // ─── Inline code ───────────────────────────────────────────────────────────
+
+  test("preserves inline code backticks unchanged", () => {
+    expect(markdownToSlack("Use `npm install` to install")).toBe(
+      "Use `npm install` to install",
+    );
+  });
+
+  // ─── Links ─────────────────────────────────────────────────────────────────
+
+  test("converts [text](url) to Slack <url|text> format", () => {
+    expect(markdownToSlack("[Click here](https://example.com)")).toBe(
+      "<https://example.com|Click here>",
+    );
+  });
+
+  test("handles multiple links", () => {
+    const input = "[A](https://a.com) and [B](https://b.com)";
+    expect(markdownToSlack(input)).toBe(
+      "<https://a.com|A> and <https://b.com|B>",
+    );
+  });
+
+  // ─── Horizontal rules ──────────────────────────────────────────────────────
+
+  test("converts --- to unicode line", () => {
+    expect(markdownToSlack("---")).toBe("─────────────────────");
+  });
+
+  test("converts longer --- to unicode line", () => {
+    expect(markdownToSlack("------")).toBe("─────────────────────");
+  });
+
+  // ─── Tables (require tight separators like |---|---| without spaces) ───────
+
+  test("converts markdown table with tight separator to code block", () => {
+    const table = "| Name | Value |\n|---|---|\n| foo | bar |\n";
+    const result = markdownToSlack(table);
+    expect(result).toContain("```");
+    expect(result).toContain("| Name | Value |");
+    expect(result).toContain("| foo | bar |");
+  });
+
+  test("converts markdown table with spaced separator | --- | --- |", () => {
+    const table = "| Name | Value |\n| --- | --- |\n| foo | bar |\n";
+    const result = markdownToSlack(table);
+    expect(result).toContain("```");
+    expect(result).toContain("| Name | Value |");
+    expect(result).toContain("| foo | bar |");
+  });
+
+  // ─── Trim ──────────────────────────────────────────────────────────────────
+
+  test("trims leading and trailing whitespace", () => {
+    expect(markdownToSlack("  hello  ")).toBe("hello");
+  });
+
+  // ─── Combined ──────────────────────────────────────────────────────────────
+
+  test("handles multi-line message with heading, bold, and link", () => {
+    const input = [
+      "# Report",
+      "",
+      "This is **important** information.",
+      "See [docs](https://docs.example.com) for details.",
+    ].join("\n");
+
+    const result = markdownToSlack(input);
+    expect(result).toContain("_Report_");
+    expect(result).toContain("_important_");
+    expect(result).toContain("<https://docs.example.com|docs>");
+  });
+
+  test("passes through plain text unchanged", () => {
+    expect(markdownToSlack("plain text with no markdown")).toBe(
+      "plain text with no markdown",
+    );
+  });
+
+  test("empty string returns empty string", () => {
+    expect(markdownToSlack("")).toBe("");
+  });
+});
+
+describe("markdownToBlocks", () => {
+  test("returns null when no table is present", () => {
+    expect(markdownToBlocks("just some *bold* text")).toBeNull();
+  });
+
+  test("builds a table block from a markdown table", () => {
+    const result = markdownToBlocks(
+      "| Name | Value |\n|---|---|\n| foo | bar |\n",
+    );
+    expect(result).not.toBeNull();
+    const table = result?.blocks.find((b) => b.type === "table") as
+      | { type: "table"; rows: Array<Array<{ type: string; text: string }>> }
+      | undefined;
+    expect(table).toBeDefined();
+    expect(table?.rows).toEqual([
+      [
+        { type: "raw_text", text: "Name" },
+        { type: "raw_text", text: "Value" },
+      ],
+      [
+        { type: "raw_text", text: "foo" },
+        { type: "raw_text", text: "bar" },
+      ],
+    ]);
+  });
+
+  test("coerces an empty corner/header cell to a non-empty placeholder (Slack rejects 0-char cells)", () => {
+    // Blank leading header cell — a common markdown table shape that previously
+    // produced text: "" and failed Slack with invalid_blocks.
+    const result = markdownToBlocks(
+      "|  | Col A | Col B |\n|---|---|---|\n| Row 1 | x | y |\n",
+    );
+    const table = result?.blocks.find((b) => b.type === "table") as
+      | { type: "table"; rows: Array<Array<{ type: string; text: string }>> }
+      | undefined;
+    expect(table).toBeDefined();
+    const allCells = table?.rows.flat() ?? [];
+    // No cell may have empty text.
+    expect(allCells.every((c) => c.text.length > 0)).toBe(true);
+    // The blank corner cell specifically became the placeholder.
+    expect(table?.rows[0][0]).toEqual({ type: "raw_text", text: " " });
+  });
+});

--- a/agent/src/format.unit.test.ts
+++ b/agent/src/format.unit.test.ts
@@ -3,40 +3,41 @@
  * markdownToSlack: pure function, no mocking needed.
  *
  * Note on conversion order:
- * The pipeline is: tables → headings(*) → bold(*) → italic(*→_) → code → links → hr
- * Headings and **bold** are first wrapped in *, then the italic pass converts *x* → _x_.
- * So headings and bold both render as _italic_ style in Slack (Slack italic = bold in some clients).
+ * The pipeline is: tables → italic(*→_) → headings(*) → bold(**→*) → code → links → hr
+ * The italic pass runs first (on the original markdown) so that the lookbehind/lookahead
+ * can distinguish *italic* from **bold**. Headings and **bold** become *text* (Slack bold),
+ * while *italic* becomes _text_ (Slack italic).
  */
 
 import { describe, expect, test } from "bun:test";
 import { markdownToBlocks, markdownToSlack } from "./format.ts";
 
 describe("markdownToSlack", () => {
-  // ─── Headings (become _italic_ due to conversion order) ───────────────────
+  // ─── Headings (become *bold* in Slack) ────────────────────────────────────
 
-  test("converts h1 heading — wraps in underscores (italic)", () => {
-    expect(markdownToSlack("# Hello World")).toBe("_Hello World_");
+  test("converts h1 heading — wraps in asterisks (Slack bold)", () => {
+    expect(markdownToSlack("# Hello World")).toBe("*Hello World*");
   });
 
-  test("converts h2 heading — wraps in underscores", () => {
-    expect(markdownToSlack("## Section Title")).toBe("_Section Title_");
+  test("converts h2 heading — wraps in asterisks", () => {
+    expect(markdownToSlack("## Section Title")).toBe("*Section Title*");
   });
 
-  test("converts h6 heading — wraps in underscores", () => {
-    expect(markdownToSlack("###### Deep Heading")).toBe("_Deep Heading_");
+  test("converts h6 heading — wraps in asterisks", () => {
+    expect(markdownToSlack("###### Deep Heading")).toBe("*Deep Heading*");
   });
 
-  // ─── Bold (also becomes _italic_ due to conversion order) ─────────────────
+  // ─── Bold (becomes *bold* in Slack) ───────────────────────────────────────
 
-  test("converts **bold** — becomes _underscored_ in Slack", () => {
+  test("converts **bold** — becomes *bold* in Slack", () => {
     expect(markdownToSlack("This is **bold** text")).toBe(
-      "This is _bold_ text",
+      "This is *bold* text",
     );
   });
 
   test("handles multiple **bold** spans", () => {
     expect(markdownToSlack("**first** and **second**")).toBe(
-      "_first_ and _second_",
+      "*first* and *second*",
     );
   });
 
@@ -116,8 +117,8 @@ describe("markdownToSlack", () => {
     ].join("\n");
 
     const result = markdownToSlack(input);
-    expect(result).toContain("_Report_");
-    expect(result).toContain("_important_");
+    expect(result).toContain("*Report*");
+    expect(result).toContain("*important*");
     expect(result).toContain("<https://docs.example.com|docs>");
   });
 

--- a/agent/src/health.ts
+++ b/agent/src/health.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+
+/**
+ * Create a minimal Hono health app for container liveness probes.
+ *
+ * GET /health → 200 { status: "ok" }
+ *
+ * No Slack state — the Shipwright reference agent is a CLI runner, not a
+ * long-lived Slack socket process.
+ */
+export function createHealthApp(): Hono {
+  const app = new Hono();
+  app.get("/health", (c) => c.json({ status: "ok" }));
+  return app;
+}

--- a/agent/src/health.unit.test.ts
+++ b/agent/src/health.unit.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for createHealthApp() in agent/src/health.ts
+ *
+ * Uses Hono's in-process app.request() — no real socket needed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createHealthApp } from "./health.ts";
+
+describe("GET /health", () => {
+  test("returns 200 with { status: 'ok' }", async () => {
+    const app = createHealthApp();
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string };
+    expect(body).toEqual({ status: "ok" });
+  });
+
+  test("response is JSON", async () => {
+    const app = createHealthApp();
+    const res = await app.request("/health");
+    expect(res.headers.get("content-type")).toContain("application/json");
+  });
+});
+
+describe("unknown routes", () => {
+  test("GET /other returns 404", async () => {
+    const app = createHealthApp();
+    const res = await app.request("/other");
+    expect(res.status).toBe(404);
+  });
+
+  test("POST /health returns 404 (only GET is registered)", async () => {
+    const app = createHealthApp();
+    const res = await app.request("/health", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+});

--- a/agent/src/markers.ts
+++ b/agent/src/markers.ts
@@ -1,0 +1,117 @@
+/**
+ * Response marker parsing for agent replies.
+ *
+ * Claude can embed special markers in its response text to trigger side-effect
+ * actions. Markers are stripped from the visible message before posting.
+ *
+ * Supported markers:
+ *   [silent]                        — skip posting
+ *   [upload:/path/to/file]          — upload a file
+ *   [speak:text]                    — synthesize speech and upload audio file
+ *   [react:emoji1,emoji2]           — add emoji reactions
+ *
+ * Malformed markers are logged and left in the cleaned text (not crashed on).
+ */
+
+interface SilentMarker {
+  type: "silent";
+}
+
+interface UploadMarker {
+  type: "upload";
+  path: string;
+}
+
+interface SpeakMarker {
+  type: "speak";
+  text: string;
+}
+
+interface ReactMarker {
+  type: "react";
+  emojis: string[];
+}
+
+export type Marker = SilentMarker | UploadMarker | SpeakMarker | ReactMarker;
+
+interface ParseMarkersResult {
+  cleaned: string;
+  markers: Marker[];
+}
+
+// Regex patterns — greedy non-nested matching.
+// [silent] must appear at the end of the response so meta-discussion of the
+// marker (e.g. "Use [silent] to skip posting") doesn't accidentally silence it.
+const SILENT_REGEX = /\[silent\]\s*$/i;
+const UPLOAD_REGEX = /\[upload:([^\]]+)\]/gi;
+const SPEAK_REGEX = /\[speak:([\s\S]*?)\]/gi;
+const REACT_REGEX = /\[react:([^\]]+)\]/gi;
+
+/**
+ * Parse all response markers from text.
+ * Returns the cleaned text (markers stripped) and an ordered list of markers found.
+ * Malformed markers are logged and left in the cleaned text.
+ */
+export function parseMarkers(text: string): ParseMarkersResult {
+  const markers: Marker[] = [];
+  let cleaned = text;
+
+  // [silent]
+  if (SILENT_REGEX.test(cleaned)) {
+    markers.push({ type: "silent" });
+    cleaned = cleaned.replace(SILENT_REGEX, "").trim();
+  }
+
+  // [upload:/path]
+  cleaned = cleaned.replace(UPLOAD_REGEX, (_match, pathRaw: string) => {
+    const path = pathRaw.trim();
+    if (!path) {
+      console.warn(
+        "[markers] malformed [upload:] marker — empty path, leaving in text:",
+        _match,
+      );
+      return _match;
+    }
+    markers.push({ type: "upload", path });
+    return "";
+  });
+  UPLOAD_REGEX.lastIndex = 0;
+  cleaned = cleaned.trim();
+
+  // [speak:text]
+  cleaned = cleaned.replace(SPEAK_REGEX, (_match, textRaw: string) => {
+    const text = textRaw.trim();
+    if (!text) {
+      console.warn(
+        "[markers] malformed [speak:] marker — empty text, leaving in text:",
+        _match,
+      );
+      return _match;
+    }
+    markers.push({ type: "speak", text });
+    return "";
+  });
+  SPEAK_REGEX.lastIndex = 0;
+  cleaned = cleaned.trim();
+
+  // [react:emoji1,emoji2,...]
+  cleaned = cleaned.replace(REACT_REGEX, (_match, raw: string) => {
+    const emojis = raw
+      .split(",")
+      .map((e) => e.trim())
+      .filter(Boolean);
+    if (emojis.length === 0) {
+      console.warn(
+        "[markers] malformed [react:] marker — empty emoji list, leaving in text:",
+        _match,
+      );
+      return _match;
+    }
+    markers.push({ type: "react", emojis });
+    return "";
+  });
+  REACT_REGEX.lastIndex = 0;
+  cleaned = cleaned.trim();
+
+  return { cleaned, markers };
+}

--- a/agent/src/markers.unit.test.ts
+++ b/agent/src/markers.unit.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for parseMarkers() in agent/src/markers.ts
+ *
+ * Pure function — no side effects, no mocks needed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseMarkers } from "./markers.ts";
+
+// ─── [silent] ─────────────────────────────────────────────────────────────────
+
+describe("[silent] marker", () => {
+  test("detects [silent] and returns silent marker", () => {
+    const { markers } = parseMarkers("[silent]");
+    expect(markers).toHaveLength(1);
+    expect(markers[0].type).toBe("silent");
+  });
+
+  test("strips [silent] from cleaned text", () => {
+    const { cleaned } = parseMarkers("[silent]");
+    expect(cleaned).toBe("");
+  });
+
+  test("[silent] in middle does NOT trigger silent marker", () => {
+    const { cleaned, markers } = parseMarkers("before [silent] after");
+    expect(markers.some((m) => m.type === "silent")).toBe(false);
+    expect(cleaned).toBe("before [silent] after");
+  });
+
+  test("[silent] at end triggers silent marker and strips it", () => {
+    const { cleaned, markers } = parseMarkers("All done.\n[silent]");
+    expect(markers.some((m) => m.type === "silent")).toBe(true);
+    expect(cleaned).toBe("All done.");
+  });
+
+  test("[silent] at start without trailing position is NOT silent", () => {
+    const { markers } = parseMarkers("[silent] but also text");
+    expect(markers.some((m) => m.type === "silent")).toBe(false);
+  });
+
+  test("[silent] with trailing whitespace still triggers silent", () => {
+    const { markers } = parseMarkers("[silent]   \n  ");
+    expect(markers.some((m) => m.type === "silent")).toBe(true);
+  });
+
+  test("is case-insensitive", () => {
+    const { markers } = parseMarkers("[SILENT]");
+    expect(markers.some((m) => m.type === "silent")).toBe(true);
+  });
+
+  test("text without [silent] has no silent marker", () => {
+    const { markers } = parseMarkers("Hello world");
+    expect(markers.some((m) => m.type === "silent")).toBe(false);
+  });
+});
+
+// ─── [upload:...] ─────────────────────────────────────────────────────────────
+
+describe("[upload:...] marker", () => {
+  test("parses a file path", () => {
+    const { markers, cleaned } = parseMarkers(
+      "See attached [upload:/tmp/report.pdf]",
+    );
+    const uploadMarker = markers.find((m) => m.type === "upload");
+    expect(uploadMarker).toBeDefined();
+    expect((uploadMarker as { type: "upload"; path: string }).path).toBe(
+      "/tmp/report.pdf",
+    );
+    expect(cleaned).toBe("See attached");
+  });
+
+  test("parses multiple upload markers", () => {
+    const { markers } = parseMarkers("[upload:/tmp/a.pdf][upload:/tmp/b.png]");
+    const uploads = markers.filter((m) => m.type === "upload") as {
+      type: "upload";
+      path: string;
+    }[];
+    expect(uploads).toHaveLength(2);
+    expect(uploads[0].path).toBe("/tmp/a.pdf");
+    expect(uploads[1].path).toBe("/tmp/b.png");
+  });
+
+  test("strips upload marker from cleaned text", () => {
+    const { cleaned } = parseMarkers("Done [upload:/tmp/out.csv]");
+    expect(cleaned).not.toContain("[upload:");
+  });
+
+  test("malformed upload with empty path is left in text", () => {
+    const { cleaned, markers } = parseMarkers("[upload:]");
+    expect(cleaned).toContain("[upload:]");
+    expect(markers.some((m) => m.type === "upload")).toBe(false);
+  });
+
+  test("malformed upload with whitespace-only path is left in text", () => {
+    const { cleaned, markers } = parseMarkers("[upload:   ]");
+    expect(cleaned).toContain("[upload:   ]");
+    expect(markers.some((m) => m.type === "upload")).toBe(false);
+  });
+});
+
+// ─── Multiple markers ─────────────────────────────────────────────────────────
+
+describe("multiple markers in one response", () => {
+  test("parses upload + speak together", () => {
+    const { markers, cleaned } = parseMarkers(
+      "Here is the report [upload:/tmp/report.pdf][speak:report ready]",
+    );
+    expect(markers.some((m) => m.type === "upload")).toBe(true);
+    expect(markers.some((m) => m.type === "speak")).toBe(true);
+    expect(cleaned).toBe("Here is the report");
+  });
+
+  test("silent with other markers — silent must be at end", () => {
+    const { markers } = parseMarkers("[upload:/tmp/out.txt][silent]");
+    expect(markers.some((m) => m.type === "silent")).toBe(true);
+    expect(markers.some((m) => m.type === "upload")).toBe(true);
+  });
+
+  test("no text remaining when all content is markers", () => {
+    const { cleaned } = parseMarkers("[silent]");
+    expect(cleaned).toBe("");
+  });
+});
+
+// ─── No markers ───────────────────────────────────────────────────────────────
+
+describe("no markers", () => {
+  test("returns unchanged text when no markers present", () => {
+    const input = "Just a plain response with no markers.";
+    const { cleaned, markers } = parseMarkers(input);
+    expect(cleaned).toBe(input);
+    expect(markers).toHaveLength(0);
+  });
+
+  test("returns empty string for empty input", () => {
+    const { cleaned, markers } = parseMarkers("");
+    expect(cleaned).toBe("");
+    expect(markers).toHaveLength(0);
+  });
+});
+
+// ─── [speak:...] ──────────────────────────────────────────────────────────────
+
+describe("[speak:text] marker", () => {
+  test("parses [speak:text] and returns speak marker", () => {
+    const { markers } = parseMarkers("[speak:Hello there]");
+    expect(markers).toHaveLength(1);
+    expect(markers[0].type).toBe("speak");
+    if (markers[0].type === "speak") {
+      expect(markers[0].text).toBe("Hello there");
+    }
+  });
+
+  test("strips [speak:text] from cleaned text", () => {
+    const { cleaned } = parseMarkers("Response text [speak:Hello there]");
+    expect(cleaned).toBe("Response text");
+  });
+
+  test("handles multi-word speak text", () => {
+    const { markers } = parseMarkers("[speak:The answer is 42, my friend]");
+    expect(markers[0].type).toBe("speak");
+    if (markers[0].type === "speak") {
+      expect(markers[0].text).toBe("The answer is 42, my friend");
+    }
+  });
+
+  test("malformed [speak:] with empty text — left in cleaned text", () => {
+    const { cleaned, markers } = parseMarkers("[speak:]");
+    expect(markers.some((m) => m.type === "speak")).toBe(false);
+    expect(cleaned).toContain("[speak:]");
+  });
+
+  test("speak with surrounding text preserves other content", () => {
+    const { cleaned, markers } = parseMarkers(
+      "Here is my answer. [speak:Here is my answer]",
+    );
+    expect(cleaned).toBe("Here is my answer.");
+    expect(markers.some((m) => m.type === "speak")).toBe(true);
+  });
+});
+
+// ─── [react:...] ──────────────────────────────────────────────────────────────
+
+describe("[react:emoji] marker", () => {
+  test("parses single emoji and returns react marker", () => {
+    const { markers } = parseMarkers("Nice work! [react:thumbsup]");
+    const reactMarker = markers.find((m) => m.type === "react");
+    expect(reactMarker).toBeDefined();
+    if (reactMarker?.type === "react") {
+      expect(reactMarker.emojis).toEqual(["thumbsup"]);
+    }
+  });
+
+  test("strips [react:emoji] from cleaned text", () => {
+    const { cleaned } = parseMarkers("Done [react:white_check_mark]");
+    expect(cleaned).toBe("Done");
+    expect(cleaned).not.toContain("[react:");
+  });
+
+  test("parses comma-separated emojis", () => {
+    const { markers } = parseMarkers("[react:thumbsup,tada]");
+    const reactMarker = markers.find((m) => m.type === "react");
+    expect(reactMarker).toBeDefined();
+    if (reactMarker?.type === "react") {
+      expect(reactMarker.emojis).toEqual(["thumbsup", "tada"]);
+    }
+  });
+
+  test("parses three emojis", () => {
+    const { markers } = parseMarkers("All good [react:thumbsup,tada,rocket]");
+    const reactMarker = markers.find((m) => m.type === "react");
+    if (reactMarker?.type === "react") {
+      expect(reactMarker.emojis).toEqual(["thumbsup", "tada", "rocket"]);
+    }
+  });
+
+  test("trims whitespace from emoji names", () => {
+    const { markers } = parseMarkers("[react: thumbsup , tada ]");
+    const reactMarker = markers.find((m) => m.type === "react");
+    if (reactMarker?.type === "react") {
+      expect(reactMarker.emojis).toEqual(["thumbsup", "tada"]);
+    }
+  });
+
+  test("malformed [react:] with empty content is left in text", () => {
+    const { cleaned, markers } = parseMarkers("[react:]");
+    expect(markers.some((m) => m.type === "react")).toBe(false);
+    expect(cleaned).toContain("[react:]");
+  });
+
+  test("react marker coexists with other markers", () => {
+    const { markers, cleaned } = parseMarkers("Done [react:thumbsup][silent]");
+    expect(markers.some((m) => m.type === "react")).toBe(true);
+    expect(markers.some((m) => m.type === "silent")).toBe(true);
+    expect(cleaned).toBe("Done");
+  });
+});

--- a/agent/src/posthog.ts
+++ b/agent/src/posthog.ts
@@ -1,0 +1,211 @@
+/**
+ * Forward shipwright metrics.jsonl entries to PostHog.
+ *
+ * Dev-task writes metrics reliably via the Write tool (not Bash), so we forward
+ * them from the cron handler rather than relying on Claude to run posthog_send.py.
+ *
+ * Usage:
+ *   const snapshot = snapshotMetrics(workspace);
+ *   await runner(message);
+ *   await forwardNewMetrics(workspace, snapshot);
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { TokenUsage } from "./claude.ts";
+import { liveClaudeConfig } from "./claude.ts";
+
+interface MetricsEntry {
+  task?: string;
+  title?: string;
+  session?: string;
+  repo?: string;
+  estimated_h?: number | null;
+  pr?: number | null;
+  files_changed?: number;
+  started_at?: string;
+  ts?: string;
+  simplify?: Record<string, number>;
+  requirements?: Record<string, number>;
+  ci?: { fix_attempts?: number; failures?: string[] };
+  [key: string]: unknown;
+}
+
+// All paths where dev-task may write metrics.jsonl, relative to workspace root.
+// The model writes to inconsistent paths depending on how it interprets the session
+// field, so we scan the known candidates rather than relying on a single path.
+function metricsFilePaths(workspace: string): string[] {
+  const paths: string[] = [
+    join(workspace, "state", "metrics.jsonl"),
+    join(workspace, "planning", "metrics.jsonl"),
+  ];
+
+  // Also pick up planning/{session}/metrics.jsonl
+  const planningDir = join(workspace, "planning");
+  if (existsSync(planningDir)) {
+    try {
+      for (const entry of readdirSync(planningDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          paths.push(join(planningDir, entry.name, "metrics.jsonl"));
+        }
+      }
+    } catch {
+      // Non-fatal — scan failure just means we miss subdirectory entries
+    }
+  }
+
+  return paths;
+}
+
+/** Read current line counts for all metrics files. Call before running Claude. */
+export function snapshotMetrics(workspace: string): Map<string, number> {
+  const snapshot = new Map<string, number>();
+  for (const path of metricsFilePaths(workspace)) {
+    if (!existsSync(path)) continue;
+    try {
+      const lines = readFileSync(path, "utf8")
+        .split("\n")
+        .filter((l) => l.trim());
+      snapshot.set(path, lines.length);
+    } catch {
+      // If we can't read it before, treat as 0 so we forward everything after
+      snapshot.set(path, 0);
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Read any lines appended since the snapshot, parse them as MetricsEntry objects,
+ * and POST them to PostHog as `shipwright_task_complete` events.
+ *
+ * Exits silently if POSTHOG_PROJECT_API_KEY is absent or PostHog is unreachable —
+ * metrics are best-effort and must never fail a cron run.
+ */
+export async function forwardNewMetrics(
+  workspace: string,
+  snapshot: Map<string, number>,
+): Promise<void> {
+  const apiKey = process.env.POSTHOG_PROJECT_API_KEY;
+  if (!apiKey) return;
+
+  const entries: MetricsEntry[] = [];
+
+  for (const path of metricsFilePaths(workspace)) {
+    if (!existsSync(path)) continue;
+    let lines: string[];
+    try {
+      lines = readFileSync(path, "utf8")
+        .split("\n")
+        .filter((l) => l.trim());
+    } catch {
+      continue;
+    }
+
+    const prevCount = snapshot.get(path) ?? 0;
+    for (const line of lines.slice(prevCount)) {
+      try {
+        entries.push(JSON.parse(line) as MetricsEntry);
+      } catch {
+        // Skip malformed lines
+      }
+    }
+  }
+
+  if (entries.length === 0) return;
+
+  const host = (process.env.POSTHOG_HOST ?? "https://us.i.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+
+  const batch = entries.map((entry) => ({
+    event: "shipwright_task_complete",
+    distinct_id: `shipwright/${entry.repo ?? "unknown"}/${entry.task ?? "unknown"}`,
+    timestamp: entry.ts ?? new Date().toISOString(),
+    properties: {
+      $insert_id: `shipwright_task_complete/${entry.repo ?? "unknown"}/${entry.task ?? "unknown"}`,
+      ...entry,
+    },
+  }));
+
+  try {
+    const res = await fetch(`${host}/batch/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_key: apiKey, batch }),
+    });
+    if (!res.ok) {
+      console.warn(
+        `[agent:posthog] batch POST failed: ${res.status} — ${entries.length} event(s) dropped`,
+      );
+    } else {
+      console.log(
+        `[agent:posthog] forwarded ${entries.length} metrics event(s) to PostHog`,
+      );
+    }
+  } catch (err) {
+    // PostHog is best-effort — never propagate to the caller
+    console.warn(
+      `[agent:posthog] batch POST error: ${(err as Error).message} — ${entries.length} event(s) dropped`,
+    );
+  }
+}
+
+type SessionType = "slack_dm" | "slack_mention" | "cron";
+
+/**
+ * Forward token usage data to PostHog as an `agent_token_usage` event.
+ *
+ * Best-effort — never throws, never blocks the caller.
+ * No-op when POSTHOG_PROJECT_API_KEY is absent or usage is undefined.
+ */
+export async function forwardTokenUsage(
+  usage: TokenUsage | undefined,
+  sessionType: SessionType,
+  model?: string,
+): Promise<void> {
+  if (!usage) return;
+  const apiKey = process.env.POSTHOG_PROJECT_API_KEY;
+  if (!apiKey) return;
+
+  const agentId = process.env.SHIPWRIGHT_AGENT_ID ?? "unknown";
+  const resolvedModel = model ?? liveClaudeConfig.model;
+  const ts = new Date().toISOString();
+  const host = (process.env.POSTHOG_HOST ?? "https://us.i.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+
+  const event = {
+    event: "agent_token_usage",
+    distinct_id: `agent/${agentId}`,
+    timestamp: ts,
+    properties: {
+      $insert_id: `agent_token_usage/${agentId}/${ts}`,
+      agent_id: agentId,
+      session_type: sessionType,
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cache_read_input_tokens: usage.cache_read_input_tokens,
+      cache_creation_input_tokens: usage.cache_creation_input_tokens,
+      model: resolvedModel,
+    },
+  };
+
+  try {
+    const res = await fetch(`${host}/batch/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_key: apiKey, batch: [event] }),
+    });
+    if (!res.ok) {
+      console.warn(`[agent:posthog] token usage POST failed: ${res.status}`);
+    }
+  } catch (err) {
+    // PostHog is best-effort — never propagate to the caller
+    console.warn(
+      `[agent:posthog] token usage POST error: ${(err as Error).message}`,
+    );
+  }
+}

--- a/agent/src/posthog.ts
+++ b/agent/src/posthog.ts
@@ -85,6 +85,7 @@ export function snapshotMetrics(workspace: string): Map<string, number> {
 export async function forwardNewMetrics(
   workspace: string,
   snapshot: Map<string, number>,
+  fetchFn: typeof fetch = globalThis.fetch,
 ): Promise<void> {
   const apiKey = process.env.POSTHOG_PROJECT_API_KEY;
   if (!apiKey) return;
@@ -130,7 +131,7 @@ export async function forwardNewMetrics(
   }));
 
   try {
-    const res = await fetch(`${host}/batch/`, {
+    const res = await fetchFn(`${host}/batch/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ api_key: apiKey, batch }),
@@ -164,6 +165,7 @@ export async function forwardTokenUsage(
   usage: TokenUsage | undefined,
   sessionType: SessionType,
   model?: string,
+  fetchFn: typeof fetch = globalThis.fetch,
 ): Promise<void> {
   if (!usage) return;
   const apiKey = process.env.POSTHOG_PROJECT_API_KEY;
@@ -194,7 +196,7 @@ export async function forwardTokenUsage(
   };
 
   try {
-    const res = await fetch(`${host}/batch/`, {
+    const res = await fetchFn(`${host}/batch/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ api_key: apiKey, batch: [event] }),

--- a/agent/src/posthog.unit.test.ts
+++ b/agent/src/posthog.unit.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for agent/src/posthog.ts — snapshotMetrics and forwardNewMetrics.
  *
- * posthog.ts directly wraps fetch(), so global.fetch mocking is acceptable
- * here per the project's no-global-mock exception for client implementations.
+ * Both forwardNewMetrics and forwardTokenUsage accept an optional fetchFn
+ * parameter for DI — tests pass a mock directly, following the same pattern
+ * as makeWhisperSvcClient in voice.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -120,7 +121,6 @@ describe("snapshotMetrics", () => {
 // ─── forwardNewMetrics ────────────────────────────────────────────────────────
 
 describe("forwardNewMetrics", () => {
-  const originalFetch = globalThis.fetch;
   let mockFetch: ReturnType<typeof mock>;
   const originalApiKey = process.env.POSTHOG_PROJECT_API_KEY;
 
@@ -128,12 +128,10 @@ describe("forwardNewMetrics", () => {
     mockFetch = mock(() =>
       Promise.resolve(new Response(null, { status: 200 })),
     );
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
     process.env.POSTHOG_PROJECT_API_KEY = "phc_test-key";
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
     if (originalApiKey === undefined) {
       process.env.POSTHOG_PROJECT_API_KEY = undefined;
     } else {
@@ -147,7 +145,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(join(ws, "state", "metrics.jsonl"), `${SAMPLE_ENTRY}\n`);
 
     const snap = new Map<string, number>();
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).not.toHaveBeenCalled();
     rmSync(ws, { recursive: true });
@@ -159,7 +157,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(path, `${SAMPLE_ENTRY}\n`);
 
     const snap = new Map([[path, 1]]);
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).not.toHaveBeenCalled();
     rmSync(ws, { recursive: true });
@@ -168,7 +166,7 @@ describe("forwardNewMetrics", () => {
   test("no-op when workspace has no metrics files at all", async () => {
     const ws = makeTmpWorkspace();
     const snap = new Map<string, number>();
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).not.toHaveBeenCalled();
     rmSync(ws, { recursive: true });
@@ -180,7 +178,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(path, `${SAMPLE_ENTRY}\n`);
 
     const snap = new Map([[path, 0]]);
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
@@ -209,7 +207,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(path, `${SAMPLE_ENTRY}\n`);
 
     const snap = new Map([[path, 0]]);
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     const body = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
@@ -226,7 +224,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(path, `${SAMPLE_ENTRY}\n${SAMPLE_ENTRY_2}\n`);
 
     const snap = new Map([[path, 0]]);
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse(
@@ -248,7 +246,7 @@ describe("forwardNewMetrics", () => {
     // snapshot sees 1 line; then a second line is added
     const snap = new Map([[path, 1]]);
     writeFileSync(path, `${SAMPLE_ENTRY}\n${SAMPLE_ENTRY_2}\n`);
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse(
@@ -267,7 +265,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(planningPath, `${SAMPLE_ENTRY_2}\n`);
 
     const snap = new Map<string, number>(); // both files unseen
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse(
@@ -283,7 +281,7 @@ describe("forwardNewMetrics", () => {
     writeFileSync(path, `not-json\n${SAMPLE_ENTRY}\n{broken\n`);
 
     const snap = new Map([[path, 0]]);
-    await forwardNewMetrics(ws, snap);
+    await forwardNewMetrics(ws, snap, mockFetch as unknown as typeof fetch);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse(
@@ -294,20 +292,20 @@ describe("forwardNewMetrics", () => {
   });
 
   test("does not throw when fetch fails — silent no-op", async () => {
-    mockFetch.mockImplementationOnce(() =>
-      Promise.reject(new Error("network error")),
-    );
+    const failFetch = mock(() => Promise.reject(new Error("network error")));
     const ws = makeTmpWorkspace();
     const path = join(ws, "state", "metrics.jsonl");
     writeFileSync(path, `${SAMPLE_ENTRY}\n`);
 
     const snap = new Map([[path, 0]]);
-    await expect(forwardNewMetrics(ws, snap)).resolves.toBeUndefined();
+    await expect(
+      forwardNewMetrics(ws, snap, failFetch as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
     rmSync(ws, { recursive: true });
   });
 
   test("does not throw when fetch returns non-200 — silent no-op", async () => {
-    mockFetch.mockImplementationOnce(() =>
+    const errorFetch = mock(() =>
       Promise.resolve(new Response(null, { status: 500 })),
     );
     const ws = makeTmpWorkspace();
@@ -315,7 +313,9 @@ describe("forwardNewMetrics", () => {
     writeFileSync(path, `${SAMPLE_ENTRY}\n`);
 
     const snap = new Map([[path, 0]]);
-    await expect(forwardNewMetrics(ws, snap)).resolves.toBeUndefined();
+    await expect(
+      forwardNewMetrics(ws, snap, errorFetch as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
     rmSync(ws, { recursive: true });
   });
 });
@@ -323,7 +323,6 @@ describe("forwardNewMetrics", () => {
 // ─── forwardTokenUsage ────────────────────────────────────────────────────────
 
 describe("forwardTokenUsage", () => {
-  const originalFetch = globalThis.fetch;
   let mockFetch: ReturnType<typeof mock>;
   const originalApiKey = process.env.POSTHOG_PROJECT_API_KEY;
   const originalAgentId = process.env.SHIPWRIGHT_AGENT_ID;
@@ -339,13 +338,11 @@ describe("forwardTokenUsage", () => {
     mockFetch = mock(() =>
       Promise.resolve(new Response(null, { status: 200 })),
     );
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
     process.env.POSTHOG_PROJECT_API_KEY = "phc_test-key";
     process.env.SHIPWRIGHT_AGENT_ID = "agent-abc-123";
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
     if (originalApiKey === undefined) {
       process.env.POSTHOG_PROJECT_API_KEY = undefined;
     } else {
@@ -359,7 +356,12 @@ describe("forwardTokenUsage", () => {
   });
 
   test("sends agent_token_usage event with all fields", async () => {
-    await forwardTokenUsage(SAMPLE_USAGE, "slack_dm", "claude-sonnet-4-5");
+    await forwardTokenUsage(
+      SAMPLE_USAGE,
+      "slack_dm",
+      "claude-sonnet-4-5",
+      mockFetch as unknown as typeof fetch,
+    );
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
@@ -387,21 +389,34 @@ describe("forwardTokenUsage", () => {
 
   test("no-op when POSTHOG_PROJECT_API_KEY is absent", async () => {
     process.env.POSTHOG_PROJECT_API_KEY = undefined;
-    await forwardTokenUsage(SAMPLE_USAGE, "cron");
+    await forwardTokenUsage(
+      SAMPLE_USAGE,
+      "cron",
+      undefined,
+      mockFetch as unknown as typeof fetch,
+    );
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test("no-op when usage is undefined", async () => {
-    await forwardTokenUsage(undefined, "slack_mention");
+    await forwardTokenUsage(
+      undefined,
+      "slack_mention",
+      undefined,
+      mockFetch as unknown as typeof fetch,
+    );
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test("does not throw when fetch fails", async () => {
-    mockFetch.mockImplementationOnce(() =>
-      Promise.reject(new Error("network error")),
-    );
+    const failFetch = mock(() => Promise.reject(new Error("network error")));
     await expect(
-      forwardTokenUsage(SAMPLE_USAGE, "slack_dm"),
+      forwardTokenUsage(
+        SAMPLE_USAGE,
+        "slack_dm",
+        undefined,
+        failFetch as unknown as typeof fetch,
+      ),
     ).resolves.toBeUndefined();
   });
 });

--- a/agent/src/posthog.unit.test.ts
+++ b/agent/src/posthog.unit.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for agent/src/posthog.ts — snapshotMetrics and forwardNewMetrics.
+ *
+ * posthog.ts directly wraps fetch(), so global.fetch mocking is acceptable
+ * here per the project's no-global-mock exception for client implementations.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TokenUsage } from "./claude.ts";
+import {
+  forwardNewMetrics,
+  forwardTokenUsage,
+  snapshotMetrics,
+} from "./posthog.ts";
+
+const SAMPLE_ENTRY = JSON.stringify({
+  task: "T-009",
+  title: "Update test.yml",
+  session: "test-readiness",
+  repo: "app-vitals/vitals-os",
+  estimated_h: null,
+  pr: 1031,
+  files_changed: 1,
+  started_at: "2026-05-13T05:45:00.000Z",
+  ts: "2026-05-13T05:46:00.000Z",
+  simplify: {
+    total: 0,
+    dry: 0,
+    dead_code: 0,
+    naming: 0,
+    complexity: 0,
+    consistency: 0,
+  },
+  requirements: { met: 3, partial: 0, not_met: 0, total: 4 },
+  ci: { fix_attempts: 0, failures: [] },
+});
+
+const SAMPLE_ENTRY_2 = JSON.stringify({
+  task: "T-010",
+  title: "Add canary stub",
+  session: "test-readiness",
+  repo: "app-vitals/vitals-os",
+  pr: 1032,
+  ts: "2026-05-13T06:00:00.000Z",
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpWorkspace(): string {
+  const ws = mkdtempSync(join(tmpdir(), "posthog-test-ws-"));
+  mkdirSync(join(ws, "state"), { recursive: true });
+  mkdirSync(join(ws, "planning"), { recursive: true });
+  return ws;
+}
+
+// ─── snapshotMetrics ──────────────────────────────────────────────────────────
+
+describe("snapshotMetrics", () => {
+  test("returns empty Map when no metrics files exist", () => {
+    const ws = makeTmpWorkspace();
+    const snap = snapshotMetrics(ws);
+    expect(snap.size).toBe(0);
+    rmSync(ws, { recursive: true });
+  });
+
+  test("records line count for state/metrics.jsonl", () => {
+    const ws = makeTmpWorkspace();
+    writeFileSync(
+      join(ws, "state", "metrics.jsonl"),
+      `${SAMPLE_ENTRY}\n${SAMPLE_ENTRY_2}\n`,
+    );
+
+    const snap = snapshotMetrics(ws);
+    expect(snap.get(join(ws, "state", "metrics.jsonl"))).toBe(2);
+    rmSync(ws, { recursive: true });
+  });
+
+  test("records line count for planning/metrics.jsonl", () => {
+    const ws = makeTmpWorkspace();
+    writeFileSync(join(ws, "planning", "metrics.jsonl"), `${SAMPLE_ENTRY}\n`);
+
+    const snap = snapshotMetrics(ws);
+    expect(snap.get(join(ws, "planning", "metrics.jsonl"))).toBe(1);
+    rmSync(ws, { recursive: true });
+  });
+
+  test("picks up planning/{session}/metrics.jsonl", () => {
+    const ws = makeTmpWorkspace();
+    mkdirSync(join(ws, "planning", "test-readiness"), { recursive: true });
+    writeFileSync(
+      join(ws, "planning", "test-readiness", "metrics.jsonl"),
+      `${SAMPLE_ENTRY}\n`,
+    );
+
+    const snap = snapshotMetrics(ws);
+    expect(
+      snap.get(join(ws, "planning", "test-readiness", "metrics.jsonl")),
+    ).toBe(1);
+    rmSync(ws, { recursive: true });
+  });
+
+  test("snapshots multiple files simultaneously", () => {
+    const ws = makeTmpWorkspace();
+    writeFileSync(join(ws, "state", "metrics.jsonl"), `${SAMPLE_ENTRY}\n`);
+    writeFileSync(
+      join(ws, "planning", "metrics.jsonl"),
+      `${SAMPLE_ENTRY}\n${SAMPLE_ENTRY_2}\n`,
+    );
+
+    const snap = snapshotMetrics(ws);
+    expect(snap.get(join(ws, "state", "metrics.jsonl"))).toBe(1);
+    expect(snap.get(join(ws, "planning", "metrics.jsonl"))).toBe(2);
+    rmSync(ws, { recursive: true });
+  });
+});
+
+// ─── forwardNewMetrics ────────────────────────────────────────────────────────
+
+describe("forwardNewMetrics", () => {
+  const originalFetch = globalThis.fetch;
+  let mockFetch: ReturnType<typeof mock>;
+  const originalApiKey = process.env.POSTHOG_PROJECT_API_KEY;
+
+  beforeEach(() => {
+    mockFetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test-key";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      process.env.POSTHOG_PROJECT_API_KEY = undefined;
+    } else {
+      process.env.POSTHOG_PROJECT_API_KEY = originalApiKey;
+    }
+  });
+
+  test("no-op when POSTHOG_PROJECT_API_KEY is absent", async () => {
+    process.env.POSTHOG_PROJECT_API_KEY = undefined;
+    const ws = makeTmpWorkspace();
+    writeFileSync(join(ws, "state", "metrics.jsonl"), `${SAMPLE_ENTRY}\n`);
+
+    const snap = new Map<string, number>();
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    rmSync(ws, { recursive: true });
+  });
+
+  test("no-op when no new lines since snapshot", async () => {
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n`);
+
+    const snap = new Map([[path, 1]]);
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    rmSync(ws, { recursive: true });
+  });
+
+  test("no-op when workspace has no metrics files at all", async () => {
+    const ws = makeTmpWorkspace();
+    const snap = new Map<string, number>();
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    rmSync(ws, { recursive: true });
+  });
+
+  test("POSTs new entry as shipwright_task_complete event", async () => {
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n`);
+
+    const snap = new Map([[path, 0]]);
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/batch/");
+    const body = JSON.parse(init.body as string) as {
+      api_key: string;
+      batch: {
+        event: string;
+        distinct_id: string;
+        properties: { task: string };
+      }[];
+    };
+    expect(body.api_key).toBe("phc_test-key");
+    expect(body.batch).toHaveLength(1);
+    expect(body.batch[0].event).toBe("shipwright_task_complete");
+    expect(body.batch[0].distinct_id).toBe(
+      "shipwright/app-vitals/vitals-os/T-009",
+    );
+    expect(body.batch[0].properties.task).toBe("T-009");
+    rmSync(ws, { recursive: true });
+  });
+
+  test("sets $insert_id for PostHog deduplication", async () => {
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n`);
+
+    const snap = new Map([[path, 0]]);
+    await forwardNewMetrics(ws, snap);
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: { properties: { $insert_id: string } }[] };
+    expect(body.batch[0].properties.$insert_id).toBe(
+      "shipwright_task_complete/app-vitals/vitals-os/T-009",
+    );
+    rmSync(ws, { recursive: true });
+  });
+
+  test("batches multiple new entries in a single POST", async () => {
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n${SAMPLE_ENTRY_2}\n`);
+
+    const snap = new Map([[path, 0]]);
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: { properties: { task: string } }[] };
+    expect(body.batch).toHaveLength(2);
+    expect(body.batch.map((e) => e.properties.task)).toEqual([
+      "T-009",
+      "T-010",
+    ]);
+    rmSync(ws, { recursive: true });
+  });
+
+  test("only forwards lines added since snapshot", async () => {
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n`);
+
+    // snapshot sees 1 line; then a second line is added
+    const snap = new Map([[path, 1]]);
+    writeFileSync(path, `${SAMPLE_ENTRY}\n${SAMPLE_ENTRY_2}\n`);
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: { properties: { task: string } }[] };
+    expect(body.batch).toHaveLength(1);
+    expect(body.batch[0].properties.task).toBe("T-010");
+    rmSync(ws, { recursive: true });
+  });
+
+  test("collects new entries from multiple files in one batch", async () => {
+    const ws = makeTmpWorkspace();
+    const statePath = join(ws, "state", "metrics.jsonl");
+    const planningPath = join(ws, "planning", "metrics.jsonl");
+    writeFileSync(statePath, `${SAMPLE_ENTRY}\n`);
+    writeFileSync(planningPath, `${SAMPLE_ENTRY_2}\n`);
+
+    const snap = new Map<string, number>(); // both files unseen
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: unknown[] };
+    expect(body.batch).toHaveLength(2);
+    rmSync(ws, { recursive: true });
+  });
+
+  test("skips malformed JSON lines without throwing", async () => {
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `not-json\n${SAMPLE_ENTRY}\n{broken\n`);
+
+    const snap = new Map([[path, 0]]);
+    await forwardNewMetrics(ws, snap);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: unknown[] };
+    expect(body.batch).toHaveLength(1); // only the valid entry
+    rmSync(ws, { recursive: true });
+  });
+
+  test("does not throw when fetch fails — silent no-op", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.reject(new Error("network error")),
+    );
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n`);
+
+    const snap = new Map([[path, 0]]);
+    await expect(forwardNewMetrics(ws, snap)).resolves.toBeUndefined();
+    rmSync(ws, { recursive: true });
+  });
+
+  test("does not throw when fetch returns non-200 — silent no-op", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(new Response(null, { status: 500 })),
+    );
+    const ws = makeTmpWorkspace();
+    const path = join(ws, "state", "metrics.jsonl");
+    writeFileSync(path, `${SAMPLE_ENTRY}\n`);
+
+    const snap = new Map([[path, 0]]);
+    await expect(forwardNewMetrics(ws, snap)).resolves.toBeUndefined();
+    rmSync(ws, { recursive: true });
+  });
+});
+
+// ─── forwardTokenUsage ────────────────────────────────────────────────────────
+
+describe("forwardTokenUsage", () => {
+  const originalFetch = globalThis.fetch;
+  let mockFetch: ReturnType<typeof mock>;
+  const originalApiKey = process.env.POSTHOG_PROJECT_API_KEY;
+  const originalAgentId = process.env.SHIPWRIGHT_AGENT_ID;
+
+  const SAMPLE_USAGE: TokenUsage = {
+    input_tokens: 100,
+    output_tokens: 200,
+    cache_read_input_tokens: 50,
+    cache_creation_input_tokens: 10,
+  };
+
+  beforeEach(() => {
+    mockFetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test-key";
+    process.env.SHIPWRIGHT_AGENT_ID = "agent-abc-123";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      process.env.POSTHOG_PROJECT_API_KEY = undefined;
+    } else {
+      process.env.POSTHOG_PROJECT_API_KEY = originalApiKey;
+    }
+    if (originalAgentId === undefined) {
+      process.env.SHIPWRIGHT_AGENT_ID = undefined;
+    } else {
+      process.env.SHIPWRIGHT_AGENT_ID = originalAgentId;
+    }
+  });
+
+  test("sends agent_token_usage event with all fields", async () => {
+    await forwardTokenUsage(SAMPLE_USAGE, "slack_dm", "claude-sonnet-4-5");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/batch/");
+    const body = JSON.parse(init.body as string) as {
+      api_key: string;
+      batch: {
+        event: string;
+        distinct_id: string;
+        properties: Record<string, unknown>;
+      }[];
+    };
+    expect(body.api_key).toBe("phc_test-key");
+    expect(body.batch).toHaveLength(1);
+    const evt = body.batch[0];
+    expect(evt.event).toBe("agent_token_usage");
+    expect(evt.properties.agent_id).toBe("agent-abc-123");
+    expect(evt.properties.session_type).toBe("slack_dm");
+    expect(evt.properties.input_tokens).toBe(100);
+    expect(evt.properties.output_tokens).toBe(200);
+    expect(evt.properties.cache_read_input_tokens).toBe(50);
+    expect(evt.properties.cache_creation_input_tokens).toBe(10);
+    expect(evt.properties.model).toBe("claude-sonnet-4-5");
+  });
+
+  test("no-op when POSTHOG_PROJECT_API_KEY is absent", async () => {
+    process.env.POSTHOG_PROJECT_API_KEY = undefined;
+    await forwardTokenUsage(SAMPLE_USAGE, "cron");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("no-op when usage is undefined", async () => {
+    await forwardTokenUsage(undefined, "slack_mention");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("does not throw when fetch fails", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.reject(new Error("network error")),
+    );
+    await expect(
+      forwardTokenUsage(SAMPLE_USAGE, "slack_dm"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/agent/src/sessions.ts
+++ b/agent/src/sessions.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import { type Clock, SystemClock } from "./clock.ts";
 
 interface SessionEntry {
   sessionId: string;
@@ -21,10 +22,13 @@ export function threadKey(channel: string, threadTs: string): string {
  *
  * Module-level default store removed — callers must wire their own store
  * via createFileSessionStore(config.paths.sessions).
+ *
+ * @param clock - Injectable clock for deterministic testing. Defaults to SystemClock.
  */
 export function createFileSessionStore(
   file: string,
   ttlMs: number = DEFAULT_TTL_MS,
+  clock: Clock = SystemClock(),
 ): {
   get: (key: string) => string | undefined;
   set: (key: string, id: string) => void;
@@ -59,7 +63,7 @@ export function createFileSessionStore(
       const map = load();
       const entry = map[key];
       if (!entry) return undefined;
-      if (isExpired(entry, Date.now())) {
+      if (isExpired(entry, clock.now().getTime())) {
         // Lazy prune: remove expired entry on access
         delete map[key];
         save(map);
@@ -69,7 +73,7 @@ export function createFileSessionStore(
     },
     set: (key, id) => {
       const map = load();
-      map[key] = { sessionId: id, updatedAt: Date.now() };
+      map[key] = { sessionId: id, updatedAt: clock.now().getTime() };
       save(map);
     },
     clear: (key) => {
@@ -80,7 +84,7 @@ export function createFileSessionStore(
     /** Remove all expired sessions. Returns count of pruned entries. */
     prune: () => {
       const map = load();
-      const now = Date.now();
+      const now = clock.now().getTime();
       let pruned = 0;
       for (const key of Object.keys(map)) {
         if (isExpired(map[key], now)) {

--- a/agent/src/sessions.ts
+++ b/agent/src/sessions.ts
@@ -1,0 +1,96 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+interface SessionEntry {
+  sessionId: string;
+  updatedAt: number; // epoch ms
+}
+
+/** On-disk format: values can be a plain string (legacy) or a SessionEntry object. */
+type SessionMap = Record<string, string | SessionEntry>;
+
+/** Default TTL: 7 days in milliseconds. Sessions older than this are pruned on load. */
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Key is channel:thread_ts (or channel:ts for the root of a new thread). */
+export function threadKey(channel: string, threadTs: string): string {
+  return `${channel}:${threadTs}`;
+}
+
+/**
+ * Create a file-backed session store at a specific path.
+ *
+ * Module-level default store removed — callers must wire their own store
+ * via createFileSessionStore(config.paths.sessions).
+ */
+export function createFileSessionStore(
+  file: string,
+  ttlMs: number = DEFAULT_TTL_MS,
+): {
+  get: (key: string) => string | undefined;
+  set: (key: string, id: string) => void;
+  clear: (key: string) => void;
+  prune: () => number;
+  size: () => number;
+} {
+  function load(): SessionMap {
+    try {
+      return JSON.parse(readFileSync(file, "utf8")) as SessionMap;
+    } catch {
+      return {};
+    }
+  }
+  function save(map: SessionMap): void {
+    writeFileSync(file, JSON.stringify(map, null, 2));
+  }
+
+  /** Extract sessionId from either legacy string or SessionEntry format. */
+  function resolveId(value: string | SessionEntry): string {
+    return typeof value === "string" ? value : value.sessionId;
+  }
+
+  /** Check if entry is expired. Legacy string entries are always considered valid (no timestamp). */
+  function isExpired(value: string | SessionEntry, now: number): boolean {
+    if (typeof value === "string") return false; // legacy format, no TTL
+    return now - value.updatedAt > ttlMs;
+  }
+
+  return {
+    get: (key) => {
+      const map = load();
+      const entry = map[key];
+      if (!entry) return undefined;
+      if (isExpired(entry, Date.now())) {
+        // Lazy prune: remove expired entry on access
+        delete map[key];
+        save(map);
+        return undefined;
+      }
+      return resolveId(entry);
+    },
+    set: (key, id) => {
+      const map = load();
+      map[key] = { sessionId: id, updatedAt: Date.now() };
+      save(map);
+    },
+    clear: (key) => {
+      const map = load();
+      delete map[key];
+      save(map);
+    },
+    /** Remove all expired sessions. Returns count of pruned entries. */
+    prune: () => {
+      const map = load();
+      const now = Date.now();
+      let pruned = 0;
+      for (const key of Object.keys(map)) {
+        if (isExpired(map[key], now)) {
+          delete map[key];
+          pruned++;
+        }
+      }
+      if (pruned > 0) save(map);
+      return pruned;
+    },
+    size: () => Object.keys(load()).length,
+  };
+}

--- a/agent/src/sessions.unit.test.ts
+++ b/agent/src/sessions.unit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for createFileSessionStore and threadKey in agent/src/sessions.ts
+ *
+ * Uses a tmp dir — no mocks, pure file I/O.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFileSessionStore, threadKey } from "./sessions.ts";
+
+const TMP_DIR = mkdtempSync(join(tmpdir(), "sessions-unit-test-"));
+const SESSIONS_FILE = join(TMP_DIR, "sessions.json");
+
+afterAll(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+// ─── threadKey ─────────────────────────────────────────────────────────────
+
+describe("threadKey", () => {
+  test("returns channel:ts format", () => {
+    expect(threadKey("C123", "1234567890.000100")).toBe(
+      "C123:1234567890.000100",
+    );
+  });
+
+  test("different channels produce different keys", () => {
+    expect(threadKey("C1", "ts")).not.toBe(threadKey("C2", "ts"));
+  });
+});
+
+// ─── createFileSessionStore ────────────────────────────────────────────────
+
+describe("createFileSessionStore", () => {
+  let store: ReturnType<typeof createFileSessionStore>;
+
+  beforeEach(() => {
+    // Fresh file path per test group to avoid bleed
+    const file = join(TMP_DIR, `sessions-${Date.now()}-${Math.random()}.json`);
+    store = createFileSessionStore(file, 60_000);
+  });
+
+  test("get returns undefined for missing key", () => {
+    expect(store.get("no-such-key")).toBeUndefined();
+  });
+
+  test("set + get roundtrip", () => {
+    store.set("key1", "session-abc");
+    expect(store.get("key1")).toBe("session-abc");
+  });
+
+  test("set overwrites existing entry", () => {
+    store.set("key1", "session-old");
+    store.set("key1", "session-new");
+    expect(store.get("key1")).toBe("session-new");
+  });
+
+  test("clear removes key", () => {
+    store.set("key1", "session-abc");
+    store.clear("key1");
+    expect(store.get("key1")).toBeUndefined();
+  });
+
+  test("clear on missing key is a no-op", () => {
+    expect(() => store.clear("does-not-exist")).not.toThrow();
+  });
+
+  test("size returns count of stored entries", () => {
+    expect(store.size()).toBe(0);
+    store.set("k1", "s1");
+    expect(store.size()).toBe(1);
+    store.set("k2", "s2");
+    expect(store.size()).toBe(2);
+    store.clear("k1");
+    expect(store.size()).toBe(1);
+  });
+
+  test("TTL-based expiry: expired entry returns undefined", () => {
+    const shortTtlFile = join(
+      TMP_DIR,
+      `sessions-ttl-${Date.now()}.json`,
+    );
+    const shortStore = createFileSessionStore(shortTtlFile, 1); // 1ms TTL
+    shortStore.set("k", "session-xyz");
+    // The set() writes updatedAt = Date.now(). We need it to expire.
+    // Spin until enough time has passed (should be near-instant).
+    const deadline = Date.now() + 1000;
+    while (Date.now() < deadline) {
+      const val = shortStore.get("k");
+      if (val === undefined) break;
+    }
+    expect(shortStore.get("k")).toBeUndefined();
+  });
+
+  test("prune removes expired entries and returns count", () => {
+    const pruneFile = join(TMP_DIR, `sessions-prune-${Date.now()}.json`);
+    const pruneStore = createFileSessionStore(pruneFile, 1); // 1ms TTL
+    pruneStore.set("k1", "s1");
+    pruneStore.set("k2", "s2");
+    // Wait for TTL to expire
+    const deadline = Date.now() + 1000;
+    while (Date.now() < deadline) {
+      if (pruneStore.size() === 0) break;
+      const pruned = pruneStore.prune();
+      if (pruned > 0) break;
+    }
+    expect(pruneStore.size()).toBe(0);
+  });
+
+  test("prune returns 0 when nothing is expired", () => {
+    store.set("k1", "s1");
+    store.set("k2", "s2");
+    expect(store.prune()).toBe(0);
+    expect(store.size()).toBe(2);
+  });
+
+  test("legacy string format support: get returns sessionId string", () => {
+    // Write a legacy-format file manually
+    const legacyFile = join(TMP_DIR, `sessions-legacy-${Date.now()}.json`);
+    writeFileSync(
+      legacyFile,
+      JSON.stringify({ "C1:ts1": "legacy-session-id" }),
+    );
+    const legacyStore = createFileSessionStore(legacyFile, 60_000);
+    // Legacy string entries have no TTL — always valid
+    expect(legacyStore.get("C1:ts1")).toBe("legacy-session-id");
+  });
+
+  test("multiple keys are independent", () => {
+    store.set("k1", "s1");
+    store.set("k2", "s2");
+    expect(store.get("k1")).toBe("s1");
+    expect(store.get("k2")).toBe("s2");
+    store.clear("k1");
+    expect(store.get("k1")).toBeUndefined();
+    expect(store.get("k2")).toBe("s2");
+  });
+});

--- a/agent/src/users.ts
+++ b/agent/src/users.ts
@@ -1,0 +1,45 @@
+/**
+ * Generic user display name resolver with in-memory cache.
+ *
+ * Uses a structural UserResolverClient interface instead of importing
+ * @slack/web-api directly — keeping the agent package Slack-agnostic.
+ */
+
+// In-memory cache — survives for the lifetime of the process
+const cache = new Map<string, string>();
+
+export interface UserResolverClient {
+  users: {
+    info(args: { user: string }): Promise<{
+      user?: {
+        profile?: { display_name?: string; real_name?: string };
+        name?: string;
+      };
+    }>;
+  };
+}
+
+export async function resolveDisplayName(
+  userId: string,
+  client: UserResolverClient,
+): Promise<string> {
+  const cached = cache.get(userId);
+  if (cached !== undefined) return cached;
+
+  try {
+    const res = await client.users.info({ user: userId });
+    const name =
+      res.user?.profile?.display_name ||
+      res.user?.profile?.real_name ||
+      res.user?.name ||
+      userId;
+    cache.set(userId, name);
+    return name;
+  } catch (err) {
+    console.warn(
+      `[users] failed to resolve display name for ${userId}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return userId;
+  }
+}

--- a/agent/src/users.ts
+++ b/agent/src/users.ts
@@ -5,8 +5,15 @@
  * @slack/web-api directly — keeping the agent package Slack-agnostic.
  */
 
-// In-memory cache — survives for the lifetime of the process
+// In-memory cache — survives for the lifetime of the process.
+// Export clearCache() for test teardown to prevent cross-test leakage
+// when Bun shares the module between test files.
 const cache = new Map<string, string>();
+
+/** Clear the in-memory display name cache. Use in test afterEach teardown. */
+export function clearCache(): void {
+  cache.clear();
+}
 
 export interface UserResolverClient {
   users: {

--- a/agent/src/voice.ts
+++ b/agent/src/voice.ts
@@ -1,0 +1,254 @@
+import { type SpawnOptions, spawn } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const VOICE_DIR = join(tmpdir(), "shipwright-agent-voice");
+const WHISPER_MAX_BYTES = 25 * 1024 * 1024; // 25MB
+
+export interface VoiceConfig {
+  groqApiKey?: string;
+  elevenLabsApiKey?: string;
+  voiceId?: string;
+  whisperServiceUrl?: string;
+}
+
+// DI seam for the whisper-svc HTTP client — replaces spawnFn from the old local-Whisper path
+export type WhisperClientFn = (
+  audioBuffer: Buffer,
+  audioPath: string,
+) => Promise<string | null>;
+
+type SpawnFn = (
+  command: string,
+  args: string[],
+  options?: SpawnOptions,
+) => ReturnType<typeof spawn>;
+
+const defaultSpawn: SpawnFn = (cmd, args, opts) => spawn(cmd, args, opts ?? {});
+
+/**
+ * Creates an HTTP client that transcribes audio via the whisper-svc POST /transcribe endpoint.
+ * Accepts an optional fetchFn for dependency injection in tests (avoids global.fetch mocking).
+ */
+export function makeWhisperSvcClient(
+  serviceUrl: string,
+  fetchFn: typeof fetch = globalThis.fetch,
+): WhisperClientFn {
+  return async (
+    audioBuffer: Buffer,
+    audioPath: string,
+  ): Promise<string | null> => {
+    const formData = new FormData();
+    const blob = new Blob([new Uint8Array(audioBuffer)]);
+    formData.append("file", blob, audioPath.split("/").pop() ?? "audio.wav");
+
+    let resp: Response;
+    try {
+      resp = await fetchFn(`${serviceUrl}/transcribe`, {
+        method: "POST",
+        body: formData,
+      });
+    } catch (err) {
+      console.warn("[voice] whisper-svc request failed:", err);
+      return null;
+    }
+
+    if (!resp.ok) {
+      console.warn(
+        "[voice] whisper-svc transcription failed:",
+        resp.status,
+        await resp.text(),
+      );
+      return null;
+    }
+
+    const data = (await resp.json()) as { text: string };
+    return data.text ?? null;
+  };
+}
+
+/**
+ * Transcribe an audio file via Groq Whisper API.
+ * Returns the transcription text, or null on any error.
+ */
+async function transcribeGroq(
+  audioPath: string,
+  fileBuffer: Buffer,
+  apiKey: string,
+): Promise<string | null> {
+  const formData = new FormData();
+  const blob = new Blob([new Uint8Array(fileBuffer)]);
+  formData.append("file", blob, audioPath.split("/").pop() ?? "audio.webm");
+  formData.append("model", "whisper-large-v3");
+
+  let resp: Response;
+  try {
+    resp = await fetch("https://api.groq.com/openai/v1/audio/transcriptions", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: formData,
+    });
+  } catch (err) {
+    console.error("[voice] Groq STT request failed:", err);
+    return null;
+  }
+
+  if (!resp.ok) {
+    console.error("[voice] Groq STT failed:", resp.status, await resp.text());
+    return null;
+  }
+
+  const data = (await resp.json()) as { text: string };
+  return data.text ?? null;
+}
+
+/**
+ * Transcribe an audio file.
+ * Fallback chain: Groq (if key set) → whisper-svc HTTP (if URL set or client injected) → null
+ *
+ * Accepts an optional whisperClientFn for DI in tests.
+ */
+export async function transcribeAudio(
+  audioPath: string,
+  voiceConfig: VoiceConfig = {},
+  whisperClientFn?: WhisperClientFn,
+): Promise<string | null> {
+  let fileBuffer: Buffer;
+  try {
+    fileBuffer = readFileSync(audioPath);
+  } catch (err) {
+    console.warn("[voice] could not read audio file:", err);
+    return null;
+  }
+
+  if (fileBuffer.byteLength > WHISPER_MAX_BYTES) {
+    console.warn(
+      `[voice] audio file exceeds 25MB limit (${fileBuffer.byteLength} bytes) — skipping transcription`,
+    );
+    return null;
+  }
+
+  const apiKey = voiceConfig.groqApiKey;
+  if (apiKey) {
+    const groqResult = await transcribeGroq(audioPath, fileBuffer, apiKey);
+    if (groqResult !== null) {
+      return groqResult;
+    }
+    console.warn(
+      "[voice] Groq transcription failed — falling back to whisper-svc",
+    );
+  }
+
+  const clientFn =
+    whisperClientFn ??
+    (voiceConfig.whisperServiceUrl
+      ? makeWhisperSvcClient(voiceConfig.whisperServiceUrl)
+      : null);
+
+  if (!clientFn) return null;
+  return clientFn(fileBuffer, audioPath);
+}
+
+/**
+ * Synthesize speech from text using ElevenLabs (if key available) or edge-tts fallback.
+ * Returns the path to the generated audio file, or null on failure.
+ */
+export async function synthesizeSpeech(
+  text: string,
+  voiceConfig: VoiceConfig = {},
+  spawnFn: SpawnFn = defaultSpawn,
+): Promise<string | null> {
+  mkdirSync(VOICE_DIR, { recursive: true });
+
+  const elevenKey = voiceConfig.elevenLabsApiKey;
+  if (elevenKey) {
+    return synthesizeElevenLabs(text, elevenKey, voiceConfig.voiceId);
+  }
+
+  return synthesizeEdgeTTS(text, spawnFn);
+}
+
+async function synthesizeElevenLabs(
+  text: string,
+  apiKey: string,
+  voiceId?: string,
+): Promise<string | null> {
+  const vid = voiceId ?? "CwhRBWXzGAHq8TQ4Fs17"; // Roger
+
+  let resp: Response;
+  try {
+    resp = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${vid}`, {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text, model_id: "eleven_flash_v2_5" }),
+    });
+  } catch (err) {
+    console.error("[voice] ElevenLabs TTS request failed:", err);
+    return null;
+  }
+
+  if (!resp.ok) {
+    console.error(
+      "[voice] ElevenLabs TTS failed:",
+      resp.status,
+      await resp.text(),
+    );
+    return null;
+  }
+
+  const outPath = join(VOICE_DIR, `${Date.now()}-response.mp3`);
+  writeFileSync(outPath, Buffer.from(await resp.arrayBuffer()));
+  return outPath;
+}
+
+function synthesizeEdgeTTS(
+  text: string,
+  spawnFn: SpawnFn = defaultSpawn,
+): Promise<string | null> {
+  const outPath = join(VOICE_DIR, `${Date.now()}-response.mp3`);
+
+  return new Promise((resolve) => {
+    let proc: ReturnType<typeof spawn>;
+    try {
+      proc = spawnFn("edge-tts", [
+        "--voice",
+        "en-US-GuyNeural",
+        // edge-tts validates pitch as `[+-]\d+Hz` — `%` is only valid for rate/volume.
+        "--pitch=-15Hz",
+        "--text",
+        text,
+        "--write-media",
+        outPath,
+      ]);
+    } catch (err) {
+      console.error("[voice] edge-tts spawn error:", err);
+      resolve(null);
+      return;
+    }
+
+    const stderrChunks: Buffer[] = [];
+    proc.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+    let errorFired = false;
+    proc.on("error", (err) => {
+      errorFired = true;
+      console.error("[voice] edge-tts spawn error:", err);
+      resolve(null);
+    });
+
+    proc.on("close", (code) => {
+      if (errorFired) return;
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString();
+        console.error("[voice] edge-tts failed with exit code", code, stderr);
+        resolve(null);
+        return;
+      }
+      resolve(outPath);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Port 10 core agent modules from vitals-os/agent/src/ to the Shipwright reference agent: `claude.ts`, `markers.ts`, `format.ts`, `sessions.ts`, `config.ts`, `health.ts`, `analytics.ts`, `posthog.ts`, `users.ts`, `voice.ts`
- Adapt for Shipwright: config reads `SHIPWRIGHT_API_URL`, `SHIPWRIGHT_INTERNAL_API_KEY`, `SHIPWRIGHT_AGENT_ID` instead of vitals-os env vars
- Add 6 unit test files (102 tests) for markers, format, sessions, config, health, and posthog

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All ported modules pass bun typecheck with no vitals-os env var names remaining | MET |
| 2 | markers.ts unit tests pass (end-anchored regex for [silent], [upload:], [react:], [speak:]) | MET |
| 3 | config.ts reads SHIPWRIGHT_* env vars exclusively | MET |
| 4 | Health endpoint GET /health returns { status: 'ok' } with 200 | MET |
| 5 | Unit tests for markers, format, sessions, config; no existing tests retired | MET |

## Test Plan
- [x] `bun test agent/src/` — 191 pass, 55 skip (integration, need DB), 0 fail
- [x] `bun run --cwd agent typecheck` — clean
- [x] `bunx biome lint agent/src/` — clean
- [x] Coverage: config 100%, health 100%, sessions 100%, posthog 98%, markers 91%, format 86%

Generated with [Claude Code](https://claude.com/claude-code)
