### PR TITLE
test(agent): relabel setup unit→integration (ATP-2.2)

### DIFF
--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for agent/src/setup.ts
+ * Integration tests for agent/src/setup.ts
  *
  * Tests use injected execFn — no real claude/mise binaries needed.
  * All file I/O runs against a real temp dir (no mocks needed for fs).


### PR DESCRIPTION
## Summary
- Renames `agent/src/setup.unit.test.ts` → `setup.integration.test.ts` to correct the layer label
- Updates the file header comment from "Unit tests" to "Integration tests"
- No test content changes — all 44 existing tests are preserved as-is

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Old file setup.unit.test.ts deleted; setup.integration.test.ts exists with identical test content | MET |
| 2 | File header comment updated to reflect integration layer | MET |
| 3 | Test layer: integration (correct — tests write/read real files in tmp dirs throughout) | MET |
| 4 | All existing tests pass; bun test passes | MET |
| 5 | No test-env.ts import needed | MET |

## Test Plan
- [x] 44/44 tests pass in setup.integration.test.ts
- [x] bunx biome lint clean on changed file
- [x] Pure rename — no production code changed

Generated with [Claude Code](https://claude.com/claude-code)
