### PR TITLE
fix(agent): run cron preChecks with cwd=workspace

### DIFF
--- a/agent/src/cron-handler.integration.test.ts
+++ b/agent/src/cron-handler.integration.test.ts
@@ -570,6 +570,29 @@ describe("handleCronRequest — preCheck", () => {
     expect(runArg).toContain("precheck prompt");
   });
 
+  test("runs preCheck with cwd = workspace (resolves state relative to workspace)", async () => {
+    // Mirrors check-dev-task.ts → JsonTaskStore(process.cwd()) reading
+    // `state/todos.json`. The file lives in the workspace; the preCheck must run
+    // there, not in the agent's cwd (/app in prod, the repo root in tests).
+    const ws = join(tmpDir, "ws");
+    mkdirSync(join(ws, "state"), { recursive: true });
+    writeFileSync(join(ws, "state", "todos.json"), "[]");
+    const script = join(tmpDir, "check.ts");
+    writeFileSync(
+      script,
+      `import { existsSync } from "node:fs";\nconsole.log(existsSync("state/todos.json") ? "HAS_STATE" : "NO_STATE");\nprocess.exit(0);`,
+    );
+
+    await handleCronRequest(
+      { jobId: "j1", prompt: "original", channel: "C-TEST", preCheck: script },
+      { ...deps, workspace: ws },
+    );
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+    const runArg = (mockRunner.mock.calls as unknown as string[][])[0][0];
+    expect(runArg).toContain("HAS_STATE");
+  });
+
   test("skips job when preCheck script not found (plugin: format)", async () => {
     await handleCronRequest(
       {

--- a/agent/src/cron-handler.ts
+++ b/agent/src/cron-handler.ts
@@ -141,7 +141,14 @@ export async function handleCronRequest(
       return;
     }
 
+    // Run the preCheck from the workspace, not the agent's cwd (/app). Plugin
+    // preChecks resolve state relative to process.cwd() — e.g. check-dev-task.ts
+    // → JsonTaskStore(process.cwd()) reads `state/todos.json`. Without this the
+    // store roots at /app, the file is missing, and the job is wrongly suppressed
+    // ("/app/state/todos.json not found — run setup first"). Mirrors the claude
+    // run, which is already rooted at the workspace.
     const checkProc = Bun.spawn(["bun", scriptPath], {
+      ...(workspace ? { cwd: workspace } : {}),
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## Problem

okwow's enabled `shipwright-dev-task` cron was suppressed on every tick:

```
[agent:cron] preCheck for job "shipwright-dev-task" crashed (exit 2):
/app/state/todos.json not found — run setup first — session suppressed
```

## Root cause

Plugin preCheck scripts resolve their state relative to `process.cwd()`:
`check-dev-task.ts` → `createTaskStore()` → `new JsonTaskStore(process.cwd())` (`create-task-store.ts:73`) → reads `state/todos.json`. The cron handler spawned the preCheck with **no `cwd`**, so it inherited the agent process cwd (`/app`, the Dockerfile `WORKDIR`) → looked for `/app/state/todos.json` → missing → exit 2 → job suppressed. Real state lives in `$AGENT_HOME/workspace/state`.

Not an extraction regression — vitals-os has the identical no-`cwd` spawn; it's a latent bug that surfaces now because the harness runs the shipwright system-cron preChecks. The actual claude run was already rooted at the workspace (via `claude.ts`); only the preCheck spawn wasn't.

## Fix

Pass `cwd: workspace` (when set) to the preCheck `Bun.spawn`. Added a test that writes `state/todos.json` in the workspace and asserts a cwd-relative preCheck finds it. cron-handler tests: 53 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)