### PR TITLE
feat: replace password login with Google OAuth (ADM-2.1)

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -82,21 +82,7 @@ export function renderLoginPage(opts?: { error?: string }): string {
       <h1 class="login-title">Shipwright Admin</h1>
       <p class="login-subtitle">Sign in to manage your agents.</p>
       ${errorHtml}
-      <form method="POST" action="/admin/login">
-        <div class="form-group">
-          <label class="form-label" for="password">Password</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            class="form-input"
-            placeholder="Enter admin password"
-            autocomplete="current-password"
-            required
-          />
-        </div>
-        <button type="submit" class="btn btn-primary" style="width:100%">Sign in</button>
-      </form>
+      <a href="/auth/google" class="btn btn-primary" style="width:100%;justify-content:center;text-decoration:none">Sign in with Google</a>
     </div>
   </div>
 </body>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -123,9 +123,10 @@ describe("renderLoginPage", () => {
     expect(html).toContain("Admin Login");
   });
 
-  test("includes login form pointing at /admin/login", () => {
+  test("includes Sign in with Google link pointing at /auth/google", () => {
     const html = renderLoginPage();
-    expect(html).toContain('action="/admin/login"');
+    expect(html).toContain("Sign in with Google");
+    expect(html).toContain('href="/auth/google"');
   });
 
   test("no error div when no error provided", () => {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -8,13 +8,16 @@
 
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
+import type { GoogleAuthClient, GoogleTokenResponse, GoogleUserInfo } from "./google-auth-client.ts";
 import { createAdminUIApp } from "./admin-ui.ts";
 import type { AdminUIDeps } from "./admin-ui.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const SESSION_SECRET = "test-admin-session-secret-32-bytes!";
-const ADMIN_PASSWORD = "correct-horse-battery-staple";
+const GOOGLE_CLIENT_ID = "test-google-client-id";
+const GOOGLE_CLIENT_SECRET = "test-google-client-secret";
+const ADMIN_ALLOWED_EMAILS = ["admin@example.com", "other@example.com"];
 const AGENT_ID = "agent-test-123";
 const CRON_ID = "cron-test-456";
 const TOOL_ID = "tool-test-789";
@@ -58,11 +61,15 @@ const MOCK_TOKEN = {
 
 // ─── JWT helper ───────────────────────────────────────────────────────────────
 
-async function makeSessionCookie(secret = SESSION_SECRET): Promise<string> {
+async function makeSessionCookie(
+  secret = SESSION_SECRET,
+  userId = "google-sub-123",
+  email = "admin@example.com",
+): Promise<string> {
   return sign(
     {
-      userId: "admin",
-      email: "admin",
+      userId,
+      email,
       iat: Math.floor(Date.now() / 1000),
       exp: Math.floor(Date.now() / 1000) + 3600,
     },
@@ -71,9 +78,35 @@ async function makeSessionCookie(secret = SESSION_SECRET): Promise<string> {
   );
 }
 
+// ─── Mock Google client ───────────────────────────────────────────────────────
+
+function makeGoogleClient(overrides?: {
+  exchangeCode?: (params: unknown) => Promise<GoogleTokenResponse>;
+  getUserInfo?: (accessToken: string) => Promise<GoogleUserInfo>;
+}): GoogleAuthClient {
+  return {
+    exchangeCode:
+      overrides?.exchangeCode ??
+      (() =>
+        Promise.resolve({
+          accessToken: "test-access-token",
+          refreshToken: "test-refresh-token",
+          expiresIn: 3600,
+        })),
+    getUserInfo:
+      overrides?.getUserInfo ??
+      (() =>
+        Promise.resolve({
+          sub: "google-sub-123",
+          email: "admin@example.com",
+          name: "Admin User",
+        })),
+  };
+}
+
 // ─── Mock deps ────────────────────────────────────────────────────────────────
 
-function makeMockDeps(): AdminUIDeps {
+function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
   return {
     prisma: {
       agent: {
@@ -132,7 +165,10 @@ function makeMockDeps(): AdminUIDeps {
       list: async () => [],
     },
     sessionSecret: SESSION_SECRET,
-    adminPassword: ADMIN_PASSWORD,
+    googleClientId: GOOGLE_CLIENT_ID,
+    googleClientSecret: GOOGLE_CLIENT_SECRET,
+    adminAllowedEmails: ADMIN_ALLOWED_EMAILS,
+    googleClient: makeGoogleClient(),
     slackClient: {
       createAppManifest: async () => ({
         appId: "A123456",
@@ -140,6 +176,7 @@ function makeMockDeps(): AdminUIDeps {
       }),
     },
     appBaseUrl: "https://example.com",
+    ...overrides,
   };
 }
 
@@ -164,40 +201,146 @@ describe("admin UI — unauthenticated redirects", () => {
 // ─── Login page ───────────────────────────────────────────────────────────────
 
 describe("admin UI — login page", () => {
-  it("GET /admin/login returns 200 with login form", async () => {
+  it("GET /admin/login returns 200 with Sign in with Google button (no password form)", async () => {
     const app = createAdminUIApp(makeMockDeps());
     const res = await app.request("/admin/login");
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain("<form");
-    expect(html).toContain('type="password"');
+    expect(html).toContain("Sign in with Google");
+    expect(html).not.toContain('type="password"');
+    expect(html).not.toContain('name="password"');
+  });
+});
+
+// ─── OAuth routes ─────────────────────────────────────────────────────────────
+
+describe("admin UI — GET /auth/google", () => {
+  it("redirects to Google OAuth URL and sets oauth_state cookie", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/auth/google");
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("accounts.google.com");
+    expect(location).toContain("openid");
+    expect(location).toContain("profile");
+    expect(location).toContain("email");
+    const cookie = res.headers.get("Set-Cookie") ?? "";
+    expect(cookie).toContain("oauth_state=");
+    expect(cookie).toContain("HttpOnly");
   });
 
-  it("POST /admin/login with valid password sets session cookie and redirects to /admin/agents", async () => {
-    const app = createAdminUIApp(makeMockDeps());
-    const body = new URLSearchParams({ password: ADMIN_PASSWORD });
-    const res = await app.request("/admin/login", {
-      method: "POST",
-      body: body.toString(),
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  it("redirects to /admin/login?error=server_error when googleClientId is empty", async () => {
+    const app = createAdminUIApp(makeMockDeps({ googleClientId: "" }));
+    const res = await app.request("/auth/google");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=server_error");
+  });
+});
+
+describe("admin UI — GET /auth/callback", () => {
+  // Helper: set a nonce cookie and matching state query param
+  function callbackRequest(nonce: string, queryOverrides?: Record<string, string>): Request {
+    const params = new URLSearchParams({ state: nonce, code: "auth-code-123", ...queryOverrides });
+    return new Request(`https://example.com/auth/callback?${params.toString()}`, {
+      headers: { Cookie: `oauth_state=${nonce}` },
     });
+  }
+
+  it("happy path — valid state, code exchanged, email in allowlist → sets session cookie and redirects to /admin/agents", async () => {
+    const nonce = "test-nonce-abc";
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(callbackRequest(nonce));
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe("/admin/agents");
-    const cookie = res.headers.get("Set-Cookie");
-    expect(cookie).toBeTruthy();
+    const cookie = res.headers.get("Set-Cookie") ?? "";
     expect(cookie).toContain("admin_session=");
     expect(cookie).toContain("HttpOnly");
   });
 
-  it("POST /admin/login with wrong password returns 401", async () => {
+  it("state mismatch → redirects to /admin/login?error=invalid_state", async () => {
     const app = createAdminUIApp(makeMockDeps());
-    const body = new URLSearchParams({ password: "wrong-password" });
-    const res = await app.request("/admin/login", {
-      method: "POST",
-      body: body.toString(),
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    });
-    expect(res.status).toBe(401);
+    const res = await app.request(
+      new Request("https://example.com/auth/callback?state=wrong-state&code=auth-code", {
+        headers: { Cookie: "oauth_state=stored-nonce" },
+      }),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=invalid_state");
+  });
+
+  it("missing oauth_state cookie → redirects to /admin/login?error=invalid_state", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      new Request("https://example.com/auth/callback?state=some-state&code=code"),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=invalid_state");
+  });
+
+  it("missing GOOGLE_CLIENT_ID → redirects to /admin/login?error=server_error", async () => {
+    const nonce = "test-nonce-abc";
+    const app = createAdminUIApp(makeMockDeps({ googleClientId: "" }));
+    const res = await app.request(callbackRequest(nonce));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=server_error");
+  });
+
+  it("access_denied param → redirects to /admin/login?error=access_denied", async () => {
+    const nonce = "test-nonce-abc";
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      new Request(`https://example.com/auth/callback?error=access_denied&state=${nonce}`, {
+        headers: { Cookie: `oauth_state=${nonce}` },
+      }),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=access_denied");
+  });
+
+  it("token exchange failure → redirects to /admin/login?error=auth_failed", async () => {
+    const nonce = "test-nonce-abc";
+    const app = createAdminUIApp(
+      makeMockDeps({
+        googleClient: makeGoogleClient({
+          exchangeCode: () => Promise.reject(new Error("token exchange failed")),
+        }),
+      }),
+    );
+    const res = await app.request(callbackRequest(nonce));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=auth_failed");
+  });
+
+  it("userinfo fetch failure → redirects to /admin/login?error=auth_failed", async () => {
+    const nonce = "test-nonce-abc";
+    const app = createAdminUIApp(
+      makeMockDeps({
+        googleClient: makeGoogleClient({
+          getUserInfo: () => Promise.reject(new Error("userinfo failed")),
+        }),
+      }),
+    );
+    const res = await app.request(callbackRequest(nonce));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("error=auth_failed");
+  });
+
+  it("email not in allowlist → returns 403", async () => {
+    const nonce = "test-nonce-abc";
+    const app = createAdminUIApp(
+      makeMockDeps({
+        googleClient: makeGoogleClient({
+          getUserInfo: () =>
+            Promise.resolve({
+              sub: "google-sub-999",
+              email: "notallowed@example.com",
+              name: "Not Allowed",
+            }),
+        }),
+      }),
+    );
+    const res = await app.request(callbackRequest(nonce));
+    expect(res.status).toBe(403);
   });
 });
 

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -99,6 +99,7 @@ function makeGoogleClient(overrides?: {
         Promise.resolve({
           sub: "google-sub-123",
           email: "admin@example.com",
+          email_verified: true,
           name: "Admin User",
         })),
   };
@@ -334,6 +335,7 @@ describe("admin UI — GET /auth/callback", () => {
             Promise.resolve({
               sub: "google-sub-999",
               email: "notallowed@example.com",
+              email_verified: true,
               name: "Not Allowed",
             }),
         }),

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -3,8 +3,9 @@
  * Admin UI — server-rendered Hono app factory.
  *
  * Routes:
- *   GET  /admin/login                 — login form
- *   POST /admin/login                 — submit password → set session cookie → redirect
+ *   GET  /admin/login                 — login page (Google sign-in button)
+ *   GET  /auth/google                 — redirect to Google OAuth consent
+ *   GET  /auth/callback               — Google OAuth callback → set session cookie
  *   POST /admin/logout                — clear cookie → redirect to login
  *   GET  /admin/agents                — list all agents (auth required)
  *   GET  /admin/agents/:id            — agent detail (auth required)
@@ -15,10 +16,10 @@
  *   GET  /admin/provision/complete    — OAuth callback → store credentials
  *
  * Auth: httpOnly JWT cookie named "admin_session".
- * Login is password-only (adminPassword from deps) — no DB user lookup.
+ * Login is Google OAuth — no password, no DB user lookup.
+ * Allowed users are controlled by the adminAllowedEmails allowlist in deps.
  */
 
-import { timingSafeEqual as cryptoTimingSafeEqual } from "node:crypto";
 import { Hono, type MiddlewareHandler } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { sign, verify } from "hono/jwt";
@@ -33,6 +34,7 @@ import {
 import type { AgentCronJobService } from "./agent-cron-jobs.ts";
 import type { AgentEnvService } from "./agent-envs.ts";
 import { ForbiddenError, UnprocessableEntityError } from "./errors.ts";
+import type { GoogleAuthClient } from "./google-auth-client.ts";
 import type { AgentPluginService } from "./agent-plugins.ts";
 import type { AgentTokenService } from "./agent-tokens.ts";
 import type { AgentToolService } from "./agent-tools.ts";
@@ -112,7 +114,10 @@ export interface AdminUIDeps {
   agentTokenService: Pick<AgentTokenService, "listForAgent" | "create" | "revoke">;
   agentPluginService: Pick<AgentPluginService, "list">;
   sessionSecret: string;
-  adminPassword: string;
+  googleClient: GoogleAuthClient;
+  googleClientId: string;
+  googleClientSecret: string;
+  adminAllowedEmails: string[];
   slackClient: AdminUISlackClient;
   appBaseUrl: string;
 }
@@ -120,31 +125,24 @@ export interface AdminUIDeps {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const SESSION_COOKIE = "admin_session";
+const OAUTH_STATE_COOKIE = "oauth_state";
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const SESSION_TTL_SECONDS = 8 * 60 * 60; // 8 hours
+const OAUTH_STATE_TTL_SECONDS = 600; // 10 min
 const ADMIN_USER_NAME = "admin";
-
-// ─── Timing-safe comparison ───────────────────────────────────────────────────
-
-/**
- * Constant-time string comparison using node:crypto's timingSafeEqual.
- * Returns false immediately on length mismatch (length is not secret here —
- * the admin password length is fixed, so early-exit is fine).
- */
-function safeCompare(a: string, b: string): boolean {
-  const ab = Buffer.from(a, "utf8");
-  const bb = Buffer.from(b, "utf8");
-  if (ab.length !== bb.length) return false;
-  return cryptoTimingSafeEqual(ab, bb);
-}
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
-async function createSessionToken(secret: string): Promise<string> {
+async function createSessionToken(
+  secret: string,
+  userId: string,
+  email: string,
+): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   return sign(
     {
-      userId: "admin",
-      email: "admin",
+      userId,
+      email,
       iat: now,
       exp: now + SESSION_TTL_SECONDS,
     },
@@ -164,8 +162,9 @@ async function verifySessionToken(
     >;
     return (
       typeof payload.userId === "string" &&
-      payload.userId === "admin" &&
-      typeof payload.email === "string"
+      payload.userId.length > 0 &&
+      typeof payload.email === "string" &&
+      payload.email.length > 0
     );
   } catch {
     return false;
@@ -198,7 +197,10 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono {
     agentTokenService,
     agentPluginService,
     sessionSecret,
-    adminPassword,
+    googleClient,
+    googleClientId,
+    googleClientSecret,
+    adminAllowedEmails,
     slackClient,
     appBaseUrl,
   } = deps;
@@ -215,29 +217,96 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono {
     });
   }
 
-  // ─── Login / Logout ───────────────────────────────────────────────────────
+  // ─── Login / OAuth / Logout ───────────────────────────────────────────────
 
   app.get("/admin/login", (c) => {
-    return html(renderLoginPage());
+    const error = c.req.query("error") ?? undefined;
+    return html(renderLoginPage({ error }));
   });
 
-  app.post("/admin/login", async (c) => {
-    let password: string | undefined;
+  app.get("/auth/google", (c) => {
+    if (!googleClientId) {
+      return c.redirect("/admin/login?error=server_error", 302);
+    }
+
+    const nonce = crypto.randomUUID();
+    setCookie(c, OAUTH_STATE_COOKIE, nonce, {
+      httpOnly: true,
+      sameSite: "Lax",
+      maxAge: OAUTH_STATE_TTL_SECONDS,
+      path: "/auth",
+    });
+
+    const params = new URLSearchParams({
+      client_id: googleClientId,
+      redirect_uri: `${appBaseUrl}/auth/callback`,
+      response_type: "code",
+      scope: "openid profile email",
+      state: nonce,
+      prompt: "select_account",
+    });
+
+    return c.redirect(`${GOOGLE_AUTH_URL}?${params.toString()}`, 302);
+  });
+
+  app.get("/auth/callback", async (c) => {
+    const { code, state, error: googleError } = c.req.query();
+
+    // Google returned an error (e.g. access_denied)
+    if (googleError) {
+      const slug = googleError === "access_denied" ? "access_denied" : "auth_failed";
+      return c.redirect(`/admin/login?error=${slug}`, 302);
+    }
+
+    // CSRF: validate state nonce
+    const storedNonce = getCookie(c, OAUTH_STATE_COOKIE);
+    deleteCookie(c, OAUTH_STATE_COOKIE, { path: "/auth" });
+
+    if (!storedNonce || !state || storedNonce !== state) {
+      return c.redirect("/admin/login?error=invalid_state", 302);
+    }
+
+    if (!googleClientId || !googleClientSecret) {
+      return c.redirect("/admin/login?error=server_error", 302);
+    }
+
+    if (!code) {
+      return c.redirect("/admin/login?error=auth_failed", 302);
+    }
+
+    // Exchange authorization code for tokens
+    let accessToken: string;
     try {
-      const formData = await c.req.formData();
-      password = formData.get("password")?.toString();
-    } catch {
-      return html(renderLoginPage({ error: "Invalid form submission." }));
-    }
-
-    if (!password || !safeCompare(password, adminPassword)) {
-      return new Response(renderLoginPage({ error: "Invalid password." }), {
-        status: 401,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
+      const tokens = await googleClient.exchangeCode({
+        code,
+        clientId: googleClientId,
+        clientSecret: googleClientSecret,
+        redirectUri: `${appBaseUrl}/auth/callback`,
       });
+      accessToken = tokens.accessToken;
+    } catch {
+      return c.redirect("/admin/login?error=auth_failed", 302);
     }
 
-    const token = await createSessionToken(sessionSecret);
+    // Fetch user info from Google
+    let userInfo: { sub: string; email?: string; name: string };
+    try {
+      userInfo = await googleClient.getUserInfo(accessToken);
+    } catch {
+      return c.redirect("/admin/login?error=auth_failed", 302);
+    }
+
+    if (!userInfo.email) {
+      return c.redirect("/admin/login?error=auth_failed", 302);
+    }
+
+    // Check allowlist
+    if (!adminAllowedEmails.includes(userInfo.email)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    // Create session
+    const token = await createSessionToken(sessionSecret, userInfo.sub, userInfo.email);
     setCookie(c, SESSION_COOKIE, token, {
       httpOnly: true,
       secure: appBaseUrl.startsWith("https://"),

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -289,7 +289,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono {
     }
 
     // Fetch user info from Google
-    let userInfo: { sub: string; email?: string; name: string };
+    let userInfo: { sub: string; email?: string; email_verified?: boolean; name: string };
     try {
       userInfo = await googleClient.getUserInfo(accessToken);
     } catch {
@@ -300,8 +300,12 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono {
       return c.redirect("/admin/login?error=auth_failed", 302);
     }
 
+    if (!userInfo.email_verified) {
+      return c.redirect("/admin/login?error=auth_failed", 302);
+    }
+
     // Check allowlist
-    if (!adminAllowedEmails.includes(userInfo.email)) {
+    if (!adminAllowedEmails.map((e) => e.toLowerCase()).includes(userInfo.email.toLowerCase())) {
       return new Response("Forbidden", { status: 403 });
     }
 

--- a/admin/src/google-auth-client.ts
+++ b/admin/src/google-auth-client.ts
@@ -1,5 +1,5 @@
 /**
- * lib/google-auth-client.ts
+ * admin/src/google-auth-client.ts
  * Typed client for Google OAuth2 token exchange and user profile lookup.
  *
  * Interface + HTTP implementation following the project's client DI pattern.

--- a/admin/src/google-auth-client.ts
+++ b/admin/src/google-auth-client.ts
@@ -1,0 +1,114 @@
+/**
+ * lib/google-auth-client.ts
+ * Typed client for Google OAuth2 token exchange and user profile lookup.
+ *
+ * Interface + HTTP implementation following the project's client DI pattern.
+ * Tests inject a mock implementation; production uses HttpGoogleAuthClient.
+ */
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface GoogleTokenResponse {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  expiresIn: number;
+}
+
+export interface GoogleUserInfo {
+  sub: string;
+  email?: string;
+  name: string;
+  picture?: string;
+}
+
+// ─── Interface ──────────────────────────────────────────────────────────────
+
+export interface GoogleAuthClient {
+  exchangeCode(params: {
+    code: string;
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+  }): Promise<GoogleTokenResponse>;
+
+  getUserInfo(accessToken: string): Promise<GoogleUserInfo>;
+}
+
+// ─── Error ──────────────────────────────────────────────────────────────────
+
+class GoogleAuthClientError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "GoogleAuthClientError";
+  }
+}
+
+// ─── HTTP implementation ────────────────────────────────────────────────────
+
+export class HttpGoogleAuthClient implements GoogleAuthClient {
+  async exchangeCode(params: {
+    code: string;
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+  }): Promise<GoogleTokenResponse> {
+    const res = await fetch(GOOGLE_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        code: params.code,
+        client_id: params.clientId,
+        client_secret: params.clientSecret,
+        redirect_uri: params.redirectUri,
+        grant_type: "authorization_code",
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new GoogleAuthClientError(
+        `Token exchange failed: ${res.status} ${body}`,
+        res.status,
+      );
+    }
+
+    const data = (await res.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in: number;
+    };
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      idToken: data.id_token,
+      expiresIn: data.expires_in,
+    };
+  }
+
+  async getUserInfo(accessToken: string): Promise<GoogleUserInfo> {
+    const res = await fetch(GOOGLE_USERINFO_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new GoogleAuthClientError(
+        `Userinfo fetch failed: ${res.status} ${body}`,
+        res.status,
+      );
+    }
+
+    return (await res.json()) as GoogleUserInfo;
+  }
+}

--- a/admin/src/google-auth-client.ts
+++ b/admin/src/google-auth-client.ts
@@ -23,6 +23,7 @@ export interface GoogleTokenResponse {
 export interface GoogleUserInfo {
   sub: string;
   email?: string;
+  email_verified?: boolean;
   name: string;
   picture?: string;
 }

--- a/admin/src/server.ts
+++ b/admin/src/server.ts
@@ -29,4 +29,6 @@ export type { TokenCrypto } from "./token-crypto.ts";
 export { ApiError, NotFoundError, ConflictError, BadRequestError, ForbiddenError, UnprocessableEntityError, BadGatewayError } from "./errors.ts";
 export { HttpSlackProvisioningClient } from "./slack-provisioning-client.ts";
 export type { SlackProvisioningClient } from "./slack-provisioning-client.ts";
+export { HttpGoogleAuthClient } from "./google-auth-client.ts";
+export type { GoogleAuthClient } from "./google-auth-client.ts";
 export { PrismaClient } from "../prisma/client/index.js";

--- a/admin/src/slack-provisioning.integration.test.ts
+++ b/admin/src/slack-provisioning.integration.test.ts
@@ -16,7 +16,6 @@ import type { AppManifest } from "./slack-provisioning-client.ts";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const SESSION_SECRET = "test-admin-session-secret-32-bytes!";
-const ADMIN_PASSWORD = "correct-horse-battery-staple";
 const AGENT_ID = "agent-test-123";
 
 // ─── Cassette fixture ─────────────────────────────────────────────────────────
@@ -136,7 +135,20 @@ function makeMockDeps(
       list: async () => [],
     },
     sessionSecret: SESSION_SECRET,
-    adminPassword: ADMIN_PASSWORD,
+    googleClientId: "test-google-client-id",
+    googleClientSecret: "test-google-client-secret",
+    adminAllowedEmails: ["admin@example.com"],
+    googleClient: {
+      exchangeCode: async () => ({
+        accessToken: "test-access-token",
+        expiresIn: 3600,
+      }),
+      getUserInfo: async () => ({
+        sub: "google-sub-123",
+        email: "admin@example.com",
+        name: "Admin User",
+      }),
+    },
     slackClient,
     appBaseUrl: "https://example.com",
   };

--- a/agent/src/run-agent.smoke.test.ts
+++ b/agent/src/run-agent.smoke.test.ts
@@ -80,13 +80,13 @@ describe("composed app — /agents/* (runtime API)", () => {
 // ─── Admin UI routes (/admin/*) ───────────────────────────────────────────────
 
 describe("composed app — /admin/* (admin UI)", () => {
-  it("GET /admin/login returns 200 with HTML login form", async () => {
+  it("GET /admin/login returns 200 with Sign in with Google button (no password form)", async () => {
     const app = createComposedApp(makeMockDeps());
     const res = await app.request("/admin/login");
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain("<form");
-    expect(html).toContain('type="password"');
+    expect(html).toContain("Sign in with Google");
+    expect(html).not.toContain('type="password"');
   });
 
   it("GET /admin/agents without session cookie redirects to /admin/login", async () => {

--- a/agent/src/run-agent.ts
+++ b/agent/src/run-agent.ts
@@ -21,6 +21,7 @@ import {
   AgentPluginService,
   AgentTokenService,
   AgentToolService,
+  HttpGoogleAuthClient,
   HttpSlackProvisioningClient,
   PrismaClient,
   createAdminApp,
@@ -119,7 +120,10 @@ export interface ComposedAppDeps {
   >;
   internalApiKey: string;
   sessionSecret: string;
-  adminPassword: string;
+  googleClientId: string;
+  googleClientSecret: string;
+  adminAllowedEmails: string[];
+  googleClient: AdminUIDeps["googleClient"];
   slackClient: AdminUIDeps["slackClient"];
   appBaseUrl: string;
   /**
@@ -158,7 +162,10 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
     agentPluginService,
     internalApiKey,
     sessionSecret,
-    adminPassword,
+    googleClientId,
+    googleClientSecret,
+    adminAllowedEmails,
+    googleClient,
     slackClient,
     appBaseUrl,
     devChat,
@@ -223,7 +230,10 @@ export function createComposedApp(deps: ComposedAppDeps): Hono {
     agentTokenService,
     agentPluginService,
     sessionSecret,
-    adminPassword,
+    googleClientId,
+    googleClientSecret,
+    adminAllowedEmails,
+    googleClient,
     slackClient,
     appBaseUrl,
   });
@@ -317,9 +327,15 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
   // Read config values at call time (no module-level env reads)
   const internalApiKey = process.env.SHIPWRIGHT_INTERNAL_API_KEY ?? "";
   const sessionSecret = process.env.SHIPWRIGHT_SESSION_SECRET ?? "";
-  const adminPassword = process.env.SHIPWRIGHT_ADMIN_PASSWORD ?? "";
+  const googleClientId = process.env.GOOGLE_CLIENT_ID ?? "";
+  const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET ?? "";
+  const adminAllowedEmails = (process.env.ADMIN_ALLOWED_EMAILS ?? "")
+    .split(",")
+    .map((e) => e.trim())
+    .filter(Boolean);
   const appBaseUrl = process.env.APP_BASE_URL ?? `http://localhost:${port}`;
 
+  const googleClient = new HttpGoogleAuthClient();
   const slackClient = new HttpSlackProvisioningClient();
 
   // Dev-only chat transport: read the gate ONCE at composition time. When on,
@@ -341,7 +357,10 @@ export async function startServer(opts?: { port?: number }): Promise<void> {
     agentPluginService,
     internalApiKey,
     sessionSecret,
-    adminPassword,
+    googleClientId,
+    googleClientSecret,
+    adminAllowedEmails,
+    googleClient,
     slackClient,
     appBaseUrl,
     devChat,

--- a/agent/src/test-helpers/mock-deps.ts
+++ b/agent/src/test-helpers/mock-deps.ts
@@ -8,7 +8,6 @@
 import type { ComposedAppDeps } from "../run-agent.ts";
 
 export const TEST_SESSION_SECRET = "test-admin-session-secret-32-bytes!";
-export const TEST_ADMIN_PASSWORD = "correct-horse-battery-staple";
 export const TEST_INTERNAL_API_KEY = "test-internal-api-key";
 export const TEST_AGENT_ID = "agent-test-123";
 
@@ -91,7 +90,20 @@ export function makeMockDeps(): ComposedAppDeps {
     },
     internalApiKey: TEST_INTERNAL_API_KEY,
     sessionSecret: TEST_SESSION_SECRET,
-    adminPassword: TEST_ADMIN_PASSWORD,
+    googleClientId: "test-google-client-id",
+    googleClientSecret: "test-google-client-secret",
+    adminAllowedEmails: ["admin@example.com"],
+    googleClient: {
+      exchangeCode: async () => ({
+        accessToken: "test-access-token",
+        expiresIn: 3600,
+      }),
+      getUserInfo: async () => ({
+        sub: "google-sub-123",
+        email: "admin@example.com",
+        name: "Admin User",
+      }),
+    },
     slackClient: {
       createAppManifest: async () => ({
         appId: "A123",

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -86,6 +86,10 @@ All child models cascade-delete with their `Agent`.
 | `AGENT_HOME` | entrypoint | Persistent storage root (default: `~/.shipwright-agent`). Mount a PVC here in Kubernetes so mise caches, workspace files, and `~/.claude` survive pod restarts. |
 | `PORT` | server | Hono server port (default: `3000`). |
 | `SHIPWRIGHT_SESSION_SECRET` | admin API | Secret for verifying the `admin_session` JWT cookie. |
+| `GOOGLE_CLIENT_ID` | admin UI (OAuth) | Google OAuth 2.0 client ID. Required for the admin login flow. |
+| `GOOGLE_CLIENT_SECRET` | admin UI (OAuth) | Google OAuth 2.0 client secret. Required for the admin login flow. |
+| `ADMIN_ALLOWED_EMAILS` | admin UI (OAuth) | Comma-separated list of Google email addresses permitted to log in to the admin UI. |
+| `APP_BASE_URL` | admin UI (OAuth) | Public base URL of the server (e.g. `https://shipwright.example.com`). Used to construct the OAuth redirect URI. Defaults to `http://localhost:{PORT}`. |
 | `SHIPWRIGHT_ENCRYPTION_KEY` | secrets at rest | 64-char hex (32 bytes) for AES-256-GCM. **If unset, secrets are stored in plain text** (logged warning) — set it in any real deployment. |
 | `GH_APP_ID` | GitHub App auth | GitHub App ID (integer as string). Required when using the App auth path. |
 | `GH_APP_PRIVATE_KEY` | GitHub App auth | PEM private key for the GitHub App (newlines may be `\n`-escaped). Required when using the App auth path. |
@@ -102,6 +106,7 @@ All child models cascade-delete with their `Agent`.
 | `admin/src/admin-ui.ts` | Admin UI factory `createAdminUIApp()` — server-rendered Hono app (login, agent list/detail, Slack provisioning) with POST mutation routes for cron jobs, tools, and tokens (create/toggle/delete/revoke). |
 | `admin/src/admin-ui-pages.ts` | Page rendering functions (`renderLoginPage`, `renderAgentsPage`, `renderAgentDetailPage`, `renderProvision*`). |
 | `admin/src/admin-ui-styles.ts` | Shared CSS helpers (`baseStyles`, `escapeHtml`, `renderAdminToolbar`). |
+| `admin/src/google-auth-client.ts` | `GoogleAuthClient` interface + `HttpGoogleAuthClient` — typed Google OAuth2 token exchange and user profile lookup; injected into the admin UI for testability. |
 | `admin/src/slack-provisioning-client.ts` | `SlackProvisioningClient` interface + `HttpSlackProvisioningClient` — drives the one-time Slack app creation flow. |
 | `admin/src/agent-envs.ts` | Env service — encrypted key/value store + config bundle assembly. |
 | `admin/src/agent-cron-jobs.ts` | Cron service + system-cron reconciliation. |


### PR DESCRIPTION
## Summary
- Replace password-based admin login with Google OAuth using a stateless nonce-cookie pattern
- Copy `HttpGoogleAuthClient` from vitals-os into `admin/src/`; wire up `GET /auth/google` (redirect + nonce), `GET /auth/callback` (exchange, validate, set session), remove `POST /admin/login`
- Remove `adminPassword` from `AdminUIDeps`; add `googleClient`, `googleClientId`, `googleClientSecret`, `adminAllowedEmails`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | GET /admin/login renders Sign in with Google button (no password form) | ✅ MET |
| 2 | GET /auth/google redirects to Google OAuth URL with openid/profile/email scopes, sets oauth_state nonce cookie | ✅ MET |
| 3 | GET /auth/callback: happy path sets session cookie → /admin/agents; email not in allowlist → 403 | ✅ MET |
| 4 | Smoke tests: state mismatch, missing clientId, access_denied, token failure, userinfo failure | ✅ MET |
| 5 | adminPassword removed from AdminUIDeps; admin-api.ts session middleware unchanged | ✅ MET |
| 6 | New auth route smoke tests added; password login smoke tests retired | ✅ MET |

## Test Plan
- [x] 233 admin tests pass (0 fail)
- [x] New smoke tests cover all 5 error paths + happy path
- [x] Lint clean (`bunx biome lint .`)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
