### PR TITLE
feat(agent): add shared test-env.ts fixture (ATP-1.1)

### DIFF
--- a/agent/src/test-env.ts
+++ b/agent/src/test-env.ts
@@ -1,0 +1,25 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const TEST_AGENT_HOME = join(
+  tmpdir(),
+  `shipwright-agent-test-${process.pid}`,
+);
+
+mkdirSync(join(TEST_AGENT_HOME, "workspace"), { recursive: true });
+writeFileSync(
+  join(TEST_AGENT_HOME, "workspace", "CLAUDE.md"),
+  "# Shipwright Agent\n",
+);
+
+process.env.AGENT_HOME = TEST_AGENT_HOME;
+process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
+process.env.SLACK_APP_TOKEN = "xapp-test-token";
+process.env.SLACK_SIGNING_SECRET = "test-signing-secret";
+process.env.ANTHROPIC_MODEL = "claude-opus-4-6";
+process.env.SLACK_ALERT_CHANNEL = "#alerts";
+process.env.SLACK_OWNER_USER = "U12345";
+process.env.SHIPWRIGHT_API_URL = "https://api.shipwright.app";
+process.env.SHIPWRIGHT_INTERNAL_API_KEY = "key-123";
+process.env.SHIPWRIGHT_AGENT_ID = "agent-test-456";

--- a/agent/src/test-env.ts
+++ b/agent/src/test-env.ts
@@ -1,0 +1,28 @@
+// Import FIRST in test files — sets env vars before claude.ts reads process.env.ANTHROPIC_MODEL at module load time.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const TEST_AGENT_HOME = join(
+  tmpdir(),
+  `shipwright-agent-config-test-${process.pid}`,
+);
+
+const workspaceDir = join(TEST_AGENT_HOME, "workspace");
+mkdirSync(workspaceDir, { recursive: true });
+writeFileSync(
+  join(workspaceDir, "CLAUDE.md"),
+  "# CLAUDE.md\n\nTest workspace — do not use in production.\n",
+);
+
+process.env.AGENT_HOME = TEST_AGENT_HOME;
+process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
+process.env.SLACK_APP_TOKEN = "xapp-test-token";
+process.env.SLACK_SIGNING_SECRET = "test-signing-secret";
+process.env.ANTHROPIC_MODEL = "claude-opus-4-6";
+process.env.SLACK_ALERT_CHANNEL = "#alerts";
+process.env.SLACK_OWNER_USER = "U12345";
+process.env.SHIPWRIGHT_API_URL = "https://api.shipwright.app";
+process.env.SHIPWRIGHT_INTERNAL_API_KEY = "key-123";
+process.env.SHIPWRIGHT_AGENT_ID = "agent-test-123";


### PR DESCRIPTION
## Summary
- Adds `agent/src/test-env.ts` — the shipwright-adapted version of vitals-os's `test-env.ts`
- Creates a pid-scoped `TEST_AGENT_HOME` tmp dir with `workspace/CLAUDE.md` present, matching what `setup.ts` expects
- Sets all 10 required env vars for agent tests: `AGENT_HOME`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`, `ANTHROPIC_MODEL`, `SLACK_ALERT_CHANNEL`, `SLACK_OWNER_USER`, `SHIPWRIGHT_API_URL`, `SHIPWRIGHT_INTERNAL_API_KEY`, `SHIPWRIGHT_AGENT_ID`

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | File exists at agent/src/test-env.ts | MET |
| 2 | Creates TEST_AGENT_HOME tmp dir with workspace/CLAUDE.md present | MET |
| 3 | Sets all 10 required env vars | MET |
| 4 | Exports TEST_AGENT_HOME as named constant (pid-scoped) | MET |
| 5 | No VITALS_OS_* variables present | MET |
| 6 | Shared fixture only — no tests of its own | MET |

## Test Plan
- [x] Biome lint: clean (241 files, no issues)
- [x] Typecheck: all 4 packages pass
- [x] `bun test agent/src/`: 427 pass (2 pre-existing failures in smoke tests unrelated to this change)
- [x] No VITALS_OS_* env vars in the new file

Generated with [Claude Code](https://claude.com/claude-code)
