### PR TITLE
fix(metrics): consume the admin session (admin_session) instead of vitals_session

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,7 +143,7 @@ Used only by `agent/src/run-migration.ts` when migrating agents from the Vitals 
 | Name | Type | Default | Description |
 |---|---|---|---|
 | `DATABASE_URL_SHIPWRIGHT_ADMIN` | `string` | required | Postgres connection string for the admin service schema (e.g. `postgresql://user:pass@host:5432/db`). |
-| `SHIPWRIGHT_SESSION_SECRET` | `string` | — | HS256 secret for signing session cookies. Used by the metrics service (`vitals_session` cookie) and the admin service (`admin_session` cookie). |
+| `SHIPWRIGHT_SESSION_SECRET` | `string` | — | HS256 secret for the `admin_session` cookie. The admin service signs it on Google-OAuth login; the metrics service verifies it to reuse the same session (the two must share the value). |
 | `SHIPWRIGHT_ENCRYPTION_KEY` | `string` | — | 64-char hex (32 bytes) for AES-256-GCM encryption of secrets at rest. **If unset, secrets are stored in plain text** — always set this in any real deployment. |
 | `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` | `string` | — | Comma-separated list of Google email addresses permitted to log in to the admin UI. |
 | `SHIPWRIGHT_ADMIN_APP_BASE_URL` | `string` | `http://localhost:{PORT}` | Public base URL of the admin service, used to construct the Google OAuth redirect URI. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -81,9 +81,9 @@ All metric endpoints are `GET`, return JSON, and accept the same date-window que
 The `/metrics/*` endpoints accept **either** credential:
 
 - **Bearer API key** — tokens parsed from `METRICS_API_KEYS`. Scoped tokens (scope `!== "*"`) are rejected with `403` on metrics routes.
-- **Session cookie** (`vitals_session`) — when `METRICS_REQUIRE_OWNER_ROLE=true` and an accounts client is configured, the caller's role is checked and non-`OWNER` users get `403`.
+- **Session cookie** (`admin_session`) — when `METRICS_REQUIRE_OWNER_ROLE=true` and an accounts client is configured, the caller's role is checked and non-`OWNER` users get `403`.
 
-The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/auth/login`. In offline mode (`METRICS_OFFLINE=true`), session auth is skipped entirely and `/dashboard` is served as "Offline User". `/health` is always open.
+The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/admin/login`. In offline mode (`METRICS_OFFLINE=true`), session auth is skipped entirely and `/dashboard` is served as "Offline User". `/health` is always open.
 
 ## Environment
 
@@ -96,7 +96,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `DATABASE_URL_METRICS` | | — | Alias for `METRICS_DATABASE_URL`. Accepted when `METRICS_DATABASE_URL` is absent. |
 | `METRICS_API_PORT` | | `3460` | Listen port. |
 | `METRICS_API_KEYS` | | — | Comma-parsed Bearer API keys for `/metrics/*`. |
-| `SHIPWRIGHT_SESSION_SECRET` | | — | HS256 secret for verifying the `vitals_session` cookie. |
+| `SHIPWRIGHT_SESSION_SECRET` | | — | HS256 secret for verifying the `admin_session` cookie. |
 | `METRICS_REQUIRE_OWNER_ROLE` | | `false` | When `true`, gate dashboard/API on `OWNER` role via the accounts client. |
 | `METRICS_ADMIN_URL` | | `http://localhost:3000` | Shipwright admin service base URL (agent name lookups). |
 | `METRICS_INTERNAL_API_KEY` | | — | Internal key for the accounts client. |

--- a/metrics/e2e/dashboard.e2e.ts
+++ b/metrics/e2e/dashboard.e2e.ts
@@ -6,9 +6,9 @@
  * calls are intercepted at the network layer so no real PostHog credentials are needed.
  *
  * Session cookie auth: injectSessionCookie() signs a JWT with E2E_SESSION_SECRET,
