### PR TITLE
feat(agent): add dev-only gated POST /chat endpoint + doctor guard (LDS-2.2)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -103,6 +103,7 @@ tasks:
       - task: secret-scan
 
   doctor:
-    desc: Validate task-store config and report active backend
+    desc: Validate task-store config and report active backend; check dev-chat production guard
     cmds:
       - bun plugins/shipwright/scripts/task_store.ts doctor
+      - bun agent/src/check-dev-chat-guard.ts

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,3 +106,4 @@ tasks:
     desc: Validate task-store config and report active backend
     cmds:
       - bun plugins/shipwright/scripts/task_store.ts doctor
+      - bun agent/src/check-dev-chat-guard.ts

--- a/agent/src/chat.smoke.test.ts
+++ b/agent/src/chat.smoke.test.ts
@@ -1,0 +1,171 @@
+/**
+ * agent/src/chat.smoke.test.ts
+ * Smoke tests for the /chat endpoint via app.request().
+ *
+ * Uses an injected fake runner — no real Claude, no mock.module(), no global.*
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createChatApp } from "./chat.ts";
+
+// ─── Fake runner ──────────────────────────────────────────────────────────────
+
+const fakeRunner = async (message: string, _sessionKey?: string) => ({
+  result: `echo: ${message}`,
+  sessionId: "claude-session-123",
+});
+
+// ─── devChat: true ────────────────────────────────────────────────────────────
+
+describe("chat endpoint — devChat: true", () => {
+  it("POST /chat with message returns { result, sessionId }", async () => {
+    const app = createChatApp({ runner: fakeRunner });
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result).toBe("echo: hello");
+    expect(typeof body.sessionId).toBe("string");
+    expect(body.sessionId.length).toBeGreaterThan(0);
+  });
+
+  it("POST /chat without session generates a new sessionId each call", async () => {
+    const app = createChatApp({ runner: fakeRunner });
+
+    const res1 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "first" }),
+    });
+    const body1 = await res1.json();
+
+    const res2 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "second" }),
+    });
+    const body2 = await res2.json();
+
+    // Without a session passed in, each call gets a fresh session key
+    expect(body1.sessionId).not.toBe(body2.sessionId);
+  });
+
+  it("POST /chat with session preserves sessionId (continuity)", async () => {
+    const app = createChatApp({ runner: fakeRunner });
+
+    // First call: no session → get a sessionId back
+    const res1 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "first" }),
+    });
+    const body1 = await res1.json();
+    const sessionId = body1.sessionId;
+    expect(typeof sessionId).toBe("string");
+
+    // Second call: pass the sessionId back → same sessionId returned
+    const res2 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "second", session: sessionId }),
+    });
+    const body2 = await res2.json();
+    expect(body2.sessionId).toBe(sessionId);
+    expect(body2.result).toBe("echo: second");
+  });
+
+  it("POST /chat passes sessionKey to runner for continuation", async () => {
+    const calls: Array<{ message: string; sessionKey?: string }> = [];
+    const trackingRunner = async (message: string, sessionKey?: string) => {
+      calls.push({ message, sessionKey });
+      return { result: `echo: ${message}`, sessionId: "claude-session-abc" };
+    };
+
+    const app = createChatApp({ runner: trackingRunner });
+
+    // First call: no session
+    const res1 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "msg1" }),
+    });
+    const body1 = await res1.json();
+    const chatSessionId = body1.sessionId;
+
+    // Second call: pass session back
+    await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "msg2", session: chatSessionId }),
+    });
+
+    // First call: sessionKey is the generated UUID (same as chatSessionId)
+    expect(calls[0].sessionKey).toBe(chatSessionId);
+    // Second call: sessionKey is the same chat session UUID
+    expect(calls[1].sessionKey).toBe(chatSessionId);
+  });
+
+  it("POST /chat returns 400 when message is missing", async () => {
+    const app = createChatApp({ runner: fakeRunner });
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session: "some-session" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /chat returns 400 when body is not JSON", async () => {
+    const app = createChatApp({ runner: fakeRunner });
+    const res = await app.request("/chat", {
+      method: "POST",
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── devChat: false (route absent) ───────────────────────────────────────────
+//
+// When devChat is false, the chat app is NOT mounted. We verify this by
+// constructing a plain Hono app without the chat route — which mirrors exactly
+// what createComposedApp does when devChat !== true.
+
+describe("chat endpoint — devChat: false (route not registered)", () => {
+  it("POST /chat returns 404 when chat app is not mounted", async () => {
+    // Simulate a root app that does NOT have the chat route registered
+    const { Hono } = await import("hono");
+    const root = new Hono();
+    // Intentionally do NOT mount createChatApp
+    root.get("/health", (c) => c.json({ status: "ok" }));
+
+    const res = await root.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /chat returns 200 when chat app IS mounted (devChat: true)", async () => {
+    // Simulate createComposedApp with devChat: true by mounting chatApp at root
+    const { Hono } = await import("hono");
+    const root = new Hono();
+    const chatApp = createChatApp({ runner: fakeRunner });
+    root.route("/", chatApp);
+    root.get("/health", (c) => c.json({ status: "ok" }));
+
+    const res = await root.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result).toBe("echo: hello");
+    expect(typeof body.sessionId).toBe("string");
+  });
+});

--- a/agent/src/chat.smoke.test.ts
+++ b/agent/src/chat.smoke.test.ts
@@ -1,9 +1,5 @@
 /**
- * agent/src/chat.smoke.test.ts
- *
- * Smoke tests for the POST /chat endpoint.
- * Uses Hono's in-process app.request() — no real socket, no real Claude.
- * Runner is injected as a fake — no mock.module(), no global.* overrides.
+ * agent/src/chat.smoke.test.ts — POST /chat, in-process app.request(), fake runner.
  */
 
 import { describe, expect, it } from "bun:test";

