### PR TITLE
fix(agent): install claude/node system-wide, not via mise (fixes 'claude is not a valid shim')

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -51,6 +51,16 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # non-root runtime user can invoke it).
 RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
 
+# Install Node.js + Claude Code CLI system-wide (as root), matching vitals-os.
+# claude is a plain binary on PATH (/usr/bin/claude) backed by system node — it is
+# NOT a mise shim, so its resolution never depends on the active mise/workspace
+# context (which is what broke the previous mise-reshim approach: "claude is not a
+# valid shim"). mise stays purely a runtime *workspace* tool-version manager.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code@2.1.170 \
+    && rm -rf /var/lib/apt/lists/*
+
 # ─── Build stage ──────────────────────────────────────────────────────────────
 
 FROM base AS build
@@ -98,17 +108,11 @@ RUN mkdir -p /data/agent-home && chown 1000:1000 /data/agent-home
 USER 1000
 ENV HOME=/home/bun
 
-# mise-managed tool shims (node, npm, claude) live under the user's data dir.
+# mise runtime *workspace* tool shims live under the user's data dir, first on
+# PATH. node + claude are system-wide (installed in the base stage) and resolve
+# via the inherited /usr/bin — they are intentionally NOT mise shims.
 # /app/agent/scripts/bin holds the git-credential-shipwright.sh and gh wrappers.
 ENV PATH="/home/bun/.local/share/mise/shims:/app/agent/scripts/bin:${PATH}"
-
-# Node.js 20 LTS via mise (Debian bookworm's apt provides Node 18 which is EOL).
-RUN mise use --global node@20
-
-# Install Claude Code globally via the mise-managed node's npm, then reshim so
-# the `claude` shim is created on PATH.
-RUN npm install -g @anthropic-ai/claude-code@2.1.170 \
-    && mise reshim
 
 # Copy installed node_modules + agent source from the build stage, owned by the
 # runtime user. (The agent dir carries its own workspace node_modules symlinks;

--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -465,43 +465,22 @@ describe("runMiseStartup", () => {
     expect(process.env.MISE_DATA_DIR).toBe(join(testHome, "mise"));
   });
 
-  it("seeds MISE_DATA_DIR from image on fresh PVC (shims absent)", async () => {
+  it("does NOT seed/copy the image mise dir onto the PVC", async () => {
+    // node + claude are system binaries (image /usr/bin), not mise tools, so
+    // runMiseStartup must NOT copy the image mise dir onto the PVC. The old seed
+    // hack did, which on a reused PVC left claude resolving to a shim with no
+    // install ("claude is not a valid shim").
     mkdirSync(join(testHome, "workspace"), { recursive: true });
-    // Simulate image mise dir with a shim file
     const imageMiseDir = join(testHome, ".local", "share", "mise");
     mkdirSync(join(imageMiseDir, "shims"), { recursive: true });
-    writeFileSync(join(imageMiseDir, "shims", "node"), "mise-shim", "utf8");
-    // PVC mise dir exists but has no shims (fresh PVC)
-    mkdirSync(join(testHome, "mise"), { recursive: true });
+    writeFileSync(join(imageMiseDir, "shims", "claude"), "image-shim", "utf8");
     process.env.HOME = testHome;
     // biome-ignore lint/performance/noDelete: intentional env-var removal (not object property)
     delete process.env.XDG_DATA_HOME;
     const mockExec = async () => ({ stdout: "", exitCode: 0 });
     await runMiseStartup(testHome, mockExec);
-    expect(existsSync(join(testHome, "mise", "shims", "node"))).toBe(true);
-  });
-
-  it("skips seed when shims already exist on PVC", async () => {
-    mkdirSync(join(testHome, "workspace"), { recursive: true });
-    // Pre-create shims on PVC (simulates a subsequent boot)
-    mkdirSync(join(testHome, "mise", "shims"), { recursive: true });
-    writeFileSync(
-      join(testHome, "mise", "shims", "node"),
-      "pvc-version",
-      "utf8",
-    );
-    // Image also has shims — should not overwrite
-    const imageMiseDir = join(testHome, ".local", "share", "mise");
-    mkdirSync(join(imageMiseDir, "shims"), { recursive: true });
-    writeFileSync(join(imageMiseDir, "shims", "node"), "image-version", "utf8");
-    process.env.HOME = testHome;
-    // biome-ignore lint/performance/noDelete: intentional env-var removal (not object property)
-    delete process.env.XDG_DATA_HOME;
-    const mockExec = async () => ({ stdout: "", exitCode: 0 });
-    await runMiseStartup(testHome, mockExec);
-    expect(readFileSync(join(testHome, "mise", "shims", "node"), "utf8")).toBe(
-      "pvc-version",
-    );
+    // The image's claude shim must NOT have been copied to the PVC.
+    expect(existsSync(join(testHome, "mise", "shims", "claude"))).toBe(false);
   });
 
   it("pins MISE_CACHE_DIR and XDG_CACHE_HOME to the PVC", async () => {

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -8,7 +8,6 @@
  */
 
 import {
-  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -429,32 +428,16 @@ export async function runMiseStartup(
 ): Promise<void> {
   const workspaceDir = join(home, "workspace");
 
-  // On a fresh PVC the $AGENT_HOME/mise/ directory exists (created by
-  // ensureAgentHome) but is empty — no shims yet. Seed it from the image's
-  // default mise data dir so the baked toolchain (node, claude) is available
-  // on the PVC from the first restart onward. Subsequent boots skip the copy.
-  const pvMiseDir = join(home, "mise");
-  const pvShimsDir = join(pvMiseDir, "shims");
-  const imageMiseDir = join(
-    process.env.XDG_DATA_HOME ??
-      join(process.env.HOME ?? home, ".local", "share"),
-    "mise",
-  );
-  if (!existsSync(pvShimsDir) && existsSync(imageMiseDir)) {
-    try {
-      cpSync(imageMiseDir, pvMiseDir, { recursive: true });
-      console.log("[agent] seeded MISE_DATA_DIR from image on fresh PVC");
-    } catch (err) {
-      console.warn(
-        "[agent] failed to seed MISE_DATA_DIR from image — continuing without PVC shims",
-        err,
-      );
-    }
-  }
-  process.env.MISE_DATA_DIR = pvMiseDir;
-
-  // Pin mise + XDG cache dirs to the PVC so download tarballs land on
-  // persistent storage.
+  // Pin mise + XDG cache/data dirs to the PVC before any mise calls so installs
+  // and download tarballs land on persistent storage, not ephemeral. node and
+  // claude are system-wide binaries (installed in the image, on /usr/bin), NOT
+  // mise tools — so repointing MISE_DATA_DIR at the PVC does NOT affect them.
+  // MISE_DATA_DIR holds only workspace-declared runtime tools.
+  //
+  // (Do NOT seed/copy the image mise dir onto the PVC here — that hack existed
+  // when node+claude were mise-managed; on a reused PVC the copy was skipped and
+  // claude resolved to a shim with no install: "claude is not a valid shim".)
+  process.env.MISE_DATA_DIR = join(home, "mise");
   process.env.MISE_CACHE_DIR = join(home, "mise", "cache");
   process.env.XDG_CACHE_HOME = join(home, "cache");
   mkdirSync(process.env.MISE_CACHE_DIR, { recursive: true });
@@ -478,6 +461,6 @@ export async function runMiseStartup(
 
   // Prepend MISE_DATA_DIR/shims to PATH so workspace-declared tools are found
   // in non-interactive bash sessions.
-  const shimsDir = join(pvMiseDir, "shims");
+  const shimsDir = join(process.env.MISE_DATA_DIR, "shims");
   process.env.PATH = [shimsDir, process.env.PATH ?? ""].join(":");
 }


### PR DESCRIPTION
## Problem

After the okwow harness pod came up healthy (Slack connected), every `claude` invocation failed:

```
mise ERROR claude is not a valid shim. This likely means you uninstalled a tool
and the shim does not point to anything.
  at /app/agent/src/claude.ts:198 (_spawn → spawner(["claude", ...]))
```

## Root cause

claude was installed under a **mise-managed node** (`mise use --global node@20` → `npm i -g claude-code` → `mise reshim`), so `claude` became a **mise shim** (`/home/bun/.local/share/mise/shims/claude → mise`). But `runMiseStartup` repoints `MISE_DATA_DIR` at the PVC. When the image's claude shim runs, mise resolves the tool against the PVC mise dir — which has **no claude install** → "not a valid shim".

A seed-hack tried to paper over this by copying the image mise dir onto the PVC, but on a **reused** PVC (every migrated agent) the copy is skipped because `mise/shims` already exists, so it never helps.

This is a divergence from the **vitals-os runtime** this was extracted from, which installs Node via NodeSource and `npm i -g @anthropic-ai/claude-code` as a plain **system binary** (`/usr/bin/claude`) — entirely independent of mise. (Confirmed on the live okwow pod: `claude` → image shim → `mise`; `MISE_DATA_DIR` PVC has node/npm shims but no claude.)

## Fix (match vitals-os)

- **Dockerfile**: install Node 22 (NodeSource) + `@anthropic-ai/claude-code@2.1.170` system-wide in the base stage (as root). Drop `mise use --global node@20`, the mise-node npm install, and `mise reshim`. `claude`/`node` are now system binaries on `/usr/bin`, never mise shims.
- **setup.ts `runMiseStartup`**: drop the image→PVC seed/copy hack. Just point `MISE_DATA_DIR`/cache dirs at the PVC and install workspace-declared tools — identical to vitals-os. mise stays purely a runtime *workspace* tool-version manager.
- **tests**: replace the two seed-behavior tests with one asserting no image→PVC copy. `setup.integration.test.ts`: 50 pass / 0 fail; biome clean.

## No PVC cleanup needed

The okwow PVC's mise dir holds node/npm/pip shims (original vitals-os state, working) and **no claude shim** — the broken claude shim existed only in the image, which this change no longer creates. After deploy, `claude` resolves to `/usr/bin/claude`; `node`/`npm` keep resolving via the PVC mise shims, exactly as under the working vitals-os runtime on this same PVC.

## Rollout

Merge → `build-agent.yml` builds `agent-v0.2.4` → bump `shipwrightAgentSvc.image.tag` in vitals-os `values-prod.yaml` → deploy → validate `claude` runs in okwow (Slack message triggering a Bash/agent action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)