### PR TITLE
chore: sync shipwright plugin from vitals-os v4.26.5

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.26.4",
+  "version": "4.26.5",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -141,8 +141,12 @@ Read `state/reviews.json`. For each candidate PR:
   ```bash
   gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid'
   ```
-  If `headRefOid` differs from `lastReviewedCommit`: eligible for re-review.
-  If same: skip.
+  If `headRefOid` differs from `lastReviewedCommit`: check whether the update is merge-only before marking eligible:
+  ```bash
+  gh api repos/{org}/{repo}/pulls/{pr}/commits --paginate
+  ```
+  Find `lastReviewedCommit` in the commit list. Check if every commit after it has `parents.length >= 2` (i.e., all are merge commits — merge-from-base or merge-from-main). If yes: skip and print `Skipping #{pr} — merge-only update since {lastReviewedCommit[0..7]}`. If no (real code changes exist), or if the anchor commit is not found, or if the API call fails: eligible for re-review.
+  If `headRefOid` is the same as `lastReviewedCommit`: skip.
 - **Entry with `status: "cleaned"` or `"merged"`**: skip.
 
 If a `pending` entry is missing `diffSize` (created before this field was added), populate
@@ -181,8 +185,9 @@ commits since the last review.
 
 **Tier 1 — Re-review of posted reviews** (highest priority)
 Entry has `status: "posted"` (or `posted: true`) AND the current head SHA differs from
-`lastReviewedCommit`. The author pushed changes after seeing our feedback — re-reviewing
-closes the loop and can unblock a merge.
+`lastReviewedCommit`, AND the new commits are not merge-only (as determined by the
+deduplication check above). The author pushed real code changes after seeing our feedback —
+re-reviewing closes the loop and can unblock a merge.
 
 **Tier 2 — First review of pending PRs**
 Entry has `status: "pending"`, or the PR has no entry yet. Never been reviewed — give

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -18,7 +18,7 @@ import {
   getCurrentUser,
   ghJson,
   readAllowSelfReview,
-  resolveRepos,
+  resolveAllRepos,
   resolveWorkspacePath,
 } from "./check-helpers.ts";
 import { createTaskStore, loadConfig } from "./create-task-store.ts";
