### PR TITLE
feat(sww-2.1): hero + install section

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,23 +1,38 @@
 ---
-// Minimal on-brand placeholder home page (SWW-1.1).
-// Proves the build, fonts, theme, and dark-premium base layout work.
-// The full Hero/Body/Footer sections land in later tasks (SWW-2.x).
+// Home page hero + install section (SWW-2.1).
+// Builds the real hero on top of the SWW-1.1 scaffold: agent-led tagline with a
+// gradient on "Claude Code", primary/secondary CTAs, the "Built on Claude Code"
+// eyebrow, and the install command. No pricing, no email form, no runtime JS.
 import BaseLayout from "../layouts/BaseLayout.astro";
 
-const tagline = "The open-source autonomous delivery agent for Claude Code.";
+const taglinePrefix = "The open-source autonomous delivery agent for ";
+const taglineGradient = "Claude Code";
+const tagline = `${taglinePrefix}${taglineGradient}.`;
 const install = "/plugin install shipwright@app-vitals/shipwright";
+const githubUrl = "https://github.com/app-vitals/shipwright";
 ---
 
 <BaseLayout title="Shipwright Harness" description={tagline}>
   <section
     class="relative z-10 flex min-h-screen flex-col justify-center py-24"
   >
-    <p class="sw-label">Shipwright Harness</p>
-    <h1 class="sw-display sw-gradient-text max-w-3xl">{tagline}</h1>
-    <p class="sw-editorial mt-2 max-w-xl text-lg">
+    <p class="sw-label">Built on Claude Code</p>
+    <h1 class="sw-display mt-4 max-w-3xl">
+      {taglinePrefix}<span class="sw-gradient-text">{taglineGradient}</span>.
+    </h1>
+    <p class="mt-4 max-w-xl text-lg">
       A deployable cloud agent and the autonomous coding system that powers it —
       running on your own codebase.
     </p>
-    <pre class="sw-code mt-8 w-fit"><code>{install}</code></pre>
+
+    <div class="mt-8 flex flex-wrap items-center gap-4">
+      <a class="sw-btn" href="#install">Get started</a>
+      <a class="sw-btn sw-btn-secondary" href={githubUrl}>View on GitHub</a>
+    </div>
+
+    <div id="install" class="mt-10 max-w-xl">
+      <p class="sw-label">Install</p>
+      <pre class="sw-code mt-3 w-fit"><code>{install}</code></pre>
+    </div>
   </section>
 </BaseLayout>

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -38,3 +38,36 @@ test("home document ships NO runtime JS (zero <script> tags)", async ({
   const scriptCount = await page.locator("script").count();
   expect(scriptCount).toBe(0);
 });
+
+// SWW-2.1: Hero + install section.
+
+test("primary 'Get started' CTA renders", async ({ page }) => {
+  await page.goto("/");
+  const cta = page.getByRole("link", { name: "Get started" });
+  await expect(cta).toBeVisible();
+  await expect(cta).toHaveAttribute("href", "#install");
+});
+
+test("exact install command string renders", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByText("/plugin install shipwright@app-vitals/shipwright", {
+      exact: true,
+    }),
+  ).toBeVisible();
+});
+
+test("secondary 'View on GitHub' CTA points at the repo", async ({ page }) => {
+  await page.goto("/");
+  const cta = page.getByRole("link", { name: "View on GitHub" });
+  await expect(cta).toBeVisible();
+  await expect(cta).toHaveAttribute(
+    "href",
+    "https://github.com/app-vitals/shipwright",
+  );
+});
+
+test("eyebrow features 'Built on Claude Code'", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText(/Built on Claude Code/i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Add the real Hero + install section to the marketing home page on top of the SWW-1.1 scaffold (no re-scaffold).
- Agent-led tagline with a gradient on **Claude Code**, "Built on Claude Code" eyebrow, primary `Get started` + secondary `View on GitHub` CTAs, and the exact install command.
- Extends the Playwright smoke with 4 new assertions; no existing tests retired. Zero runtime JS preserved.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Canonical tagline with gradient only on 'Claude Code' | MET |
| 2 | Exact install string `/plugin install shipwright@app-vitals/shipwright` | MET |
| 3 | 'Get started' (green) + 'View on GitHub' + 'Built on Claude Code' eyebrow; no pricing, no email | MET |
| 4 | Playwright smoke extended for CTA + exact install string; no tests retired | MET |
| 5 | Safe to deploy standalone | MET |

## Test Plan
- `cd site && bun run test` → 8/8 Playwright tests pass (4 original + 4 new).
- `cd site && bunx astro build` → builds clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
