### PR TITLE
feat(sww-2.2): add problem, how-it-works, differentiators, demo, social-proof body sections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,28 @@ jobs:
 
       - name: Test
         run: task test
+
+  site:
+    name: site build / brand-lint / smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.x"
+
+      - name: Install site dependencies
+        run: cd site && bun install
+
+      - name: Build site
+        run: cd site && bunx astro build
+
+      - name: Brand-lint built dist
+        run: cd site && npm run brand-lint
+
+      - name: Install Playwright chromium
+        run: cd site && bunx playwright install --with-deps chromium
+
+      - name: Playwright smoke
+        run: cd site && bunx playwright test

--- a/brand/brand.css
+++ b/brand/brand.css
@@ -114,6 +114,7 @@ code, .sw-mono { font-family: var(--sw-font-mono); }
 .sw-pill-success { background: var(--sw-color-brand-soft); color: var(--sw-color-brand-default); }
 .sw-pill-progress { background: var(--sw-color-support-patriot); color: var(--sw-color-support-patriot-bright); }
 
+.sw-h1 { font-family: var(--sw-font-display); font-size: var(--sw-text-h1-size); line-height: var(--sw-text-h1-line); font-weight: var(--sw-text-h1-weight); letter-spacing: var(--sw-text-h1-tracking); color: var(--sw-color-text-heading); }
 .sw-code { background: var(--sw-color-bg-overlay); border-radius: var(--sw-radius-md); padding: 0.85rem 1rem; font-family: var(--sw-font-mono); color: var(--sw-color-text-body); overflow: auto; }
 .sw-gradient-text { background: var(--sw-gradient-brand); -webkit-background-clip: text; background-clip: text; color: transparent; }
 .sw-orb { position: absolute; border-radius: 50%; filter: blur(80px); pointer-events: none; z-index: 0; }

--- a/brand/build-brand-css.ts
+++ b/brand/build-brand-css.ts
@@ -110,6 +110,7 @@ code, .sw-mono { font-family: var(--sw-font-mono); }
 .sw-pill-success { background: var(--sw-color-brand-soft); color: var(--sw-color-brand-default); }
 .sw-pill-progress { background: var(--sw-color-support-patriot); color: var(--sw-color-support-patriot-bright); }
 
+.sw-h1 { font-family: var(--sw-font-display); font-size: var(--sw-text-h1-size); line-height: var(--sw-text-h1-line); font-weight: var(--sw-text-h1-weight); letter-spacing: var(--sw-text-h1-tracking); color: var(--sw-color-text-heading); }
 .sw-code { background: var(--sw-color-bg-overlay); border-radius: var(--sw-radius-md); padding: 0.85rem 1rem; font-family: var(--sw-font-mono); color: var(--sw-color-text-body); overflow: auto; }
 .sw-gradient-text { background: var(--sw-gradient-brand); -webkit-background-clip: text; background-clip: text; color: transparent; }
 .sw-orb { position: absolute; border-radius: 50%; filter: blur(80px); pointer-events: none; z-index: 0; }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@
 | **Unit** | `bun test` | Pure logic — no I/O of any kind (no filesystem, network, or subprocess). | `*.unit.test.ts` |
 | **Integration** | `bun test` + injected recorded doubles | Real dependency behavior via recorded fixtures / injected doubles — exercises the seam without a live external service. | `*.integration.test.ts` |
 | **Smoke** | `bun test` + Hono `app.request()` | HTTP route contracts (status, shape, auth, errors) via in-process `app.request()` — no real socket. | `*.smoke.test.ts` |
-| **E2E** | `@playwright/test` | Full browser-driven flows against a real running server. Phase B (dashboard) only. | `*.spec.ts` (in `site/`) |
+| **E2E** | `@playwright/test` | Full browser-driven flows against a real running server. Marketing site home page (Phase A); metrics dashboard (Phase B+). | `*.spec.ts` (in `site/`) |
 
 The layer is encoded in the filename suffix. When adding a test, classify in order: no I/O → **unit**; calls an external service → **integration** (inject a recorded double); tests an HTTP route → **smoke** (`app.request()`); multi-step browser flow → **e2e**. If none fit, escalate — don't invent a fifth layer.
 
@@ -48,7 +48,7 @@ cd site && npm test                  # playwright (*.spec.ts)
 | Metrics (`metrics`) | unit, integration, smoke | `bun test --filter metrics` |
 | Agent (`agent`) | unit, integration, smoke | `bun test --filter agent` |
 
