### PR TITLE
feat(agent): add pricing utility and cost_usd to agent_token_usage event

### DIFF
--- a/agent/src/posthog.ts
+++ b/agent/src/posthog.ts
@@ -14,6 +14,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { TokenUsage } from "./claude.ts";
 import { liveClaudeConfig } from "./claude.ts";
+import { calculateCost } from "./pricing.ts";
 
 interface MetricsEntry {
   task?: string;
@@ -192,6 +193,7 @@ export async function forwardTokenUsage(
       cache_read_input_tokens: usage.cache_read_input_tokens,
       cache_creation_input_tokens: usage.cache_creation_input_tokens,
       model: resolvedModel,
+      cost_usd: calculateCost(usage, resolvedModel),
     },
   };
 

--- a/agent/src/posthog.unit.test.ts
+++ b/agent/src/posthog.unit.test.ts
@@ -385,6 +385,33 @@ describe("forwardTokenUsage", () => {
     expect(evt.properties.cache_read_input_tokens).toBe(50);
     expect(evt.properties.cache_creation_input_tokens).toBe(10);
     expect(evt.properties.model).toBe("claude-sonnet-4-5");
+    // "claude-sonnet-4-5" is not in RATES → cost_usd must be 0
+    expect(evt.properties.cost_usd).toBe(0);
+  });
+
+  test("cost_usd reflects actual cost for a known model (claude-sonnet-4-6)", async () => {
+    // sonnet-4-6: $3/1M input, $15/1M output
+    // 100 input + 200 output + 50 cache_read + 10 cache_creation
+    // input:       100 / 1_000_000 * 3     = 0.0003
+    // output:      200 / 1_000_000 * 15    = 0.003
+    // cache_write:  10 / 1_000_000 * 3.75  = 0.0000375
+    // cache_read:   50 / 1_000_000 * 0.3   = 0.000015
+    // total ≈ 0.0033525
+    await forwardTokenUsage(
+      SAMPLE_USAGE,
+      "slack_dm",
+      "claude-sonnet-4-6",
+      mockFetch as unknown as typeof fetch,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      batch: { properties: Record<string, unknown> }[];
+    };
+    const evt = body.batch[0];
+    expect(typeof evt.properties.cost_usd).toBe("number");
+    expect(evt.properties.cost_usd as number).toBeCloseTo(0.0033525, 8);
   });
 
   test("no-op when POSTHOG_PROJECT_API_KEY is absent", async () => {

--- a/agent/src/pricing.ts
+++ b/agent/src/pricing.ts
@@ -1,0 +1,38 @@
+import type { TokenUsage } from "./claude.ts";
+
+interface ModelRates {
+  input: number; // USD per million tokens
+  output: number; // USD per million tokens
+}
+
+const RATES: Record<string, ModelRates> = {
+  "claude-fable-5": { input: 10.0, output: 50.0 },
+  "claude-opus-4-8": { input: 5.0, output: 25.0 },
+  "claude-opus-4-7": { input: 5.0, output: 25.0 },
+  "claude-opus-4-6": { input: 5.0, output: 25.0 },
+  "claude-sonnet-4-6": { input: 3.0, output: 15.0 },
+  "claude-haiku-4-5": { input: 1.0, output: 5.0 },
+};
+
+const TOKENS_PER_MILLION = 1_000_000;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+const CACHE_READ_MULTIPLIER = 0.1;
+
+// Cache write: 1.25x input price; cache read: 0.1x input price (Anthropic API contract).
+export function calculateCost(usage: TokenUsage, model: string): number {
+  const rates = RATES[model];
+  if (!rates) return 0;
+
+  const inputCost = (usage.input_tokens / TOKENS_PER_MILLION) * rates.input;
+  const outputCost = (usage.output_tokens / TOKENS_PER_MILLION) * rates.output;
+  const cacheWriteCost =
+    (usage.cache_creation_input_tokens / TOKENS_PER_MILLION) *
+    rates.input *
+    CACHE_WRITE_MULTIPLIER;
+  const cacheReadCost =
+    (usage.cache_read_input_tokens / TOKENS_PER_MILLION) *
+    rates.input *
+    CACHE_READ_MULTIPLIER;
+
+  return inputCost + outputCost + cacheWriteCost + cacheReadCost;
+}

--- a/agent/src/pricing.unit.test.ts
+++ b/agent/src/pricing.unit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for agent/src/pricing.ts — calculateCost
+ *
+ * Pure function tests — no I/O, no mocks needed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { TokenUsage } from "./claude.ts";
+import { calculateCost } from "./pricing.ts";
+
+// Sample usage with all four token types
+const BASE_USAGE: TokenUsage = {
+  input_tokens: 1_000_000,
+  output_tokens: 1_000_000,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
+const ZERO_USAGE: TokenUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
+describe("calculateCost", () => {
+  // ─── Known models — basic input + output ─────────────────────────────────────
+
+  test("claude-fable-5: $10/1M input + $50/1M output", () => {
+    // 1M input @ $10 + 1M output @ $50 = $60
+    expect(calculateCost(BASE_USAGE, "claude-fable-5")).toBe(60);
+  });
+
+  test("claude-opus-4-8: $5/1M input + $25/1M output", () => {
+    // 1M input @ $5 + 1M output @ $25 = $30
+    expect(calculateCost(BASE_USAGE, "claude-opus-4-8")).toBe(30);
+  });
+
+  test("claude-opus-4-7: $5/1M input + $25/1M output", () => {
+    expect(calculateCost(BASE_USAGE, "claude-opus-4-7")).toBe(30);
+  });
+
+  test("claude-opus-4-6: $5/1M input + $25/1M output", () => {
+    expect(calculateCost(BASE_USAGE, "claude-opus-4-6")).toBe(30);
+  });
+
+  test("claude-sonnet-4-6: $3/1M input + $15/1M output", () => {
+    // 1M input @ $3 + 1M output @ $15 = $18
+    expect(calculateCost(BASE_USAGE, "claude-sonnet-4-6")).toBe(18);
+  });
+
+  test("claude-haiku-4-5: $1/1M input + $5/1M output", () => {
+    // 1M input @ $1 + 1M output @ $5 = $6
+    expect(calculateCost(BASE_USAGE, "claude-haiku-4-5")).toBe(6);
+  });
+
+  // ─── Unknown model ────────────────────────────────────────────────────────────
+
+  test("unknown model returns exactly 0", () => {
+    expect(calculateCost(BASE_USAGE, "claude-unknown-99")).toBe(0);
+    expect(calculateCost(BASE_USAGE, "")).toBe(0);
+    expect(calculateCost(BASE_USAGE, "gpt-4o")).toBe(0);
+  });
+
+  // ─── Cache token types ───────────────────────────────────────────────────────
+
+  test("cache_creation_input_tokens billed at 1.25x input price (sonnet-4-6)", () => {
+    // sonnet-4-6 input: $3/1M → cache write: $3 * 1.25 / 1M = $3.75/1M
+    // 1M cache_creation tokens @ $3.75 = $3.75
+    const usage: TokenUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+    };
+    expect(calculateCost(usage, "claude-sonnet-4-6")).toBeCloseTo(3.75, 10);
+  });
+
+  test("cache_read_input_tokens billed at 0.1x input price (sonnet-4-6)", () => {
+    // sonnet-4-6 input: $3/1M → cache read: $3 * 0.1 / 1M = $0.30/1M
+    // 1M cache_read tokens @ $0.30 = $0.30
+    const usage: TokenUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 1_000_000,
+      cache_creation_input_tokens: 0,
+    };
+    expect(calculateCost(usage, "claude-sonnet-4-6")).toBeCloseTo(0.3, 10);
+  });
+
+  test("all four token types combined (haiku-4-5)", () => {
+    // haiku input: $1/1M, output: $5/1M
+    // 100k input:        100_000 / 1_000_000 * 1   = 0.10
+    // 200k output:       200_000 / 1_000_000 * 5   = 1.00
+    // 50k cache_write:    50_000 / 1_000_000 * 1.25 = 0.0625
+    // 10k cache_read:     10_000 / 1_000_000 * 0.1  = 0.001
+    // total = 1.1635
+    const usage: TokenUsage = {
+      input_tokens: 100_000,
+      output_tokens: 200_000,
+      cache_creation_input_tokens: 50_000,
+      cache_read_input_tokens: 10_000,
+    };
+    expect(calculateCost(usage, "claude-haiku-4-5")).toBeCloseTo(1.1635, 10);
+  });
+
+  test("zero usage returns 0 for any known model", () => {
+    expect(calculateCost(ZERO_USAGE, "claude-sonnet-4-6")).toBe(0);
+    expect(calculateCost(ZERO_USAGE, "claude-fable-5")).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #322

## Summary
- Adds `agent/src/pricing.ts` with a per-model rate table (6 models: Fable 5, Opus 4.8/4.7/4.6, Sonnet 4.6, Haiku 4.5) and `calculateCost(usage, model)` returning USD cost; unknown models return 0
- Updates `agent/src/posthog.ts` to import `calculateCost` and add `cost_usd: calculateCost(usage, resolvedModel)` to the `agent_token_usage` event properties
- Cache write tokens are billed at 1.25× the input price; cache read at 0.1×

## Tests
- `agent/src/pricing.unit.test.ts` (new, 11 tests): all 6 models × known USD values, unknown model → 0, cache write/read multipliers, combined usage
- `agent/src/posthog.unit.test.ts` (updated): asserts `cost_usd: 0` for unknown model + new test verifying correct cost for `claude-sonnet-4-6`

## Test plan
- [ ] `bun test agent/src/pricing.unit.test.ts agent/src/posthog.unit.test.ts` — 32 pass, 0 fail
- [ ] `bunx biome lint` — clean on changed files
- [ ] `pricing.ts` 100% line coverage; `posthog.ts` 97.76% line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)