--- a/agent/src/chat.smoke.test.ts
+++ b/agent/src/chat.smoke.test.ts
@@ -1,0 +1,243 @@
+/**
+ * agent/src/chat.smoke.test.ts
+ *
+ * Smoke tests for the POST /chat endpoint.
+ * Uses Hono's in-process app.request() — no real socket, no real Claude.
+ * Runner is injected as a fake — no mock.module(), no global.* overrides.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createChatApp } from "./chat.ts";
+import { createComposedApp } from "./run-agent.ts";
+import type { ComposedAppDeps } from "./run-agent.ts";
+
+// ─── Fake runner ──────────────────────────────────────────────────────────────
+
+type FakeRunner = (
+  message: string,
+  sessionKey: string,
+) => Promise<{ result: string; sessionId?: string }>;
+
+function makeFakeRunner(): {
+  runner: FakeRunner;
+  calls: Array<{ message: string; sessionKey: string }>;
+} {
+  const calls: Array<{ message: string; sessionKey: string }> = [];
+  const runner: FakeRunner = async (message, sessionKey) => {
+    calls.push({ message, sessionKey });
+    return { result: `reply:${message}`, sessionId: sessionKey };
+  };
+  return { runner, calls };
+}
+
+// ─── Minimal ComposedAppDeps double ───────────────────────────────────────────
+
+function makeMockDeps(
+  overrides: Partial<ComposedAppDeps> = {},
+): ComposedAppDeps {
+  const base: ComposedAppDeps = {
+    prisma: {
+      agent: {
+        findUnique: async () => null,
+        findMany: async () => [],
+        create: async () => {
+          throw new Error("not implemented");
+        },
+      },
+      agentPlugin: {
+        findMany: async () => [],
+      },
+    } as never,
+    agentEnvService: {
+      getConfigBundle: async () => null,
+      getByAgentId: async () => ({}),
+      upsert: async () => {},
+      patch: async () => {},
+      deleteKey: async () => {},
+    },
+    agentCronJobService: {
+      list: async () => [],
+      create: async () => {
+        throw new Error("not implemented");
+      },
+      update: async () => {
+        throw new Error("not implemented");
+      },
+      delete: async () => {},
+      reconcileSystemCrons: async () => ({ created: 0, updated: 0, deleted: 0 }),
+      get: async () => {
+        throw new Error("not implemented");
+      },
+      setEnabled: async () => {
+        throw new Error("not implemented");
+      },
+    },
+    agentToolService: {
+      list: async () => [],
+      add: async () => {
+        throw new Error("not implemented");
+      },
+      remove: async () => {},
+      toggle: async () => {
+        throw new Error("not implemented");
+      },
+    },
+    agentTokenService: {
+      create: async () => {
+        throw new Error("not implemented");
+      },
+      listForAgent: async () => [],
+      revoke: async () => null,
+    },
+    agentPluginService: {
+      list: async () => [],
+      add: async () => {
+        throw new Error("not implemented");
+      },
+      remove: async () => {},
+      removeByName: async () => {},
+    },
+    internalApiKey: "test-key",
+    sessionSecret: "test-session-secret-32-bytes!!!",
+    adminPassword: "test-password",
+    slackClient: {
+      createAppManifest: async () => ({
+        appId: "A123",
+        oauthRedirectUrl: "https://slack.com/oauth",
+      }),
+    },
+    appBaseUrl: "http://localhost:3000",
+  };
+  return { ...base, ...overrides };
+}
+
+// ─── createChatApp standalone tests ──────────────────────────────────────────
+
+describe("createChatApp — POST /chat", () => {
+  it("returns {result, sessionId} from the injected runner", async () => {
+    const { runner } = makeFakeRunner();
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: string; sessionId: string };
+    expect(body.result).toBe("reply:hello");
+    expect(typeof body.sessionId).toBe("string");
+    expect(body.sessionId.length).toBeGreaterThan(0);
+  });
+
+  it("passes the provided session back as sessionKey on the next call (continuity)", async () => {
+    const { runner, calls } = makeFakeRunner();
+    const app = createChatApp({ runner });
+
+    // First call — no session provided
+    const res1 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "first" }),
+    });
+    expect(res1.status).toBe(200);
+    const body1 = (await res1.json()) as { result: string; sessionId: string };
+    const sessionId = body1.sessionId;
+    expect(typeof sessionId).toBe("string");
+
+    // Second call — pass back the returned sessionId
+    const res2 = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "second", session: sessionId }),
+    });
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as { result: string; sessionId: string };
+
+    // The second call must use the same sessionKey as the first
+    expect(calls[1].sessionKey).toBe(calls[0].sessionKey);
+    // The sessionId returned should be stable
+    expect(body2.sessionId).toBe(sessionId);
+  });
+
+  it("generates a new sessionKey when no session is provided", async () => {
+    const { runner, calls } = makeFakeRunner();
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hi" }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0].sessionKey).toBeTruthy();
+  });
+
+  it("returns 400 when message is missing", async () => {
+    const { runner } = makeFakeRunner();
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── devChat flag via createComposedApp ───────────────────────────────────────
+
+describe("createComposedApp — devChat:true mounts /chat", () => {
+  it("POST /chat returns {result, sessionId} with devChat:true", async () => {
+    const { runner } = makeFakeRunner();
+    const app = createComposedApp({
+      ...makeMockDeps(),
+      devChat: true,
+      runner,
+    });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello from composed app" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: string; sessionId: string };
+    expect(body.result).toBe("reply:hello from composed app");
+    expect(typeof body.sessionId).toBe("string");
+  });
+});
+
+describe("createComposedApp — devChat:false (default) does NOT mount /chat", () => {
+  it("POST /chat returns 404 when devChat is false", async () => {
+    const { runner } = makeFakeRunner();
+    const app = createComposedApp({
+      ...makeMockDeps(),
+      devChat: false,
+      runner,
+    });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "should be gone" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /chat returns 404 when devChat is not set (default-deny)", async () => {
+    const app = createComposedApp(makeMockDeps());
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "should be gone" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/agent/src/chat.ts
+++ b/agent/src/chat.ts
@@ -15,8 +15,8 @@
  *   - Response body: { result: string, sessionId: string }
  *   - `session` in the request is the chat-level session key (a UUID).
  *     If absent, a fresh UUID is generated.
- *   - The in-memory Map<sessionKey, claudeSessionId> stores the Claude internal
- *     session ID for continuation — never exposed in the response.
+ *   - Claude session resumption is handled by the injected runner's sessions
+ *     store (passed to createRunClaude in run-agent.ts startServer).
  *   - The `sessionId` in the response is always the chat-level session key
  *     (the UUID), which the caller passes back on the next request.
  */
