### PR TITLE
feat: backend-agnostic MetricsProvider interface (PostHog & SQLite providers, SQLite default)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Shipwright Harness is the open-source autonomous delivery agent for [Claude Code
 - **[Quickstart](./quickstart.md)** — prerequisites, step-by-step setup (clone → quickstart.sh → plugin install → task dev), and the copy-paste session prompt.
 - **[Architecture](./architecture.md)** — the three-artifact design (plugin → metrics → agent), supporting surfaces, and workspace layout.
 - **[Testing](./testing.md)** — the four-layer test model (unit / integration / smoke / e2e), run commands, speed budgets, and the isolation contract.
-- **[Metrics dashboard](./metrics.md)** — the stateless PostHog-backed service: JSON endpoints, dashboard, auth, and environment.
+- **[Metrics dashboard](./metrics.md)** — the provider-agnostic metrics service (sqlite default / posthog / fixtures): JSON endpoints, dashboard, auth, and environment.
 - **[Shipwright agent](./agent.md)** — the autonomous runner: runtime + admin APIs, data model, and environment.
 - **[Test system](./test-readiness/test-system.md)** — the full authoritative test blueprint (source for [Testing](./testing.md)).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ Shipwright Harness is the open-source autonomous delivery agent for [Claude Code
 | Phase | Artifact | Directory | What it is |
 |---|---|---|---|
 | **A** | **Plugin** (the system) | `plugins/shipwright/` | The Claude Code plugin users `/plugin install` — commands, skills, agents, scripts for the full delivery loop. Repo-agnostic. |
-| **B** | **Metrics dashboard** | `metrics/` | Hono service: PostHog-backed JSON endpoints + a server-rendered dashboard. Optional local SQLite event store for offline ingest (`POST /batch/`). |
+| **B** | **Metrics dashboard** | `metrics/` | Hono service: backend-agnostic `MetricsProvider` JSON endpoints + a server-rendered dashboard. Three modes: fixtures (offline), posthog (live), sqlite (default — local SQLite store + `POST /batch/` ingest). |
 | **C** | **Shipwright agent** | `agent/` | Hono service + Prisma store; a thin autonomous runner: pick next ready task → build → ship PR → forward metrics. |
 
 The hard architectural rule: **no new coupling.** The plugin stays repo-agnostic; the metrics service and the agent each stand alone. Everything runs offline by default (fixtures / injected doubles / scratch queue); live external calls happen only when an env var explicitly enables them.
@@ -29,7 +29,7 @@ The plugin is pure TypeScript with **no server, no database, and no external HTT
 
 ## B — Metrics dashboard
 
-A Hono service that turns the pipeline's PostHog events into analytics. Five read-only JSON endpoints (`/metrics/summary|trends|features|queue|tokens`) plus a session-gated `/dashboard`. By default every response is computed from a live PostHog query (cached in-process). An optional local SQLite event store (`local-store.ts`) can be injected to enable a `POST /batch/` ingest route for offline event collection. See **[metrics.md](./metrics.md)**.
+A Hono service that turns pipeline events into analytics. Five read-only JSON endpoints (`/metrics/summary|trends|features|queue|tokens`) plus a session-gated `/dashboard`, all served by a backend-agnostic `MetricsProvider` interface. The active backend is selected from env at startup: **fixtures** (offline), **posthog** (live PostHog queries), or **sqlite** (local SQLite store — the default when no PostHog keys are configured). In sqlite mode, `POST /batch/` ingest is always active. See **[metrics.md](./metrics.md)**.
 
 ## C — Shipwright agent
 
@@ -52,7 +52,7 @@ The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the s
 ```
 shipwright/
 ├── plugins/shipwright/   A — the plugin (commands, skills, agents, scripts)
-├── metrics/              B — PostHog-backed Hono service + optional local SQLite store
+├── metrics/              B — provider-agnostic Hono service (sqlite default / posthog / fixtures)
 ├── agent/                C — Shipwright agent (Hono + Prisma)
 ├── site/                 marketing site (Astro, separate toolchain)
 ├── brand/                locked design system

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,10 +1,16 @@
 # Metrics Dashboard
 
-> Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Five read-only JSON endpoints backed by PostHog queries, plus a session-gated server-rendered dashboard, and an optional local SQLite event store for offline ingest (`POST /batch/`).
+> Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Five read-only JSON endpoints served by a backend-agnostic `MetricsProvider`, plus a session-gated server-rendered dashboard. Three modes: **fixtures** (offline), **posthog** (live PostHog queries), and **sqlite** (local SQLite store — the default).
 
 ## Overview
 
-The metrics service reads pipeline telemetry from PostHog and exposes it two ways: machine-readable JSON under `/metrics/*` (for tooling and the `/shipwright:metrics` command) and a human-facing `/dashboard`. By default it owns no persistent state — HogQL queries are validated pre-deploy and results are cached in-process. When a `localStore` is injected, an additional `POST /batch/` ingest route is registered that writes PostHog-shaped events to a local SQLite database (`metrics/src/local-store.ts`); the route is absent (404) otherwise.
+The metrics service exposes pipeline telemetry two ways: machine-readable JSON under `/metrics/*` (for tooling and the `/shipwright:metrics` command) and a human-facing `/dashboard`. All read endpoints are served by a backend-agnostic `MetricsProvider` interface (`metrics/src/metrics-provider.ts`). The active backend is selected at startup by `selectProviderMode()` (`metrics/src/select-provider.ts`) based on env vars, in priority order:
+
+1. `METRICS_OFFLINE=true` → **fixtures** mode: fixture PostHog client; auth bypassed.
+2. PostHog read keys present → **posthog** mode: live `PostHogProvider` (`metrics/src/providers/posthog-provider.ts`).
+3. Otherwise (default) → **sqlite** mode: `SqliteProvider` (`metrics/src/providers/sqlite-provider.ts`) over a local SQLite event store; `POST /batch/` ingest is always registered in this mode.
+
+In sqlite mode (the default), the server creates a `LocalEventStore` (`metrics/src/local-store.ts`) at `METRICS_DB_PATH` (`state/metrics.db` by default) and wires it into both the provider and the `POST /batch/` ingest route.
 
 Entrypoint: `metrics/src/server.ts` (standalone Bun server, default port **3460**). The app factory `createMetricsApp()` in `metrics/src/api.ts` is what tests drive via `app.request()`.
 
@@ -98,12 +104,16 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 
 | File | Purpose |
 |---|---|
-| `metrics/src/server.ts` | Process entrypoint — env validation, wiring, `Bun.serve`. |
+| `metrics/src/server.ts` | Process entrypoint — env validation, provider selection, wiring, `Bun.serve`. |
 | `metrics/src/api.ts` | App factory `createMetricsApp()`, route + auth middleware registration, dashboard handler. |
-| `metrics/src/queries.ts` | HogQL query builders (summary, trends, features, queue, tokens). |
+| `metrics/src/metrics-provider.ts` | `MetricsProvider` interface + `MetricQuery` / `MetricTable` types — the backend-agnostic read seam. |
+| `metrics/src/select-provider.ts` | Pure env-to-mode selector (`selectProviderMode()`) — maps env vars to `"fixtures" \| "posthog" \| "sqlite"`. |
+| `metrics/src/providers/posthog-provider.ts` | `PostHogProvider` — implements `MetricsProvider` over a `PostHogClient` and HogQL query builders. |
+| `metrics/src/providers/sqlite-provider.ts` | `SqliteProvider` — implements `MetricsProvider` by querying the local `LocalEventStore` directly. |
+| `metrics/src/queries.ts` | HogQL query builders (summary, trends, features, queue, tokens); used by `PostHogProvider`. |
 | `metrics/src/posthog-client.ts` | PostHog client (interface + `Http` impl). |
 | `metrics/src/fixtures/posthog-fixtures.ts` | Fixture PostHog client (`createFixturePostHogClient()`) — pre-recorded sample data for every query type; used in offline mode and integration tests. |
-| `metrics/src/local-store.ts` | Local SQLite event store (`LocalEventStore` interface + `createLocalEventStore()`). Deduplicates on `insert_id`; used by `POST /batch/`. |
+| `metrics/src/local-store.ts` | Local SQLite event store (`LocalEventStore` interface + `createLocalEventStore()`). Deduplicates on `insert_id`; used by `POST /batch/` and `SqliteProvider`. |
 | `metrics/src/validate-hogql.ts` | Pre-deploy HogQL validation runner (`validate:hogql`). |
 | `metrics/src/cache.ts` | In-process query-result cache. |
 | `metrics/src/secrets.ts` | Secrets resolution: env-first, optional GCP Secret Manager fallback. |

--- a/docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md
+++ b/docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md
@@ -1,0 +1,142 @@
+# Metrics Backend Interface — Pluggable Event-Store Providers
+
+**Date:** 2026-06-08
+**Status:** Implemented — the interface + PostHog & SQLite providers and the default-local mode landed in LDS-1.3 (PR #148). Postgres provider pending LDS-1.4.
+**Supersedes:** the read-side approach of LDS-1.2 (`LocalSqlitePostHogClient` implementing the HogQL-string seam) — now cancelled.
+**Tracked by:** LDS-1.3 (interface + PostHog & SQLite providers + default-local mode), LDS-1.4 (Postgres provider).
+
+---
+
+## 1. Summary
+
+The metrics service can already read from PostHog (live) and offline fixtures, and after LDS-1.1 it can *ingest* events into a local SQLite store via `POST /batch/`. That left us with two parallel "metric systems" (PostHog and SQLite) and no single contract uniting them. This design introduces **one backend-agnostic interface** — `MetricsProvider` — so the dashboard and API are identical regardless of which event store backs them.
+
+**Backend matrix (committed):**
+
+| Backend | Model | Query language | Role |
+|---|---|---|---|
+| **PostHog** | event store (ClickHouse) | HogQL | Hosted default; what we run today. |
+| **Postgres** | event store (relational) | SQL | Self-hosted "real deployment" tier. |
+| **SQLite** | event store (relational) | SQL | Local/dev default; zero-dependency (LDS-1.1). |
+
+All three are **event stores** — they persist events-with-properties and support arbitrary aggregation — so every metric we compute (counts, averages, group-bys, cycle-time joins) is expressible in all three with identical results.
+
+**Prometheus is explicitly out of scope.** It is a numeric time-series database: it cannot store event properties, and the bulk of these dashboards (estimation accuracy, complexity distribution, per-feature breakdowns, per-task cycle-time joins) require event-level granularity it does not retain. Prometheus is the right tool for *operational/runtime* metrics, not *event-level delivery analytics*. Forcing it behind this interface would produce misleading empty charts. If runtime metrics are ever wanted, that is a separate, additive surface — not a provider here.
+
+---
+
+## 2. The coupling we are removing
+
+The current read seam is `PostHogClientLike.query(hogql: string) → HogQLResult`. The contract is a **HogQL string** plus a tabular result. PostHog executes HogQL natively; a SQL backend cannot. The cancelled LDS-1.2 worked around this by *parsing* HogQL (`detectQueryType`) to recover intent and translate to SQL — brittle, and it keeps HogQL as the lingua franca (i.e. still PostHog-shaped).
+
+The fix is to move the seam **above** any query language: the API expresses *what metric it wants* as typed data, and each provider renders that to its own native query.
+
+---
+
+## 3. The interface
+
+```ts
+// metrics/src/metrics-provider.ts
+
+// What the dashboard/API asks for — query INTENT as data, not a query string.
+export type MetricQuery =
+  | { kind: "summary";            range: DateRange }
+  | { kind: "summaryCycleTime";   range: DateRange }
+  | { kind: "trends";             range: DateRange; groupBy: "hour" | "day" | "week" }
+  | { kind: "featuresTasks";      range: DateRange }
+  | { kind: "featuresCi";         range: DateRange }
+  | { kind: "featuresReviews";    range: DateRange }
+  | { kind: "queueFunnel";        range: DateRange }
+  | { kind: "queueCycleStarted";  range: DateRange }
+  | { kind: "queueCycleMerged";   range: DateRange }
+  | { kind: "tokensTotals";       range: DateRange }
+  | { kind: "tokensBySessionType"; range: DateRange }
+  | { kind: "tokensByAgent";      range: DateRange }
+  | { kind: "tokensTrends";       range: DateRange };
+
+// The normalized result — today's HogQLResult shape, renamed to drop the vendor name.
+export type MetricTable = { columns: string[]; results: unknown[][]; types: string[] };
+
+export interface MetricsProvider {
+  query(q: MetricQuery): Promise<MetricTable>;
+}
+```
+
+**No capability/degrade layer.** Every committed backend is an event store that serves every metric, so a `supports()`/capability mechanism would be dead weight (YAGNI). It is only needed if a capability-asymmetric backend (e.g. Prometheus) is ever admitted — and that decision has been made the other way. If that ever changes, the capability layer is added then, not now.
+
+---
+
+## 4. Components
+
+| Unit | File | Responsibility |
+|---|---|---|
+| Interface + types | `metrics/src/metrics-provider.ts` | `MetricQuery`, `MetricTable`, `MetricsProvider`. |
+| PostHog provider | `metrics/src/providers/posthog-provider.ts` | Maps `MetricQuery` → existing HogQL builders (`queries.ts`) → existing PostHog client. Behavior-preserving wrapper. |
+| Fixture provider | `metrics/src/providers/fixture-provider.ts` | Wraps the existing offline fixtures behind the interface. |
+| SQLite provider | `metrics/src/providers/sqlite-provider.ts` | Maps each `MetricQuery` → SQL aggregation over the LDS-1.1 `events` table. |
+| Postgres provider | `metrics/src/providers/postgres-provider.ts` (LDS-1.4) | Same SQL builders as SQLite, dialect-parameterized; pg execution seam. |
+
+The SQL providers share one set of `MetricQuery → SQL` builders parameterized by dialect, with a thin executor seam (`bun:sqlite` vs a pg driver) so SQLite and Postgres cannot drift.
+
+---
+
+## 5. Data flow
+
+```
+api.ts handler
+  → builds a typed MetricQuery  (was: a HogQL string)
+  → provider.query(q) → MetricTable
+  → existing row→domain transform + rate calcs (UNCHANGED)
+  → JSON response
+```
+
+`createMetricsApp` takes `provider: MetricsProvider` in place of `postHogClient`. The substantial transform/rate-calc logic in `api.ts` is untouched — it already consumes the tabular shape, now called `MetricTable`.
+
+---
+
+## 6. Mode selection (`server.ts`)
+
+A pure, unit-tested selector chooses the provider from env:
+
+```
+METRICS_OFFLINE === "true"                                 → FixtureProvider
+else POSTHOG_PERSONAL_API_KEY && POSTHOG_PROJECT_ID set    → PostHogProvider (live)
+else METRICS_DATABASE_URL is a postgres URL                → PostgresProvider   (LDS-1.4)
+else                                                        → SqliteProvider     (local default)
+```
+
+This keeps every existing test that relies on `METRICS_OFFLINE=true` working, makes local SQLite the zero-config default, and leaves live PostHog exactly as today when its read-keys are present.
+
+---
+
+## 7. Write path
+
+Ingest stays the PostHog-shaped `POST /batch/` from LDS-1.1. SQLite and Postgres both insert into the same `events` table (dedup on `insert_id`); the active backend owns the write. PostHog's own ingest is unchanged (the agent forwarder / `posthog_send.py` already POST to `{POSTHOG_HOST}/batch/`). Prometheus's push/scrape model is not relevant here — another reason it is not a provider.
+
+---
+
+## 8. Testing (lands with the code, at the correct layer)
+
+Honors the repo isolation contract: inject doubles, **no `mock.module()`, no global overrides**.
+
+| Area | Layer | Coverage |
+|---|---|---|
+| `MetricQuery → SQL` builders | `*.unit.test.ts` | per-kind column/row/type assertions over seeded events |
+| Mode selector | `*.unit.test.ts` | env → provider choice, all branches |
+| PostHog provider | reuse existing | existing fixtures/integration tests pass through the wrapper unchanged |
+| SQLite/Postgres provider end-to-end | `*.integration.test.ts` | seed via store or `/batch/`, query each kind, assert dashboard-shaped parity |
+
+---
+
+## 9. Build phases
+
+1. **LDS-1.3** — interface + types; PostHog & fixture providers (behavior-preserving); SQLite provider (13 kinds); `createMetricsApp`/`api.ts` switched to the provider seam; mode selection with SQLite default. Verifiable: `task api` with no env renders real local data; existing PostHog tests green.
+2. **LDS-1.4** — Postgres provider (shared dialect-parameterized SQL); Postgres `events` DDL/migration; connection-URL mode selection; result parity with SQLite. Verifiable: same dashboard off a Postgres backend.
+
+---
+
+## 10. Out of scope
+
+- Prometheus / any numeric time-series backend (wrong data model for event-level analytics — see §1).
+- Runtime/operational metrics (a separate concern, not this interface).
+- Changing what metrics exist or how they are computed — this is a backend-portability change only.

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -16,6 +16,8 @@ import { ErrorSchema } from "./lib/api-schemas.ts";
 import { registerWithAuthz } from "./lib/api-utils.ts";
 import { createSessionMiddleware } from "./lib/session-middleware.ts";
 import type { LocalEventStore } from "./local-store.ts";
+import type { MetricsProvider } from "./metrics-provider.ts";
+import { PostHogProvider } from "./providers/posthog-provider.ts";
 import { renderDashboardPage } from "./dashboard/dashboard-page.ts";
 import {
   resolveDateRangeForMeta,
@@ -60,6 +62,13 @@ export type PostHogClientLike = {
 };
 
 export interface MetricsDeps {
+  /**
+   * Backend-agnostic read seam. When provided, all handler reads route through
+   * it. When absent, a PostHogProvider is auto-constructed from the resolved
+   * postHogClient + (optionally overridden) builder functions — so existing
+   * `postHogClient` + `buildXQueryFn` DI tests behave identically.
+   */
+  provider?: MetricsProvider;
   postHogClient?: PostHogClientLike;
   buildSummaryQueryFn?: typeof buildSummaryQuery;
   buildSummaryCycleTimeQueryFn?: typeof buildSummaryCycleTimeQuery;
@@ -288,34 +297,45 @@ function handleQueryError(
 
 // ─── Handler factory ─────────────────────────────────────────────────────────
 
+/**
+ * Resolve the active read provider. If `deps.provider` is set it wins;
+ * otherwise a PostHogProvider is constructed over the resolved client +
+ * builder overrides — reproducing the previous client.query(builder(...))
+ * behavior exactly, so existing DI tests route through it unchanged.
+ */
+function resolveProvider(
+  client: PostHogClientLike,
+  deps?: MetricsDeps,
+): MetricsProvider {
+  if (deps?.provider) return deps.provider;
+  return new PostHogProvider(client, {
+    summary: deps?.buildSummaryQueryFn ?? buildSummaryQuery,
+    summaryCycleTime:
+      deps?.buildSummaryCycleTimeQueryFn ?? buildSummaryCycleTimeQuery,
+    trends: deps?.buildTrendsQueryFn ?? buildTrendsQuery,
+    featuresTasks: deps?.buildFeaturesTasksQueryFn ?? buildFeaturesTasksQuery,
+    featuresCi: deps?.buildFeaturesCiQueryFn ?? buildFeaturesCiQuery,
+    featuresReviews:
+      deps?.buildFeaturesReviewsQueryFn ?? buildFeaturesReviewsQuery,
+    queueFunnel: deps?.buildQueueFunnelQueryFn ?? buildQueueFunnelQuery,
+    queueCycleStarted:
+      deps?.buildQueueCycleStartedQueryFn ?? buildQueueCycleStartedQuery,
+    queueCycleMerged:
+      deps?.buildQueueCycleMergedQueryFn ?? buildQueueCycleMergedQuery,
+    tokensTotals: deps?.buildTokensTotalsQueryFn ?? buildTokensTotalsQuery,
+    tokensBySessionType:
+      deps?.buildTokensBySessionTypeQueryFn ?? buildTokensBySessionTypeQuery,
+    tokensByAgent: deps?.buildTokensByAgentQueryFn ?? buildTokensByAgentQuery,
+    tokensTrends: deps?.buildTokensTrendsQueryFn ?? buildTokensTrendsQuery,
+  });
+}
+
 export function createMetricsHandlers(
   client: PostHogClientLike,
   accountsClient: AccountsClient,
   deps?: MetricsDeps,
 ) {
-  const _buildSummary = deps?.buildSummaryQueryFn ?? buildSummaryQuery;
-  const _buildSummaryCycleTime =
-    deps?.buildSummaryCycleTimeQueryFn ?? buildSummaryCycleTimeQuery;
-  const _buildTrends = deps?.buildTrendsQueryFn ?? buildTrendsQuery;
-  const _buildFeaturesTasks =
-    deps?.buildFeaturesTasksQueryFn ?? buildFeaturesTasksQuery;
-  const _buildFeaturesCi = deps?.buildFeaturesCiQueryFn ?? buildFeaturesCiQuery;
-  const _buildFeaturesReviews =
-    deps?.buildFeaturesReviewsQueryFn ?? buildFeaturesReviewsQuery;
-  const _buildQueueFunnel =
-    deps?.buildQueueFunnelQueryFn ?? buildQueueFunnelQuery;
-  const _buildQueueCycleStarted =
-    deps?.buildQueueCycleStartedQueryFn ?? buildQueueCycleStartedQuery;
-  const _buildQueueCycleMerged =
-    deps?.buildQueueCycleMergedQueryFn ?? buildQueueCycleMergedQuery;
-  const _buildTokensTotals =
-    deps?.buildTokensTotalsQueryFn ?? buildTokensTotalsQuery;
-  const _buildTokensBySessionType =
-    deps?.buildTokensBySessionTypeQueryFn ?? buildTokensBySessionTypeQuery;
-  const _buildTokensByAgent =
-    deps?.buildTokensByAgentQueryFn ?? buildTokensByAgentQuery;
-  const _buildTokensTrends =
-    deps?.buildTokensTrendsQueryFn ?? buildTokensTrendsQuery;
+  const provider = resolveProvider(client, deps);
 
   const handleSummary: AppHandler<typeof summaryRoute> = async (c) => {
     const { preset, from, to } = c.req.valid("query");
@@ -334,8 +354,8 @@ export function createMetricsHandlers(
 
     try {
       const [result, cycleTimeResult] = await Promise.all([
-        client.query(_buildSummary(dateRange)),
-        client.query(_buildSummaryCycleTime(dateRange)),
+        provider.query({ kind: "summary", range: dateRange }),
+        provider.query({ kind: "summaryCycleTime", range: dateRange }),
       ]);
       const row = rowToObject(result) ?? {};
       const cycleTimeRow = rowToObject(cycleTimeResult) ?? {};
@@ -440,8 +460,11 @@ export function createMetricsHandlers(
     const startMs = Date.now(); // infra: request timing telemetry
 
     try {
-      const hogql = _buildTrends(dateRange, grouping);
-      const result = await client.query(hogql);
+      const result = await provider.query({
+        kind: "trends",
+        range: dateRange,
+        groupBy: grouping,
+      });
 
       const rows = result.results.map((raw) => {
         const row = Object.fromEntries(
@@ -508,9 +531,9 @@ export function createMetricsHandlers(
 
     try {
       const [tasksResult, ciResult, reviewsResult] = await Promise.all([
-        client.query(_buildFeaturesTasks(dateRange)),
-        client.query(_buildFeaturesCi(dateRange)),
-        client.query(_buildFeaturesReviews(dateRange)),
+        provider.query({ kind: "featuresTasks", range: dateRange }),
+        provider.query({ kind: "featuresCi", range: dateRange }),
+        provider.query({ kind: "featuresReviews", range: dateRange }),
       ]);
 
       // Build lookup maps from CI and reviews results
@@ -612,9 +635,9 @@ export function createMetricsHandlers(
     try {
       const [funnelResult, cycleStartedResult, cycleMergedResult] =
         await Promise.all([
-          client.query(_buildQueueFunnel(dateRange)),
-          client.query(_buildQueueCycleStarted(dateRange)),
-          client.query(_buildQueueCycleMerged(dateRange)),
+          provider.query({ kind: "queueFunnel", range: dateRange }),
+          provider.query({ kind: "queueCycleStarted", range: dateRange }),
+          provider.query({ kind: "queueCycleMerged", range: dateRange }),
         ]);
 
       const funnelRow = rowToObject(funnelResult) ?? {};
@@ -713,10 +736,10 @@ export function createMetricsHandlers(
     try {
       const [totalsResult, bySessionTypeResult, byAgentResult, trendsResult] =
         await Promise.all([
-          client.query(_buildTokensTotals(dateRange)),
-          client.query(_buildTokensBySessionType(dateRange)),
-          client.query(_buildTokensByAgent(dateRange)),
-          client.query(_buildTokensTrends(dateRange)),
+          provider.query({ kind: "tokensTotals", range: dateRange }),
+          provider.query({ kind: "tokensBySessionType", range: dateRange }),
+          provider.query({ kind: "tokensByAgent", range: dateRange }),
+          provider.query({ kind: "tokensTrends", range: dateRange }),
         ]);
 
       const totalsRow = rowToObject(totalsResult) ?? {};

--- a/metrics/src/formatters.ts
+++ b/metrics/src/formatters.ts
@@ -8,6 +8,7 @@
 
 import { type Clock, SystemClock } from "./lib/clock.ts";
 import { DASHBOARD_TZ } from "./queries.ts";
+import type { QueryDateRange } from "./queries.ts";
 import type { ResponseMeta } from "./schemas.ts";
 import type { DatePreset, ResolvedDateRange } from "./types.ts";
 
@@ -145,6 +146,27 @@ export function resolveDateRangeForMeta(
     };
   }
   return resolvePreset("today");
+}
+
+/**
+ * Resolve a typed QueryDateRange (preset or custom from/to) to concrete UTC
+ * instants on LA day boundaries. This is the single window-semantics source
+ * the SqliteProvider uses for `WHERE timestamp BETWEEN`, so local SQL and the
+ * PostHog HogQL date filters agree on what "today" / "7d" / a custom range
+ * mean.
+ */
+export function resolveQueryRange(
+  range: QueryDateRange,
+  clock: Clock = SystemClock(),
+): { from: string; to: string } {
+  if (typeof range === "string") {
+    const r = resolvePreset(range, clock);
+    return { from: r.from, to: r.to };
+  }
+  return {
+    from: laMidnightUtc(range.from).toISOString(),
+    to: laEndOfDayUtc(range.to).toISOString(),
+  };
 }
 
 // ─── Response envelope ────────────────────────────────────────────────────────

--- a/metrics/src/metrics-provider.integration.test.ts
+++ b/metrics/src/metrics-provider.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * metrics/src/metrics-provider.integration.test.ts
+ * Integration: seed events via POST /batch/, build the app with a
+ * SqliteProvider over the same store, and hit the /metrics/* endpoints via
+ * app.request() — asserting dashboard-shaped JSON comes back from real local
+ * data (no PostHog, no HogQL).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { type MetricsDeps, createMetricsApp } from "./api.ts";
+import { parseApiKeys } from "./lib/api-auth.ts";
+import { makeAccountsClientMock } from "./lib/test-helpers.ts";
+import { createLocalEventStore } from "./local-store.ts";
+import { SqliteProvider } from "./providers/sqlite-provider.ts";
+
+const ADMIN_KEY = "sk_admin_lds13";
+const apiKeys = parseApiKeys(`admin:${ADMIN_KEY}:*`);
+const noopAccountsClient = makeAccountsClientMock(async () => []);
+
+function authHeader() {
+  return { Authorization: `Bearer ${ADMIN_KEY}` };
+}
+
+function buildApp() {
+  const store = createLocalEventStore({ path: ":memory:" });
+  const provider = new SqliteProvider(store);
+  const deps: MetricsDeps = { provider, localStore: store };
+  const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
+  return { app, store };
+}
+
+function batch() {
+  return {
+    api_key: "phc_dummy",
+    batch: [
+      {
+        event: "shipwright_task_complete",
+        distinct_id: "d",
+        timestamp: "2026-06-02T12:00:00.000Z",
+        properties: {
+          $insert_id: "c1",
+          task: "QS-1.1",
+          actual_h: 4,
+          estimated_h: 5,
+          complexity: 3,
+          started_at: "2026-06-02T08:00:00.000Z",
+          ts: "2026-06-02T12:00:00.000Z",
+        },
+      },
+      {
+        event: "shipwright_task_blocked",
+        distinct_id: "d",
+        timestamp: "2026-06-02T15:00:00.000Z",
+        properties: { $insert_id: "b1", task_id: "QS-1.2" },
+      },
+      {
+        event: "shipwright_ci_result",
+        distinct_id: "d",
+        timestamp: "2026-06-02T10:00:00.000Z",
+        properties: {
+          $insert_id: "ci1",
+          task_id: "QS-1.1",
+          passed_first_try: true,
+          fix_attempts: 0,
+        },
+      },
+      {
+        event: "shipwright_task_reviewed",
+        distinct_id: "d",
+        timestamp: "2026-06-02T13:00:00.000Z",
+        properties: {
+          $insert_id: "r1",
+          task_id: "QS-1.1",
+          verdict: "SHIP IT",
+          findings: 1,
+        },
+      },
+      {
+        event: "shipwright_task_started",
+        distinct_id: "d",
+        timestamp: "2026-06-02T08:00:00.000Z",
+        properties: { $insert_id: "s1", task_id: "QS-1.1" },
+      },
+      {
+        event: "agent_token_usage",
+        distinct_id: "d",
+        timestamp: "2026-06-02T09:00:00.000Z",
+        properties: {
+          $insert_id: "t1",
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_read_input_tokens: 200,
+          cache_creation_input_tokens: 100,
+          session_type: "cron",
+          agent_id: "agent-a",
+        },
+      },
+    ],
+  };
+}
+
+const RANGE = "from=2026-06-01&to=2026-06-07";
+
+async function ingest(app: ReturnType<typeof buildApp>["app"]) {
+  const res = await app.request("/batch/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(batch()),
+  });
+  expect(res.status).toBe(200);
+}
+
+describe("metrics via SqliteProvider (integration)", () => {
+  test("GET /metrics/summary returns aggregated local data", async () => {
+    const { app, store } = buildApp();
+    await ingest(app);
+
+    const res = await app.request(`/metrics/summary?${RANGE}`, {
+      headers: authHeader(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.tasksCompleted).toBe(1);
+    expect(body.data.tasksBlocked).toBe(1);
+    expect(body.data.ciGatesTotal).toBe(1);
+    expect(body.data.ciFirstPass).toBe(1);
+    expect(body.data.ciFirstPassRate).toBe(100);
+    expect(body.data.reviewsTotal).toBe(1);
+    expect(body.data.reviewsShipIt).toBe(1);
+    expect(body.data.complexityDist.c3).toBe(1);
+    expect(body.meta.dateRange.from).toBeTruthy();
+    store.close();
+  });
+
+  test("GET /metrics/trends returns rows", async () => {
+    const { app, store } = buildApp();
+    await ingest(app);
+
+    const res = await app.request(`/metrics/trends?${RANGE}`, {
+      headers: authHeader(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data.rows)).toBe(true);
+    const total = body.data.rows.reduce(
+      (acc: number, r: { tasksCompleted: number }) => acc + r.tasksCompleted,
+      0,
+    );
+    expect(total).toBe(1);
+    store.close();
+  });
+
+  test("GET /metrics/features returns per-prefix breakdown", async () => {
+    const { app, store } = buildApp();
+    await ingest(app);
+
+    const res = await app.request(`/metrics/features?${RANGE}`, {
+      headers: authHeader(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const qs = body.data.features.find(
+      (f: { prefix: string }) => f.prefix === "QS",
+    );
+    expect(qs).toBeDefined();
+    expect(qs.tasksCompleted).toBe(1);
+    expect(qs.ciFirstPassRate).toBe(100);
+    expect(qs.reviewShipItRate).toBe(100);
+    store.close();
+  });
+
+  test("GET /metrics/queue returns funnel + cycle", async () => {
+    const { app, store } = buildApp();
+    await ingest(app);
+
+    const res = await app.request(`/metrics/queue?${RANGE}`, {
+      headers: authHeader(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.tasksStarted).toBe(1);
+    expect(body.data.tasksMerged).toBe(1);
+    expect(body.data.tasksBlocked).toBe(1);
+    store.close();
+  });
+
+  test("GET /metrics/tokens returns totals + breakdowns", async () => {
+    const { app, store } = buildApp();
+    await ingest(app);
+
+    const res = await app.request(`/metrics/tokens?${RANGE}`, {
+      headers: authHeader(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.totals.input).toBe(1000);
+    expect(body.data.totals.total).toBe(1800);
+    const cron = body.data.bySessionType.find(
+      (s: { sessionType: string }) => s.sessionType === "cron",
+    );
+    expect(cron.input).toBe(1000);
+    store.close();
+  });
+});

--- a/metrics/src/metrics-provider.ts
+++ b/metrics/src/metrics-provider.ts
@@ -1,0 +1,39 @@
+/**
+ * metrics/src/metrics-provider.ts
+ * Backend-agnostic read seam for the metrics dashboard.
+ *
+ * A `MetricsProvider` answers typed `MetricQuery` requests and returns a
+ * `MetricTable` (an alias of the existing PostHog result shape) so the
+ * handlers in api.ts are identical regardless of which backend served the
+ * data. PostHog and SQLite both implement this; no HogQL string ever crosses
+ * the handler↔provider boundary.
+ */
+
+import type { QueryDateRange, TrendsGroupBy } from "./queries.ts";
+import type { HogQLResult } from "./types.ts";
+
+/** Result shape every backend returns — an alias, NOT a narrowing. */
+export type MetricTable = HogQLResult;
+
+/** The 13 typed read queries the dashboard issues. */
+export type MetricQuery =
+  | { kind: "summary"; range: QueryDateRange }
+  | { kind: "summaryCycleTime"; range: QueryDateRange }
+  | { kind: "trends"; range: QueryDateRange; groupBy: TrendsGroupBy }
+  | { kind: "featuresTasks"; range: QueryDateRange }
+  | { kind: "featuresCi"; range: QueryDateRange }
+  | { kind: "featuresReviews"; range: QueryDateRange }
+  | { kind: "queueFunnel"; range: QueryDateRange }
+  | { kind: "queueCycleStarted"; range: QueryDateRange }
+  | { kind: "queueCycleMerged"; range: QueryDateRange }
+  | { kind: "tokensTotals"; range: QueryDateRange }
+  | { kind: "tokensBySessionType"; range: QueryDateRange }
+  | { kind: "tokensByAgent"; range: QueryDateRange }
+  | { kind: "tokensTrends"; range: QueryDateRange };
+
+export type MetricQueryKind = MetricQuery["kind"];
+
+/** Read seam: every backend serves every query kind. */
+export interface MetricsProvider {
+  query(q: MetricQuery): Promise<MetricTable>;
+}

--- a/metrics/src/providers/posthog-provider.ts
+++ b/metrics/src/providers/posthog-provider.ts
@@ -1,0 +1,76 @@
+/**
+ * metrics/src/providers/posthog-provider.ts
+ * MetricsProvider backed by PostHog (HogQL). The ONLY place HogQL exists on
+ * the read path: query(q) selects the matching builder, produces the HogQL
+ * string, and hands it to the injected PostHogClientLike. Builder overrides
+ * are accepted so existing sentinel-based DI tests route unchanged.
+ */
+
+import type { PostHogClientLike } from "../api.ts";
+import type {
+  MetricQuery,
+  MetricTable,
+  MetricsProvider,
+} from "../metrics-provider.ts";
+import type { QueryDateRange, TrendsGroupBy } from "../queries.ts";
+
+/** The 13 HogQL builders, keyed by MetricQuery kind. */
+export interface BuilderFns {
+  summary: (range: QueryDateRange) => string;
+  summaryCycleTime: (range: QueryDateRange) => string;
+  trends: (range: QueryDateRange, groupBy: TrendsGroupBy) => string;
+  featuresTasks: (range: QueryDateRange) => string;
+  featuresCi: (range: QueryDateRange) => string;
+  featuresReviews: (range: QueryDateRange) => string;
+  queueFunnel: (range: QueryDateRange) => string;
+  queueCycleStarted: (range: QueryDateRange) => string;
+  queueCycleMerged: (range: QueryDateRange) => string;
+  tokensTotals: (range: QueryDateRange) => string;
+  tokensBySessionType: (range: QueryDateRange) => string;
+  tokensByAgent: (range: QueryDateRange) => string;
+  tokensTrends: (range: QueryDateRange) => string;
+}
+
+export class PostHogProvider implements MetricsProvider {
+  constructor(
+    private readonly client: PostHogClientLike,
+    private readonly builders: BuilderFns,
+  ) {}
+
+  async query(q: MetricQuery): Promise<MetricTable> {
+    const hogql = this.buildHogql(q);
+    return this.client.query(hogql);
+  }
+
+  private buildHogql(q: MetricQuery): string {
+    const b = this.builders;
+    switch (q.kind) {
+      case "summary":
+        return b.summary(q.range);
+      case "summaryCycleTime":
+        return b.summaryCycleTime(q.range);
+      case "trends":
+        return b.trends(q.range, q.groupBy);
+      case "featuresTasks":
+        return b.featuresTasks(q.range);
+      case "featuresCi":
+        return b.featuresCi(q.range);
+      case "featuresReviews":
+        return b.featuresReviews(q.range);
+      case "queueFunnel":
+        return b.queueFunnel(q.range);
+      case "queueCycleStarted":
+        return b.queueCycleStarted(q.range);
+      case "queueCycleMerged":
+        return b.queueCycleMerged(q.range);
+      case "tokensTotals":
+        return b.tokensTotals(q.range);
+      case "tokensBySessionType":
+        return b.tokensBySessionType(q.range);
+      case "tokensByAgent":
+        return b.tokensByAgent(q.range);
+      case "tokensTrends":
+        return b.tokensTrends(q.range);
+    }
+  }
+}

--- a/metrics/src/providers/posthog-provider.unit.test.ts
+++ b/metrics/src/providers/posthog-provider.unit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * metrics/src/providers/posthog-provider.unit.test.ts
+ * Unit tests for PostHogProvider: each MetricQuery kind routes to the matching
+ * builder, the resulting HogQL is handed to the client, and the client result
+ * is returned verbatim. Trends must forward its groupBy to the builder.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { PostHogClientLike } from "../api.ts";
+import type { MetricQuery } from "../metrics-provider.ts";
+import type { QueryDateRange, TrendsGroupBy } from "../queries.ts";
+import type { HogQLResult } from "../types.ts";
+import { PostHogProvider } from "./posthog-provider.ts";
+
+function makeResult(tag: string): HogQLResult {
+  return { columns: [tag], results: [[tag]], types: ["String"] };
+}
+
+/** Client that records the last HogQL string it received. */
+function recordingClient(): { client: PostHogClientLike; seen: string[] } {
+  const seen: string[] = [];
+  return {
+    seen,
+    client: {
+      async query(hogql: string): Promise<HogQLResult> {
+        seen.push(hogql);
+        return makeResult(hogql);
+      },
+    },
+  };
+}
+
+/** Builder overrides that emit a unique sentinel per kind. */
+function sentinelBuilders() {
+  const groupByCapture: TrendsGroupBy[] = [];
+  return {
+    groupByCapture,
+    builders: {
+      summary: (_r: QueryDateRange) => "S:summary",
+      summaryCycleTime: (_r: QueryDateRange) => "S:cycle",
+      trends: (_r: QueryDateRange, g: TrendsGroupBy) => {
+        groupByCapture.push(g);
+        return `S:trends:${g}`;
+      },
+      featuresTasks: (_r: QueryDateRange) => "S:ftasks",
+      featuresCi: (_r: QueryDateRange) => "S:fci",
+      featuresReviews: (_r: QueryDateRange) => "S:freviews",
+      queueFunnel: (_r: QueryDateRange) => "S:qfunnel",
+      queueCycleStarted: (_r: QueryDateRange) => "S:qstarted",
+      queueCycleMerged: (_r: QueryDateRange) => "S:qmerged",
+      tokensTotals: (_r: QueryDateRange) => "S:ttotals",
+      tokensBySessionType: (_r: QueryDateRange) => "S:tsession",
+      tokensByAgent: (_r: QueryDateRange) => "S:tagent",
+      tokensTrends: (_r: QueryDateRange) => "S:ttrends",
+    },
+  };
+}
+
+const cases: Array<{ q: MetricQuery; expected: string }> = [
+  { q: { kind: "summary", range: "today" }, expected: "S:summary" },
+  { q: { kind: "summaryCycleTime", range: "today" }, expected: "S:cycle" },
+  { q: { kind: "featuresTasks", range: "today" }, expected: "S:ftasks" },
+  { q: { kind: "featuresCi", range: "today" }, expected: "S:fci" },
+  { q: { kind: "featuresReviews", range: "today" }, expected: "S:freviews" },
+  { q: { kind: "queueFunnel", range: "today" }, expected: "S:qfunnel" },
+  { q: { kind: "queueCycleStarted", range: "today" }, expected: "S:qstarted" },
+  { q: { kind: "queueCycleMerged", range: "today" }, expected: "S:qmerged" },
+  { q: { kind: "tokensTotals", range: "today" }, expected: "S:ttotals" },
+  {
+    q: { kind: "tokensBySessionType", range: "today" },
+    expected: "S:tsession",
+  },
+  { q: { kind: "tokensByAgent", range: "today" }, expected: "S:tagent" },
+  { q: { kind: "tokensTrends", range: "today" }, expected: "S:ttrends" },
+];
+
+describe("PostHogProvider routing", () => {
+  for (const { q, expected } of cases) {
+    test(`${q.kind} routes to its builder and returns the client result`, async () => {
+      const { client, seen } = recordingClient();
+      const { builders } = sentinelBuilders();
+      const provider = new PostHogProvider(client, builders);
+
+      const result = await provider.query(q);
+
+      expect(seen).toEqual([expected]);
+      expect(result.columns).toEqual([expected]);
+    });
+  }
+
+  test("trends forwards groupBy to the builder", async () => {
+    const { client, seen } = recordingClient();
+    const { builders, groupByCapture } = sentinelBuilders();
+    const provider = new PostHogProvider(client, builders);
+
+    await provider.query({ kind: "trends", range: "7d", groupBy: "week" });
+
+    expect(groupByCapture).toEqual(["week"]);
+    expect(seen).toEqual(["S:trends:week"]);
+  });
+});

--- a/metrics/src/providers/sqlite-provider.ts
+++ b/metrics/src/providers/sqlite-provider.ts
@@ -1,0 +1,550 @@
+/**
+ * metrics/src/providers/sqlite-provider.ts
+ * MetricsProvider backed by the local SQLite event store (LDS-1.1). Each
+ * MetricQuery kind reads the relevant event rows from the store within the
+ * resolved date window and aggregates them into a MetricTable whose columns
+ * EXACTLY match what the api.ts handlers expect — so the dashboard renders
+ * identically whether the data came from PostHog or local SQLite.
+ *
+ * Event/property selection mirrors the HogQL builders in queries.ts. Date
+ * windows are resolved via the shared `resolveQueryRange` helper so local SQL
+ * and PostHog agree on what each preset / custom range means.
+ */
+
+import { type Clock, SystemClock } from "../lib/clock.ts";
+import { resolveQueryRange } from "../formatters.ts";
+import type { LocalEventStore, StoredEvent } from "../local-store.ts";
+import type {
+  MetricQuery,
+  MetricTable,
+  MetricsProvider,
+} from "../metrics-provider.ts";
+import type { QueryDateRange } from "../queries.ts";
+
+// ─── Event-name alias sets (mirror queries.ts) ────────────────────────────────
+
+const TASK_COMPLETED_EVENTS = [
+  "shipwright_task_merged",
+  "shipwright_task_complete",
+  "shipwright_task_completed",
+];
+const TASK_REVIEWED_EVENTS = [
+  "shipwright_task_approved",
+  "shipwright_task_reviewed",
+  "shipwright_review_complete",
+];
+const DASHBOARD_TZ = "America/Los_Angeles";
+
+// ─── Value helpers ────────────────────────────────────────────────────────────
+
+function num(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+/** Mean of the non-null numeric values, or null when none. */
+function avg(values: Array<number | null>): number | null {
+  const nums = values.filter((v): v is number => v !== null);
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+/** Sum of the non-null numeric values (0 when none). */
+function sum(values: Array<number | null>): number {
+  return values.reduce<number>((a, b) => a + (b ?? 0), 0);
+}
+
+/** Coalesced task identity: properties.task_id ?? properties.task. */
+function taskKey(e: StoredEvent): string | null {
+  const id = e.properties.task_id;
+  if (typeof id === "string" && id) return id;
+  const t = e.properties.task;
+  if (typeof t === "string" && t) return t;
+  return null;
+}
+
+const FEATURE_PREFIX_RE = /^[A-Z]+-[0-9]+\.[0-9]+$/;
+function featurePrefix(e: StoredEvent): string | null {
+  const key = taskKey(e);
+  if (!key || !FEATURE_PREFIX_RE.test(key)) return null;
+  const m = key.match(/^([A-Z]+)-/);
+  return m ? m[1] : null;
+}
+
+/** Per-event cycle hours from started_at→ts, or null when not derivable. */
+function cycleHours(e: StoredEvent): number | null {
+  const start = e.properties.started_at;
+  const end = e.properties.ts;
+  if (typeof start !== "string" || typeof end !== "string") return null;
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (Number.isNaN(ms)) return null;
+  return ms / (1000 * 60 * 60);
+}
+
+/** LA-local YYYY-MM-DD bucket for a stored UTC timestamp. */
+function dayBucket(ts: string): string {
+  return new Date(ts).toLocaleDateString("en-CA", { timeZone: DASHBOARD_TZ });
+}
+
+function table(columns: string[], results: unknown[][]): MetricTable {
+  return {
+    columns,
+    results,
+    types: columns.map(() => "String"),
+    hasMore: false,
+    limit: 100,
+    offset: 0,
+  };
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export class SqliteProvider implements MetricsProvider {
+  constructor(
+    private readonly store: LocalEventStore,
+    private readonly clock: Clock = SystemClock(),
+  ) {}
+
+  async query(q: MetricQuery): Promise<MetricTable> {
+    const win = resolveQueryRange(q.range, this.clock);
+    switch (q.kind) {
+      case "summary":
+        return this.summary(win);
+      case "summaryCycleTime":
+        return this.summaryCycleTime(win);
+      case "trends":
+        return this.trends(win);
+      case "featuresTasks":
+        return this.featuresTasks(win);
+      case "featuresCi":
+        return this.featuresCi(win);
+      case "featuresReviews":
+        return this.featuresReviews(win);
+      case "queueFunnel":
+        return this.queueFunnel(win);
+      case "queueCycleStarted":
+        return this.cycleRows(win, TASK_COMPLETED_EVENTS, "started");
+      case "queueCycleMerged":
+        return this.cycleRows(win, TASK_COMPLETED_EVENTS, "merged");
+      case "tokensTotals":
+        return this.tokensTotals(win);
+      case "tokensBySessionType":
+        return this.tokensGrouped(win, "session_type");
+      case "tokensByAgent":
+        return this.tokensGrouped(win, "agent_id");
+      case "tokensTrends":
+        return this.tokensTrends(win);
+    }
+  }
+
+  // ─ Read helpers ─
+
+  private events(name: string, win: { from: string; to: string }) {
+    return this.store.queryByEvent(name, win);
+  }
+
+  private eventsAny(names: string[], win: { from: string; to: string }) {
+    return names.flatMap((n) => this.events(n, win));
+  }
+
+  // ─ Summary ─
+
+  private summary(win: { from: string; to: string }): MetricTable {
+    const completed = this.eventsAny(TASK_COMPLETED_EVENTS, win);
+    const blocked = this.events("shipwright_task_blocked", win);
+    const ci = this.events("shipwright_ci_result", win);
+    const simplify = this.events("shipwright_simplify_complete", win);
+    const reviews = this.eventsAny(TASK_REVIEWED_EVENTS, win);
+
+    const actualHours = completed.map((e) => {
+      const a = num(e.properties.actual_h);
+      return a ?? cycleHours(e);
+    });
+
+    const ciFirst = ci.filter(
+      (e) => String(e.properties.passed_first_try) === "true",
+    ).length;
+
+    const complexityCount = (n: number) =>
+      completed.filter((e) => num(e.properties.complexity) === n).length;
+
+    const cascadeDepths = completed
+      .filter((e) => e.properties.fix_cascade_depth != null)
+      .map((e) => num(e.properties.fix_cascade_depth));
+
+    const columns = [
+      "tasks_completed",
+      "tasks_blocked",
+      "avg_actual_hours",
+      "avg_estimated_hours",
+      "avg_retries",
+      "avg_files_changed",
+      "ci_gates_total",
+      "ci_first_pass",
+      "avg_fix_attempts",
+      "simplify_total",
+      "simplify_total_fixes",
+      "simplify_avg_dry",
+      "simplify_avg_dead_code",
+      "simplify_avg_naming",
+      "simplify_avg_complexity",
+      "simplify_avg_consistency",
+      "reviews_total",
+      "reviews_ship_it",
+      "complexity_1",
+      "complexity_2",
+      "complexity_3",
+      "complexity_4",
+      "complexity_5",
+      "avg_fix_cascade_depth",
+    ];
+
+    const row = [
+      completed.length,
+      blocked.length,
+      avg(actualHours),
+      avg(completed.map((e) => num(e.properties.estimated_h))),
+      avg(completed.map((e) => num(e.properties.retries))),
+      avg(completed.map((e) => num(e.properties.files_changed))),
+      ci.length,
+      ciFirst,
+      avg(ci.map((e) => num(e.properties.fix_attempts))),
+      simplify.length,
+      sum(simplify.map((e) => num(e.properties.total_fixes))),
+      avg(simplify.map((e) => num(e.properties.dry))),
+      avg(simplify.map((e) => num(e.properties.dead_code))),
+      avg(simplify.map((e) => num(e.properties.naming))),
+      avg(simplify.map((e) => num(e.properties.complexity_fixes))),
+      avg(simplify.map((e) => num(e.properties.consistency))),
+      reviews.length,
+      reviews.filter((e) => e.properties.verdict === "SHIP IT").length,
+      complexityCount(1),
+      complexityCount(2),
+      complexityCount(3),
+      complexityCount(4),
+      complexityCount(5),
+      avg(cascadeDepths),
+    ];
+
+    return table(columns, [row]);
+  }
+
+  // ─ Summary cycle time ─
+
+  private summaryCycleTime(win: { from: string; to: string }): MetricTable {
+    const completed = this.eventsAny(TASK_COMPLETED_EVENTS, win);
+    const positive = completed
+      .map(cycleHours)
+      .filter((h): h is number => h !== null && h > 0);
+    const avgHours = positive.length
+      ? positive.reduce((a, b) => a + b, 0) / positive.length
+      : null;
+    return table(["avg_cycle_time_hours"], [[avgHours]]);
+  }
+
+  // ─ Trends ─
+
+  private trends(win: { from: string; to: string }): MetricTable {
+    const completed = this.eventsAny(TASK_COMPLETED_EVENTS, win);
+    const blocked = this.events("shipwright_task_blocked", win);
+    const ci = this.events("shipwright_ci_result", win);
+    const simplify = this.events("shipwright_simplify_complete", win);
+    const reviews = this.eventsAny(TASK_REVIEWED_EVENTS, win);
+    const started = this.events("shipwright_task_started", win);
+
+    const periods = new Set<string>();
+    const bucketOf = (e: StoredEvent) => dayBucket(e.timestamp);
+    for (const e of [
+      ...completed,
+      ...blocked,
+      ...ci,
+      ...simplify,
+      ...reviews,
+      ...started,
+    ]) {
+      periods.add(bucketOf(e));
+    }
+
+    const columns = [
+      "period",
+      "tasks_completed",
+      "ci_gates",
+      "ci_first_pass",
+      "ci_first_pass_count",
+      "simplify_passes",
+      "simplify_fixes",
+      "tasks_blocked",
+      "reviews",
+      "tasks_started",
+      "reviews_ship_it",
+      "avg_actual_hours",
+      "avg_estimated_hours",
+      "avg_retries",
+      "avg_files_changed",
+      "avg_fix_attempts",
+      "avg_cycle_time_hours",
+      "estimation_accuracy",
+      "simplify_avg_dry",
+      "simplify_avg_dead_code",
+      "simplify_avg_naming",
+      "simplify_avg_complexity",
+      "simplify_avg_consistency",
+      "avg_review_findings",
+    ];
+
+    const inP = <T extends StoredEvent>(arr: T[], p: string) =>
+      arr.filter((e) => bucketOf(e) === p);
+
+    const rows = [...periods]
+      .sort()
+      .map((p) => {
+        const c = inP(completed, p);
+        const cCi = inP(ci, p);
+        const cSimplify = inP(simplify, p);
+        const cReviews = inP(reviews, p);
+
+        const positiveCycle = c
+          .map(cycleHours)
+          .filter((h): h is number => h !== null && h > 0);
+        const avgCycle = positiveCycle.length
+          ? positiveCycle.reduce((a, b) => a + b, 0) / positiveCycle.length
+          : null;
+
+        const estAcc = c
+          .map((e) => {
+            const est = num(e.properties.estimated_h);
+            const act = num(e.properties.actual_h);
+            if (est === null || act === null || est <= 0) return null;
+            return act / est;
+          })
+          .filter((v): v is number => v !== null);
+
+        return [
+          p,
+          c.length,
+          cCi.length,
+          cCi.filter((e) => String(e.properties.passed_first_try) === "true")
+            .length,
+          cCi.filter((e) => String(e.properties.first_pass) === "true").length,
+          cSimplify.length,
+          sum(cSimplify.map((e) => num(e.properties.total_fixes))),
+          inP(blocked, p).length,
+          cReviews.length,
+          inP(started, p).length,
+          cReviews.filter((e) => e.properties.verdict === "SHIP IT").length,
+          avg(
+            c.map((e) => num(e.properties.actual_h) ?? cycleHours(e)),
+          ),
+          avg(c.map((e) => num(e.properties.estimated_h))),
+          avg(c.map((e) => num(e.properties.retries))),
+          avg(c.map((e) => num(e.properties.files_changed))),
+          avg(cCi.map((e) => num(e.properties.fix_attempts))),
+          avgCycle,
+          estAcc.length
+            ? estAcc.reduce((a, b) => a + b, 0) / estAcc.length
+            : null,
+          avg(cSimplify.map((e) => num(e.properties.dry))),
+          avg(cSimplify.map((e) => num(e.properties.dead_code))),
+          avg(cSimplify.map((e) => num(e.properties.naming))),
+          avg(cSimplify.map((e) => num(e.properties.complexity_fixes))),
+          avg(cSimplify.map((e) => num(e.properties.consistency))),
+          avg(cReviews.map((e) => num(e.properties.findings))),
+        ];
+      });
+
+    return table(columns, rows);
+  }
+
+  // ─ Features ─
+
+  private groupByPrefix(events: StoredEvent[]): Map<string, StoredEvent[]> {
+    const map = new Map<string, StoredEvent[]>();
+    for (const e of events) {
+      const p = featurePrefix(e);
+      if (!p) continue;
+      const arr = map.get(p) ?? [];
+      arr.push(e);
+      map.set(p, arr);
+    }
+    return map;
+  }
+
+  private featuresTasks(win: { from: string; to: string }): MetricTable {
+    const completed = this.eventsAny(TASK_COMPLETED_EVENTS, win);
+    const groups = this.groupByPrefix(completed);
+    const columns = [
+      "feature_prefix",
+      "tasks_completed",
+      "avg_actual_h",
+      "avg_estimated_h",
+    ];
+    const rows = [...groups.entries()]
+      .map(([prefix, group]) => [
+        prefix,
+        group.length,
+        avg(group.map((e) => num(e.properties.actual_h))),
+        avg(group.map((e) => num(e.properties.estimated_h))),
+      ])
+      .sort((a, b) => Number(b[1]) - Number(a[1]));
+    return table(columns, rows);
+  }
+
+  private featuresCi(win: { from: string; to: string }): MetricTable {
+    const ci = this.events("shipwright_ci_result", win);
+    const groups = this.groupByPrefix(ci);
+    const columns = ["feature_prefix", "ci_total", "ci_first_pass"];
+    const rows = [...groups.entries()].map(([prefix, group]) => [
+      prefix,
+      group.length,
+      group.filter((e) => String(e.properties.passed_first_try) === "true")
+        .length,
+    ]);
+    return table(columns, rows);
+  }
+
+  private featuresReviews(win: { from: string; to: string }): MetricTable {
+    const reviews = this.eventsAny(TASK_REVIEWED_EVENTS, win);
+    const groups = this.groupByPrefix(reviews);
+    const columns = ["feature_prefix", "reviews_total", "reviews_ship_it"];
+    const rows = [...groups.entries()].map(([prefix, group]) => [
+      prefix,
+      group.length,
+      group.filter((e) => e.properties.verdict === "SHIP IT").length,
+    ]);
+    return table(columns, rows);
+  }
+
+  // ─ Queue ─
+
+  private queueFunnel(win: { from: string; to: string }): MetricTable {
+    const started = this.events("shipwright_task_started", win);
+    const approved = this.eventsAny(TASK_REVIEWED_EVENTS, win);
+    const merged = this.eventsAny(TASK_COMPLETED_EVENTS, win);
+    const blocked = this.events("shipwright_task_blocked", win);
+
+    const columns = [
+      "tasks_started",
+      "tasks_approved",
+      "tasks_merged",
+      "tasks_blocked",
+      "avg_review_findings",
+    ];
+    const row = [
+      started.length,
+      approved.length,
+      merged.length,
+      blocked.length,
+      avg(approved.map((e) => num(e.properties.findings))),
+    ];
+    return table(columns, [row]);
+  }
+
+  private cycleRows(
+    win: { from: string; to: string },
+    events: string[],
+    which: "started" | "merged",
+  ): MetricTable {
+    const source =
+      which === "started"
+        ? this.events("shipwright_task_started", win)
+        : this.eventsAny(events, win);
+    const columns = ["task_id", "timestamp"];
+    const rows = source
+      .map((e) => [taskKey(e), e.timestamp])
+      .filter((r) => r[0] !== null);
+    return table(columns, rows);
+  }
+
+  // ─ Tokens ─
+
+  private tokenSumRow(events: StoredEvent[]): {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheCreation: number;
+    total: number;
+  } {
+    const input = sum(events.map((e) => num(e.properties.input_tokens)));
+    const output = sum(events.map((e) => num(e.properties.output_tokens)));
+    const cacheRead = sum(
+      events.map((e) => num(e.properties.cache_read_input_tokens)),
+    );
+    const cacheCreation = sum(
+      events.map((e) => num(e.properties.cache_creation_input_tokens)),
+    );
+    return {
+      input,
+      output,
+      cacheRead,
+      cacheCreation,
+      total: input + output + cacheRead + cacheCreation,
+    };
+  }
+
+  private tokenColumns(groupCol?: string): string[] {
+    const base = [
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "total_tokens",
+    ];
+    return groupCol ? [groupCol, ...base] : base;
+  }
+
+  private tokensTotals(win: { from: string; to: string }): MetricTable {
+    const events = this.events("agent_token_usage", win);
+    const t = this.tokenSumRow(events);
+    return table(this.tokenColumns(), [
+      [t.input, t.output, t.cacheRead, t.cacheCreation, t.total],
+    ]);
+  }
+
+  private tokensGrouped(
+    win: { from: string; to: string },
+    prop: "session_type" | "agent_id",
+  ): MetricTable {
+    const events = this.events("agent_token_usage", win);
+    const groups = new Map<string, StoredEvent[]>();
+    for (const e of events) {
+      const key = e.properties[prop];
+      const k = typeof key === "string" ? key : String(key ?? "");
+      const arr = groups.get(k) ?? [];
+      arr.push(e);
+      groups.set(k, arr);
+    }
+    const rows = [...groups.entries()]
+      .map(([key, group]) => {
+        const t = this.tokenSumRow(group);
+        return [key, t.input, t.output, t.cacheRead, t.cacheCreation, t.total];
+      })
+      .sort((a, b) => Number(b[5]) - Number(a[5]));
+    return table(this.tokenColumns(prop), rows);
+  }
+
+  private tokensTrends(win: { from: string; to: string }): MetricTable {
+    const events = this.events("agent_token_usage", win);
+    const groups = new Map<string, StoredEvent[]>();
+    for (const e of events) {
+      const p = dayBucket(e.timestamp);
+      const arr = groups.get(p) ?? [];
+      arr.push(e);
+      groups.set(p, arr);
+    }
+    const rows = [...groups.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([period, group]) => {
+        const t = this.tokenSumRow(group);
+        return [
+          period,
+          t.input,
+          t.output,
+          t.cacheRead,
+          t.cacheCreation,
+          t.total,
+        ];
+      });
+    return table(this.tokenColumns("period"), rows);
+  }
+}

--- a/metrics/src/providers/sqlite-provider.unit.test.ts
+++ b/metrics/src/providers/sqlite-provider.unit.test.ts
@@ -1,0 +1,316 @@
+/**
+ * metrics/src/providers/sqlite-provider.unit.test.ts
+ * Unit tests for SqliteProvider: seed PostHog-shaped events into an in-memory
+ * store, then assert every MetricQuery kind returns a correctly-shaped
+ * MetricTable with the aggregated values the api.ts handlers expect, and that
+ * date-range filtering is honored.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type LocalEventStore, createLocalEventStore } from "../local-store.ts";
+import type { MetricQuery } from "../metrics-provider.ts";
+import { SqliteProvider } from "./sqlite-provider.ts";
+
+let store: LocalEventStore;
+let provider: SqliteProvider;
+
+/** Custom range covering all seeded events (all within June 2026, LA). */
+const RANGE = { from: "2026-06-01", to: "2026-06-07" } as const;
+
+/** Map column array + a single row into an object for ergonomic assertions. */
+function row0(table: { columns: string[]; results: unknown[][] }) {
+  const r = table.results[0] ?? [];
+  return Object.fromEntries(table.columns.map((c, i) => [c, r[i]]));
+}
+
+function rows(table: { columns: string[]; results: unknown[][] }) {
+  return table.results.map((raw) =>
+    Object.fromEntries(table.columns.map((c, i) => [c, (raw as unknown[])[i]])),
+  );
+}
+
+function seed(
+  event: string,
+  timestamp: string,
+  properties: Record<string, unknown>,
+  insertId?: string,
+) {
+  store.insertEvent({
+    event,
+    timestamp,
+    properties,
+    insertId: insertId ?? `${event}-${timestamp}-${Math.random()}`,
+  });
+}
+
+beforeEach(() => {
+  store = createLocalEventStore({ path: ":memory:" });
+  provider = new SqliteProvider(store);
+
+  // ─ Completion events (2 completed) ─
+  seed("shipwright_task_complete", "2026-06-02T12:00:00.000Z", {
+    task: "QS-1.1",
+    actual_h: 4,
+    estimated_h: 5,
+    retries: 1,
+    files_changed: 6,
+    complexity: 3,
+    fix_cascade_depth: 2,
+    started_at: "2026-06-02T08:00:00.000Z",
+    ts: "2026-06-02T12:00:00.000Z",
+  });
+  seed("shipwright_task_complete", "2026-06-03T12:00:00.000Z", {
+    task: "QS-1.2",
+    actual_h: 6,
+    estimated_h: 5,
+    retries: 3,
+    files_changed: 10,
+    complexity: 5,
+    fix_cascade_depth: 4,
+    started_at: "2026-06-03T06:00:00.000Z",
+    ts: "2026-06-03T12:00:00.000Z",
+  });
+
+  // ─ Blocked (1) ─
+  seed("shipwright_task_blocked", "2026-06-02T15:00:00.000Z", {
+    task_id: "QS-1.3",
+  });
+
+  // ─ CI results (2 total, 1 first-pass) ─
+  seed("shipwright_ci_result", "2026-06-02T10:00:00.000Z", {
+    task_id: "QS-1.1",
+    passed_first_try: true,
+    fix_attempts: 0,
+    first_pass: true,
+  });
+  seed("shipwright_ci_result", "2026-06-03T10:00:00.000Z", {
+    task_id: "QS-1.2",
+    passed_first_try: false,
+    fix_attempts: 2,
+    first_pass: false,
+  });
+
+  // ─ Simplify (1) ─
+  seed("shipwright_simplify_complete", "2026-06-02T11:00:00.000Z", {
+    task_id: "QS-1.1",
+    total_fixes: 5,
+    dry: 2,
+    dead_code: 1,
+    naming: 1,
+    complexity_fixes: 0.5,
+    consistency: 0.5,
+  });
+
+  // ─ Reviews (2 total, 1 SHIP IT) ─
+  seed("shipwright_task_reviewed", "2026-06-02T13:00:00.000Z", {
+    task_id: "QS-1.1",
+    verdict: "SHIP IT",
+    findings: 1,
+  });
+  seed("shipwright_task_reviewed", "2026-06-03T13:00:00.000Z", {
+    task_id: "QS-1.2",
+    verdict: "REVISE",
+    findings: 3,
+  });
+
+  // ─ Started (2) — used by queue cycle + trends ─
+  seed("shipwright_task_started", "2026-06-02T08:00:00.000Z", {
+    task_id: "QS-1.1",
+  });
+  seed("shipwright_task_started", "2026-06-03T06:00:00.000Z", {
+    task_id: "QS-1.2",
+  });
+
+  // ─ Token usage (2 events) ─
+  seed("agent_token_usage", "2026-06-02T09:00:00.000Z", {
+    input_tokens: 1000,
+    output_tokens: 500,
+    cache_read_input_tokens: 200,
+    cache_creation_input_tokens: 100,
+    session_type: "cron",
+    agent_id: "agent-a",
+  });
+  seed("agent_token_usage", "2026-06-03T09:00:00.000Z", {
+    input_tokens: 2000,
+    output_tokens: 800,
+    cache_read_input_tokens: 400,
+    cache_creation_input_tokens: 150,
+    session_type: "slack_dm",
+    agent_id: "agent-b",
+  });
+});
+
+afterEach(() => {
+  store.close();
+});
+
+async function q(query: MetricQuery) {
+  return provider.query(query);
+}
+
+describe("SqliteProvider.summary", () => {
+  test("aggregates completion / ci / simplify / review metrics", async () => {
+    const table = await q({ kind: "summary", range: RANGE });
+    const r = row0(table);
+
+    expect(r.tasks_completed).toBe(2);
+    expect(r.tasks_blocked).toBe(1);
+    expect(Number(r.avg_actual_hours)).toBeCloseTo(5, 5); // (4+6)/2
+    expect(Number(r.avg_estimated_hours)).toBeCloseTo(5, 5);
+    expect(Number(r.avg_retries)).toBeCloseTo(2, 5); // (1+3)/2
+    expect(Number(r.avg_files_changed)).toBeCloseTo(8, 5);
+    expect(r.ci_gates_total).toBe(2);
+    expect(r.ci_first_pass).toBe(1);
+    expect(Number(r.avg_fix_attempts)).toBeCloseTo(1, 5); // (0+2)/2
+    expect(r.simplify_total).toBe(1);
+    expect(Number(r.simplify_total_fixes)).toBeCloseTo(5, 5);
+    expect(Number(r.simplify_avg_dry)).toBeCloseTo(2, 5);
+    expect(r.reviews_total).toBe(2);
+    expect(r.reviews_ship_it).toBe(1);
+    expect(r.complexity_3).toBe(1);
+    expect(r.complexity_5).toBe(1);
+    expect(r.complexity_1).toBe(0);
+    expect(Number(r.avg_fix_cascade_depth)).toBeCloseTo(3, 5); // (2+4)/2
+  });
+
+  test("date range outside seeded events yields zero counts", async () => {
+    const table = await q({
+      kind: "summary",
+      range: { from: "2025-01-01", to: "2025-01-02" },
+    });
+    const r = row0(table);
+    expect(r.tasks_completed).toBe(0);
+    expect(r.ci_gates_total).toBe(0);
+  });
+});
+
+describe("SqliteProvider.summaryCycleTime", () => {
+  test("avg cycle hours from started_at→ts", async () => {
+    const table = await q({ kind: "summaryCycleTime", range: RANGE });
+    const r = row0(table);
+    // QS-1.1: 4h, QS-1.2: 6h → avg 5
+    expect(Number(r.avg_cycle_time_hours)).toBeCloseTo(5, 5);
+  });
+});
+
+describe("SqliteProvider.trends", () => {
+  test("groups by day with per-period columns", async () => {
+    const table = await q({ kind: "trends", range: RANGE, groupBy: "day" });
+    const all = rows(table);
+    expect(all.length).toBeGreaterThanOrEqual(2);
+    expect(table.columns).toContain("period");
+    expect(table.columns).toContain("tasks_completed");
+
+    const totalCompleted = all.reduce(
+      (acc, x) => acc + Number(x.tasks_completed ?? 0),
+      0,
+    );
+    expect(totalCompleted).toBe(2);
+    const totalStarted = all.reduce(
+      (acc, x) => acc + Number(x.tasks_started ?? 0),
+      0,
+    );
+    expect(totalStarted).toBe(2);
+  });
+});
+
+describe("SqliteProvider.features", () => {
+  test("featuresTasks groups by prefix", async () => {
+    const table = await q({ kind: "featuresTasks", range: RANGE });
+    const all = rows(table);
+    const qs = all.find((x) => x.feature_prefix === "QS");
+    expect(qs).toBeDefined();
+    expect(qs?.tasks_completed).toBe(2);
+    expect(Number(qs?.avg_actual_h)).toBeCloseTo(5, 5);
+  });
+
+  test("featuresCi groups by prefix", async () => {
+    const table = await q({ kind: "featuresCi", range: RANGE });
+    const qs = rows(table).find((x) => x.feature_prefix === "QS");
+    expect(qs?.ci_total).toBe(2);
+    expect(qs?.ci_first_pass).toBe(1);
+  });
+
+  test("featuresReviews groups by prefix", async () => {
+    const table = await q({ kind: "featuresReviews", range: RANGE });
+    const qs = rows(table).find((x) => x.feature_prefix === "QS");
+    expect(qs?.reviews_total).toBe(2);
+    expect(qs?.reviews_ship_it).toBe(1);
+  });
+});
+
+describe("SqliteProvider.queue", () => {
+  test("queueFunnel counts", async () => {
+    const table = await q({ kind: "queueFunnel", range: RANGE });
+    const r = row0(table);
+    expect(r.tasks_started).toBe(2);
+    expect(r.tasks_approved).toBe(2); // reviewed events
+    expect(r.tasks_merged).toBe(2); // completed events
+    expect(r.tasks_blocked).toBe(1);
+    expect(Number(r.avg_review_findings)).toBeCloseTo(2, 5); // (1+3)/2
+  });
+
+  test("queueCycleStarted returns task_id + timestamp rows", async () => {
+    const table = await q({ kind: "queueCycleStarted", range: RANGE });
+    const all = rows(table);
+    expect(all).toHaveLength(2);
+    expect(table.columns).toEqual(["task_id", "timestamp"]);
+    const ids = all.map((x) => x.task_id).sort();
+    expect(ids).toEqual(["QS-1.1", "QS-1.2"]);
+  });
+
+  test("queueCycleMerged returns task_id + timestamp rows", async () => {
+    const table = await q({ kind: "queueCycleMerged", range: RANGE });
+    const all = rows(table);
+    expect(all).toHaveLength(2);
+    const ids = all.map((x) => x.task_id).sort();
+    expect(ids).toEqual(["QS-1.1", "QS-1.2"]);
+  });
+});
+
+describe("SqliteProvider.tokens", () => {
+  test("tokensTotals sums all token fields", async () => {
+    const table = await q({ kind: "tokensTotals", range: RANGE });
+    const r = row0(table);
+    expect(Number(r.input_tokens)).toBe(3000);
+    expect(Number(r.output_tokens)).toBe(1300);
+    expect(Number(r.cache_read_input_tokens)).toBe(600);
+    expect(Number(r.cache_creation_input_tokens)).toBe(250);
+    expect(Number(r.total_tokens)).toBe(3000 + 1300 + 600 + 250);
+  });
+
+  test("tokensBySessionType groups by session_type", async () => {
+    const table = await q({ kind: "tokensBySessionType", range: RANGE });
+    const all = rows(table);
+    const cron = all.find((x) => x.session_type === "cron");
+    expect(Number(cron?.input_tokens)).toBe(1000);
+    const dm = all.find((x) => x.session_type === "slack_dm");
+    expect(Number(dm?.input_tokens)).toBe(2000);
+  });
+
+  test("tokensByAgent groups by agent_id", async () => {
+    const table = await q({ kind: "tokensByAgent", range: RANGE });
+    const all = rows(table);
+    const a = all.find((x) => x.agent_id === "agent-a");
+    expect(Number(a?.total_tokens)).toBe(1000 + 500 + 200 + 100);
+  });
+
+  test("tokensTrends groups by day", async () => {
+    const table = await q({ kind: "tokensTrends", range: RANGE });
+    const all = rows(table);
+    expect(all.length).toBeGreaterThanOrEqual(2);
+    expect(table.columns).toContain("period");
+    const total = all.reduce((acc, x) => acc + Number(x.input_tokens ?? 0), 0);
+    expect(total).toBe(3000);
+  });
+
+  test("tokens honor date-range filtering", async () => {
+    const table = await q({
+      kind: "tokensTotals",
+      range: { from: "2026-06-03", to: "2026-06-03" },
+    });
+    const r = row0(table);
+    // Only the 2026-06-03 event (input 2000) falls in range.
+    expect(Number(r.input_tokens)).toBe(2000);
+  });
+});

--- a/metrics/src/select-provider.ts
+++ b/metrics/src/select-provider.ts
@@ -1,0 +1,39 @@
+/**
+ * metrics/src/select-provider.ts
+ * Pure mode selector mapping the process environment to a provider mode.
+ * Kept side-effect-free so server.ts wiring is fully unit-testable.
+ */
+
+/** The three read-backend modes the server can run in. */
+export type ProviderMode = "fixtures" | "posthog" | "sqlite";
+
+/**
+ * Minimal env shape the selector reads (subset of process.env). The index
+ * signature keeps `process.env` (ProcessEnv) assignable while documenting the
+ * keys actually consumed.
+ */
+export interface ProviderEnv {
+  METRICS_OFFLINE?: string;
+  POSTHOG_PERSONAL_API_KEY?: string;
+  POSTHOG_PROJECT_ID?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Select the provider mode from env, in priority order:
+ *   1. METRICS_OFFLINE === "true"            → fixtures
+ *   2. both PostHog read keys non-empty      → posthog
+ *   3. otherwise                             → sqlite (default-local)
+ */
+export function selectProviderMode(env: ProviderEnv): ProviderMode {
+  if (env.METRICS_OFFLINE === "true") return "fixtures";
+
+  const hasPostHog =
+    typeof env.POSTHOG_PERSONAL_API_KEY === "string" &&
+    env.POSTHOG_PERSONAL_API_KEY.length > 0 &&
+    typeof env.POSTHOG_PROJECT_ID === "string" &&
+    env.POSTHOG_PROJECT_ID.length > 0;
+  if (hasPostHog) return "posthog";
+
+  return "sqlite";
+}

--- a/metrics/src/select-provider.unit.test.ts
+++ b/metrics/src/select-provider.unit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * metrics/src/select-provider.unit.test.ts
+ * Unit tests for the pure mode selector that maps env → provider mode.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { selectProviderMode } from "./select-provider.ts";
+
+describe("selectProviderMode", () => {
+  test("METRICS_OFFLINE=true → fixtures (highest priority)", () => {
+    expect(
+      selectProviderMode({
+        METRICS_OFFLINE: "true",
+        POSTHOG_PERSONAL_API_KEY: "phk",
+        POSTHOG_PROJECT_ID: "123",
+      }),
+    ).toBe("fixtures");
+  });
+
+  test("PostHog read-keys present → posthog", () => {
+    expect(
+      selectProviderMode({
+        POSTHOG_PERSONAL_API_KEY: "phk",
+        POSTHOG_PROJECT_ID: "123",
+      }),
+    ).toBe("posthog");
+  });
+
+  test("no env → sqlite (default)", () => {
+    expect(selectProviderMode({})).toBe("sqlite");
+  });
+
+  test("only one PostHog key present → sqlite (both required)", () => {
+    expect(selectProviderMode({ POSTHOG_PERSONAL_API_KEY: "phk" })).toBe(
+      "sqlite",
+    );
+    expect(selectProviderMode({ POSTHOG_PROJECT_ID: "123" })).toBe("sqlite");
+  });
+
+  test("empty-string PostHog keys are treated as absent → sqlite", () => {
+    expect(
+      selectProviderMode({
+        POSTHOG_PERSONAL_API_KEY: "",
+        POSTHOG_PROJECT_ID: "",
+      }),
+    ).toBe("sqlite");
+  });
+
+  test("METRICS_OFFLINE other than 'true' is ignored", () => {
+    expect(selectProviderMode({ METRICS_OFFLINE: "1" })).toBe("sqlite");
+    expect(selectProviderMode({ METRICS_OFFLINE: "false" })).toBe("sqlite");
+  });
+});

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -7,26 +7,27 @@
  *   /dashboard   — Server-rendered dashboard UI
  *   /health      — Health check (no auth required)
  *
- * Offline mode (METRICS_OFFLINE=true):
- *   - Skips the POSTHOG_* required-env gate
- *   - Injects a fixture PostHog client via deps.postHogClient
- *   - Bypasses session auth for /dashboard (serves as "Offline User")
- *   - Safe to run with no secrets or external services configured
+ * Backend mode (pure selector — see select-provider.ts):
+ *   METRICS_OFFLINE=true                  → fixtures (PostHogProvider over
+ *                                            fixture client; auth bypassed)
+ *   POSTHOG read-keys present             → posthog (live PostHogProvider)
+ *   otherwise (DEFAULT)                   → sqlite  (SqliteProvider over the
+ *                                            local store; POST /batch/ ingest)
  */
 
 import { HttpAccountsClient } from "./lib/accounts-client.ts";
 import { parseApiKeys } from "./lib/api-auth.ts";
-import { loadEnv, validateRequiredEnv } from "./lib/env.ts";
+import { loadEnv } from "./lib/env.ts";
 import { createMetricsApp } from "./api.ts";
 import type { MetricsDeps } from "./api.ts";
+import { createLocalEventStore } from "./local-store.ts";
+import { SqliteProvider } from "./providers/sqlite-provider.ts";
+import { selectProviderMode } from "./select-provider.ts";
 
 loadEnv();
 
-const offlineMode = process.env.METRICS_OFFLINE === "true";
-
-if (!offlineMode) {
-  validateRequiredEnv(["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"]);
-}
+const mode = selectProviderMode(process.env);
+const offlineMode = mode === "fixtures";
 
 const port = Number(process.env.METRICS_API_PORT ?? 3460);
 const accountsClient = new HttpAccountsClient(
@@ -36,7 +37,7 @@ const accountsClient = new HttpAccountsClient(
 
 let deps: MetricsDeps;
 
-if (offlineMode) {
+if (mode === "fixtures") {
   const { createFixturePostHogClient } = await import(
     "./fixtures/posthog-fixtures.ts"
   );
@@ -47,6 +48,20 @@ if (offlineMode) {
     offlineMode: true,
   };
   console.log("[metrics-api] Running in OFFLINE mode — fixture data injected");
+} else if (mode === "sqlite") {
+  const store = createLocalEventStore({
+    path: process.env.METRICS_DB_PATH ?? "state/metrics.db",
+  });
+  deps = {
+    provider: new SqliteProvider(store),
+    localStore: store,
+    sessionSecret: process.env.SESSION_SECRET ?? "",
+    requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
+    dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
+  };
+  console.log(
+    "[metrics-api] Running in LOCAL mode — SQLite provider + /batch/ ingest",
+  );
 } else {
   deps = {
     sessionSecret: process.env.SESSION_SECRET ?? "",


### PR DESCRIPTION
## Summary
- Introduces a backend-agnostic **`MetricsProvider`** seam (`metrics/src/metrics-provider.ts`): a typed `MetricQuery` discriminated union (13 read kinds) + `MetricTable` (alias of `HogQLResult`). Handlers express query *intent* as data — **no HogQL string crosses the handler↔provider boundary**.
- **`PostHogProvider`** — maps each `MetricQuery` to the existing HogQL builders; the only place HogQL lives on the read path. **`SqliteProvider`** — aggregates the LDS-1.1 `events` store into the same `MetricTable` shape, so the dashboard renders identically off local data.
- **`createMetricsApp` auto-wraps** the legacy `postHogClient` + `buildXQueryFn` injection into a `PostHogProvider` when no explicit `provider` is passed — so all existing tests pass **unchanged**.
- **`selectProviderMode()`** (pure, unit-tested): `METRICS_OFFLINE` → fixtures · PostHog read-keys → live · else → **SQLite (new default)**. SQLite mode also wires the store into `POST /batch/` ingest.
- Supersedes the cancelled LDS-1.2 (no `detectQueryType` HogQL parsing). Prometheus remains out of scope (numeric time-series ≠ event-level analytics).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Provider seam; handlers depend only on it, no HogQL crosses boundary | MET |
| 2 | PostHog reproduces behavior exactly; existing tests pass unchanged | MET |
| 3 | SqliteProvider correct shape for 13 kinds; range filtering; real local data | MET |
| 4 | server.ts mode selection — pure, unit-tested selector | MET |
| 5 | Tests at correct layers; no mock.module/global.*; Clock injected | MET |
| 6 | No detectQueryType; no existing tests retired | MET |

## Test Plan
- New: `metrics-provider.integration.test.ts` (seed via `POST /batch/`, query `/metrics/*` through SqliteProvider), `providers/sqlite-provider.unit.test.ts` (13 kinds + range filtering), `providers/posthog-provider.unit.test.ts` (kind→builder routing), `select-provider.unit.test.ts` (all env branches).
- Full metrics suite: **613 pass / 0 fail**; existing test files unedited (AC#2).
- Coverage: posthog-provider 100%, sqlite-provider 100% lines, select-provider 100%.
- [x] typecheck, lint, check-strings clean

Generated with [Claude Code](https://claude.com/claude-code)
