### PR TITLE
feat(she-4.2): port Slack + cron runtime from vitals-os

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@prisma/client": "^6.19.2",
+    "@slack/bolt": "^4.7.3",
+    "@slack/web-api": "^7.16.0",
     "hono": "^4"
   },
   "devDependencies": {

--- a/agent/src/cron-handler.integration.test.ts
+++ b/agent/src/cron-handler.integration.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Integration tests for cron-handler.ts
+ *
+ * Strategy: inject all deps. No real Slack or Claude calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WebClient } from "@slack/web-api";
+import { ValidationError, handleCronRequest } from "./cron-handler.ts";
+
+// ─── Shared mocks ─────────────────────────────────────────────────────────────
+
+const mockPostMessage = mock(() =>
+  Promise.resolve({ ok: true, ts: "1234567890.000001" }),
+);
+const mockConversationsOpen = mock(() =>
+  Promise.resolve({ channel: { id: "D_DM_CHANNEL" } }),
+);
+const mockReactionsAdd = mock(() => Promise.resolve({ ok: true }));
+const mockFilesUploadV2 = mock(() => Promise.resolve({ ok: true }));
+const mockSlack = {
+  chat: { postMessage: mockPostMessage },
+  conversations: { open: mockConversationsOpen },
+  reactions: { add: mockReactionsAdd },
+  files: { uploadV2: mockFilesUploadV2 },
+} as unknown as WebClient;
+
+const mockRunner = mock(() =>
+  Promise.resolve({ result: "claude reply", sessionId: "sess-1" }),
+);
+
+const deps = {
+  slack: mockSlack,
+  runner: mockRunner,
+  formatter: (text: string) => text,
+};
+
+afterEach(() => {
+  mockPostMessage.mockClear();
+  mockConversationsOpen.mockClear();
+  mockRunner.mockClear();
+  mockReactionsAdd.mockClear();
+  mockFilesUploadV2.mockClear();
+});
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+describe("handleCronRequest — validation", () => {
+  test("throws ValidationError when prompt is empty string", async () => {
+    await expect(
+      handleCronRequest({ jobId: "j1", prompt: "" }, deps),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("throws ValidationError when neither channel nor user is provided (and not silent)", async () => {
+    await expect(
+      handleCronRequest({ jobId: "j1", prompt: "hello" }, deps),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("does not throw when silent=true and no channel/user", async () => {
+    await expect(
+      handleCronRequest({ jobId: "j1", prompt: "hello", silent: true }, deps),
+    ).resolves.toBeUndefined();
+  });
+
+  test("runs runner but skips posting when silent=true", async () => {
+    await handleCronRequest({ jobId: "j1", prompt: "hello", silent: true }, deps);
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Channel delivery ─────────────────────────────────────────────────────────
+
+describe("handleCronRequest — channel delivery", () => {
+  test("posts result to channel", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "the report", sessionId: "s1" });
+
+    await handleCronRequest(
+      { jobId: "daily", prompt: "Summarise the day", channel: "C-REPORTS" },
+      deps,
+    );
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    const runArg = (mockRunner.mock.calls as unknown as string[][])[0][0];
+    expect(runArg).toContain("daily");
+    expect(runArg).toContain("Summarise the day");
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    expect((mockPostMessage.mock.calls as unknown as unknown[][])[0][0]).toMatchObject({
+      channel: "C-REPORTS",
+      text: "the report",
+    });
+  });
+
+  test("prefers channel over user when both are provided", async () => {
+    await handleCronRequest(
+      { jobId: "dual", prompt: "hello", channel: "C-MAIN", user: "U-SOMEONE" },
+      deps,
+    );
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    expect((mockPostMessage.mock.calls as unknown as unknown[][])[0][0]).toMatchObject({ channel: "C-MAIN" });
+    expect(mockConversationsOpen).not.toHaveBeenCalled();
+  });
+
+  test("calls onPost callback with channel and ts after posting", async () => {
+    const onPost = mock((_ch: string, _ts: string) => {});
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", channel: "C-TEST" },
+      { ...deps, onPost },
+    );
+
+    expect(onPost).toHaveBeenCalledTimes(1);
+    expect(onPost.mock.calls[0]).toEqual(["C-TEST", "1234567890.000001"]);
+  });
+
+  test("calls onSession callback when sessionId is returned", async () => {
+    const onSession = mock((_ch: string, _ts: string, _sid: string) => {});
+    mockRunner.mockResolvedValueOnce({ result: "reply", sessionId: "sess-xyz" });
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", channel: "C-TEST" },
+      { ...deps, onSession },
+    );
+
+    expect(onSession).toHaveBeenCalledTimes(1);
+    expect(onSession.mock.calls[0]).toEqual(["C-TEST", "1234567890.000001", "sess-xyz"]);
+  });
+});
+
+// ─── User (DM) delivery ───────────────────────────────────────────────────────
+
+describe("handleCronRequest — user DM delivery", () => {
+  test("opens DM and posts when only user is provided", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "dm reply", sessionId: "s2" });
+
+    await handleCronRequest(
+      { jobId: "dm-job", prompt: "check in", user: "U-DAN" },
+      deps,
+    );
+
+    expect(mockConversationsOpen).toHaveBeenCalledTimes(1);
+    expect((mockConversationsOpen.mock.calls as unknown as unknown[][])[0][0]).toMatchObject({ users: "U-DAN" });
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    expect((mockPostMessage.mock.calls as unknown as unknown[][])[0][0]).toMatchObject({
+      channel: "D_DM_CHANNEL",
+      text: "dm reply",
+    });
+  });
+
+  test("calls onPost with DM channel after DM post", async () => {
+    const onPost = mock((_ch: string, _ts: string) => {});
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", user: "U-DAN" },
+      { ...deps, onPost },
+    );
+
+    expect(onPost).toHaveBeenCalledTimes(1);
+    expect(onPost.mock.calls[0][0]).toBe("D_DM_CHANNEL");
+  });
+});
+
+// ─── Silent marker ────────────────────────────────────────────────────────────
+
+describe("handleCronRequest — [silent] marker", () => {
+  test("[silent] in result suppresses channel post", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "text [silent]", sessionId: "s3" });
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", channel: "C-MAIN" },
+      deps,
+    );
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  test("[silent] in result suppresses DM post", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "text [silent]", sessionId: "s4" });
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", user: "U-DAN" },
+      deps,
+    );
+
+    expect(mockConversationsOpen).not.toHaveBeenCalled();
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  test("silent=true dep flag suppresses post", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "result", sessionId: "s5" });
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", channel: "C-MAIN", silent: true },
+      deps,
+    );
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ─── preCheck ─────────────────────────────────────────────────────────────────
+
+describe("handleCronRequest — preCheck", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
+  });
+
+  test("skips job when preCheck script exits 1 (no work)", async () => {
+    const script = join(tmpDir, "check.ts");
+    writeFileSync(script, "process.exit(1);");
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "hello", channel: "C-TEST", preCheck: script },
+      deps,
+    );
+
+    expect(mockRunner).not.toHaveBeenCalled();
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  test("uses preCheck output as prompt when it exits 0 with output", async () => {
+    const script = join(tmpDir, "check.ts");
+    writeFileSync(script, `console.log("precheck prompt"); process.exit(0);`);
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "original", channel: "C-TEST", preCheck: script },
+      deps,
+    );
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    const runArg = (mockRunner.mock.calls as unknown as string[][])[0][0];
+    expect(runArg).toContain("precheck prompt");
+  });
+
+  test("skips job when preCheck script not found (plugin: format)", async () => {
+    await handleCronRequest(
+      {
+        jobId: "j1",
+        prompt: "hello",
+        channel: "C-TEST",
+        preCheck: "nonexistent-plugin:check.ts",
+      },
+      { ...deps, pluginCacheDir: tmpDir },
+    );
+
+    expect(mockRunner).not.toHaveBeenCalled();
+  });
+});

--- a/agent/src/cron-handler.integration.test.ts
+++ b/agent/src/cron-handler.integration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WebClient } from "@slack/web-api";

