### PR TITLE
fix(docker): set NODE_ENV=production in all three service images

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 # Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
 # install package-specific deps under the workspace dir (/app/admin/node_modules),
 # NOT the hoisted root — both are required at runtime.

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -78,6 +78,8 @@ FROM base AS runtime
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 # Set AGENT_HOME — the PVC should be mounted here in Kubernetes
 ENV AGENT_HOME=/data/agent-home
 

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 # Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
 # install package-specific deps under the workspace dir (/app/metrics/node_modules),
 # NOT the hoisted root — both are required at runtime.


### PR DESCRIPTION
## Summary

- Adds `ENV NODE_ENV=production` to the runtime stage of `agent/Dockerfile`, `admin/Dockerfile`, and `metrics/Dockerfile`

## Why

The production guards for `ADMIN_DEV_AUTH`, `SHIPWRIGHT_DEV_CHAT`, and `METRICS_DASHBOARD_DEV_AUTH` all key off `NODE_ENV === "production"` — but that var was never actually set in any of the images. Without it, accidentally enabling one of those dev-auth flags in a prod deployment would silently pass right through the guard. Spotted while reviewing #285.

Mirrors the vitals-os pattern, which sets `NODE_ENV=production` both in its Dockerfile and Helm values.

No impact on local dev — `task stack` / `bun run` don't use the Dockerfiles.

## Test plan

- [ ] CI passes (no code logic changed, just env var in image)
- [ ] Confirm `NODE_ENV` is visible inside a built container: `docker run --rm shipwright-metrics printenv NODE_ENV` → `production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)