### PR TITLE
style: fix pre-existing biome lint warnings in plugin scripts

### DIFF
--- a/plugins/shipwright/scripts/check-banned-strings.unit.test.ts
+++ b/plugins/shipwright/scripts/check-banned-strings.unit.test.ts
@@ -8,12 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { scanForBannedStrings } from "./check-banned-strings.ts";

--- a/plugins/shipwright/scripts/check-dev-task.test.ts
+++ b/plugins/shipwright/scripts/check-dev-task.test.ts
@@ -16,10 +16,10 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { FixedClock } from "./test-helpers/doubles.ts";
 import { run } from "./check-dev-task.ts";
 import type { Clock } from "./clock.ts";
 import type { Task } from "./store.ts";
+import { FixedClock } from "./test-helpers/doubles.ts";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `check-dev-task.test.ts`: sort imports per biome organize-imports rule
- `check-banned-strings.unit.test.ts`: reformat per biome formatter

Both were pre-existing issues on main, surfaced while working on #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)