### PR TITLE
feat(she-6.1): data migration script

### DIFF
--- a/agent/scripts/migrate.ts
+++ b/agent/scripts/migrate.ts
@@ -1,0 +1,54 @@
+/**
+ * agent/scripts/migrate.ts
+ * CLI entry point for the data migration script.
+ *
+ * Reads env vars:
+ *   VITALS_OS_API_URL        — base URL of the vitals-os accounts API
+ *   VITALS_OS_API_KEY        — bearer token for the accounts API
+ *   SHIPWRIGHT_ADMIN_URL     — base URL of the shipwright admin API
+ *   SHIPWRIGHT_SESSION_TOKEN — admin_session JWT cookie value
+ *
+ * Exits 0 on full success, non-zero if any agent migration failed.
+ * Reports failing agent IDs and fields to stderr.
+ */
+
+import { HttpAccountsMigrationClient } from "../src/accounts-migration-client.ts";
+import { HttpShipwrightAdminClient } from "../src/shipwright-admin-client.ts";
+import { runMigration } from "../src/migrate.ts";
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`Error: required environment variable ${name} is not set`);
+    process.exit(1);
+  }
+  return val;
+}
+
+const vitalsOsApiUrl = requireEnv("VITALS_OS_API_URL");
+const vitalsOsApiKey = requireEnv("VITALS_OS_API_KEY");
+const shipwrightAdminUrl = requireEnv("SHIPWRIGHT_ADMIN_URL");
+const shipwrightSessionToken = requireEnv("SHIPWRIGHT_SESSION_TOKEN");
+
+const accountsClient = new HttpAccountsMigrationClient(
+  vitalsOsApiUrl,
+  vitalsOsApiKey,
+);
+const adminClient = new HttpShipwrightAdminClient(
+  shipwrightAdminUrl,
+  shipwrightSessionToken,
+);
+
+console.log("Starting data migration...");
+
+const result = await runMigration(accountsClient, adminClient);
+
+console.log(`Migration complete: ${result.migrated} agent(s) migrated.`);
+
+if (result.failed.length > 0) {
+  console.error(`\n${result.failed.length} failure(s):`);
+  for (const failure of result.failed) {
+    console.error(`  agent=${failure.agentId} field=${failure.field}: ${failure.error}`);
+  }
+  process.exit(1);
+}

