### PR TITLE
fix(check-patch): apply merge-only filter so stale reviews still trigger patch

### DIFF
--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -228,6 +228,41 @@ export function resolveRepos(workspacePath: string): string[] {
   return [];
 }
 
+// ─── Merge-only detection ────────────────────────────────────────────────────
+
+export interface CommitInfo {
+  sha: string;
+  parents: Array<{ sha: string }>;
+}
+
+/**
+ * Returns true if all commits after `lastReviewedCommit` are merge commits
+ * (parents.length >= 2). Returns false on error, missing anchor, or if there
+ * are no commits after the anchor.
+ *
+ * Shared by check-review (skip re-review after merge-from-main) and check-patch
+ * (still trigger patch when only merge commits landed since a stale review).
+ */
+export async function isMergeOnlyUpdate(
+  prNumber: number,
+  lastReviewedCommit: string,
+  deps: {
+    listPrCommits: (prNumber: number, repo?: string) => Promise<CommitInfo[]>;
+  },
+  repo?: string,
+): Promise<boolean> {
+  try {
+    const commits = await deps.listPrCommits(prNumber, repo);
+    const anchorIndex = commits.findIndex((c) => c.sha === lastReviewedCommit);
+    if (anchorIndex === -1) return false;
+    const subsequent = commits.slice(anchorIndex + 1);
+    if (subsequent.length === 0) return false;
+    return subsequent.every((c) => c.parents.length >= 2);
+  } catch {
+    return false;
+  }
+}
+
 // ─── gh CLI helper ────────────────────────────────────────────────────────────
 
 /**

--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type { CommitInfo } from "./check-helpers.ts";
 import { run } from "./check-patch.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -82,6 +83,7 @@ function makeDeps(
     repo: string,
     pr: number,
   ) => Promise<void> = async () => {},
+  listPrCommits: (_prNumber: number) => Promise<CommitInfo[]> = async () => [],
 ) {
   return {
     listOwnOpenPrs: async (_repo: string) => ownPrs,
@@ -110,6 +112,7 @@ function makeDeps(
       return mergeStatusByPr[pr] ?? { isBehind: false, isDirty: false };
     },
     updateBranch,
+    listPrCommits,
   };
 }
 
@@ -507,5 +510,155 @@ describe("check-patch", () => {
     );
     expect(result.exit).toBe(0);
     expect(result.output.toLowerCase()).toContain("patch");
+  });
+
+  // ─── Merge-only stale findings ────────────────────────────────────────────
+
+  test("exits 0 when stale COMMENT review has findings and all new commits are merge-only", async () => {
+    const pr = makeOwnPr({ headRefOid: "merge-sha" });
+    const reviewData = makePrReviewData({
+      headRefOid: "merge-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "reviewer1" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "review-sha" }, // posted before the merge commit
+            body: "Please fix this",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const commits: CommitInfo[] = [
+      { sha: "review-sha", parents: [{ sha: "p0" }] },
+      { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] }, // merge commit
+    ];
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => commits,
+      ),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("patch");
+  });
+
+  test("exits 0 when stale review has unresolved threads and all new commits are merge-only", async () => {
+    const pr = makeOwnPr({ headRefOid: "merge-sha" });
+    const reviewData = makePrReviewData({
+      headRefOid: "merge-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "reviewer1" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "review-sha" },
+            body: "",
+          },
+        ],
+      },
+      reviewThreads: {
+        nodes: [
+          {
+            isResolved: false,
+            comments: {
+              nodes: [{ author: { login: "reviewer1" }, body: "Fix this" }],
+            },
+          },
+        ],
+      },
+    });
+    const commits: CommitInfo[] = [
+      { sha: "review-sha", parents: [{ sha: "p0" }] },
+      { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] },
+    ];
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => commits,
+      ),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("patch");
+  });
+
+  test("exits 1 when stale review has findings but real commits pushed since (not merge-only)", async () => {
+    const pr = makeOwnPr({ headRefOid: "real-work-sha" });
+    const reviewData = makePrReviewData({
+      headRefOid: "real-work-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "reviewer1" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "review-sha" },
+            body: "Please fix this",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const commits: CommitInfo[] = [
+      { sha: "review-sha", parents: [{ sha: "p0" }] },
+      { sha: "real-work-sha", parents: [{ sha: "p1" }] }, // regular (non-merge) commit
+    ];
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => commits,
+      ),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when stale COMMENT review at older commit has no findings (empty body, no unresolved threads)", async () => {
+    const pr = makeOwnPr({ headRefOid: "merge-sha" });
+    const reviewData = makePrReviewData({
+      headRefOid: "merge-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "reviewer1" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "review-sha" },
+            body: "",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const commits: CommitInfo[] = [
+      { sha: "review-sha", parents: [{ sha: "p0" }] },
+      { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] },
+    ];
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => commits,
+      ),
+    );
+    expect(result.exit).toBe(1);
   });
 });

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -16,11 +16,13 @@
  *   bun plugins/shipwright/scripts/check-patch.ts
  */
 
