### PR TITLE
feat(QS-1.1): offline/fixture mode for metrics service

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,6 +20,14 @@ bun metrics/src/server.ts          # serves on :3460 (override with METRICS_API_
 
 `server.ts` calls `validateRequiredEnv(["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"])` and **fails fast** listing any missing vars. Env can also be loaded from a dotenv file (`SHIPWRIGHT_ENV_FILE`, default `~/.shipwright/.env`) — set vars are never overwritten.
 
+**Offline mode** — run without any PostHog credentials or external services:
+
+```bash
+METRICS_OFFLINE=true bun metrics/src/server.ts
+```
+
+When `METRICS_OFFLINE=true`, `server.ts` skips the PostHog env gate, injects a fixture PostHog client (pre-recorded sample data for every query type), and bypasses session auth for `/dashboard` (serves as "Offline User"). Safe for local development and CI environments with no secrets configured.
+
 Validate every HogQL query before deploy (metadata-only, read-only key sufficient):
 
 ```bash
@@ -49,14 +57,15 @@ The `/metrics/*` endpoints accept **either** credential:
 - **Bearer API key** — tokens parsed from `METRICS_API_KEYS`. Scoped tokens (scope `!== "*"`) are rejected with `403` on metrics routes.
 - **Session cookie** (`vitals_session`) — when `METRICS_REQUIRE_OWNER_ROLE=true` and an accounts client is configured, the caller's role is checked and non-`OWNER` users get `403`.
 
-The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/auth/login`. `/health` is always open.
+The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/auth/login`. In offline mode (`METRICS_OFFLINE=true`), session auth is skipped entirely and `/dashboard` is served as "Offline User". `/health` is always open.
 
 ## Environment
 
 | Variable | Required | Default | Purpose |
 |---|---|---|---|
-| `POSTHOG_PERSONAL_API_KEY` | ✅ | — | PostHog personal API key for queries. |
-| `POSTHOG_PROJECT_ID` | ✅ | — | PostHog project id (no default — must be set explicitly). |
+| `POSTHOG_PERSONAL_API_KEY` | ✅ (not offline) | — | PostHog personal API key for queries. Not required when `METRICS_OFFLINE=true`. |
+| `POSTHOG_PROJECT_ID` | ✅ (not offline) | — | PostHog project id. Not required when `METRICS_OFFLINE=true`. |
+| `METRICS_OFFLINE` | | `false` | When `true`, skips PostHog env gate, injects fixture data, and bypasses dashboard session auth. |
 | `METRICS_API_PORT` | | `3460` | Listen port. |
 | `METRICS_API_KEYS` | | — | Comma-parsed Bearer API keys for `/metrics/*`. |
 | `SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
@@ -74,7 +83,8 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `metrics/src/server.ts` | Process entrypoint — env validation, wiring, `Bun.serve`. |
 | `metrics/src/api.ts` | App factory `createMetricsApp()`, route + auth middleware registration, dashboard handler. |
 | `metrics/src/queries.ts` | HogQL query builders (summary, trends, features, queue, tokens). |
-| `metrics/src/posthog-client.ts` | PostHog client (interface + `Http` impl; `Recorded` double for tests). |
+| `metrics/src/posthog-client.ts` | PostHog client (interface + `Http` impl). |
+| `metrics/src/fixtures/posthog-fixtures.ts` | Fixture PostHog client (`createFixturePostHogClient()`) — pre-recorded sample data for every query type; used in offline mode and integration tests. |
 | `metrics/src/validate-hogql.ts` | Pre-deploy HogQL validation runner (`validate:hogql`). |
 | `metrics/src/cache.ts` | In-process query-result cache. |
 | `metrics/src/secrets.ts` | Secrets resolution: env-first, optional GCP Secret Manager fallback. |
@@ -83,7 +93,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 
 ## Testing
 
-Unit + integration + smoke layers (`bun test --filter metrics`). Integration tests inject a `RecordedPostHogClient` (cassettes under `metrics/tests/fixtures/posthog/`); smoke tests drive the Hono app via `app.request()`. Keep `POSTHOG_PERSONAL_API_KEY` **unset** so the suite stays offline. See [testing.md](./testing.md).
+Unit + integration + smoke layers (`bun test --filter metrics`). Integration tests inject a `createFixturePostHogClient()` double (from `metrics/src/fixtures/posthog-fixtures.ts`) — pre-recorded sample results, no network calls; smoke tests drive the Hono app via `app.request()`. Keep `POSTHOG_PERSONAL_API_KEY` **unset** so the suite stays offline. See [testing.md](./testing.md).
 
 ## See also
 

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -79,6 +79,12 @@ export interface MetricsDeps {
   requireOwnerRole?: boolean;
   /** Optional single-token bearer gate (METRICS_DASHBOARD_TOKEN). Default off. */
   dashboardToken?: string;
+  /**
+   * Offline mode: skip session auth and inject a default local user for /dashboard.
+   * When true, /dashboard is served without a valid session cookie.
+   * Default false.
+   */
+  offlineMode?: boolean;
 }
 
 // ─── Route definitions (inlined) ─────────────────────────────────────────────
