### PR TITLE
chore: rename DATABASE_URL_AGENT_TEST → DATABASE_URL_ADMIN_TEST

### DIFF
--- a/admin/src/admin-api.integration.test.ts
+++ b/admin/src/admin-api.integration.test.ts
@@ -2,7 +2,7 @@
  * agent/src/admin-api.integration.test.ts
  * Integration tests for the admin CRUD API against a real SQLite DB.
  *
- * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise.
  *
  * Key assertions:
  * - POST /admin/api/agents/:id/envs encrypts values at rest
@@ -22,7 +22,7 @@ import { AgentTokenService } from "./agent-tokens.ts";
 import { AgentToolService } from "./agent-tools.ts";
 import { makeTokenCrypto } from "./token-crypto.ts";
 
-const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
 const describeOrSkip = TEST_DB ? describe : describe.skip;
 
 const SESSION_SECRET = "test-admin-session-secret-32-bytes!";

--- a/admin/src/agent-cron-jobs.integration.test.ts
+++ b/admin/src/agent-cron-jobs.integration.test.ts
@@ -2,7 +2,7 @@
  * agent/src/agent-cron-jobs.integration.test.ts
  * Integration tests for AgentCronJobService against a real SQLite DB.
  *
- * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise.
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
@@ -10,7 +10,7 @@ import { PrismaClient } from "../prisma/client/index.js";
 import { AgentCronJobService } from "./agent-cron-jobs.ts";
 import { NotFoundError, UnprocessableEntityError } from "./errors.ts";
 
-const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
 
 const describeOrSkip = TEST_DB ? describe : describe.skip;
 

--- a/admin/src/agent-envs.integration.test.ts
+++ b/admin/src/agent-envs.integration.test.ts
@@ -2,7 +2,7 @@
  * agent/src/agent-envs.integration.test.ts
  * Integration tests for AgentEnvService against a real SQLite DB.
  *
- * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise.
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
@@ -11,7 +11,7 @@ import { AgentEnvService } from "./agent-envs.ts";
 import { UnprocessableEntityError } from "./errors.ts";
 import { identityCrypto } from "./token-crypto.ts";
 
-const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
 
 const describeOrSkip = TEST_DB ? describe : describe.skip;
 

--- a/admin/src/agent-tokens.integration.test.ts
+++ b/admin/src/agent-tokens.integration.test.ts
@@ -2,7 +2,7 @@
  * agent/src/agent-tokens.integration.test.ts
  * Integration tests for AgentTokenService against a real SQLite DB.
  *
- * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise.
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
@@ -10,7 +10,7 @@ import { PrismaClient } from "../prisma/client/index.js";
 import { AgentTokenService } from "./agent-tokens.ts";
 import { UnprocessableEntityError } from "./errors.ts";
 
-const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
 
 const describeOrSkip = TEST_DB ? describe : describe.skip;
 

--- a/admin/src/agent-tools.integration.test.ts
+++ b/admin/src/agent-tools.integration.test.ts
@@ -2,7 +2,7 @@
  * agent/src/agent-tools.integration.test.ts
  * Integration tests for AgentToolService against a real SQLite DB.
  *
- * Requires DATABASE_URL_AGENT_TEST to be set; skips otherwise.
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise.
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
@@ -10,7 +10,7 @@ import { PrismaClient } from "../prisma/client/index.js";
 import { AgentToolService } from "./agent-tools.ts";
 import { NotFoundError } from "./errors.ts";
 
-const TEST_DB = process.env.DATABASE_URL_AGENT_TEST;
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
 
 const describeOrSkip = TEST_DB ? describe : describe.skip;
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -148,7 +148,7 @@ All child models cascade-delete with their `Agent`.
 
 ## Testing
 
