### PR TITLE
fix(agent): remove duplicate health server in entrypoint-main (EADDRINUSE crash)

### DIFF
--- a/agent/src/entrypoint-main.ts
+++ b/agent/src/entrypoint-main.ts
@@ -6,16 +6,16 @@
  * Wires all real dependencies and calls runEntrypoint().
  * Run via: bun run agent/src/entrypoint-main.ts [--agent-id X] [--api-url Y] [--api-key Z]
  *
- * The health server is started in-process on SHIPWRIGHT_HEALTH_PORT (default 3459)
- * BEFORE the startup sequence so K8s liveness probes are reachable during init.
- * The agent server (index.ts) runs as a subprocess — spawnAgentServer.
+ * The agent server (index.ts) runs as a subprocess (spawnAgentServer) and owns
+ * the single health server. Do NOT start a health server here too — index.ts
+ * binds the same port, so a second listener would fail with EADDRINUSE and crash
+ * the agent on startup.
  */
 
 import { join } from "node:path";
 import { parseCliArgs } from "./cli-args.ts";
 import { runEntrypoint } from "./entrypoint.ts";
 import { createGitHubTokenManager, getBotIdentity } from "./github-app-auth.ts";
-import { DEFAULT_HEALTH_PORT, startHealthServer } from "./health.ts";
 import { setupGitHubAuth } from "./setup-github-auth.ts";
 import {
   ensureDotClaudeSymlink,
@@ -23,15 +23,6 @@ import {
   runMiseStartup,
 } from "./setup.ts";
 import { HttpShipwrightRuntimeClient } from "./shipwright-runtime-client.ts";
-
-// ─── Health server (in-process, before startup sequence) ─────────────────────
-// Start the health server immediately so liveness probes are reachable during
-// the full startup sequence (config fetch, mise, plugin install, etc.).
-const healthPort = Number(
-  process.env.SHIPWRIGHT_HEALTH_PORT ?? DEFAULT_HEALTH_PORT,
-);
-console.log(`[entrypoint-main] starting health server on port ${healthPort}`);
-startHealthServer(healthPort);
 
 const { agentId, apiUrl, apiKey } = parseCliArgs(
   process.argv.slice(2),


### PR DESCRIPTION
## Problem

The first GKE rollout of an agent on the Shipwright harness (okwow) hit `CrashLoopBackOff`:

```
[entrypoint-main] starting health server on port 3459
...
error: Failed to start server. Is port 3459 in use?  (EADDRINUSE)
  at /app/agent/src/index.ts:94
```

`entrypoint-main.ts` started a health server in-process on `SHIPWRIGHT_HEALTH_PORT` (3459), then spawned the agent server `index.ts` via `spawnAgentServer` — and `index.ts` **also** calls `startHealthServer` on the same port. The second bind fails → the agent process dies → crash-loop on every start.

## Root cause

A new behavior introduced during the vitals-os → shipwright extraction. The vitals-os runtime this was extracted from runs a **single** health server, owned by the agent server (`index.ts`), with the entrypoint importing it in-process. The extraction added a second, earlier health server in `entrypoint-main` "so liveness is reachable during setup" — but `index.ts` (the actual spawned server) already owns one.

Note: `run-agent.ts` carries a stale comment ("entrypoint-main starts the health server, don't start here") — that was written for the old `entrypoint → run-agent.ts` wiring, which was itself a bug. `entrypoint.ts` now correctly spawns `index.ts`, and `run-agent.ts` is a dev-only thin server not in the prod path, so it's left untouched here.

## Fix

Remove the in-process health server (and its now-unused import) from `entrypoint-main.ts`. The spawned `index.ts` owns the one health server — matching the vitals-os model that runs in prod today.

Liveness still has `initialDelaySeconds: 15`; the spawned server binds within that window (same timing as the in-process vitals-os model).

## Validation

- `agent/src/entrypoint.integration.test.ts` + `health.integration.test.ts`: 28 pass, 0 fail
- biome clean
- No remaining references to `startHealthServer`/`DEFAULT_HEALTH_PORT` in `entrypoint-main.ts`

## Rollout

Merging triggers `build-agent.yml` → new `agent-v0.2.x`. Then bump `shipwrightAgentSvc.image.tag` in vitals-os `values-prod.yaml` and redeploy to bring okwow up healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)