### PR TITLE
fix(check-review-patch): always output orchestrator prompt, not sub-command

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.27.1",
+  "version": "4.27.2",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.27.1
+# Shipwright v4.27.2
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/scripts/check-review-patch.test.ts
+++ b/plugins/shipwright/scripts/check-review-patch.test.ts
@@ -156,8 +156,7 @@ describe("check-review-patch (combined precheck)", () => {
       patchDeps: makePatchDepsIdle(),
     });
     expect(result.exit).toBe(0);
-    expect(result.output).toBeTruthy();
-    expect(result.output.toLowerCase()).toContain("review");
+    expect(result.output).toContain("/shipwright:review-patch");
   });
 
   test("exits 0 when only patch check triggers (review is idle)", async () => {
@@ -166,8 +165,24 @@ describe("check-review-patch (combined precheck)", () => {
       patchDeps: makePatchDepsTriggering(),
     });
     expect(result.exit).toBe(0);
-    expect(result.output).toBeTruthy();
-    expect(result.output.toLowerCase()).toContain("patch");
+    expect(result.output).toContain("/shipwright:review-patch");
+  });
+
+  test("exits 0 with same orchestrator prompt regardless of which sub-check triggered", async () => {
+    const reviewOnly = await run({
+      reviewDeps: makeReviewDepsTriggering(),
+      patchDeps: makePatchDepsIdle(),
+    });
+    const patchOnly = await run({
+      reviewDeps: makeReviewDepsIdle(),
+      patchDeps: makePatchDepsTriggering(),
+    });
+    const both = await run({
+      reviewDeps: makeReviewDepsTriggering(),
+      patchDeps: makePatchDepsTriggering(),
+    });
+    expect(reviewOnly.output).toBe(patchOnly.output);
+    expect(reviewOnly.output).toBe(both.output);
   });
 
   test("exits 0 and short-circuits when both would trigger (patch check NOT called)", async () => {
@@ -187,7 +202,7 @@ describe("check-review-patch (combined precheck)", () => {
     });
 
     expect(result.exit).toBe(0);
-    expect(result.output).toBeTruthy();
+    expect(result.output).toContain("/shipwright:review-patch");
     expect(patchCalled).toBe(false); // short-circuited
   });
 

--- a/plugins/shipwright/scripts/check-review-patch.ts
+++ b/plugins/shipwright/scripts/check-review-patch.ts
@@ -43,15 +43,26 @@ interface RunResult {
   output: string;
 }
 
+// Fixed prompt used whenever either sub-check has work. The harness uses
+// preCheck output as the session prompt, so we always invoke the full
+// orchestrator rather than routing to a single sub-command.
+const ORCHESTRATOR_PROMPT =
+  "Review and patch open PRs via /shipwright:review-patch";
+
 export async function run(deps: Deps): Promise<RunResult> {
   // Try review check first
   const reviewResult = await runReview(deps.reviewDeps);
   if (reviewResult.exit === 0) {
-    return reviewResult;
+    return { exit: 0, output: ORCHESTRATOR_PROMPT };
   }
 
   // Fall through to patch check
-  return runPatch(deps.patchDeps);
+  const patchResult = await runPatch(deps.patchDeps);
+  if (patchResult.exit === 0) {
+    return { exit: 0, output: ORCHESTRATOR_PROMPT };
+  }
+
+  return { exit: 1, output: "" };
 }
 
 // ─── Production deps ──────────────────────────────────────────────────────────

--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -295,7 +295,7 @@ curl -sf -X POST \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins" \
-  -d '{"name": "shipwright", "version": "4.27.1"}' | jq .
+  -d '{"name": "shipwright", "version": "4.27.2"}' | jq .
 
 # Update a plugin version
 # name goes in the query param — scoped names like @scope/pkg contain "/" which breaks path matching
@@ -303,7 +303,7 @@ curl -sf -X PATCH \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins?name=shipwright" \
-  -d '{"version": "4.27.1"}' | jq .
+  -d '{"version": "4.27.2"}' | jq .
 
 # Remove a plugin
 curl -sf -X DELETE \


### PR DESCRIPTION
## Summary

- `check-review-patch.ts` was passing through the sub-check's output string as the session prompt. Since the harness uses preCheck stdout to replace the cron's stored prompt, the session received \"Review open PRs via /shipwright:review\" (or the patch equivalent) — invoking a single sub-command instead of the full orchestrator.
- PRs that needed patching were never patched because `/shipwright:review-patch` was never invoked.
- Fix: always emit a fixed constant prompt (`"Review and patch open PRs via /shipwright:review-patch"`) when either sub-check exits 0. The orchestrator re-runs both prechecks internally and handles each phase correctly.

## Test plan

- [x] Existing tests updated: both triggering cases assert `output` contains `/shipwright:review-patch`
- [x] New test: same orchestrator prompt emitted regardless of which sub-check triggered
- [x] Short-circuit test: patch deps not called when review exits 0
- [x] `bun test plugins/shipwright/scripts/check-review-patch.test.ts` — 5 pass, 0 fail

## Version

`4.27.1` → `4.27.2` (patch: bug fix, no behavior change at the API level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)