### PR TITLE
fix(agent): add native build toolchain (build-essential, libssl-dev, pkg-config, jq)

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -31,11 +31,20 @@ FROM oven/bun:1-slim AS base
 #   - curl         — used by the mise installer and gh keyring setup
 #   - ca-certificates — TLS trust for API calls
 #   - unzip        — needed by some mise-managed tools
+#   - jq           — bash JSON parsing in the time-tracking Claude Code hooks
+#   - build-essential / libssl-dev / pkg-config — native + Rust toolchain so the
+#     agent can build client code at runtime (e.g. Rust projects + OpenSSL crates).
+#     Mirrors the vitals-os runtime image. (voice deps — python/edge-tts/ffmpeg —
+#     deliberately omitted; voice is not deployed on the Shipwright harness yet.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
     unzip \
+    jq \
+    build-essential \
+    libssl-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI via official GitHub apt keyring


### PR DESCRIPTION
## Why

The vitals-os → shipwright agent extraction kept only the bare agent-runtime deps and dropped the **client-work toolchain** that agents need to build/run the repos they operate on. Traced through the vitals-os `Dockerfile` history:

| Dep | vitals-os origin | Purpose |
|---|---|---|
| `jq` | #566 | the ported time-tracking Claude Code hooks parse JSON in bash |
| `build-essential` | #714 → #715 | native/Rust linker support |
| `libssl-dev` + `pkg-config` | #1403 | Rust crates needing OpenSSL — **added for the fern agent**, which migrates next |

Without these, **fern** (Rust) would fail to build client code the same way okwow failed on the claude shim.

## Deliberately NOT added

- **Voice deps** (`python3`/`edge-tts`/`ffmpeg`) — voice/TTS is not deployed on the Shipwright harness yet. (When it is, `python3` + `edge-tts` are the live deps; `synthesizeSpeech` is already wired in `index.ts` and would ENOENT on the edge-tts fallback without them.)
- **`ffmpeg`** is dead even in vitals-os since STT moved to whisper-svc (#1354) — zero `agent/src` references in either repo.

## Change

Adds `jq build-essential libssl-dev pkg-config` to the base-stage apt install. One layer, mirrors the vitals-os runtime image.

## Rollout

Merge → `build-agent.yml` builds `agent-v0.2.5`. Not urgent for okwow (already healthy on v0.2.4), but should land before the **fern** migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)