-The plugin has **no smoke/e2e layer** (no HTTP surface). E2E (Playwright) covers only the metrics dashboard UI in `site/`.
+The plugin has **no smoke/e2e layer** (no HTTP surface). E2E (Playwright) covers the marketing site home page (`site/tests/home.spec.ts`) and, in Phase B+, the metrics dashboard UI.
 
 ## Speed budgets
 

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "playwright test"
+    "test": "playwright test",
+    "brand-lint": "bun ../brand/brand-lint.ts $(find dist -type f \\( -name '*.html' -o -name '*.css' \\))",
+    "build:check": "astro build && npm run brand-lint"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.2.1",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,8 +1,7 @@
 ---
-// Home page hero + install section (SWW-2.1).
-// Builds the real hero on top of the SWW-1.1 scaffold: agent-led tagline with a
-// gradient on "Claude Code", primary/secondary CTAs, the "Built on Claude Code"
-// eyebrow, and the install command. No pricing, no email form, no runtime JS.
+// Home page — hero, install, problem, how-it-works, differentiators, demo,
+// social proof (SWW-2.1 + SWW-2.2).
+// No runtime JS, no hardcoded hex colors, no competitor names.
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const taglinePrefix = "The open-source autonomous delivery agent for ";
@@ -78,6 +77,7 @@ $ /shipwright:deploy
 ---
 
 <BaseLayout title="Shipwright Harness" description={tagline}>
+  <!-- ── Hero ── -->
   <section
     class="relative z-10 flex min-h-screen flex-col justify-center py-24"
   >

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -104,7 +104,7 @@ $ /shipwright:deploy
   <!-- 1. Problem -->
   <section id="problem" class="relative z-10 py-24">
     <p class="sw-label">The bottleneck</p>
-    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+    <h2 class="sw-h1 mt-4 max-w-2xl">
       AI tools are fast. Your pipeline isn't.
     </h2>
     <p class="mt-5 max-w-2xl text-lg">
@@ -118,7 +118,7 @@ $ /shipwright:deploy
   <!-- 2. How it works -->
   <section id="how-it-works" class="relative z-10 py-24">
     <p class="sw-label">How it works</p>
-    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+    <h2 class="sw-h1 mt-4 max-w-2xl">
       A deployable agent, backed by a system that does the work.
     </h2>
     <p class="mt-5 max-w-2xl text-lg">
@@ -147,7 +147,7 @@ $ /shipwright:deploy
   <!-- 3. Differentiators -->
   <section id="differentiators" class="relative z-10 py-24">
     <p class="sw-label">Why Shipwright Harness</p>
-    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+    <h2 class="sw-h1 mt-4 max-w-2xl">
       Built on Claude Code. Owned by you.
     </h2>
     <p class="mt-5 max-w-2xl text-lg">
@@ -178,7 +178,7 @@ $ /shipwright:deploy
   <!-- 4. Demo -->
   <section id="demo" class="relative z-10 py-24">
     <p class="sw-label">A run, end to end</p>
-    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+    <h2 class="sw-h1 mt-4 max-w-2xl">
       Install, then watch it ship.
     </h2>
     <p class="mt-5 max-w-2xl text-lg">
@@ -193,7 +193,7 @@ $ /shipwright:deploy
   <!-- 5. Social proof -->
   <section id="social-proof" class="relative z-10 py-24">
     <p class="sw-label">Get started</p>
-    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+    <h2 class="sw-h1 mt-4 max-w-2xl">
       Star it, install it, ship with it.
     </h2>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -10,6 +10,71 @@ const taglineGradient = "Claude Code";
 const tagline = `${taglinePrefix}${taglineGradient}.`;
 const install = "/plugin install shipwright@app-vitals/shipwright";
 const githubUrl = "https://github.com/app-vitals/shipwright";
