### PR TITLE
fix(admin): navbar highlight reflects current path

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -125,7 +125,7 @@ export function renderAgentsPage(
   <style>${baseStyles()}</style>
 </head>
 <body>
-  ${renderAdminToolbar(userName)}
+  ${renderAdminToolbar(userName, "/admin/agents")}
   <div class="vos-page">
     <div class="page-header">
       <h1 class="page-title">Agents</h1>
@@ -292,7 +292,7 @@ export function renderAgentDetailPage(
   <style>${baseStyles()}</style>
 </head>
 <body>
-  ${renderAdminToolbar(userName)}
+  ${renderAdminToolbar(userName, "/admin/agents")}
   <div class="vos-page">
     <div class="page-header">
       <div>
@@ -515,7 +515,7 @@ export function renderProvisionStartPage(
   <style>${baseStyles()}</style>
 </head>
 <body>
-  ${renderAdminToolbar(userName)}
+  ${renderAdminToolbar(userName, "/admin/provision")}
   <div class="vos-page">
     <div class="page-header">
       <h1 class="page-title">Provision Agent</h1>
@@ -553,7 +553,7 @@ export function renderProvisionPasteForm(
   <style>${baseStyles()}</style>
 </head>
 <body>
-  ${renderAdminToolbar(userName)}
+  ${renderAdminToolbar(userName, "/admin/provision")}
   <div class="vos-page">
     <div class="page-header">
       <h1 class="page-title">Provision Agent</h1>
@@ -612,7 +612,7 @@ export function renderProvisionCompletePage(
   <style>${baseStyles()}</style>
 </head>
 <body>
-  ${renderAdminToolbar(userName)}
+  ${renderAdminToolbar(userName, "/admin/provision")}
   <div class="vos-page">
     <div class="page-header">
       <h1 class="page-title">Provision Agent</h1>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -21,6 +21,7 @@ import {
   renderProvisionPasteForm,
   renderProvisionStartPage,
 } from "./admin-ui-pages.ts";
+import { renderAdminToolbar } from "./admin-ui-styles.ts";
 
 // ─── Shared fixtures ──────────────────────────────────────────────────────────
 
@@ -835,5 +836,36 @@ describe("renderProvisionCompletePage", () => {
     });
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+// ─── renderAdminToolbar — active nav highlight ────────────────────────────────
+
+describe("renderAdminToolbar — active nav highlight", () => {
+  test("activePath /admin/agents: Agents link is active, Provision is not", () => {
+    const html = renderAdminToolbar(USER_NAME, "/admin/agents");
+    expect(html).toContain('href="/admin/agents" class="vos-nav-link active"');
+    expect(html).toContain('href="/admin/provision" class="vos-nav-link"');
+    expect(html).not.toContain('href="/admin/provision" class="vos-nav-link active"');
+  });
+
+  test("activePath sub-path /admin/agents/agent-id: Agents link is still active (startsWith)", () => {
+    const html = renderAdminToolbar(USER_NAME, "/admin/agents/agent-id");
+    expect(html).toContain('href="/admin/agents" class="vos-nav-link active"');
+    expect(html).not.toContain('href="/admin/provision" class="vos-nav-link active"');
+  });
+
+  test("activePath /admin/provision: Provision link is active, Agents is not", () => {
+    const html = renderAdminToolbar(USER_NAME, "/admin/provision");
+    expect(html).toContain('href="/admin/provision" class="vos-nav-link active"');
+    expect(html).toContain('href="/admin/agents" class="vos-nav-link"');
+    expect(html).not.toContain('href="/admin/agents" class="vos-nav-link active"');
+  });
+
+  test("activePath '' (default): neither link is active", () => {
+    const html = renderAdminToolbar(USER_NAME);
+    expect(html).not.toContain('class="vos-nav-link active"');
+    expect(html).toContain('href="/admin/agents" class="vos-nav-link"');
+    expect(html).toContain('href="/admin/provision" class="vos-nav-link"');
   });
 });

--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -367,12 +367,14 @@ export function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
-export function renderAdminToolbar(userName: string): string {
+export function renderAdminToolbar(userName: string, activePath: string): string {
+  const active = (prefix: string) =>
+    activePath.startsWith(prefix) ? " active" : "";
   return `<nav class="vos-toolbar" aria-label="Site navigation">
     <a href="/admin/agents" class="vos-wordmark">Shipwright Admin</a>
     <div class="vos-nav">
-      <a href="/admin/agents" class="vos-nav-link active">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Provision</a>
+      <a href="/admin/agents" class="vos-nav-link${active("/admin/agents")}">Agents</a>
+      <a href="/admin/provision" class="vos-nav-link${active("/admin/provision")}">Provision</a>
     </div>
     <div class="vos-user">
       <span class="vos-username">${escapeHtml(userName)}</span>

--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -367,7 +367,7 @@ export function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
-export function renderAdminToolbar(userName: string, activePath: string): string {
+export function renderAdminToolbar(userName: string, activePath = ""): string {
   const active = (prefix: string) =>
     activePath.startsWith(prefix) ? " active" : "";
   return `<nav class="vos-toolbar" aria-label="Site navigation">


### PR DESCRIPTION
## Summary
- `renderAdminToolbar` was hardcoding `active` on the Agents link — regardless of which page you were on
- Added an `activePath: string` param and apply the class via `startsWith` prefix match
- Updated all 5 call sites: agents pages pass `/admin/agents`, provision pages pass `/admin/provision`

## Test plan
- [ ] Navigate to `/admin/agents` → Agents link is highlighted
- [ ] Click into an agent detail page → Agents link stays highlighted
- [ ] Navigate to `/admin/provision` (any step) → Provision link is highlighted