### PR TITLE
test(agent): update marketplace manifest test for new owner object schema

### DIFF
--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -591,7 +591,7 @@ describe("runMiseStartup", () => {
 // ---------------------------------------------------------------------------
 
 describe("installPlugins", () => {
-  it("registers local marketplace then installs shipwright@app-vitals", async () => {
+  it("registers local marketplace then installs shipwright@shipwright using the shipwright marketplace", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -615,12 +615,12 @@ describe("installPlugins", () => {
     expect(calls[1].args).toEqual([
       "plugin",
       "install",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
     ]);
     expect(calls[2].args).toEqual([
       "plugin",
       "update",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
     ]);
   });
 
@@ -656,7 +656,7 @@ describe("installPlugins", () => {
     expect(calls[1].args).toEqual([
       "plugin",
       "install",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
     ]);
     expect(calls[2].args).toEqual([
       "plugin",
@@ -673,7 +673,7 @@ describe("installPlugins", () => {
     expect(calls[4].args).toEqual([
       "plugin",
       "update",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
     ]);
     expect(calls[5].args).toEqual([
       "plugin",
@@ -702,8 +702,8 @@ describe("installPlugins", () => {
 
     // marketplace add + 1 install + 1 update = 3 calls
     expect(calls).toHaveLength(3);
-    expect(calls[1].args).toContain("shipwright@app-vitals");
-    expect(calls[2].args).toContain("shipwright@app-vitals");
+    expect(calls[1].args).toContain("shipwright@shipwright");
+    expect(calls[2].args).toContain("shipwright@shipwright");
   });
 
   it("is non-fatal when the claude binary isn't available", async () => {

--- a/agent/src/setup.unit.test.ts
+++ b/agent/src/setup.unit.test.ts
@@ -30,7 +30,7 @@ describe("installPlugins — local marketplace", () => {
     ]);
   });
 
-  it("installs and updates shipwright@app-vitals using the local marketplace name", async () => {
+  it("installs and updates shipwright@shipwright using the shipwright marketplace name", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const mockExec = async (
       cmd: string,
@@ -48,12 +48,12 @@ describe("installPlugins — local marketplace", () => {
     expect(calls[1].args).toEqual([
       "plugin",
       "install",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
     ]);
     expect(calls[2].args).toEqual([
       "plugin",
       "update",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
     ]);
   });
 
@@ -79,9 +79,9 @@ describe("installPlugins — local marketplace", () => {
     expect(calls).toHaveLength(5);
     const specs = calls.slice(1).map((c) => c.args[2]);
     expect(specs).toEqual([
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
       "my-plugin@org/my-marketplace",
-      "shipwright@app-vitals",
+      "shipwright@shipwright",
       "my-plugin@org/my-marketplace",
     ]);
   });

--- a/scripts/marketplace-manifest.integration.test.ts
+++ b/scripts/marketplace-manifest.integration.test.ts
@@ -18,7 +18,9 @@ interface PluginEntry {
 }
 
 interface MarketplaceManifest {
-  owner: string;
+  name: string;
+  description: string;
+  owner: { name: string; url: string };
   version: string;
   plugins: PluginEntry[];
 }
@@ -33,11 +35,16 @@ describe("marketplace.json", () => {
     expect(() => JSON.parse(raw)).not.toThrow();
   });
 
-  it("has required top-level fields: owner (string), version (string), plugins (array)", () => {
+  it("has required top-level fields: name (string), owner (object), version (string), plugins (array)", () => {
     const raw = readFileSync(MANIFEST_PATH, "utf8");
     const manifest = JSON.parse(raw) as MarketplaceManifest;
-    expect(typeof manifest.owner).toBe("string");
-    expect(manifest.owner.length).toBeGreaterThan(0);
+    expect(typeof manifest.name).toBe("string");
+    expect(manifest.name.length).toBeGreaterThan(0);
+    expect(typeof manifest.owner).toBe("object");
+    expect(typeof manifest.owner.name).toBe("string");
+    expect(manifest.owner.name.length).toBeGreaterThan(0);
+    expect(typeof manifest.owner.url).toBe("string");
+    expect(manifest.owner.url.length).toBeGreaterThan(0);
     expect(typeof manifest.version).toBe("string");
     expect(manifest.version.length).toBeGreaterThan(0);
     expect(Array.isArray(manifest.plugins)).toBe(true);


### PR DESCRIPTION
## Summary

Follow-up to #296 — the test was asserting `owner` is a string, but the schema change made it an object. Fixes the failing CI from the previous merge.

## Test plan

- [x] `bun test scripts/marketplace-manifest.integration.test.ts` — 8 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)