@@ -62,14 +62,11 @@ export function checkDevChatGuard(
 /**
  * Create the dev chat Hono sub-app.
  *
- * In-memory Map tracks chat sessionKey → Claude internal sessionId.
- * This Map lives for the lifetime of the app instance.
+ * Claude session resumption is handled by the runner's injected sessions store.
+ * The chat-level sessionKey (UUID) is the handle exposed to callers.
  */
 export function createChatApp(deps: ChatAppDeps): Hono {
   const { runner } = deps;
-
-  // chat sessionKey (UUID) → Claude internal session ID
-  const claudeSessions = new Map<string, string>();
 
   const app = new Hono();
 
@@ -95,13 +92,7 @@ export function createChatApp(deps: ChatAppDeps): Hono {
     const sessionKey =
       typeof session === "string" && session.length > 0 ? session : randomUUID();
 
-    // Call runner with the chat-level session key
     const output = await runner(message, sessionKey);
-
-    // Store the Claude internal session ID for future continuation
-    if (output.sessionId) {
-      claudeSessions.set(sessionKey, output.sessionId);
-    }
 
     // Return result + chat-level session key (NOT the Claude internal session ID)
     return c.json({ result: output.result, sessionId: sessionKey });

--- a/agent/src/chat.ts
+++ b/agent/src/chat.ts
@@ -1,0 +1,106 @@
+/**
+ * agent/src/chat.ts
+ *
+ * Dev-only local chat transport.
+ *
+ * Exports:
+ *   ChatRunner            — the runner type (matches the createRunClaude seam)
+ *   createChatApp         — Hono sub-app with POST /chat
+ *   checkDevChatProductionGuard — doctor/CI predicate
+ *
+ * Mount point: root /chat (mounted via run-agent.ts when devChat:true).
+ * Session continuity: client passes back the sessionId returned on the first
+ * call as the `session` field on subsequent calls. The value is used directly
+ * as the sessionKey passed to the runner, which manages Claude session IDs
+ * internally via its injected session store.
+ */
+
+import { Hono } from "hono";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export type ChatRunner = (
+  message: string,
+  sessionKey: string,
+) => Promise<{ result: string; sessionId?: string }>;
+
+interface ChatAppDeps {
+  runner: ChatRunner;
+}
+
+// ─── App factory ────────────────────────────────────────────────────────────
+
+/**
+ * Creates a Hono app with a single POST /chat route.
+ *
+ * Request body:  { message: string; session?: string }
+ * Response body: { result: string; sessionId: string }
+ *
+ * The `session` field in the request is the token the client received from a
+ * prior call. On the first call, omit it — a new UUID is generated. Pass the
+ * returned `sessionId` back as `session` on subsequent calls to continue the
+ * same Claude session.
+ */
+export function createChatApp({ runner }: ChatAppDeps): Hono {
+  const app = new Hono();
+
+  app.post("/chat", async (c) => {
+    let body: { message?: unknown; session?: unknown };
+    try {
+      body = (await c.req.json()) as { message?: unknown; session?: unknown };
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const message = body.message;
+    if (typeof message !== "string" || message.length === 0) {
+      return c.json({ error: "message is required" }, 400);
+    }
+
+    // If client supplied a session token, reuse it as the sessionKey.
+    // Otherwise, generate a new UUID — this becomes the continuity handle.
+    const sessionKey =
+      typeof body.session === "string" && body.session.length > 0
+        ? body.session
+        : crypto.randomUUID();
+
+    const output = await runner(message, sessionKey);
+
+    return c.json({
+      result: output.result,
+      sessionId: sessionKey,
+    });
+  });
+
+  return app;
+}
+
+// ─── Doctor guard ────────────────────────────────────────────────────────────
+
+/**
+ * Validate that SHIPWRIGHT_DEV_CHAT is not enabled in a production config.
+ *
+ * "Production" is detected by NODE_ENV==="production" OR
+ * SHIPWRIGHT_ENV==="production".
+ *
+ * Returns { ok: true } when safe, { ok: false, reason: string } otherwise.
+ */
+export function checkDevChatProductionGuard(
+  env: Record<string, string | undefined>,
+): { ok: boolean; reason?: string } {
+  const devChatEnabled = env.SHIPWRIGHT_DEV_CHAT === "true";
+  const isProduction =
+    env.NODE_ENV === "production" || env.SHIPWRIGHT_ENV === "production";
+
+  if (devChatEnabled && isProduction) {
+    return {
+      ok: false,
+      reason:
+        "SHIPWRIGHT_DEV_CHAT=true is set in a production config. " +
+        "The /chat endpoint is dev-only and must not be enabled in production. " +
+        "Unset SHIPWRIGHT_DEV_CHAT or set it to 'false'.",
+    };
+  }
+
+  return { ok: true };
+}

--- a/agent/src/chat.ts
+++ b/agent/src/chat.ts
@@ -1,0 +1,111 @@
+/**
+ * agent/src/chat.ts
+ *
+ * Dev-only local chat transport.
+ *
+ * Exports:
+ *   createChatApp({ runner }) — Hono app with POST /chat
+ *   checkDevChatGuard(env)    — doctor guard: fails if SHIPWRIGHT_DEV_CHAT is set
+ *
+ * The /chat endpoint is only mounted when devChat: true is passed to
+ * createComposedApp in run-agent.ts. Default is off (gated).
+ *
+ * Session model:
+ *   - Request body: { message: string, session?: string }
+ *   - Response body: { result: string, sessionId: string }
+ *   - `session` in the request is the chat-level session key (a UUID).
+ *     If absent, a fresh UUID is generated.
+ *   - The in-memory Map<sessionKey, claudeSessionId> stores the Claude internal
+ *     session ID for continuation — never exposed in the response.
+ *   - The `sessionId` in the response is always the chat-level session key
+ *     (the UUID), which the caller passes back on the next request.
+ */
+
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type Runner = (
+  message: string,
+  sessionKey?: string,
+) => Promise<{ result: string; sessionId?: string; usage?: unknown }>;
+
+export interface ChatAppDeps {
+  runner: Runner;
+}
+
+// ─── Guard ────────────────────────────────────────────────────────────────────
+
+/**
+ * Doctor guard — fails if SHIPWRIGHT_DEV_CHAT is set in the environment.
+ *
+ * This is a production config guard: the dev chat endpoint must never be
+ * accidentally enabled in a production deployment. Any non-empty value for
+ * SHIPWRIGHT_DEV_CHAT is treated as a failure.
+ */
+export function checkDevChatGuard(
+  env: Record<string, string | undefined>,
+): { ok: boolean; reason?: string } {
+  const val = env.SHIPWRIGHT_DEV_CHAT;
+  if (val !== undefined && val !== "") {
+    return {
+      ok: false,
+      reason: `SHIPWRIGHT_DEV_CHAT is set to "${val}" — dev chat endpoint must not be enabled in production. Unset SHIPWRIGHT_DEV_CHAT before deploying.`,
+    };
+  }
+  return { ok: true };
+}
+
+// ─── Chat app factory ─────────────────────────────────────────────────────────
+
+/**
+ * Create the dev chat Hono sub-app.
+ *
+ * In-memory Map tracks chat sessionKey → Claude internal sessionId.
+ * This Map lives for the lifetime of the app instance.
+ */
+export function createChatApp(deps: ChatAppDeps): Hono {
+  const { runner } = deps;
+
+  // chat sessionKey (UUID) → Claude internal session ID
+  const claudeSessions = new Map<string, string>();
+
+  const app = new Hono();
+
+  app.post("/chat", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+
+    if (
+      typeof body !== "object" ||
+      body === null ||
+      typeof (body as Record<string, unknown>).message !== "string"
+    ) {
+      return c.json({ error: "missing required field: message" }, 400);
+    }
+
+    const { message, session } = body as { message: string; session?: string };
+
+    // Use provided session key or generate a fresh one
+    const sessionKey =
+      typeof session === "string" && session.length > 0 ? session : randomUUID();
+
+    // Call runner with the chat-level session key
+    const output = await runner(message, sessionKey);
+
+    // Store the Claude internal session ID for future continuation
+    if (output.sessionId) {
+      claudeSessions.set(sessionKey, output.sessionId);
+    }
+
+    // Return result + chat-level session key (NOT the Claude internal session ID)
+    return c.json({ result: output.result, sessionId: sessionKey });
+  });
+
+  return app;
+}

--- a/agent/src/chat.ts
+++ b/agent/src/chat.ts
@@ -1,19 +1,4 @@
-/**
- * agent/src/chat.ts
- *
- * Dev-only local chat transport.
- *
- * Exports:
- *   ChatRunner            — the runner type (matches the createRunClaude seam)
- *   createChatApp         — Hono sub-app with POST /chat
- *   checkDevChatProductionGuard — doctor/CI predicate
- *
- * Mount point: root /chat (mounted via run-agent.ts when devChat:true).
- * Session continuity: client passes back the sessionId returned on the first
- * call as the `session` field on subsequent calls. The value is used directly
- * as the sessionKey passed to the runner, which manages Claude session IDs
- * internally via its injected session store.
- */
+/** Dev-only POST /chat transport, gated by devChat:true in ComposedAppDeps. */
 
 import { Hono } from "hono";
 
@@ -30,17 +15,6 @@ interface ChatAppDeps {
 
 // ─── App factory ────────────────────────────────────────────────────────────
 
-/**
- * Creates a Hono app with a single POST /chat route.
- *
- * Request body:  { message: string; session?: string }
- * Response body: { result: string; sessionId: string }
- *
- * The `session` field in the request is the token the client received from a
- * prior call. On the first call, omit it — a new UUID is generated. Pass the
- * returned `sessionId` back as `session` on subsequent calls to continue the
- * same Claude session.
- */
 export function createChatApp({ runner }: ChatAppDeps): Hono {
   const app = new Hono();
 
@@ -77,14 +51,6 @@ export function createChatApp({ runner }: ChatAppDeps): Hono {
 
 // ─── Doctor guard ────────────────────────────────────────────────────────────
 
-/**
- * Validate that SHIPWRIGHT_DEV_CHAT is not enabled in a production config.
- *
- * "Production" is detected by NODE_ENV==="production" OR
- * SHIPWRIGHT_ENV==="production".
- *
- * Returns { ok: true } when safe, { ok: false, reason: string } otherwise.
- */
 export function checkDevChatProductionGuard(
   env: Record<string, string | undefined>,
 ): { ok: boolean; reason?: string } {

--- a/agent/src/chat.unit.test.ts
+++ b/agent/src/chat.unit.test.ts
@@ -1,9 +1,4 @@
-/**
- * agent/src/chat.unit.test.ts
- *
- * Unit tests for the doctor guard predicate checkDevChatProductionGuard.
- * Pure logic — no I/O, no env side effects.
- */
+/** agent/src/chat.unit.test.ts — checkDevChatProductionGuard predicate. */
 
 import { describe, expect, it } from "bun:test";
 import { checkDevChatProductionGuard } from "./chat.ts";

--- a/agent/src/chat.unit.test.ts
+++ b/agent/src/chat.unit.test.ts
@@ -1,0 +1,66 @@
+/**
+ * agent/src/chat.unit.test.ts
+ *
+ * Unit tests for the doctor guard predicate checkDevChatProductionGuard.
+ * Pure logic — no I/O, no env side effects.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { checkDevChatProductionGuard } from "./chat.ts";
+
+describe("checkDevChatProductionGuard", () => {
+  it("fails when SHIPWRIGHT_DEV_CHAT=true in NODE_ENV=production", () => {
+    const result = checkDevChatProductionGuard({
+      SHIPWRIGHT_DEV_CHAT: "true",
+      NODE_ENV: "production",
+    });
+    expect(result.ok).toBe(false);
+    expect(typeof result.reason).toBe("string");
+    expect(result.reason?.length).toBeGreaterThan(0);
+  });
+
+  it("fails when SHIPWRIGHT_DEV_CHAT=true in SHIPWRIGHT_ENV=production", () => {
+    const result = checkDevChatProductionGuard({
+      SHIPWRIGHT_DEV_CHAT: "true",
+      SHIPWRIGHT_ENV: "production",
+    });
+    expect(result.ok).toBe(false);
+    expect(typeof result.reason).toBe("string");
+  });
+
+  it("passes when SHIPWRIGHT_DEV_CHAT=true in NODE_ENV=development", () => {
+    const result = checkDevChatProductionGuard({
+      SHIPWRIGHT_DEV_CHAT: "true",
+      NODE_ENV: "development",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("passes when SHIPWRIGHT_DEV_CHAT is unset in NODE_ENV=production", () => {
+    const result = checkDevChatProductionGuard({
+      NODE_ENV: "production",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("passes when SHIPWRIGHT_DEV_CHAT=false in NODE_ENV=production", () => {
+    const result = checkDevChatProductionGuard({
+      SHIPWRIGHT_DEV_CHAT: "false",
+      NODE_ENV: "production",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("passes when neither env var is set", () => {
+    const result = checkDevChatProductionGuard({});
+    expect(result.ok).toBe(true);
+  });
+
+  it("passes when SHIPWRIGHT_DEV_CHAT=true but no production env indicator", () => {
+    const result = checkDevChatProductionGuard({
+      SHIPWRIGHT_DEV_CHAT: "true",
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/agent/src/chat.unit.test.ts
+++ b/agent/src/chat.unit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * agent/src/chat.unit.test.ts
+ * Unit tests for the checkDevChatGuard predicate.
+ *
+ * Tests purely against the guard function — no Hono, no runner, no network.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { checkDevChatGuard } from "./chat.ts";
+
+describe("checkDevChatGuard", () => {
+  it("passes when SHIPWRIGHT_DEV_CHAT is not set", () => {
+    const result = checkDevChatGuard({});
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("passes when SHIPWRIGHT_DEV_CHAT is empty string", () => {
+    const result = checkDevChatGuard({ SHIPWRIGHT_DEV_CHAT: "" });
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("fails when SHIPWRIGHT_DEV_CHAT is 'true'", () => {
+    const result = checkDevChatGuard({ SHIPWRIGHT_DEV_CHAT: "true" });
+    expect(result.ok).toBe(false);
+    expect(typeof result.reason).toBe("string");
+    expect((result.reason ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("fails when SHIPWRIGHT_DEV_CHAT is any non-empty value", () => {
+    const result = checkDevChatGuard({ SHIPWRIGHT_DEV_CHAT: "1" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it("fails when SHIPWRIGHT_DEV_CHAT is 'false' (any non-empty value is truthy)", () => {
+    // Even the string "false" is a non-empty value — the guard treats any set value as a problem
+    const result = checkDevChatGuard({ SHIPWRIGHT_DEV_CHAT: "false" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it("reason message mentions SHIPWRIGHT_DEV_CHAT", () => {
+    const result = checkDevChatGuard({ SHIPWRIGHT_DEV_CHAT: "true" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("SHIPWRIGHT_DEV_CHAT");
+  });
+});

--- a/agent/src/check-dev-chat-guard.ts
+++ b/agent/src/check-dev-chat-guard.ts
@@ -1,13 +1,5 @@
 #!/usr/bin/env bun
-/**
- * agent/src/check-dev-chat-guard.ts
- *
- * CLI guard: fails with a non-zero exit code if SHIPWRIGHT_DEV_CHAT is set
- * in a production config. Run as part of `task doctor`.
- *
- * Usage:
- *   bun agent/src/check-dev-chat-guard.ts
- */
+/** CI guard: exits 1 if SHIPWRIGHT_DEV_CHAT is set in a production config. Run via `task doctor`. */
 
 import { checkDevChatProductionGuard } from "./chat.ts";
 

--- a/agent/src/check-dev-chat-guard.ts
+++ b/agent/src/check-dev-chat-guard.ts
@@ -1,0 +1,23 @@
+/**
+ * agent/src/check-dev-chat-guard.ts
+ *
+ * Doctor guard script for SHIPWRIGHT_DEV_CHAT.
+ * Fails with exit 1 if SHIPWRIGHT_DEV_CHAT is set in the environment.
+ *
+ * Run as part of `task doctor` to enforce that the dev chat endpoint is
+ * never accidentally enabled in a production deployment.
+ *
+ * Usage: bun agent/src/check-dev-chat-guard.ts
+ */
+
+import { checkDevChatGuard } from "./chat.ts";
+
+if (import.meta.main) {
+  const result = checkDevChatGuard(process.env as Record<string, string | undefined>);
+  if (!result.ok) {
+    console.error(`[error] ${result.reason}`);
+    process.exit(1);
+  }
+  console.log("[ok] SHIPWRIGHT_DEV_CHAT: not set");
+  process.exit(0);
+}

--- a/agent/src/check-dev-chat-guard.ts
+++ b/agent/src/check-dev-chat-guard.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+/**
+ * agent/src/check-dev-chat-guard.ts
+ *
+ * CLI guard: fails with a non-zero exit code if SHIPWRIGHT_DEV_CHAT is set
+ * in a production config. Run as part of `task doctor`.
+ *
+ * Usage:
+ *   bun agent/src/check-dev-chat-guard.ts
+ */
+
+import { checkDevChatProductionGuard } from "./chat.ts";
+
+const result = checkDevChatProductionGuard(
+  process.env as Record<string, string | undefined>,
+);
+
+if (!result.ok) {
+  process.stderr.write(`[dev-chat-guard] FAIL: ${result.reason}\n`);
+  process.exit(1);
+}
+
+console.log("[dev-chat-guard] ok");

--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -30,8 +30,12 @@ import {
   HttpSlackProvisioningClient,
 } from "@shipwright/admin";
 import type { AdminUIDeps } from "@shipwright/admin";
+import { createChatApp, checkDevChatProductionGuard } from "./chat.ts";
+import type { ChatRunner } from "./chat.ts";
+import { createRunClaude } from "./claude.ts";
 import { createConfig } from "./config.ts";
 import { createHealthApp } from "./health.ts";
+import { createFileSessionStore } from "./sessions.ts";
 import { ensureAgentHome } from "./setup.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -119,6 +123,19 @@ export interface ComposedAppDeps {
   adminPassword: string;
   slackClient: AdminUIDeps["slackClient"];
   appBaseUrl: string;
+  /**
+   * When true, mounts the dev-only POST /chat endpoint.
+   * Default: false (default-deny).
+   * Only set this from SHIPWRIGHT_DEV_CHAT==="true" at startup — never read
+   * the env var inline inside a request handler.
+   */
+  devChat?: boolean;
+  /**
+   * Runner injected when devChat is true. Required for /chat to function.
+   * In production startServer(), this is wired to createRunClaude().
+   * In tests, inject a fake runner.
+   */
+  runner?: ChatRunner;
 }
 
 // ─── App factory ──────────────────────────────────────────────────────────────
@@ -150,6 +167,8 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
     adminPassword,
     slackClient,
     appBaseUrl,
+    devChat = false,
+    runner,
   } = deps;
 
   const root = new Hono();
@@ -157,6 +176,14 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
   // 1. Health check — no auth, mounted at root
   const healthApp = createHealthApp();
   root.route("/", healthApp);
+
+  // 1a. Dev-only chat endpoint — only mounted when devChat is true (default-deny).
+  //     Read from SHIPWRIGHT_DEV_CHAT==="true" once at startup and passed in via
+  //     deps.devChat. Never read the env var inline in a request handler.
+  if (devChat && runner) {
+    const chatApp = createChatApp({ runner });
+    root.route("/", chatApp);
+  }
 
   // 2. Runtime API — Bearer SHIPWRIGHT_INTERNAL_API_KEY
   //
@@ -300,7 +327,29 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
   const adminPassword = process.env.SHIPWRIGHT_ADMIN_PASSWORD ?? "";
   const appBaseUrl = process.env.APP_BASE_URL ?? `http://localhost:${port}`;
 
+  // Dev chat — read once at startup, never inside a request handler
+  const devChat = process.env.SHIPWRIGHT_DEV_CHAT === "true";
+
+  // Doctor guard: warn if dev chat is enabled in production config
+  const guardResult = checkDevChatProductionGuard(process.env as Record<string, string | undefined>);
+  if (!guardResult.ok) {
+    console.warn(`[run-agent] WARNING: ${guardResult.reason}`);
+  }
+
   const slackClient = new HttpSlackProvisioningClient();
+
+  // Wire up a real runner for the /chat endpoint when devChat is enabled
+  let chatRunner: ChatRunner | undefined;
+  if (devChat) {
+    const chatSessionFile = join(agentHome, "chat-sessions.json");
+    const chatSessions = createFileSessionStore(chatSessionFile);
+    chatRunner = createRunClaude(
+      Bun.spawn,
+      chatSessions,
+      undefined,
+      config.paths.workspace,
+    );
+  }
 
   const app = createComposedApp({
     prisma,
@@ -314,6 +363,8 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
     adminPassword,
     slackClient,
     appBaseUrl,
+    devChat,
+    runner: chatRunner,
   });
 
   Bun.serve({ fetch: app.fetch, port });

--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -123,18 +123,9 @@ export interface ComposedAppDeps {
   adminPassword: string;
   slackClient: AdminUIDeps["slackClient"];
   appBaseUrl: string;
-  /**
-   * When true, mounts the dev-only POST /chat endpoint.
-   * Default: false (default-deny).
-   * Only set this from SHIPWRIGHT_DEV_CHAT==="true" at startup — never read
-   * the env var inline inside a request handler.
-   */
+  /** Mounts POST /chat when true; read once from SHIPWRIGHT_DEV_CHAT==="true" at startup. */
   devChat?: boolean;
-  /**
-   * Runner injected when devChat is true. Required for /chat to function.
-   * In production startServer(), this is wired to createRunClaude().
-   * In tests, inject a fake runner.
-   */
+  /** Required when devChat:true; injected as a fake in tests. */
   runner?: ChatRunner;
 }
 
@@ -177,9 +168,7 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
   const healthApp = createHealthApp();
   root.route("/", healthApp);
 
-  // 1a. Dev-only chat endpoint — only mounted when devChat is true (default-deny).
-  //     Read from SHIPWRIGHT_DEV_CHAT==="true" once at startup and passed in via
-  //     deps.devChat. Never read the env var inline in a request handler.
+  // 1a. Dev-only /chat — gated by devChat (default-deny).
   if (devChat && runner) {
     const chatApp = createChatApp({ runner });
     root.route("/", chatApp);

--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -328,11 +328,16 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
 
   const slackClient = new HttpSlackProvisioningClient();
 
-  // Build the runner for the dev chat endpoint (only wired when devChat is true)
+  // Build the runner for the dev chat endpoint (only wired when devChat is true).
+  // Pass an in-memory sessions store so Claude sessions are resumed across calls.
   let chatRunner: Runner | undefined;
   if (devChat) {
     const { createRunClaude } = await import("./claude.ts");
-    chatRunner = createRunClaude();
+    const chatSessionMap = new Map<string, string>();
+    chatRunner = createRunClaude(undefined, {
+      get: (key) => chatSessionMap.get(key),
+      set: (key, id) => { chatSessionMap.set(key, id); },
+    });
   }
 
   const app = createComposedApp({

--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -30,6 +30,8 @@ import {
   HttpSlackProvisioningClient,
 } from "@shipwright/admin";
 import type { AdminUIDeps } from "@shipwright/admin";
+import { createChatApp } from "./chat.ts";
+import type { Runner } from "./chat.ts";
 import { createConfig } from "./config.ts";
 import { createHealthApp } from "./health.ts";
 import { ensureAgentHome } from "./setup.ts";
@@ -119,6 +121,17 @@ export interface ComposedAppDeps {
   adminPassword: string;
   slackClient: AdminUIDeps["slackClient"];
   appBaseUrl: string;
+  /**
+   * Enable the dev-only POST /chat endpoint.
+   * Read once from SHIPWRIGHT_DEV_CHAT === "true" in startServer().
+   * Default: false (route not registered).
+   */
+  devChat?: boolean;
+  /**
+   * Runner injected when devChat is true.
+   * Required if devChat is true; ignored otherwise.
+   */
+  runner?: Runner;
 }
 
 // ─── App factory ──────────────────────────────────────────────────────────────
@@ -150,9 +163,18 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
     adminPassword,
     slackClient,
     appBaseUrl,
+    devChat,
+    runner,
   } = deps;
 
   const root = new Hono();
+
+  // 0. Dev chat endpoint — only when devChat is explicitly enabled.
+  //    Mounted first so POST /chat is not shadowed by any catch-all routes.
+  if (devChat === true && runner !== undefined) {
+    const chatApp = createChatApp({ runner });
+    root.route("/", chatApp);
+  }
 
   // 1. Health check — no auth, mounted at root
   const healthApp = createHealthApp();
@@ -300,7 +322,18 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
   const adminPassword = process.env.SHIPWRIGHT_ADMIN_PASSWORD ?? "";
   const appBaseUrl = process.env.APP_BASE_URL ?? `http://localhost:${port}`;
 
+  // Dev chat endpoint — gated by SHIPWRIGHT_DEV_CHAT. Read once here; never
+  // read inline in route handlers (composition option, not runtime env read).
+  const devChat = process.env.SHIPWRIGHT_DEV_CHAT === "true";
+
   const slackClient = new HttpSlackProvisioningClient();
+
+  // Build the runner for the dev chat endpoint (only wired when devChat is true)
+  let chatRunner: Runner | undefined;
+  if (devChat) {
+    const { createRunClaude } = await import("./claude.ts");
+    chatRunner = createRunClaude();
+  }
 
   const app = createComposedApp({
     prisma,
@@ -314,6 +347,8 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
     adminPassword,
     slackClient,
     appBaseUrl,
+    devChat,
+    runner: chatRunner,
   });
 
   Bun.serve({ fetch: app.fetch, port });

--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -34,7 +34,6 @@ import { createChatApp } from "./chat.ts";
 import type { Runner } from "./chat.ts";
 import { createConfig } from "./config.ts";
 import { createHealthApp } from "./health.ts";
-import { createFileSessionStore } from "./sessions.ts";
 import { ensureAgentHome } from "./setup.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -180,12 +179,6 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
   // 1. Health check — no auth, mounted at root
   const healthApp = createHealthApp();
   root.route("/", healthApp);
-
-  // 1a. Dev-only /chat — gated by devChat (default-deny).
-  if (devChat && runner) {
-    const chatApp = createChatApp({ runner });
-    root.route("/", chatApp);
-  }
 
   // 2. Runtime API — Bearer SHIPWRIGHT_INTERNAL_API_KEY
   //

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -73,6 +73,7 @@ All child models cascade-delete with their `Agent`.
 | `GH_APP_PRIVATE_KEY` | GitHub App auth | PEM private key for the GitHub App (newlines may be `\n`-escaped). Required when using the App auth path. |
 | `GH_APP_INSTALLATION_ID` | GitHub App auth | Installation ID for the target org/repo. Required when using the App auth path. |
 | `GH_TOKEN` | GitHub PAT auth | Personal Access Token for the legacy `gh auth setup-git` path. Used only if the App env vars are absent. |
+| `SHIPWRIGHT_DEV_CHAT` | dev only | Set to `"true"` to enable the `POST /chat` endpoint. Must **never** be set in production — `task doctor` enforces this via `check-dev-chat-guard.ts`. |
 
 ## Key Files
 
@@ -90,7 +91,9 @@ All child models cascade-delete with their `Agent`.
 | `agent/src/entrypoint-main.ts` | Production CLI entry point — wires real deps and calls `runEntrypoint()`. Invoked by the Dockerfile `ENTRYPOINT`. |
 | `agent/src/entrypoint.ts` | Container startup sequence (`runEntrypoint()`) — dependency-injected for testability. Validates vars, fetches config, applies env, symlinks `~/.claude`, runs GitHub auth + mise + plugin install, then spawns the server. |
 | `agent/src/cli-args.ts` | CLI argument parsing (`parseCliArgs()`) — `--agent-id`, `--api-url`, `--api-key` flags with env var fallbacks. Pure, no I/O. |
-| `agent/src/run-agent.ts` | Composes all sub-apps into a single Hono root app (`createComposedApp(deps: ComposedAppDeps)`). Exports `PrismaLike` and `ComposedAppDeps` for test injection. `startServer()` wires real deps and calls `createComposedApp`; invoked by `entrypoint.ts` after all environment setup is complete. |
+| `agent/src/run-agent.ts` | Composes all sub-apps into a single Hono root app (`createComposedApp(deps: ComposedAppDeps)`). Exports `PrismaLike` and `ComposedAppDeps` for test injection. `ComposedAppDeps` accepts optional `devChat` (boolean) and `runner` fields to mount the dev chat endpoint. `startServer()` wires real deps and calls `createComposedApp`; invoked by `entrypoint.ts` after all environment setup is complete. |
+| `agent/src/chat.ts` | Dev-only chat transport. `createChatApp({ runner })` — Hono sub-app with `POST /chat`. Exports `Runner` and `ChatAppDeps` types. `checkDevChatGuard(env)` — production guard that fails if `SHIPWRIGHT_DEV_CHAT` is set. |
+| `agent/src/check-dev-chat-guard.ts` | Doctor script: runs `checkDevChatGuard` against `process.env` and exits 1 if `SHIPWRIGHT_DEV_CHAT` is set. Invoked by `task doctor`. |
 | `agent/src/shipwright-config-client.ts` | `ShipwrightConfigClient` interface + `HttpShipwrightConfigClient` (real HTTP) + `RecordedShipwrightConfigClient` (cassette double for tests). |
 | `agent/src/setup.ts` | Workspace bootstrapping — directory scaffolding, identity-file seeding, plugin installation, and mise startup. Safe to call on every agent startup (idempotent). |
 | `admin/src/crypto.ts` / `token-crypto.ts` | AES-256-GCM + token hashing helpers. |

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -30,6 +30,10 @@ Mounted at `/agents/*`. The harness polls this every ~60s. Auth: **Bearer token*
 | GET | `/agents/:id/config` | Agent config bundle: decrypted `env`, `allowedTools`, and installed `plugins` (with derived marketplace). `404` if the agent doesn't exist. |
 | GET | `/agents/:id/crons` | Enabled cron jobs for the agent. `404` if the agent doesn't exist. |
 
+### Dev chat API (`chat.ts`) — dev-only
+
+Mounted at `POST /chat` only when `SHIPWRIGHT_DEV_CHAT=true`. **Not mounted in production.** No auth — intended for local developer use only. Accepts `{ message: string, session?: string }` and returns `{ result: string, sessionId: string }`. The `sessionId` is a UUID continuity handle; pass it back as `session` to continue the same conversation. `checkDevChatProductionGuard()` emits a startup warning if `SHIPWRIGHT_DEV_CHAT=true` is detected alongside a production config.
+
 ### Admin CRUD API (`admin-api.ts`) — human-facing
 
 Mounted at `/admin/api/*`. Auth: **session cookie** `admin_session` (httpOnly JWT verified with `SHIPWRIGHT_SESSION_SECRET`; absent/invalid → `401`).
@@ -67,6 +71,7 @@ All child models cascade-delete with their `Agent`.
 | `SHIPWRIGHT_INTERNAL_API_KEY` | ✅ (entrypoint + runtime API) | Bearer token for the config fetch at startup and for `/agents/*`. Also settable via `--api-key`. |
 | `AGENT_HOME` | entrypoint | Persistent storage root (default: `~/.shipwright-agent`). Mount a PVC here in Kubernetes so mise caches, workspace files, and `~/.claude` survive pod restarts. |
 | `PORT` | server | Hono server port (default: `3000`). |
+| `SHIPWRIGHT_DEV_CHAT` | dev chat | Set to `true` to mount the dev-only `POST /chat` endpoint. Default: unset (endpoint not mounted). Must not be set to `true` in a production deployment. |
 | `SHIPWRIGHT_SESSION_SECRET` | admin API | Secret for verifying the `admin_session` JWT cookie. |
 | `SHIPWRIGHT_ENCRYPTION_KEY` | secrets at rest | 64-char hex (32 bytes) for AES-256-GCM. **If unset, secrets are stored in plain text** (logged warning) — set it in any real deployment. |
 | `GH_APP_ID` | GitHub App auth | GitHub App ID (integer as string). Required when using the App auth path. |
@@ -90,7 +95,9 @@ All child models cascade-delete with their `Agent`.
 | `agent/src/entrypoint-main.ts` | Production CLI entry point — wires real deps and calls `runEntrypoint()`. Invoked by the Dockerfile `ENTRYPOINT`. |
 | `agent/src/entrypoint.ts` | Container startup sequence (`runEntrypoint()`) — dependency-injected for testability. Validates vars, fetches config, applies env, symlinks `~/.claude`, runs GitHub auth + mise + plugin install, then spawns the server. |
 | `agent/src/cli-args.ts` | CLI argument parsing (`parseCliArgs()`) — `--agent-id`, `--api-url`, `--api-key` flags with env var fallbacks. Pure, no I/O. |
-| `agent/src/run-agent.ts` | Composes all sub-apps into a single Hono root app (`createComposedApp(deps: ComposedAppDeps)`). Exports `PrismaLike` and `ComposedAppDeps` for test injection. `startServer()` wires real deps and calls `createComposedApp`; invoked by `entrypoint.ts` after all environment setup is complete. |
+| `agent/src/run-agent.ts` | Composes all sub-apps into a single Hono root app (`createComposedApp(deps: ComposedAppDeps)`). Exports `PrismaLike` and `ComposedAppDeps` for test injection. `ComposedAppDeps` includes optional `devChat?: boolean` and `runner?: ChatRunner` fields that gate the `/chat` surface. `startServer()` wires real deps and calls `createComposedApp`; invoked by `entrypoint.ts` after all environment setup is complete. |
+| `agent/src/chat.ts` | Dev-only `POST /chat` Hono app factory (`createChatApp({ runner })`). Also exports `checkDevChatProductionGuard(env)` — returns `{ ok, reason }` and is called at startup to warn if `SHIPWRIGHT_DEV_CHAT=true` is set in a production environment. |
+| `agent/src/check-dev-chat-guard.ts` | CLI guard script (`task doctor`). Calls `checkDevChatProductionGuard()` and exits `1` with a descriptive message if the production guard fails. Safe to run in CI. |
 | `agent/src/shipwright-config-client.ts` | `ShipwrightConfigClient` interface + `HttpShipwrightConfigClient` (real HTTP) + `RecordedShipwrightConfigClient` (cassette double for tests). |
 | `agent/src/setup.ts` | Workspace bootstrapping — directory scaffolding, identity-file seeding, plugin installation, and mise startup. Safe to call on every agent startup (idempotent). |
 | `admin/src/crypto.ts` / `token-crypto.ts` | AES-256-GCM + token hashing helpers. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ A Hono service that turns pipeline events into analytics. Five read-only JSON en
 
 ## C — Shipwright agent
 
-A thin autonomous runner with a Prisma-backed store (SQLite locally, PostgreSQL in production) and three HTTP surfaces: a machine-polled **runtime API** (`/agents/:id/config`, `/agents/:id/crons`), a human-facing **admin CRUD API** (`/admin/api/agents/:id/...` for envs, crons, tools, tokens, plugins), and a server-rendered **admin UI** (`/admin/...` — login, agent list/detail, Slack provisioning). See **[agent.md](./agent.md)**.
+A thin autonomous runner with a Prisma-backed store (SQLite locally, PostgreSQL in production) and three HTTP surfaces: a machine-polled **runtime API** (`/agents/:id/config`, `/agents/:id/crons`), a human-facing **admin CRUD API** (`/admin/api/agents/:id/...` for envs, crons, tools, tokens, plugins), and a server-rendered **admin UI** (`/admin/...` — login, agent list/detail, Slack provisioning). A fourth dev-only surface — `POST /chat` — is conditionally mounted when `SHIPWRIGHT_DEV_CHAT=true`; it is never enabled in production. See **[agent.md](./agent.md)**.
 
 > The container starts via `agent/src/entrypoint-main.ts` (Dockerfile `ENTRYPOINT`), which runs the full startup sequence (`entrypoint.ts`) and then spawns `run-agent.ts`. Implemented surfaces: the admin CRUD API, the admin UI, and the runtime API (all in `admin/src/` — package `@shipwright/admin`), the Prisma store (`admin/prisma/schema.prisma`), the Slack event handler (`slack.ts`), and the cron runtime (`cron-handler.ts`).
 


### PR DESCRIPTION
## Summary
- Add dev-only `POST /chat` endpoint in `agent/src/chat.ts`, gated by `devChat:true` in `ComposedAppDeps`
- Wire into `run-agent.ts` via `SHIPWRIGHT_DEV_CHAT==="true"` read once at startup (default-deny)
- Add `checkDevChatProductionGuard` predicate + `check-dev-chat-guard.ts` CLI wired into `task doctor`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | POST /chat returns {result,sessionId}; session continuity via returned token | MET |
| 2 | devChat:false (default) → /chat absent, returns 404 | MET |
| 3 | Doctor guard fails when SHIPWRIGHT_DEV_CHAT set in production config | MET |
| 4 | Smoke + unit tests with injected fake runner; no real Claude, no mock.module() | MET |
| 5 | Additive, gated off by default — safe to deploy standalone | MET |

## Test Plan
- [x] 14 new tests across `chat.smoke.test.ts` and `chat.unit.test.ts`
- [x] Full test suite: 2053 pass, 0 fail
- [x] Lint: clean (`bunx biome lint .`)
- [x] Typecheck: all workspaces pass
- [x] Docs refreshed: `docs/agent.md`

Generated with [Claude Code](https://claude.com/claude-code)
