### PR TITLE
fix(check-deploy): treat queued Deploy runs older than 1 hour as stale

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.27.0",
+  "version": "4.27.1",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.27.0
+# Shipwright v4.27.1
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -46,6 +46,7 @@ interface CiRun {
 interface WorkflowRun {
   name: string;
   status: string;
+  createdAt?: string;
 }
 
 interface Deps {
@@ -74,6 +75,19 @@ function isCiGreen(runs: CiRun[]): boolean {
   return runs.some(
     (run) => run.status === "completed" && run.conclusion === "success",
   );
+}
+
+// Queued runs older than 1 hour are treated as stuck/ghost runs and ignored.
+const STALE_QUEUED_RUN_MS = 60 * 60 * 1000;
+
+function isActiveRun(run: WorkflowRun, now: string): boolean {
+  if (run.status === "in_progress") return true;
+  if (run.status === "queued") {
+    if (!run.createdAt) return true; // no timestamp → conservative, treat as active
+    const ageMs = new Date(now).getTime() - new Date(run.createdAt).getTime();
+    return ageMs < STALE_QUEUED_RUN_MS;
+  }
+  return false;
 }
 
 function hasSelfApproveReview(reviews: GhReview[], userLogin: string): boolean {
@@ -111,18 +125,16 @@ export async function run(deps: Deps): Promise<RunResult> {
     );
   }
 
-  // Deploying guard: bail out if any configured repo has an active Deploy workflow run
+  // Deploying guard: bail out if any configured repo has an active Deploy workflow run.
+  // Queued runs older than 1 hour are treated as stuck/ghost and skipped.
+  const now = deps.clock ? deps.clock() : new Date().toISOString();
   for (const repo of deps.repos) {
     const [org, repoName] = repo.includes("/")
       ? (repo.split("/", 2) as [string, string])
       : (["app-vitals", repo] as [string, string]);
     try {
       const activeRuns = await deps.fetchActiveDeployRuns(org, repoName);
-      if (
-        activeRuns.some(
-          (r) => r.status === "in_progress" || r.status === "queued",
-        )
-      ) {
+      if (activeRuns.some((r) => isActiveRun(r, now))) {
         return { exit: 1, output: "", candidate: null };
       }
     } catch (err) {
@@ -212,6 +224,7 @@ interface GhWorkflowRunsJson {
     name: string;
     status: string;
     conclusion: string | null;
+    created_at: string;
   }>;
 }
 
@@ -238,7 +251,7 @@ async function buildProductionDeps(): Promise<Deps> {
       ]);
       return [...inProgress.workflow_runs, ...queued.workflow_runs]
         .filter((r) => r.name === "Deploy")
-        .map((r) => ({ name: r.name, status: r.status }));
+        .map((r) => ({ name: r.name, status: r.status, createdAt: r.created_at }));
     },
     listOpenPrs: async (repo: string) => {
       return ghJson<GhPrListJson[]>([

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -35,6 +35,7 @@ interface CiRun {
 interface WorkflowRun {
   name: string;
   status: string;
+  createdAt?: string;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -57,6 +58,7 @@ interface MakeDepsOptions {
   activeDeployRuns?: WorkflowRun[];
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
+  clock?: () => string;
 }
 
 function makeDeps({
@@ -67,11 +69,13 @@ function makeDeps({
   activeDeployRuns = [],
   currentUser = "bodhi-agent",
   isSelfReviewAllowed = true,
+  clock,
 }: MakeDepsOptions = {}) {
   return {
     getCurrentUser: () => currentUser,
     isSelfReviewAllowed,
     repos,
+    clock,
     listOpenPrs: async (repo: string) => prs[repo] ?? [],
     fetchCiRuns: async (
       _org: string,
@@ -109,7 +113,7 @@ describe("check-deploy (new behaviors)", () => {
     expect(result.candidate).toBeNull();
   });
 
-  test("deploying guard: exits 1 when a Deploy run is queued", async () => {
+  test("deploying guard: exits 1 when a Deploy run is queued (no timestamp — conservative)", async () => {
     const pr = makeGhPr({ reviewDecision: "APPROVED" });
     const result = await run(
       makeDeps({
@@ -120,6 +124,38 @@ describe("check-deploy (new behaviors)", () => {
     );
     expect(result.exit).toBe(1);
     expect(result.candidate).toBeNull();
+  });
+
+  test("deploying guard: exits 1 when a Deploy run is queued and recent (< 1 hour)", async () => {
+    const createdAt = "2026-06-12T10:00:00Z";
+    const now = "2026-06-12T10:30:00Z"; // 30 min later
+    const pr = makeGhPr({ reviewDecision: "APPROVED" });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        activeDeployRuns: [{ name: "Deploy", status: "queued", createdAt }],
+        clock: () => now,
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.candidate).toBeNull();
+  });
+
+  test("deploying guard: proceeds when a queued Deploy run is stale (> 1 hour)", async () => {
+    const createdAt = "2026-06-12T10:00:00Z";
+    const now = "2026-06-12T11:01:00Z"; // 61 min later
+    const pr = makeGhPr({ reviewDecision: "APPROVED" });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        activeDeployRuns: [{ name: "Deploy", status: "queued", createdAt }],
+        clock: () => now,
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
   });
 
   test("deploying guard: proceeds when no active Deploy runs exist", async () => {

--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -295,7 +295,7 @@ curl -sf -X POST \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins" \
-  -d '{"name": "shipwright", "version": "4.27.0"}' | jq .
+  -d '{"name": "shipwright", "version": "4.27.1"}' | jq .
 
 # Update a plugin version
 # name goes in the query param — scoped names like @scope/pkg contain "/" which breaks path matching
@@ -303,7 +303,7 @@ curl -sf -X PATCH \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins?name=shipwright" \
-  -d '{"version": "4.27.0"}' | jq .
+  -d '{"version": "4.27.1"}' | jq .
 
 # Remove a plugin
 curl -sf -X DELETE \


### PR DESCRIPTION
## Summary

- A Deploy workflow stuck in "queued" (GitHub ghost run, infra hiccup) permanently blocked the deploy cron — experienced today when a run queued since May 15 blocked all deploys
- Add a 1-hour staleness cap: queued runs older than 1 hour are ignored; runs with no timestamp are treated conservatively as active; `in_progress` runs always block as before
- Two new unit tests cover the recent (<1h) and stale (>1h) cases

## Test plan

- [x] `bun test plugins/shipwright/scripts/check-deploy.unit.test.ts` — 19 pass
- [x] `bun test plugins/shipwright/scripts/` — 533 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)