@@ -217,13 +217,13 @@ interface GhWorkflowRunsJson {
 
 async function buildProductionDeps(): Promise<Deps> {
   const workspacePath = resolveWorkspacePath();
-  const repos = resolveRepos(workspacePath);
+  const allRepos = resolveAllRepos(workspacePath);
   const clock = () => new Date().toISOString();
 
   return {
     getCurrentUser,
     isSelfReviewAllowed: readAllowSelfReview(workspacePath),
-    repos: repos.length > 0 ? repos : ["app-vitals/shipwright"],
+    repos: allRepos,
     clock,
     fetchActiveDeployRuns: async (org: string, repo: string) => {
       const [inProgress, queued] = await Promise.all([
@@ -280,7 +280,7 @@ async function buildProductionDeps(): Promise<Deps> {
       if (prOpenTasks.length === 0) return;
 
       const now = clock();
-      const defaultRepo = repos[0] ?? "app-vitals/shipwright";
+      const defaultRepo = allRepos[0] ?? "app-vitals/shipwright";
 
       for (const task of prOpenTasks) {
         if (!task.id) continue;

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -87,7 +87,68 @@ export function readReviews(workspacePath: string): ReviewEntry[] {
   return JSON.parse(readFileSync(reviewsPath, "utf-8")) as ReviewEntry[];
 }
 
+// ─── Shipwright config ────────────────────────────────────────────────────────
+
+export interface ShipwrightGitHubConfig {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Read state/shipwright.config.json and return the github task store config,
+ * or null if the file is absent, unreadable, or not using the github task store.
+ */
+export function readShipwrightConfig(
+  workspacePath: string,
+): ShipwrightGitHubConfig | null {
+  const configPath = join(workspacePath, "state", "shipwright.config.json");
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
+    if (typeof raw !== "object" || raw === null) return null;
+    const cfg = raw as Record<string, unknown>;
+    if (cfg.taskStore !== "github") return null;
+    const gh = cfg.github;
+    if (
+      typeof gh === "object" &&
+      gh !== null &&
+      typeof (gh as Record<string, unknown>).owner === "string" &&
+      typeof (gh as Record<string, unknown>).repo === "string"
+    ) {
+      return {
+        owner: (gh as Record<string, unknown>).owner as string,
+        repo: (gh as Record<string, unknown>).repo as string,
+      };
+    }
+  } catch {
+    // unreadable or invalid JSON
+  }
+  return null;
+}
+
 // ─── Repos resolution ────────────────────────────────────────────────────────
+
+/**
+ * Resolve the full ordered list of "owner/repo" strings for this workspace.
+ *
+ * Priority:
+ * 1. shipwright.config.json github repo — placed first, deduped from scanned list
+ * 2. Scanned repos from workspace/repos/ or SHIPWRIGHT_REPOS_DIR
+ * 3. Default "app-vitals/shipwright" if nothing else is found
+ */
+export function resolveAllRepos(workspacePath: string): string[] {
+  const shipwrightConfig = readShipwrightConfig(workspacePath);
+  const scannedRepos = resolveRepos(workspacePath);
+
+  if (shipwrightConfig) {
+    const primary = `${shipwrightConfig.owner}/${shipwrightConfig.repo}`;
+    return [primary, ...scannedRepos.filter((r) => r !== primary)];
+  }
+  if (scannedRepos.length > 0) {
+    return scannedRepos;
+  }
+  return ["app-vitals/shipwright"];
+}
 
 /**
  * Parse a git remote URL into "org/repo" format.

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -341,12 +341,12 @@ describe("resolveAllRepos", () => {
     mkdirSync(reposDir, { recursive: true });
     makeGitClone(
       reposDir,
-      "marketplace",
-      "https://github.com/app-vitals/marketplace.git",
+      "other-repo",
+      "https://github.com/example-org/other-repo.git",
     );
     const result = resolveAllRepos(tmpDir);
     expect(result[0]).toBe("app-vitals/shipwright");
-    expect(result).toContain("app-vitals/marketplace");
+    expect(result).toContain("example-org/other-repo");
   });
 
   test("deduplicates config repo when it also appears in scanned repos", () => {
@@ -367,8 +367,8 @@ describe("resolveAllRepos", () => {
     );
     makeGitClone(
       reposDir,
-      "marketplace",
-      "https://github.com/app-vitals/marketplace.git",
+      "other-repo",
+      "https://github.com/example-org/other-repo.git",
     );
     const result = resolveAllRepos(tmpDir);
     expect(result.filter((r) => r === "app-vitals/shipwright")).toHaveLength(1);

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -320,7 +320,11 @@ describe("resolveAllRepos", () => {
   test("returns scanned repos when no shipwright config present", () => {
     const reposDir = join(tmpDir, "repos");
     mkdirSync(reposDir, { recursive: true });
-    makeGitClone(reposDir, "patrol", "https://github.com/app-vitals/patrol.git");
+    makeGitClone(
+      reposDir,
+      "patrol",
+      "https://github.com/app-vitals/patrol.git",
+    );
     expect(resolveAllRepos(tmpDir)).toEqual(["app-vitals/patrol"]);
   });
 
@@ -335,7 +339,11 @@ describe("resolveAllRepos", () => {
     );
     const reposDir = join(tmpDir, "repos");
     mkdirSync(reposDir, { recursive: true });
-    makeGitClone(reposDir, "marketplace", "https://github.com/app-vitals/marketplace.git");
+    makeGitClone(
+      reposDir,
+      "marketplace",
+      "https://github.com/app-vitals/marketplace.git",
+    );
     const result = resolveAllRepos(tmpDir);
     expect(result[0]).toBe("app-vitals/shipwright");
     expect(result).toContain("app-vitals/marketplace");
@@ -352,8 +360,16 @@ describe("resolveAllRepos", () => {
     );
     const reposDir = join(tmpDir, "repos");
     mkdirSync(reposDir, { recursive: true });
-    makeGitClone(reposDir, "shipwright", "https://github.com/app-vitals/shipwright.git");
-    makeGitClone(reposDir, "marketplace", "https://github.com/app-vitals/marketplace.git");
+    makeGitClone(
+      reposDir,
+      "shipwright",
+      "https://github.com/app-vitals/shipwright.git",
+    );
+    makeGitClone(
+      reposDir,
+      "marketplace",
+      "https://github.com/app-vitals/marketplace.git",
+    );
     const result = resolveAllRepos(tmpDir);
     expect(result.filter((r) => r === "app-vitals/shipwright")).toHaveLength(1);
     expect(result[0]).toBe("app-vitals/shipwright");
@@ -367,7 +383,11 @@ describe("resolveAllRepos", () => {
     );
     const reposDir = join(tmpDir, "repos");
     mkdirSync(reposDir, { recursive: true });
-    makeGitClone(reposDir, "patrol", "https://github.com/app-vitals/patrol.git");
+    makeGitClone(
+      reposDir,
+      "patrol",
+      "https://github.com/app-vitals/patrol.git",
+    );
     expect(resolveAllRepos(tmpDir)).toEqual(["app-vitals/patrol"]);
   });
 });

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -14,7 +14,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getCurrentUser, resolveRepos } from "./check-helpers.ts";
+import {
+  getCurrentUser,
+  readShipwrightConfig,
+  resolveAllRepos,
+  resolveRepos,
+} from "./check-helpers.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -218,6 +223,152 @@ describe("resolveRepos", () => {
 
     const result = resolveRepos(tmpDir);
     expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readShipwrightConfig
+// ---------------------------------------------------------------------------
+
+describe("readShipwrightConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shipwright-config-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns null when config file does not exist", () => {
+    expect(readShipwrightConfig(tmpDir)).toBeNull();
+  });
+
+  test("returns null when config file has non-github taskStore", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      JSON.stringify({ taskStore: "todos" }),
+    );
+    expect(readShipwrightConfig(tmpDir)).toBeNull();
+  });
+
+  test("returns null when config has github taskStore but missing owner/repo", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      JSON.stringify({ taskStore: "github", github: {} }),
+    );
+    expect(readShipwrightConfig(tmpDir)).toBeNull();
+  });
+
+  test("returns null when config file contains invalid JSON", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      "not valid json",
+    );
+    expect(readShipwrightConfig(tmpDir)).toBeNull();
+  });
+
+  test("returns owner and repo for valid github taskStore config", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      JSON.stringify({
+        taskStore: "github",
+        github: { owner: "app-vitals", repo: "shipwright" },
+      }),
+    );
+    expect(readShipwrightConfig(tmpDir)).toEqual({
+      owner: "app-vitals",
+      repo: "shipwright",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAllRepos
+// ---------------------------------------------------------------------------
+
+describe("resolveAllRepos", () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "resolve-all-repos-test-"));
+    savedEnv = process.env.SHIPWRIGHT_REPOS_DIR;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_REPOS_DIR;
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env.SHIPWRIGHT_REPOS_DIR = savedEnv;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_REPOS_DIR;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns default fallback when no config and no scanned repos", () => {
+    expect(resolveAllRepos(tmpDir)).toEqual(["app-vitals/shipwright"]);
+  });
+
+  test("returns scanned repos when no shipwright config present", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(reposDir, "patrol", "https://github.com/app-vitals/patrol.git");
+    expect(resolveAllRepos(tmpDir)).toEqual(["app-vitals/patrol"]);
+  });
+
+  test("places config repo first when shipwright config is present", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      JSON.stringify({
+        taskStore: "github",
+        github: { owner: "app-vitals", repo: "shipwright" },
+      }),
+    );
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(reposDir, "marketplace", "https://github.com/app-vitals/marketplace.git");
+    const result = resolveAllRepos(tmpDir);
+    expect(result[0]).toBe("app-vitals/shipwright");
+    expect(result).toContain("app-vitals/marketplace");
+  });
+
+  test("deduplicates config repo when it also appears in scanned repos", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      JSON.stringify({
+        taskStore: "github",
+        github: { owner: "app-vitals", repo: "shipwright" },
+      }),
+    );
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(reposDir, "shipwright", "https://github.com/app-vitals/shipwright.git");
+    makeGitClone(reposDir, "marketplace", "https://github.com/app-vitals/marketplace.git");
+    const result = resolveAllRepos(tmpDir);
+    expect(result.filter((r) => r === "app-vitals/shipwright")).toHaveLength(1);
+    expect(result[0]).toBe("app-vitals/shipwright");
+  });
+
+  test("falls back to scanned repos when config has non-github taskStore", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      JSON.stringify({ taskStore: "todos" }),
+    );
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(reposDir, "patrol", "https://github.com/app-vitals/patrol.git");
+    expect(resolveAllRepos(tmpDir)).toEqual(["app-vitals/patrol"]);
   });
 });
 

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -21,7 +21,7 @@ import {
   ghGraphql,
   ghJson,
   ghRun,
-  resolveRepos,
+  resolveAllRepos,
   resolveWorkspacePath,
 } from "./check-helpers.ts";
 
@@ -200,25 +200,28 @@ interface GraphqlResponse {
 
 export async function buildProductionDeps(): Promise<Deps> {
   const workspacePath = resolveWorkspacePath();
-  const repos = resolveRepos(workspacePath);
-  const orgRepo = repos[0] ?? "app-vitals/shipwright";
+  const allRepos = resolveAllRepos(workspacePath);
 
   return {
     listOwnOpenPrs: async (_repo: string) => {
       const user = await getCurrentUser();
-      const items = ghJson<GhPrListItem[]>([
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--repo",
-        orgRepo,
-        "--author",
-        user,
-        "--json",
-        "number,title,headRefName,headRefOid",
-      ]);
-      return items.map((item) => ({ ...item, repo: orgRepo }));
+      const allPrs: (GhPrListItem & { repo: string })[] = [];
+      for (const repo of allRepos) {
+        const items = ghJson<GhPrListItem[]>([
+          "pr",
+          "list",
+          "--state",
+          "open",
+          "--repo",
+          repo,
+          "--author",
+          user,
+          "--json",
+          "number,title,headRefName,headRefOid",
+        ]);
+        allPrs.push(...items.map((item) => ({ ...item, repo })));
+      }
+      return allPrs;
     },
     fetchPrReviews: async (org: string, repo: string, pr: number) => {
       const query = `{
@@ -276,14 +279,14 @@ export async function buildProductionDeps(): Promise<Deps> {
         return { hasFailing: false };
       }
     },
-    fetchMergeStatus: async (_org: string, _repo: string, pr: number) => {
+    fetchMergeStatus: async (org: string, repo: string, pr: number) => {
       try {
         const data = ghJson<{ mergeStateStatus: string }>([
           "pr",
           "view",
           String(pr),
           "--repo",
-          orgRepo,
+          `${org}/${repo}`,
           "--json",
           "mergeStateStatus",
         ]);
@@ -298,8 +301,8 @@ export async function buildProductionDeps(): Promise<Deps> {
         return { isBehind: false, isDirty: false };
       }
     },
-    updateBranch: async (_org: string, _repo: string, pr: number) => {
-      ghRun(["pr", "update-branch", String(pr), "--repo", orgRepo]);
+    updateBranch: async (org: string, repo: string, pr: number) => {
+      ghRun(["pr", "update-branch", String(pr), "--repo", `${org}/${repo}`]);
     },
   };
 }

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -74,6 +74,7 @@ export interface Deps {
     org: string,
     repo: string,
     pr: number,
+    sha: string,
   ) => Promise<CiCheckStatus>;
   fetchMergeStatus: (
     org: string,
@@ -159,7 +160,12 @@ export async function run(deps: Deps): Promise<RunResult> {
       };
     }
 
-    const ciStatus = await deps.fetchCiStatus(org, repo, pr.number);
+    const ciStatus = await deps.fetchCiStatus(
+      org,
+      repo,
+      pr.number,
+      pr.headRefOid,
+    );
     if (ciStatus.hasFailing) {
       return {
         exit: 0,
@@ -245,28 +251,27 @@ export async function buildProductionDeps(): Promise<Deps> {
       const response = ghGraphql<GraphqlResponse>(query);
       return response.data.repository.pullRequest;
     },
-    fetchCiStatus: async (_org: string, _repo: string, pr: number) => {
-      type CheckItem = { state: string; conclusion: string | null };
+    fetchCiStatus: async (
+      org: string,
+      repo: string,
+      pr: number,
+      sha: string,
+    ) => {
+      type ApiResponse = {
+        workflow_runs: { status: string; conclusion: string | null }[];
+      };
       try {
-        const checks = ghJson<CheckItem[]>([
-          "pr",
-          "checks",
-          String(pr),
-          "--repo",
-          orgRepo,
-          "--json",
-          "name,state,conclusion",
+        const data = ghJson<ApiResponse>([
+          "api",
+          `repos/${org}/${repo}/actions/runs?head_sha=${sha}`,
         ]);
-        const hasFailing = checks.some(
-          (c) =>
-            c.state === "FAILURE" ||
-            c.conclusion === "failure" ||
-            c.conclusion === "timed_out",
+        const hasFailing = data.workflow_runs.some(
+          (r) => r.conclusion === "failure" || r.conclusion === "timed_out",
         );
         return { hasFailing };
       } catch (err) {
         process.stderr.write(
-          `check-patch: gh checks query failed for PR ${pr}: ${String(err)}\n`,
+          `check-patch: actions/runs query failed for PR ${pr} sha ${sha}: ${String(err)}\n`,
         );
         return { hasFailing: false };
       }

--- a/plugins/shipwright/scripts/check-review-patch.ts
+++ b/plugins/shipwright/scripts/check-review-patch.ts
@@ -18,38 +18,18 @@
  */
 
 import {
-  getCurrentUser,
-  ghJson,
-  readAllowSelfReview,
-  readReviews,
-  resolveRepos,
-  resolveWorkspacePath,
-} from "./check-helpers.ts";
-import type { ReviewEntry } from "./check-helpers.ts";
-import {
   type Deps as PatchDeps,
   buildProductionDeps as buildPatchProductionDeps,
   run as runPatch,
 } from "./check-patch.ts";
-import { type CommitInfo, run as runReview } from "./check-review.ts";
+import {
+  buildProductionDeps as buildReviewProductionDeps,
+  run as runReview,
+} from "./check-review.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface PrInfo {
-  number: number;
-  title: string;
-  author: { login: string };
-  headRefName: string;
-  headRefOid: string;
-}
-
-interface ReviewDeps {
-  getCurrentUser: () => string;
-  isSelfReviewAllowed: boolean;
-  listOpenPrs: (repo: string) => Promise<PrInfo[]>;
-  readReviews: () => ReviewEntry[];
-  listPrCommits: (prNumber: number) => Promise<CommitInfo[]>;
-}
+type ReviewDeps = Awaited<ReturnType<typeof buildReviewProductionDeps>>;
 
 export interface Deps {
   reviewDeps: ReviewDeps;
@@ -77,37 +57,10 @@ export async function run(deps: Deps): Promise<RunResult> {
 // ─── Production deps ──────────────────────────────────────────────────────────
 
 async function buildProductionDeps(): Promise<Deps> {
-  const workspacePath = resolveWorkspacePath();
-  const repos = resolveRepos(workspacePath);
-  const orgRepo = repos[0] ?? "app-vitals/shipwright";
-
-  const reviewDeps: ReviewDeps = {
-    getCurrentUser,
-    isSelfReviewAllowed: readAllowSelfReview(workspacePath),
-    listOpenPrs: async (_repo: string) => {
-      return ghJson<PrInfo[]>([
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--repo",
-        orgRepo,
-        "--json",
-        "number,title,author,headRefName,headRefOid",
-      ]);
-    },
-    readReviews: () => readReviews(workspacePath),
-    listPrCommits: async (prNumber: number) => {
-      return ghJson<CommitInfo[]>([
-        "api",
-        `repos/${orgRepo}/pulls/${prNumber}/commits`,
-        "--paginate",
-      ]);
-    },
-  };
-
-  const patchDeps = await buildPatchProductionDeps();
-
+  const [reviewDeps, patchDeps] = await Promise.all([
+    buildReviewProductionDeps(),
+    buildPatchProductionDeps(),
+  ]);
   return { reviewDeps, patchDeps };
 }
 

--- a/plugins/shipwright/scripts/check-review.test.ts
+++ b/plugins/shipwright/scripts/check-review.test.ts
@@ -18,6 +18,7 @@ interface PrInfo {
   author: { login: string };
   headRefName: string;
   headRefOid: string;
+  repo?: string;
 }
 
 interface ReviewEntry {
@@ -25,6 +26,7 @@ interface ReviewEntry {
   repo: string;
   lastReviewedCommit?: string;
   status?: string;
+  posted?: boolean;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -41,6 +43,7 @@ function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
     author: { login: "danmcaulay" },
     headRefName: "feat/x",
     headRefOid: "abc123def456",
+    repo: "example-repo",
     ...overrides,
   };
 }
@@ -268,6 +271,68 @@ describe("check-review", () => {
     const result = await run(deps);
     expect(result.exit).toBe(0);
     expect(listPrCommitsCalled).toBe(false);
+  });
+
+  // ─── Tier 3: staged-but-unposted review + new commits → skip on cron ─────
+
+  test("Tier 3: exits 1 (skips PR) when entry has posted=false and head SHA changed (staged review deferred)", async () => {
+    // posted: false = review written to reviews.json but not yet posted to GitHub.
+    // The review skill explicitly defers these on no-arg runs. The cron precheck
+    // must match that behaviour so it doesn't re-trigger the skill.
+    const pr = makePr({ number: 42, headRefOid: "sha-new" });
+    const entry: ReviewEntry = {
+      pr: 42,
+      repo: "example-repo",
+      lastReviewedCommit: "sha-old",
+      posted: false,
+    };
+    const result = await run(makeDeps([pr], [entry]));
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("Tier 3: exits 0 (triggers review) when entry has posted=true and head SHA changed (new real commits)", async () => {
+    // posted: true = review was already posted. New commits have landed.
+    // This is regular re-review territory — the cron should fire.
+    const pr = makePr({ number: 42, headRefOid: "sha-new" });
+    const entry: ReviewEntry = {
+      pr: 42,
+      repo: "example-repo",
+      lastReviewedCommit: "sha-old",
+      posted: true,
+    };
+    const result = await run(makeDeps([pr], [entry]));
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  // ─── Multi-repo: dedup map keyed on "repo:pr" to avoid cross-repo collisions ─
+
+  test("multi-repo: two repos with the same PR number are deduped independently", async () => {
+    // PR #42 in repo-A is reviewed (matches lastReviewedCommit).
+    // PR #42 in repo-B is NOT reviewed (no entry). Without the repo:pr key fix,
+    // repo-A's entry would suppress repo-B and exit 1 (wrong).
+    const prA = makePr({ number: 42, headRefOid: "sha-A", repo: "example-org/repo-a" });
+    const prB = makePr({ number: 42, headRefOid: "sha-B", repo: "example-org/repo-b" });
+    const entries: ReviewEntry[] = [
+      {
+        pr: 42,
+        repo: "example-org/repo-a",
+        lastReviewedCommit: "sha-A",
+        status: "posted",
+      },
+      // No entry for repo-b PR #42 → should trigger
+    ];
+    const deps = {
+      listOpenPrs: async (_repo: string) => [prA, prB],
+      readReviews: () => entries,
+      getCurrentUser: () => "bodhi-agent",
+      isSelfReviewAllowed: false,
+      listPrCommits: async (_prNumber: number): Promise<CommitInfo[]> => [],
+    };
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
   });
 });
 

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -129,6 +129,10 @@ export async function run(deps: Deps): Promise<RunResult> {
     }
 
     if (entry.lastReviewedCommit !== pr.headRefOid) {
+      // Staged (unposted) review + new commits = Tier 3: the review skill deliberately
+      // defers these on no-arg runs. Match that behaviour so the cron doesn't spin.
+      if (entry.posted === false) continue;
+
       // New commits since last review — check if they are all merge commits
       const mergeOnly = await isMergeOnlyUpdate(
         pr.number,

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -95,10 +95,12 @@ export async function run(deps: Deps): Promise<RunResult> {
   const currentUser = await deps.getCurrentUser();
   const reviews = deps.readReviews();
 
-  // Build a lookup from PR number → review entry
-  const reviewByPr = new Map<number, ReviewEntry>();
+  // Build a lookup from "repo:pr-number" → review entry.
+  // Keying on number alone causes cross-repo collisions when multiple repos
+  // are configured — two repos can share PR numbers. Include the repo in the key.
+  const reviewByPr = new Map<string, ReviewEntry>();
   for (const entry of reviews) {
-    reviewByPr.set(entry.pr, entry);
+    reviewByPr.set(`${entry.repo ?? ""}:${entry.pr}`, entry);
   }
 
   // We don't know the repo here without a context — use a placeholder for tests.
@@ -108,7 +110,7 @@ export async function run(deps: Deps): Promise<RunResult> {
   for (const pr of prs) {
     if (!deps.isSelfReviewAllowed && pr.author.login === currentUser) continue;
 
-    const entry = reviewByPr.get(pr.number);
+    const entry = reviewByPr.get(`${pr.repo ?? ""}:${pr.number}`);
 
     // No entry → eligible
     if (!entry) {

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -25,7 +25,7 @@ import {
   parseAllowSelfReview,
   readAllowSelfReview,
   readReviews,
-  resolveRepos,
+  resolveAllRepos,
   resolveWorkspacePath,
 } from "./check-helpers.ts";
 
@@ -39,6 +39,7 @@ interface PrInfo {
   author: { login: string };
   headRefName: string;
   headRefOid: string;
+  repo?: string;
 }
 
 export interface CommitInfo {
@@ -51,7 +52,7 @@ interface Deps {
   isSelfReviewAllowed: boolean;
   listOpenPrs: (repo: string) => Promise<PrInfo[]>;
   readReviews: () => ReviewEntry[];
-  listPrCommits: (prNumber: number) => Promise<CommitInfo[]>;
+  listPrCommits: (prNumber: number, repo?: string) => Promise<CommitInfo[]>;
 }
 
 // ─── Terminal statuses ────────────────────────────────────────────────────────
@@ -69,9 +70,10 @@ export async function isMergeOnlyUpdate(
   prNumber: number,
   lastReviewedCommit: string,
   deps: Pick<Deps, "listPrCommits">,
+  repo?: string,
 ): Promise<boolean> {
   try {
-    const commits = await deps.listPrCommits(prNumber);
+    const commits = await deps.listPrCommits(prNumber, repo);
     const anchorIndex = commits.findIndex((c) => c.sha === lastReviewedCommit);
     if (anchorIndex === -1) return false;
     const subsequent = commits.slice(anchorIndex + 1);
@@ -138,6 +140,7 @@ export async function run(deps: Deps): Promise<RunResult> {
         pr.number,
         entry.lastReviewedCommit,
         deps,
+        pr.repo,
       );
       if (mergeOnly) continue; // skip: only merge-from-main activity, no real work
       return {
@@ -154,31 +157,41 @@ export async function run(deps: Deps): Promise<RunResult> {
 
 // ─── Production deps ──────────────────────────────────────────────────────────
 
-async function buildProductionDeps(): Promise<Deps> {
+export async function buildProductionDeps(): Promise<Deps> {
   const workspacePath = resolveWorkspacePath();
-  const repos = resolveRepos(workspacePath);
-  const orgRepo = repos[0] ?? "app-vitals/shipwright";
+  const allRepos = resolveAllRepos(workspacePath);
 
   return {
     getCurrentUser,
     isSelfReviewAllowed: readAllowSelfReview(workspacePath),
     listOpenPrs: async (_repo: string) => {
-      return ghJson<PrInfo[]>([
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--repo",
-        orgRepo,
-        "--json",
-        "number,title,author,headRefName,headRefOid",
-      ]);
+      const allPrs: PrInfo[] = [];
+      for (const repo of allRepos) {
+        const repoPrs = ghJson<PrInfo[]>([
+          "pr",
+          "list",
+          "--state",
+          "open",
+          "--repo",
+          repo,
+          "--json",
+          "number,title,author,headRefName,headRefOid",
+        ]);
+        allPrs.push(...repoPrs.map((pr) => ({ ...pr, repo })));
+      }
+      return allPrs;
     },
     readReviews: () => readReviews(workspacePath),
-    listPrCommits: async (prNumber: number) => {
+    listPrCommits: async (prNumber: number, repo?: string) => {
+      const targetRepo = repo ?? allRepos[0];
+      if (!repo) {
+        process.stderr.write(
+          `warn: listPrCommits called without repo for PR #${prNumber}; falling back to ${targetRepo}\n`,
+        );
+      }
       return ghJson<CommitInfo[]>([
         "api",
-        `repos/${orgRepo}/pulls/${prNumber}/commits`,
+        `repos/${targetRepo}/pulls/${prNumber}/commits`,
         "--paginate",
       ]);
     },


### PR DESCRIPTION
## Summary

Syncs all generic improvements from vitals-os plugins/shipwright (v4.26.4 → v4.26.5).

**Multi-repo support** (precheck scripts were only querying the first configured repo)
- `check-helpers`: add `readShipwrightConfig` + `resolveAllRepos` — prioritises `shipwright.config.json` github repo, falls back to scanned repos, then `"app-vitals/shipwright"` default
- `check-patch`: iterate `allRepos` in `listOwnOpenPrs`; de-close `fetchMergeStatus` / `updateBranch` from closed-over `orgRepo`
- `check-review`: export `buildProductionDeps`; multi-repo `listOpenPrs` (each PrInfo tagged with source repo); `listPrCommits` routes to correct repo per PR
- `check-review-patch`: remove duplicated dep-building; delegate to `buildProductionDeps` from check-review and check-patch
- `check-deploy`: use `resolveAllRepos`

**Bug fixes**
- `check-patch`: switch CI status from `gh pr checks` to Actions API with head SHA — fixes incompatibility with fine-grained PATs
- `check-review`: skip `posted === false` entries when new commits arrive — prevents cron spinning on staged-but-not-posted Tier 3 reviews
- `review.md`: add merge-only eligibility check — skip re-review when every new commit since `lastReviewedCommit` is a merge-from-main commit

**Tests**
- `check-helpers.unit.test.ts`: 10 new unit tests for `readShipwrightConfig` and `resolveAllRepos`

## Test plan

- [ ] `resolveAllRepos` returns `shipwright.config.json` repo first, scanned repos following
- [ ] Precheck scripts query PRs across all configured repos
- [ ] CI status uses Actions API with head SHA
- [ ] Staged reviews don't spin the cron
- [ ] Merge-only PRs skipped in eligibility check

🤖 Generated with [Claude Code](https://claude.com/claude-code)