### PR TITLE
fix(agent): symlink ~/.claude.json (MCP) + activate mise in bash (extraction parity)

### DIFF
--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -448,6 +448,12 @@ describe("runMiseStartup", () => {
   const originalHome = process.env.HOME;
   const originalPath = process.env.PATH;
 
+  beforeEach(() => {
+    // Isolate HOME to the per-test dir so the ~/.bashrc mise-activate append in
+    // runMiseStartup never touches the real developer/CI home.
+    process.env.HOME = testHome;
+  });
+
   afterEach(() => {
     // Restore env vars modified by runMiseStartup (and the tests below)
     process.env.MISE_DATA_DIR = originalMiseDataDir;

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  appendFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -277,7 +278,8 @@ const DEFAULT_DOT_CLAUDE_FS: DotClaudeFs = {
 
 /**
  * Symlink `linkPath` (~/.claude) → `target` ($AGENT_HOME/dot-claude), ensuring
- * the TARGET directory exists first.
+ * the TARGET directory exists first. ALSO symlinks the sibling `~/.claude.json`
+ * → `$AGENT_HOME/claude.json` (see below).
  *
  * The target MUST be created before symlinking: on a fresh PVC the target does
  * not exist, so without this the symlink dangles and every write under
@@ -289,6 +291,15 @@ const DEFAULT_DOT_CLAUDE_FS: DotClaudeFs = {
  * `symlinkSync` throw EEXIST on a re-run. `lstatSync` sees the link itself, so
  * a stale/dangling symlink is detected and replaced. A real directory at
  * `linkPath` is removed (logged) before relinking.
+ *
+ * `~/.claude.json` holds Claude Code's MCP server registrations (`claude mcp
+ * add`) and lives OUTSIDE `~/.claude/`, so it needs its own symlink to survive
+ * pod restarts. Without it, registered MCP servers (e.g. Linear) silently
+ * disappear — Claude reads the ephemeral image copy instead of the PVC's. The
+ * target is `$AGENT_HOME/claude.json` (sibling of the dot-claude dir), matching
+ * the path the vitals-os runtime used, so a migrated PVC's existing MCP config
+ * is picked up. Unlike the dir, the target is NOT pre-created: it is a FILE that
+ * Claude writes on first use, so a dangling symlink is correct until then.
  */
 export function ensureDotClaudeSymlink(
   target: string,
@@ -319,6 +330,27 @@ export function ensureDotClaudeSymlink(
 
   fs.symlinkSync(target, linkPath);
   log(`[entrypoint] symlinked ${linkPath} → ${target}`);
+
+  // ── ~/.claude.json (MCP server registrations) — file symlink, no mkdir ──────
+  const jsonTarget = join(target, "..", "claude.json");
+  const jsonLink = `${linkPath}.json`;
+  let existingJson: ReturnType<typeof lstatSync> | null = null;
+  try {
+    existingJson = fs.lstatSync(jsonLink);
+  } catch {
+    existingJson = null;
+  }
+  if (existingJson) {
+    if (existingJson.isSymbolicLink()) {
+      fs.unlinkSync(jsonLink);
+    } else {
+      // The image ships a real ~/.claude.json — remove it before symlinking so
+      // the PVC copy (with MCP registrations) is the one Claude reads.
+      fs.rmSync(jsonLink, { recursive: false });
+    }
+  }
+  fs.symlinkSync(jsonTarget, jsonLink);
+  log(`[entrypoint] symlinked ${jsonLink} → ${jsonTarget}`);
 }
 
 export function ensureAgentHome(home: string): void {
@@ -442,6 +474,22 @@ export async function runMiseStartup(
   process.env.XDG_CACHE_HOME = join(home, "cache");
   mkdirSync(process.env.MISE_CACHE_DIR, { recursive: true });
   mkdirSync(process.env.XDG_CACHE_HOME, { recursive: true });
+
+  // Activate mise in any bash session the agent spawns (e.g. Claude Code's Bash
+  // tool). The shims-on-PATH prepend below only reaches direct subprocesses;
+  // login/interactive shells re-source profile files that reset PATH, so
+  // workspace-declared tools (e.g. fern's Rust toolchain) would be missing
+  // without this. Ported from the vitals-os runtime; dropped in the extraction.
+  // Unconditional (before the mise.toml check) so it's ready for any workspace
+  // tools; idempotent so repeated boots don't stack duplicate lines.
+  const bashrc = join(process.env.HOME ?? home, ".bashrc");
+  if (
+    !existsSync(bashrc) ||
+    !readFileSync(bashrc, "utf8").includes("mise activate bash")
+  ) {
+    appendFileSync(bashrc, '\neval "$(mise activate bash)"\n');
+    console.log(`[agent] mise activation appended to ${bashrc}`);
+  }
 
   // Skip mise install if no mise.toml declared
   const miseTomlPath = join(workspaceDir, "mise.toml");


### PR DESCRIPTION
## Problem

While migrating **okwow** onto the harness, Claude Code came up but the **Linear MCP wasn't available** (`claude mcp list` → "No MCP servers configured") — even though okwow's PVC has `/data/agent-home/claude.json` carrying its `linear-server` registration from the vitals-os runtime.

## Root cause — two runtime-wiring steps dropped in the vitals-os → shipwright extraction

**1. `~/.claude.json` symlink (MCP registrations).** Claude Code stores MCP server registrations (`claude mcp add`) in `~/.claude.json`, which lives **outside** `~/.claude/`. The vitals-os entrypoint symlinks **both** `~/.claude` (dir) **and** `~/.claude.json` (file) to the PVC — the extraction ported only the directory. So shipwright reads the **ephemeral image copy** of `~/.claude.json` (no MCP servers) instead of the PVC's.

**2. `mise activate bash` in `~/.bashrc`.** The shims-on-PATH prepend in `runMiseStartup` only reaches direct subprocesses. Claude Code's Bash tool spawns login/interactive shells that re-source profile files and reset PATH, so **workspace-declared mise tools** (e.g. **fern's** Rust toolchain) would be missing. vitals-os appends the activation line; shipwright didn't do it at all.

A full sweep confirmed these are the **only** two gaps: vitals-os has exactly two symlinks (both now ported) and the only mise difference was `mise activate` (now ported). All other mise wiring (`MISE_DATA_DIR`/`MISE_CACHE_DIR`/`XDG_CACHE_HOME`, `mise trust`/`install`, shims-on-PATH) already matched.

## Fix

- `ensureDotClaudeSymlink` also links `~/.claude.json → $AGENT_HOME/claude.json` (file-aware: no mkdir; replaces the real image file; dangling-until-first-write is fine). Same path the vitals-os runtime used, so migrated PVCs are picked up.
- `runMiseStartup` appends `eval "$(mise activate bash)"` to `~/.bashrc` (idempotent, unconditional).
- Tests updated; `HOME` isolated in the runMiseStartup suite so the bashrc append never touches the real home. **setup tests: 54 pass / 0 fail**, biome clean.

## Rollout

Merge → `build-agent.yml` builds the next `agent-v0.2.x`. After bumping the tag in vitals-os `values-prod.yaml` and redeploying, okwow's Linear MCP will resolve from the PVC config (verify: `claude mcp list` shows `linear-server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)