+import type { CommitInfo } from "./check-helpers.ts";
 import {
   getCurrentUser,
   ghGraphql,
   ghJson,
   ghRun,
+  isMergeOnlyUpdate,
   resolveAllRepos,
   resolveWorkspacePath,
 } from "./check-helpers.ts";
@@ -82,6 +84,7 @@ export interface Deps {
     pr: number,
   ) => Promise<MergeStatusInfo>;
   updateBranch: (org: string, repo: string, pr: number) => Promise<void>;
+  listPrCommits: (prNumber: number, repo?: string) => Promise<CommitInfo[]>;
 }
 
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
@@ -110,6 +113,46 @@ function hasUnaddressedFindings(data: PrReviewData): boolean {
 
   // No unresolved threads — check if any qualifying review has a non-empty body
   return qualifyingReviews.some((r) => r.body.trim().length > 0);
+}
+
+// ─── Merge-only stale findings ────────────────────────────────────────────────
+
+/**
+ * Returns true if the PR has unaddressed review findings at a stale commit and
+ * all commits since that review are merge commits. Mirrors check-review's
+ * merge-only skip: a branch updated only via merge-from-main hasn't had real
+ * author activity, so findings from the pre-merge review are still valid.
+ */
+async function hasMergeOnlyStaleFindings(
+  prNumber: number,
+  data: PrReviewData,
+  deps: Pick<Deps, "listPrCommits">,
+  repo?: string,
+): Promise<boolean> {
+  const { headRefOid, reviews, reviewThreads } = data;
+
+  const staleReviews = reviews.nodes.filter(
+    (r) =>
+      (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
+      r.commit.oid !== headRefOid,
+  );
+
+  if (staleReviews.length === 0) return false;
+
+  const unresolvedThreads = reviewThreads.nodes.filter((t) => !t.isResolved);
+  const hasFindings =
+    unresolvedThreads.length > 0 ||
+    staleReviews.some((r) => r.body.trim().length > 0);
+
+  if (!hasFindings) return false;
+
+  // Anchor on the most recent stale review commit
+  const anchorCommit = [...staleReviews].sort(
+    (a, b) =>
+      new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+  )[0].commit.oid;
+
+  return isMergeOnlyUpdate(prNumber, anchorCommit, deps, repo);
 }
 
 // ─── Core logic ───────────────────────────────────────────────────────────────
@@ -153,6 +196,16 @@ export async function run(deps: Deps): Promise<RunResult> {
 
     const reviewData = await deps.fetchPrReviews(org, repo, pr.number);
     if (hasUnaddressedFindings(reviewData)) {
+      return {
+        exit: 0,
+        output:
+          "Fix unaddressed review findings on own open PRs via /shipwright:patch",
+      };
+    }
+
+    // If findings exist at a stale commit but all new commits are merges, the
+    // findings are still valid — only a merge-from-main landed, not real author work.
+    if (await hasMergeOnlyStaleFindings(pr.number, reviewData, deps, pr.repo)) {
       return {
         exit: 0,
         output:
@@ -303,6 +356,14 @@ export async function buildProductionDeps(): Promise<Deps> {
     },
     updateBranch: async (org: string, repo: string, pr: number) => {
       ghRun(["pr", "update-branch", String(pr), "--repo", `${org}/${repo}`]);
+    },
+    listPrCommits: async (prNumber: number, repo?: string) => {
+      const targetRepo = repo ?? allRepos[0];
+      return ghJson<CommitInfo[]>([
+        "api",
+        `repos/${targetRepo}/pulls/${prNumber}/commits`,
+        "--paginate",
+      ]);
     },
   };
 }

--- a/plugins/shipwright/scripts/check-review-patch.test.ts
+++ b/plugins/shipwright/scripts/check-review-patch.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { ReviewEntry } from "./check-helpers.ts";
+import type { CommitInfo, ReviewEntry } from "./check-helpers.ts";
 import type { PrReviewData } from "./check-patch.ts";
 import { run } from "./check-review-patch.ts";
 
@@ -111,6 +111,7 @@ function makePatchDepsTriggering() {
       _repo: string,
       _pr: number,
     ): Promise<void> => {},
+    listPrCommits: async (): Promise<CommitInfo[]> => [],
   };
 }
 
