### PR TITLE
feat(docs): local secrets file and task stack quickstart (LPP-3.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,11 @@ CLAUDE.local.md
 planning/
 
 # --- Local JSON task-store state (only written if the github backend isn't active) ---
-state/
+state/*
 # Allow workspace templates that live under agent/workspace/state/
 !agent/workspace/state/
-
-# --- Dev agent credentials (never commit) ---
-state/dev-agent.env
+# Allow the committed example file for dev-agent credentials
+!state/dev-agent.env.example
 
 # --- Database files (local dev only — never commit) ---
 *.db

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ A thin autonomous runner with a Prisma-backed store (PostgreSQL) and four HTTP s
 |---|---|---|
 | Marketing site | `site/` | Astro + Tailwind (**shipwright-harness.com**). **Not** a Bun workspace; Playwright smoke tests (`*.spec.ts`). |
 | Brand system | `brand/` | Locked design system (`BRAND.md`, `tokens.json`) + CSS build + lint, consumed by `site/`. |
-| Local state | `state/` | Git-ignored JSON task-store fallback + cached review state (only written when the GitHub backend isn't active). |
+| Local state | `state/` | Mostly git-ignored: JSON task-store fallback + cached review state (only written when the GitHub backend isn't active). `state/dev-agent.env.example` is committed as a credentials template; the actual `state/dev-agent.env` is git-ignored. |
 
 ## Workspace layout
 
@@ -57,7 +57,7 @@ shipwright/
 ├── admin/                C — Admin service: CRUD API, admin UI, Prisma store (@shipwright/admin)
 ├── site/                 marketing site (Astro, separate toolchain)
 ├── brand/                locked design system
-├── state/                local task-store / review-cache fallback
+├── state/                local task-store / review-cache fallback (dev-agent.env.example committed; dev-agent.env git-ignored)
 ├── docs/                 this documentation
 └── Taskfile.yml          single local entrypoint (task setup / ci / test / …)
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,3 +76,105 @@ The two networked / interactive steps of the prompt are **not** part of the scri
 - The `/plugin install shipwright@app-vitals/shipwright` step — it runs inside an interactive Claude Code session, not a shell.
 
 Both are documented in the prompt above; only the deterministic shell portion is scripted and tested.
+
+---
+
+## Full dev stack (`task stack`)
+
+This section gets you from a fresh clone to a **working chat turn** against the local Shipwright agent. The full stack runs the metrics dashboard, admin service, agent (in Docker), and a chat REPL — all in one tmux session.
+
+### Prerequisites
+
+| Tool | Why | Install |
+|---|---|---|
+| **tmux** | 5-pane session manager — `task stack` fails fast without it. | `brew install tmux` / `apt install tmux` |
+| **Docker** | Runs the Shipwright agent container. | <https://docs.docker.com/get-docker/> |
+| **Postgres** | Admin service database. The stack launcher detects if it is missing and offers to install it. | `brew install postgresql@16` or see the prompt on first `task stack` run. |
+| **Bun** | Runtime + package manager. | <https://bun.sh> |
+| **go-task** (`task`) | Single local entrypoint. | <https://taskfile.dev/installation/> |
+| **Claude Code** | Provides the OAuth token used by the agent. | <https://www.anthropic.com/claude-code> |
+
+### Step 1 — Clone and install dependencies
+
+```bash
+git clone https://github.com/app-vitals/shipwright.git
+cd shipwright
+task setup
+```
+
+`task setup` runs `bun install` across all workspaces. It is idempotent — safe to re-run.
+
+### Step 2 — Create your credentials file
+
+```bash
+cp state/dev-agent.env.example state/dev-agent.env
+```
+
+`state/dev-agent.env` is git-ignored and never committed. `state/dev-agent.env.example` (committed) documents every variable.
+
+### Step 3 — Fill in `CLAUDE_CODE_OAUTH_TOKEN`
+
+Open `state/dev-agent.env` in an editor. The only **required** value is `CLAUDE_CODE_OAUTH_TOKEN`.
+
+Get it from a Claude Code session:
+
+```bash
+cat ~/.claude/.credentials.json
+# copy the value of "accessToken"
+```
+
+Paste it into `state/dev-agent.env`:
+
+```
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oaut01-...
+```
+
+`GH_TOKEN` is optional — add it if you want the agent to open PRs or push branches.
+
+### Step 4 — Launch the stack
+
+```bash
+task stack
+```
+
+This command:
+
+1. Checks that tmux is installed.
+2. Verifies Postgres is reachable — if not, it prints the exact `brew` commands and asks `[y/N]` before running them.
+3. Runs `prisma migrate deploy` (idempotent) so the admin schema is up to date.
+4. Runs `scripts/seed-dev-agent.ts` — upserts a `dev-agent` record in the admin DB with your `CLAUDE_CODE_OAUTH_TOKEN`.
+5. Builds the `shipwright-agent-dev` Docker image.
+6. Attaches you to a tmux session named `shipwright` with five panes:
+
+| Pane | Service | URL |
+|---|---|---|
+| metrics | Metrics dashboard (offline SQLite) | `http://localhost:3460/dashboard` |
+| admin | Admin CRUD API + UI | `http://localhost:3001` |
+| agent | Shipwright agent (Docker) | `http://localhost:3000` |
+| chat | Chat REPL (`scripts/chat.ts`) | _(terminal TUI)_ |
+| logs | Scratch shell | _(ad-hoc commands)_ |
+
+The admin dev-login page opens automatically in your browser: `http://localhost:3001/admin/dev-login`.
+
+### Step 5 — Send a chat turn
+
+The `chat` pane is focused on attach. Type a message and press Enter to get a response from the local agent. A successful reply confirms the full stack is working.
+
+### Teardown
+
+```bash
+tmux kill-session -t shipwright
+```
+
+This stops all five panes. Re-run `task stack` to start a fresh session.
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `tmux is not installed` | `brew install tmux` / `apt install tmux`, then re-run `task stack`. |
+| `session 'shipwright' already running` | Run `tmux kill-session -t shipwright`, then `task stack` again. |
+| `state/dev-agent.env not found` | Run `cp state/dev-agent.env.example state/dev-agent.env` and fill in `CLAUDE_CODE_OAUTH_TOKEN`. |
+| `CLAUDE_CODE_OAUTH_TOKEN is missing` | Open `state/dev-agent.env` and add the token (see Step 3). |
+| Docker build fails | Ensure Docker Desktop is running: `docker info`. |
+| Postgres unreachable | Follow the `[y/N]` prompt on `task stack`, or run `brew services start postgresql@16` manually. |

--- a/scripts/dev-agent-env.unit.test.ts
+++ b/scripts/dev-agent-env.unit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * scripts/dev-agent-env.unit.test.ts
+ * Unit tests for state/dev-agent.env.example — verifies the committed example
+ * file exists, is parseable, and documents the required keys a developer needs
+ * to fill in before running `task stack`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const EXAMPLE_FILE = resolve(process.cwd(), "state/dev-agent.env.example");
+
+function readExample(): string {
+  return readFileSync(EXAMPLE_FILE, "utf8");
+}
+
+describe("state/dev-agent.env.example — structure", () => {
+  test("the example file exists", () => {
+    expect(() => statSync(EXAMPLE_FILE)).not.toThrow();
+  });
+
+  test("contains CLAUDE_CODE_OAUTH_TOKEN key", () => {
+    expect(readExample()).toMatch(/CLAUDE_CODE_OAUTH_TOKEN\s*=/);
+  });
+
+  test("contains GH_TOKEN key", () => {
+    expect(readExample()).toMatch(/GH_TOKEN\s*=/);
+  });
+
+  test("has a comment explaining CLAUDE_CODE_OAUTH_TOKEN", () => {
+    const content = readExample();
+    // There should be a comment line above or near CLAUDE_CODE_OAUTH_TOKEN
+    expect(content).toMatch(/#.*CLAUDE_CODE_OAUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN.*#/i);
+  });
+
+  test("CLAUDE_CODE_OAUTH_TOKEN value is a placeholder (not a real token)", () => {
+    const content = readExample();
+    // Value should be empty or a recognisable placeholder like <your-token> / YOUR_TOKEN_HERE
+    const match = content.match(/CLAUDE_CODE_OAUTH_TOKEN\s*=\s*(\S*)/);
+    expect(match).not.toBeNull();
+    const value = match?.[1] ?? "";
+    // A real Claude OAuth token starts with sk-ant- and is long — the example
+    // must not accidentally commit a real token.
+    expect(value).not.toMatch(/^sk-ant-/);
+  });
+});

--- a/state/dev-agent.env.example
+++ b/state/dev-agent.env.example
@@ -1,0 +1,34 @@
+# state/dev-agent.env — local dev agent credentials
+#
+# Copy this file to state/dev-agent.env and fill in the values below.
+# state/dev-agent.env is git-ignored and will never be committed.
+#
+#   cp state/dev-agent.env.example state/dev-agent.env
+#
+# Used by: scripts/seed-dev-agent.ts (run automatically by `task stack` as a
+# preflight before the agent Docker container starts).
+
+# ─── Required ─────────────────────────────────────────────────────────────────
+
+# CLAUDE_CODE_OAUTH_TOKEN — the OAuth token Claude Code uses to authenticate
+# the Shipwright agent against the Anthropic API.
+#
+# How to get it:
+#   1. Open a Claude Code session in any terminal.
+#   2. Run:  cat ~/.claude/.credentials.json
+#   3. Copy the value of the "accessToken" field.
+#
+# The token looks like: sk-ant-oaut01-...
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# ─── Optional ─────────────────────────────────────────────────────────────────
+
+# GH_TOKEN — a GitHub personal access token (classic or fine-grained).
+# Required if you want the agent to open pull requests, push branches, or
+# read private repositories via the GitHub API.
+#
+# Minimum scopes (classic PAT): repo, read:user
+# Fine-grained: Contents (read/write), Pull requests (read/write)
+#
+# Generate one at: https://github.com/settings/tokens
+GH_TOKEN=


### PR DESCRIPTION
## Summary

- Adds `state/dev-agent.env.example` (committed) documenting `CLAUDE_CODE_OAUTH_TOKEN` (required) and `GH_TOKEN` (optional) with inline instructions for obtaining each
- Updates `.gitignore` to allow `state/dev-agent.env.example` while keeping the real `state/dev-agent.env` ignored
- Extends `docs/quickstart.md` with a new **Full dev stack (`task stack`)** section: 5 numbered steps from fresh clone to working chat turn, pane map, teardown, and troubleshooting table

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `state/dev-agent.env.example` exists with all required vars documented | ✅ MET |
| 2 | CLAUDE.md or docs/ has a quickstart covering the full flow from fresh clone to working task stack | ✅ MET |
| 3 | A developer following only the docs can reach a working chat turn without prior context | ✅ MET |

## Test Plan

- [x] 5 unit tests in `scripts/dev-agent-env.unit.test.ts` verify the example file exists, contains required keys, has comments, and has no real token value
- [x] `bun test` passes — 5/5
- [x] `bunx biome lint .` clean — 265 files checked, no fixes applied
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
