### PR TITLE
fix: use latest plugin version when resolving scripts from cache

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.26.1",
+  "version": "4.26.4",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.26.0
+# Shipwright v4.26.4
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -38,7 +38,7 @@ AGENT_LOGIN=$(gh api user --jq '.login')
 
 Resolve the configured repos:
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 REPOS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos)
 ```
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -19,7 +19,7 @@ Auto-detect the project toolchain (run once, reuse throughout). Skip this step u
 **First, check for an interrupted task** — if a prior session left a task `in_progress`, resume it:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" query --status in_progress
 ```
 
@@ -34,7 +34,7 @@ Record `task_started_at` (current ISO timestamp) for metrics.
 **If no in_progress task**, pick the next ready pending task:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" query --ready
 ```
 
@@ -109,7 +109,7 @@ If the task's current status is already `in_progress`:
 ### Mark In-Progress
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set startedAt={ISO timestamp} --set status=in_progress
 ```
 
@@ -437,7 +437,7 @@ Store these counts for use in Step 10b metrics.
 If any criterion is PARTIAL or NOT MET after the fix loop, mark the task blocked via task_store.ts, then fire `shipwright_task_blocked`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set blockedReason=requirements_not_met --set status=blocked
 ```
 
@@ -663,7 +663,7 @@ If PR creation fails, OR if CI checks fail after max retries (Step 9b.5), after 
 This cleanup ensures no orphaned PRs or branches are left behind. Mark the task blocked via task_store.ts, then fire `shipwright_task_blocked`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set blockedReason=pr_creation_failed --set status=blocked
 ```
 
@@ -854,7 +854,7 @@ Failing checks:
 Run PR Failure Cleanup (Step 9) and stop. Mark the task blocked via task_store.ts, then fire `shipwright_task_blocked`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set blockedReason=ci_max_retries_exhausted --set status=blocked
 ```
 
@@ -869,7 +869,7 @@ POSTHOG_SCRIPT=$(find ~/.claude/plugins/cache -name "posthog_send.py" -path "*/s
 ### 10a. Update Queue
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set pr={pr_number} --set prCreatedAt={ISO timestamp} --set status=pr_open
 ```
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -33,7 +33,7 @@ CURRENT_USER=$(gh api /user -q '.login')
 Resolve the list of repos to scan. Use the same resolver as other shipwright commands:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 REPOS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos)
 ```
 

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -40,7 +40,7 @@ If `SHIPWRIGHT_CONFIG` is set, read the config file and check the `taskStore` fi
 When `taskStore` is `"github"`, run the task store setup before any context loading:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 [ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" setup
 ```
 
@@ -57,7 +57,7 @@ If `SHIPWRIGHT_CONFIG` is not set, or `taskStore` is `"json"` (the default), ski
 2. Glob the repo structure to understand the codebase layout
 3. Check for any existing tasks in this session to avoid duplicates:
    ```bash
-   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
    [ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" query --session {session}
    ```
    The output is a JSON array. If non-empty, print the existing task IDs and skip re-adding them.
@@ -273,7 +273,7 @@ Write the new tasks to a temp file `/tmp/new-tasks-{session}.json` as a JSON arr
 Append them to `state/todos.json` via task_store.ts (idempotent by id — safe to re-run):
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks-{session}.json
 ```
 
@@ -391,7 +391,7 @@ jq --arg src "$PARENT_REF" \
 **Step 6d — Append tasks to the store:**
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks-{session}-linked.json
 ```
 

--- a/plugins/shipwright/commands/refresh-plan.md
+++ b/plugins/shipwright/commands/refresh-plan.md
@@ -21,7 +21,7 @@ Follow all steps in order.
 5. Query task_store for live statuses:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" query --session $ARGUMENTS
 ```
 

--- a/plugins/shipwright/commands/research-docs.md
+++ b/plugins/shipwright/commands/research-docs.md
@@ -93,7 +93,7 @@ For any module that has no corresponding doc (identified by scanning for modules
 Do NOT generate the doc automatically. Instead, write a follow-on task via `task_store.ts append`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 # Write task JSON to temp file, then:
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/missing-docs-tasks.json
 ```

--- a/plugins/shipwright/commands/review-patch.md
+++ b/plugins/shipwright/commands/review-patch.md
@@ -30,7 +30,7 @@ Store `START_TIME` — it is used in every subsequent iteration to check elapsed
 Resolve the plugin scripts directory from the cache:
 
 ```bash
-CHECK_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "check-patch.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+CHECK_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "check-patch.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 ```
 
 Run both prechecks to determine if there is anything to do:

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -104,7 +104,7 @@ processed or skipped, continue to Step 3b.
 If `review_external_prs` is true, resolve the configured repos and fetch open PRs for each:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
 REPOS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos)
 ```
 
@@ -631,7 +631,7 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
 1. Parse the argument: extract `org`, `repo`, and `pr` number. For bare numbers,
    infer `org/repo` via:
    ```bash
-   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
    bun "$PLUGIN_SCRIPTS/task_store.ts" repos | head -1
    ```
    Fall back to the current workspace repo if the command fails.


### PR DESCRIPTION
## Summary

- Replace `find ... | head -1 | xargs dirname` with `find ... | sort -V | tail -1 | xargs dirname` across all PLUGIN_SCRIPTS/CHECK_SCRIPTS resolutions in every command file
- `head -1` returns whichever version the filesystem puts first (hash-tree order on ext4), which on the agent resolves to 4.26.0 — not the newest installed version
- 4.26.0 has a bug where `listPrCommits` ignores the `repo` parameter and always uses `allRepos[0]`, so merge-only detection silently fails for any repo that isn't first — causing unnecessary re-reviews of PRs with only merge commits since last review
- Posthog lookups and `task_store.ts repos | head -1` (getting first configured repo) are intentionally unchanged
- Bump to 4.26.4 (skipping 4.26.2/4.26.3 published from vitals-os); also syncs README which was still at v4.26.0

## Files changed

- 8 command files: `review-patch.md`, `review.md`, `dev-task.md`, `plan-session.md`, `patch.md`, `deploy.md`, `refresh-plan.md`, `research-docs.md`
- `plugin.json`: 4.26.1 → 4.26.4
- `README.md`: v4.26.0 → v4.26.4

## Test plan

- [ ] Confirm `find ... | sort -V | tail -1` resolves to 4.26.4 once published
- [ ] Confirm `posthog_send.py` and `task_store.ts repos | head -1` lines unchanged
- [ ] Confirm review-patch loop uses correct `check-review.ts` version (merge-only detection works for second repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)