@@ -142,6 +143,7 @@ function makePatchDepsIdle() {
       _repo: string,
       _pr: number,
     ): Promise<void> => {},
+    listPrCommits: async (): Promise<CommitInfo[]> => [],
   };
 }
 

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -18,10 +18,11 @@
  *   bun plugins/shipwright/scripts/check-review.ts
  */
 
-import type { ReviewEntry } from "./check-helpers.ts";
+import type { CommitInfo, ReviewEntry } from "./check-helpers.ts";
 import {
   getCurrentUser,
   ghJson,
+  isMergeOnlyUpdate,
   parseAllowSelfReview,
   readAllowSelfReview,
   readReviews,
@@ -29,6 +30,8 @@ import {
   resolveWorkspacePath,
 } from "./check-helpers.ts";
 
+export type { CommitInfo } from "./check-helpers.ts";
+export { isMergeOnlyUpdate } from "./check-helpers.ts";
 export { parseAllowSelfReview } from "./check-helpers.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -42,11 +45,6 @@ interface PrInfo {
   repo?: string;
 }
 
-export interface CommitInfo {
-  sha: string;
-  parents: Array<{ sha: string }>;
-}
-
 interface Deps {
   getCurrentUser: () => string;
   isSelfReviewAllowed: boolean;
@@ -58,31 +56,6 @@ interface Deps {
 // ─── Terminal statuses ────────────────────────────────────────────────────────
 
 const TERMINAL_STATUSES = new Set(["cleaned", "merged"]);
-
-// ─── Merge-only detection ─────────────────────────────────────────────────────
-
-/**
- * Returns true if all commits since lastReviewedCommit are merge commits
- * (parents.length >= 2). Returns false on any error, if the anchor commit is
- * not found, or if there are no commits after the anchor.
- */
-export async function isMergeOnlyUpdate(
-  prNumber: number,
-  lastReviewedCommit: string,
-  deps: Pick<Deps, "listPrCommits">,
-  repo?: string,
-): Promise<boolean> {
-  try {
-    const commits = await deps.listPrCommits(prNumber, repo);
-    const anchorIndex = commits.findIndex((c) => c.sha === lastReviewedCommit);
-    if (anchorIndex === -1) return false;
-    const subsequent = commits.slice(anchorIndex + 1);
-    if (subsequent.length === 0) return false;
-    return subsequent.every((c) => c.parents.length >= 2);
-  } catch {
-    return false;
-  }
-}
 
 // ─── Core logic ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Mirrors check-review's merge-only skip logic in check-patch: after a merge-from-main, COMMENT/CHANGES_REQUESTED reviews fall off the HEAD commit filter in `hasUnaddressedFindings` and the PR silently drops out of the patch queue even though the review findings are still valid
- Moves `CommitInfo` + `isMergeOnlyUpdate` from `check-review.ts` → `check-helpers.ts` so both scripts share the implementation
- Adds `hasMergeOnlyStaleFindings` to `check-patch.ts`: when `hasUnaddressedFindings` returns false, checks whether stale reviews have findings AND all commits since the review are merge commits — if so, returns exit 0 so patch still runs
- Adds `listPrCommits` to the `Deps` interface and `buildProductionDeps`
- 4 new unit tests: merge-only trigger, non-merge (skip), unresolved-threads trigger, and no-findings (skip)

## Test plan

- [x] `bun test check-patch.test.ts check-review.test.ts check-helpers.unit.test.ts` — 72 pass, 0 fail
- [x] `bunx biome check` — clean on all 4 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)