+const discoveryUrl = "https://cal.com/app-vitals/discovery";
+
+// How-it-works: the four pipeline stages (plan → build → review → ship).
+const stages = [
+  {
+    name: "Plan",
+    body: "Read the spec, explore the codebase, and emit a sequenced task queue with estimates.",
+  },
+  {
+    name: "Build",
+    body: "Pick the next ready task, branch, write the feature and its tests at the correct layer.",
+  },
+  {
+    name: "Review",
+    body: "Deep single-pass review with inline findings and a recorded verdict before anything merges.",
+  },
+  {
+    name: "Ship",
+    body: "Merge the green PR, deploy, and forward the metrics that close the feedback loop.",
+  },
+];
+
+// Differentiators: generic, no competitor names. Claude Code is the platform.
+const differentiators = [
+  {
+    label: "Own it",
+    title: "Free & open-source (MIT)",
+    body: "No tiers, no seats, no data leaving your control. Clone it, run it in your own cloud, fork it if you want to.",
+  },
+  {
+    label: "Test-readiness",
+    title: "Tests land with the code",
+    body: "Every task ships its tests at the correct layer — unit, integration, smoke, or e2e — in the same PR. No 'tests later'.",
+  },
+  {
+    label: "Metric-first",
+    title: "Measured, not vibes",
+    body: "First-time-quality, estimation accuracy, and review verdicts are tracked per task so the pipeline gets honestly better.",
+  },
+  {
+    label: "Repo-agnostic",
+    title: "Runs on your stack",
+    body: "Node, Rust, Go, Python, Ruby, Make — the plugin drives any repository it's pointed at, not a blessed template.",
+  },
+];
+
+// Static, illustrative pipeline transcript for the demo (no real player, no JS).
+const demoTranscript = `$ /plugin install shipwright@app-vitals/shipwright
+✓ shipwright installed
+
+$ /shipwright:dev-task
+→ picking next ready task … SWW-2.2 (frontend)
+  branch feat/sww-2-2-body-sections
+  writing tests → 7 specs (e2e)
+  implementing … 5 sections
+  ✓ playwright   15 passed
+  ✓ PR #102 opened
+
+$ /shipwright:review
+  deep single-pass review … 0 blocking findings
+  verdict: APPROVE
+
+$ /shipwright:deploy
+  merge --squash … ✓ merged
+  deploy … ✓ live   metrics → forwarded`;
 ---
 
 <BaseLayout title="Shipwright Harness" description={tagline}>
@@ -34,5 +99,125 @@ const githubUrl = "https://github.com/app-vitals/shipwright";
       <p class="sw-label">Install</p>
       <pre class="sw-code mt-3 w-fit"><code>{install}</code></pre>
     </div>
