### PR TITLE
docs: add architecture, testing, metrics, and agent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,71 @@
 # CLAUDE.md
 
-Guidance for Claude Code (claude.ai/code) and contributors working in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What Shipwright is
 
-Shipwright is a **Claude Code plugin toolchain for the full delivery loop — spec → plan → execute → review → deploy** — plus a metrics dashboard and a reference agent. You install the plugin into Claude Code and drive planning, queue-based execution, policy-controlled review, a test-readiness pipeline, and autonomous deploy against your own repository.
+Shipwright Harness is **the open-source (MIT) autonomous delivery agent for Claude Code** — a deployable agent plus the autonomous coding system that powers it. The system is a Claude Code plugin (`shipwright`) covering the full delivery loop — **spec → plan → execute → review → deploy** — alongside a metrics dashboard and a reference agent. The brand is **Shipwright Harness**; the installable package is **`shipwright`**.
 
-> 🚧 **Early development.** The toolchain is being built out in this repository and isn't ready for general installation yet. Track progress in the [issues](https://github.com/app-vitals/shipwright/issues).
+> The plugin is repo-agnostic: it runs its planning/execution/review/deploy commands against *any* repository. This repo is both the source of the plugin **and** the codebase it ships against.
 
-## Architecture / roadmap (A → B → C)
+## Architecture — three artifacts, sequenced A → B → C
 
-Three artifacts, sequenced so the repo is useful at the end of each phase:
+| Phase | Artifact | Directory | What it is |
+|---|---|---|---|
+| **A** | **Plugin** (the system) | `plugins/shipwright/` | Commands, skills, agents, scripts users `/plugin install`. Repo-agnostic. |
+| **B** | **Metrics dashboard** | `metrics/` | Stateless Hono service: PostHog-backed JSON endpoints + a server-rendered dashboard. No database. |
+| **C** | **Reference agent** | `agent/` | Hono service + Prisma store; a thin autonomous runner: pick next ready task → build → ship PR → forward metrics. |
 
