### PR TITLE
fix(bootstrap): remove unused SLACK_TEAM_ID

### DIFF
--- a/agent/scripts/bootstrap-agent.ts
+++ b/agent/scripts/bootstrap-agent.ts
@@ -120,7 +120,6 @@ console.log("  Use the manifest from the Shipwright admin UI for this agent.");
 
 const slackBotToken = await prompt("  Paste the Bot OAuth token (xoxb-...): ");
 const slackAppToken = await prompt("  Paste the App-level token (xapp-...): ");
-const slackTeamId = await prompt("  Paste the Slack workspace ID (T...): ");
 
 if (!slackBotToken.startsWith("xoxb-")) {
   console.error("Error: Bot token must start with xoxb-");
@@ -147,7 +146,6 @@ console.log("\n[bootstrap] Storing credentials...");
 const envPayload: Record<string, string> = {
   SLACK_BOT_TOKEN: slackBotToken,
   SLACK_APP_TOKEN: slackAppToken,
-  SLACK_TEAM_ID: slackTeamId,
   ANTHROPIC_API_KEY: anthropicApiKey,
 };
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,7 +138,6 @@ Used only by one-time operator scripts in `agent/scripts/` (e.g. `bootstrap-agen
 |---|---|---|---|
 | `SHIPWRIGHT_ADMIN_URL` | `string` | required | Base URL of the Shipwright admin API. Required by `bootstrap-agent.ts` to store credentials via the admin service. Env-var-only. |
 | `SHIPWRIGHT_SESSION_TOKEN` | `string` | required | Value of the `admin_session` JWT cookie for authenticating against the admin API. Required by `bootstrap-agent.ts`. Env-var-only (secret). |
-| `SLACK_TEAM_ID` | `string` | required | Slack workspace ID (`T...`). Collected interactively by `bootstrap-agent.ts` and stored as an agent env var. |
 
 ### Server
 


### PR DESCRIPTION
## Summary
- `SLACK_TEAM_ID` was collected interactively by `bootstrap-agent.ts` and stored as an agent env var, but is never read by the running agent
- Remove the prompt, env payload entry, and docs table row

## Test Plan
- [ ] `bootstrap-agent.ts` no longer prompts for workspace ID
- [ ] `check-config-docs` still passes (`bun run check:config-docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)