### PR TITLE
docs: backend-agnostic metrics provider interface design (PostHog/Postgres/SQLite)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Shipwright Harness is **the open-source (MIT) autonomous delivery agent for Clau
 | Phase | Artifact | Directory | What it is |
 |---|---|---|---|
 | **A** | **Plugin** (the system) | `plugins/shipwright/` | Commands, skills, agents, scripts users `/plugin install`. Repo-agnostic. |
-| **B** | **Metrics dashboard** | `metrics/` | Stateless Hono service: PostHog-backed JSON endpoints + a server-rendered dashboard. No database. |
+| **B** | **Metrics dashboard** | `metrics/` | Hono service: JSON endpoints + a server-rendered dashboard over a backend-agnostic event-store interface (PostHog · SQLite, with Postgres planned). PostHog-shaped `POST /batch/` ingest live today. |
 | **C** | **Shipwright agent** | `agent/` | Hono service + Prisma store; a thin autonomous runner: pick next ready task → build → ship PR → forward metrics. |
 
 Supporting surfaces (not phased):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ Shipwright Harness is the open-source autonomous delivery agent for [Claude Code
 | Phase | Artifact | Directory | What it is |
 |---|---|---|---|
 | **A** | **Plugin** (the system) | `plugins/shipwright/` | The Claude Code plugin users `/plugin install` — commands, skills, agents, scripts for the full delivery loop. Repo-agnostic. |
-| **B** | **Metrics dashboard** | `metrics/` | Hono service: PostHog-backed JSON endpoints + a server-rendered dashboard. Optional local SQLite event store for offline ingest (`POST /batch/`). |
+| **B** | **Metrics dashboard** | `metrics/` | Hono service: JSON endpoints + a server-rendered dashboard over a backend-agnostic event-store interface (PostHog · Postgres · SQLite), with a PostHog-shaped `POST /batch/` ingest route. |
 | **C** | **Shipwright agent** | `agent/` | Hono service + Prisma store; a thin autonomous runner: pick next ready task → build → ship PR → forward metrics. |
 
 The hard architectural rule: **no new coupling.** The plugin stays repo-agnostic; the metrics service and the agent each stand alone. Everything runs offline by default (fixtures / injected doubles / scratch queue); live external calls happen only when an env var explicitly enables them.
@@ -29,7 +29,7 @@ The plugin is pure TypeScript with **no server, no database, and no external HTT
 
 ## B — Metrics dashboard
 
-A Hono service that turns the pipeline's PostHog events into analytics. Five read-only JSON endpoints (`/metrics/summary|trends|features|queue|tokens`) plus a session-gated `/dashboard`. By default every response is computed from a live PostHog query (cached in-process). An optional local SQLite event store (`local-store.ts`) can be injected to enable a `POST /batch/` ingest route for offline event collection. See **[metrics.md](./metrics.md)**.
+A Hono service that turns the pipeline's events into analytics. Five read-only JSON endpoints (`/metrics/summary|trends|features|queue|tokens`) plus a session-gated `/dashboard`, served over a backend-agnostic **`MetricsProvider`** seam: query intent is expressed as typed data and each provider renders it to its store's native query. Supported backends are all **event stores** — PostHog (HogQL, live today), SQLite (local, `POST /batch/` ingest live today), and Postgres (planned) — so results are identical across them. Prometheus is intentionally excluded (numeric time-series, not event-level). See **[metrics.md](./metrics.md)** and the design spec under `docs/superpowers/specs/`.
 
 ## C — Shipwright agent
 
@@ -52,7 +52,7 @@ The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the s
 ```
 shipwright/
 ├── plugins/shipwright/   A — the plugin (commands, skills, agents, scripts)
-├── metrics/              B — PostHog-backed Hono service + optional local SQLite store
+├── metrics/              B — Hono service over a pluggable event-store interface (PostHog · Postgres · SQLite)
 ├── agent/                C — Shipwright agent (Hono + Prisma)
 ├── site/                 marketing site (Astro, separate toolchain)
 ├── brand/                locked design system

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,12 +1,24 @@
 # Metrics Dashboard
 
-> Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Five read-only JSON endpoints backed by PostHog queries, plus a session-gated server-rendered dashboard, and an optional local SQLite event store for offline ingest (`POST /batch/`).
+> Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Five read-only JSON endpoints, a session-gated server-rendered dashboard, and a PostHog-shaped `POST /batch/` ingest route — designed over a **backend-agnostic event-store interface** (PostHog · Postgres · SQLite).
 
 ## Overview
 
-The metrics service reads pipeline telemetry from PostHog and exposes it two ways: machine-readable JSON under `/metrics/*` (for tooling and the `/shipwright:metrics` command) and a human-facing `/dashboard`. By default it owns no persistent state — HogQL queries are validated pre-deploy and results are cached in-process. When a `localStore` is injected, an additional `POST /batch/` ingest route is registered that writes PostHog-shaped events to a local SQLite database (`metrics/src/local-store.ts`); the route is absent (404) otherwise.
+The metrics service reads pipeline telemetry from an **event store** and exposes it two ways: machine-readable JSON under `/metrics/*` (for tooling and the `/shipwright:metrics` command) and a human-facing `/dashboard`. The goal is that the dashboard and API are identical regardless of which store backs them — see [Backends](#backends). When a writable store is active, a `POST /batch/` ingest route accepts PostHog-shaped events; it is absent (404) otherwise.
 
 Entrypoint: `metrics/src/server.ts` (standalone Bun server, default port **3460**). The app factory `createMetricsApp()` in `metrics/src/api.ts` is what tests drive via `app.request()`.
+
+## Backends
+
+Metrics is designed around a backend-agnostic **`MetricsProvider`** seam: the API expresses query *intent* as typed data and each provider renders it to its store's native query, returning a normalized result. Because every supported backend is an **event store** (events-with-properties + arbitrary aggregation), all metrics return identical results across them.
+
+| Backend | Model | Status |
+|---|---|---|
+| **PostHog** (HogQL) | hosted event store | **Live today** — the default when `POSTHOG_PERSONAL_API_KEY` + `POSTHOG_PROJECT_ID` are set. |
+| **SQLite** (SQL) | local event store | Ingest (`POST /batch/`) **live today**; read-side + local-default mode planned (LDS-1.3). |
+| **Postgres** (SQL) | self-hosted event store | Planned (LDS-1.4) — shares the SQLite SQL layer, dialect-parameterized. |
+
+> **Prometheus is intentionally not a backend.** It is a numeric time-series database and cannot store event properties, so it cannot serve event-level delivery analytics (estimation accuracy, complexity distribution, per-feature breakdowns, cycle-time joins). It is the right tool for runtime/operational metrics — a separate concern from this service. See `docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md`.
 
 ## Running locally
 

--- a/docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md
+++ b/docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md
@@ -1,0 +1,142 @@
+# Metrics Backend Interface — Pluggable Event-Store Providers
+
+**Date:** 2026-06-08
+**Status:** Approved design, pre-implementation
+**Supersedes:** the read-side approach of LDS-1.2 (`LocalSqlitePostHogClient` implementing the HogQL-string seam) — now cancelled.
+**Tracked by:** LDS-1.3 (interface + PostHog & SQLite providers + default-local mode), LDS-1.4 (Postgres provider).
+
+---
+
+## 1. Summary
+
+The metrics service can already read from PostHog (live) and offline fixtures, and after LDS-1.1 it can *ingest* events into a local SQLite store via `POST /batch/`. That left us with two parallel "metric systems" (PostHog and SQLite) and no single contract uniting them. This design introduces **one backend-agnostic interface** — `MetricsProvider` — so the dashboard and API are identical regardless of which event store backs them.
+
+**Backend matrix (committed):**
+
+| Backend | Model | Query language | Role |
+|---|---|---|---|
+| **PostHog** | event store (ClickHouse) | HogQL | Hosted default; what we run today. |
+| **Postgres** | event store (relational) | SQL | Self-hosted "real deployment" tier. |
+| **SQLite** | event store (relational) | SQL | Local/dev default; zero-dependency (LDS-1.1). |
+
+All three are **event stores** — they persist events-with-properties and support arbitrary aggregation — so every metric we compute (counts, averages, group-bys, cycle-time joins) is expressible in all three with identical results.
+
+**Prometheus is explicitly out of scope.** It is a numeric time-series database: it cannot store event properties, and the bulk of these dashboards (estimation accuracy, complexity distribution, per-feature breakdowns, per-task cycle-time joins) require event-level granularity it does not retain. Prometheus is the right tool for *operational/runtime* metrics, not *event-level delivery analytics*. Forcing it behind this interface would produce misleading empty charts. If runtime metrics are ever wanted, that is a separate, additive surface — not a provider here.
+
+---
+
+## 2. The coupling we are removing
+
+The current read seam is `PostHogClientLike.query(hogql: string) → HogQLResult`. The contract is a **HogQL string** plus a tabular result. PostHog executes HogQL natively; a SQL backend cannot. The cancelled LDS-1.2 worked around this by *parsing* HogQL (`detectQueryType`) to recover intent and translate to SQL — brittle, and it keeps HogQL as the lingua franca (i.e. still PostHog-shaped).
+
+The fix is to move the seam **above** any query language: the API expresses *what metric it wants* as typed data, and each provider renders that to its own native query.
+
+---
+
+## 3. The interface
+
+```ts
+// metrics/src/metrics-provider.ts
+
+// What the dashboard/API asks for — query INTENT as data, not a query string.
+export type MetricQuery =
+  | { kind: "summary";            range: DateRange }
+  | { kind: "summaryCycleTime";   range: DateRange }
+  | { kind: "trends";             range: DateRange; groupBy: "hour" | "day" | "week" }
+  | { kind: "featuresTasks";      range: DateRange }
+  | { kind: "featuresCi";         range: DateRange }
+  | { kind: "featuresReviews";    range: DateRange }
+  | { kind: "queueFunnel";        range: DateRange }
+  | { kind: "queueCycleStarted";  range: DateRange }
+  | { kind: "queueCycleMerged";   range: DateRange }
+  | { kind: "tokensTotals";       range: DateRange }
+  | { kind: "tokensBySessionType"; range: DateRange }
+  | { kind: "tokensByAgent";      range: DateRange }
+  | { kind: "tokensTrends";       range: DateRange };
+
+// The normalized result — today's HogQLResult shape, renamed to drop the vendor name.
+export type MetricTable = { columns: string[]; results: unknown[][]; types: string[] };
+
+export interface MetricsProvider {
+  query(q: MetricQuery): Promise<MetricTable>;
+}
+```
+
+**No capability/degrade layer.** Every committed backend is an event store that serves every metric, so a `supports()`/capability mechanism would be dead weight (YAGNI). It is only needed if a capability-asymmetric backend (e.g. Prometheus) is ever admitted — and that decision has been made the other way. If that ever changes, the capability layer is added then, not now.
+
+---
+
+## 4. Components
+
+| Unit | File | Responsibility |
+|---|---|---|
+| Interface + types | `metrics/src/metrics-provider.ts` | `MetricQuery`, `MetricTable`, `MetricsProvider`. |
+| PostHog provider | `metrics/src/providers/posthog-provider.ts` | Maps `MetricQuery` → existing HogQL builders (`queries.ts`) → existing PostHog client. Behavior-preserving wrapper. |
+| Fixture provider | `metrics/src/providers/fixture-provider.ts` | Wraps the existing offline fixtures behind the interface. |
+| SQLite provider | `metrics/src/providers/sqlite-provider.ts` | Maps each `MetricQuery` → SQL aggregation over the LDS-1.1 `events` table. |
+| Postgres provider | `metrics/src/providers/postgres-provider.ts` (LDS-1.4) | Same SQL builders as SQLite, dialect-parameterized; pg execution seam. |
+
+The SQL providers share one set of `MetricQuery → SQL` builders parameterized by dialect, with a thin executor seam (`bun:sqlite` vs a pg driver) so SQLite and Postgres cannot drift.
+
+---
+
+## 5. Data flow
+
+```
+api.ts handler
+  → builds a typed MetricQuery  (was: a HogQL string)
+  → provider.query(q) → MetricTable
+  → existing row→domain transform + rate calcs (UNCHANGED)
+  → JSON response
+```
+
+`createMetricsApp` takes `provider: MetricsProvider` in place of `postHogClient`. The substantial transform/rate-calc logic in `api.ts` is untouched — it already consumes the tabular shape, now called `MetricTable`.
+
+---
+
+## 6. Mode selection (`server.ts`)
+
+A pure, unit-tested selector chooses the provider from env:
+
+```
+METRICS_OFFLINE === "true"                                 → FixtureProvider
+else POSTHOG_PERSONAL_API_KEY && POSTHOG_PROJECT_ID set    → PostHogProvider (live)
+else METRICS_DATABASE_URL is a postgres URL                → PostgresProvider   (LDS-1.4)
+else                                                        → SqliteProvider     (local default)
+```
+
+This keeps every existing test that relies on `METRICS_OFFLINE=true` working, makes local SQLite the zero-config default, and leaves live PostHog exactly as today when its read-keys are present.
+
+---
+
+## 7. Write path
+
+Ingest stays the PostHog-shaped `POST /batch/` from LDS-1.1. SQLite and Postgres both insert into the same `events` table (dedup on `insert_id`); the active backend owns the write. PostHog's own ingest is unchanged (the agent forwarder / `posthog_send.py` already POST to `{POSTHOG_HOST}/batch/`). Prometheus's push/scrape model is not relevant here — another reason it is not a provider.
+
+---
+
+## 8. Testing (lands with the code, at the correct layer)
+
+Honors the repo isolation contract: inject doubles, **no `mock.module()`, no global overrides**.
+
+| Area | Layer | Coverage |
+|---|---|---|
+| `MetricQuery → SQL` builders | `*.unit.test.ts` | per-kind column/row/type assertions over seeded events |
+| Mode selector | `*.unit.test.ts` | env → provider choice, all branches |
+| PostHog provider | reuse existing | existing fixtures/integration tests pass through the wrapper unchanged |
+| SQLite/Postgres provider end-to-end | `*.integration.test.ts` | seed via store or `/batch/`, query each kind, assert dashboard-shaped parity |
+
+---
+
+## 9. Build phases
+
+1. **LDS-1.3** — interface + types; PostHog & fixture providers (behavior-preserving); SQLite provider (13 kinds); `createMetricsApp`/`api.ts` switched to the provider seam; mode selection with SQLite default. Verifiable: `task api` with no env renders real local data; existing PostHog tests green.
+2. **LDS-1.4** — Postgres provider (shared dialect-parameterized SQL); Postgres `events` DDL/migration; connection-URL mode selection; result parity with SQLite. Verifiable: same dashboard off a Postgres backend.
+
+---
+
+## 10. Out of scope
+
+- Prometheus / any numeric time-series backend (wrong data model for event-level analytics — see §1).
+- Runtime/operational metrics (a separate concern, not this interface).
+- Changing what metrics exist or how they are computed — this is a backend-portability change only.


### PR DESCRIPTION
## Summary
Design + docs for a **backend-agnostic metrics interface** so the dashboard/API are identical regardless of the event store behind them.

- Adds design spec `docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md`: a typed `MetricsProvider` seam (query *intent* as data → normalized table), replacing the HogQL-string read seam.
- **Backend matrix: PostHog · Postgres · SQLite** — all event stores, so results are identical. **Prometheus explicitly out of scope** (numeric time-series; can't serve event-level analytics).
- No capability/degrade layer (YAGNI — only needed for a capability-asymmetric backend like Prometheus, which is excluded).
- Updates `docs/metrics.md` (new **Backends** section) and `docs/architecture.md` with honest "live today vs planned" status.

## Status reflected in docs (accurate, not aspirational)
- PostHog read — **live today**
- SQLite ingest (`POST /batch/`) — **live today** (PR #131)
- SQLite read-side + local-default mode — **planned (LDS-1.3)**
- Postgres provider — **planned (LDS-1.4)**

## Supersedes
Cancels the read-side approach of **LDS-1.2** (`LocalSqlitePostHogClient` parsing HogQL → SQL). Tracked by new tasks **LDS-1.3** (interface + PostHog & SQLite providers + default-local mode) and **LDS-1.4** (Postgres provider).

## Test Plan
- Docs-only change; no code paths touched.
- [x] Changed files scanned for banned identifiers (none)

Generated with [Claude Code](https://claude.com/claude-code)
