### PR TITLE
test(agent): cover ~/.claude.json symlink and bashrc mise-activate paths

### DIFF
--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -110,6 +110,49 @@ describe("ensureDotClaudeSymlink", () => {
     expect(lstatSync(link).isSymbolicLink()).toBe(true);
     expect(existsSync(link)).toBe(true);
   });
+
+  it("creates the sibling ~/.claude.json symlink (dangling until Claude writes it)", () => {
+    mkdirSync(testHome, { recursive: true });
+    const target = join(testHome, "dot-claude");
+    const link = join(testHome, "home-claude");
+
+    ensureDotClaudeSymlink(target, link, undefined, () => {});
+
+    const jsonLink = `${link}.json`;
+    expect(lstatSync(jsonLink).isSymbolicLink()).toBe(true);
+    // Target does not exist yet — Claude writes it on first use. Resolves once created.
+    const jsonTarget = join(target, "..", "claude.json");
+    writeFileSync(jsonTarget, '{"mcpServers":{}}', "utf8");
+    expect(readFileSync(jsonLink, "utf8")).toBe('{"mcpServers":{}}');
+  });
+
+  it("replaces a dangling ~/.claude.json symlink on re-run", () => {
+    mkdirSync(testHome, { recursive: true });
+    const target = join(testHome, "dot-claude");
+    const link = join(testHome, "home-claude");
+    const jsonLink = `${link}.json`;
+
+    symlinkSync(join(testHome, "missing.json"), jsonLink);
+    expect(existsSync(jsonLink)).toBe(false); // dangling
+
+    ensureDotClaudeSymlink(target, link, undefined, () => {});
+
+    expect(lstatSync(jsonLink).isSymbolicLink()).toBe(true);
+  });
+
+  it("replaces a real file at ~/.claude.json (image ships a real file — PVC copy wins)", () => {
+    mkdirSync(testHome, { recursive: true });
+    const target = join(testHome, "dot-claude");
+    const link = join(testHome, "home-claude");
+    const jsonLink = `${link}.json`;
+
+    writeFileSync(jsonLink, "{}", "utf8");
+    expect(lstatSync(jsonLink).isSymbolicLink()).toBe(false);
+
+    ensureDotClaudeSymlink(target, link, undefined, () => {});
+
+    expect(lstatSync(jsonLink).isSymbolicLink()).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -568,6 +611,25 @@ describe("runMiseStartup", () => {
     await runMiseStartup(testHome, mockExec);
     const expectedShims = join(testHome, "mise", "shims");
     expect(process.env.PATH?.startsWith(`${expectedShims}:`)).toBe(true);
+  });
+
+  it("appends mise activate bash to ~/.bashrc", async () => {
+    mkdirSync(join(testHome, "workspace"), { recursive: true });
+    const mockExec = async () => ({ stdout: "", exitCode: 0 });
+    await runMiseStartup(testHome, mockExec);
+    const bashrc = join(testHome, ".bashrc");
+    expect(existsSync(bashrc)).toBe(true);
+    expect(readFileSync(bashrc, "utf8")).toContain("mise activate bash");
+  });
+
+  it("does not duplicate the mise activate line on repeated calls (idempotent)", async () => {
+    mkdirSync(join(testHome, "workspace"), { recursive: true });
+    const mockExec = async () => ({ stdout: "", exitCode: 0 });
+    await runMiseStartup(testHome, mockExec);
+    await runMiseStartup(testHome, mockExec);
+    const content = readFileSync(join(testHome, ".bashrc"), "utf8");
+    const count = (content.match(/mise activate bash/g) ?? []).length;
+    expect(count).toBe(1);
   });
 });
 

