### PR TITLE
feat(metrics): dev-auth dashboard bypass so task stack shows real metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,6 +190,7 @@ Optional. When unset, voice transcription and synthesis are disabled.
 |---|---|---|---|
 | `SHIPWRIGHT_DEV_CHAT` | `bool` | `false` | Enables the unauthenticated `POST /chat` endpoint. Blocked at startup when `NODE_ENV=production`. |
 | `ADMIN_DEV_AUTH` | `bool` | `false` | Enables `GET /admin/dev-login` (bypasses Google OAuth, mints a dev session). Blocked when `NODE_ENV=production`. |
+| `METRICS_DASHBOARD_DEV_AUTH` | `bool` | `false` | Bypasses `/dashboard` session auth and `/metrics/*` API auth for local dev. Must not be enabled in production — exits with an error if `NODE_ENV=production`. |
 
 ---
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -94,6 +94,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `METRICS_OFFLINE` | | `false` | When `true`, skips PostHog env gate, injects fixture data, and bypasses dashboard session auth. |
 | `METRICS_DATABASE_URL` | ✅ (postgres mode) | — | Postgres connection URL (`postgres://...`). Selects postgres mode. Takes precedence over `DATABASE_URL_METRICS`. |
 | `DATABASE_URL_METRICS` | | — | Alias for `METRICS_DATABASE_URL`. Accepted when `METRICS_DATABASE_URL` is absent. |
+| `METRICS_BASE_PATH` | | — | URL path prefix the app is mounted at (e.g. `/sw`). All routes including `/dashboard` and `/metrics/*` are served under this prefix. |
 | `METRICS_API_PORT` | | `3460` | Listen port. |
 | `METRICS_API_KEYS` | | — | Comma-parsed Bearer API keys for `/metrics/*`. |
 | `SHIPWRIGHT_SESSION_SECRET` | | — | HS256 secret for verifying the `admin_session` cookie. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -101,6 +101,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `METRICS_ADMIN_URL` | | `http://localhost:3000` | Shipwright admin service base URL (agent name lookups). |
 | `METRICS_INTERNAL_API_KEY` | | — | Internal key for the accounts client. |
 | `METRICS_DASHBOARD_TOKEN` | | — | Optional dashboard access token. |
