### PR TITLE
feat(sww-2.3): add COSS services bridge section and site footer

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -15,6 +15,13 @@ const {
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+// Footer links (SWW-2.3): repo, license, platform, community.
+const repoUrl = "https://github.com/app-vitals/shipwright";
+const licenseUrl = "https://github.com/app-vitals/shipwright/blob/main/LICENSE";
+const claudeCodeUrl = "https://claude.com/claude-code";
+const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
+const year = new Date().getFullYear();
 ---
 
 <!doctype html>
@@ -69,5 +76,25 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <main class="sw-container relative">
       <slot />
     </main>
+
+    <!--
+      Site footer (SWW-2.3): repo · license · platform · community.
+      Pure markup, zero runtime JS. Border color comes from a brand token var
+      (no raw hex) so brand-lint stays green.
+    -->
+    <footer class="sw-container relative z-10 py-12">
+      <div
+        class="flex flex-col gap-6 pt-8 sm:flex-row sm:items-center sm:justify-between"
+        style="border-top: 1px solid var(--sw-color-border-subtle);"
+      >
+        <p class="sw-label">Shipwright Harness · MIT-licensed · © {year}</p>
+        <nav class="flex flex-wrap gap-x-6 gap-y-2 text-sm" aria-label="Footer">
+          <a href={repoUrl}>GitHub</a>
+          <a href={licenseUrl}>MIT License</a>
+          <a href={claudeCodeUrl}>Claude Code</a>
+          <a href={discussionsUrl}>GitHub Discussions</a>
+        </nav>
+      </div>
+    </footer>
   </body>
 </html>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -220,4 +220,22 @@ $ /shipwright:deploy
       <a href={discoveryUrl}>Book a discovery call</a>.
     </p>
   </section>
+
+  <!-- 6. Services bridge (COSS) — soft, no-pressure, no pricing -->
+  <section id="services" class="relative z-10 py-24">
+    <p class="sw-label">Work with us</p>
+    <h2 class="sw-h1 mt-4 max-w-2xl">
+      Work with the people who built it.
+    </h2>
+    <p class="mt-5 max-w-2xl text-lg">
+      Shipwright Harness is yours to run — free, open-source, and self-hosted,
+      always. If you'd rather have a hand standing it up on your own codebase,
+      the people who build it can help you get there faster. No commitment —
+      just a conversation about your pipeline.
+    </p>
+
+    <div class="mt-8">
+      <a class="sw-btn" href={discoveryUrl}>Book a discovery call</a>
+    </div>
+  </section>
 </BaseLayout>

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -155,3 +155,67 @@ test("social proof links to GitHub and repeats the install command", async ({
     }),
   ).toBeVisible();
 });
+
+// SWW-2.3: Services bridge (COSS) + site footer.
+
+test("services bridge links to the discovery call", async ({ page }) => {
+  await page.goto("/");
+  const section = page.locator("#services");
+  await expect(section).toBeVisible();
+  await expect(
+    section.getByRole("link", { name: /discovery call/i }),
+  ).toHaveAttribute("href", "https://cal.com/app-vitals/discovery");
+});
+
+test("services bridge stays soft — no email-capture form", async ({ page }) => {
+  await page.goto("/");
+  const section = page.locator("#services");
+  // COSS bridge is a single off-page CTA, not a lead-gen form.
+  expect(await section.locator("form, input").count()).toBe(0);
+});
+
+test("footer links to repo, license (MIT), Claude Code, and community", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const footer = page.locator("footer");
+  await expect(footer).toBeVisible();
+  // Repository.
+  await expect(
+    footer.getByRole("link", { name: "GitHub", exact: true }),
+  ).toHaveAttribute("href", "https://github.com/app-vitals/shipwright");
+  // License (MIT).
+  await expect(
+    footer.getByRole("link", { name: /MIT License/i }),
+  ).toHaveAttribute("href", /LICENSE/);
+  // Claude Code — the platform, featured (never a competitor).
+  await expect(
+    footer.getByRole("link", { name: /Claude Code/i }),
+  ).toHaveAttribute("href", "https://claude.com/claude-code");
+  // Community — GitHub Discussions.
+  await expect(
+    footer.getByRole("link", { name: /GitHub Discussions/i }),
+  ).toHaveAttribute("href", /github\.com\/app-vitals\/shipwright\/discussions/);
+});
+
+test("page markets no pricing anywhere", async ({ page }) => {
+  await page.goto("/");
+  const text = (await page.locator("body").textContent()) ?? "";
+  const lower = text.toLowerCase();
+  for (const term of [
+    "pricing",
+    "per month",
+    "per seat",
+    "per user",
+    "/month",
+    "/mo",
+    "subscription",
+    "free trial",
+    "billed annually",
+  ]) {
+    expect(lower).not.toContain(term);
+  }
+  // No dollar-amount price tags. The demo transcript uses "$ " shell prompts
+  // (dollar + space), never "$<digit>", so this only catches real prices.
+  expect(text).not.toMatch(/\$\d/);
+});


### PR DESCRIPTION
## Summary
- Add the quiet COSS "services bridge" section (`#services`) — soft, no-pressure "work with the people who built it" copy with the discovery-call as the only off-page CTA. No pricing, no email-capture form.
- Add the site footer in `BaseLayout` — repo, MIT license, Claude Code (the platform), and GitHub Discussions links. Zero runtime JS; border color via a brand-token CSS var so brand-lint stays green.

## Acceptance Criteria
- [x] Services section links to https://cal.com/app-vitals/discovery; no pricing anywhere on the page
- [x] Footer includes repo, license (MIT), Claude Code, and community (GitHub Discussions) links
- [x] Smoke extended to assert the discovery link + footer links AND that no pricing strings render — no tests retired (15 → 19)
- [x] brand-lint on dist green (only sw-*/brand-tokened utilities)
- [x] Zero runtime JS (no `<script>` tags)
- [x] Safe to deploy standalone

## Test Plan
- `cd site && npm test` — 19/19 Playwright smoke specs pass
- `cd site && npm run build:check` — astro build + brand-lint on dist both green
- [x] lint + check-strings green

Generated with [Claude Code](https://claude.com/claude-code)
