### PR TITLE
feat(ci): add build-agent.yml to publish shipwright-agent image

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -1,0 +1,46 @@
+name: Build and Push Agent Image
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-and-push:
+    name: build / tag / push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: "agent-v"
+          default_bump: patch
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f agent/Dockerfile \
+            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-agent.yml` — mirrors `build-admin.yml` exactly
- On push to `main`: tags `agent-vX.Y.Z`, authenticates to GCP via WIF, builds from `agent/Dockerfile`, pushes `shipwright-agent:agent-vX.Y.Z` to Artifact Registry
- Gating dependency for migrating GKE client agents (okwow, fern-dan, keaunu, sideby-dan, warchild) from the vitals-os runtime to the Shipwright harness

## Test plan

- [ ] Merge → CI triggers `build-agent.yml` → `agent-v0.1.0` tag created → image pushed to `us-west1-docker.pkg.dev/vitals-os-prod/vitals-os/shipwright-agent:agent-v0.1.0`
- [ ] Verify image in Artifact Registry before wiring into Helm

🤖 Generated with [Claude Code](https://claude.com/claude-code)