### PR TITLE
fix(agent): correct marketplace.json schema and rename marketplace to shipwright

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,10 @@
 {
-  "owner": "app-vitals",
+  "name": "shipwright",
+  "description": "Shipwright — AI-powered engineering workflow plugins for Claude Code",
+  "owner": {
+    "name": "app-vitals",
+    "url": "https://github.com/app-vitals"
+  },
   "version": "0.1.0",
   "plugins": [
     {

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -34,8 +34,8 @@ const WORKSPACE_TEMPLATE_DIR = join(import.meta.dir, "..", "workspace");
 // marketplace is always used regardless of whether the GitHub repo is accessible.
 const SHIPWRIGHT_REPO_ROOT = join(import.meta.dir, "..", "..");
 
-// Local marketplace name — matches the `owner` field in .claude-plugin/marketplace.json.
-const SHIPWRIGHT_MARKETPLACE = "app-vitals";
+// Local marketplace name — matches the `name` field in .claude-plugin/marketplace.json.
+const SHIPWRIGHT_MARKETPLACE = "shipwright";
 
 // Default plugin installed on all Shipwright agents.
 const DEFAULT_PLUGINS: readonly string[] = ["shipwright"];


### PR DESCRIPTION
## Summary

- Fixes \`claude plugin marketplace add\` failing with exit 1 on every agent startup
- Claude Code's marketplace parser requires a top-level \`name\` string and an \`owner\` object; the old schema had \`owner\` as a string and no \`name\` field
- Renames marketplace from \`app-vitals\` to \`shipwright\` so plugin specs read \`shipwright@shipwright\`

## Test plan

- [x] \`claude plugin marketplace add <repo>\` succeeds (exit 0)
- [x] \`claude plugin install shipwright@shipwright\` succeeds (exit 0)
- [ ] Agent startup logs no \`marketplace add exited 1\` errors after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)