### PR TITLE
fix: use SHIPWRIGHT_SESSION_SECRET (suite-wide) for metrics session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Tests land **with** the code, at the correct layer — same PR, no "add tests la
 Env vars read by Shipwright services are namespaced so each service is portable across any infra:
 
 - **Suite-wide:** `SHIPWRIGHT_<THING>` — e.g. `SHIPWRIGHT_SESSION_SECRET`, `SHIPWRIGHT_ENCRYPTION_KEY`, `SHIPWRIGHT_INTERNAL_API_KEY`.
-- **Per-subservice:** `SHIPWRIGHT_<SUBSERVICE>_<THING>` — e.g. `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, `SHIPWRIGHT_ADMIN_APP_BASE_URL`, `SHIPWRIGHT_METRICS_SESSION_SECRET`.
+- **Per-subservice:** `SHIPWRIGHT_<SUBSERVICE>_<THING>` — e.g. `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, `SHIPWRIGHT_ADMIN_APP_BASE_URL`.
 - **DB connection strings:** `DATABASE_URL_SHIPWRIGHT_<SUBSERVICE>` — never bare `DATABASE_URL` (collides with the host's own DB var).
 - **Universally-meaningful third-party vars** keep conventional names: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `PORT`.
 - **Secret manager IDs** map 1:1 to env var names: lowercase-kebab ↔ uppercase-snake (e.g. `shipwright-admin-allowed-emails` ↔ `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -96,7 +96,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `DATABASE_URL_METRICS` | | — | Alias for `METRICS_DATABASE_URL`. Accepted when `METRICS_DATABASE_URL` is absent. |
 | `METRICS_API_PORT` | | `3460` | Listen port. |
 | `METRICS_API_KEYS` | | — | Comma-parsed Bearer API keys for `/metrics/*`. |
-| `SHIPWRIGHT_METRICS_SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
+| `SHIPWRIGHT_SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
 | `METRICS_REQUIRE_OWNER_ROLE` | | `false` | When `true`, gate dashboard/API on `OWNER` role via the accounts client. |
 | `METRICS_ACCOUNTS_URL` | | `http://localhost:3457` | Accounts service base URL (role lookups). |
 | `METRICS_INTERNAL_API_KEY` | | — | Internal key for the accounts client. |

--- a/metrics/e2e/test-server.ts
+++ b/metrics/e2e/test-server.ts
@@ -10,7 +10,7 @@ import { makeAccountsClientMock } from "../src/lib/test-doubles.ts";
 const port = Number.parseInt(process.env.METRICS_E2E_PORT ?? "3461", 10);
 const apiKeys = parseApiKeys("e2e:sk_e2e_test_key:*");
 const sessionSecret =
-  process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "e2e-test-session-secret-32b";
+  process.env.SHIPWRIGHT_SESSION_SECRET ?? "e2e-test-session-secret-32b";
 const noopAccountsClient = makeAccountsClientMock(async () => []);
 const app = createMetricsApp(apiKeys, noopAccountsClient, { sessionSecret });
 

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -915,7 +915,7 @@ export function createMetricsApp(
       projectId: process.env.POSTHOG_PROJECT_ID ?? "",
     });
 
-  const sessionSecret = deps?.sessionSecret ?? process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "";
+  const sessionSecret = deps?.sessionSecret ?? process.env.SHIPWRIGHT_SESSION_SECRET ?? "";
   const requireOwnerRole = deps?.requireOwnerRole ?? false;
   const dashboardToken = deps?.dashboardToken;
   const offlineMode = deps?.offlineMode ?? false;

--- a/metrics/src/lib/session-middleware.ts
+++ b/metrics/src/lib/session-middleware.ts
@@ -3,7 +3,7 @@
  * Shared Hono middleware factory for session cookie verification.
  *
  * Usage:
- *   app.use('*', createSessionMiddleware(process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? ''))
+ *   app.use('*', createSessionMiddleware(process.env.SHIPWRIGHT_SESSION_SECRET ?? ''))
  *
  * On success: sets c.get('session') with { userId, email, name } and calls next().
  * On Bearer token present: calls next() without setting session (API calls bypass
@@ -11,7 +11,7 @@
  * On missing/invalid session: redirects to /auth/login?returnTo=<encoded-path>.
  * On missing secret: returns 500 Internal Server Error (not a redirect).
  *
- * The session cookie is "vitals_session" — a HS256 JWT signed with SHIPWRIGHT_METRICS_SESSION_SECRET
+ * The session cookie is "vitals_session" — a HS256 JWT signed with SHIPWRIGHT_SESSION_SECRET
  * containing { userId, email, name, iat, exp }.
  */
 
@@ -35,7 +35,7 @@ export type SessionEnv = { Variables: { session: SessionPayload } };
 /**
  * Creates a Hono middleware that reads and verifies the vitals_session cookie.
  *
- * @param secret - The JWT signing secret (SHIPWRIGHT_METRICS_SESSION_SECRET). Pass empty string to
+ * @param secret - The JWT signing secret (SHIPWRIGHT_SESSION_SECRET). Pass empty string to
  *                 trigger a 500 response (guards against missing env var at call site).
  */
 export function createSessionMiddleware(secret: string) {
@@ -50,7 +50,7 @@ export function createSessionMiddleware(secret: string) {
 
     // Missing secret is a server misconfiguration — return 500, not a login redirect
     if (!secret) {
-      console.error("[session-middleware] SHIPWRIGHT_METRICS_SESSION_SECRET is not set");
+      console.error("[session-middleware] SHIPWRIGHT_SESSION_SECRET is not set");
       return c.text("Internal Server Error", 500);
     }
 

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -81,7 +81,7 @@ if (mode === "fixtures") {
   deps = {
     provider: pgStore.provider,
     localStore: localStoreShim,
-    sessionSecret: process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "",
+    sessionSecret: process.env.SHIPWRIGHT_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
   };
@@ -95,7 +95,7 @@ if (mode === "fixtures") {
   deps = {
     provider: new SqliteProvider(store),
     localStore: store,
-    sessionSecret: process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "",
+    sessionSecret: process.env.SHIPWRIGHT_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
   };
@@ -104,7 +104,7 @@ if (mode === "fixtures") {
   );
 } else {
   deps = {
-    sessionSecret: process.env.SHIPWRIGHT_METRICS_SESSION_SECRET ?? "",
+    sessionSecret: process.env.SHIPWRIGHT_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
   };


### PR DESCRIPTION
`SESSION_SECRET` was renamed to `SHIPWRIGHT_METRICS_SESSION_SECRET` in the env-namespacing sweep (#206 / #207), but per the established convention `SHIPWRIGHT_SESSION_SECRET` is the suite-wide name shared across services — not a per-subservice var.

## Changes

Renames `SHIPWRIGHT_METRICS_SESSION_SECRET` → `SHIPWRIGHT_SESSION_SECRET` in:

- `metrics/src/server.ts` (3 reads, one per provider mode branch)
- `metrics/src/api.ts` (fallback read in `createMetricsApp`)
- `metrics/src/lib/session-middleware.ts` (docstring usage example, cookie description comment, `@param`, and `console.error` log string)
- `metrics/e2e/test-server.ts` (env fallback for the pinned test secret)
- `docs/metrics.md` (environment table)
- `CLAUDE.md` (removes `SHIPWRIGHT_METRICS_SESSION_SECRET` from per-subservice examples — it belongs under suite-wide)

## Test plan

- [ ] `bunx biome lint` on changed files — clean
- [ ] `bun test --filter metrics` — session secret is injected directly in test code, no env reads in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)