+  </section>
+
+  <!-- 1. Problem -->
+  <section id="problem" class="relative z-10 py-24">
+    <p class="sw-label">The bottleneck</p>
+    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+      AI tools are fast. Your pipeline isn't.
+    </h2>
+    <p class="mt-5 max-w-2xl text-lg">
+      AI writes a feature in seconds. Then it sits — waiting on planning, code
+      review, test coverage, and the manual steps it takes to actually ship.
+      Generation got cheap; everything around it stayed human-paced. The work
+      didn't disappear, it just moved downstream.
+    </p>
+  </section>
+
+  <!-- 2. How it works -->
+  <section id="how-it-works" class="relative z-10 py-24">
+    <p class="sw-label">How it works</p>
+    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+      A deployable agent, backed by a system that does the work.
+    </h2>
+    <p class="mt-5 max-w-2xl text-lg">
+      Shipwright Harness is a deployable agent you run on your own codebase, and
+      an autonomous coding system that powers it. The agent picks up ready work
+      and drives it through four stages — end to end, with you in the loop only
+      where it counts.
+    </p>
+
+    <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {
+        stages.map((stage, i) => (
+          <div class="sw-card flex flex-col gap-3">
+            <div class="flex items-center justify-between">
+              <span class="sw-pill sw-pill-progress">{`0${i + 1}`}</span>
+              <span class="sw-label">Stage</span>
+            </div>
+            <h3 class="text-xl">{stage.name}</h3>
+            <p>{stage.body}</p>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <!-- 3. Differentiators -->
+  <section id="differentiators" class="relative z-10 py-24">
+    <p class="sw-label">Why Shipwright Harness</p>
+    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+      Built on Claude Code. Owned by you.
+    </h2>
+    <p class="mt-5 max-w-2xl text-lg">
+      It runs on Claude Code — the platform it's built for — and stays entirely
+      in your hands: open-source, self-hosted, and measured.
+    </p>
+
+    <div class="mt-10 grid gap-4 sm:grid-cols-2">
+      {
+        differentiators.map((d) => (
+          <div class="sw-card flex flex-col gap-2">
+            <span class="sw-label">{d.label}</span>
+            <h3 class="text-xl">{d.title}</h3>
+            <p>{d.body}</p>
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="sw-callout mt-6 max-w-3xl">
+      <p>
+        Built on Claude Code, free and open-source under the MIT license — you
+        own it and run it in your own cloud.
+      </p>
+    </div>
+  </section>
+
+  <!-- 4. Demo -->
+  <section id="demo" class="relative z-10 py-24">
+    <p class="sw-label">A run, end to end</p>
+    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+      Install, then watch it ship.
+    </h2>
+    <p class="mt-5 max-w-2xl text-lg">
+      One install, then plan → build → review → ship from the command line.
+      Here's an illustrative transcript of a single task moving through the
+      pipeline.
+    </p>
+
+    <pre class="sw-code mt-8 max-w-3xl text-sm leading-relaxed"><code>{demoTranscript}</code></pre>
+  </section>
+
+  <!-- 5. Social proof -->
+  <section id="social-proof" class="relative z-10 py-24">
+    <p class="sw-label">Get started</p>
+    <h2 class="mt-4 max-w-2xl text-3xl md:text-4xl">
+      Star it, install it, ship with it.
+    </h2>
+
+    <div class="mt-8 grid gap-4 sm:grid-cols-2">
+      <div class="sw-card flex flex-col gap-3">
+        <span class="sw-label">On GitHub</span>
+        <p>
+          Read the source, file an issue, or star the repo to follow along as it
+          grows.
+        </p>
+        <a class="sw-btn sw-btn-secondary w-fit" href={githubUrl}>
+          Star on GitHub
+        </a>
+      </div>
+      <div class="sw-card flex flex-col gap-3">
+        <span class="sw-label">Install</span>
+        <p>Drop it into Claude Code and point it at any repository.</p>
+        <pre class="sw-code w-fit text-sm"><code>{install}</code></pre>
+      </div>
+    </div>
+
+    <p class="mt-8 max-w-2xl">
+      Want a walkthrough on your own codebase?{" "}
+      <a href={discoveryUrl}>Book a discovery call</a>.
+    </p>
   </section>
 </BaseLayout>

--- a/site/src/styles/brand.css
+++ b/site/src/styles/brand.css
@@ -116,6 +116,7 @@ code, .sw-mono { font-family: var(--sw-font-mono); }
 .sw-pill-success { background: var(--sw-color-brand-soft); color: var(--sw-color-brand-default); }
 .sw-pill-progress { background: var(--sw-color-support-patriot); color: var(--sw-color-support-patriot-bright); }
 
+.sw-h1 { font-family: var(--sw-font-display); font-size: var(--sw-text-h1-size); line-height: var(--sw-text-h1-line); font-weight: var(--sw-text-h1-weight); letter-spacing: var(--sw-text-h1-tracking); color: var(--sw-color-text-heading); }
 .sw-code { background: var(--sw-color-bg-overlay); border-radius: var(--sw-radius-md); padding: 0.85rem 1rem; font-family: var(--sw-font-mono); color: var(--sw-color-text-body); overflow: auto; }
 .sw-gradient-text { background: var(--sw-gradient-brand); -webkit-background-clip: text; background-clip: text; color: transparent; }
 .sw-orb { position: absolute; border-radius: 50%; filter: blur(80px); pointer-events: none; z-index: 0; }

--- a/site/tailwind.config.mjs
+++ b/site/tailwind.config.mjs
@@ -6,7 +6,18 @@ export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {
     extend: {
+      // Preflight emits theme defaults into dist; point them at brand tokens so
+      // brand-lint stays green (Tailwind's stock #e5e7eb border / #9ca3af
+      // placeholder are off-brand hexes).
+      borderColor: {
+        DEFAULT: "#334155", // border.muted
+      },
       colors: {
+        // Preflight placeholders read theme('colors.gray.400'); alias it to a
+        // brand token so no stock #9ca3af leaks into dist.
+        gray: {
+          400: "#475569", // border.strong
+        },
         // Navy bases
         navy: {
           base: "#080E1E",

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -43,13 +43,15 @@ test("home document ships NO runtime JS (zero <script> tags)", async ({
 
 test("primary 'Get started' CTA renders", async ({ page }) => {
   await page.goto("/");
-  const cta = page.getByRole("link", { name: "Get started" });
+  // The hero CTA is the first "Get started" link on the page.
+  const cta = page.getByRole("link", { name: "Get started" }).first();
   await expect(cta).toBeVisible();
   await expect(cta).toHaveAttribute("href", "#install");
 });
 
 test("exact install command string renders", async ({ page }) => {
   await page.goto("/");
+  // The hero install block has id="install" — use that to scope.
   await expect(
     page
       .locator("#install")

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -51,9 +51,11 @@ test("primary 'Get started' CTA renders", async ({ page }) => {
 test("exact install command string renders", async ({ page }) => {
   await page.goto("/");
   await expect(
-    page.getByText("/plugin install shipwright@app-vitals/shipwright", {
-      exact: true,
-    }),
+    page
+      .locator("#install")
+      .getByText("/plugin install shipwright@app-vitals/shipwright", {
+        exact: true,
+      }),
   ).toBeVisible();
 });
 
@@ -69,5 +71,85 @@ test("secondary 'View on GitHub' CTA points at the repo", async ({ page }) => {
 
 test("eyebrow features 'Built on Claude Code'", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByText(/Built on Claude Code/i)).toBeVisible();
+  await expect(page.getByText(/Built on Claude Code/i).first()).toBeVisible();
+});
+
+// SWW-2.2: Body sections (problem / how-it-works / differentiators / demo / social proof).
+
+test("problem section renders its headline", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: /pipeline isn't/i }),
+  ).toBeVisible();
+});
+
+test("how-it-works leads with the agent and never headlines 'the loop'", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const section = page.locator("#how-it-works");
+  await expect(section).toBeVisible();
+  // Positively features the deployable agent.
+  await expect(section.getByText(/deployable agent/i).first()).toBeVisible();
+  // Brand rule: the section heading must NOT market "the loop" / "the delivery loop".
+  const heading = section.getByRole("heading").first();
+  await expect(heading).not.toHaveText(/the (delivery )?loop/i);
+});
+
+test("how-it-works presents all four pipeline stages", async ({ page }) => {
+  await page.goto("/");
+  const section = page.locator("#how-it-works");
+  for (const stage of ["Plan", "Build", "Review", "Ship"]) {
+    await expect(
+      section.getByText(new RegExp(`^${stage}$`, "i")).first(),
+    ).toBeVisible();
+  }
+});
+
+test("differentiators feature 'Built on Claude Code' and free/open-source (MIT)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const section = page.locator("#differentiators");
+  await expect(section).toBeVisible();
+  await expect(section.getByText(/Built on Claude Code/i).first()).toBeVisible();
+  await expect(section.getByText(/open[- ]source/i).first()).toBeVisible();
+  await expect(section.getByText(/MIT/).first()).toBeVisible();
+});
+
+test("differentiators name no competitors", async ({ page }) => {
+  await page.goto("/");
+  const text =
+    (await page.locator("#differentiators").textContent())?.toLowerCase() ?? "";
+  for (const competitor of ["devin", "cursor", "copilot", "windsurf", "github copilot"]) {
+    expect(text).not.toContain(competitor);
+  }
+});
+
+test("demo renders a static terminal block with no runtime JS", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const demo = page.locator("#demo");
+  await expect(demo).toBeVisible();
+  await expect(demo.locator("pre, code").first()).toBeVisible();
+  await expect(demo.getByText(/dev-task/i).first()).toBeVisible();
+  // Reconfirm zero runtime JS (no asciinema player injected).
+  expect(await page.locator("script").count()).toBe(0);
+});
+
+test("social proof links to GitHub and repeats the install command", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const section = page.locator("#social-proof");
+  await expect(section).toBeVisible();
+  await expect(
+    section.getByRole("link", { name: /github/i }).first(),
+  ).toHaveAttribute("href", /github\.com\/app-vitals\/shipwright/);
+  await expect(
+    section.getByText("/plugin install shipwright@app-vitals/shipwright", {
+      exact: true,
+    }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Add five marketing body sections to the home page on top of the existing hero: **Problem**, **How it works** (leads with the deployable agent; plan → build → review → ship — never headlines "the loop"), **Differentiators** (free/MIT, test-readiness, metrics, repo-agnostic; "Built on Claude Code" featured, no competitor names), a static **Demo** terminal transcript (zero runtime JS), and **Social proof** (GitHub star link + install snippet).
- Wire a **brand-lint-on-dist** check: new `brand-lint` npm script and a parallel `site` CI job (build → brand-lint `dist` → Playwright smoke). Aliased Tailwind preflight defaults (`#e5e7eb` border / `#9ca3af` placeholder) to brand tokens so built HTML/CSS carries no off-brand hexes.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All sections present; how-it-works leads with the agent, never headlines "the loop" | MET |
| 2 | Differentiators generic, no competitor names; "Built on Claude Code" featured | MET |
| 3 | Built `dist/` passes `brand/brand-lint.ts` (no off-brand hexes) | MET |
| 4 | Playwright smoke extended for section headings + brand-lint-on-dist in CI; no tests retired | MET |
| 5 | Safe to deploy standalone | MET |

## Test Plan
- Playwright smoke: 15 passed (8 pre-existing + 7 new section-heading/voice assertions).
- `astro build` + `brand-lint` over `dist`: on-brand (index.html + bundled CSS).
- `biome lint` clean; hero section and BaseLayout untouched; zero `<script>` tags.
- [x] Pre-commit checks passing

Closes #89

Generated with [Claude Code](https://claude.com/claude-code)
