### PR TITLE
feat(store): wire jira into createTaskStore factory and doctor output

### DIFF
--- a/plugins/shipwright/scripts/create-task-store.unit.test.ts
+++ b/plugins/shipwright/scripts/create-task-store.unit.test.ts
@@ -15,7 +15,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig } from "./create-task-store";
+import { JiraTaskStore } from "./adapters/jira";
+import { createTaskStore, loadConfig } from "./create-task-store";
 
 describe("loadConfig discovery", () => {
   let tmpDir: string;
@@ -117,5 +118,57 @@ describe("loadConfig discovery", () => {
     } finally {
       rmSync(isolatedDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("createTaskStore — jira factory branch", () => {
+  // Save and restore JIRA env vars around each test
+  const savedEmail = process.env.JIRA_EMAIL;
+  const savedToken = process.env.JIRA_API_TOKEN;
+
+  afterEach(() => {
+    if (savedEmail !== undefined) {
+      process.env.JIRA_EMAIL = savedEmail;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional
+      delete process.env.JIRA_EMAIL;
+    }
+    if (savedToken !== undefined) {
+      process.env.JIRA_API_TOKEN = savedToken;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional
+      delete process.env.JIRA_API_TOKEN;
+    }
+  });
+
+  // Test: valid config → returns JiraTaskStore instance
+  test("returns JiraTaskStore when taskStore is 'jira' with valid config", () => {
+    process.env.JIRA_EMAIL = "test@example.com";
+    process.env.JIRA_API_TOKEN = "test-token";
+    const store = createTaskStore({
+      taskStore: "jira",
+      jira: { baseUrl: "https://example.atlassian.net", projectKey: "SHIP" },
+    });
+    expect(store).toBeInstanceOf(JiraTaskStore);
+  });
+
+  // Test: missing config.jira → exits non-zero with a clear error
+  test("exits non-zero with clear error when taskStore is 'jira' but jira config is missing", () => {
+    // Run in a subprocess so process.exit(1) doesn't terminate the test runner.
+    // Derive the factory module path by replacing the test file suffix.
+    const testFilePath = new URL(import.meta.url).pathname;
+    const factoryPath = testFilePath.replace(".unit.test.ts", ".ts");
+    const proc = Bun.spawnSync(
+      [
+        "bun",
+        "--eval",
+        `import { createTaskStore } from ${JSON.stringify(factoryPath)}; createTaskStore({ taskStore: "jira" });`,
+      ],
+      { env: { ...process.env } },
+    );
+    expect(proc.exitCode).toBe(1);
+    const stderr = proc.stderr.toString();
+    expect(stderr).toContain("jira.baseUrl");
+    expect(stderr).toContain("jira.projectKey");
   });
 });

--- a/plugins/shipwright/scripts/task_store.ts
+++ b/plugins/shipwright/scripts/task_store.ts
@@ -22,10 +22,11 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { JiraTaskStore } from "./adapters/jira";
 import { JsonTaskStore } from "./adapters/json";
 import { resolveRepos } from "./check-helpers";
 import { createTaskStore, loadConfig } from "./create-task-store";
-import type { Task, TaskStore } from "./store";
+import type { Task, TaskStore, TaskStoreConfig } from "./store";
 
 const NUMERIC_FIELDS = new Set(["pr", "hours"]);
 
@@ -309,9 +310,26 @@ async function cmdCleanup(adapter: TaskStore): Promise<void> {
   );
 }
 
-function cmdDoctor(adapter: TaskStore, configSource: string): void {
+function cmdDoctor(
+  adapter: TaskStore,
+  configSource: string,
+  config: TaskStoreConfig,
+): void {
   if (adapter instanceof JsonTaskStore) {
     adapter.doctor(configSource);
+  } else if (adapter instanceof JiraTaskStore) {
+    console.log("backend: jira");
+    if (configSource === "default") {
+      console.log("config: default (no SHIPWRIGHT_CONFIG set)");
+    } else {
+      console.log(`config: ${configSource}`);
+    }
+    if (config.jira?.baseUrl) {
+      console.log(`baseUrl: ${config.jira.baseUrl}`);
+    }
+    if (config.jira?.projectKey) {
+      console.log(`projectKey: ${config.jira.projectKey}`);
+    }
   } else {
     console.log("backend: github");
     if (configSource === "default") {
@@ -372,7 +390,7 @@ async function main(): Promise<void> {
       await cmdCleanup(adapter);
       break;
     case "doctor":
-      cmdDoctor(adapter, configSource);
+      cmdDoctor(adapter, configSource, config);
       break;
   }
 }


### PR DESCRIPTION
## Summary
- Wires the `jira` branch into `createTaskStore()`: validates `jira.baseUrl` + `jira.projectKey` are present and returns a `JiraTaskStore`, or exits 1 with a clear error if config is missing
- Updates `cmdDoctor` in `task_store.ts` to detect `JiraTaskStore` and report `backend: jira` with `baseUrl` and `projectKey`
- Adds unit tests covering both the valid-config path and the missing-config error path for the jira factory branch

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | createTaskStore() returns JiraTaskStore when taskStore is 'jira' with valid config | ✅ MET |
| 2 | createTaskStore() exits non-zero with clear error when jira config is missing | ✅ MET |
| 3 | doctor subcommand reports jira backend with baseUrl and projectKey | ✅ MET |
| 4 | Unit test covers valid config path and missing-config error path | ✅ MET |
| 5 | Existing json and github factory paths unchanged; their unit tests pass unmodified | ✅ MET |

## Test Plan
- [x] `bun test plugins/shipwright/scripts/create-task-store.unit.test.ts` — 7 tests pass (5 pre-existing + 2 new)
- [x] `bun test plugins/shipwright/scripts/` — 496 tests pass across 16 files
- [x] `bunx biome lint .` — no issues

Generated with [Claude Code](https://claude.com/claude-code)
