### PR TITLE
feat: add metrics Dockerfile and build-push workflow

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -1,0 +1,46 @@
+name: Build and Push Metrics Image
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-and-push:
+    name: build / tag / push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: "metrics-v"
+          default_bump: patch
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f metrics/Dockerfile \
+            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-metrics:${{ steps.tag.outputs.new_tag }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-metrics:${{ steps.tag.outputs.new_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,15 @@ jobs:
       - name: Build agent Docker image
         run: docker build -f agent/Dockerfile -t shipwright-agent:ci .
 
+  metrics-docker-build:
+    name: metrics docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build metrics Docker image
+        run: docker build -f metrics/Dockerfile -t shipwright-metrics:ci .
+
   e2e:
     name: e2e (metrics dashboard)
     runs-on: ubuntu-latest

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,19 +1,23 @@
-# Shipwright Admin Service — container image
+# Shipwright Metrics Dashboard — container image
 #
 # Build from repo root:
-#   docker build -f admin/Dockerfile -t shipwright-admin .
+#   docker build -f metrics/Dockerfile -t shipwright-metrics .
 #
-# Run:
+# Run (PostHog mode):
 #   docker run \
-#     -e DATABASE_URL_SHIPWRIGHT_ADMIN=postgres://... \
+#     -e POSTHOG_PERSONAL_API_KEY=phx_... \
+#     -e POSTHOG_PROJECT_ID=<project-id> \
 #     -e SHIPWRIGHT_SESSION_SECRET=... \
-#     -e GOOGLE_CLIENT_ID=... \
-#     -e GOOGLE_CLIENT_SECRET=... \
-#     -e SHIPWRIGHT_ADMIN_ALLOWED_EMAILS=admin@example.com \
-#     -e SHIPWRIGHT_ADMIN_APP_BASE_URL=https://admin.example.com \
-#     -e SHIPWRIGHT_INTERNAL_API_KEY=... \
-#     -p 3000:3000 \
-#     shipwright-admin
+#     -p 3460:3460 \
+#     shipwright-metrics
+#
+# Optional env vars:
+#   METRICS_API_PORT           — listen port (default: 3460)
+#   METRICS_API_KEYS           — Bearer API keys for /metrics/* endpoints
+#   METRICS_REQUIRE_OWNER_ROLE — gate dashboard on OWNER role (default: false)
+#   METRICS_ACCOUNTS_URL       — accounts service base URL (default: http://localhost:3457)
+#   METRICS_INTERNAL_API_KEY   — internal key for accounts client
+#   SHIPWRIGHT_ENV_FILE        — dotenv file loaded at startup (default: ~/.shipwright/.env)
 
 # ─── Stage 1: dependencies ────────────────────────────────────────────────────
 FROM oven/bun:1-slim AS deps
@@ -22,10 +26,10 @@ WORKDIR /app
 
 # Copy workspace manifests for dependency install
 COPY package.json bun.lock ./
+COPY metrics/package.json ./metrics/
 COPY admin/package.json ./admin/
 COPY admin/prisma ./admin/prisma/
 COPY agent/package.json ./agent/
-COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 
 RUN bun install --frozen-lockfile
@@ -33,7 +37,7 @@ RUN bun install --frozen-lockfile
 # ─── Stage 2: production image ────────────────────────────────────────────────
 FROM oven/bun:1-slim AS production
 
-# Install system dependencies (ca-certificates only — no Claude Code, no gh CLI, no mise)
+# Install system dependencies (ca-certificates only — stateless service, no toolchain needed)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -46,9 +50,6 @@ COPY --from=deps /app/node_modules ./node_modules
 # Copy entire monorepo source
 COPY . .
 
-# Generate Prisma client
-RUN cd admin && bunx prisma generate --schema=prisma/schema.prisma
+EXPOSE 3460
 
-EXPOSE 3000
-
-ENTRYPOINT ["bun", "run", "admin/src/main.ts"]
+ENTRYPOINT ["bun", "run", "metrics/src/server.ts"]


### PR DESCRIPTION
Adds the missing container build for the metrics dashboard — needed to deploy it as a persistent service to replace the Vitals OS metrics dashboard.

## What's in this PR

**`metrics/Dockerfile`** — two-stage build matching the admin pattern:
- Stage 1 (`deps`): installs all workspace deps with frozen lockfile
- Stage 2 (`production`): `ca-certificates` only — stateless service, no Prisma/Claude Code/mise needed
- Exposes `:3460`, entrypoint `bun run metrics/src/server.ts`

**`.github/workflows/build-metrics.yml`** — mirrors `build-admin.yml` exactly:
- Triggers on merge to `main`
- Bumps `metrics-v*` tag via `mathieudutour/github-tag-action`
- Authenticates to GCP via workload identity, builds and pushes `shipwright-metrics` to Artifact Registry
- Same secrets: `WIF_PROVIDER`, `GCP_SA_EMAIL`, `ARTIFACT_REGISTRY_HOST`, `ARTIFACT_REGISTRY_REPO`

**`.github/workflows/ci.yml`** — adds `metrics-docker-build` job alongside the existing `admin-docker-build` and `agent-docker-build` CI sanity checks

**`admin/Dockerfile`** — fixes stale env var names in the comment header (missed in the namespacing sweep):
- `DATABASE_URL` → `DATABASE_URL_SHIPWRIGHT_ADMIN`
- `ADMIN_ALLOWED_EMAILS` → `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`
- `APP_BASE_URL` → `SHIPWRIGHT_ADMIN_APP_BASE_URL`

## Runtime env vars

Required for PostHog mode (the deployment target):
```
POSTHOG_PERSONAL_API_KEY
POSTHOG_PROJECT_ID
SHIPWRIGHT_SESSION_SECRET
```

Optional:
```
METRICS_API_PORT          (default: 3460)
METRICS_API_KEYS
METRICS_REQUIRE_OWNER_ROLE
METRICS_ACCOUNTS_URL
METRICS_INTERNAL_API_KEY
SHIPWRIGHT_ENV_FILE
```

## Test plan

- [ ] `metrics-docker-build` CI job passes on this PR
- [ ] `build-metrics.yml` pushes a `metrics-v*` image to Artifact Registry on merge
- [ ] Container starts and serves `/health` → `{ status: "ok" }`
- [ ] `/dashboard` loads with valid PostHog credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)