### PR TITLE
fix: point runMigrations cwd to admin/ after schema move

### DIFF
--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -252,7 +252,7 @@ async function runMigrations(): Promise<void> {
   const proc = Bun.spawn(
     ["bunx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"],
     {
-      cwd: join(import.meta.dir, ".."),
+      cwd: join(import.meta.dir, "../../admin"),
       env: { ...process.env, DATABASE_URL_AGENT: databaseUrl },
       stdout: "pipe",
       stderr: "pipe",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.26.4
+# Shipwright v4.26.5
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 


### PR DESCRIPTION
## Summary

- Fixes `runMigrations()` boot crash introduced by #133: `cwd` was still pointing to `agent/` after the Prisma schema moved to `admin/prisma/schema.prisma`. When `DATABASE_URL_AGENT` is set, the server would throw a file-not-found error before serving any requests.
- Bumps `plugins/shipwright/README.md` version header from `v4.26.4` → `v4.26.5` to match the plugin sync in 94d7cbe.

## Test plan

- [ ] Set `DATABASE_URL_AGENT` locally and confirm `runMigrations()` no longer throws at boot
- [ ] Verify `task db:provision` and `task db:migrate` still work (fixed in #133)

Closes the two outstanding findings from the #133 review that slipped through before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)