--- a/agent/src/accounts-migration-client.ts
+++ b/agent/src/accounts-migration-client.ts
@@ -1,0 +1,93 @@
+/**
+ * agent/src/accounts-migration-client.ts
+ * AccountsMigrationClient — reads agent data from the vitals-os accounts API.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface VitalsAgentRecord {
+  id: string;
+  name: string;
+}
+
+export interface VitalsAgentConfig {
+  env: Record<string, string>;
+  tools: string[];
+}
+
+export interface VitalsAgentCron {
+  schedule: string;
+  prompt: string;
+  channel: string | null;
+  user: string | null;
+  silent: boolean;
+  enabled: boolean;
+  preCheck: string | null;
+  name: string | null;
+}
+
+export interface AccountsMigrationClient {
+  listAgents(): Promise<VitalsAgentRecord[]>;
+  getAgentConfig(agentId: string): Promise<VitalsAgentConfig>;
+  getAgentCrons(agentId: string): Promise<VitalsAgentCron[]>;
+}
+
+// ─── HTTP implementation ──────────────────────────────────────────────────────
+
+export class HttpAccountsMigrationClient implements AccountsMigrationClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  private get headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  async listAgents(): Promise<VitalsAgentRecord[]> {
+    const url = `${this.baseUrl}/accounts/agents?role=AGENT`;
+    const res = await globalThis.fetch(url, { headers: this.headers });
+    if (!res.ok) {
+      throw new Error(
+        `listAgents failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const data = await res.json() as { agents?: VitalsAgentRecord[] } | VitalsAgentRecord[];
+    // Handle both array response and wrapped { agents: [] } response
+    if (Array.isArray(data)) return data;
+    if (data && typeof data === "object" && "agents" in data && Array.isArray(data.agents)) {
+      return data.agents;
+    }
+    return data as VitalsAgentRecord[];
+  }
+
+  async getAgentConfig(agentId: string): Promise<VitalsAgentConfig> {
+    const url = `${this.baseUrl}/accounts/agents/${agentId}/config`;
+    const res = await globalThis.fetch(url, { headers: this.headers });
+    if (!res.ok) {
+      throw new Error(
+        `getAgentConfig(${agentId}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    return res.json() as Promise<VitalsAgentConfig>;
+  }
+
+  async getAgentCrons(agentId: string): Promise<VitalsAgentCron[]> {
+    const url = `${this.baseUrl}/accounts/agents/${agentId}/crons`;
+    const res = await globalThis.fetch(url, { headers: this.headers });
+    if (!res.ok) {
+      throw new Error(
+        `getAgentCrons(${agentId}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const data = await res.json() as { crons?: VitalsAgentCron[] } | VitalsAgentCron[];
+    if (Array.isArray(data)) return data;
+    if (data && typeof data === "object" && "crons" in data && Array.isArray(data.crons)) {
+      return data.crons;
+    }
+    return data as VitalsAgentCron[];
+  }
+}

--- a/agent/src/migrate.integration.test.ts
+++ b/agent/src/migrate.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * agent/src/migrate.integration.test.ts
+ * Integration tests for the data migration script.
+ *
+ * Uses in-memory recorded doubles — no database or network required.
+ * Runs unconditionally.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import type { AccountsMigrationClient, VitalsAgentRecord, VitalsAgentConfig, VitalsAgentCron } from "./accounts-migration-client.ts";
+import type { ShipwrightAdminMigrationClient } from "./shipwright-admin-client.ts";
+import { runMigration } from "./migrate.ts";
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const AGENTS: VitalsAgentRecord[] = [
+  { id: "agent-001", name: "Warchild" },
+  { id: "agent-002", name: "Backup Agent" },
+];
+
+const CONFIGS: Record<string, VitalsAgentConfig> = {
+  "agent-001": {
+    env: { SLACK_BOT_TOKEN: "xoxb-test-001", ANTHROPIC_API_KEY: "sk-ant-001" },
+    tools: ["Read", "Write", "Bash"],
+  },
+  "agent-002": {
+    env: { SLACK_BOT_TOKEN: "xoxb-test-002" },
+    tools: ["Read"],
+  },
+};
+
+const CRONS: Record<string, VitalsAgentCron[]> = {
+  "agent-001": [
+    {
+      schedule: "30 19 * * *",
+      prompt: "/shipwright:dev-task",
+      channel: "C123456",
+      user: null,
+      silent: false,
+      enabled: true,
+      preCheck: null,
+      name: "dev-task",
+    },
+  ],
+  "agent-002": [],
+};
+
+// ─── Recorded doubles ─────────────────────────────────────────────────────────
+
+class RecordedAccountsClient implements AccountsMigrationClient {
+  async listAgents(): Promise<VitalsAgentRecord[]> {
+    return [...AGENTS];
+  }
+
+  async getAgentConfig(agentId: string): Promise<VitalsAgentConfig> {
+    const config = CONFIGS[agentId];
+    if (!config) throw new Error(`No config for agent ${agentId}`);
+    return { ...config, env: { ...config.env }, tools: [...config.tools] };
+  }
+
+  async getAgentCrons(agentId: string): Promise<VitalsAgentCron[]> {
+    const crons = CRONS[agentId] ?? [];
+    return crons.map((c) => ({ ...c }));
+  }
+}
+
+interface UpsertEnvsCall { agentId: string; env: Record<string, string>; }
+interface AddToolCall { agentId: string; pattern: string; }
+interface CreateCronCall { agentId: string; cron: VitalsAgentCron; }
+
+class RecordedShipwrightAdminClient implements ShipwrightAdminMigrationClient {
+  upsertEnvsCalls: UpsertEnvsCall[] = [];
+  addToolCalls: AddToolCall[] = [];
+  createCronCalls: CreateCronCall[] = [];
+
+  /** Set to an agentId to make the next upsertEnvs call for that agent throw. */
+  failNextEnvsForAgent: string | null = null;
+
+  private cronStore: Map<string, VitalsAgentCron[]> = new Map();
+
+  async upsertEnvs(agentId: string, env: Record<string, string>): Promise<void> {
+    if (this.failNextEnvsForAgent === agentId) {
+      this.failNextEnvsForAgent = null;
+      throw new Error(`Simulated upsertEnvs failure for agent ${agentId}`);
+    }
+    this.upsertEnvsCalls.push({ agentId, env: { ...env } });
+  }
+
+  async listCrons(agentId: string): Promise<VitalsAgentCron[]> {
+    return [...(this.cronStore.get(agentId) ?? [])];
+  }
+
+  async createCron(agentId: string, cron: VitalsAgentCron): Promise<void> {
+    this.createCronCalls.push({ agentId, cron: { ...cron } });
+    const existing = this.cronStore.get(agentId) ?? [];
+    this.cronStore.set(agentId, [...existing, { ...cron }]);
+  }
+
+  async addTool(agentId: string, pattern: string): Promise<void> {
+    this.addToolCalls.push({ agentId, pattern });
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("runMigration (integration)", () => {
+  let accountsClient: RecordedAccountsClient;
+  let adminClient: RecordedShipwrightAdminClient;
+
+  beforeEach(() => {
+    accountsClient = new RecordedAccountsClient();
+    adminClient = new RecordedShipwrightAdminClient();
+  });
+
+  it("migrates all agents with env vars, tools, and crons", async () => {
+    const result = await runMigration(accountsClient, adminClient);
+
+    expect(result.migrated).toBe(2);
+    expect(result.failed).toHaveLength(0);
+
+    // agent-001: SLACK_BOT_TOKEN and ANTHROPIC_API_KEY in upsertEnvs call
+    const env001Call = adminClient.upsertEnvsCalls.find(
+      (c) => c.agentId === "agent-001",
+    );
+    expect(env001Call).toBeDefined();
+    expect(env001Call?.env.SLACK_BOT_TOKEN).toBe("xoxb-test-001");
+    expect(env001Call?.env.ANTHROPIC_API_KEY).toBe("sk-ant-001");
+
+    // agent-001: 3 addTool calls (Read, Write, Bash)
+    const tools001 = adminClient.addToolCalls.filter(
+      (c) => c.agentId === "agent-001",
+    );
+    expect(tools001).toHaveLength(3);
+    const patterns001 = tools001.map((c) => c.pattern);
+    expect(patterns001).toContain("Read");
+    expect(patterns001).toContain("Write");
+    expect(patterns001).toContain("Bash");
+
+    // agent-001: 1 createCron call
+    const crons001 = adminClient.createCronCalls.filter(
+      (c) => c.agentId === "agent-001",
+    );
+    expect(crons001).toHaveLength(1);
+    expect(crons001[0]?.cron.schedule).toBe("30 19 * * *");
+    expect(crons001[0]?.cron.prompt).toBe("/shipwright:dev-task");
+  });
+
+  it("re-running is idempotent — crons not duplicated", async () => {
+    // First run
+    const result1 = await runMigration(accountsClient, adminClient);
+    expect(result1.migrated).toBe(2);
+    const createCronCountAfterFirst = adminClient.createCronCalls.length;
+
+    // Second run (crons already in cronStore from first run)
+    const result2 = await runMigration(accountsClient, adminClient);
+    expect(result2.migrated).toBe(2);
+
+    // No new crons should have been created
+    const createCronCountAfterSecond = adminClient.createCronCalls.length;
+    expect(createCronCountAfterSecond).toBe(createCronCountAfterFirst);
+  });
+
+  it("continues processing remaining agents when one fails, reports failure", async () => {
+    // Make upsertEnvs fail for agent-001
+    adminClient.failNextEnvsForAgent = "agent-001";
+
+    const result = await runMigration(accountsClient, adminClient);
+
+    // agent-001 should fail, agent-002 should succeed
+    expect(result.migrated).toBe(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.agentId).toBe("agent-001");
+    expect(result.failed[0]?.field).toBe("env");
+    expect(typeof result.failed[0]?.error).toBe("string");
+
+    // agent-002 envs should still have been written
+    const env002Call = adminClient.upsertEnvsCalls.find(
+      (c) => c.agentId === "agent-002",
+    );
+    expect(env002Call).toBeDefined();
+    expect(env002Call?.env.SLACK_BOT_TOKEN).toBe("xoxb-test-002");
+  });
+});

--- a/agent/src/migrate.ts
+++ b/agent/src/migrate.ts
@@ -1,0 +1,112 @@
+/**
+ * agent/src/migrate.ts
+ * Core migration logic — enumerate agents from vitals-os accounts API,
+ * write env vars, tools, and cron jobs to the shipwright admin API.
+ *
+ * Idempotent: envs replace-all, tools upsert internally, crons skip duplicates.
+ * Continues on per-agent failure; reports failing agent + field.
+ */
+
+import type { AccountsMigrationClient } from "./accounts-migration-client.ts";
+import type { ShipwrightAdminMigrationClient } from "./shipwright-admin-client.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AgentMigrationFailure {
+  agentId: string;
+  field: string;
+  error: string;
+}
+
+export interface MigrationResult {
+  migrated: number;
+  failed: AgentMigrationFailure[];
+}
+
+// ─── Core migration function ──────────────────────────────────────────────────
+
+export async function runMigration(
+  accountsClient: AccountsMigrationClient,
+  adminClient: ShipwrightAdminMigrationClient,
+): Promise<MigrationResult> {
+  const agents = await accountsClient.listAgents();
+
+  let migrated = 0;
+  const failed: AgentMigrationFailure[] = [];
+
+  for (const agent of agents) {
+    const { id: agentId } = agent;
+    let agentFailed = false;
+
+    // 1. Migrate env vars
+    try {
+      const config = await accountsClient.getAgentConfig(agentId);
+      await adminClient.upsertEnvs(agentId, config.env);
+
+      // 2. Migrate tools (upsert — inherently idempotent)
+      for (const pattern of config.tools) {
+        try {
+          await adminClient.addTool(agentId, pattern);
+        } catch (err) {
+          failed.push({
+            agentId,
+            field: `tool:${pattern}`,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          agentFailed = true;
+        }
+      }
+    } catch (err) {
+      failed.push({
+        agentId,
+        field: "env",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      agentFailed = true;
+    }
+
+    // 3. Migrate crons (skip duplicates matched by schedule+prompt)
+    try {
+      const sourceCrons = await accountsClient.getAgentCrons(agentId);
+      const existingCrons = await adminClient.listCrons(agentId);
+
+      for (const cron of sourceCrons) {
+        const isDuplicate = existingCrons.some(
+          (existing) =>
+            existing.schedule === cron.schedule &&
+            existing.prompt === cron.prompt,
+        );
+
+        if (!isDuplicate) {
+          try {
+            await adminClient.createCron(agentId, cron);
+          } catch (err) {
+            const cronLabel = cron.name ?? cron.schedule;
+            failed.push({
+              agentId,
+              field: `cron:${cronLabel}`,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            agentFailed = true;
+          }
+        }
+      }
+    } catch (err) {
+      // Only record if not already failed on env (avoid double-counting)
+      if (!agentFailed) {
+        failed.push({
+          agentId,
+          field: "crons",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        agentFailed = true;
+      }
+    }
+
+    if (!agentFailed) {
+      migrated++;
+    }
+  }
+
+  return { migrated, failed };
+}

--- a/agent/src/migrate.ts
+++ b/agent/src/migrate.ts
@@ -36,14 +36,13 @@ export async function runMigration(
 
   for (const agent of agents) {
     const { id: agentId } = agent;
-    let agentFailed = false;
+    const failedBefore = failed.length;
 
-    // 1. Migrate env vars
+    // 1. Migrate env vars + tools
     try {
       const config = await accountsClient.getAgentConfig(agentId);
       await adminClient.upsertEnvs(agentId, config.env);
 
-      // 2. Migrate tools (upsert — inherently idempotent)
       for (const pattern of config.tools) {
         try {
           await adminClient.addTool(agentId, pattern);
@@ -53,7 +52,6 @@ export async function runMigration(
             field: `tool:${pattern}`,
             error: err instanceof Error ? err.message : String(err),
           });
-          agentFailed = true;
         }
       }
     } catch (err) {
@@ -62,10 +60,9 @@ export async function runMigration(
         field: "env",
         error: err instanceof Error ? err.message : String(err),
       });
-      agentFailed = true;
     }
 
-    // 3. Migrate crons (skip duplicates matched by schedule+prompt)
+    // 2. Migrate crons (skip duplicates matched by schedule+prompt)
     try {
       const sourceCrons = await accountsClient.getAgentCrons(agentId);
       const existingCrons = await adminClient.listCrons(agentId);
@@ -87,23 +84,18 @@ export async function runMigration(
               field: `cron:${cronLabel}`,
               error: err instanceof Error ? err.message : String(err),
             });
-            agentFailed = true;
           }
         }
       }
     } catch (err) {
-      // Only record if not already failed on env (avoid double-counting)
-      if (!agentFailed) {
-        failed.push({
-          agentId,
-          field: "crons",
-          error: err instanceof Error ? err.message : String(err),
-        });
-        agentFailed = true;
-      }
+      failed.push({
+        agentId,
+        field: "crons",
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
-    if (!agentFailed) {
+    if (failed.length === failedBefore) {
       migrated++;
     }
   }

--- a/agent/src/shipwright-admin-client.ts
+++ b/agent/src/shipwright-admin-client.ts
@@ -1,0 +1,88 @@
+/**
+ * agent/src/shipwright-admin-client.ts
+ * ShipwrightAdminMigrationClient — writes agent data to the shipwright admin API.
+ */
+
+import type { VitalsAgentCron } from "./accounts-migration-client.ts";
+
+// ─── Interface ────────────────────────────────────────────────────────────────
+
+export interface ShipwrightAdminMigrationClient {
+  upsertEnvs(agentId: string, env: Record<string, string>): Promise<void>;
+  listCrons(agentId: string): Promise<VitalsAgentCron[]>;
+  createCron(agentId: string, cron: VitalsAgentCron): Promise<void>;
+  addTool(agentId: string, pattern: string): Promise<void>;
+}
+
+// ─── HTTP implementation ──────────────────────────────────────────────────────
+
+export class HttpShipwrightAdminClient implements ShipwrightAdminMigrationClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly sessionToken: string,
+  ) {}
+
+  private get headers(): Record<string, string> {
+    return {
+      Cookie: `admin_session=${this.sessionToken}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  async upsertEnvs(
+    agentId: string,
+    env: Record<string, string>,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/admin/api/agents/${agentId}/envs`;
+    const res = await globalThis.fetch(url, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(env),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `upsertEnvs(${agentId}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+  }
+
+  async listCrons(agentId: string): Promise<VitalsAgentCron[]> {
+    const url = `${this.baseUrl}/admin/api/agents/${agentId}/crons`;
+    const res = await globalThis.fetch(url, { headers: this.headers });
+    if (!res.ok) {
+      throw new Error(
+        `listCrons(${agentId}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const data = await res.json() as { crons: VitalsAgentCron[] };
+    return data.crons;
+  }
+
+  async createCron(agentId: string, cron: VitalsAgentCron): Promise<void> {
+    const url = `${this.baseUrl}/admin/api/agents/${agentId}/crons`;
+    const res = await globalThis.fetch(url, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(cron),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `createCron(${agentId}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+  }
+
+  async addTool(agentId: string, pattern: string): Promise<void> {
+    const url = `${this.baseUrl}/admin/api/agents/${agentId}/tools`;
+    const res = await globalThis.fetch(url, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify({ pattern }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `addTool(${agentId}, ${pattern}) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `agent/scripts/migrate.ts` CLI to migrate agent data from vitals-os accounts API to shipwright admin API
- Migrates env vars, tool patterns, and cron jobs per agent; idempotent (crons deduped by schedule+prompt, envs replace-all, tools upsert)
- Exits non-zero and reports `agent=<id> field=<field>` to stderr on any write failure; remaining agents still processed

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Script completes for all agents; SLACK_BOT_TOKEN and ANTHROPIC_API_KEY present after running | ✅ MET |
| 2 | All cron jobs, tools, and tokens present with correct fields | ✅ MET |
| 3 | Re-running is a no-op — no duplicate rows | ✅ MET |
| 4 | Exits non-zero and prints failing agent ID + field name; remaining agents processed | ✅ MET |
| 5 | Integration tests with RecordedAccountsClient and RecordedShipwrightAdminClient | ✅ MET |

## Test Plan
- [x] `bun test agent/src/migrate.integration.test.ts` — 3 tests pass (full migration, idempotency, failure isolation)
- [x] `bun test` — full suite 1326 pass / 0 fail
- [x] `cd agent && bun run typecheck` — clean
- [x] `bunx biome lint` — clean

Generated with [Claude Code](https://claude.com/claude-code)
