### PR TITLE
fix(plugin): sync vitals-os bug fixes — assignee fallback + multi-repo review keying (v4.26.7)

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.26.6",
+  "version": "4.26.7",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.26.6
+# Shipwright v4.26.7
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/scripts/adapters/github.ts
+++ b/plugins/shipwright/scripts/adapters/github.ts
@@ -140,7 +140,7 @@ function issueToTask(issue: GhIssue): TaskWithMeta {
   }
 
   // Fall back to GitHub issue assignee when not set in the YAML block
-  if (task.assignee === undefined && issue.assignees.length > 0) {
+  if (task.assignee === undefined && issue.assignees?.[0]) {
     task.assignee = issue.assignees[0].login;
   }
 

--- a/plugins/shipwright/scripts/adapters/github.ts
+++ b/plugins/shipwright/scripts/adapters/github.ts
@@ -57,6 +57,10 @@ interface GhMilestone {
   number: number;
 }
 
+interface GhAssignee {
+  login: string;
+}
+
 interface GhIssue {
   number: number;
   title: string;
@@ -65,6 +69,7 @@ interface GhIssue {
   labels: GhLabel[];
   url: string;
   milestone: GhMilestone | null;
+  assignees: GhAssignee[];
 }
 
 // Internal task with issue number attached for writes
@@ -132,6 +137,11 @@ function issueToTask(issue: GhIssue): TaskWithMeta {
   if (labelStatus !== undefined) {
     task.status = labelStatus;
     task._labelStatus = labelStatus;
+  }
+
+  // Fall back to GitHub issue assignee when not set in the YAML block
+  if (task.assignee === undefined && issue.assignees.length > 0) {
+    task.assignee = issue.assignees[0].login;
   }
 
   // Attach issue number for internal use
@@ -207,7 +217,7 @@ export class GitHubTaskStore implements TaskStore {
       "--state",
       "all",
       "--json",
-      "number,title,body,labels,state,url,milestone",
+      "number,title,body,labels,state,url,milestone,assignees",
       "--limit",
       "500",
     ]);

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -65,6 +65,7 @@ function makeIssue(
   statusLabel: string,
   bodyMeta: Record<string, unknown>,
   state: "OPEN" | "CLOSED" = "OPEN",
+  assignees: { login: string }[] = [],
 ) {
   const meta = JSON.stringify(bodyMeta, null, 2);
   const body = `Task description\n\n\`\`\`shipwright\n${meta}\n\`\`\``;
@@ -76,6 +77,7 @@ function makeIssue(
     labels: [{ name: `status:${statusLabel}` }],
     url: `https://github.com/test-owner/test-repo/issues/${number}`,
     milestone: null,
+    assignees,
   };
 }
 
@@ -194,7 +196,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -223,7 +225,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -251,7 +253,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -277,7 +279,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -306,7 +308,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -341,7 +343,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -375,7 +377,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -410,7 +412,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -432,7 +434,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -462,7 +464,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -492,7 +494,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -528,7 +530,7 @@ describe("GitHubTaskStore.query", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -537,6 +539,58 @@ describe("GitHubTaskStore.query", () => {
     const tasks = await adapter.query({ ready: true, assignee: "dmcaulay" });
     expect(tasks).toHaveLength(2);
     expect(tasks.map((t) => t.id).sort()).toEqual(["TSR-1.1", "TSR-1.2"]);
+  });
+
+  test("query --ready --assignee falls back to GitHub issue assignee when not in YAML block", async () => {
+    const issues = [
+      // Mine — YAML has assignee
+      makeIssue(1, "TSR-1.1: Mine", "pending", {
+        id: "TSR-1.1",
+        title: "Mine",
+        status: "pending",
+        assignee: "dmcaulay",
+        dependencies: [],
+      }),
+      // Theirs — no YAML assignee, but GitHub issue assignee is dodizzle
+      makeIssue(
+        2,
+        "TSR-1.2: Theirs",
+        "pending",
+        {
+          id: "TSR-1.2",
+          title: "Theirs",
+          status: "pending",
+          dependencies: [],
+        },
+        "OPEN",
+        [{ login: "dodizzle" }],
+      ),
+      // Mine via fallback — no YAML assignee, but GitHub issue assignee is dmcaulay
+      makeIssue(
+        3,
+        "TSR-1.3: Mine via fallback",
+        "pending",
+        {
+          id: "TSR-1.3",
+          title: "Mine via fallback",
+          status: "pending",
+          dependencies: [],
+        },
+        "OPEN",
+        [{ login: "dmcaulay" }],
+      ),
+    ];
+
+    const fakeGh = await writeFakeGh(tmpDir, {
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
+        issues,
+    });
+    process.env.GH_CMD = fakeGh;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    const tasks = await adapter.query({ ready: true, assignee: "dmcaulay" });
+    expect(tasks).toHaveLength(2);
+    expect(tasks.map((t) => t.id).sort()).toEqual(["TSR-1.1", "TSR-1.3"]);
   });
 });
 
@@ -704,7 +758,7 @@ process.exit(0);
 describe("GitHubTaskStore.update", () => {
   test("throws if task not found", async () => {
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         [],
     });
     process.env.GH_CMD = fakeGh;
@@ -1029,7 +1083,7 @@ process.exit(0);
 describe("GH_CMD injection", () => {
   test("uses GH_CMD env var instead of 'gh'", async () => {
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         [],
     });
     process.env.GH_CMD = fakeGh;
@@ -1187,7 +1241,7 @@ describe("GitHubTaskStore.query assignee filter", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -1216,7 +1270,7 @@ describe("GitHubTaskStore.query assignee filter", () => {
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
     process.env.GH_CMD = fakeGh;
@@ -1639,7 +1693,7 @@ process.exit(0);
     ];
 
     const fakeGh = await writeFakeGh(tmpDir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
       "api repos/test-owner/test-repo/milestones?per_page=100": [],
     });
@@ -1767,7 +1821,7 @@ process.exit(0);
 
 describe("GitHubTaskStore.cleanup (plan issues)", () => {
   const TASK_LIST_KEY =
-    "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500";
+    "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500";
   const PLAN_LIST_KEY =
     "issue list --repo test-owner/test-repo --state open --search [plan] in:title --json number,title --limit 100";
   const MILESTONES_KEY =
@@ -2259,7 +2313,7 @@ describe("GitHubTaskStore.query ready+assignee filter", () => {
     issues: ReturnType<typeof makeIssue>[],
   ): Promise<string> {
     return writeFakeGh(dir, {
-      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone --limit 500":
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
         issues,
     });
   }

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -95,12 +95,10 @@ export async function run(deps: Deps): Promise<RunResult> {
   const currentUser = await deps.getCurrentUser();
   const reviews = deps.readReviews();
 
-  // Build a lookup from "repo:pr-number" → review entry.
-  // Keying on number alone causes cross-repo collisions when multiple repos
-  // are configured — two repos can share PR numbers. Include the repo in the key.
-  const reviewByPr = new Map<string, ReviewEntry>();
+  // Build a lookup from PR number → review entry
+  const reviewByPr = new Map<number, ReviewEntry>();
   for (const entry of reviews) {
-    reviewByPr.set(`${entry.repo ?? ""}:${entry.pr}`, entry);
+    reviewByPr.set(entry.pr, entry);
   }
 
   // We don't know the repo here without a context — use a placeholder for tests.
@@ -110,7 +108,7 @@ export async function run(deps: Deps): Promise<RunResult> {
   for (const pr of prs) {
     if (!deps.isSelfReviewAllowed && pr.author.login === currentUser) continue;
 
-    const entry = reviewByPr.get(`${pr.repo ?? ""}:${pr.number}`);
+    const entry = reviewByPr.get(pr.number);
 
     // No entry → eligible
     if (!entry) {

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -95,10 +95,12 @@ export async function run(deps: Deps): Promise<RunResult> {
   const currentUser = await deps.getCurrentUser();
   const reviews = deps.readReviews();
 
-  // Build a lookup from PR number → review entry
-  const reviewByPr = new Map<number, ReviewEntry>();
+  // Build a lookup from "repo:pr-number" → review entry.
+  // Keying on number alone causes cross-repo collisions when multiple repos
+  // are configured — two repos can share PR numbers. Include the repo in the key.
+  const reviewByPr = new Map<string, ReviewEntry>();
   for (const entry of reviews) {
-    reviewByPr.set(entry.pr, entry);
+    reviewByPr.set(`${entry.repo ?? ""}:${entry.pr}`, entry);
   }
 
   // We don't know the repo here without a context — use a placeholder for tests.
@@ -108,7 +110,7 @@ export async function run(deps: Deps): Promise<RunResult> {
   for (const pr of prs) {
     if (!deps.isSelfReviewAllowed && pr.author.login === currentUser) continue;
 
-    const entry = reviewByPr.get(pr.number);
+    const entry = reviewByPr.get(`${pr.repo ?? ""}:${pr.number}`);
 
     // No entry → eligible
     if (!entry) {


### PR DESCRIPTION
## Summary

- **`adapters/github.ts`**: fall back to GitHub issue assignee when the YAML block has no `assignee` field; adds `assignees` to the `gh issue list --json` field list and populates `task.assignee` from the first assignee in `issueToTask()`. Fixes `--assignee` filtering silently dropping tasks owned via GitHub assignment rather than YAML.
- **`check-review.ts`**: key the `reviewByPr` map on `"repo:pr-number"` instead of bare PR number. Bare number causes cross-repo collisions when multiple repos are configured (two repos can share the same PR number), causing one repo's review state to shadow the other's.
- Version bumped to **4.26.7** (patch).

Backported from `app-vitals/vitals-os` plugin v4.26.7 (PRs #1452, #1453, and the check-review fix).

## Test plan

- [x] `bun test plugins/shipwright/scripts/adapters/github.unit.test.ts plugins/shipwright/scripts/check-review.test.ts` — 90 pass, 0 fail
- [x] `bunx biome check` — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)