@@ -885,6 +891,7 @@ export function createMetricsApp(
   const sessionSecret = deps?.sessionSecret ?? process.env.SESSION_SECRET ?? "";
   const requireOwnerRole = deps?.requireOwnerRole ?? false;
   const dashboardToken = deps?.dashboardToken;
+  const offlineMode = deps?.offlineMode ?? false;
 
   const app = new OpenAPIHono<AuthEnv>({
     defaultHook: (result, c) => {
@@ -902,6 +909,9 @@ export function createMetricsApp(
     console.error("unhandled error:", err);
     return c.json({ error: err.message }, 500);
   });
+
+  // Health check — no auth required
+  app.get("/health", (c) => c.json({ status: "ok" }, 200));
 
   // /metrics/* — accepts bearer token OR session cookie; returns 401 JSON on failure
   app.use(
@@ -946,11 +956,22 @@ export function createMetricsApp(
   };
 
   // Dashboard routes are protected by session cookie — redirect to /auth/login on failure
-  app.use("/dashboard", createSessionMiddleware(sessionSecret));
-  app.use("/dashboard/*", createSessionMiddleware(sessionSecret));
+  // In offline mode: skip session auth entirely and inject a default local user
+  if (!offlineMode) {
+    app.use("/dashboard", createSessionMiddleware(sessionSecret));
+    app.use("/dashboard/*", createSessionMiddleware(sessionSecret));
+  }
 
   // /dashboard — server-rendered with shared toolbar and user name from session
   app.get("/dashboard", async (c) => {
+    // Offline mode: inject a default local user, skip all session/owner checks
+    if (offlineMode) {
+      const body = renderDashboardPage({ userName: "Offline User", isOwner: true });
+      return new Response(body, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
     const sessionToken = getCookie(c, "vitals_session");
     let userName = "Unknown";
     let userId: string | undefined;

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -79,11 +79,7 @@ export interface MetricsDeps {
   requireOwnerRole?: boolean;
   /** Optional single-token bearer gate (METRICS_DASHBOARD_TOKEN). Default off. */
   dashboardToken?: string;
-  /**
-   * Offline mode: skip session auth and inject a default local user for /dashboard.
-   * When true, /dashboard is served without a valid session cookie.
-   * Default false.
-   */
+  /** Offline mode: skip session auth and serve /dashboard as a default local user. Default false. */
   offlineMode?: boolean;
 }
 

--- a/metrics/src/fixtures/posthog-fixtures.integration.test.ts
+++ b/metrics/src/fixtures/posthog-fixtures.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * metrics/src/fixtures/posthog-fixtures.integration.test.ts
+ * Integration tests: createFixturePostHogClient() implements PostHogClientLike
+ * and returns valid HogQLResult for every query type used by the dashboard.
+ *
+ * No mock.module(), no global.* overrides. Tests the fixture client injected
+ * via deps.postHogClient into createMetricsApp.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseApiKeys } from "../lib/api-auth.ts";
+import { makeAccountsClientMock } from "../lib/test-helpers.ts";
+import { type MetricsDeps, createMetricsApp } from "../api.ts";
+import {
+  buildFeaturesCiQuery,
+  buildFeaturesReviewsQuery,
+  buildFeaturesTasksQuery,
+  buildQueueCycleMergedQuery,
+  buildQueueCycleStartedQuery,
+  buildQueueFunnelQuery,
+  buildSummaryCycleTimeQuery,
+  buildSummaryQuery,
+  buildTokensByAgentQuery,
+  buildTokensBySessionTypeQuery,
+  buildTokensTotalsQuery,
+  buildTokensTrendsQuery,
+  buildTrendsQuery,
+} from "../queries.ts";
+import { createFixturePostHogClient } from "./posthog-fixtures.ts";
+
+const ADMIN_KEY = "sk_admin_fixtures";
+const apiKeys = parseApiKeys(`admin:${ADMIN_KEY}:*`);
+const noopAccountsClient = makeAccountsClientMock(async () => []);
+
+describe("createFixturePostHogClient — implements PostHogClientLike", () => {
+  test("query() returns a HogQLResult with columns and results arrays", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query("SELECT 1");
+    expect(Array.isArray(result.columns)).toBe(true);
+    expect(Array.isArray(result.results)).toBe(true);
+    expect(Array.isArray(result.types)).toBe(true);
+  });
+});
+
+describe("createFixturePostHogClient — summary query", () => {
+  test("returns valid columns for buildSummaryQuery", async () => {
+    const client = createFixturePostHogClient();
+    const hogql = buildSummaryQuery("7d");
+    const result = await client.query(hogql);
+    expect(result.results.length).toBeGreaterThan(0);
+    const row = Object.fromEntries(
+      result.columns.map((col, i) => [col, (result.results[0] as unknown[])[i]]),
+    );
+    expect(typeof row.tasks_completed).toBe("number");
+    expect(typeof row.ci_gates_total).toBe("number");
+    expect(typeof row.reviews_total).toBe("number");
+  });
+
+  test("returns valid columns for buildSummaryCycleTimeQuery", async () => {
+    const client = createFixturePostHogClient();
+    const hogql = buildSummaryCycleTimeQuery("7d");
+    const result = await client.query(hogql);
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.columns).toContain("avg_cycle_time_hours");
+  });
+});
+
+describe("createFixturePostHogClient — trends query", () => {
+  test("returns time-series rows for buildTrendsQuery", async () => {
+    const client = createFixturePostHogClient();
+    const hogql = buildTrendsQuery("7d");
+    const result = await client.query(hogql);
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.columns).toContain("period");
+    expect(result.columns).toContain("tasks_completed");
+  });
+});
+
+describe("createFixturePostHogClient — features queries", () => {
+  test("tasks query returns feature_prefix rows", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildFeaturesTasksQuery("7d"));
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.columns).toContain("feature_prefix");
+    expect(result.columns).toContain("tasks_completed");
+  });
+
+  test("CI query returns ci_total and ci_first_pass columns", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildFeaturesCiQuery("7d"));
+    expect(result.columns).toContain("feature_prefix");
+    expect(result.columns).toContain("ci_total");
+    expect(result.columns).toContain("ci_first_pass");
+  });
+
+  test("reviews query returns reviews_total and reviews_ship_it", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildFeaturesReviewsQuery("7d"));
+    expect(result.columns).toContain("feature_prefix");
+    expect(result.columns).toContain("reviews_total");
+    expect(result.columns).toContain("reviews_ship_it");
+  });
+});
+
+describe("createFixturePostHogClient — queue queries", () => {
+  test("funnel query returns tasks_started and avg_review_findings", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildQueueFunnelQuery("7d"));
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.columns).toContain("tasks_started");
+    expect(result.columns).toContain("avg_review_findings");
+  });
+
+  test("cycle started query returns task_id and timestamp", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildQueueCycleStartedQuery("7d"));
+    expect(result.columns).toContain("task_id");
+    expect(result.columns).toContain("timestamp");
+  });
+
+  test("cycle merged query returns task_id and timestamp", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildQueueCycleMergedQuery("7d"));
+    expect(result.columns).toContain("task_id");
+    expect(result.columns).toContain("timestamp");
+  });
+});
+
+describe("createFixturePostHogClient — tokens queries", () => {
+  test("totals query returns all token columns", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildTokensTotalsQuery("7d"));
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.columns).toContain("input_tokens");
+    expect(result.columns).toContain("output_tokens");
+    expect(result.columns).toContain("total_tokens");
+  });
+
+  test("by session type query returns session_type grouping", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildTokensBySessionTypeQuery("7d"));
+    expect(result.columns).toContain("session_type");
+    expect(result.columns).toContain("total_tokens");
+  });
+
+  test("by agent query returns agent_id grouping", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildTokensByAgentQuery("7d"));
+    expect(result.columns).toContain("agent_id");
+    expect(result.columns).toContain("total_tokens");
+  });
+
+  test("trends query returns period and daily token sums", async () => {
+    const client = createFixturePostHogClient();
+    const result = await client.query(buildTokensTrendsQuery("7d"));
+    expect(result.columns).toContain("period");
+    expect(result.columns).toContain("total_tokens");
+  });
+});
+
+describe("createFixturePostHogClient — injected via deps.postHogClient", () => {
+  test("summary endpoint returns 200 with fixture data via DI seam", async () => {
+    const deps: MetricsDeps = {
+      postHogClient: createFixturePostHogClient(),
+      sessionSecret: "",
+      offlineMode: true,
+    };
+    const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
+
+    const res = await app.request("/metrics/summary", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.data.tasksCompleted).toBe("number");
+    expect(body.data.tasksCompleted).toBeGreaterThanOrEqual(0);
+  });
+
+  test("tokens endpoint returns 200 with fixture data via DI seam", async () => {
+    const deps: MetricsDeps = {
+      postHogClient: createFixturePostHogClient(),
+      sessionSecret: "",
+      offlineMode: true,
+    };
+    const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
+
+    const res = await app.request("/metrics/tokens?preset=7d", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.totals).toBeTruthy();
+    expect(body.data.totals.total).toBeGreaterThan(0);
+  });
+});

