### PR TITLE
feat(docs): local secrets file and task stack quickstart (LPP-3.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,12 @@ CLAUDE.local.md
 planning/
 
 # --- Local JSON task-store state (only written if the github backend isn't active) ---
-state/
+# Use state/* (not state/) so per-file negations below can take effect.
+state/*
 # Allow workspace templates that live under agent/workspace/state/
 !agent/workspace/state/
+# Allow the dev-agent env example (the actual env file stays ignored)
+!state/dev-agent.env.example
 
 # --- Dev agent credentials (never commit) ---
 state/dev-agent.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,12 @@ Run the metrics service locally:
 task api        # start metrics dashboard in offline mode → http://localhost:3460/dashboard
 task ui         # same as task api (API and UI are one process)
 task dev        # dev supervisor: starts metrics + Ctrl-C kills all children
-task stack      # full dev stack in a tmux session (5 panes) — requires tmux
+task stack      # full dev stack in a tmux session (5 panes) — requires tmux + Docker + state/dev-agent.env
 ```
 
-`task stack` (`scripts/dev-tmux.ts`) launches one tmux session named `shipwright` with a 5-pane dashboard: **metrics** (offline SQLite, :3460), **admin** (CRUD API + UI, :3001), **agent** with the dev `/chat` endpoint enabled (:3000), the **chat** REPL, and a scratch **logs** shell. It runs a Prisma `migrate deploy` preflight before the admin pane so the admin service's Postgres schema is up to date; the preflight first checks Postgres is reachable and, on macOS, prints the exact `brew`/`createdb` commands and offers to run them (`[y/N]`) before launching. Closing the session (`tmux kill-session -t shipwright`) stops every pane. `task stack` is additive — it does not touch `task dev`, which stays the no-tmux fallback the quickstart depends on; if tmux isn't installed, `task stack` fails fast and points you at `task dev`. The command/pane-env sequence is built by a pure, injected-exec builder (mirrors `scripts/dev.ts`) and unit-tested in `scripts/dev-tmux.unit.test.ts`.
+**`task stack` requires `state/dev-agent.env`** — copy `state/dev-agent.env.example` and fill in `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) before running. See `docs/quickstart.md` for the full flow.
+
+`task stack` (`scripts/dev-tmux.ts`) launches one tmux session named `shipwright` with a 5-pane dashboard: **metrics** (SQLite, :3460), **admin** (CRUD API + UI, :3001), **agent** in Docker with the dev `/chat` endpoint enabled (:3000), the **chat** REPL, and a scratch **logs** shell. It runs a Prisma `migrate deploy` preflight before the admin pane so the admin service's Postgres schema is up to date; the preflight first checks Postgres is reachable and, on macOS, prints the exact `brew`/`createdb` commands and offers to run them (`[y/N]`) before launching. The agent pane builds the Docker image from `agent/Dockerfile` and runs it with `--env-file state/dev-agent.env` so secrets are injected at runtime without appearing in the command or the image. Closing the session (`tmux kill-session -t shipwright`) stops every pane. `task stack` is additive — it does not touch `task dev`, which stays the no-tmux fallback the quickstart depends on; if tmux isn't installed, `task stack` fails fast and points you at `task dev`. The command/pane-env sequence is built by a pure, injected-exec builder (mirrors `scripts/dev.ts`) and unit-tested in `scripts/dev-tmux.unit.test.ts`.
 
 ## Before you commit — this repository is going public
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,6 +85,8 @@ tmux kill-session -t shipwright
 
 ---
 
+## Option A — Metrics dashboard only (no secrets needed)
+
 ### Prerequisites
 
 | Tool | Why | Install |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,75 @@ The **metrics dashboard** runs locally right now in **offline mode**: it serves 
 
 The plugin (Phase A) and the Shipwright agent (Phase C) are still being built; see the [README](../README.md) and the [`shipwright-oss` milestone](https://github.com/app-vitals/shipwright/milestones) for live status.
 
+### Prerequisites
+
+| Tool | Why | Install |
+|---|---|---|
+| **Claude Code** | Runs the `/plugin install` step of the prompt. Not needed by `scripts/quickstart.sh`. | <https://www.anthropic.com/claude-code> |
+| **git** | Clone the repo. | <https://git-scm.com/downloads> |
+| **Bun** | Runtime + package manager for all workspaces. | <https://bun.sh> |
+| **go-task** (`task`) | The single local entrypoint (`task setup`, `task dev`). | <https://taskfile.dev/installation/> |
+
+### The one-prompt onboarding
+
+Paste this into a **Claude Code** session pointed at where you want to work. It sequences **two execution contexts** — shell steps run in a terminal, and one step runs *inside* the Claude Code session:
+
+```text
+Set up Shipwright Harness locally and open the metrics dashboard.
+
+1. In a terminal, run:
+     git clone https://github.com/app-vitals/shipwright.git && cd shipwright && ./scripts/quickstart.sh
+   This checks prerequisites, installs dependencies (task setup), and starts the
+   metrics dashboard in offline mode (no accounts or secrets needed). Leave it running.
+
+2. Inside this Claude Code session, install the plugin:
+     /plugin install shipwright@app-vitals/shipwright
+
+3. Open the dashboard in your browser:
+     http://localhost:3460/dashboard
+```
+
+### Which lines run where
+
+| Step | Where it runs | Command |
+|---|---|---|
+| 1. Clone + bootstrap + serve | **Terminal** (shell) | `git clone … && cd shipwright && ./scripts/quickstart.sh` |
+| 2. Install the plugin | **Inside the Claude Code session** | `/plugin install shipwright@app-vitals/shipwright` |
+| 3. Open the dashboard | **Browser** | `http://localhost:3460/dashboard` |
+
+The distinction matters: step 1 is a shell command, step 2 is a slash command that only works **inside** an interactive Claude Code session (it is not a terminal command).
+
+### What `scripts/quickstart.sh` does
+
+Run it from **inside** the cloned repo (the prompt's step 1 clones and `cd`s for you first). It is **idempotent** — safe to re-run:
+
+1. Verifies prerequisites (`git`, `bun`, `task`) and fails with an install pointer if any is missing.
+2. Runs `task setup` (idempotent `bun install` across all workspaces).
+3. Starts the dashboard with `task dev` (the dev supervisor; Ctrl-C stops it) and points you at `http://localhost:3460/dashboard`.
+
+### Offline by default
+
+`task dev` (and `task api` / `task ui`) bake in `METRICS_OFFLINE=true`. In offline mode the dashboard serves from fixtures, so you need **no PostHog project, no accounts service, and no database** to run it. Live external calls only happen when you explicitly set the relevant env vars — local-first is the default.
+
+### CI / testing: `QUICKSTART_SKIP_SERVE`
+
+The final `task dev` step is long-running (it blocks while the server runs), which would hang CI. Set the `QUICKSTART_SKIP_SERVE` env var to a non-empty value to run every deterministic step (prereq checks + `task setup` + the next-steps message) and then exit 0 **without** starting the server:
+
+```bash
+QUICKSTART_SKIP_SERVE=1 ./scripts/quickstart.sh
+```
+
+This is primarily for CI and the smoke test (`scripts/quickstart.smoke.test.ts`) — it lets the deterministic onboarding path be verified without blocking on a live server. In normal use, leave it unset.
+
+### What this doesn't cover automatically
+
+The two networked / interactive steps of the prompt are **not** part of the script (and are not run in CI):
+
+- The `git clone` itself — it lives in the prompt's shell line, before the script runs.
+- The `/plugin install shipwright@app-vitals/shipwright` step — it runs inside an interactive Claude Code session, not a shell.
+
+Both are documented in the prompt above; only the deterministic shell portion is scripted and tested.
+
 ---
 
 ## Option B — Full dev stack (agent chat turn from clone)
@@ -82,76 +151,3 @@ Then use the **chat** pane (or `bun scripts/chat.ts` in a new terminal) to send 
 ```bash
 tmux kill-session -t shipwright
 ```
-
----
-
-## Option A — Metrics dashboard only (no secrets needed)
-
-### Prerequisites
-
-| Tool | Why | Install |
-|---|---|---|
-| **Claude Code** | Runs the `/plugin install` step of the prompt. Not needed by `scripts/quickstart.sh`. | <https://www.anthropic.com/claude-code> |
-| **git** | Clone the repo. | <https://git-scm.com/downloads> |
-| **Bun** | Runtime + package manager for all workspaces. | <https://bun.sh> |
-| **go-task** (`task`) | The single local entrypoint (`task setup`, `task dev`). | <https://taskfile.dev/installation/> |
-
-### The one-prompt onboarding
-
-Paste this into a **Claude Code** session pointed at where you want to work. It sequences **two execution contexts** — shell steps run in a terminal, and one step runs *inside* the Claude Code session:
-
-```text
-Set up Shipwright Harness locally and open the metrics dashboard.
-
-1. In a terminal, run:
-     git clone https://github.com/app-vitals/shipwright.git && cd shipwright && ./scripts/quickstart.sh
-   This checks prerequisites, installs dependencies (task setup), and starts the
-   metrics dashboard in offline mode (no accounts or secrets needed). Leave it running.
-
-2. Inside this Claude Code session, install the plugin:
-     /plugin install shipwright@app-vitals/shipwright
-
-3. Open the dashboard in your browser:
-     http://localhost:3460/dashboard
-```
-
-### Which lines run where
-
-| Step | Where it runs | Command |
-|---|---|---|
-| 1. Clone + bootstrap + serve | **Terminal** (shell) | `git clone … && cd shipwright && ./scripts/quickstart.sh` |
-| 2. Install the plugin | **Inside the Claude Code session** | `/plugin install shipwright@app-vitals/shipwright` |
-| 3. Open the dashboard | **Browser** | `http://localhost:3460/dashboard` |
-
-The distinction matters: step 1 is a shell command, step 2 is a slash command that only works **inside** an interactive Claude Code session (it is not a terminal command).
-
-### What `scripts/quickstart.sh` does
-
-Run it from **inside** the cloned repo (the prompt's step 1 clones and `cd`s for you first). It is **idempotent** — safe to re-run:
-
-1. Verifies prerequisites (`git`, `bun`, `task`) and fails with an install pointer if any is missing.
-2. Runs `task setup` (idempotent `bun install` across all workspaces).
-3. Starts the dashboard with `task dev` (the dev supervisor; Ctrl-C stops it) and points you at `http://localhost:3460/dashboard`.
-
-### Offline by default
-
-`task dev` (and `task api` / `task ui`) bake in `METRICS_OFFLINE=true`. In offline mode the dashboard serves from fixtures, so you need **no PostHog project, no accounts service, and no database** to run it. Live external calls only happen when you explicitly set the relevant env vars — local-first is the default.
-
-### CI / testing: `QUICKSTART_SKIP_SERVE`
-
-The final `task dev` step is long-running (it blocks while the server runs), which would hang CI. Set the `QUICKSTART_SKIP_SERVE` env var to a non-empty value to run every deterministic step (prereq checks + `task setup` + the next-steps message) and then exit 0 **without** starting the server:
-
-```bash
-QUICKSTART_SKIP_SERVE=1 ./scripts/quickstart.sh
-```
-
-This is primarily for CI and the smoke test (`scripts/quickstart.smoke.test.ts`) — it lets the deterministic onboarding path be verified without blocking on a live server. In normal use, leave it unset.
-
-### What this doesn't cover automatically
-
-The two networked / interactive steps of the prompt are **not** part of the script (and are not run in CI):
-
-- The `git clone` itself — it lives in the prompt's shell line, before the script runs.
-- The `/plugin install shipwright@app-vitals/shipwright` step — it runs inside an interactive Claude Code session, not a shell.
-
-Both are documented in the prompt above; only the deterministic shell portion is scripted and tested.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,14 +1,91 @@
 # Quickstart
 
+## Option A — Metrics dashboard only (no secrets needed)
+
 > Get the Shipwright Harness metrics dashboard running locally in one prompt — offline by default, no external accounts or secrets.
 
-## What you can run today
+### What you can run today
 
 The **metrics dashboard** runs locally right now in **offline mode**: it serves from fixtures with **no PostHog key, no accounts, and no database**. That is the core promise of this quickstart — a running dashboard at `http://localhost:3460/dashboard` from a single copy-paste prompt.
 
 The plugin (Phase A) and the Shipwright agent (Phase C) are still being built; see the [README](../README.md) and the [`shipwright-oss` milestone](https://github.com/app-vitals/shipwright/milestones) for live status.
 
-## Prerequisites
+---
+
+## Option B — Full dev stack (agent chat turn from clone)
+
+Run the complete local stack — metrics dashboard, admin UI, and the Shipwright agent in Docker — so you can send a real chat turn and see it round-trip.
+
+### Prerequisites
+
+| Tool | Why | Install |
+|---|---|---|
+| **git** | Clone the repo. | <https://git-scm.com/downloads> |
+| **Bun** | Runtime + package manager. | <https://bun.sh> |
+| **go-task** (`task`) | Single local entrypoint. | <https://taskfile.dev/installation/> |
+| **Docker** | Runs the agent in an isolated container. | <https://docs.docker.com/get-docker/> |
+| **tmux** | `task stack` multiplexes the 5 panes. | `brew install tmux` / `apt install tmux` |
+| **PostgreSQL** | Admin service DB (local). | `brew install postgresql@16` / `apt install postgresql` |
+| **Claude Code** | Runs the `/plugin install` step. | <https://www.anthropic.com/claude-code> |
+
+### Step 1 — Clone and install
+
+```bash
+git clone https://github.com/app-vitals/shipwright.git
+cd shipwright
+task setup
+```
+
+### Step 2 — Add your auth token
+
+```bash
+cp state/dev-agent.env.example state/dev-agent.env
+```
+
+Open `state/dev-agent.env` and fill in **one** of:
+
+- **`CLAUDE_CODE_OAUTH_TOKEN`** — get it by running `claude /oauth-token` in Claude Code (recommended for personal development)
+- **`ANTHROPIC_API_KEY`** — from <https://console.anthropic.com/> → API Keys
+
+`state/dev-agent.env` is git-ignored — it never leaves your machine.
+
+### Step 3 — Launch the stack
+
+```bash
+task stack
+```
+
+This opens a tmux session (`shipwright`) with 5 panes:
+
+| Pane | What | URL |
+|---|---|---|
+| metrics | Dashboard in SQLite mode | <http://localhost:3460/dashboard> |
+| admin | Admin CRUD API + UI | <http://localhost:3001/admin> |
+| agent | Shipwright agent in Docker | <http://localhost:3000> |
+| chat | TUI chat REPL | _(terminal)_ |
+| logs | Scratch shell | _(terminal)_ |
+
+A browser window opens automatically to the admin dev-login page.
+
+### Step 4 — Install the plugin and send a chat turn
+
+Inside a **Claude Code** session pointed at this repo:
+
+```
+/plugin install shipwright@app-vitals/shipwright
+```
+
+Then use the **chat** pane (or `bun scripts/chat.ts` in a new terminal) to send a message. The turn should round-trip through the Docker agent.
+
+### Stopping the stack
+
+```bash
+tmux kill-session -t shipwright
+```
+
+---
+
+### Prerequisites
 
 | Tool | Why | Install |
 |---|---|---|
@@ -17,7 +94,7 @@ The plugin (Phase A) and the Shipwright agent (Phase C) are still being built; s
 | **Bun** | Runtime + package manager for all workspaces. | <https://bun.sh> |
 | **go-task** (`task`) | The single local entrypoint (`task setup`, `task dev`). | <https://taskfile.dev/installation/> |
 
-## The one-prompt onboarding
+### The one-prompt onboarding
 
 Paste this into a **Claude Code** session pointed at where you want to work. It sequences **two execution contexts** — shell steps run in a terminal, and one step runs *inside* the Claude Code session:
 
@@ -46,7 +123,7 @@ Set up Shipwright Harness locally and open the metrics dashboard.
 
 The distinction matters: step 1 is a shell command, step 2 is a slash command that only works **inside** an interactive Claude Code session (it is not a terminal command).
 
-## What `scripts/quickstart.sh` does
+### What `scripts/quickstart.sh` does
 
 Run it from **inside** the cloned repo (the prompt's step 1 clones and `cd`s for you first). It is **idempotent** — safe to re-run:
 
@@ -54,11 +131,11 @@ Run it from **inside** the cloned repo (the prompt's step 1 clones and `cd`s for
 2. Runs `task setup` (idempotent `bun install` across all workspaces).
 3. Starts the dashboard with `task dev` (the dev supervisor; Ctrl-C stops it) and points you at `http://localhost:3460/dashboard`.
 
-## Offline by default
+### Offline by default
 
 `task dev` (and `task api` / `task ui`) bake in `METRICS_OFFLINE=true`. In offline mode the dashboard serves from fixtures, so you need **no PostHog project, no accounts service, and no database** to run it. Live external calls only happen when you explicitly set the relevant env vars — local-first is the default.
 
-## CI / testing: `QUICKSTART_SKIP_SERVE`
+### CI / testing: `QUICKSTART_SKIP_SERVE`
 
 The final `task dev` step is long-running (it blocks while the server runs), which would hang CI. Set the `QUICKSTART_SKIP_SERVE` env var to a non-empty value to run every deterministic step (prereq checks + `task setup` + the next-steps message) and then exit 0 **without** starting the server:
 
@@ -68,7 +145,7 @@ QUICKSTART_SKIP_SERVE=1 ./scripts/quickstart.sh
 
 This is primarily for CI and the smoke test (`scripts/quickstart.smoke.test.ts`) — it lets the deterministic onboarding path be verified without blocking on a live server. In normal use, leave it unset.
 
-## What this doesn't cover automatically
+### What this doesn't cover automatically
 
 The two networked / interactive steps of the prompt are **not** part of the script (and are not run in CI):
 

--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -713,6 +713,13 @@ if (import.meta.main) {
     process.exit(1);
   }
 
+  if (!existsSync("state/dev-agent.env")) {
+    console.error(
+      "[stack] state/dev-agent.env not found — copy state/dev-agent.env.example and fill in CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY",
+    );
+    process.exit(1);
+  }
+
   ensureDepsInstalled();
   await ensurePostgresReady(DEV_DATABASE_URL);
 

--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -164,6 +164,8 @@ export const STACK_PANES: Pane[] = [
     label: "agent",
     // All env is passed via -e flags inside cmd; pane env stays empty so
     // paneShellLine() emits no inline prefix — docker manages its own env.
+    // Secrets (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) come from the
+    // developer's local state/dev-agent.env — see state/dev-agent.env.example.
     cmd: [
       "docker",
       "run",
@@ -179,6 +181,8 @@ export const STACK_PANES: Pane[] = [
       // Placeholder replaced in buildStackCommands — see note there.
       "__REPO_VOLUME_PLACEHOLDER__",
       "--add-host=host.docker.internal:host-gateway",
+      "--env-file",
+      "state/dev-agent.env",
       "-e",
       "SHIPWRIGHT_DEV_CHAT=true",
       "-e",

--- a/scripts/dev-tmux.unit.test.ts
+++ b/scripts/dev-tmux.unit.test.ts
@@ -437,6 +437,14 @@ describe("agent pane — docker run", () => {
     const envKeys = Object.keys(agent.env ?? {});
     expect(envKeys.length).toBe(0);
   });
+
+  test("agent pane docker run loads state/dev-agent.env via --env-file", () => {
+    // Secrets (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) must NOT be hardcoded
+    // in the pane definition — they are injected via the developer's local env file.
+    const agent = STACK_PANES.find((p) => p.label === "agent") as Pane;
+    const cmdStr = agent.cmd.join(" ");
+    expect(cmdStr).toContain("--env-file state/dev-agent.env");
+  });
 });
 
 describe("buildStackCommands — docker build + seed preflights", () => {

--- a/state/dev-agent.env.example
+++ b/state/dev-agent.env.example
@@ -1,0 +1,35 @@
+# state/dev-agent.env — local developer secrets for the Docker agent container
+#
+# Usage:
+#   cp state/dev-agent.env.example state/dev-agent.env
+#   # Fill in at least one of the auth options below, then:
+#   task stack
+#
+# This file is loaded by `docker run --env-file state/dev-agent.env` in task stack.
+# state/dev-agent.env is git-ignored — never commit it.
+# This example file IS tracked — keep it up to date when adding new vars.
+
+# ---------------------------------------------------------------------------
+# Auth — provide one of the two options below
+# ---------------------------------------------------------------------------
+
+# Option A (recommended for personal development): Claude Code OAuth token.
+# Obtain via: claude /oauth-token  (requires Claude Code installed)
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Option B: Anthropic API key.
+# https://console.anthropic.com/ → API Keys
+ANTHROPIC_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Optional overrides (leave blank to use defaults baked into task stack)
+# ---------------------------------------------------------------------------
+
+# Claude model for the agent (default: claude-sonnet-4-6)
+# ANTHROPIC_MODEL=claude-sonnet-4-6
+
+# Fallback model if the primary is unavailable
+# ANTHROPIC_FALLBACK_MODEL=
+
+# Thinking effort level (extended | auto | none)
+# ANTHROPIC_EFFORT_LEVEL=


### PR DESCRIPTION
## Summary

- Add `state/dev-agent.env.example` with `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` documented — the one secret needed to run the Docker agent locally
- Pass `--env-file state/dev-agent.env` to `docker run` in `task stack` so secrets inject at runtime without appearing in the command or the image
- Update `.gitignore` from `state/` to `state/*` so `state/dev-agent.env.example` is tracked while `state/dev-agent.env` stays ignored
- Add **Option B — Full dev stack** section to `docs/quickstart.md` covering the complete flow: clone → `task setup` → `cp state/dev-agent.env.example state/dev-agent.env` → fill in token → `task stack`
- Update `CLAUDE.md` `task stack` description to mention the env file requirement and Docker secret injection

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `state/dev-agent.env.example` exists with all required vars documented | ✅ MET |
| 2 | CLAUDE.md or docs/ has a quickstart covering full flow from fresh clone to working task stack | ✅ MET |
| 3 | A developer following only the docs can reach a working chat turn without prior context | ✅ MET |

## Test Plan

- [x] New unit test: `agent pane docker run loads state/dev-agent.env via --env-file` — verifies secret injection is wired
- [x] All 52 `dev-tmux.unit.test.ts` tests pass including the isolation test (exactly 2 `-v` mounts — `--env-file` does not add a volume mount)
- [x] All 611 scripts-layer tests pass (0 fail)
- [x] Biome lint clean across 264 files

Generated with [Claude Code](https://claude.com/claude-code)