-| Phase | Artifact | What it is |
-|---|---|---|
-| **A** | **Plugin** | The toolchain users `/plugin install` (commands, skills, agents, scripts). Repo-agnostic — runs its planning/execution/review/deploy commands against any repo. |
-| **B** | **Metrics dashboard** | A stateless Hono service: PostHog-backed JSON endpoints + a server-rendered dashboard (task throughput, CI first-pass rate, review verdicts, estimation accuracy). No database. |
-| **C** | **Reference agent** | A thin, purpose-built autonomous runner: pick the next ready task → build → ship a PR → forward metrics, on a schedule or as a one-shot. |
+Supporting surfaces (not phased):
+- `site/` — Astro + Tailwind marketing site (**shipwright-harness.com**). Self-contained; **not** a Bun workspace; Playwright smoke tests.
+- `brand/` — locked design system (`BRAND.md`, `tokens.json`) + CSS build + lint, consumed by `site/` and brand artifacts. Editing brand artifacts triggers the `shipwright-brand` skill.
+- `state/` — git-ignored local JSON task-store fallback + cached review state (only written when the GitHub backend isn't active).
 
-Two cross-cutting concerns span all three:
-- **CI gates** (`.github/workflows/ci.yml`) — lint → typecheck → `bun test` → secret-scan → task-store doctor (+ e2e/agent jobs), each merge-blocking, each with a local-parity command.
-- **Local orchestration** (`Taskfile.yml`, go-task) — the single local entrypoint: `task dev` runs UI + API + agent together; `task ui`/`api`/`agent` run them independently; `task test`/`task ci` run the suite/gates.
+## Commands
+
+go-task (`Taskfile.yml`) is the single local entrypoint; the root `package.json` mirrors a subset as `bun run` scripts.
+
+```bash
+task setup        # bun install across all workspaces
+task ci           # lint → check-strings → typecheck → test (the merge-blocking gate; CI runs this exact chain)
+task test         # bun test            (single file: bun test path/to/file.test.ts)
+task lint         # bunx biome lint .
+task format       # bunx biome format --write .
+task typecheck    # bun run --filter='*' typecheck
+task check-strings  # scan the plugin for banned/confidential identifiers
+```
+
+Database (agent only):
+```bash
+export DATABASE_URL_AGENT="file:./agent/dev.db"   # SQLite for local dev; postgres URL for prod
+task db:provision   # prisma migrate deploy (idempotent)
+task db:migrate     # prisma migrate dev (creates a new migration)
+```
+
+Marketing site (run from `site/`, **not** part of `bun test`):
+```bash
+cd site && npm run dev      # astro dev
+cd site && npm run build    # astro build
+cd site && npm test         # playwright test (*.spec.ts)
+```
+
+> `bunfig.toml` excludes `site/**` from the root `bun test` scan — Playwright's `*.spec.ts` files would otherwise crash Bun's runner. Keep site tests as `*.spec.ts` to stay isolated.
+
+There is **no `task dev`/`task api`/`task agent`** yet — services are started directly via their own entrypoints. Don't assume aggregate run tasks exist; check `Taskfile.yml`.
 
 ## Before you commit — this repository is going public
 
-This repo is **private today but destined to be a public, MIT open-source project.** Git history is permanent — anything committed and pushed can't be truly unpublished. **Scrub before the commit, not after the push.**
+This repo is **private today but destined to be a public, MIT open-source project.** Git history is permanent. **Scrub before the commit, not after the push.**
 
-**The rule:** review every change before staging it; never commit content you haven't eyeballed for proprietary material. Stage specific files — never `git add -A`/`-u` blindly. When unsure whether something is proprietary, **ask before committing.**
+**The rule:** review every change before staging it. Stage specific files — **never `git add -A`/`-u` blindly**. When unsure whether something is proprietary, **ask before committing.**
 
-**Scrub for (categories):**
-- **Secrets & credentials** — API keys/tokens (PostHog personal API key, `ANTHROPIC_API_KEY`, `GH_TOKEN`), `SESSION_SECRET`, `.env` contents, private keys, OAuth tokens. Use env vars/placeholders, never literals.
-- **Client / customer / partner names** and identifying engagement details — use generic placeholders.
-- **Internal infrastructure identifiers** — cloud project names, analytics project IDs, cluster/namespace names, internal hostnames/URLs, deployment specifics.
-- **Internal references** — internal PR/issue numbers, Slack/Jira/Linear links, internal-only doc links.
-- **Local filesystem paths** revealing usernames/machine layout (e.g. `/Users/<name>/...`).
-- **Financials, compensation, revenue, and any PII.**
+**Scrub for:** secrets & credentials (PostHog API key, `ANTHROPIC_API_KEY`, `GH_TOKEN`, `SESSION_SECRET`, `.env` contents, private keys) · client/customer/partner names · internal infra identifiers (cloud project names, analytics project IDs, internal hostnames) · internal PR/issue/Slack/Jira links · local filesystem paths revealing usernames (`/Users/<name>/...`) · financials, compensation, PII.
 
-The CI secret scan (`gitleaks`/`detect-secrets`) and a client-name audit are the final backstop — not a substitute for this discipline.
-
-> Internal, build-time-only notes (kept out of public history) live in the git-ignored `CLAUDE.local.md`. Read it for operational context before working in this repo.
+`task check-strings` (banned-strings scan) is the CI backstop — not a substitute for this discipline. Internal, build-time-only notes live in the git-ignored `CLAUDE.local.md`; **read it for operational context before working in this repo.**
 
 ## How work is tracked
 
-The task store is **GitHub Issues** in this repo, configured via `.shipwright.json` (`taskStore: "github"`). Work is planned as issues under the **`shipwright-oss`** milestone, each with a machine-readable ```` ```shipwright ```` YAML block (`id`, `layer`, `branch`, `dependencies`, `hours`, `status`, `pr`) and a `status:*` label.
+The task store is **GitHub Issues** in this repo, configured via `.shipwright.json` (`taskStore: "github"`, owner `app-vitals`, repo `shipwright`). Work is planned as issues under the **`shipwright-oss`** milestone, each with a machine-readable ```` ```shipwright ```` YAML block (`id`, `layer`, `branch`, `dependencies`, `hours`, `status`, `pr`) and a `status:*` label.
 
 **Find the next ready task:**
 ```bash
@@ -55,45 +78,54 @@ pending → in_progress → pr_open → merged → deployed → done
 ```
 plus `approved`, `blocked`, `cancelled`.
 
-### The execution loop
+### Execution loop
 
 1. Pick a `status:pending` task whose every `dependencies` entry is `status:done`.
 2. Branch from the task's YAML `branch` field (`feat/sw-x-y-slug`) — never work on `main`.
 3. Build + land tests **in the same PR, at the correct layer** (no "tests later").
 4. Open a PR; move the status label through its lifecycle.
 
-Driven by Shipwright's own commands: `/shipwright:dev-task` (build + test + PR) → `/shipwright:review` / `/shipwright:patch` → `/shipwright:deploy`.
+Driven by Shipwright's own commands: `/shipwright:dev-task` → `/shipwright:review` / `/shipwright:patch` → `/shipwright:deploy`. The `ship-loop` skill drains the queue autonomously (one pipeline step per call, wrapped by `/loop`).
 
-> **Task-store config resolution:** Shipwright auto-discovers `.shipwright.json` by walking up from the process working directory. Place `.shipwright.json` at the repository root and it will be found automatically. If no `.shipwright.json` is found, the `SHIPWRIGHT_CONFIG` env var is checked next; if that is also unset, the JSON backend is used as a fallback. If task operations seem to no-op, run `doctor` to confirm which backend is active.
+**Task-store config resolution** (`plugins/shipwright/scripts/create-task-store.ts` → `loadConfig`): (1) walk up from cwd for `.shipwright.json`; (2) fall back to `SHIPWRIGHT_CONFIG` env var; (3) fall back to local JSON (`state/`). If task operations seem to no-op, confirm which backend is active.
+
+## Test conventions
+
+Tests land **with** the code, at the correct layer — same PR, no "add tests later" tasks. Layer is encoded in the filename:
+
+| Suffix | Layer | What it covers |
+|---|---|---|
+| `*.unit.test.ts` | unit | pure logic, no I/O |
+| `*.integration.test.ts` | integration | real dependency behavior via recorded fixtures / injected doubles |
+| `*.smoke.test.ts` | smoke | Hono endpoints via in-process `app.request()` (no real socket) |
+| `*.spec.ts` (in `site/`) | e2e | the site in a real browser via Playwright |
+
+**Test isolation (hard rule):** inject time via a `Clock`; test external clients (PostHog, GitHub) with recorded fixtures. **No `mock.module()`, no `global.fetch`/`global.*` overrides** — Bun shares the test process, so leaked globals break sibling suites.
 
 ## Conventions
 
-- **Tests land with the code, at the correct layer** — same PR, no "add tests later" tasks:
-  - **unit** — pure logic, no I/O.
-  - **integration** — real dependency behavior via recorded fixtures / injected doubles.
-  - **smoke** — Hono endpoints via in-process `app.request()` (no real socket).
-  - **e2e** — the dashboard in a real browser via Playwright.
-- **Test isolation:** inject time via a `Clock`; test external clients (PostHog, GitHub) with recorded fixtures. **No `mock.module()`, no `global.fetch`/`global.*` overrides** — Bun shares the test process, so leaked globals break sibling suites.
 - **No new coupling:** the plugin stays repo-agnostic; the metrics service and the agent depend on no external platform service.
-- **License:** MIT across all artifacts.
 - **Local-first:** everything runs offline by default (fixtures / injected doubles / scratch queue); live external calls only when env explicitly enables them.
+- **Conventional Commits** — required (a `pr-title-lint` workflow enforces PR titles); releases are automated via semantic-release.
+- **Lint/format:** Biome (2-space indent, organize-imports). Run `task lint` before committing.
+- **License:** MIT across all artifacts.
 
 ## Database env vars
 
-Each service that uses Prisma reads its own `DATABASE_URL_*` env var — never a shared connection.
+Each Prisma service reads its own `DATABASE_URL_*` — never a shared connection.
 
 | Variable | Service | Schema |
 |----------|---------|--------|
 | `DATABASE_URL_AGENT` | `@shipwright/agent` | `agent/prisma/schema.prisma` |
 
-Set `DATABASE_URL_AGENT` before running `task db:provision` or `task db:migrate`.
-For local development a SQLite URL works: `DATABASE_URL_AGENT="file:./agent/dev.db"`.
-For production use a PostgreSQL URL: `DATABASE_URL_AGENT="postgresql://user:pass@host:5432/agent"`.
+The schema uses `provider = "sqlite"` for local portability. Swap to `postgresql` and regenerate migrations when deploying against real Postgres.
 
-> Note: the schema currently uses `sqlite` as the provider for local portability.
-> Swap `provider = "sqlite"` to `provider = "postgresql"` in `agent/prisma/schema.prisma`
-> and regenerate migrations when deploying against a real Postgres instance.
+## Reference
 
-## Repository layout
+To load additional context into a session, add `@docs/filename.md` entries here — don't create separate `CLAUDE-REFERENCE.md` or similar files.
 
-This is the standalone home of Shipwright. Product code fills in across phases A → B → C; today the repo holds the open-source foundation — this file, `LICENSE`, `README.md`, `.gitignore`, and `.shipwright.json` — and its planning lives in [GitHub Issues](https://github.com/app-vitals/shipwright/issues).
+- **docs/architecture.md** — the three-artifact A→B→C design (plugin / metrics / agent), supporting surfaces, and workspace layout
+- **docs/testing.md** — the four-layer test model (unit / integration / smoke / e2e), run commands, speed budgets, and the isolation contract
+- **docs/metrics.md** — metrics service (B): JSON endpoints, server-rendered dashboard, dual auth (Bearer / session), and environment
+- **docs/agent.md** — reference agent (C): runtime + admin CRUD APIs, the six-model Prisma store, and encryption/env notes
+- **docs/test-readiness/test-system.md** — the authoritative test blueprint: layer matrix, boundary rules, per-component budgets, CI pipeline shape, and the full isolation contract

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,19 @@ Shipwright Harness is the open-source autonomous delivery agent for [Claude Code
 
 ## Contents
 
-- **[Test system](./test-readiness/test-system.md)** — the four-layer test architecture (unit / integration / smoke / e2e), per-component run commands, speed budgets, and the test-isolation contract.
+- **[Architecture](./architecture.md)** — the three-artifact design (plugin → metrics → agent), supporting surfaces, and workspace layout.
+- **[Testing](./testing.md)** — the four-layer test model (unit / integration / smoke / e2e), run commands, speed budgets, and the isolation contract.
+- **[Metrics dashboard](./metrics.md)** — the stateless PostHog-backed service: JSON endpoints, dashboard, auth, and environment.
+- **[Reference agent](./agent.md)** — the autonomous runner: runtime + admin APIs, data model, and environment.
+- **[Test system](./test-readiness/test-system.md)** — the full authoritative test blueprint (source for [Testing](./testing.md)).
 
-## Coming as the plugin lands
+## Command reference
+
+The plugin's commands (`brainstorm`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, the five-phase test-readiness pipeline, and more) are documented at their source: see [`plugins/shipwright/README.md`](../plugins/shipwright/README.md) and [`plugins/shipwright/CLAUDE.md`](../plugins/shipwright/CLAUDE.md).
+
+## Coming as the toolchain matures
 
 - **Getting started** — install, configure the task store, point Shipwright at your repo.
-- **Command reference** — `brainstorm`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, and the five-phase test-readiness pipeline.
 - **Configuration** — task-store backends (GitHub Issues / local), toolchain detection, environment.
 - **Deploying the agent** — running Shipwright autonomously on GitHub Actions or self-hosted.
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,89 @@
+# Reference Agent
+
+> The reference agent (artifact **C**) is a thin autonomous runner: pick the next ready task → build → ship a PR → forward metrics. It has a Prisma-backed store (SQLite locally, PostgreSQL in production) and two HTTP surfaces — a machine-polled **runtime API** and a human-facing **admin CRUD API**.
+
+## Overview
+
+The agent owns six first-class Prisma models (`Agent` and its `Env` / `CronJob` / `Tool` / `Token` / `Plugin` children) on a **dedicated database** (`DATABASE_URL_AGENT`). Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer; agent API tokens are stored only as SHA-256 hashes.
+
+> The top-level runner (`agent/src/index.ts`) is currently a Phase-C placeholder (`export {}`). The implemented surfaces are the admin CRUD API (`admin-api.ts`), the runtime API (`api.ts`), and the Prisma store + service classes. On startup the runner is expected to call `POST /admin/api/agents/:id/crons/reconcile` to sync system crons.
+
+## Running locally
+
+```bash
+export DATABASE_URL_AGENT="file:./agent/dev.db"   # SQLite for local dev; postgres URL for prod
+
+task db:provision          # prisma migrate deploy (idempotent)
+task db:migrate            # prisma migrate dev (create a new migration)
+```
+
+The schema declares `provider = "sqlite"` for local portability — swap to `postgresql` and regenerate migrations to deploy against real Postgres. Each Prisma service reads its **own** `DATABASE_URL_*`; never point this at a shared database.
+
+## HTTP surfaces
+
+### Runtime API (`api.ts`) — machine-polled
+
+Mounted at `/agents/*`. The harness polls this every ~60s. Auth: **Bearer token** matching `SHIPWRIGHT_INTERNAL_API_KEY` (any mismatch → `401`).
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/agents/:id/config` | Agent config bundle: decrypted `env`, `allowedTools`, and installed `plugins` (with derived marketplace). `404` if the agent doesn't exist. |
+| GET | `/agents/:id/crons` | Enabled cron jobs for the agent. `404` if the agent doesn't exist. |
+
+### Admin CRUD API (`admin-api.ts`) — human-facing
+
+Mounted at `/admin/api/*`. Auth: **session cookie** `admin_session` (httpOnly JWT verified with `SHIPWRIGHT_SESSION_SECRET`; absent/invalid → `401`).
+
+| Resource | Endpoints |
+|---|---|
+| Envs | `POST` / `GET` / `PATCH` `/admin/api/agents/:id/envs`, `DELETE /admin/api/agents/:id/envs/:key` |
+| Crons | `POST` / `GET` `/admin/api/agents/:id/crons`, `PATCH` / `DELETE` `/admin/api/agents/:id/crons/:cronId`, `POST /admin/api/agents/:id/crons/reconcile` |
+| Tools | `POST` / `GET` `/admin/api/agents/:id/tools`, `PATCH` / `DELETE` `/admin/api/agents/:id/tools/:toolId` |
+| Tokens | `POST` / `GET` `/admin/api/agents/:id/tokens`, `DELETE /admin/api/agents/:id/tokens/:tokenId` |
+| Plugins | `POST` / `GET` / `PATCH` `/admin/api/agents/:id/plugins`, `DELETE /admin/api/agents/:id/plugins` |
+
+Token creation returns the **raw token once** at creation; only its SHA-256 hash is persisted, so validation is an O(1) hash-index lookup.
+
+## Data model
+
+| Model | Owns | Notable fields |
+|---|---|---|
+| `Agent` | The runner identity | `name`, `slackId` (unique), `slackBotToken` / `anthropicApiKey` (AES-256-GCM encrypted). |
+| `AgentEnv` | Key/value env store | `key`, `value` (encrypted); unique per `[agentId, key]`. |
+| `AgentCronJob` | Scheduled prompts | `schedule` (cron expr), `prompt`, `channel` **xor** `user`, `silent`, `enabled`, `preCheck`, `name`/`system` (system-cron key). |
+| `AgentTool` | Allowed tool patterns | `pattern` (e.g. `Read`, `Bash`), `enabled`; unique per `[agentId, pattern]`. |
+| `AgentToken` | Scoped API tokens | `token` (SHA-256 hash), `label`, `revokedAt`. |
+| `AgentPlugin` | Installed Claude Code plugins | `name` (package), `version` (null = latest), `enabled`; unique per `[agentId, name]`. |
+
+All child models cascade-delete with their `Agent`.
+
+## Environment
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `DATABASE_URL_AGENT` | ✅ | Dedicated Prisma datasource (`file:./...` SQLite or a Postgres URL). |
+| `SHIPWRIGHT_INTERNAL_API_KEY` | runtime API | Bearer token for `/agents/*`. |
+| `SHIPWRIGHT_SESSION_SECRET` | admin API | Secret for verifying the `admin_session` JWT cookie. |
+| `SHIPWRIGHT_ENCRYPTION_KEY` | secrets at rest | 64-char hex (32 bytes) for AES-256-GCM. **If unset, secrets are stored in plain text** (logged warning) — set it in any real deployment. |
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `agent/src/api.ts` | Runtime API factory `createAgentRuntimeApp()` (DI for services). |
+| `agent/src/admin-api.ts` | Admin CRUD factory `createAdminApp()` + session-auth middleware. |
+| `agent/src/agent-envs.ts` | Env service — encrypted key/value store + config bundle assembly. |
+| `agent/src/agent-cron-jobs.ts` | Cron service + system-cron reconciliation. |
+| `agent/src/agent-tools.ts` / `agent-tokens.ts` / `agent-plugins.ts` | Per-resource service classes. |
+| `agent/src/crypto.ts` / `token-crypto.ts` | AES-256-GCM + token hashing helpers. |
+| `agent/src/system-crons.ts` | System-cron definitions reconciled onto each agent. |
+| `agent/prisma/schema.prisma` | The six-model schema (`DATABASE_URL_AGENT`). |
+
+## Testing
+
+Unit + integration + smoke layers (`bun test --filter agent`). DB integration tests run against a real scratch SQLite database (`DATABASE_URL_AGENT="file:./test.db"`), provisioning the schema via `prisma migrate deploy` per suite — **no Prisma mocking**. Smoke tests drive the Hono apps via `app.request()`. See [testing.md](./testing.md).
+
+## See also
+
+- [architecture.md](./architecture.md) — the A→B→C artifact design.
+- `CLAUDE.md` → "Database env vars" — the per-service `DATABASE_URL_*` convention.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+> How Shipwright Harness is structured: three sequenced artifacts (plugin → metrics → agent) plus supporting surfaces, all MIT, all local-first.
+
+## Overview
+
+Shipwright Harness is the open-source autonomous delivery agent for [Claude Code](https://www.anthropic.com/claude-code). It ships as three artifacts, built and sequenced **A → B → C**, each independently runnable and depending on **no external platform service**:
+
+| Phase | Artifact | Directory | What it is |
+|---|---|---|---|
+| **A** | **Plugin** (the system) | `plugins/shipwright/` | The Claude Code plugin users `/plugin install` — commands, skills, agents, scripts for the full delivery loop. Repo-agnostic. |
+| **B** | **Metrics dashboard** | `metrics/` | Stateless Hono service: PostHog-backed JSON endpoints + a server-rendered dashboard. No database. |
+| **C** | **Reference agent** | `agent/` | Hono service + Prisma store; a thin autonomous runner: pick next ready task → build → ship PR → forward metrics. |
+
+The hard architectural rule: **no new coupling.** The plugin stays repo-agnostic; the metrics service and the agent each stand alone. Everything runs offline by default (fixtures / injected doubles / scratch queue); live external calls happen only when an env var explicitly enables them.
+
+## A — Plugin
+
+The plugin drives the delivery loop: **spec → plan → execute → review → deploy**. It is repo-agnostic — it runs its commands against *any* repository, and this repo is both its source and a codebase it ships against.
+
+Key surfaces (see `plugins/shipwright/README.md` and `plugins/shipwright/CLAUDE.md` for the full command/skill catalog):
+
+- **Commands** (`commands/`) — `brainstorm`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, the five-phase test-readiness pipeline (`test-inventory` → `test-design` → `test-migration` → `test-roadmap` → `test-publish`), `metrics`, `research`, `research-docs`, and more.
+- **Skills** (`skills/`) — autonomous behaviors including `ship-loop` (drains the task queue one pipeline step per call) and `shipwright-brand`.
+- **Scripts** (`scripts/`) — the task-store adapters, `check-dev-task.ts`, and supporting tooling.
+- **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, …).
+
+The plugin is pure TypeScript with **no server, no database, and no external HTTP in production code** — only `unit` and `integration` test layers apply.
+
+## B — Metrics dashboard
+
+A stateless Hono service that turns the pipeline's PostHog events into analytics. Five read-only JSON endpoints (`/metrics/summary|trends|features|queue|tokens`) plus a session-gated `/dashboard`. No database — every response is computed from a live PostHog query (cached in-process). See **[metrics.md](./metrics.md)**.
+
+## C — Reference agent
+
+A thin autonomous runner with a Prisma-backed store (SQLite locally, PostgreSQL in production) and two HTTP surfaces: a machine-polled **runtime API** (`/agents/:id/config`, `/agents/:id/crons`) and a human-facing **admin CRUD API** (`/admin/api/agents/:id/...` for envs, crons, tools, tokens, plugins). See **[agent.md](./agent.md)**.
+
+> The agent's top-level runner (`agent/src/index.ts`) is currently a Phase-C placeholder; the implemented surfaces are the admin CRUD API, the runtime API, and the Prisma store.
+
+## Supporting surfaces
+
+| Surface | Directory | Notes |
+|---|---|---|
+| Marketing site | `site/` | Astro + Tailwind (**shipwright-harness.com**). **Not** a Bun workspace; Playwright smoke tests (`*.spec.ts`). |
+| Brand system | `brand/` | Locked design system (`BRAND.md`, `tokens.json`) + CSS build + lint, consumed by `site/`. |
+| Local state | `state/` | Git-ignored JSON task-store fallback + cached review state (only written when the GitHub backend isn't active). |
+
+## Workspace layout
+
+The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the single local entrypoint. Three workspaces — `plugins/shipwright`, `metrics`, `agent` — are wired into the root `package.json`. The `site/` is intentionally excluded from the root `bun test` scan (its Playwright `*.spec.ts` files would crash Bun's runner).
+
+```
+shipwright/
+├── plugins/shipwright/   A — the plugin (commands, skills, agents, scripts)
+├── metrics/              B — stateless PostHog-backed Hono service
+├── agent/                C — reference agent (Hono + Prisma)
+├── site/                 marketing site (Astro, separate toolchain)
+├── brand/                locked design system
+├── state/                local task-store / review-cache fallback
+├── docs/                 this documentation
+└── Taskfile.yml          single local entrypoint (task setup / ci / test / …)
+```
+
+## See also
+
+- **[testing.md](./testing.md)** — the four-layer test architecture and isolation contract.
+- **[metrics.md](./metrics.md)** — metrics service API and dashboard.
+- **[agent.md](./agent.md)** — reference agent runtime + admin APIs and data model.
+- `CLAUDE.md` — contributor conventions and the pre-public scrub rule.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,91 @@
+# Metrics Dashboard
+
+> Stateless Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Five read-only JSON endpoints backed by PostHog queries, plus a session-gated server-rendered dashboard. **No database** — every response is computed live from PostHog (cached in-process).
+
+## Overview
+
+The metrics service reads pipeline telemetry from PostHog and exposes it two ways: machine-readable JSON under `/metrics/*` (for tooling and the `/shipwright:metrics` command) and a human-facing `/dashboard`. It owns no persistent state — there is no DB and no write path; HogQL queries are validated pre-deploy and their results cached in-process.
+
+Entrypoint: `metrics/src/server.ts` (standalone Bun server, default port **3460**). The app factory `createMetricsApp()` in `metrics/src/api.ts` is what tests drive via `app.request()`.
+
+## Running locally
+
+```bash
+# Required: a PostHog personal API key + project id
+export POSTHOG_PERSONAL_API_KEY=phx_...
+export POSTHOG_PROJECT_ID=<your-project-id>
+
+bun metrics/src/server.ts          # serves on :3460 (override with METRICS_API_PORT)
+```
+
+`server.ts` calls `validateRequiredEnv(["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"])` and **fails fast** listing any missing vars. Env can also be loaded from a dotenv file (`SHIPWRIGHT_ENV_FILE`, default `~/.shipwright/.env`) — set vars are never overwritten.
+
+Validate every HogQL query before deploy (metadata-only, read-only key sufficient):
+
+```bash
+POSTHOG_PERSONAL_API_KEY=phx_... POSTHOG_PROJECT_ID=<id> bun run validate:hogql
+```
+
+## API Endpoints
+
+All metric endpoints are `GET`, return JSON, and accept the same date-window query params: `preset` (`today` | `7d` | `30d` | `90d`) or an explicit `from`/`to` range. `/metrics/trends` additionally accepts `groupBy`.
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/metrics/summary` | Headline totals + average cycle time over the window. |
+| GET | `/metrics/trends` | Time-series trends; supports `groupBy`. |
+| GET | `/metrics/features` | Per-feature task / CI / review breakdown. |
+| GET | `/metrics/queue` | Shipwright v3 queue metrics: funnel counts, block rate, avg cycle time (days), avg review findings. |
+| GET | `/metrics/tokens` | Token usage — totals, by agent, by session type, and trends. |
+| GET | `/dashboard` | Server-rendered dashboard HTML (session-gated). |
+| GET | `/dashboard/*` | Static dashboard assets (`styles.css`, `app.js`). |
+| GET | `/health` | Liveness check — `{ status: "ok" }`, **no auth**. |
+| GET | `/openapi.json` | OpenAPI 3.1 document for the service. |
+
+## Auth
+
+The `/metrics/*` endpoints accept **either** credential:
+
+- **Bearer API key** — tokens parsed from `METRICS_API_KEYS`. Scoped tokens (scope `!== "*"`) are rejected with `403` on metrics routes.
+- **Session cookie** (`vitals_session`) — when `METRICS_REQUIRE_OWNER_ROLE=true` and an accounts client is configured, the caller's role is checked and non-`OWNER` users get `403`.
+
+The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/auth/login`. `/health` is always open.
+
+## Environment
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `POSTHOG_PERSONAL_API_KEY` | ✅ | — | PostHog personal API key for queries. |
+| `POSTHOG_PROJECT_ID` | ✅ | — | PostHog project id (no default — must be set explicitly). |
+| `METRICS_API_PORT` | | `3460` | Listen port. |
+| `METRICS_API_KEYS` | | — | Comma-parsed Bearer API keys for `/metrics/*`. |
+| `SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
+| `METRICS_REQUIRE_OWNER_ROLE` | | `false` | When `true`, gate dashboard/API on `OWNER` role via the accounts client. |
+| `METRICS_ACCOUNTS_URL` | | `http://localhost:3457` | Accounts service base URL (role lookups). |
+| `METRICS_INTERNAL_API_KEY` | | — | Internal key for the accounts client. |
+| `METRICS_DASHBOARD_TOKEN` | | — | Optional dashboard access token. |
+| `GCP_PROJECT_ID` | | — | Optional — enables GCP Secret Manager as an env-absent fallback for secrets. |
+| `SHIPWRIGHT_ENV_FILE` | | `~/.shipwright/.env` | Dotenv file loaded at startup (existing vars win). |
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `metrics/src/server.ts` | Process entrypoint — env validation, wiring, `Bun.serve`. |
+| `metrics/src/api.ts` | App factory `createMetricsApp()`, route + auth middleware registration, dashboard handler. |
+| `metrics/src/queries.ts` | HogQL query builders (summary, trends, features, queue, tokens). |
+| `metrics/src/posthog-client.ts` | PostHog client (interface + `Http` impl; `Recorded` double for tests). |
+| `metrics/src/validate-hogql.ts` | Pre-deploy HogQL validation runner (`validate:hogql`). |
+| `metrics/src/cache.ts` | In-process query-result cache. |
+| `metrics/src/secrets.ts` | Secrets resolution: env-first, optional GCP Secret Manager fallback. |
+| `metrics/src/dashboard/` | Server-rendered dashboard (`dashboard-page.ts`, `app.js`, `styles.css`, `index.html`). |
+| `metrics/src/lib/` | Shared closure: accounts client, api-auth, session middleware, env, errors, clock. |
+
+## Testing
+
+Unit + integration + smoke layers (`bun test --filter metrics`). Integration tests inject a `RecordedPostHogClient` (cassettes under `metrics/tests/fixtures/posthog/`); smoke tests drive the Hono app via `app.request()`. Keep `POSTHOG_PERSONAL_API_KEY` **unset** so the suite stays offline. See [testing.md](./testing.md).
+
+## See also
+
+- [architecture.md](./architecture.md) — where the metrics service sits in the A→B→C design.
+- `plugins/shipwright/references/metrics-schema.md` — the `metrics.jsonl` schema the pipeline emits, which feeds these queries.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,78 @@
+# Testing
+
+> Shipwright uses a four-layer test model (unit / integration / smoke / e2e). Tests land **with** the code, at the correct layer, in the same PR — there are no "add tests later" tasks. This doc is a digest of the authoritative blueprint at [`test-readiness/test-system.md`](./test-readiness/test-system.md).
+
+## Layers
+
+| Layer | Framework | Boundary rule | Suffix |
+|---|---|---|---|
+| **Unit** | `bun test` | Pure logic — no I/O of any kind (no filesystem, network, or subprocess). | `*.unit.test.ts` |
+| **Integration** | `bun test` + injected recorded doubles | Real dependency behavior via recorded fixtures / injected doubles — exercises the seam without a live external service. | `*.integration.test.ts` |
+| **Smoke** | `bun test` + Hono `app.request()` | HTTP route contracts (status, shape, auth, errors) via in-process `app.request()` — no real socket. | `*.smoke.test.ts` |
+| **E2E** | `@playwright/test` | Full browser-driven flows against a real running server. Phase B (dashboard) only. | `*.spec.ts` (in `site/`) |
+
+The layer is encoded in the filename suffix. When adding a test, classify in order: no I/O → **unit**; calls an external service → **integration** (inject a recorded double); tests an HTTP route → **smoke** (`app.request()`); multi-step browser flow → **e2e**. If none fit, escalate — don't invent a fifth layer.
+
+## Running tests
+
+go-task (`Taskfile.yml`) is the single local entrypoint:
+
+```bash
+task setup        # bun install across all workspaces
+task ci           # lint → check-strings → typecheck → test (the merge-blocking gate)
+task test         # bun test (all packages)
+```
+
+Run a single package or file directly:
+
+```bash
+bun test --filter metrics            # one workspace
+bun test --filter agent
+bun test --filter plugins/shipwright
+bun test path/to/file.test.ts        # one file
+```
+
+The marketing site is **not** part of the root `bun test` scan — run its Playwright suite separately:
+
+```bash
+cd site && npm test                  # playwright (*.spec.ts)
+```
+
+> `bunfig.toml` excludes `site/**` from the root runner. Keep site tests as `*.spec.ts` to stay isolated — Bun would otherwise try to execute Playwright specs and crash.
+
+### Per-component layers
+
+| Component | Layers in use | Run command |
+|---|---|---|
+| Plugin (`plugins/shipwright`) | unit, integration | `bun test --filter plugins/shipwright` |
+| Metrics (`metrics`) | unit, integration, smoke | `bun test --filter metrics` |
+| Agent (`agent`) | unit, integration, smoke | `bun test --filter agent` |
+
+The plugin has **no smoke/e2e layer** (no HTTP surface). E2E (Playwright) covers only the metrics dashboard UI in `site/`.
+
+## Speed budgets
+
+| Layer | Per-test 95p | Per-test hard cap | Suite target |
+|---|---|---|---|
+| Unit | <50 ms | <200 ms | <30 s |
+| Integration | <500 ms | <2 s | <60 s |
+| Smoke | <2 s | <10 s | <30 s |
+| E2E | <30 s | <90 s | <5 min |
+| **Full CI pipeline** | — | — | **<5 min wall** |
+
+A unit test over 200 ms is a suspected hidden integration test (audit its imports for I/O). A smoke test over 10 s is a suspected e2e test in disguise (rebuild).
+
+## Test isolation contract (hard rules)
+
+- **Time:** any production code path that calls `new Date()` / `Date.now()` non-trivially must accept a `Clock` interface; tests inject `FixedClock(t)`. Raw `Date.now()` in code under test is a bug.
+- **External HTTP:** service clients (`PostHogClient`, `GithubClient`, …) are interfaces with an `Http*Client` production impl; tests inject `Recorded*Client` doubles replaying cassettes from `tests/fixtures/<service>/*.json` (versioned JSON committed to the repo).
+- **No global state:** **no `mock.module()`**, **no `global.fetch` / `global.*` overrides.** Bun runs test files in the same process, so module-level mocks and global mutation leak across sibling suites. Each test must be independently runnable, order-independent.
+- **Offline by default:** no live external calls. `POSTHOG_PERSONAL_API_KEY` must be absent for metrics unit/integration/smoke tests; `DATABASE_URL_AGENT` must point at a scratch file (e.g. `file:./test.db`) for agent integration/smoke tests.
+
+## CI gates
+
+CI runs the exact `task ci` chain: **lint → check-strings → typecheck → test**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright dashboard) runs last and only in Phase B+.
+
+## References
+
+- **[test-readiness/test-system.md](./test-readiness/test-system.md)** — the full blueprint: layer definitions, boundary-violation patterns, per-component budgets, the CI pipeline diagram, and the complete isolation contract. (Read-only — produced by the test-readiness plugin pipeline.)


### PR DESCRIPTION
Generated via `/shipwright:research-docs` (full-project audit). The repo's code is mature but `docs/` held only an index + the test-readiness blueprint — this fills the gaps and wires the docs into `CLAUDE.md`.

## What's added
- **docs/architecture.md** — the three-artifact A→B→C design (plugin / metrics / agent), supporting surfaces, workspace layout.
- **docs/testing.md** — the four-layer test model digested from `test-readiness/test-system.md`: run commands, speed budgets, isolation contract.
- **docs/metrics.md** — metrics service: 5 GET endpoints + dashboard, dual auth (Bearer / session), env table.
- **docs/agent.md** — reference agent: runtime API + admin CRUD (~21 routes), 6 Prisma models, encryption/env notes.

## What's updated
- **docs/README.md** — replaced the stale "Coming as the plugin lands" section with a live Contents index + a pointer to the plugin's own command docs.
- **CLAUDE.md** — aligned with the current architecture (artifact table, Commands, test conventions) and added a `## Reference` section listing the new `docs/` files (mirrors the vitals-os `@docs/*` index convention).

## Notes
- No top-level plugin command doc — README/CLAUDE.md point at `plugins/shipwright/README.md`/`CLAUDE.md` to avoid duplicate-rot.
- agent.md documents the *implemented* surfaces; `agent/src/index.ts` is still a Phase-C placeholder (called out explicitly).
- Verified public-safe: `check-banned-strings` clean; no `/Users/`, `vitals-os`, or secret leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)