- * which matches the SESSION_SECRET the test server is started with (see startTestServer).
- * This is the fix from PR #107: pin SESSION_SECRET on the spawn env so CI environments
- * that export a real SESSION_SECRET do not break cookie auth in tests.
+ * which matches the SHIPWRIGHT_SESSION_SECRET the test server is started with (see startTestServer).
+ * Pin SHIPWRIGHT_SESSION_SECRET on the spawn env so CI environments that export a real
+ * SHIPWRIGHT_SESSION_SECRET do not break cookie auth in tests.
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
@@ -24,7 +24,7 @@ const TEST_PORT = 3461;
 const BASE_URL = `http://localhost:${TEST_PORT}`;
 
 /**
- * E2E_SESSION_SECRET must match SESSION_SECRET passed to the test server spawn env.
+ * E2E_SESSION_SECRET must match SHIPWRIGHT_SESSION_SECRET passed to the test server spawn env.
  * Both are pinned here to ensure they stay in sync. See startTestServer() for the fix.
  */
 const E2E_SESSION_SECRET = "e2e-test-session-secret-32b";
@@ -42,7 +42,7 @@ async function startTestServer(): Promise<void> {
       METRICS_E2E_PORT: String(TEST_PORT),
       POSTHOG_PERSONAL_API_KEY: "phx_e2e_fake",
       POSTHOG_PROJECT_ID: "99999",
-      SESSION_SECRET: E2E_SESSION_SECRET, // ← pin session secret so CI envs don't break cookie auth
+      SHIPWRIGHT_SESSION_SECRET: E2E_SESSION_SECRET, // ← pin session secret so CI envs don't break cookie auth
     },
     stdio: "pipe",
     cwd: resolve(__dirname, "../.."),