--- a/metrics/src/fixtures/posthog-fixtures.ts
+++ b/metrics/src/fixtures/posthog-fixtures.ts
@@ -1,0 +1,383 @@
+/**
+ * metrics/src/fixtures/posthog-fixtures.ts
+ * Fixture PostHog client for offline/dev mode.
+ *
+ * Returns pre-recorded sample HogQLResult for every dashboard query type.
+ * Pattern-matches on hogql strings to route to the correct fixture.
+ * Falls back to a zero-row generic result for unknown queries.
+ *
+ * Usage:
+ *   import { createFixturePostHogClient } from './fixtures/posthog-fixtures.ts';
+ *   const app = createMetricsApp(apiKeys, accountsClient, {
+ *     postHogClient: createFixturePostHogClient(),
+ *     offlineMode: true,
+ *   });
+ */
+
+import type { PostHogClientLike } from "../api.ts";
+import type { HogQLResult } from "../types.ts";
+
+function makeResult(columns: string[], rows: unknown[][]): HogQLResult {
+  return {
+    columns,
+    results: rows,
+    types: columns.map(() => "String"),
+    hasMore: false,
+    limit: 100,
+    offset: 0,
+  };
+}
+
+// ─── Summary fixture ─────────────────────────────────────────────────────────
+
+const SUMMARY_COLUMNS = [
+  "tasks_completed",
+  "tasks_blocked",
+  "avg_actual_hours",
+  "avg_estimated_hours",
+  "avg_retries",
+  "avg_files_changed",
+  "ci_gates_total",
+  "ci_first_pass",
+  "avg_fix_attempts",
+  "simplify_total",
+  "simplify_total_fixes",
+  "simplify_avg_dry",
+  "simplify_avg_dead_code",
+  "simplify_avg_naming",
+  "simplify_avg_complexity",
+  "simplify_avg_consistency",
+  "reviews_total",
+  "reviews_ship_it",
+  "complexity_1",
+  "complexity_2",
+  "complexity_3",
+  "complexity_4",
+  "complexity_5",
+  "avg_fix_cascade_depth",
+];
+
+const SUMMARY_FIXTURE = makeResult(SUMMARY_COLUMNS, [
+  [
+    // tasks_completed, tasks_blocked
+    24, 2,
+    // avg_actual_hours, avg_estimated_hours
+    3.2, 3.5,
+    // avg_retries, avg_files_changed
+    1.1, 6.0,
+    // ci_gates_total, ci_first_pass
+    18, 14,
+    // avg_fix_attempts
+    0.4,
+    // simplify_total, simplify_total_fixes
+    8, 22,
+    // simplify_avg_dry, simplify_avg_dead_code, simplify_avg_naming, simplify_avg_complexity, simplify_avg_consistency
+    2.5, 1.8, 1.2, 0.6, 0.9,
+    // reviews_total, reviews_ship_it
+    12, 10,
+    // complexity_1, 2, 3, 4, 5
+    4, 8, 7, 4, 1,
+    // avg_fix_cascade_depth
+    1.3,
+  ],
+]);
+
+// ─── Cycle time fixture ────────────────────────────────────────────────────
+
+const CYCLE_TIME_FIXTURE = makeResult(["avg_cycle_time_hours"], [[4.8]]);
+
+// ─── Trends fixture ───────────────────────────────────────────────────────────
+
+const TRENDS_COLUMNS = [
+  "period",
+  "tasks_completed",
+  "ci_gates",
+  "ci_first_pass",
+  "ci_first_pass_count",
+  "simplify_passes",
+  "simplify_fixes",
+  "tasks_blocked",
+  "reviews",
+  "tasks_started",
+  "reviews_ship_it",
+  "avg_actual_hours",
+  "avg_estimated_hours",
+  "avg_retries",
+  "avg_files_changed",
+  "avg_fix_attempts",
+  "avg_cycle_time_hours",
+  "estimation_accuracy",
+  "simplify_avg_dry",
+  "simplify_avg_dead_code",
+  "simplify_avg_naming",
+  "simplify_avg_complexity",
+  "simplify_avg_consistency",
+  "avg_review_findings",
+];
+
+const TRENDS_FIXTURE = makeResult(TRENDS_COLUMNS, [
+  ["2026-06-01", 3, 4, 3, 2, 1, 5, 0, 2, 4, 2, 3.1, 3.5, 1.0, 6.0, 0.3, 4.5, 0.89, 2.2, 1.5, 1.0, 0.5, 0.8, 1.8],
+  ["2026-06-02", 4, 5, 4, 3, 2, 7, 1, 3, 5, 2, 3.4, 3.5, 1.2, 5.5, 0.5, 5.0, 0.97, 2.8, 2.0, 1.3, 0.7, 1.1, 2.0],
+  ["2026-06-03", 2, 3, 2, 1, 0, 0, 0, 1, 3, 1, 2.9, 3.0, null, null, null, null, null, null, null, null, null, null, null],
+  ["2026-06-04", 5, 6, 5, 4, 3, 10, 1, 4, 6, 3, 3.6, 3.8, 0.8, 7.0, 0.2, 5.2, 0.95, 3.1, 2.2, 1.5, 0.9, 1.2, 1.5],
+  ["2026-06-05", 4, 4, 4, 3, 2, 8, 0, 2, 5, 2, 3.0, 3.2, 1.0, 5.0, 0.4, 4.8, 0.94, 2.5, 1.8, 1.1, 0.6, 0.9, 2.2],
+  ["2026-06-06", 3, 5, 3, 2, 1, 3, 0, 3, 4, 3, 3.3, 3.5, 1.1, 6.5, 0.5, 5.5, 0.94, 2.0, 1.6, 1.2, 0.8, 1.0, 1.9],
+  ["2026-06-07", 3, 4, 3, 2, 1, 4, 0, 2, 4, 2, 3.2, 3.4, 1.0, 6.0, 0.4, 4.9, 0.94, 2.3, 1.7, 1.1, 0.7, 0.9, 2.1],
+]);
+
+// ─── Features tasks fixture ───────────────────────────────────────────────────
+
+const FEATURES_TASKS_COLUMNS = [
+  "feature_prefix",
+  "tasks_completed",
+  "avg_actual_h",
+  "avg_estimated_h",
+];
+
+const FEATURES_TASKS_FIXTURE = makeResult(FEATURES_TASKS_COLUMNS, [
+  ["QS", 8, 3.2, 3.5],
+  ["MQ", 6, 2.8, 3.0],
+  ["DR", 4, 4.1, 4.0],
+  ["UE", 3, 2.5, 2.5],
+  ["SM", 3, 3.8, 4.0],
+]);
+
+// ─── Features CI fixture ──────────────────────────────────────────────────────
+
+const FEATURES_CI_COLUMNS = ["feature_prefix", "ci_total", "ci_first_pass"];
+
+const FEATURES_CI_FIXTURE = makeResult(FEATURES_CI_COLUMNS, [
+  ["QS", 16, 13],
+  ["MQ", 12, 10],
+  ["DR", 8, 6],
+  ["UE", 6, 5],
+  ["SM", 6, 5],
+]);
+
+// ─── Features reviews fixture ─────────────────────────────────────────────────
+
+const FEATURES_REVIEWS_COLUMNS = [
+  "feature_prefix",
+  "reviews_total",
+  "reviews_ship_it",
+];
+
+const FEATURES_REVIEWS_FIXTURE = makeResult(FEATURES_REVIEWS_COLUMNS, [
+  ["QS", 8, 7],
+  ["MQ", 6, 5],
+  ["DR", 4, 3],
+  ["UE", 3, 3],
+  ["SM", 3, 2],
+]);
+
+// ─── Queue funnel fixture ─────────────────────────────────────────────────────
+
+const QUEUE_FUNNEL_COLUMNS = [
+  "tasks_started",
+  "tasks_approved",
+  "tasks_merged",
+  "tasks_blocked",
+  "avg_review_findings",
+];
+
+const QUEUE_FUNNEL_FIXTURE = makeResult(QUEUE_FUNNEL_COLUMNS, [
+  [28, 24, 24, 2, 1.8],
+]);
+
+// ─── Queue cycle fixtures ─────────────────────────────────────────────────────
+
+const QUEUE_CYCLE_COLUMNS = ["task_id", "timestamp"];
+
+const QUEUE_CYCLE_STARTED_FIXTURE = makeResult(QUEUE_CYCLE_COLUMNS, [
+  ["QS-1.1", "2026-06-01T09:00:00.000Z"],
+  ["QS-1.2", "2026-06-02T10:00:00.000Z"],
+  ["MQ-2.1", "2026-06-03T08:30:00.000Z"],
+  ["DR-1.1", "2026-06-04T11:00:00.000Z"],
+]);
+
+const QUEUE_CYCLE_MERGED_FIXTURE = makeResult(QUEUE_CYCLE_COLUMNS, [
+  ["QS-1.1", "2026-06-02T14:00:00.000Z"],
+  ["QS-1.2", "2026-06-03T16:00:00.000Z"],
+  ["MQ-2.1", "2026-06-04T17:00:00.000Z"],
+  ["DR-1.1", "2026-06-06T10:00:00.000Z"],
+]);
+
+// ─── Tokens fixtures ──────────────────────────────────────────────────────────
+
+const TOKENS_TOTALS_COLUMNS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+];
+
+const TOKENS_TOTALS_FIXTURE = makeResult(TOKENS_TOTALS_COLUMNS, [
+  [842000, 210000, 380000, 95000, 1527000],
+]);
+
+const TOKENS_BY_SESSION_TYPE_COLUMNS = [
+  "session_type",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+];
+
+const TOKENS_BY_SESSION_TYPE_FIXTURE = makeResult(
+  TOKENS_BY_SESSION_TYPE_COLUMNS,
+  [
+    ["cron", 420000, 105000, 190000, 48000, 763000],
+    ["slack_dm", 280000, 70000, 126000, 32000, 508000],
+    ["slack_mention", 142000, 35000, 64000, 15000, 256000],
+  ],
+);
+
+const TOKENS_BY_AGENT_COLUMNS = [
+  "agent_id",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+];
+
+const TOKENS_BY_AGENT_FIXTURE = makeResult(TOKENS_BY_AGENT_COLUMNS, [
+  ["agent-shipwright", 500000, 125000, 225000, 57000, 907000],
+  ["agent-dev", 342000, 85000, 155000, 38000, 620000],
+]);
+
+const TOKENS_TRENDS_COLUMNS = [
+  "period",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+];
+
+const TOKENS_TRENDS_FIXTURE = makeResult(TOKENS_TRENDS_COLUMNS, [
+  ["2026-06-01", 120000, 30000, 54000, 14000, 218000],
+  ["2026-06-02", 130000, 32000, 58000, 15000, 235000],
+  ["2026-06-03", 112000, 28000, 50000, 13000, 203000],
+  ["2026-06-04", 140000, 35000, 63000, 16000, 254000],
+  ["2026-06-05", 125000, 31000, 56000, 14000, 226000],
+  ["2026-06-06", 108000, 27000, 48000, 12000, 195000],
+  ["2026-06-07", 107000, 27000, 51000, 11000, 196000],
+]);
+
+// ─── Generic fallback ─────────────────────────────────────────────────────────
+
+const GENERIC_FALLBACK = makeResult([], []);
+
+// ─── Query pattern detection ─────────────────────────────────────────────────
+
+function detectQueryType(
+  hogql: string,
+): keyof typeof FIXTURES | "generic" {
+  // Summary cycle time: single column avg, completion events with started_at/ts dateDiff
+  if (
+    hogql.includes("avg_cycle_time_hours") &&
+    hogql.includes("started_at") &&
+    !hogql.includes("tasks_completed") &&
+    !hogql.includes("GROUP BY period")
+  ) {
+    return "summaryCycleTime";
+  }
+  // Summary: aggregates over all event types (simplify_total is unique to summary)
+  if (hogql.includes("simplify_total") && !hogql.includes("GROUP BY period")) {
+    return "summary";
+  }
+  // Trends: time-series with GROUP BY period and pipeline columns
+  if (hogql.includes("GROUP BY period") && hogql.includes("ci_gates")) {
+    return "trends";
+  }
+  // Queue funnel: aggregates over tasks_started/approved/merged in a single query
+  if (hogql.includes("tasks_started") && hogql.includes("tasks_approved") && hogql.includes("tasks_merged")) {
+    return "queueFunnel";
+  }
+  // Queue cycle started: WHERE clause targets only shipwright_task_started
+  if (
+    hogql.includes("event = 'shipwright_task_started'") &&
+    hogql.includes("task_id") &&
+    hogql.includes("timestamp")
+  ) {
+    return "queueCycleStarted";
+  }
+  // Features tasks: SELECT feature_prefix, tasks_completed, avg_actual_h
+  // Must check before queueCycleMerged since both target completion events
+  if (hogql.includes("GROUP BY feature_prefix") && hogql.includes("avg_actual_h")) {
+    return "featuresTasks";
+  }
+  // Features CI: per-prefix CI first pass
+  if (hogql.includes("GROUP BY feature_prefix") && hogql.includes("ci_first_pass") && hogql.includes("ci_total")) {
+    return "featuresCi";
+  }
+  // Features reviews: per-prefix reviews
+  if (hogql.includes("GROUP BY feature_prefix") && hogql.includes("reviews_ship_it")) {
+    return "featuresReviews";
+  }
+  // Queue cycle merged: completion events with task_id + timestamp (no GROUP BY feature_prefix)
+  if (
+    hogql.includes("task_id") &&
+    hogql.includes("timestamp") &&
+    !hogql.includes("GROUP BY feature_prefix") &&
+    !hogql.includes("GROUP BY period") &&
+    !hogql.includes("tasks_approved")
+  ) {
+    return "queueCycleMerged";
+  }
+  // Tokens totals: aggregate sums, agent_token_usage, no GROUP BY
+  if (hogql.includes("agent_token_usage") && hogql.includes("total_tokens") && !hogql.includes("GROUP BY")) {
+    return "tokensTotals";
+  }
+  // Tokens by session type: GROUP BY session_type
+  if (hogql.includes("session_type") && hogql.includes("GROUP BY session_type")) {
+    return "tokensBySessionType";
+  }
+  // Tokens by agent: GROUP BY agent_id
+  if (hogql.includes("agent_id") && hogql.includes("GROUP BY agent_id")) {
+    return "tokensByAgent";
+  }
+  // Tokens trends: agent_token_usage with GROUP BY period
+  if (hogql.includes("agent_token_usage") && hogql.includes("GROUP BY period")) {
+    return "tokensTrends";
+  }
+  return "generic";
+}
+
+const FIXTURES = {
+  summary: SUMMARY_FIXTURE,
+  summaryCycleTime: CYCLE_TIME_FIXTURE,
+  trends: TRENDS_FIXTURE,
+  featuresTasks: FEATURES_TASKS_FIXTURE,
+  featuresCi: FEATURES_CI_FIXTURE,
+  featuresReviews: FEATURES_REVIEWS_FIXTURE,
+  queueFunnel: QUEUE_FUNNEL_FIXTURE,
+  queueCycleStarted: QUEUE_CYCLE_STARTED_FIXTURE,
+  queueCycleMerged: QUEUE_CYCLE_MERGED_FIXTURE,
+  tokensTotals: TOKENS_TOTALS_FIXTURE,
+  tokensBySessionType: TOKENS_BY_SESSION_TYPE_FIXTURE,
+  tokensByAgent: TOKENS_BY_AGENT_FIXTURE,
+  tokensTrends: TOKENS_TRENDS_FIXTURE,
+};
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a fixture PostHogClientLike that returns pre-recorded sample results
+ * for every query type used by the dashboard. Suitable for offline/dev mode.
+ *
+ * Pattern-matches on the hogql string to route to the correct fixture.
+ * Never makes network calls.
+ */
+export function createFixturePostHogClient(): PostHogClientLike {
+  return {
+    async query(hogql: string): Promise<HogQLResult> {
+      const type = detectQueryType(hogql);
+      if (type === "generic") return GENERIC_FALLBACK;
+      return FIXTURES[type];
+    },
+  };
+}

