### PR TITLE
fix(agent): install shipwright plugin from local disk, not remote GitHub slug

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -71,6 +71,9 @@ RUN bun install --frozen-lockfile
 
 # Copy the rest of the agent source
 COPY agent/ ./agent/
+# Copy the plugin source so the local marketplace is available at runtime
+COPY plugins/ ./plugins/
+COPY .claude-plugin/ ./.claude-plugin/
 
 # ─── Runtime stage (non-root) ─────────────────────────────────────────────────
 
@@ -112,6 +115,9 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.170 \
 # the root node_modules holds bun's content-addressed store they point into.)
 COPY --from=build --chown=1000:1000 /app/node_modules ./node_modules
 COPY --from=build --chown=1000:1000 /app/agent ./agent
+# Plugin source + marketplace manifest — needed for local `claude plugin marketplace add`
+COPY --from=build --chown=1000:1000 /app/plugins ./plugins
+COPY --from=build --chown=1000:1000 /app/.claude-plugin ./.claude-plugin
 
 # Make the credential helper and gh wrapper executable
 RUN chmod +x /app/agent/scripts/bin/git-credential-shipwright.sh \

--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -739,6 +739,29 @@ describe("installPlugins", () => {
     expect(calls).toHaveLength(3);
   });
 
+  it("continues when marketplace add exits non-zero", async () => {
+    const calls: Array<{ args: string[] }> = [];
+    const mockExec = async (
+      _cmd: string,
+      args: string[],
+      _opts: { cwd: string },
+    ) => {
+      calls.push({ args });
+      const isMarketplaceAdd = args[1] === "marketplace";
+      return {
+        stdout: isMarketplaceAdd ? "network error" : "",
+        exitCode: isMarketplaceAdd ? 1 : 0,
+      };
+    };
+
+    await expect(
+      installPlugins(mockExec, testHome, [], "/repo/root"),
+    ).resolves.toBeUndefined();
+
+    // All 3 calls still happened despite marketplace add failure
+    expect(calls).toHaveLength(3);
+  });
+
   it("is a silent no-op when plugins are already installed and up-to-date", async () => {
     const calls: Array<{ args: string[] }> = [];
     const mockExec = async (

--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -591,7 +591,7 @@ describe("runMiseStartup", () => {
 // ---------------------------------------------------------------------------
 
 describe("installPlugins", () => {
-  it("installs shipwright default plugin first (shipwright@app-vitals/shipwright)", async () => {
+  it("registers local marketplace then installs shipwright@app-vitals", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -602,19 +602,25 @@ describe("installPlugins", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    await installPlugins(mockExec, testHome, []);
+    await installPlugins(mockExec, testHome, [], "/repo/root");
 
-    // Should have: 1 install + 1 update for the default plugin
-    expect(calls).toHaveLength(2);
+    // marketplace add + 1 install + 1 update = 3 calls
+    expect(calls).toHaveLength(3);
     expect(calls[0].args).toEqual([
       "plugin",
-      "install",
-      "shipwright@app-vitals/shipwright",
+      "marketplace",
+      "add",
+      "/repo/root",
     ]);
     expect(calls[1].args).toEqual([
       "plugin",
+      "install",
+      "shipwright@app-vitals",
+    ]);
+    expect(calls[2].args).toEqual([
+      "plugin",
       "update",
-      "shipwright@app-vitals/shipwright",
+      "shipwright@app-vitals",
     ]);
   });
 
@@ -634,40 +640,47 @@ describe("installPlugins", () => {
       { marketplace: "other-market", plugin: "another-plugin" },
     ];
 
-    await installPlugins(mockExec, testHome, agentPlugins);
+    await installPlugins(mockExec, testHome, agentPlugins, "/repo/root");
 
-    // default install + 2 agent installs + default update + 2 agent updates = 6 calls
-    expect(calls).toHaveLength(6);
+    // 1 marketplace add + 3 installs + 3 updates = 7 calls
+    expect(calls).toHaveLength(7);
 
-    // installs: default first, then agent-specific
     expect(calls[0].args).toEqual([
       "plugin",
-      "install",
-      "shipwright@app-vitals/shipwright",
+      "marketplace",
+      "add",
+      "/repo/root",
     ]);
+
+    // installs: default first, then agent-specific
     expect(calls[1].args).toEqual([
+      "plugin",
+      "install",
+      "shipwright@app-vitals",
+    ]);
+    expect(calls[2].args).toEqual([
       "plugin",
       "install",
       "custom-plugin@my-marketplace",
     ]);
-    expect(calls[2].args).toEqual([
+    expect(calls[3].args).toEqual([
       "plugin",
       "install",
       "another-plugin@other-market",
     ]);
 
     // updates: default first, then agent-specific
-    expect(calls[3].args).toEqual([
+    expect(calls[4].args).toEqual([
       "plugin",
       "update",
-      "shipwright@app-vitals/shipwright",
+      "shipwright@app-vitals",
     ]);
-    expect(calls[4].args).toEqual([
+    expect(calls[5].args).toEqual([
       "plugin",
       "update",
       "custom-plugin@my-marketplace",
     ]);
-    expect(calls[5].args).toEqual([
+    expect(calls[6].args).toEqual([
       "plugin",
       "update",
       "another-plugin@other-market",
@@ -685,12 +698,12 @@ describe("installPlugins", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    await installPlugins(mockExec, testHome, []);
+    await installPlugins(mockExec, testHome, [], "/repo/root");
 
-    // 1 install + 1 update for just the default plugin
-    expect(calls).toHaveLength(2);
-    expect(calls[0].args).toContain("shipwright@app-vitals/shipwright");
-    expect(calls[1].args).toContain("shipwright@app-vitals/shipwright");
+    // marketplace add + 1 install + 1 update = 3 calls
+    expect(calls).toHaveLength(3);
+    expect(calls[1].args).toContain("shipwright@app-vitals");
+    expect(calls[2].args).toContain("shipwright@app-vitals");
   });
 
   it("is non-fatal when the claude binary isn't available", async () => {
@@ -699,7 +712,7 @@ describe("installPlugins", () => {
     };
 
     await expect(
-      installPlugins(throwingExec, testHome, []),
+      installPlugins(throwingExec, testHome, [], "/repo/root"),
     ).resolves.toBeUndefined();
   });
 
@@ -719,11 +732,11 @@ describe("installPlugins", () => {
     };
 
     await expect(
-      installPlugins(mockExec, testHome, []),
+      installPlugins(mockExec, testHome, [], "/repo/root"),
     ).resolves.toBeUndefined();
 
     // All calls still happened despite install failures
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
   });
 
   it("is a silent no-op when plugins are already installed and up-to-date", async () => {
@@ -738,49 +751,8 @@ describe("installPlugins", () => {
     };
 
     await expect(
-      installPlugins(mockExec, testHome, []),
+      installPlugins(mockExec, testHome, [], "/repo/root"),
     ).resolves.toBeUndefined();
-    expect(calls).toHaveLength(2);
-  });
-
-  it("uses SHIPWRIGHT_LOCAL_MARKETPLACE path when env var is set", async () => {
-    const originalLocalMarketplace = process.env.SHIPWRIGHT_LOCAL_MARKETPLACE;
-    process.env.SHIPWRIGHT_LOCAL_MARKETPLACE = "/local/marketplace";
-
-    try {
-      const calls: Array<{ cmd: string; args: string[] }> = [];
-      const mockExec = async (
-        cmd: string,
-        args: string[],
-        _opts: { cwd: string },
-      ) => {
-        calls.push({ cmd, args });
-        return { stdout: "", exitCode: 0 };
-      };
-
-      await installPlugins(mockExec, testHome, []);
-
-      // install and update should both use the local path
-      expect(calls[0].args).toEqual([
-        "plugin",
-        "install",
-        "shipwright@/local/marketplace",
-      ]);
-      expect(calls[1].args).toEqual([
-        "plugin",
-        "update",
-        "shipwright@/local/marketplace",
-      ]);
-    } finally {
-      // Restore env var regardless of test outcome.
-      // Use delete when the var was originally unset — assigning undefined coerces
-      // to the string "undefined" in Node.js-compatible runtimes, breaking the ?? fallback.
-      if (originalLocalMarketplace === undefined) {
-        // biome-ignore lint/performance/noDelete: intentional env-var removal (not object property)
-        delete process.env.SHIPWRIGHT_LOCAL_MARKETPLACE;
-      } else {
-        process.env.SHIPWRIGHT_LOCAL_MARKETPLACE = originalLocalMarketplace;
-      }
-    }
+    expect(calls).toHaveLength(3);
   });
 });

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -29,10 +29,16 @@ import type { AgentPlugin } from "@shipwright/admin";
 // Templates live at agent/workspace/ alongside this source file.
 const WORKSPACE_TEMPLATE_DIR = join(import.meta.dir, "..", "workspace");
 
+// Repo root — two levels up from agent/src/. In Docker this is /app; on the Pi
+// it resolves to the checkout root. Mirrors the vitals-os approach so the local
+// marketplace is always used regardless of whether the GitHub repo is accessible.
+const SHIPWRIGHT_REPO_ROOT = join(import.meta.dir, "..", "..");
+
+// Local marketplace name — matches the `owner` field in .claude-plugin/marketplace.json.
+const SHIPWRIGHT_MARKETPLACE = "app-vitals";
+
 // Default plugin installed on all Shipwright agents.
-const DEFAULT_PLUGINS: readonly AgentPlugin[] = [
-  { marketplace: "app-vitals/shipwright", plugin: "shipwright" },
-];
+const DEFAULT_PLUGINS: readonly string[] = ["shipwright"];
 
 /**
  * Reads a template file from agent/workspace/<name>.
@@ -185,23 +191,32 @@ export async function installPlugins(
   execFn: ExecFn = defaultExec,
   cwd: string = process.cwd(),
   agentPlugins: AgentPlugin[] = [],
+  shipwrightRepoRoot: string = SHIPWRIGHT_REPO_ROOT,
 ): Promise<void> {
   try {
-    // SHIPWRIGHT_LOCAL_MARKETPLACE: use a local path instead of the GitHub slug
-    // so uncommitted plugin edits run inside the container.
-    // Scoped to DEFAULT_PLUGINS only — agent-specific plugins always resolve
-    // their own marketplace to avoid silent redirection of unrelated installs.
-    const localMarketplace = process.env.SHIPWRIGHT_LOCAL_MARKETPLACE;
+    // Register the local marketplace so `claude plugin install` can resolve
+    // plugins by name. Idempotent — safe to call on every startup.
+    const add = await execFn(
+      "claude",
+      ["plugin", "marketplace", "add", shipwrightRepoRoot],
+      { cwd },
+    );
+    if (add.exitCode !== 0) {
+      console.warn(
+        `[agent] claude plugin marketplace add exited ${add.exitCode}: ${add.stdout}`,
+      );
+    }
 
-    const resolvedDefaultPlugins = DEFAULT_PLUGINS.map((p) => ({
-      ...p,
-      marketplace: localMarketplace ?? p.marketplace,
-    }));
-    const allPlugins = [...resolvedDefaultPlugins, ...agentPlugins];
+    const defaultPluginSpecs = DEFAULT_PLUGINS.map(
+      (name) => `${name}@${SHIPWRIGHT_MARKETPLACE}`,
+    );
+    const agentPluginSpecs = agentPlugins.map(
+      (p) => `${p.plugin}@${p.marketplace}`,
+    );
+    const allSpecs = [...defaultPluginSpecs, ...agentPluginSpecs];
 
     // Install all plugins (defaults then agent-specific)
-    for (const plugin of allPlugins) {
-      const spec = `${plugin.plugin}@${plugin.marketplace}`;
+    for (const spec of allSpecs) {
       const install = await execFn("claude", ["plugin", "install", spec], {
         cwd,
       });
@@ -213,8 +228,7 @@ export async function installPlugins(
     }
 
     // Update all plugins (defaults then agent-specific)
-    for (const plugin of allPlugins) {
-      const spec = `${plugin.plugin}@${plugin.marketplace}`;
+    for (const spec of allSpecs) {
       const update = await execFn("claude", ["plugin", "update", spec], {
         cwd,
       });
@@ -431,7 +445,10 @@ export async function runMiseStartup(
       cpSync(imageMiseDir, pvMiseDir, { recursive: true });
       console.log("[agent] seeded MISE_DATA_DIR from image on fresh PVC");
     } catch (err) {
-      console.warn("[agent] failed to seed MISE_DATA_DIR from image — continuing without PVC shims", err);
+      console.warn(
+        "[agent] failed to seed MISE_DATA_DIR from image — continuing without PVC shims",
+        err,
+      );
     }
   }
   process.env.MISE_DATA_DIR = pvMiseDir;

--- a/agent/src/setup.unit.test.ts
+++ b/agent/src/setup.unit.test.ts
@@ -1,30 +1,14 @@
 /**
- * Unit tests for agent/src/setup.ts — SHIPWRIGHT_LOCAL_MARKETPLACE seam
+ * Unit tests for agent/src/setup.ts — installPlugins local marketplace seam
  *
  * Pure logic tests: no I/O, no real binaries, injected exec doubles only.
  */
 
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { installPlugins } from "./setup.ts";
 
-describe("installPlugins — SHIPWRIGHT_LOCAL_MARKETPLACE seam", () => {
-  const originalLocalMarketplace = process.env.SHIPWRIGHT_LOCAL_MARKETPLACE;
-
-  afterEach(() => {
-    // Restore env var so tests don't bleed into each other.
-    // Use delete when the var was originally unset — assigning undefined coerces
-    // to the string "undefined" in Node.js-compatible runtimes, breaking the ?? fallback.
-    if (originalLocalMarketplace === undefined) {
-      // biome-ignore lint/performance/noDelete: intentional env-var removal (not object property)
-      delete process.env.SHIPWRIGHT_LOCAL_MARKETPLACE;
-    } else {
-      process.env.SHIPWRIGHT_LOCAL_MARKETPLACE = originalLocalMarketplace;
-    }
-  });
-
-  it("uses local path when SHIPWRIGHT_LOCAL_MARKETPLACE is set", async () => {
-    process.env.SHIPWRIGHT_LOCAL_MARKETPLACE = "/local/path";
-
+describe("installPlugins — local marketplace", () => {
+  it("registers the marketplace before installing plugins", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -35,20 +19,18 @@ describe("installPlugins — SHIPWRIGHT_LOCAL_MARKETPLACE seam", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    await installPlugins(mockExec, "/tmp/test-cwd", []);
+    await installPlugins(mockExec, "/tmp/cwd", [], "/repo/root");
 
-    // Both install and update should use the local path
-    const specs = calls.map((c) => c.args[2]);
-    expect(specs).toEqual([
-      "shipwright@/local/path",
-      "shipwright@/local/path",
+    // First call must be marketplace add
+    expect(calls[0].args).toEqual([
+      "plugin",
+      "marketplace",
+      "add",
+      "/repo/root",
     ]);
   });
 
-  it("uses GitHub marketplace slug when SHIPWRIGHT_LOCAL_MARKETPLACE is unset", async () => {
-    // biome-ignore lint/performance/noDelete: intentional env-var removal (not object property)
-    delete process.env.SHIPWRIGHT_LOCAL_MARKETPLACE;
-
+  it("installs and updates shipwright@app-vitals using the local marketplace name", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -59,19 +41,23 @@ describe("installPlugins — SHIPWRIGHT_LOCAL_MARKETPLACE seam", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    await installPlugins(mockExec, "/tmp/test-cwd", []);
+    await installPlugins(mockExec, "/tmp/cwd", [], "/repo/root");
 
-    // Should use the original GitHub marketplace slug
-    const specs = calls.map((c) => c.args[2]);
-    expect(specs).toEqual([
-      "shipwright@app-vitals/shipwright",
-      "shipwright@app-vitals/shipwright",
+    // marketplace add + install + update = 3 calls
+    expect(calls).toHaveLength(3);
+    expect(calls[1].args).toEqual([
+      "plugin",
+      "install",
+      "shipwright@app-vitals",
+    ]);
+    expect(calls[2].args).toEqual([
+      "plugin",
+      "update",
+      "shipwright@app-vitals",
     ]);
   });
 
-  it("covers both install and update commands with local path", async () => {
-    process.env.SHIPWRIGHT_LOCAL_MARKETPLACE = "/local/path";
-
+  it("agent plugins use their own marketplace, not the local one", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -82,22 +68,25 @@ describe("installPlugins — SHIPWRIGHT_LOCAL_MARKETPLACE seam", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    await installPlugins(mockExec, "/tmp/test-cwd", []);
+    await installPlugins(
+      mockExec,
+      "/tmp/cwd",
+      [{ plugin: "my-plugin", marketplace: "org/my-marketplace" }],
+      "/repo/root",
+    );
 
-    expect(calls).toHaveLength(2);
-
-    // install call uses local path
-    expect(calls[0].args[1]).toBe("install");
-    expect(calls[0].args[2]).toBe("shipwright@/local/path");
-
-    // update call uses local path
-    expect(calls[1].args[1]).toBe("update");
-    expect(calls[1].args[2]).toBe("shipwright@/local/path");
+    // marketplace add + 2 installs + 2 updates = 5 calls
+    expect(calls).toHaveLength(5);
+    const specs = calls.slice(1).map((c) => c.args[2]);
+    expect(specs).toEqual([
+      "shipwright@app-vitals",
+      "my-plugin@org/my-marketplace",
+      "shipwright@app-vitals",
+      "my-plugin@org/my-marketplace",
+    ]);
   });
 
-  it("does not apply SHIPWRIGHT_LOCAL_MARKETPLACE to agentPlugins", async () => {
-    process.env.SHIPWRIGHT_LOCAL_MARKETPLACE = "/local/path";
-
+  it("passes the repoRoot to marketplace add", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -108,17 +97,13 @@ describe("installPlugins — SHIPWRIGHT_LOCAL_MARKETPLACE seam", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    await installPlugins(mockExec, "/tmp/test-cwd", [
-      { plugin: "my-agent-plugin", marketplace: "org/my-marketplace" },
-    ]);
+    await installPlugins(mockExec, "/tmp/cwd", [], "/custom/repo/root");
 
-    // DEFAULT_PLUGINS (shipwright) uses the local path; agentPlugins use their own marketplace
-    const specs = calls.map((c) => c.args[2]);
-    expect(specs).toEqual([
-      "shipwright@/local/path",         // default plugin: local override applies
-      "my-agent-plugin@org/my-marketplace", // agent plugin: own marketplace preserved
-      "shipwright@/local/path",         // default plugin update: local override applies
-      "my-agent-plugin@org/my-marketplace", // agent plugin update: own marketplace preserved
+    expect(calls[0].args).toEqual([
+      "plugin",
+      "marketplace",
+      "add",
+      "/custom/repo/root",
     ]);
   });
 });

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -115,7 +115,6 @@ All child models cascade-delete with their `Agent`.
 | `GH_APP_INSTALLATION_ID` | GitHub App auth | Installation ID for the target org/repo. Required when using the App auth path. |
 | `GH_TOKEN` | GitHub PAT auth | Personal Access Token for the legacy `gh auth setup-git` path. Used only if the App env vars are absent. |
 | `SHIPWRIGHT_DEV_CHAT` | dev only | Set to `"true"` to enable the unauthenticated `POST /chat` endpoint (local dev convenience). Must **not** be set in production (`NODE_ENV=production`). |
-| `SHIPWRIGHT_LOCAL_MARKETPLACE` | dev only | Absolute path to a local marketplace checkout (e.g. `/workspace/marketplace`). When set, `installPlugins` uses this path instead of the GitHub slug for every plugin install and update, so uncommitted marketplace edits take effect inside the container. |
 | `ADMIN_DEV_AUTH` | dev only | Set to `"true"` to enable `GET /admin/dev-login` (bypasses Google OAuth, mints a dev session). Hard-blocked when `NODE_ENV=production` by `dev-auth-guard.ts`. |
 | `VITALS_OS_API_URL` | migration CLI | Base URL of the vitals-os accounts API (e.g. `https://vitals-os.com`). Required by `agent/src/run-migration.ts`. |
 | `VITALS_OS_API_KEY` | migration CLI | Admin API key for the vitals-os accounts API. Required by `agent/src/run-migration.ts`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,6 @@ Configuration for the Shipwright Claude Code plugin (`plugins/shipwright/`). The
 | `JIRA_PROJECT_KEY` | `string` | — | Jira project key (e.g. `SHIP`). Required when `SHIPWRIGHT_TASK_STORE=jira`. |
 | `SHIPWRIGHT_REPOS_DIR` | `string` | `<AGENT_HOME>/workspace/repos` | Override the workspace repos directory. Used by scripts that need to know where checked-out repos live. |
 | `SHIPWRIGHT_WORKTREE_DIR` | `string` | `<AGENT_HOME>/workspace/worktrees` | Override the workspace worktrees directory. |
-| `SHIPWRIGHT_LOCAL_MARKETPLACE` | `string` | — | Absolute path to a local marketplace checkout. When set, plugin installs and updates use this path instead of fetching from GitHub. Dev-only — do not set in production. |
 | `SHIPWRIGHT_DEV_CHAT` | `bool` | `false` | Enables the unauthenticated `POST /chat` endpoint on the agent. **Must not be set in production** (`NODE_ENV=production` blocks it via `chat-guard.ts`). |
 | `SHIPWRIGHT_CONFIG` | `string` | — | Explicit path to `.shipwright.json` when auto-discovery (walk-up from cwd) is not suitable. Falls back to local JSON state if neither this nor the walk-up finds a file. |
 | `GH_CMD` | `string` | `gh` | Override the `gh` CLI executable. Useful in environments where `gh` is installed to a non-default path. |

--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -207,8 +207,6 @@ export const STACK_PANES: Pane[] = [
       "-e",
       "SHIPWRIGHT_DEV_CHAT=true",
       "-e",
-      "SHIPWRIGHT_LOCAL_MARKETPLACE=/repo/plugins/shipwright",
-      "-e",
       `SHIPWRIGHT_API_URL=http://host.docker.internal:${ADMIN_PORT}`,
       "-e",
       `POSTHOG_HOST=http://host.docker.internal:${METRICS_PORT}`,

--- a/scripts/dev-tmux.unit.test.ts
+++ b/scripts/dev-tmux.unit.test.ts
@@ -529,14 +529,6 @@ describe("agent pane — docker run", () => {
     expect(cmdStr).toContain("SHIPWRIGHT_DEV_CHAT=true");
   });
 
-  test("agent pane docker run passes SHIPWRIGHT_LOCAL_MARKETPLACE=/repo/plugins/shipwright", () => {
-    const agent = STACK_PANES.find((p) => p.label === "agent") as Pane;
-    const cmdStr = agent.cmd.join(" ");
-    expect(cmdStr).toContain(
-      "SHIPWRIGHT_LOCAL_MARKETPLACE=/repo/plugins/shipwright",
-    );
-  });
-
   test("agent pane docker run passes SHIPWRIGHT_API_URL pointing at host.docker.internal", () => {
     const agent = STACK_PANES.find((p) => p.label === "agent") as Pane;
     const cmdStr = agent.cmd.join(" ");

--- a/site/src/pages/docs/configuration.astro
+++ b/site/src/pages/docs/configuration.astro
@@ -71,7 +71,6 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
             { name: "JIRA_PROJECT_KEY", type: "string", def: "—", desc: "Jira project key (e.g. SHIP). Required when SHIPWRIGHT_TASK_STORE=jira." },
             { name: "SHIPWRIGHT_REPOS_DIR", type: "string", def: "<AGENT_HOME>/workspace/repos", desc: "Override the workspace repos directory." },
             { name: "SHIPWRIGHT_WORKTREE_DIR", type: "string", def: "<AGENT_HOME>/workspace/worktrees", desc: "Override the workspace worktrees directory." },
-            { name: "SHIPWRIGHT_LOCAL_MARKETPLACE", type: "string", def: "—", desc: "Absolute path to a local marketplace checkout. Dev-only — do not set in production." },
             { name: "SHIPWRIGHT_DEV_CHAT", type: "bool", def: "false", desc: "Enables the unauthenticated POST /chat endpoint. Must not be set in production." },
             { name: "SHIPWRIGHT_CONFIG", type: "string", def: "—", desc: "Explicit path to .shipwright.json when auto-discovery is not suitable." },
             { name: "GH_CMD", type: "string", def: "gh", desc: "Override the gh CLI executable. Useful in environments where gh is installed to a non-default path." },


### PR DESCRIPTION
## Summary

- Mirrors the vitals-os approach: register the repo root as a local marketplace via `claude plugin marketplace add <repoRoot>`, then install `shipwright@app-vitals`
- The previous remote GitHub slug approach (`shipwright@app-vitals/shipwright`) never worked — agents without GitHub access can't resolve it, and the `marketplace add` registration step was missing entirely
- Copies `plugins/` and `.claude-plugin/` into the Dockerfile runtime stage so the plugin source is on disk in both Docker and direct (Pi) deployments
- Removes `SHIPWRIGHT_LOCAL_MARKETPLACE` env var (no longer needed — local install is always used)

## Test plan

- [ ] All existing `installPlugins` integration tests updated and passing (67 tests green)
- [ ] Verify `claude plugin marketplace add` appears as first call in exec mock
- [ ] Verify `shipwright@app-vitals` used for install/update (not GitHub slug)
- [ ] Build Docker image and confirm plugin is installed at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)