### PR TITLE
chore: namespace metrics SESSION_SECRET and seed DATABASE_URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Tests land **with** the code, at the correct layer — same PR, no "add tests la
 Env vars read by Shipwright services are namespaced so each service is portable across any infra:
 
 - **Suite-wide:** `SHIPWRIGHT_<THING>` — e.g. `SHIPWRIGHT_SESSION_SECRET`, `SHIPWRIGHT_ENCRYPTION_KEY`, `SHIPWRIGHT_INTERNAL_API_KEY`.
-- **Per-subservice:** `SHIPWRIGHT_<SUBSERVICE>_<THING>` — e.g. `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, `SHIPWRIGHT_ADMIN_APP_BASE_URL`.
+- **Per-subservice:** `SHIPWRIGHT_<SUBSERVICE>_<THING>` — e.g. `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, `SHIPWRIGHT_ADMIN_APP_BASE_URL`, `SHIPWRIGHT_METRICS_SESSION_SECRET`.
 - **DB connection strings:** `DATABASE_URL_SHIPWRIGHT_<SUBSERVICE>` — never bare `DATABASE_URL` (collides with the host's own DB var).
 - **Universally-meaningful third-party vars** keep conventional names: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `PORT`.
 - **Secret manager IDs** map 1:1 to env var names: lowercase-kebab ↔ uppercase-snake (e.g. `shipwright-admin-allowed-emails` ↔ `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`).

--- a/admin/README.md
+++ b/admin/README.md
@@ -11,7 +11,7 @@ The HTTP server is implemented in `admin/src/main.ts`, which composes the admin 
 bun install
 
 # Export required env vars (see Environment Variables table below)
-export DATABASE_URL=postgresql://...
+export DATABASE_URL_SHIPWRIGHT_ADMIN=postgresql://...
 export SHIPWRIGHT_SESSION_SECRET=...
 # ... (remaining vars)
 
@@ -25,12 +25,12 @@ The service listens on `http://localhost:3000` by default. Visit `/admin` for th
 
 | Variable | Required | Description |
 |---|---|---|
-| `DATABASE_URL` | Yes | PostgreSQL connection string for the admin Prisma schema |
+| `DATABASE_URL_SHIPWRIGHT_ADMIN` | Yes | PostgreSQL connection string for the admin Prisma schema |
 | `SHIPWRIGHT_SESSION_SECRET` | Yes | JWT cookie secret for admin UI sessions |
 | `GOOGLE_CLIENT_ID` | Yes | Google OAuth 2.0 client ID for admin UI login |
 | `GOOGLE_CLIENT_SECRET` | Yes | Google OAuth 2.0 client secret |
-| `ADMIN_ALLOWED_EMAILS` | Yes | Comma-separated list of emails permitted to log in |
-| `APP_BASE_URL` | Yes | Public base URL used for OAuth redirect (defaults to `http://localhost:3000`) |
+| `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` | Yes | Comma-separated list of emails permitted to log in |
+| `SHIPWRIGHT_ADMIN_APP_BASE_URL` | Yes | Public base URL used for OAuth redirect (defaults to `http://localhost:3000`) |
 | `SHIPWRIGHT_INTERNAL_API_KEY` | Yes | Bearer token for the agent runtime API (`/agents/*`) |
 | `SHIPWRIGHT_ENCRYPTION_KEY` | Recommended | 64-char hex key for AES-256-GCM encryption of stored secrets |
 | `PORT` | No | HTTP server port (defaults to `3000`) |
@@ -40,7 +40,7 @@ The service listens on `http://localhost:3000` by default. Visit `/admin` for th
 The admin service uses its own PostgreSQL database. Run migrations before starting:
 
 ```bash
-export DATABASE_URL=postgres://...
+export DATABASE_URL_SHIPWRIGHT_ADMIN=postgres://...
 cd admin && bunx prisma migrate deploy --schema=prisma/schema.prisma
 ```
 
@@ -56,12 +56,12 @@ Run the image:
 
 ```bash
 docker run \
-  -e DATABASE_URL=postgres://... \
+  -e DATABASE_URL_SHIPWRIGHT_ADMIN=postgres://... \
   -e SHIPWRIGHT_SESSION_SECRET=... \
   -e GOOGLE_CLIENT_ID=... \
   -e GOOGLE_CLIENT_SECRET=... \
-  -e ADMIN_ALLOWED_EMAILS=admin@example.com \
-  -e APP_BASE_URL=https://admin.example.com \
+  -e SHIPWRIGHT_ADMIN_ALLOWED_EMAILS=admin@example.com \
+  -e SHIPWRIGHT_ADMIN_APP_BASE_URL=https://admin.example.com \
   -e SHIPWRIGHT_INTERNAL_API_KEY=... \
   -p 3000:3000 \
   shipwright-admin

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -96,7 +96,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `DATABASE_URL_METRICS` | | — | Alias for `METRICS_DATABASE_URL`. Accepted when `METRICS_DATABASE_URL` is absent. |
 | `METRICS_API_PORT` | | `3460` | Listen port. |
 | `METRICS_API_KEYS` | | — | Comma-parsed Bearer API keys for `/metrics/*`. |
-| `SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
+| `SHIPWRIGHT_METRICS_SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
 | `METRICS_REQUIRE_OWNER_ROLE` | | `false` | When `true`, gate dashboard/API on `OWNER` role via the accounts client. |
 | `METRICS_ACCOUNTS_URL` | | `http://localhost:3457` | Accounts service base URL (role lookups). |
 | `METRICS_INTERNAL_API_KEY` | | — | Internal key for the accounts client. |

--- a/metrics/e2e/test-server.ts
+++ b/metrics/e2e/test-server.ts
@@ -10,7 +10,7 @@ import { makeAccountsClientMock } from "../src/lib/test-doubles.ts";
 const port = Number.parseInt(process.env.METRICS_E2E_PORT ?? "3461", 10);
 const apiKeys = parseApiKeys("e2e:sk_e2e_test_key:*");
 const sessionSecret =
-  process.env.SESSION_SECRET ?? "e2e-test-session-secret-32b";
+  process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "e2e-test-session-secret-32b";
 const noopAccountsClient = makeAccountsClientMock(async () => []);
 const app = createMetricsApp(apiKeys, noopAccountsClient, { sessionSecret });
 

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -915,7 +915,7 @@ export function createMetricsApp(
       projectId: process.env.POSTHOG_PROJECT_ID ?? "",
     });
 
-  const sessionSecret = deps?.sessionSecret ?? process.env.SESSION_SECRET ?? "";
+  const sessionSecret = deps?.sessionSecret ?? process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "";
   const requireOwnerRole = deps?.requireOwnerRole ?? false;
   const dashboardToken = deps?.dashboardToken;
   const offlineMode = deps?.offlineMode ?? false;

--- a/metrics/src/lib/session-middleware.ts
+++ b/metrics/src/lib/session-middleware.ts
@@ -3,7 +3,7 @@
  * Shared Hono middleware factory for session cookie verification.
  *
  * Usage:
- *   app.use('*', createSessionMiddleware(process.env.SESSION_SECRET ?? ''))
+ *   app.use('*', createSessionMiddleware(process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? ''))
  *
  * On success: sets c.get('session') with { userId, email, name } and calls next().
  * On Bearer token present: calls next() without setting session (API calls bypass
@@ -11,7 +11,7 @@
  * On missing/invalid session: redirects to /auth/login?returnTo=<encoded-path>.
  * On missing secret: returns 500 Internal Server Error (not a redirect).
  *
- * The session cookie is "vitals_session" — a HS256 JWT signed with SESSION_SECRET
+ * The session cookie is "vitals_session" — a HS256 JWT signed with SHIPWRIGHT_METRICS_SESSION_SECRET
  * containing { userId, email, name, iat, exp }.
  */
 
@@ -35,7 +35,7 @@ export type SessionEnv = { Variables: { session: SessionPayload } };
 /**
  * Creates a Hono middleware that reads and verifies the vitals_session cookie.
  *
- * @param secret - The JWT signing secret (SESSION_SECRET). Pass empty string to
+ * @param secret - The JWT signing secret (SHIPWRIGHT_METRICS_SESSION_SECRET). Pass empty string to
  *                 trigger a 500 response (guards against missing env var at call site).
  */
 export function createSessionMiddleware(secret: string) {
@@ -50,7 +50,7 @@ export function createSessionMiddleware(secret: string) {
 
     // Missing secret is a server misconfiguration — return 500, not a login redirect
     if (!secret) {
-      console.error("[session-middleware] SESSION_SECRET is not set");
+      console.error("[session-middleware] SHIPWRIGHT_METRICS_SESSION_SECRET is not set");
       return c.text("Internal Server Error", 500);
     }
 

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -81,7 +81,7 @@ if (mode === "fixtures") {
   deps = {
     provider: pgStore.provider,
     localStore: localStoreShim,
-    sessionSecret: process.env.SESSION_SECRET ?? "",
+    sessionSecret: process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
   };
@@ -95,7 +95,7 @@ if (mode === "fixtures") {
   deps = {
     provider: new SqliteProvider(store),
     localStore: store,
-    sessionSecret: process.env.SESSION_SECRET ?? "",
+    sessionSecret: process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
   };
@@ -104,7 +104,7 @@ if (mode === "fixtures") {
   );
 } else {
   deps = {
-    sessionSecret: process.env.SESSION_SECRET ?? "",
+    sessionSecret: process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
   };

--- a/scripts/seed-dev-agent.ts
+++ b/scripts/seed-dev-agent.ts
@@ -226,12 +226,12 @@ if (import.meta.main) {
       if (argv[i]?.startsWith("--db-url="))
         return argv[i].slice("--db-url=".length);
     }
-    return process.env.DATABASE_URL;
+    return process.env.DATABASE_URL_SHIPWRIGHT_ADMIN;
   })();
 
   if (!dbUrl) {
     console.error(
-      "Error: DATABASE_URL is not set. Pass --db-url <url> or set the DATABASE_URL env var.",
+      "Error: DATABASE_URL_SHIPWRIGHT_ADMIN is not set. Pass --db-url <url> or set the DATABASE_URL_SHIPWRIGHT_ADMIN env var.",
     );
     process.exit(1);
   }


### PR DESCRIPTION
Completes the namespacing sweep started in #206. Stacks on top of that branch — base is `feat/namespace-admin-env`.

## Changes

**`metrics/src/server.ts`** — `SESSION_SECRET` → `SHIPWRIGHT_METRICS_SESSION_SECRET` (3 reads, one per provider mode branch)

**`metrics/src/api.ts`** — `SESSION_SECRET` → `SHIPWRIGHT_METRICS_SESSION_SECRET` (fallback read in `createMetricsApp`)

**`metrics/src/lib/session-middleware.ts`** — update docstring usage example, cookie description comment, `@param` comment, and the `console.error` log string

**`metrics/e2e/test-server.ts`** — `SESSION_SECRET` → `SHIPWRIGHT_METRICS_SESSION_SECRET`

**`scripts/seed-dev-agent.ts`** — `DATABASE_URL` → `DATABASE_URL_SHIPWRIGHT_ADMIN` (env fallback + error message)

**`admin/README.md`** — update env table, local dev `export` example, database migration example, and `docker run -e` flags

**`docs/metrics.md`** — update environment table row

**`CLAUDE.md`** — add `SHIPWRIGHT_METRICS_SESSION_SECRET` to the per-subservice examples in the namespacing convention section

## No `.env.example` files exist

The repo uses inline docs (README + CLAUDE.md) as the canonical reference — no example env files to update.

## Test plan

- [ ] `bunx biome lint` on changed source files — clean
- [ ] `bun test --filter metrics` passes (no env reads in test code changed — tests inject `sessionSecret` directly)
- [ ] `task stack` starts the metrics service cleanly when `SHIPWRIGHT_METRICS_SESSION_SECRET` is exported
- [ ] Admin service starts when `DATABASE_URL_SHIPWRIGHT_ADMIN` and `SHIPWRIGHT_ADMIN_*` vars are exported (covered by #206)

🤖 Generated with [Claude Code](https://claude.com/claude-code)