--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -448,6 +448,12 @@ describe("runMiseStartup", () => {
   const originalHome = process.env.HOME;
   const originalPath = process.env.PATH;
 
+  beforeEach(() => {
+    // Isolate HOME to the per-test dir so the ~/.bashrc mise-activate append in
+    // runMiseStartup never touches the real developer/CI home.
+    process.env.HOME = testHome;
+  });
+
   afterEach(() => {
     // Restore env vars modified by runMiseStartup (and the tests below)
     process.env.MISE_DATA_DIR = originalMiseDataDir;

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  appendFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -277,7 +278,8 @@ const DEFAULT_DOT_CLAUDE_FS: DotClaudeFs = {
 
 /**
  * Symlink `linkPath` (~/.claude) → `target` ($AGENT_HOME/dot-claude), ensuring
- * the TARGET directory exists first.
+ * the TARGET directory exists first. ALSO symlinks the sibling `~/.claude.json`
+ * → `$AGENT_HOME/claude.json` (see below).
  *
  * The target MUST be created before symlinking: on a fresh PVC the target does
  * not exist, so without this the symlink dangles and every write under
@@ -289,6 +291,15 @@ const DEFAULT_DOT_CLAUDE_FS: DotClaudeFs = {
  * `symlinkSync` throw EEXIST on a re-run. `lstatSync` sees the link itself, so
  * a stale/dangling symlink is detected and replaced. A real directory at
  * `linkPath` is removed (logged) before relinking.
+ *
+ * `~/.claude.json` holds Claude Code's MCP server registrations (`claude mcp
+ * add`) and lives OUTSIDE `~/.claude/`, so it needs its own symlink to survive
+ * pod restarts. Without it, registered MCP servers (e.g. Linear) silently
+ * disappear — Claude reads the ephemeral image copy instead of the PVC's. The
+ * target is `$AGENT_HOME/claude.json` (sibling of the dot-claude dir), matching
+ * the path the vitals-os runtime used, so a migrated PVC's existing MCP config
+ * is picked up. Unlike the dir, the target is NOT pre-created: it is a FILE that
+ * Claude writes on first use, so a dangling symlink is correct until then.
  */
 export function ensureDotClaudeSymlink(
   target: string,
@@ -319,6 +330,27 @@ export function ensureDotClaudeSymlink(
 
   fs.symlinkSync(target, linkPath);
   log(`[entrypoint] symlinked ${linkPath} → ${target}`);
+
+  // ── ~/.claude.json (MCP server registrations) — file symlink, no mkdir ──────
+  const jsonTarget = join(target, "..", "claude.json");
+  const jsonLink = `${linkPath}.json`;
+  let existingJson: ReturnType<typeof lstatSync> | null = null;
+  try {
+    existingJson = fs.lstatSync(jsonLink);
+  } catch {
+    existingJson = null;
+  }
+  if (existingJson) {
+    if (existingJson.isSymbolicLink()) {
+      fs.unlinkSync(jsonLink);
+    } else {
+      // The image ships a real ~/.claude.json — remove it before symlinking so
+      // the PVC copy (with MCP registrations) is the one Claude reads.
+      fs.rmSync(jsonLink, { recursive: false });
+    }
+  }
+  fs.symlinkSync(jsonTarget, jsonLink);
+  log(`[entrypoint] symlinked ${jsonLink} → ${jsonTarget}`);
 }
 
 export function ensureAgentHome(home: string): void {
@@ -442,6 +474,22 @@ export async function runMiseStartup(
   process.env.XDG_CACHE_HOME = join(home, "cache");
   mkdirSync(process.env.MISE_CACHE_DIR, { recursive: true });
   mkdirSync(process.env.XDG_CACHE_HOME, { recursive: true });
+
+  // Activate mise in any bash session the agent spawns (e.g. Claude Code's Bash
+  // tool). The shims-on-PATH prepend below only reaches direct subprocesses;
+  // login/interactive shells re-source profile files that reset PATH, so
+  // workspace-declared tools (e.g. fern's Rust toolchain) would be missing
+  // without this. Ported from the vitals-os runtime; dropped in the extraction.
+  // Unconditional (before the mise.toml check) so it's ready for any workspace
+  // tools; idempotent so repeated boots don't stack duplicate lines.
+  const bashrc = join(process.env.HOME ?? home, ".bashrc");
+  if (
+    !existsSync(bashrc) ||
+    !readFileSync(bashrc, "utf8").includes("mise activate bash")
+  ) {
+    appendFileSync(bashrc, '\neval "$(mise activate bash)"\n');
+    console.log(`[agent] mise activation appended to ${bashrc}`);
+  }
 
   // Skip mise install if no mise.toml declared
   const miseTomlPath = join(workspaceDir, "mise.toml");


### PR DESCRIPTION
## Summary

Addresses the two test gaps flagged in the review of #301.

- **`ensureDotClaudeSymlink`** — 3 new integration cases:
  - Fresh `~/.claude.json` symlink is created (dangling target is expected until Claude writes it)
  - Dangling `~/.claude.json` symlink is replaced on re-run
  - Real `~/.claude.json` file (image-shipped) is replaced with the PVC-backed symlink
- **`runMiseStartup`** — 2 new integration cases:
  - `~/.bashrc` receives the `mise activate bash` line
  - Calling twice does not duplicate the line (idempotency)

All 55 setup integration tests pass.

## Test plan

- [ ] `bun test agent/src/setup.integration.test.ts` → 55 pass / 0 fail
- [ ] `task ci` passes

Closes review finding from #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)