-Unit + integration + smoke layers (`bun test --filter agent`). DB integration tests run against a real Postgres database (set via `DATABASE_URL_AGENT_TEST`), provisioning the schema via `prisma migrate deploy` per suite — **no Prisma mocking**. Smoke tests drive the Hono apps via `app.request()`. See [testing.md](./testing.md).
+Unit + integration + smoke layers (`bun test --filter agent`). DB integration tests run against a real Postgres database (set via `DATABASE_URL_ADMIN_TEST`), provisioning the schema via `prisma migrate deploy` per suite — **no Prisma mocking**. Smoke tests drive the Hono apps via `app.request()`. See [testing.md](./testing.md).
 
 ## See also
 

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -77,10 +77,10 @@ The agent is a thin runner with a Prisma-backed SQLite/PostgreSQL database and a
 
 **Notes:**
 - Integration tests inject `RecordedGithubClient` for issue/PR operations and a `RecordedMetricsClient` for forwarding calls.
-- **DB integration tests** (added in SHE-1.2) run against a real SQLite database (`DATABASE_URL_AGENT="file:./test.db"`). Each test suite provisions the schema via `prisma migrate deploy` and tears down after. No Prisma mocking — service classes own all DB queries.
+- **DB integration tests** (added in SHE-1.2) run against a real Postgres database (`DATABASE_URL_ADMIN_TEST="postgresql://user:password@localhost:5432/shipwright_admin_test"`). Each test suite provisions the schema via `prisma migrate deploy` and tears down after. No Prisma mocking — service classes own all DB queries.
 - **Smoke tests** drive the Hono app via `app.request()` — no real socket, no port allocation. Import the app factory and call `app.request(new Request(...))` directly. Covers health endpoints, agent CRUD routes, and auth checks.
 - The agent's execution loop must accept a `Clock` injection for deterministic scheduling tests.
-- `DATABASE_URL_AGENT` must be set to a scratch file path (e.g. `file:./test.db`) for all integration/smoke tests to stay offline and isolated from any production DB.
+- `DATABASE_URL_ADMIN_TEST` must be set to a Postgres connection string (e.g. `postgresql://user:password@localhost:5432/shipwright_admin_test`) for DB integration tests to run; suites skip automatically when the var is absent.
 
 ## Full suite commands
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,7 +68,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 - **Time:** any production code path that calls `new Date()` / `Date.now()` non-trivially must accept a `Clock` interface; tests inject `FixedClock(t)`. Raw `Date.now()` in code under test is a bug.
 - **External HTTP:** service clients (`PostHogClient`, `GithubClient`, …) are interfaces with an `Http*Client` production impl; tests inject `Recorded*Client` doubles replaying cassettes from `tests/fixtures/<service>/*.json` (versioned JSON committed to the repo).
 - **No global state:** **no `mock.module()`**, **no `global.fetch` / `global.*` overrides.** Bun runs test files in the same process, so module-level mocks and global mutation leak across sibling suites. Each test must be independently runnable, order-independent.
-- **Offline by default:** no live external calls. `POSTHOG_PERSONAL_API_KEY` must be absent for metrics unit/integration/smoke tests; `DATABASE_URL_AGENT_TEST` must be set to a Postgres connection string for agent DB integration tests (suites skip automatically when the var is absent).
+- **Offline by default:** no live external calls. `POSTHOG_PERSONAL_API_KEY` must be absent for metrics unit/integration/smoke tests; `DATABASE_URL_ADMIN_TEST` must be set to a Postgres connection string for agent DB integration tests (suites skip automatically when the var is absent).
 
 ## CI gates
 


### PR DESCRIPTION
## Summary

- The agent DB no longer exists as a separate module — it was consolidated into `admin`
- `DATABASE_URL_AGENT_TEST` was a misnomer; renamed to `DATABASE_URL_ADMIN_TEST` to match where the tests live
- Updated 5 integration test files + 2 doc files

## Test plan

- [ ] Confirm CI passes (tests skip gracefully when var is absent, same as before)
- [ ] Update `DATABASE_URL_AGENT_TEST` → `DATABASE_URL_ADMIN_TEST` in any CI secrets / local `.env` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)