--- a/agent/src/cron-handler.ts
+++ b/agent/src/cron-handler.ts
@@ -1,0 +1,265 @@
+/**
+ * Agent cron request handler.
+ *
+ * Receives a cron payload, runs the prompt through Claude, and posts the
+ * result to Slack. Extracted as a pure function with injected deps for
+ * testability.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { WebClient } from "@slack/web-api";
+import type { TokenUsage } from "./claude.ts";
+import { markdownToSlack } from "./format.ts";
+import { parseMarkers } from "./markers.ts";
+import {
+  forwardNewMetrics,
+  forwardTokenUsage,
+  snapshotMetrics,
+} from "./posthog.ts";
+import { type SynthesizeSpeechFn, dispatchMarkers } from "./slack.ts";
+import type { VoiceConfig } from "./voice.ts";
+
+type ClaudeRunner = (
+  message: string,
+) => Promise<{ result: string; sessionId?: string; usage?: TokenUsage }>;
+
+interface CronRequest {
+  jobId: string;
+  prompt: string;
+  channel?: string;
+  user?: string;
+  silent?: boolean;
+  preCheck?: string;
+}
+
+export interface CronHandlerDeps {
+  slack: WebClient;
+  runner: ClaudeRunner;
+  formatter?: (text: string) => string;
+  /** Called after a successful post so the caller can track the thread. */
+  onPost?: (channel: string, ts: string) => void;
+  /** Called after a successful post when a sessionId is available. */
+  onSession?: (channel: string, ts: string, sessionId: string) => void;
+  /** Optional speech synthesis — if absent, [speak:] markers are skipped. */
+  synthesizeSpeechFn?: SynthesizeSpeechFn;
+  voiceConfig?: VoiceConfig;
+  /** Workspace root — used to forward metrics.jsonl entries to PostHog. */
+  workspace?: string;
+  /** Plugin cache dir — overridable for testing. */
+  pluginCacheDir?: string;
+  pluginManifestPath?: string;
+  alertsChannel?: string;
+}
+
+export async function handleCronRequest(
+  req: CronRequest,
+  deps: CronHandlerDeps,
+): Promise<void> {
+  const { jobId, channel, user, silent } = req;
+  let { prompt } = req;
+  const {
+    slack,
+    runner,
+    formatter = markdownToSlack,
+    onPost,
+    onSession,
+    synthesizeSpeechFn,
+    voiceConfig,
+    workspace,
+    pluginCacheDir,
+    pluginManifestPath = join(
+      homedir(),
+      ".claude",
+      "plugins",
+      "installed_plugins.json",
+    ),
+  } = deps;
+
+  if (!prompt) {
+    throw new ValidationError("missing required field: prompt");
+  }
+  if (!silent && !channel && !user) {
+    throw new ValidationError(
+      "missing delivery target: provide channel or user (or set silent=true)",
+    );
+  }
+
+  if (req.preCheck) {
+    const isRelative =
+      req.preCheck.startsWith("./") || req.preCheck.startsWith("../");
+    const isFilePath = isRelative || req.preCheck.startsWith("/");
+
+    let scriptPath: string | undefined;
+
+    if (isFilePath) {
+      if (isRelative && workspace === undefined) {
+        console.warn(
+          `[agent:cron] preCheck is a relative path but no workspace is set — skipping job "${jobId}"`,
+        );
+        return;
+      }
+      const candidate = isRelative
+        ? resolve(workspace as string, req.preCheck)
+        : req.preCheck;
+      if (existsSync(candidate)) scriptPath = candidate;
+    } else {
+      const [plugin, script] = req.preCheck.split(":");
+
+      if (pluginCacheDir) {
+        const candidate = join(pluginCacheDir, plugin, "scripts", script);
+        if (existsSync(candidate)) scriptPath = candidate;
+      } else {
+        try {
+          const manifest = JSON.parse(
+            readFileSync(pluginManifestPath, "utf-8"),
+          ) as {
+            version: number;
+            plugins: Record<string, Array<{ installPath?: string }>>;
+          };
+          const entry = Object.entries(manifest.plugins).find(([k]) =>
+            k.startsWith(`${plugin}@`),
+          );
+          const installPath = entry?.[1]?.[0]?.installPath;
+          if (installPath) {
+            const candidate = join(installPath, "scripts", script);
+            if (existsSync(candidate)) scriptPath = candidate;
+          }
+        } catch (err) {
+          console.warn(
+            `[agent:cron] failed to read installed_plugins.json: ${String(err)}`,
+          );
+        }
+      }
+    }
+
+    if (!scriptPath) {
+      console.warn(
+        `[agent:cron] preCheck script not found for "${req.preCheck}" — skipping job "${jobId}"`,
+      );
+      return;
+    }
+
+    const checkProc = Bun.spawn(["bun", scriptPath], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [checkOutput, checkStderr] = await Promise.all([
+      new Response(checkProc.stdout).text(),
+      new Response(checkProc.stderr).text(),
+    ]);
+    const checkExitCode = await checkProc.exited;
+    const output = checkOutput.trim();
+
+    if (checkExitCode >= 2) {
+      const detail = checkStderr.trim();
+      console.error(
+        `[agent:cron] preCheck for job "${jobId}" crashed (exit ${checkExitCode})${detail ? `: ${detail}` : ""} — session suppressed`,
+      );
+      if (deps.alertsChannel) {
+        try {
+          await deps.slack.chat.postMessage({
+            channel: deps.alertsChannel,
+            text: `[cron] preCheck for \`${jobId}\` crashed (exit ${checkExitCode}) — session suppressed${detail ? `\n\`\`\`\n${detail}\n\`\`\`` : ""}`,
+          });
+        } catch (alertErr) {
+          console.error("[agent:cron] failed to post preCheck alert:", alertErr);
+        }
+      }
+      return;
+    }
+
+    if (checkExitCode !== 0 || !output) {
+      console.log(
+        `[agent:cron] preCheck returned no work for job "${jobId}" — skipping tick`,
+      );
+      return;
+    }
+
+    prompt = output;
+  }
+
+  const now = new Date().toLocaleString("en-US", {
+    timeZone: "America/Los_Angeles",
+  });
+  const message = `[Cron job: ${jobId}] Current time: ${now}\n\n${prompt}`;
+
+  console.log(`[agent:cron] running job "${jobId}"`);
+
+  const metricsSnapshot = workspace ? snapshotMetrics(workspace) : undefined;
+  const { result, sessionId, usage } = await runner(message);
+  if (workspace && metricsSnapshot) {
+    await forwardNewMetrics(workspace, metricsSnapshot);
+  }
+  await forwardTokenUsage(usage, "cron");
+
+  const { cleaned, markers } = parseMarkers(result);
+  const isSilentMarker = markers.some((m) => m.type === "silent");
+
+  if (silent || isSilentMarker) {
+    console.log(`[agent:cron] job "${jobId}" completed (silent — no post)`);
+    return;
+  }
+
+  const formatted = formatter(cleaned);
+
+  if (channel) {
+    if (user) {
+      console.warn(
+        `[agent:cron] job "${jobId}" has both channel and user — posting to channel`,
+      );
+    }
+    const postResult = await slack.chat.postMessage({ channel, text: formatted });
+    console.log(`[agent:cron] job "${jobId}" posted to channel ${channel}`);
+    if (postResult.ts) {
+      onPost?.(channel, postResult.ts);
+      if (onSession && sessionId) onSession(channel, postResult.ts, sessionId);
+    } else {
+      console.warn(
+        `[agent:cron] job "${jobId}" postMessage returned no ts — react markers will be skipped`,
+      );
+    }
+    await dispatchMarkers(markers, {
+      client: slack,
+      channel,
+      postedTs: postResult.ts,
+      synthesizeSpeechFn,
+      voiceConfig,
+    });
+  } else if (user) {
+    const dmResult = await slack.conversations.open({ users: user });
+    const dmChannel = dmResult.channel?.id;
+    if (!dmChannel) {
+      throw new Error(`[agent:cron] could not open DM for user ${user}`);
+    }
+    const dmPostResult = await slack.chat.postMessage({
+      channel: dmChannel,
+      text: formatted,
+    });
+    console.log(`[agent:cron] job "${jobId}" posted DM to user ${user}`);
+    if (dmPostResult.ts) {
+      onPost?.(dmChannel, dmPostResult.ts);
+      if (onSession && sessionId)
+        onSession(dmChannel, dmPostResult.ts, sessionId);
+    } else {
+      console.warn(
+        `[agent:cron] job "${jobId}" DM postMessage returned no ts — react markers will be skipped`,
+      );
+    }
+    await dispatchMarkers(markers, {
+      client: slack,
+      channel: dmChannel,
+      postedTs: dmPostResult.ts,
+      synthesizeSpeechFn,
+      voiceConfig,
+    });
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}

--- a/agent/src/slack-manifest.ts
+++ b/agent/src/slack-manifest.ts
@@ -1,0 +1,142 @@
+/**
+ * agent/src/slack-manifest.ts
+ * Typed Slack app manifest builder for programmatic app creation.
+ *
+ * Used by agent/scripts/bootstrap-agent.ts to generate a per-agent manifest
+ * before calling the Slack Manifest API (apps.manifest.create).
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SlackManifestOauthConfig {
+  scopes: {
+    bot: string[];
+  };
+  redirect_urls: string[];
+}
+
+interface SlackManifestEventSubscriptions {
+  bot_events: string[];
+}
+
+interface SlackManifestSettings {
+  org_deploy_enabled: boolean;
+  socket_mode_enabled: boolean;
+  token_rotation_enabled: boolean;
+  event_subscriptions: SlackManifestEventSubscriptions;
+}
+
+interface SlackManifestAssistantView {
+  assistant_description: string;
+  suggested_prompts: { title: string; message: string }[];
+}
+
+interface SlackManifestFeatures {
+  app_home: {
+    home_tab_enabled: boolean;
+    messages_tab_enabled: boolean;
+    messages_tab_read_only_enabled: boolean;
+  };
+  bot_user: {
+    display_name: string;
+    always_online: boolean;
+  };
+  assistant_view: SlackManifestAssistantView;
+}
+
+interface SlackManifestDisplayInformation {
+  name: string;
+  description: string;
+  background_color: string;
+}
+
+export interface SlackManifest {
+  display_information: SlackManifestDisplayInformation;
+  features: SlackManifestFeatures;
+  oauth_config: SlackManifestOauthConfig;
+  settings: SlackManifestSettings;
+}
+
+// ─── Default scopes ───────────────────────────────────────────────────────────
+
+export const DEFAULT_BOT_SCOPES: string[] = [
+  "app_mentions:read",
+  "assistant:write",
+  "channels:read",
+  "chat:write",
+  "files:read",
+  "files:write",
+  "im:history",
+  "im:write",
+  "reactions:read",
+  "reactions:write",
+  "users:read",
+];
+
+// ─── Builder ──────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a Slack app manifest for a given agent name and scope list.
+ *
+ * @param agentName     Human-readable name for the Slack app (e.g. "My Agent")
+ * @param scopesOrOpts  Extra scopes array or options object with `botName`,
+ *                      `scopes`, and/or `redirectUrl`. Defaults to DEFAULT_BOT_SCOPES.
+ * @returns             A fully-typed SlackManifest object ready to serialize to JSON.
+ */
+export function buildManifest(
+  agentName: string,
+  scopesOrOpts?:
+    | string[]
+    | { botName?: string; scopes?: string[]; redirectUrl?: string },
+): SlackManifest {
+  const opts = Array.isArray(scopesOrOpts)
+    ? { scopes: scopesOrOpts }
+    : (scopesOrOpts ?? {});
+  const scopes = opts.scopes ?? [];
+  const botName = opts.botName;
+  const redirectUrl = Array.isArray(scopesOrOpts) ? undefined : opts.redirectUrl;
+  const allScopes = Array.from(new Set([...DEFAULT_BOT_SCOPES, ...scopes]));
+
+  return {
+    display_information: {
+      name: agentName,
+      description: `${agentName} — powered by Shipwright`,
+      background_color: "#1a1a2e",
+    },
+    features: {
+      app_home: {
+        home_tab_enabled: false,
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: botName ?? agentName,
+        always_online: true,
+      },
+      assistant_view: {
+        assistant_description: `${agentName} — powered by Shipwright`,
+        suggested_prompts: [],
+      },
+    },
+    oauth_config: {
+      scopes: {
+        bot: allScopes,
+      },
+      redirect_urls: [redirectUrl ?? "http://localhost:3460"],
+    },
+    settings: {
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+      event_subscriptions: {
+        bot_events: [
+          "app_mention",
+          "assistant_thread_context_changed",
+          "assistant_thread_started",
+          "message.im",
+          "reaction_added",
+        ],
+      },
+    },
+  };
+}

--- a/agent/src/slack.ts
+++ b/agent/src/slack.ts
@@ -1,0 +1,674 @@
+/**
+ * Slack Bolt event handlers for the Shipwright agent.
+ *
+ * All dependencies are injected — no global config reads, no hardcoded
+ * runClaude import. Call createSlackApp() with the runner returned by
+ * createRunClaude() and your injected config values.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { App } from "@slack/bolt";
+import type { WebAPIPlatformError } from "@slack/web-api";
+import type { AnalyticsEvent } from "./analytics.ts";
+import { ClaudeRunError, ClaudeTimeoutError } from "./claude.ts";
+import { markdownToBlocks, markdownToSlack } from "./format.ts";
+import { type Marker, parseMarkers } from "./markers.ts";
+import { forwardTokenUsage } from "./posthog.ts";
+import { threadKey as defaultThreadKey } from "./sessions.ts";
+import type { TokenUsage } from "./claude.ts";
+import type { VoiceConfig } from "./voice.ts";
+import { synthesizeSpeech, transcribeAudio } from "./voice.ts";
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+function isInvalidBlocksError(err: unknown): boolean {
+  const e = err as Partial<WebAPIPlatformError>;
+  return (
+    e.code === "slack_webapi_platform_error" &&
+    e.data?.error === "invalid_blocks"
+  );
+}
+
+export interface SlackFile {
+  name: string;
+  mimetype: string;
+  size: number;
+  url_private?: string;
+}
+
+export async function downloadFile(
+  file: SlackFile,
+  botToken: string,
+): Promise<string | null> {
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    console.warn(
+      `[slack] skipping ${file.name} (${file.size} bytes) — exceeds 10MB limit`,
+    );
+    return null;
+  }
+  const url = file.url_private;
+  if (!url) return null;
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, { headers: { Authorization: `Bearer ${botToken}` } });
+  } catch (err) {
+    console.warn(`[slack] file fetch error for ${file.name}:`, err);
+    return null;
+  }
+
+  if (!resp.ok) {
+    console.warn(`[slack] file download failed for ${file.name}: ${resp.status}`);
+    return null;
+  }
+
+  const buffer = Buffer.from(await resp.arrayBuffer());
+  const tmpPath = join(tmpdir(), `shipwright-agent-${Date.now()}-${file.name}`);
+  writeFileSync(tmpPath, buffer);
+  return tmpPath;
+}
+
+interface SlackConfig {
+  botToken: string;
+  appToken: string;
+  signingSecret: string;
+}
+
+type AppFactory = (cfg: {
+  token: string;
+  appToken: string;
+  socketMode: true;
+  signingSecret: string;
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt App type is complex
+}) => any;
+
+const defaultAppFactory: AppFactory = (cfg) =>
+  new (require("@slack/bolt").App)(cfg);
+
+export type Tracker = (event: Omit<AnalyticsEvent, "timestamp">) => void;
+const noopTracker: Tracker = () => {};
+
+type FileDownloaderFn = (file: SlackFile, botToken: string) => Promise<string | null>;
+
+type ConversationsRepliesFn = (
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt client type is complex
+  client: any,
+  channel: string,
+  ts: string,
+) => Promise<{ messages?: { user?: string; text?: string; ts?: string }[] }>;
+
+export type TranscribeAudioFn = typeof transcribeAudio;
+export type SynthesizeSpeechFn = typeof synthesizeSpeech;
+type GetSessionFn = (key: string) => string | undefined;
+
+export type ClaudeRunner = (
+  message: string,
+  sessionKey?: string,
+) => Promise<{ result: string; sessionId?: string; usage?: TokenUsage }>;
+
+export type ResolveUserFn = (
+  userId: string,
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt client is complex
+  client: any,
+) => Promise<string>;
+
+export async function dispatchMarkers(
+  markers: Marker[],
+  {
+    client,
+    channel,
+    postedTs,
+    threadTs,
+    workspace,
+    synthesizeSpeechFn,
+    voiceConfig = {},
+  }: {
+    // biome-ignore lint/suspicious/noExplicitAny: Bolt client type is complex
+    client: any;
+    channel: string;
+    postedTs?: string;
+    threadTs?: string;
+    workspace?: string;
+    synthesizeSpeechFn?: SynthesizeSpeechFn;
+    voiceConfig?: VoiceConfig;
+  },
+): Promise<void> {
+  for (const marker of markers) {
+    if (marker.type === "silent") continue;
+
+    if (marker.type === "react") {
+      if (postedTs) {
+        for (const emoji of marker.emojis) {
+          await client.reactions
+            .add({ channel, timestamp: postedTs, name: emoji })
+            .catch((err: unknown) => console.warn("[markers] react failed:", err));
+        }
+      }
+    } else if (marker.type === "upload") {
+      const absPath = marker.path.startsWith("/")
+        ? marker.path
+        : workspace
+          ? join(workspace, marker.path)
+          : marker.path;
+      if (existsSync(absPath)) {
+        await client.files
+          .uploadV2({
+            channel_id: channel,
+            thread_ts: threadTs,
+            file: readFileSync(absPath),
+            filename: absPath.split("/").pop() ?? "file",
+          })
+          .catch((err: unknown) => console.warn("[markers] upload failed:", err));
+      } else {
+        console.warn(`[markers] upload: file not found: ${absPath}`);
+      }
+    } else if (marker.type === "speak") {
+      if (!synthesizeSpeechFn) {
+        console.warn(
+          "[markers] speak marker found but synthesizeSpeechFn not injected — skipping",
+        );
+        continue;
+      }
+      try {
+        const audioPath = await synthesizeSpeechFn(marker.text, voiceConfig);
+        if (audioPath) {
+          await client.files
+            .uploadV2({
+              channel_id: channel,
+              thread_ts: threadTs,
+              file: readFileSync(audioPath),
+              filename: audioPath.split("/").pop() ?? "response.mp3",
+            })
+            .catch((err: unknown) =>
+              console.warn("[markers] speak upload failed:", err),
+            );
+        } else {
+          console.warn("[markers] speak synthesis returned null — no audio uploaded");
+        }
+      } catch (err) {
+        console.warn("[markers] speak synthesis failed:", err);
+      }
+    }
+  }
+}
+
+function _classifyError(err: unknown): { lead: string; known: boolean } {
+  if (err instanceof ClaudeTimeoutError) {
+    return {
+      lead: `:hourglass_flowing_sand: Session timed out after ${Math.round(err.timeoutMs / 60_000)} minutes. Please retry.`,
+      known: true,
+    };
+  }
+  if (err instanceof ClaudeRunError) {
+    const status = err.apiErrorStatus;
+    const detail = err.resultMessage;
+    if (status === 429 && /usage limit/i.test(detail)) {
+      return {
+        lead: ":warning: I've hit the org's monthly Claude usage limit. Please try again later or contact the agent owner.",
+        known: true,
+      };
+    }
+    if (status === 429) {
+      return {
+        lead: ":warning: Rate-limited by Anthropic — try again in a moment.",
+        known: true,
+      };
+    }
+    if (status === 529) {
+      return {
+        lead: ":warning: Anthropic's API is overloaded. This is usually transient — try again in ~30s. Status: https://status.anthropic.com",
+        known: true,
+      };
+    }
+    if (status === 500 || status === 502 || status === 503 || status === 504) {
+      return {
+        lead: `:warning: Anthropic API hiccup (${status}). This is server-side and usually transient — please retry. Status: https://status.anthropic.com`,
+        known: true,
+      };
+    }
+    if (status === 401 || status === 403) {
+      return {
+        lead: `:warning: Auth failure with Anthropic (${status}). The agent's API key may need to be refreshed.`,
+        known: true,
+      };
+    }
+    return {
+      lead: `:warning: Claude returned an error${status ? ` (${status})` : ""}.`,
+      known: false,
+    };
+  }
+  return { lead: ":warning: Something went wrong.", known: false };
+}
+
+function _detailLine(err: unknown): string {
+  if (err instanceof ClaudeRunError) return err.resultMessage;
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}
+
+export function formatRunErrorForSlack(err: unknown): string {
+  const { lead, known } = _classifyError(err);
+  const detail = _detailLine(err);
+  const stack =
+    !known && err instanceof Error && err.stack ? err.stack : undefined;
+  const stackBlock = stack ? `\n\n\`\`\`\n${stack}\n\`\`\`` : "";
+  return `${lead}\n\n_Detail:_ ${detail}${stackBlock}`;
+}
+
+const defaultConversationsRepliesFn: ConversationsRepliesFn = async (
+  client,
+  channel,
+  ts,
+) => client.conversations.replies({ channel, ts, limit: 200 });
+
+async function buildPromptWithFiles(
+  text: string,
+  files: SlackFile[] | undefined,
+  fileDownloaderFn: FileDownloaderFn,
+  botToken: string,
+  transcribeAudioFn: TranscribeAudioFn,
+  voiceConfig: VoiceConfig,
+): Promise<string> {
+  if (!files?.length) return text;
+  const fileParts: string[] = [];
+  for (const file of files) {
+    try {
+      const filePath = await fileDownloaderFn(file, botToken);
+      if (filePath) {
+        if (file.mimetype.startsWith("audio/")) {
+          try {
+            const transcript = await transcribeAudioFn(filePath, voiceConfig);
+            fileParts.push(
+              transcript ? `[voice transcript: ${transcript}]` : `[file: ${filePath}]`,
+            );
+          } catch (err) {
+            console.warn("[voice] transcription error:", err);
+            fileParts.push(`[file: ${filePath}]`);
+          }
+        } else {
+          fileParts.push(`[file: ${filePath}]`);
+        }
+      }
+    } catch (err) {
+      console.warn(`[slack] file download error for ${file.name}:`, err);
+    }
+  }
+  return fileParts.length ? `${fileParts.join("\n")}\n${text}`.trim() : text;
+}
+
+export function createSlackApp(
+  runner: ClaudeRunner,
+  formatter: (text: string) => string = markdownToSlack,
+  getThreadKey: typeof defaultThreadKey = defaultThreadKey,
+  appFactory: AppFactory = defaultAppFactory,
+  slackConfig: SlackConfig = { botToken: "", appToken: "", signingSecret: "" },
+  tracker: Tracker = noopTracker,
+  fileDownloaderFn: FileDownloaderFn = downloadFile,
+  voiceConfig: VoiceConfig = {},
+  transcribeAudioFn: TranscribeAudioFn = transcribeAudio,
+  synthesizeSpeechFn: SynthesizeSpeechFn = synthesizeSpeech,
+  resolveUserFn: ResolveUserFn = async (userId) => userId,
+  botUserId: string | undefined = undefined,
+  conversationsRepliesFn: ConversationsRepliesFn = defaultConversationsRepliesFn,
+  getSessionFn: GetSessionFn = () => undefined,
+  blocksConverter: typeof markdownToBlocks = markdownToBlocks,
+): App {
+  const app = appFactory({
+    token: slackConfig.botToken,
+    appToken: slackConfig.appToken,
+    socketMode: true,
+    signingSecret: slackConfig.signingSecret,
+  });
+
+  // DMs: respond to every message.
+  // Channels: respond only if bot has already replied in this thread.
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt callback params
+  app.message(async ({ message, say, client }: any) => {
+    if (message.subtype && message.subtype !== "file_share") return;
+    const msg = message as {
+      text?: string;
+      channel: string;
+      ts: string;
+      thread_ts?: string;
+      channel_type?: string;
+      files?: SlackFile[];
+      user?: string;
+    };
+
+    const isDM = msg.channel_type === "im";
+    const hasText = !!msg.text?.trim();
+    const hasFiles = !!msg.files?.length;
+
+    if (!hasText && !hasFiles) return;
+
+    if (!isDM) {
+      if (!msg.thread_ts) return;
+      if (!getSessionFn(getThreadKey(msg.channel, msg.thread_ts))) return;
+    }
+
+    const sessionKey = getThreadKey(msg.channel, msg.thread_ts ?? msg.ts);
+    const replyTs = msg.thread_ts ?? msg.ts;
+
+    const setStatus = async (status: string) => {
+      // biome-ignore lint/suspicious/noExplicitAny: Bolt types don't include Agents API yet
+      await (client.assistant.threads as any)
+        .setStatus({ channel_id: msg.channel, thread_ts: replyTs, status })
+        .catch(() => {});
+    };
+    await setStatus("Thinking...");
+
+    let prompt = await buildPromptWithFiles(
+      msg.text ?? "",
+      msg.files,
+      fileDownloaderFn,
+      slackConfig.botToken,
+      transcribeAudioFn,
+      voiceConfig,
+    );
+
+    if (msg.user) {
+      const name = await resolveUserFn(msg.user, client);
+      prompt = `[${name}]: ${prompt}`;
+    }
+
+    if (!isDM && msg.thread_ts) {
+      prompt = `[Thread message — respond normally, or use [silent] if no response is needed]\n${prompt}`;
+    }
+
+    const startedAt = new Date();
+    try {
+      const { result, usage } = await runner(prompt, sessionKey);
+      const endedAt = new Date();
+      await forwardTokenUsage(usage, isDM ? "slack_dm" : "slack_mention");
+      const { cleaned, markers } = parseMarkers(result);
+
+      const isSilent = markers.some((m) => m.type === "silent");
+      const dmOverride = isSilent && isDM && cleaned.trim().length > 0;
+      const shouldSuppress = isSilent && !dmOverride;
+
+      if (dmOverride) {
+        console.log("[slack] ignoring [silent] marker in DM — posting reply");
+      }
+      if (shouldSuppress) {
+        console.log(
+          `[slack] silent response — not posting (cleaned: ${cleaned.length} chars)`,
+        );
+      }
+
+      let postedTs: string | undefined;
+      if (!shouldSuppress && cleaned.trim().length > 0) {
+        const blocks = blocksConverter(cleaned);
+        let sayResult: unknown;
+        if (blocks) {
+          try {
+            sayResult = await say({
+              text: blocks.text,
+              blocks: blocks.blocks,
+              thread_ts: msg.thread_ts ?? msg.ts,
+            });
+          } catch (err: unknown) {
+            if (!isInvalidBlocksError(err)) throw err;
+            console.warn("[slack] invalid_blocks — retrying with plain text");
+            sayResult = await say({
+              text: blocks.text || formatter(cleaned),
+              thread_ts: msg.thread_ts ?? msg.ts,
+            });
+          }
+        } else {
+          sayResult = await say({
+            text: formatter(cleaned),
+            thread_ts: msg.thread_ts ?? msg.ts,
+          });
+        }
+        postedTs = (sayResult as { ts?: string } | undefined)?.ts;
+      } else if (!shouldSuppress) {
+        console.log("[slack] markers-only response — skipping text post");
+      }
+
+      await dispatchMarkers(markers, {
+        client,
+        channel: msg.channel,
+        postedTs,
+        threadTs: msg.thread_ts ?? msg.ts,
+        synthesizeSpeechFn,
+        voiceConfig,
+      });
+      tracker({
+        type: "message",
+        sessionKey,
+        durationMs: endedAt.getTime() - startedAt.getTime(),
+      });
+    } catch (err) {
+      console.error("[slack] error:", err);
+      tracker({
+        type: "error",
+        sessionKey,
+        durationMs: Date.now() - startedAt.getTime(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await say({
+        text: formatRunErrorForSlack(err),
+        thread_ts: msg.thread_ts ?? msg.ts,
+      });
+    } finally {
+      await setStatus("");
+    }
+  });
+
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt callback params
+  app.event("app_mention", async ({ event, say, client }: any) => {
+    const ev = event as {
+      text: string;
+      channel: string;
+      ts: string;
+      thread_ts?: string;
+      user?: string;
+      files?: SlackFile[];
+    };
+    const sessionKey = getThreadKey(ev.channel, ev.thread_ts ?? ev.ts);
+    const replyTs = ev.thread_ts ?? ev.ts;
+
+    const setStatus = async (status: string) => {
+      // biome-ignore lint/suspicious/noExplicitAny: Bolt types don't include Agents API yet
+      await (client.assistant.threads as any)
+        .setStatus({ channel_id: ev.channel, thread_ts: replyTs, status })
+        .catch(() => {});
+    };
+    await setStatus("Thinking...");
+
+    let prompt = await buildPromptWithFiles(
+      ev.text,
+      ev.files,
+      fileDownloaderFn,
+      slackConfig.botToken,
+      transcribeAudioFn,
+      voiceConfig,
+    );
+
+    if (ev.user) {
+      const name = await resolveUserFn(ev.user as string, client);
+      prompt = `[${name}]: ${prompt}`;
+    }
+
+    if (event.thread_ts && !getSessionFn(sessionKey)) {
+      try {
+        const repliesResult = await conversationsRepliesFn(
+          client,
+          event.channel as string,
+          event.thread_ts as string,
+        );
+        const messages = repliesResult.messages ?? [];
+        const historyLines = await Promise.all(
+          messages
+            .filter(
+              (m) =>
+                m.text &&
+                m.text.trim() !== "" &&
+                m.user &&
+                (!botUserId || m.user !== botUserId) &&
+                m.ts !== (event.ts as string),
+            )
+            .map(async (m) => {
+              const name = await resolveUserFn(m.user as string, client);
+              return `[${name}]: ${m.text}`;
+            }),
+        );
+        if (historyLines.length > 0) {
+          prompt = `[Thread context]\n${historyLines.join("\n")}\n[end thread context]\n\n${prompt}`;
+        }
+      } catch (err) {
+        console.warn("[slack] failed to fetch thread history:", err);
+      }
+    }
+
+    const startedAt = new Date();
+    try {
+      const { result, usage } = await runner(prompt, sessionKey);
+      const endedAt = new Date();
+      await forwardTokenUsage(usage, "slack_mention");
+      const { cleaned, markers } = parseMarkers(result);
+
+      const isSilent = markers.some((m) => m.type === "silent");
+      if (isSilent) {
+        console.log(
+          `[slack] silent response — not posting (channel mention, cleaned: ${cleaned.length} chars)`,
+        );
+      }
+
+      let postedMentionTs: string | undefined;
+      if (!isSilent && cleaned.trim().length > 0) {
+        const blocks = blocksConverter(cleaned);
+        let sayResult: unknown;
+        if (blocks) {
+          try {
+            sayResult = await say({
+              text: blocks.text,
+              blocks: blocks.blocks,
+              thread_ts: replyTs,
+            });
+          } catch (err: unknown) {
+            if (!isInvalidBlocksError(err)) throw err;
+            console.warn("[slack] invalid_blocks — retrying with plain text");
+            sayResult = await say({
+              text: blocks.text || formatter(cleaned),
+              thread_ts: replyTs,
+            });
+          }
+        } else {
+          sayResult = await say({ text: formatter(cleaned), thread_ts: replyTs });
+        }
+        postedMentionTs = (sayResult as { ts?: string } | undefined)?.ts;
+      } else if (!isSilent) {
+        console.log("[slack] markers-only response — skipping text post");
+      }
+
+      await dispatchMarkers(markers, {
+        client,
+        channel: ev.channel,
+        postedTs: postedMentionTs,
+        threadTs: replyTs,
+        synthesizeSpeechFn,
+        voiceConfig,
+      });
+      tracker({
+        type: "mention",
+        sessionKey,
+        durationMs: endedAt.getTime() - startedAt.getTime(),
+      });
+    } catch (err) {
+      console.error("[slack] error:", err);
+      tracker({
+        type: "error",
+        sessionKey,
+        durationMs: Date.now() - startedAt.getTime(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await say({ text: formatRunErrorForSlack(err), thread_ts: replyTs });
+    } finally {
+      await setStatus("");
+    }
+  });
+
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt callback params
+  app.event("reaction_added", async ({ event, client }: any) => {
+    const ev = event as {
+      reaction: string;
+      item: { type: string; channel: string; ts: string };
+      item_user: string;
+      user: string;
+    };
+
+    if (ev.item.type !== "message") return;
+    if (!botUserId || ev.item_user !== botUserId) return;
+    if (!ev.item.channel.startsWith("D")) return;
+
+    const sessionKey = getThreadKey(ev.item.channel, ev.item.ts);
+    const name = await resolveUserFn(ev.user, client).catch(() => ev.user);
+    const prompt = `[${name} reacted with :${ev.reaction}: to your message]`;
+
+    try {
+      const { result, usage } = await runner(prompt, sessionKey);
+      await forwardTokenUsage(usage, "slack_dm");
+      const { cleaned, markers } = parseMarkers(result);
+
+      const isSilent = markers.some((m) => m.type === "silent");
+      if (isSilent) {
+        console.log("[slack] reaction_added: silent response — not posting");
+        return;
+      }
+
+      let postResult: unknown;
+      if (cleaned.trim().length > 0) {
+        const blocks = blocksConverter(cleaned);
+        if (blocks) {
+          try {
+            postResult = await client.chat.postMessage({
+              channel: ev.item.channel,
+              text: blocks.text,
+              blocks: blocks.blocks,
+            });
+          } catch (err: unknown) {
+            if (isInvalidBlocksError(err)) {
+              console.warn("[slack] invalid_blocks — retrying with plain text");
+              postResult = await client.chat
+                .postMessage({
+                  channel: ev.item.channel,
+                  text: blocks.text || formatter(cleaned),
+                })
+                .catch((err2: unknown) => {
+                  console.warn("[slack] reaction_added: postMessage failed:", err2);
+                  return undefined;
+                });
+            } else {
+              console.warn("[slack] reaction_added: postMessage failed:", err);
+              postResult = undefined;
+            }
+          }
+        } else {
+          postResult = await client.chat
+            .postMessage({ channel: ev.item.channel, text: formatter(cleaned) })
+            .catch((err: unknown) => {
+              console.warn("[slack] reaction_added: postMessage failed:", err);
+              return undefined;
+            });
+        }
+      }
+
+      const postedTs = (postResult as { ts?: string } | undefined)?.ts;
+      await dispatchMarkers(markers, {
+        client,
+        channel: ev.item.channel,
+        postedTs,
+        threadTs: ev.item.ts,
+        synthesizeSpeechFn,
+        voiceConfig,
+      });
+    } catch (err) {
+      console.error("[slack] reaction_added error:", err);
+    }
+  });
+
+  return app;
+}

--- a/agent/src/slack.unit.test.ts
+++ b/agent/src/slack.unit.test.ts
@@ -12,10 +12,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ClaudeRunError } from "./claude.ts";
 import { threadKey } from "./sessions.ts";
 import {
-  type SlackFile,
   createSlackApp,
   dispatchMarkers,
-  downloadFile,
   formatRunErrorForSlack,
 } from "./slack.ts";
 

--- a/agent/src/slack.unit.test.ts
+++ b/agent/src/slack.unit.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Unit tests for agent/src/slack.ts
+ *
+ * Strategy: inject all dependencies via createSlackApp's params.
+ * No mock.module(), no global.fetch overrides.
+ *
+ * MockApp class captures constructor args and registered handlers,
+ * then fires them synchronously in tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ClaudeRunError } from "./claude.ts";
+import { threadKey } from "./sessions.ts";
+import {
+  type SlackFile,
+  createSlackApp,
+  dispatchMarkers,
+  downloadFile,
+  formatRunErrorForSlack,
+} from "./slack.ts";
+
+// ─── MockApp ──────────────────────────────────────────────────────────────────
+
+type HandlerFn = (...args: unknown[]) => Promise<void>;
+
+let capturedConstructorArgs: Record<string, unknown> | null = null;
+let capturedMessageHandler: HandlerFn | null = null;
+let capturedMentionHandler: HandlerFn | null = null;
+let capturedReactionAddedHandler: HandlerFn | null = null;
+
+class MockApp {
+  constructor(args: Record<string, unknown>) {
+    capturedConstructorArgs = args;
+    capturedMessageHandler = null;
+    capturedMentionHandler = null;
+    capturedReactionAddedHandler = null;
+  }
+
+  message(handler: HandlerFn) {
+    capturedMessageHandler = handler;
+  }
+
+  event(eventName: string, handler: HandlerFn) {
+    if (eventName === "app_mention") capturedMentionHandler = handler;
+    if (eventName === "reaction_added") capturedReactionAddedHandler = handler;
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: mock factory for tests
+const mockAppFactory = (cfg: any) => new MockApp(cfg) as any;
+
+// ─── Mock deps ────────────────────────────────────────────────────────────────
+
+const mockRunner = mock(
+  async (_msg: string, _key?: string): Promise<{ result: string; sessionId?: string }> => ({
+    result: "Claude response",
+    sessionId: "sess-1",
+  }),
+);
+
+const mockFormatter = mock((text: string): string => `[fmt] ${text}`);
+
+const mockSlackConfig = {
+  botToken: "xoxb-test",
+  appToken: "xapp-test",
+  signingSecret: "secret",
+};
+
+const mockResolveUserFn = mock(async (_userId: string, _client: unknown): Promise<string> => "TestUser");
+
+const mockSay = mock(() => Promise.resolve({ ts: "999.000" }));
+
+// biome-ignore lint/suspicious/noExplicitAny: mock Slack client
+const mockClient: any = {
+  assistant: {
+    threads: {
+      setStatus: mock(() => Promise.resolve()),
+    },
+  },
+  reactions: { add: mock(() => Promise.resolve()) },
+  files: { uploadV2: mock(() => Promise.resolve()) },
+  chat: { postMessage: mock(() => Promise.resolve({ ts: "999.000" })) },
+};
+
+const mockGetSessionFn = mock((_key: string): string | undefined => undefined);
+
+const mockConversationsRepliesFn = mock(async (_client: unknown, _channel: string, _ts: string) => ({
+  messages: [],
+}));
+
+const mockBlocksConverter = mock((_text: string) => null as null);
+
+beforeEach(() => {
+  mockRunner.mockClear();
+  mockFormatter.mockClear();
+  mockSay.mockClear();
+  mockResolveUserFn.mockClear();
+  mockGetSessionFn.mockClear();
+  mockConversationsRepliesFn.mockClear();
+  mockBlocksConverter.mockClear();
+  mockClient.assistant.threads.setStatus.mockClear();
+  mockClient.reactions.add.mockClear();
+  mockClient.files.uploadV2.mockClear();
+  mockClient.chat.postMessage.mockClear();
+  capturedMessageHandler = null;
+  capturedMentionHandler = null;
+  capturedReactionAddedHandler = null;
+});
+
+function makeApp() {
+  return createSlackApp(
+    mockRunner,
+    mockFormatter,
+    threadKey,
+    mockAppFactory,
+    mockSlackConfig,
+    () => {},
+    async () => null,
+    {},
+    async () => "",
+    async () => null,
+    mockResolveUserFn,
+    "U-BOT",
+    mockConversationsRepliesFn,
+    mockGetSessionFn,
+    mockBlocksConverter,
+  );
+}
+
+// ─── Factory / constructor ────────────────────────────────────────────────────
+
+describe("createSlackApp", () => {
+  test("instantiates with injected app factory (AC 1)", () => {
+    makeApp();
+    expect(capturedConstructorArgs).not.toBeNull();
+    expect(capturedConstructorArgs?.token).toBe("xoxb-test");
+    expect(capturedConstructorArgs?.appToken).toBe("xapp-test");
+    expect(capturedConstructorArgs?.socketMode).toBe(true);
+  });
+
+  test("registers message, app_mention, and reaction_added handlers", () => {
+    makeApp();
+    expect(capturedMessageHandler).not.toBeNull();
+    expect(capturedMentionHandler).not.toBeNull();
+    expect(capturedReactionAddedHandler).not.toBeNull();
+  });
+});
+
+// ─── app.message — DM routing ─────────────────────────────────────────────────
+
+describe("app.message — DM routing", () => {
+  test("responds to DM messages", async () => {
+    makeApp();
+    await capturedMessageHandler?.({
+      message: { text: "hello", channel: "D123", ts: "1.0", channel_type: "im" },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    expect(mockSay).toHaveBeenCalledTimes(1);
+  });
+
+  test("DM: [silent] marker does NOT suppress reply (DM override)", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "content [silent]", sessionId: "s1" });
+    makeApp();
+
+    await capturedMessageHandler?.({
+      message: { text: "hello", channel: "D123", ts: "1.0", channel_type: "im" },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips if message has no text and no files", async () => {
+    makeApp();
+    await capturedMessageHandler?.({
+      message: { channel: "D123", ts: "1.0", channel_type: "im" },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockRunner).not.toHaveBeenCalled();
+  });
+});
+
+// ─── app.message — Channel routing ───────────────────────────────────────────
+
+describe("app.message — channel routing", () => {
+  test("skips non-DM message without thread_ts (not in a thread)", async () => {
+    makeApp();
+    await capturedMessageHandler?.({
+      message: { text: "hi", channel: "C123", ts: "1.0", channel_type: "channel" },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockRunner).not.toHaveBeenCalled();
+  });
+
+  test("skips non-DM thread message when no session exists", async () => {
+    mockGetSessionFn.mockReturnValueOnce(undefined);
+    makeApp();
+
+    await capturedMessageHandler?.({
+      message: {
+        text: "hi",
+        channel: "C123",
+        ts: "2.0",
+        thread_ts: "1.0",
+        channel_type: "channel",
+      },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockRunner).not.toHaveBeenCalled();
+  });
+
+  test("responds to non-DM thread message when session exists", async () => {
+    mockGetSessionFn.mockReturnValueOnce("existing-session-id");
+    makeApp();
+
+    await capturedMessageHandler?.({
+      message: {
+        text: "follow up",
+        channel: "C123",
+        ts: "2.0",
+        thread_ts: "1.0",
+        channel_type: "channel",
+      },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    expect(mockSay).toHaveBeenCalledTimes(1);
+  });
+
+  test("channel thread: [silent] suppresses reply", async () => {
+    mockGetSessionFn.mockReturnValueOnce("sess-xyz");
+    mockRunner.mockResolvedValueOnce({ result: "text [silent]", sessionId: "s1" });
+    makeApp();
+
+    await capturedMessageHandler?.({
+      message: {
+        text: "hi",
+        channel: "C123",
+        ts: "2.0",
+        thread_ts: "1.0",
+        channel_type: "channel",
+      },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockSay).not.toHaveBeenCalled();
+  });
+});
+
+// ─── app_mention ──────────────────────────────────────────────────────────────
+
+describe("app_mention handler", () => {
+  test("responds to app_mention", async () => {
+    makeApp();
+
+    await capturedMentionHandler?.({
+      event: { text: "@bot hello", channel: "C123", ts: "1.0" },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    expect(mockSay).toHaveBeenCalledTimes(1);
+  });
+
+  test("app_mention: [silent] suppresses reply", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "stuff [silent]", sessionId: "s1" });
+    makeApp();
+
+    await capturedMentionHandler?.({
+      event: { text: "@bot hello", channel: "C123", ts: "1.0" },
+      say: mockSay,
+      client: mockClient,
+    });
+
+    expect(mockSay).not.toHaveBeenCalled();
+  });
+});
+
+// ─── reaction_added ───────────────────────────────────────────────────────────
+
+describe("reaction_added handler", () => {
+  test("routes reaction on bot DM message to runner", async () => {
+    makeApp();
+
+    await capturedReactionAddedHandler?.({
+      event: {
+        reaction: "thumbsup",
+        item: { type: "message", channel: "D123", ts: "1.0" },
+        item_user: "U-BOT",
+        user: "U-DAN",
+      },
+      client: mockClient,
+    });
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    const prompt = mockRunner.mock.calls[0][0] as string;
+    expect(prompt).toContain("thumbsup");
+  });
+
+  test("ignores reaction not on bot's message", async () => {
+    makeApp();
+
+    await capturedReactionAddedHandler?.({
+      event: {
+        reaction: "wave",
+        item: { type: "message", channel: "D123", ts: "1.0" },
+        item_user: "U-SOMEONE-ELSE",
+        user: "U-DAN",
+      },
+      client: mockClient,
+    });
+
+    expect(mockRunner).not.toHaveBeenCalled();
+  });
+
+  test("ignores reaction in non-DM channels", async () => {
+    makeApp();
+
+    await capturedReactionAddedHandler?.({
+      event: {
+        reaction: "wave",
+        item: { type: "message", channel: "C123", ts: "1.0" },
+        item_user: "U-BOT",
+        user: "U-DAN",
+      },
+      client: mockClient,
+    });
+
+    expect(mockRunner).not.toHaveBeenCalled();
+  });
+
+  test("reaction_added: [silent] suppresses reply", async () => {
+    mockRunner.mockResolvedValueOnce({ result: "ack [silent]", sessionId: "s1" });
+    makeApp();
+
+    await capturedReactionAddedHandler?.({
+      event: {
+        reaction: "thumbsup",
+        item: { type: "message", channel: "D123", ts: "1.0" },
+        item_user: "U-BOT",
+        user: "U-DAN",
+      },
+      client: mockClient,
+    });
+
+    expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ─── formatRunErrorForSlack ───────────────────────────────────────────────────
+
+describe("formatRunErrorForSlack", () => {
+  test("formats ClaudeRunError with 429 rate limit", () => {
+    const err = new ClaudeRunError("rate limit", 429, "usage limit reached", undefined);
+    const msg = formatRunErrorForSlack(err);
+    expect(msg).toContain("org's monthly Claude usage limit");
+  });
+
+  test("formats ClaudeRunError with 529", () => {
+    const err = new ClaudeRunError("overloaded", 529, "overloaded", undefined);
+    const msg = formatRunErrorForSlack(err);
+    expect(msg).toContain("overloaded");
+  });
+
+  test("formats unknown error", () => {
+    const msg = formatRunErrorForSlack(new Error("unexpected"));
+    expect(msg).toContain("went wrong");
+  });
+});
+
+// ─── dispatchMarkers ─────────────────────────────────────────────────────────
+
+describe("dispatchMarkers", () => {
+  test("adds react emoji for react markers", async () => {
+    await dispatchMarkers(
+      [{ type: "react", emojis: ["thumbsup"] }],
+      { client: mockClient, channel: "C123", postedTs: "1.0" },
+    );
+
+    expect(mockClient.reactions.add).toHaveBeenCalledWith({
+      channel: "C123",
+      timestamp: "1.0",
+      name: "thumbsup",
+    });
+  });
+
+  test("silent marker is skipped gracefully", async () => {
+    await dispatchMarkers(
+      [{ type: "silent" }],
+      { client: mockClient, channel: "C123" },
+    );
+    // No error thrown, no calls made
+    expect(mockClient.reactions.add).not.toHaveBeenCalled();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.19.2",
+        "@slack/bolt": "^4.7.3",
+        "@slack/web-api": "^7.16.0",
         "hono": "^4",
       },
       "devDependencies": {
@@ -168,11 +170,51 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@slack/bolt": ["@slack/bolt@4.7.3", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/oauth": "^3.0.5", "@slack/socket-mode": "^2.0.7", "@slack/types": "^2.21.1", "@slack/web-api": "^7.16.0", "axios": "^1.12.0", "express": "^5.0.0", "path-to-regexp": "^8.1.0", "raw-body": "^3", "tsscmp": "^1.0.6" }, "peerDependencies": { "@types/express": "^5.0.0" } }, "sha512-bODs8q/yNDWUPoxmQhFrRqLMA5vhB/PDizYWqb6CkQhLWEUo5JFtfJcmeU4ElGl6qSt++OKjSYNa4MPc77CleQ=="],
+
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/oauth": ["@slack/oauth@3.0.5", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/jsonwebtoken": "^9", "@types/node": ">=18", "jsonwebtoken": "^9" } }, "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A=="],
+
+    "@slack/socket-mode": ["@slack/socket-mode@2.0.7", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ=="],
+
+    "@slack/types": ["@slack/types@2.21.1", "", {}, "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="],
+
+    "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "agent-base": ["agent-base@9.0.0", "", {}, "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA=="],
 
@@ -192,15 +234,29 @@
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.17.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw=="],
+
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -224,6 +280,8 @@
 
     "color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
@@ -232,7 +290,9 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
 
@@ -245,6 +305,10 @@
     "conventional-commits-parser": ["conventional-commits-parser@6.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw=="],
 
     "convert-hrtime": ["convert-hrtime@5.0.0", "", {}, "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
@@ -262,6 +326,10 @@
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
@@ -270,7 +338,13 @@
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
 
@@ -280,6 +354,8 @@
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
     "env-ci": ["env-ci@11.2.0", "", { "dependencies": { "execa": "^8.0.0", "java-properties": "^1.0.2" } }, "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
@@ -288,11 +364,27 @@
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -304,13 +396,25 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
 
     "find-versions": ["find-versions@6.0.0", "", { "dependencies": { "semver-regex": "^4.0.5", "super-regex": "^1.0.0" } }, "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "function-timeout": ["function-timeout@1.0.2", "", {}, "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA=="],
 
@@ -318,17 +422,29 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "git-log-parser": ["git-log-parser@1.2.1", "", { "dependencies": { "argv-formatter": "~1.0.0", "spawn-error-forwarder": "~1.0.0", "split2": "~1.0.0", "stream-combiner2": "~1.1.1", "through2": "~2.0.0", "traverse": "0.6.8" } }, "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -338,11 +454,15 @@
 
     "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
     "http-proxy-agent": ["http-proxy-agent@9.0.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4" } }, "sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA=="],
 
     "https-proxy-agent": ["https-proxy-agent@9.0.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4" } }, "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -358,7 +478,11 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
@@ -368,7 +492,9 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -394,6 +520,12 @@
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
@@ -408,9 +540,19 @@
 
     "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
 
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
     "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
 
     "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "lodash.uniqby": ["lodash.uniqby@4.7.0", "", {}, "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="],
 
@@ -422,13 +564,23 @@
 
     "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -437,6 +589,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
@@ -458,7 +612,13 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -474,15 +634,21 @@
 
     "p-filter": ["p-filter@4.1.0", "", { "dependencies": { "p-map": "^7.0.1" } }, "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
     "p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
 
     "p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
     "p-reduce": ["p-reduce@2.1.0", "", {}, "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="],
 
-    "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
 
@@ -496,9 +662,13 @@
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -524,7 +694,17 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -544,7 +724,13 @@
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "semantic-release": ["semantic-release@25.0.3", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA=="],
 
@@ -552,9 +738,23 @@
 
     "semver-regex": ["semver-regex@4.0.5", "", {}, "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -575,6 +775,8 @@
     "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
     "split2": ["split2@1.0.0", "", { "dependencies": { "through2": "~2.0.0" } }, "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
 
@@ -616,11 +818,17 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "traverse": ["traverse@0.6.8", "", {}, "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA=="],
+
+    "tsscmp": ["tsscmp@1.0.6", "", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -640,11 +848,15 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
@@ -653,6 +865,10 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -670,6 +886,8 @@
 
     "@actions/http-client/undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
 
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "@semantic-release/exec/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
@@ -686,6 +904,8 @@
 
     "@semantic-release/npm/read-pkg": ["read-pkg@10.1.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.4", "normalize-package-data": "^8.0.0", "parse-json": "^8.3.0", "type-fest": "^5.4.4", "unicorn-magic": "^0.4.0" } }, "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg=="],
 
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
@@ -700,7 +920,11 @@
 
     "execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
+    "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
     "fdir/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -994,6 +1218,10 @@
 
     "nypm/citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
+    "p-event/p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "read-pkg/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
@@ -1016,11 +1244,11 @@
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@semantic-release/git/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "@semantic-release/git/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "@semantic-release/git/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
@@ -1041,6 +1269,8 @@
     "@semantic-release/npm/read-pkg/type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
 
     "@semantic-release/npm/read-pkg/unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
+
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -1065,6 +1295,8 @@
     "env-ci/execa/onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
     "env-ci/execa/strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -6,7 +6,7 @@
 
 The agent owns six first-class Prisma models (`Agent` and its `Env` / `CronJob` / `Tool` / `Token` / `Plugin` children) on a **dedicated database** (`DATABASE_URL_AGENT`). Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer; agent API tokens are stored only as SHA-256 hashes.
 
-> The top-level runner (`agent/src/index.ts`) is currently a Phase-C placeholder (`export {}`). The implemented surfaces are the admin CRUD API (`admin-api.ts`), the runtime API (`api.ts`), and the Prisma store + service classes. On startup the runner is expected to call `POST /admin/api/agents/:id/crons/reconcile` to sync system crons.
+> The top-level runner (`agent/src/index.ts`) is currently a Phase-C placeholder (`export {}`). The implemented surfaces are the admin CRUD API (`admin-api.ts`), the runtime API (`api.ts`), the Prisma store + service classes, the Slack event handler (`slack.ts`), and the cron runtime (`cron-handler.ts`). On startup the runner is expected to call `POST /admin/api/agents/:id/crons/reconcile` to sync system crons.
 
 ## Running locally
 
@@ -77,6 +77,9 @@ All child models cascade-delete with their `Agent`.
 | `agent/src/agent-tools.ts` / `agent-tokens.ts` / `agent-plugins.ts` | Per-resource service classes. |
 | `agent/src/crypto.ts` / `token-crypto.ts` | AES-256-GCM + token hashing helpers. |
 | `agent/src/system-crons.ts` | System-cron definitions reconciled onto each agent. |
+| `agent/src/cron-handler.ts` | Cron runtime: `handleCronRequest()` — runs a cron prompt through Claude and posts the result to Slack. Supports `preCheck` scripts, `silent` suppression, channel vs. DM delivery, and `onPost`/`onSession` callbacks. |
+| `agent/src/slack.ts` | Slack event handler: `createSlackApp()` — Bolt-based Socket Mode app handling DMs, `app_mention`, `reaction_added`, file attachments, and voice transcription. |
+| `agent/src/slack-manifest.ts` | Typed Slack app manifest builder (`buildManifest()`) used by `agent/scripts/bootstrap-agent.ts` to create per-agent Slack apps via the Manifest API. |
 | `agent/prisma/schema.prisma` | The six-model schema (`DATABASE_URL_AGENT`). |
 
 ## Testing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ A stateless Hono service that turns the pipeline's PostHog events into analytics
 
 A thin autonomous runner with a Prisma-backed store (SQLite locally, PostgreSQL in production) and two HTTP surfaces: a machine-polled **runtime API** (`/agents/:id/config`, `/agents/:id/crons`) and a human-facing **admin CRUD API** (`/admin/api/agents/:id/...` for envs, crons, tools, tokens, plugins). See **[agent.md](./agent.md)**.
 
-> The agent's top-level runner (`agent/src/index.ts`) is currently a Phase-C placeholder; the implemented surfaces are the admin CRUD API, the runtime API, and the Prisma store.
+> The agent's top-level runner (`agent/src/index.ts`) is currently a Phase-C placeholder; the implemented surfaces are the admin CRUD API, the runtime API, the Prisma store, the Slack event handler (`slack.ts`), and the cron runtime (`cron-handler.ts`).
 
 ## Supporting surfaces
 


### PR DESCRIPTION
## Summary
- Ports `slack.ts`, `cron-handler.ts`, and `slack-manifest.ts` from the vitals-os agent into `agent/src/`
- All dependencies are injected (`createSlackApp(runner, ...)`) — no global config reads, no hardcoded `runClaude`
- Adds `@slack/bolt` and `@slack/web-api` to the agent package

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Slack Bolt app factory instantiates with injected SlackClient and ClaudeRunner | ✅ MET |
| 2 | Cron handler routes channel vs user vs silent delivery correctly | ✅ MET |
| 3 | [silent] marker suppresses post; DM thread always receives reply | ✅ MET |
| 4 | Cron handler integration test: prompt runs → response posted → session persisted | ✅ MET |
| 5 | Unit tests for event routing; integration test using injected runner double; no tests retired | ✅ MET |

## Test Plan
- 36 new tests (unit + integration): all pass
- `cron-handler.integration.test.ts`: validation, channel/DM delivery, [silent] suppression, preCheck scripts, onPost/onSession callbacks
- `slack.unit.test.ts`: MockApp captures handlers, DM routing, channel thread routing, [silent] DM override, app_mention, reaction_added, formatRunErrorForSlack, dispatchMarkers
- Full agent suite: 239 pass, 0 fail

Generated with [Claude Code](https://claude.com/claude-code)
