### PR TITLE
feat(sww-3.2): add Vercel deploy config + alternate-domain 301 redirect

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "astro",
+  "buildCommand": "astro build",
+  "outputDirectory": "dist",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "shipwright-harness.com" }],
+      "destination": "https://shipwrightharness.com/:path*",
+      "statusCode": 301
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.shipwright-harness.com" }],
+      "destination": "https://shipwrightharness.com/:path*",
+      "statusCode": 301
+    }
+  ]
+}


### PR DESCRIPTION
Closes #92 (SWW-3.2).

Adds `site/vercel.json` so the marketing site deploys as a static Astro build on Vercel and the alternate domain 301-redirects to the canonical host.

- **Build:** `framework: astro`, `buildCommand: astro build`, `outputDirectory: dist`.
- **Canonical redirect:** host-condition `redirects` rules send `shipwright-harness.com` and `www.shipwright-harness.com` → `https://shipwrightharness.com/:path*` with a literal `"statusCode": 301` (not `permanent`, which would emit 308).
- **No new workflow / no new tests:** the existing CI `site` job already runs `astro build` → brand-lint → Playwright; canonical is already wired in `astro.config.mjs`. The edge 301 is verified manually (AC waives automated redirect testing). All 22 Playwright specs stay green; none retired.
- **Manual DNS / Vercel domain-binding step (AC3)** is documented on the issue: https://github.com/app-vitals/shipwright/issues/92#issuecomment-4645570648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
