### PR TITLE
feat(SW-1.7): wire secret-scan + task-store doctor CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,16 @@ jobs:
       - name: Check banned strings
         run: task check-strings
 
+      - name: Secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Typecheck
         run: task typecheck
 
       - name: Test
         run: task test
+
+      - name: Task store doctor
+        run: task doctor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,18 @@ jobs:
       - name: Check banned strings
         run: task check-strings
 
-      - name: Secret scan
-        run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz" | tar -xz gitleaks
-          ./gitleaks detect --source . --no-git --redact
-
       - name: Typecheck
         run: task typecheck
 
       - name: Test
         run: task test
+
+      - name: Secret scan
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz" -o gitleaks.tar.gz
+          echo "141c3b2dede46d8b3a53b47116da756bd223decc0374797559a6b50ecba5590c  gitleaks.tar.gz" | sha256sum -c
+          tar -xz -f gitleaks.tar.gz gitleaks
+          ./gitleaks detect --source . --no-git --redact
 
       - name: Task store doctor
         run: task doctor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         run: task check-strings
 
       - name: Secret scan
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks detect --source . --no-git --redact
 
       - name: Typecheck
         run: task typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ go-task (`Taskfile.yml`) is the single local entrypoint; the root `package.json`
 
 ```bash
 task setup        # bun install across all workspaces
-task ci           # lint → check-strings → typecheck → test (the merge-blocking gate; CI runs this exact chain)
+task ci           # lint → check-strings → typecheck → test → secret-scan → doctor (the merge-blocking gate; CI runs this exact chain)
 task test         # bun test            (single file: bun test path/to/file.test.ts)
 task lint         # bunx biome lint .
 task format       # bunx biome format --write .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,12 +32,14 @@ tasks:
       - bun plugins/shipwright/scripts/check-banned-strings.ts
 
   ci:
-    desc: Run all CI checks (lint → check-strings → typecheck → test)
+    desc: Run all CI checks (lint → check-strings → typecheck → test → secret-scan → doctor)
     cmds:
       - task: lint
       - task: check-strings
       - task: typecheck
       - task: test
+      - task: secret-scan
+      - task: doctor
 
   db:provision:
     desc: Create the agent database (idempotent — safe to re-run)
@@ -60,6 +62,16 @@ tasks:
         cd agent && bunx prisma migrate dev --schema=prisma/schema.prisma
 
   secret-scan:
-    desc: Scan for accidentally committed secrets
+    desc: Scan for accidentally committed secrets (gitleaks)
     cmds:
-      - echo "Secret scan placeholder — gitleaks/detect-secrets to be wired in SW-1.7"
+      - |
+        if command -v gitleaks &>/dev/null; then
+          gitleaks detect --source . --no-git --redact
+        else
+          echo "WARNING: gitleaks not installed locally — skipping secret scan. CI enforces this gate."
+        fi
+
+  doctor:
+    desc: Validate task-store config and report active backend
+    cmds:
+      - bun plugins/shipwright/scripts/task_store.ts doctor

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -88,7 +88,7 @@ The agent is a thin runner with a Prisma-backed SQLite/PostgreSQL database and a
 |---|---|---|
 | All layers, all packages | `bun test` | <2 min |
 | Single package | `bun test --filter <package-name>` | see per-component above |
-| CI gates (lint → typecheck → test) | `task ci` | <5 min |
+| CI gates (lint → check-strings → typecheck → test → secret-scan → doctor) | `task ci` | <5 min |
 
 ## CI pipeline shape
 


### PR DESCRIPTION
## Summary
- Wire real gitleaks secret scan (replacing placeholder) as CI gate 5 via direct binary download (action requires license for private repo)
- Add task-store doctor as CI gate 6 (\`task doctor\` → \`bun plugins/shipwright/scripts/task_store.ts doctor\`)
- Update \`task ci\` to full local parity: lint → check-strings → typecheck → test → secret-scan → doctor
- Update test-system.md to reflect expanded \`task ci\` gate list

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Gate 1 (lint) in ci.yml | MET — pre-existing \`task lint\` |
| 2 | Gate 2 (typecheck) in ci.yml | MET — pre-existing \`task typecheck\` |
| 3 | Gate 3 (bun test) in ci.yml | MET — pre-existing \`task test\` |
| 4 | Gate 5 (secret-scan) in ci.yml | MET — gitleaks binary download with SHA-256 checksum verification |
| 5 | Gate 6 (task-store doctor) in ci.yml | MET — \`task doctor\` step added |
| 6 | \`task ci\` local parity | MET — all 6 gates in same order as CI |
| 7 | secret-scan is real (not placeholder) | MET — gitleaks with graceful local fallback |
| 8 | doctor wired to task_store.ts | MET — exits 0, reports github backend |

## Test Plan
- [x] \`bunx biome lint .\` — passes (0 issues across 123 files)
- [x] \`bun plugins/shipwright/scripts/check-banned-strings.ts\` — passes
- [x] \`bun plugins/shipwright/scripts/task_store.ts doctor\` — exits 0, reports \`backend: github\`
- [x] \`bun test\` — 1314 pass / 0 fail

Generated with [Claude Code](https://claude.com/claude-code)