@@ -83,7 +83,7 @@ async function stopTestServer(): Promise<void> {
 
 /**
  * Inject a valid admin_session cookie into the page context.
- * Signs with E2E_SESSION_SECRET — must match the SESSION_SECRET the server uses.
+ * Signs with E2E_SESSION_SECRET — must match the SHIPWRIGHT_SESSION_SECRET the server uses.
  */
 async function injectSessionCookie(page: Page): Promise<void> {
   const payload = {

--- a/metrics/e2e/dashboard.e2e.ts
+++ b/metrics/e2e/dashboard.e2e.ts
@@ -82,7 +82,7 @@ async function stopTestServer(): Promise<void> {
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
 /**
- * Inject a valid vitals_session cookie into the page context.
+ * Inject a valid admin_session cookie into the page context.
  * Signs with E2E_SESSION_SECRET — must match the SESSION_SECRET the server uses.
  */
 async function injectSessionCookie(page: Page): Promise<void> {
@@ -95,7 +95,7 @@ async function injectSessionCookie(page: Page): Promise<void> {
   const token = await sign(payload, E2E_SESSION_SECRET, "HS256");
   await page.context().addCookies([
     {
-      name: "vitals_session",
+      name: "admin_session",
       value: token,
       domain: "localhost",
       path: "/",
@@ -416,14 +416,14 @@ test.afterAll(async () => {
 // ─── Dashboard — page load ────────────────────────────────────────────────────
 
 test.describe("Dashboard — page load", () => {
-  test("redirects unauthenticated requests to /auth/login", async ({
+  test("redirects unauthenticated requests to /admin/login", async ({
     page,
   }) => {
     const response = await page.goto(`${BASE_URL}/dashboard`, {
       waitUntil: "domcontentloaded",
     });
     // Should redirect to login
-    expect(page.url()).toContain("/auth/login");
+    expect(page.url()).toContain("/admin/login");
   });
 
   test("renders toolbar with Shipwright wordmark", async ({ page }) => {

--- a/metrics/src/api.auth-gate.integration.test.ts
+++ b/metrics/src/api.auth-gate.integration.test.ts
@@ -160,7 +160,7 @@ describe("owner gate — off by default", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -179,7 +179,7 @@ describe("owner gate — off by default", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -198,7 +198,7 @@ describe("owner gate — off by default", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -212,7 +212,7 @@ describe("owner gate — off by default", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -236,7 +236,7 @@ describe("owner gate — on when requireOwnerRole: true", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(401);
@@ -258,7 +258,7 @@ describe("owner gate — on when requireOwnerRole: true", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -338,7 +338,7 @@ describe("dashboard HTML — no dead nav links", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -358,7 +358,7 @@ describe("dashboard HTML — no dead nav links", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);

--- a/metrics/src/api.smoke.test.ts
+++ b/metrics/src/api.smoke.test.ts
@@ -931,7 +931,7 @@ describe("combined auth middleware (/metrics/*)", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -966,7 +966,7 @@ describe("combined auth middleware (/metrics/*)", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: "vitals_session=not.a.valid.jwt" },
+      headers: { Cookie: "admin_session=not.a.valid.jwt" },
     });
 
     expect(res.status).toBe(401);
@@ -980,7 +980,7 @@ describe("combined auth middleware (/metrics/*)", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(401);
@@ -990,14 +990,14 @@ describe("combined auth middleware (/metrics/*)", () => {
 // ─── Dashboard static routes ──────────────────────────────────────────────────
 
 describe("GET /dashboard static routes", () => {
-  test("GET /dashboard — redirects to /auth/login without session cookie", async () => {
+  test("GET /dashboard — redirects to /admin/login without session cookie", async () => {
     const deps: MetricsDeps = { sessionSecret: TEST_SESSION_SECRET };
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard");
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toContain("/auth/login");
+    expect(res.headers.get("location")).toContain("/admin/login");
   });
 
   test("GET /dashboard — returns HTML with correct Content-Type when session valid", async () => {
@@ -1006,7 +1006,7 @@ describe("GET /dashboard static routes", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1021,7 +1021,7 @@ describe("GET /dashboard static routes", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
     const body = await res.text();
 
@@ -1043,7 +1043,7 @@ describe("GET /dashboard static routes", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard/styles.css", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1057,7 +1057,7 @@ describe("GET /dashboard static routes", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard/app.js", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1071,7 +1071,7 @@ describe("GET /dashboard static routes", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1089,7 +1089,7 @@ describe("GET /dashboard static routes", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1634,7 +1634,7 @@ describe("owner gate — /metrics/* API endpoints", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(401);
@@ -1656,7 +1656,7 @@ describe("owner gate — /metrics/* API endpoints", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(401);
@@ -1676,7 +1676,7 @@ describe("owner gate — /metrics/* API endpoints", () => {
     );
 
     const res = await app.request("/metrics/summary", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1729,7 +1729,7 @@ describe("owner gate — /dashboard", () => {
     );
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(403);
@@ -1748,7 +1748,7 @@ describe("owner gate — /dashboard", () => {
     );
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1763,7 +1763,7 @@ describe("owner gate — /dashboard", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
 
     expect(res.status).toBe(200);
@@ -1912,7 +1912,7 @@ describe("dashboard HTML — default range button", () => {
     const app = createMetricsApp(apiKeys, noopAccountsClient, deps);
 
     const res = await app.request("/dashboard", {
-      headers: { Cookie: `vitals_session=${cookie}` },
+      headers: { Cookie: `admin_session=${cookie}` },
     });
     const body = await res.text();
 

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -921,6 +921,11 @@ export function createMetricsApp(
   const sessionSecret =
     deps?.sessionSecret ?? process.env.SHIPWRIGHT_SESSION_SECRET ?? "";
   const requireOwnerRole = deps?.requireOwnerRole ?? false;
+  if (requireOwnerRole) {
+    console.warn(
+      "[metrics] METRICS_REQUIRE_OWNER_ROLE is enabled — ensure your accountsClient URL serves /accounts/users/{id}. The Shipwright admin service does not expose this endpoint.",
+    );
+  }
   const dashboardToken = deps?.dashboardToken;
   const offlineMode = deps?.offlineMode ?? false;
   const basePath = deps?.basePath ?? process.env.METRICS_BASE_PATH ?? "";

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -20,7 +20,10 @@ import { authMiddleware } from "./lib/api-auth.ts";
 import type { AppHandler, AuthEnv, Caller } from "./lib/api-auth.ts";
 import { ErrorSchema } from "./lib/api-schemas.ts";
 import { registerWithAuthz } from "./lib/api-utils.ts";
-import { createSessionMiddleware } from "./lib/session-middleware.ts";
+import {
+  SESSION_COOKIE,
+  createSessionMiddleware,
+} from "./lib/session-middleware.ts";
 import type { LocalEventStore } from "./local-store.ts";
 import type { MetricsProvider } from "./metrics-provider.ts";
 import { PostHogClientError, createPostHogClient } from "./posthog-client.ts";
@@ -829,7 +832,7 @@ export function createMetricsHandlers(
 /**
  * Combined auth middleware for /metrics/* routes.
  * Accepts either a valid Bearer token (service-to-service) OR a valid
- * vitals_session cookie (browser dashboard). Returns 401 JSON on failure
+ * admin_session cookie (browser dashboard). Returns 401 JSON on failure
  * so API clients get a machine-readable error rather than a redirect.
  *
  * Owner gate:
@@ -865,9 +868,9 @@ function createCombinedAuthMiddleware(
       }
     }
 
-    // 2. Try session cookie
+    // 2. Try session cookie — the admin's `admin_session` (name claim optional)
     if (sessionSecret) {
-      const sessionToken = getCookie(c, "vitals_session");
+      const sessionToken = getCookie(c, SESSION_COOKIE);
       if (sessionToken) {
         try {
           const payload = (await verify(
@@ -875,14 +878,12 @@ function createCombinedAuthMiddleware(
             sessionSecret,
             "HS256",
           )) as Record<string, unknown>;
-          const { userId, email, name } = payload;
+          const { userId, email } = payload;
           if (
             typeof userId === "string" &&
             userId &&
             typeof email === "string" &&
-            email &&
-            typeof name === "string" &&
-            name
+            email
           ) {
             // Owner role gate — only when requireOwnerRole is true AND accountsClient is wired
             if (requireOwnerRole && accountsClient) {
@@ -1039,7 +1040,7 @@ export function createMetricsApp(
     },
   };
 
-  // Dashboard routes are protected by session cookie — redirect to /auth/login on failure
+  // Dashboard routes are protected by session cookie — redirect to /admin/login on failure
   // In offline mode: skip session auth entirely and inject a default local user
   if (!offlineMode) {
     app.use("/dashboard", createSessionMiddleware(sessionSecret));
@@ -1060,7 +1061,7 @@ export function createMetricsApp(
       });
     }
 
-    const sessionToken = getCookie(c, "vitals_session");
+    const sessionToken = getCookie(c, SESSION_COOKIE);
     let userName = "Unknown";
     let userId: string | undefined;
     if (sessionToken && sessionSecret) {

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -117,7 +117,7 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
     </div>
     <div class="vos-user">
       <span class="vos-username">Alice</span>
-      <form method="POST" action="/auth/logout" style="margin:0">
+      <form method="POST" action="/admin/logout" style="margin:0">
         <button type="submit" class="vos-signout-btn">Sign out</button>
       </form>
     </div>
@@ -430,7 +430,7 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
 
   </div>
 
-  <script>window.__METRICS_BASE__ = '';</script>
+  <script>window.__METRICS_BASE__ = "";</script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <script src="/dashboard/app.js"></script>
 </body>
@@ -554,7 +554,7 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
     </div>
     <div class="vos-user">
       <span class="vos-username">Alice</span>
-      <form method="POST" action="/auth/logout" style="margin:0">
+      <form method="POST" action="/admin/logout" style="margin:0">
         <button type="submit" class="vos-signout-btn">Sign out</button>
       </form>
     </div>
@@ -867,7 +867,7 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
 
   </div>
 
-  <script>window.__METRICS_BASE__ = '';</script>
+  <script>window.__METRICS_BASE__ = "";</script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <script src="/dashboard/app.js"></script>
 </body>
@@ -991,7 +991,7 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
     </div>
     <div class="vos-user">
       <span class="vos-username">Alice</span>
-      <form method="POST" action="/auth/logout" style="margin:0">
+      <form method="POST" action="/admin/logout" style="margin:0">
         <button type="submit" class="vos-signout-btn">Sign out</button>
       </form>
     </div>
@@ -1304,7 +1304,7 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
 
   </div>
 
-  <script>window.__METRICS_BASE__ = '';</script>
+  <script>window.__METRICS_BASE__ = "";</script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <script src="/dashboard/app.js"></script>
 </body>
@@ -1428,7 +1428,7 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
     </div>
     <div class="vos-user">
       <span class="vos-username">Alice</span>
-      <form method="POST" action="/auth/logout" style="margin:0">
+      <form method="POST" action="/admin/logout" style="margin:0">
         <button type="submit" class="vos-signout-btn">Sign out</button>
       </form>
     </div>
@@ -1741,7 +1741,7 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
 
   </div>
 
-  <script>window.__METRICS_BASE__ = '';</script>
+  <script>window.__METRICS_BASE__ = "";</script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <script src="/dashboard/app.js"></script>
 </body>

--- a/metrics/src/dashboard/dashboard-page.ts
+++ b/metrics/src/dashboard/dashboard-page.ts
@@ -32,7 +32,7 @@ export function renderDashboardPage(opts: DashboardPageOptions): string {
   <link rel="stylesheet" href="${base}/dashboard/styles.css" />
 </head>
 <body>
-  ${renderShipwrightToolbar({ userName: opts.userName, activePath: `${base}/dashboard`, logoutAction: "/auth/logout", metricsUrl: `${base}/dashboard` })}
+  ${renderShipwrightToolbar({ userName: opts.userName, activePath: `${base}/dashboard`, logoutAction: "/admin/logout", metricsUrl: `${base}/dashboard` })}
   <div class="app">
 
     <!-- Page Controls -->
@@ -341,7 +341,7 @@ export function renderDashboardPage(opts: DashboardPageOptions): string {
 
   </div>
 
-  <script>window.__METRICS_BASE__ = '${base}';</script>
+  <script>window.__METRICS_BASE__ = ${JSON.stringify(base)};</script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <script src="${base}/dashboard/app.js"></script>
 </body>

--- a/metrics/src/dashboard/dashboard-page.unit.test.ts
+++ b/metrics/src/dashboard/dashboard-page.unit.test.ts
@@ -418,7 +418,7 @@ describe("renderDashboardPage — MG-1.2 clickable metric graphs", () => {
 describe("renderDashboardPage — basePath", () => {
   test("sets window.__METRICS_BASE__ to the provided basePath", () => {
     const html = renderDashboardPage({ userName: "Alice", basePath: "/sw" });
-    expect(html).toContain("window.__METRICS_BASE__ = '/sw'");
+    expect(html).toContain('window.__METRICS_BASE__ = "/sw";');
   });
 
   test("prefixes the stylesheet href with basePath", () => {

--- a/metrics/src/lib/session-middleware.ts
+++ b/metrics/src/lib/session-middleware.ts
@@ -8,16 +8,23 @@
  * On success: sets c.get('session') with { userId, email, name } and calls next().
  * On Bearer token present: calls next() without setting session (API calls bypass
  *   session auth — the JSON API layer handles authentication via its own middleware).
- * On missing/invalid session: redirects to /auth/login?returnTo=<encoded-path>.
+ * On missing/invalid session: redirects to /admin/login?returnTo=<encoded-path>.
  * On missing secret: returns 500 Internal Server Error (not a redirect).
  *
- * The session cookie is "vitals_session" — a HS256 JWT signed with SHIPWRIGHT_SESSION_SECRET
- * containing { userId, email, name, iat, exp }.
+ * The session cookie is "admin_session" — the JWT issued by the admin service on
+ * Google-OAuth login, a HS256 JWT signed with SHIPWRIGHT_SESSION_SECRET containing
+ * { userId, email, iat, exp }. Metrics reuses the admin session directly (the admin
+ * is the suite's auth provider); `name` is optional and falls back to `email`.
  */
 
 import { getCookie } from "hono/cookie";
 import { createMiddleware } from "hono/factory";
 import { verify } from "hono/jwt";
+
+// The session cookie + login path are owned by the admin service — metrics
+// consumes the admin's session rather than issuing its own.
+export const SESSION_COOKIE = "admin_session";
+export const ADMIN_LOGIN_PATH = "/admin/login";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -33,7 +40,7 @@ export type SessionEnv = { Variables: { session: SessionPayload } };
 // ─── Factory ──────────────────────────────────────────────────────────────────
 
 /**
- * Creates a Hono middleware that reads and verifies the vitals_session cookie.
+ * Creates a Hono middleware that reads and verifies the admin_session cookie.
  *
  * @param secret - The JWT signing secret (SHIPWRIGHT_SESSION_SECRET). Pass empty string to
  *                 trigger a 500 response (guards against missing env var at call site).
@@ -50,13 +57,15 @@ export function createSessionMiddleware(secret: string) {
 
     // Missing secret is a server misconfiguration — return 500, not a login redirect
     if (!secret) {
-      console.error("[session-middleware] SHIPWRIGHT_SESSION_SECRET is not set");
+      console.error(
+        "[session-middleware] SHIPWRIGHT_SESSION_SECRET is not set",
+      );
       return c.text("Internal Server Error", 500);
     }
 
-    const token = getCookie(c, "vitals_session");
+    const token = getCookie(c, SESSION_COOKIE);
     const returnTo = encodeURIComponent(c.req.path);
-    const loginRedirect = `/auth/login?returnTo=${returnTo}`;
+    const loginRedirect = `${ADMIN_LOGIN_PATH}?returnTo=${returnTo}`;
 
     // Missing or empty cookie → redirect to login
     if (!token) {
@@ -77,21 +86,22 @@ export function createSessionMiddleware(secret: string) {
       return c.redirect(loginRedirect, 302);
     }
 
-    // Validate required fields are present — treat partial payloads as invalid
+    // Validate required fields are present — treat partial payloads as invalid.
+    // `name` is optional (the admin session omits it); fall back to email so the
+    // dashboard always has a display value.
     const { userId, email, name } = payload;
     if (
       typeof userId !== "string" ||
       !userId ||
       typeof email !== "string" ||
-      !email ||
-      typeof name !== "string" ||
-      !name
+      !email
     ) {
       console.debug("[session-middleware] JWT missing required fields");
       return c.redirect(loginRedirect, 302);
     }
 
-    c.set("session", { userId, email, name });
+    const displayName = typeof name === "string" && name ? name : email;
+    c.set("session", { userId, email, name: displayName });
     await next();
   });
 }


### PR DESCRIPTION
## Why
The metrics service's session auth read a `vitals_session` cookie, **required** a `name` claim, and redirected to `/auth/login`. But nothing in the Shipwright suite issues `vitals_session` — the **admin** service is the auth provider and issues an `admin_session` JWT (`{ userId, email }`, HS256, signed with `SHIPWRIGHT_SESSION_SECRET`). So the metrics dashboard/session path never authenticated end-to-end.

## What
Make metrics reuse the admin's session directly:
- Read the **`admin_session`** cookie in both `session-middleware.ts` and the combined-auth in `api.ts`.
- Treat **`name` as optional**, falling back to `email` (the admin JWT omits it).
- Redirect unauthenticated dashboard requests to **`/admin/login`**.
- Centralized as `SESSION_COOKIE` / `ADMIN_LOGIN_PATH`.

## Notes
- The owner-role check (`GET /accounts/users/{id}`) is unchanged; deployments that reuse the admin session should set `METRICS_REQUIRE_OWNER_ROLE=false` since the admin login is already allowlist-gated (that endpoint isn't served by the admin).
- Tests + docs updated; full `bun test metrics/` is green (643 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)