--- a/metrics/src/offline.smoke.test.ts
+++ b/metrics/src/offline.smoke.test.ts
@@ -1,0 +1,156 @@
+/**
+ * metrics/src/offline.smoke.test.ts
+ * Smoke tests for offline/fixture mode — drives the Hono app via app.request()
+ * with no real PostHog, no SESSION_SECRET, and no accounts service.
+ *
+ * METRICS_OFFLINE=true mode:
+ * - /health returns 200 { status: "ok" }
+ * - /metrics/summary, /metrics/trends, /metrics/features, /metrics/queue,
+ *   /metrics/tokens all return 200 with fixture data
+ * - /dashboard returns 200 with real server-rendered HTML (not JSON placeholder)
+ *
+ * No mock.module(), no global.* overrides. Uses the existing DI seam only.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseApiKeys } from "./lib/api-auth.ts";
+import { makeAccountsClientMock } from "./lib/test-helpers.ts";
+import { type MetricsDeps, createMetricsApp } from "./api.ts";
+import { createFixturePostHogClient } from "./fixtures/posthog-fixtures.ts";
+
+const ADMIN_KEY = "sk_admin_offline";
+const apiKeys = parseApiKeys(`admin:${ADMIN_KEY}:*`);
+const noopAccountsClient = makeAccountsClientMock(async () => []);
+
+function makeOfflineDeps(): MetricsDeps {
+  return {
+    postHogClient: createFixturePostHogClient(),
+    sessionSecret: "",
+    offlineMode: true,
+  };
+}
+
+describe("offline mode — /health", () => {
+  test("returns 200 { status: ok }", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+});
+
+describe("offline mode — /metrics/summary", () => {
+  test("returns 200 with fixture data (no auth header required for offline)", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/metrics/summary", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.data.tasksCompleted).toBe("number");
+    expect(typeof body.data.ciGatesTotal).toBe("number");
+    expect(body.meta).toBeTruthy();
+  });
+});
+
+describe("offline mode — /metrics/trends", () => {
+  test("returns 200 with fixture rows array", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/metrics/trends?preset=7d", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data.rows)).toBe(true);
+    expect(body.data.rows.length).toBeGreaterThan(0);
+    expect(typeof body.data.rows[0].period).toBe("string");
+    expect(typeof body.data.rows[0].tasksCompleted).toBe("number");
+  });
+});
+
+describe("offline mode — /metrics/features", () => {
+  test("returns 200 with fixture features array", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/metrics/features?preset=7d", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data.features)).toBe(true);
+    expect(body.data.features.length).toBeGreaterThan(0);
+    const f = body.data.features[0];
+    expect(typeof f.prefix).toBe("string");
+    expect(typeof f.tasksCompleted).toBe("number");
+  });
+});
+
+describe("offline mode — /metrics/queue", () => {
+  test("returns 200 with fixture queue data", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/metrics/queue?preset=7d", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.data.tasksStarted).toBe("number");
+    expect(typeof body.data.tasksMerged).toBe("number");
+  });
+});
+
+describe("offline mode — /metrics/tokens", () => {
+  test("returns 200 with fixture token data", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/metrics/tokens?preset=7d", {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.totals).toBeTruthy();
+    expect(typeof body.data.totals.input).toBe("number");
+    expect(typeof body.data.totals.total).toBe("number");
+    expect(Array.isArray(body.data.bySessionType)).toBe(true);
+    expect(Array.isArray(body.data.byAgent)).toBe(true);
+    expect(Array.isArray(body.data.trends)).toBe(true);
+  });
+});
+
+describe("offline mode — /dashboard", () => {
+  test("returns 200 with real HTML (not JSON placeholder)", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/dashboard");
+    expect(res.status).toBe(200);
+    const ct = res.headers.get("content-type");
+    expect(ct).toMatch(/text\/html/);
+    const body = await res.text();
+    // Real server-rendered page contains dashboard markup, not the JSON placeholder
+    expect(body).toContain("<!DOCTYPE html>");
+    expect(body).toContain("Metrics");
+    // Must NOT be the JSON placeholder { service: "metrics-api", status: "ok" }
+    expect(body).not.toContain('"service"');
+    expect(body).not.toContain('"metrics-api"');
+  });
+
+  test("renders with offline user name", async () => {
+    const app = createMetricsApp(apiKeys, noopAccountsClient, makeOfflineDeps());
+    const res = await app.request("/dashboard");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Offline");
+  });
+});
+
+describe("offline mode — no live credentials required", () => {
+  test("boots with empty session secret and no PostHog keys", async () => {
+    // This test verifies that no env vars are read — everything is injected via deps
+    const deps: MetricsDeps = {
+      postHogClient: createFixturePostHogClient(),
+      sessionSecret: "",
+      offlineMode: true,
+    };
+    const app = createMetricsApp(new Map(), noopAccountsClient, deps);
+    // At minimum, health must respond
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+  });
+});

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -4,42 +4,58 @@
  *
  * Serves:
  *   /metrics/*   — API endpoints (PostHog query results, auth-gated)
- *   /dashboard   — UI entrypoint (served by this process)
+ *   /dashboard   — Server-rendered dashboard UI
  *   /health      — Health check (no auth required)
+ *
+ * Offline mode (METRICS_OFFLINE=true):
+ *   - Skips the POSTHOG_* required-env gate
+ *   - Injects a fixture PostHog client via deps.postHogClient
+ *   - Bypasses session auth for /dashboard (serves as "Offline User")
+ *   - Safe to run with no secrets or external services configured
  */
 
 import { HttpAccountsClient } from "./lib/accounts-client.ts";
 import { parseApiKeys } from "./lib/api-auth.ts";
 import { loadEnv, validateRequiredEnv } from "./lib/env.ts";
 import { createMetricsApp } from "./api.ts";
