### PR TITLE
fix(shipwright): filter dev-task query by current GitHub user

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.26.5",
+  "version": "4.26.6",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.26.5
+# Shipwright v4.26.6
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -20,7 +20,8 @@ Auto-detect the project toolchain (run once, reuse throughout). Skip this step u
 
 ```bash
 PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
-bun "$PLUGIN_SCRIPTS/task_store.ts" query --status in_progress
+CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
+bun "$PLUGIN_SCRIPTS/task_store.ts" query --status in_progress ${CURRENT_USER:+--assignee "$CURRENT_USER"}
 ```
 
 If the result is a non-empty array, use the first task returned. The Step 2 orphan check will clean up any stale branch/PR from the prior session before restarting. Print:
@@ -35,7 +36,8 @@ Record `task_started_at` (current ISO timestamp) for metrics.
 
 ```bash
 PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
-bun "$PLUGIN_SCRIPTS/task_store.ts" query --ready
+CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
+bun "$PLUGIN_SCRIPTS/task_store.ts" query --ready ${CURRENT_USER:+--assignee "$CURRENT_USER"}
 ```
 
 The command returns `pending` shipwright tasks whose dependencies are all satisfied, sorted by `addedAt`. Pick the first result.


### PR DESCRIPTION
## Summary

- `dev-task` was calling `task_store.ts query --ready` with no assignee filter, returning all ready tasks regardless of assignment
- Agents were picking up tasks belonging to other agents
- Added `--assignee` to both the `in_progress` resume check and the `--ready` task pick, resolving the current user dynamically via `gh api graphql`
- Falls back to no filter if `gh` is unavailable (safe — degrades to prior behavior)
- Bumps plugin to 4.26.6

Port of app-vitals/vitals-os#1451.

## Test plan

- [ ] Verify agent picks up tasks assigned to it or unassigned
- [ ] Verify agent skips tasks assigned to a different user
- [ ] Verify \`[silent]\` behavior unchanged when no tasks found

🤖 Generated with [Claude Code](https://claude.com/claude-code)