+| `METRICS_DASHBOARD_DEV_AUTH` | | `false` | Bypasses `/dashboard` and `/metrics/*` auth for local dev (no login flow in `task stack`). Must not be enabled in production. |
 | `METRICS_DB_PATH` | | `state/metrics.db` | Path for the local SQLite event store (sqlite mode only). Pass `:memory:` for ephemeral use. |
 | `GCP_PROJECT_ID` | | — | Optional — enables GCP Secret Manager as an env-absent fallback for secrets. |
 | `SHIPWRIGHT_ENV_FILE` | | `~/.shipwright/.env` | Dotenv file loaded at startup (existing vars win). |

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -91,6 +91,14 @@ export interface MetricsDeps {
   dashboardToken?: string;
   /** Offline mode: skip session auth and serve /dashboard as a default local user. Default false. */
   offlineMode?: boolean;
+  /**
+   * Local-development auth bypass. Unlike offlineMode (which swaps in fixture
+   * data), this keeps the real injected provider but relaxes auth so both
+   * /dashboard AND /metrics/* are reachable with no session cookie and no
+   * Bearer token — there is no login flow in the local `task stack`. The
+   * metrics analogue of the admin service's ADMIN_DEV_AUTH. Default false.
+   */
+  dashboardDevAuth?: boolean;
   /** URL path prefix the app is mounted at (e.g. "/sw"). Injected into dashboard HTML for asset + API fetch URLs. */
   basePath?: string;
   /**
@@ -922,6 +930,9 @@ export function createMetricsApp(
   const requireOwnerRole = deps?.requireOwnerRole ?? false;
   const dashboardToken = deps?.dashboardToken;
   const offlineMode = deps?.offlineMode ?? false;
+  // Local-dev auth bypass for both /dashboard and /metrics/* (no login flow in
+  // `task stack`). Keeps the real provider — only relaxes auth.
+  const dashboardDevAuth = deps?.dashboardDevAuth ?? false;
   const basePath = deps?.basePath ?? process.env.METRICS_BASE_PATH ?? "";
 
   const app = new OpenAPIHono<AuthEnv>({
@@ -944,16 +955,23 @@ export function createMetricsApp(
   // Health check — no auth required
   app.get("/health", (c) => c.json({ status: "ok" }, 200));
 
-  // /metrics/* — accepts bearer token OR session cookie; returns 401 JSON on failure
+  // /metrics/* — accepts bearer token OR session cookie; returns 401 JSON on failure.
+  // In local-dev mode (dashboardDevAuth), bypass auth entirely with a synthetic
+  // caller so the browser dashboard can fetch data without a cookie or token.
   app.use(
     "/metrics/*",
-    createCombinedAuthMiddleware(
-      apiKeys,
-      sessionSecret,
-      accountsClient,
-      requireOwnerRole,
-      dashboardToken,
-    ),
+    dashboardDevAuth
+      ? createMiddleware<AuthEnv>(async (c, next) => {
+          c.set("caller", { name: "dev-auth", scope: "*" });
+          return next();
+        })
+      : createCombinedAuthMiddleware(
+          apiKeys,
+          sessionSecret,
+          accountsClient,
+          requireOwnerRole,
+          dashboardToken,
+        ),
   );
 
   const handlers = createMetricsHandlers(client, accountsClient, deps);
@@ -1040,18 +1058,18 @@ export function createMetricsApp(
   };
 
   // Dashboard routes are protected by session cookie — redirect to /auth/login on failure
-  // In offline mode: skip session auth entirely and inject a default local user
-  if (!offlineMode) {
+  // In offline / local-dev mode: skip session auth entirely and inject a default local user
+  if (!offlineMode && !dashboardDevAuth) {
     app.use("/dashboard", createSessionMiddleware(sessionSecret));
     app.use("/dashboard/*", createSessionMiddleware(sessionSecret));
   }
 
   // /dashboard — server-rendered with shared toolbar and user name from session
   app.get("/dashboard", async (c) => {
-    // Offline mode: inject a default local user, skip all session/owner checks
-    if (offlineMode) {
+    // Offline / local-dev mode: inject a default local user, skip all session/owner checks
+    if (offlineMode || dashboardDevAuth) {
       const body = renderDashboardPage({
-        userName: "Offline User",
+        userName: offlineMode ? "Offline User" : "Dev User",
         isOwner: true,
         basePath,
       });

--- a/metrics/src/dashboard-dev-auth.smoke.test.ts
+++ b/metrics/src/dashboard-dev-auth.smoke.test.ts
@@ -1,0 +1,77 @@
+/**
+ * metrics/src/dashboard-dev-auth.smoke.test.ts
+ * Smoke tests for the local-development dashboard auth bypass (dashboardDevAuth).
+ *
+ * Unlike offline/fixture mode, dashboardDevAuth keeps the real (injected) data
+ * provider — it only relaxes auth so the server-rendered dashboard AND its data
+ * endpoints are reachable from a browser with no session cookie and no Bearer
+ * token (there is no login flow in the local `task stack`). This is the metrics
+ * analogue of the admin service's ADMIN_DEV_AUTH.
+ *
+ * Contract (with dashboardDevAuth=true, empty sessionSecret, no credentials):
+ * - /dashboard returns 200 server-rendered HTML (no redirect, no 500)
+ * - /metrics/summary (and the other /metrics/* endpoints) return 200 with real
+ *   provider data — WITHOUT any Authorization header or cookie
+ *
+ * No mock.module(), no global.* overrides — DI seam only.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { type MetricsDeps, createMetricsApp } from "./api.ts";
+import { createFixturePostHogClient } from "./fixtures/posthog-fixtures.ts";
+import { parseApiKeys } from "./lib/api-auth.ts";
+import { makeAccountsClientMock } from "./lib/test-helpers.ts";
+
+const noopAccountsClient = makeAccountsClientMock(async () => []);
+
+// dashboardDevAuth keeps a real injected provider (fixture client stands in for
+// the sqlite/posthog provider here — the point under test is auth, not source).
+function makeDevAuthDeps(): MetricsDeps {
+  return {
+    postHogClient: createFixturePostHogClient(),
+    sessionSecret: "",
+    dashboardDevAuth: true,
+  };
+}
+
+describe("dashboardDevAuth — /dashboard", () => {
+  test("returns 200 server-rendered HTML with no session cookie", async () => {
+    const app = createMetricsApp(new Map(), noopAccountsClient, makeDevAuthDeps());
+    const res = await app.request("/dashboard");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toContain("<!DOCTYPE html>");
+    expect(body).toContain("Metrics");
+  });
+});
+
+describe("dashboardDevAuth — /metrics/* without credentials", () => {
+  test("/metrics/summary returns 200 with no Authorization header or cookie", async () => {
+    const app = createMetricsApp(new Map(), noopAccountsClient, makeDevAuthDeps());
+    const res = await app.request("/metrics/summary?preset=7d");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.data.tasksCompleted).toBe("number");
+  });
+
+  test("/metrics/trends returns 200 with no credentials", async () => {
+    const app = createMetricsApp(new Map(), noopAccountsClient, makeDevAuthDeps());
+    const res = await app.request("/metrics/trends?preset=7d");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data.rows)).toBe(true);
+  });
+});
+
+describe("dashboardDevAuth — disabled by default", () => {
+  test("without the flag, /metrics/summary still requires auth (401)", async () => {
+    const deps: MetricsDeps = {
+      postHogClient: createFixturePostHogClient(),
+      sessionSecret: "",
+    };
+    const app = createMetricsApp(new Map(), noopAccountsClient, deps);
+    const res = await app.request("/metrics/summary?preset=7d");
+    expect(res.status).toBe(401);
+  });
+});

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -37,6 +37,9 @@ const offlineMode = mode === "fixtures";
 
 const port = Number(process.env.METRICS_API_PORT ?? 3460);
 const basePath = process.env.METRICS_BASE_PATH ?? "";
+// Local-dev auth bypass for /dashboard + /metrics/* (no login flow in `task stack`).
+// Keeps the real provider — only relaxes auth. Never enable in production.
+const dashboardDevAuth = process.env.METRICS_DASHBOARD_DEV_AUTH === "true";
 
 if (!process.env.METRICS_ADMIN_URL && process.env.METRICS_ACCOUNTS_URL) {
   console.warn(
@@ -93,6 +96,7 @@ if (mode === "fixtures") {
     sessionSecret: process.env.SHIPWRIGHT_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
+    dashboardDevAuth,
     basePath,
   };
   console.log(
@@ -108,6 +112,7 @@ if (mode === "fixtures") {
     sessionSecret: process.env.SHIPWRIGHT_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
+    dashboardDevAuth,
     basePath,
   };
   console.log(
@@ -118,6 +123,7 @@ if (mode === "fixtures") {
     sessionSecret: process.env.SHIPWRIGHT_SESSION_SECRET ?? "",
     requireOwnerRole: process.env.METRICS_REQUIRE_OWNER_ROLE === "true",
     dashboardToken: process.env.METRICS_DASHBOARD_TOKEN,
+    dashboardDevAuth,
     basePath,
   };
 }

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -40,6 +40,10 @@ const basePath = process.env.METRICS_BASE_PATH ?? "";
 // Local-dev auth bypass for /dashboard + /metrics/* (no login flow in `task stack`).
 // Keeps the real provider — only relaxes auth. Never enable in production.
 const dashboardDevAuth = process.env.METRICS_DASHBOARD_DEV_AUTH === "true";
+if (dashboardDevAuth && process.env.NODE_ENV === "production") {
+  console.error("[metrics-api] FATAL: METRICS_DASHBOARD_DEV_AUTH cannot be enabled in production");
+  process.exit(1);
+}
 
 if (!process.env.METRICS_ADMIN_URL && process.env.METRICS_ACCOUNTS_URL) {
   console.warn(

--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -154,7 +154,13 @@ export const STACK_PANES: Pane[] = [
     cmd: ["bun", "metrics/src/server.ts"],
     // SQLite persistence mode: no METRICS_OFFLINE, no POSTHOG_PROJECT_API_KEY,
     // no METRICS_DATABASE_URL → service defaults to sqlite mode.
-    env: { METRICS_DB_PATH: "state/metrics.db" },
+    // METRICS_DASHBOARD_DEV_AUTH bypasses dashboard/login auth (there is no login
+    // flow in the stack) while KEEPING the real sqlite provider — so the dashboard
+    // shows the metrics the agent actually forwards, not fixtures.
+    env: {
+      METRICS_DB_PATH: "state/metrics.db",
+      METRICS_DASHBOARD_DEV_AUTH: "true",
+    },
   },
   {
     label: "admin",
@@ -169,6 +175,10 @@ export const STACK_PANES: Pane[] = [
       // to this agent; use "*" for an admin bypass key.
       SHIPWRIGHT_ADMIN_API_KEYS: `dev-agent:${DUMMY_AGENT_API_KEY}:dev-agent`,
       ADMIN_DEV_AUTH: "true",
+      // Point the admin toolbar's "Metrics" link at the running metrics
+      // dashboard (:3460). Without this it falls back to /sw/dashboard on the
+      // admin host (:3001) and 404s.
+      METRICS_DASHBOARD_URL: `http://localhost:${METRICS_PORT}/dashboard`,
     },
   },
   {

--- a/scripts/dev-tmux.unit.test.ts
+++ b/scripts/dev-tmux.unit.test.ts
@@ -457,12 +457,28 @@ describe("metrics pane — sqlite mode", () => {
     expect(metrics.env?.METRICS_OFFLINE).toBeUndefined();
     expect(metrics.env?.METRICS_DB_PATH).toBe("state/metrics.db");
   });
+
+  test("metrics pane enables the dashboard dev-auth bypass (real data, no login)", () => {
+    // task stack has no login flow; this lets the dashboard + /metrics/* be
+    // viewed in the browser while keeping the real sqlite provider (not fixtures).
+    const metrics = STACK_PANES.find((p) => p.label === "metrics") as Pane;
+    expect(metrics.env?.METRICS_DASHBOARD_DEV_AUTH).toBe("true");
+  });
 });
 
 describe("admin pane — dev auth", () => {
   test("admin pane has ADMIN_DEV_AUTH=true", () => {
     const admin = STACK_PANES.find((p) => p.label === "admin") as Pane;
     expect(admin.env?.ADMIN_DEV_AUTH).toBe("true");
+  });
+
+  test("admin pane points the toolbar Metrics link at the running metrics dashboard", () => {
+    // Without this the toolbar's Metrics link falls back to /sw/dashboard on the
+    // admin host (:3001), which 404s — the dashboard actually lives on :3460.
+    const admin = STACK_PANES.find((p) => p.label === "admin") as Pane;
+    expect(admin.env?.METRICS_DASHBOARD_URL).toBe(
+      `http://localhost:${METRICS_PORT}/dashboard`,
+    );
   });
 
   test("admin pane does not include SHIPWRIGHT_INTERNAL_API_KEY (removed in UNI-1.2)", () => {


### PR DESCRIPTION
## Summary
Enables both the admin and metrics dashboards in the local `task stack` dev loop, with the metrics dashboard showing **real** (sqlite-persisted) data the agent forwards — not fixtures.

Adds a `dashboardDevAuth` flag (env: `METRICS_DASHBOARD_DEV_AUTH=true`) to the metrics service — the analogue of admin's `ADMIN_DEV_AUTH`. It relaxes auth on **both** `/dashboard` and `/metrics/*` (no login flow exists in the stack) while keeping the real provider.

## Why
In `task stack`, the metrics pane ran sqlite mode with no session secret and no offline flag, so `/dashboard` 500'd on an empty HS256 key. The admin toolbar's *Metrics* link also fell back to `/sw/dashboard` on the admin host (:3001), which 404s — the dashboard actually lives on :3460.

## Changes
- `metrics/src/api.ts` — `dashboardDevAuth` dep: bypass `/dashboard` session gate (renders "Dev User") + `/metrics/*` auth (synthetic caller). Off by default.
- `metrics/src/server.ts` — reads `METRICS_DASHBOARD_DEV_AUTH` into deps (postgres/sqlite/default branches).
- `scripts/dev-tmux.ts` — metrics pane sets the flag; admin pane sets `METRICS_DASHBOARD_URL=http://localhost:3460/dashboard` so the toolbar link resolves.
- Tests: new `dashboard-dev-auth.smoke.test.ts` (bypass works with no credentials; off-by-default still 401) + `dev-tmux.unit.test.ts` assertions for the pane env.

## Verification
- Full suite: 2577 pass / 0 fail. Lint + typecheck clean.
- Live: `/dashboard` 200, `/metrics/summary` 200 with real sqlite data (no auth), dashboard renders "Dev User", admin Metrics link → :3460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)