+import type { MetricsDeps } from "./api.ts";
 
 loadEnv();
-validateRequiredEnv(["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"]);
+
+const offlineMode = process.env.METRICS_OFFLINE === "true";
+
+if (!offlineMode) {
+  validateRequiredEnv(["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"]);
+}
 
 const port = Number(process.env.METRICS_API_PORT ?? 3460);
 const accountsClient = new HttpAccountsClient(
   process.env.METRICS_ACCOUNTS_URL ?? "http://localhost:3457",
   process.env.METRICS_INTERNAL_API_KEY ?? "",
 );
-const app = createMetricsApp(
-  parseApiKeys(process.env.METRICS_API_KEYS),
-  accountsClient,
-  {
+
+let deps: MetricsDeps;
+
+if (offlineMode) {
+  const { createFixturePostHogClient } = await import(
+    "./fixtures/posthog-fixtures.ts"
+  );
+  deps = {
+    postHogClient: createFixturePostHogClient(),
+    sessionSecret: "",
+    requireOwnerRole: false,
+    offlineMode: true,
+  };
+  console.log("[metrics-api] Running in OFFLINE mode — fixture data injected");
+} else {
+  deps = {
     sessionSecret: process.env.SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
-  },
-);
+  };
+}
 
-// Health check — no auth required
-app.get("/health", (c) => c.json({ status: "ok" }, 200));
-
-// Dashboard entrypoint — returns a minimal redirect or placeholder
-// The actual dashboard UI is served by the frontend build; this path
-// is routed to this service at the ingress level.
-app.get("/dashboard", (c) =>
-  c.json({ service: "metrics-api", status: "ok" }, 200),
-);
+const app = createMetricsApp(parseApiKeys(process.env.METRICS_API_KEYS), accountsClient, deps);
 
 // OpenAPI doc for standalone mode
 app.openAPIRegistry.registerComponent("securitySchemes", "bearerAuth", {


### PR DESCRIPTION
## Summary

- Adds `METRICS_OFFLINE=true` mode to the metrics service: skips the `POSTHOG_*` required-env gate, injects a fixture `PostHogClientLike` via the existing `deps.postHogClient` DI seam, and bypasses session auth for `/dashboard` (serving as "Offline User")
- Creates `metrics/src/fixtures/posthog-fixtures.ts` with `createFixturePostHogClient()` returning pre-recorded sample data for all 13 dashboard query types
- Removes the double-registered placeholder `/health` and `/dashboard` handlers from `server.ts`; moves `/health` inside `createMetricsApp` (always available) and serves the real server-rendered dashboard in offline mode

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | /health + 5 metrics endpoints + /dashboard return 200 with fixture data when METRICS_OFFLINE=true | MET |
| 2 | Live mode unaffected: env gate + live PostHog client still apply when flag is unset | MET |
| 3 | /dashboard renders real server-rendered HTML (not JSON placeholder) in offline mode | MET |
| 4 | smoke.test.ts + integration.test.ts added; no mock.module/global.*; additive | MET |
| 5 | Safe to deploy standalone — flag default-off | MET |

## Test Plan

- [x] `metrics/src/offline.smoke.test.ts` — drives offline app via `app.request()` over /health, /metrics/summary, /metrics/trends, /metrics/features, /metrics/queue, /metrics/tokens, /dashboard
- [x] `metrics/src/fixtures/posthog-fixtures.integration.test.ts` — verifies fixture client returns correct columns for each of the 13 query types via the `deps.postHogClient` DI seam
- [x] 565 tests pass, 0 fail across all 16 test files
- [x] Typecheck and biome lint clean

Generated with [Claude Code](https://claude.com/claude-code)
