### PR TITLE
feat(agent): add pricing utility and cost_usd to agent_token_usage event

### DIFF
--- a/agent/src/posthog.ts
+++ b/agent/src/posthog.ts
@@ -14,6 +14,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { TokenUsage } from "./claude.ts";
 import { liveClaudeConfig } from "./claude.ts";
+import { calculateCost } from "./pricing.ts";
 
 interface MetricsEntry {
   task?: string;
@@ -192,6 +193,7 @@ export async function forwardTokenUsage(
       cache_read_input_tokens: usage.cache_read_input_tokens,
       cache_creation_input_tokens: usage.cache_creation_input_tokens,
       model: resolvedModel,
+      cost_usd: calculateCost(usage, resolvedModel),
     },
   };
 

--- a/agent/src/posthog.unit.test.ts
+++ b/agent/src/posthog.unit.test.ts
@@ -359,7 +359,7 @@ describe("forwardTokenUsage", () => {
     await forwardTokenUsage(
       SAMPLE_USAGE,
       "slack_dm",
-      "claude-sonnet-4-5",
+      "claude-sonnet-4-6",
       mockFetch as unknown as typeof fetch,
     );
 
@@ -384,8 +384,9 @@ describe("forwardTokenUsage", () => {
     expect(evt.properties.output_tokens).toBe(200);
     expect(evt.properties.cache_read_input_tokens).toBe(50);
     expect(evt.properties.cache_creation_input_tokens).toBe(10);
-    expect(evt.properties.model).toBe("claude-sonnet-4-5");
-    expect(evt.properties.cost_usd).toBe(0); // unknown model → 0
+    expect(evt.properties.model).toBe("claude-sonnet-4-6");
+    // (100 * 3.00 + 200 * 15.00 + 10 * 3.00 * 1.25 + 50 * 3.00 * 0.1) / 1_000_000 = 0.0033525
+    expect(evt.properties.cost_usd).toBe(0.0033525);
   });
 
   test("no-op when POSTHOG_PROJECT_API_KEY is absent", async () => {

--- a/agent/src/posthog.unit.test.ts
+++ b/agent/src/posthog.unit.test.ts
@@ -385,6 +385,7 @@ describe("forwardTokenUsage", () => {
     expect(evt.properties.cache_read_input_tokens).toBe(50);
     expect(evt.properties.cache_creation_input_tokens).toBe(10);
     expect(evt.properties.model).toBe("claude-sonnet-4-5");
+    expect(evt.properties.cost_usd).toBe(0); // unknown model → 0
   });
 
   test("no-op when POSTHOG_PROJECT_API_KEY is absent", async () => {

--- a/agent/src/pricing.ts
+++ b/agent/src/pricing.ts
@@ -19,6 +19,7 @@ export const RATES: Record<string, ModelRates> = {
   "claude-opus-4-6": { input: 5.0, output: 25.0 },
   "claude-sonnet-4-6": { input: 3.0, output: 15.0 },
   "claude-haiku-4-5": { input: 1.0, output: 5.0 },
+  "claude-haiku-4-6": { input: 1.0, output: 5.0 },
 };
 
 /**

--- a/agent/src/pricing.ts
+++ b/agent/src/pricing.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-model USD pricing table and cost calculation utility.
+ *
+ * Rates are USD per million tokens.
+ * Cache write = 1.25× input rate; cache read = 0.1× input rate.
+ */
+
+import type { TokenUsage } from "./claude.ts";
+
+interface ModelRates {
+  input: number;
+  output: number;
+}
+
+export const RATES: Record<string, ModelRates> = {
+  "claude-fable-5": { input: 10.0, output: 50.0 },
+  "claude-opus-4-8": { input: 5.0, output: 25.0 },
+  "claude-opus-4-7": { input: 5.0, output: 25.0 },
+  "claude-opus-4-6": { input: 5.0, output: 25.0 },
+  "claude-sonnet-4-6": { input: 3.0, output: 15.0 },
+  "claude-haiku-4-5": { input: 1.0, output: 5.0 },
+};
+
+/**
+ * Calculate the USD cost of a Claude API call.
+ *
+ * Returns 0 for unknown models.
+ */
+export function calculateCost(usage: TokenUsage, model: string): number {
+  const rates = RATES[model];
+  if (!rates) return 0;
+
+  const { input, output } = rates;
+  const cost =
+    usage.input_tokens * input +
+    usage.output_tokens * output +
+    usage.cache_creation_input_tokens * input * 1.25 +
+    usage.cache_read_input_tokens * input * 0.1;
+
+  return cost / 1_000_000;
+}

--- a/agent/src/pricing.unit.test.ts
+++ b/agent/src/pricing.unit.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for agent/src/pricing.ts — calculateCost()
+ *
+ * Pure function — no side effects, no mocks needed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { TokenUsage } from "./claude.ts";
+import { calculateCost } from "./pricing.ts";
+
+const SAMPLE_USAGE: TokenUsage = {
+  input_tokens: 100,
+  output_tokens: 200,
+  cache_read_input_tokens: 50,
+  cache_creation_input_tokens: 10,
+};
+
+const ZERO_USAGE: TokenUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
+// ─── unknown model ─────────────────────────────────────────────────────────────
+
+describe("unknown model", () => {
+  test("returns 0 for an unrecognised model ID", () => {
+    expect(calculateCost(SAMPLE_USAGE, "claude-sonnet-4-5")).toBe(0);
+  });
+
+  test("returns 0 for empty string model ID", () => {
+    expect(calculateCost(SAMPLE_USAGE, "")).toBe(0);
+  });
+
+  test("returns 0 for zero usage with unknown model", () => {
+    expect(calculateCost(ZERO_USAGE, "gpt-4")).toBe(0);
+  });
+});
+
+// ─── claude-sonnet-4-6 ($3.00 input, $15.00 output) ──────────────────────────
+
+describe("claude-sonnet-4-6", () => {
+  test("returns correct USD for SAMPLE_USAGE", () => {
+    // (100 * 3.00 + 200 * 15.00 + 10 * 3.00 * 1.25 + 50 * 3.00 * 0.1) / 1_000_000
+    // = (300 + 3000 + 37.5 + 15) / 1_000_000 = 0.0033525
+    expect(calculateCost(SAMPLE_USAGE, "claude-sonnet-4-6")).toBe(0.0033525);
+  });
+
+  test("returns 0 for zero usage", () => {
+    expect(calculateCost(ZERO_USAGE, "claude-sonnet-4-6")).toBe(0);
+  });
+});
+
+// ─── claude-haiku-4-5 ($1.00 input, $5.00 output) ────────────────────────────
+
+describe("claude-haiku-4-5", () => {
+  test("returns correct USD for SAMPLE_USAGE", () => {
+    // (100 * 1.00 + 200 * 5.00 + 10 * 1.00 * 1.25 + 50 * 1.00 * 0.1) / 1_000_000
+    // = (100 + 1000 + 12.5 + 5) / 1_000_000 = 0.0011175
+    expect(calculateCost(SAMPLE_USAGE, "claude-haiku-4-5")).toBe(0.0011175);
+  });
+});
+
+// ─── claude-opus-4-8 ($5.00 input, $25.00 output) ────────────────────────────
+
+describe("claude-opus-4-8", () => {
+  test("returns correct USD for SAMPLE_USAGE", () => {
+    // (100 * 5.00 + 200 * 25.00 + 10 * 5.00 * 1.25 + 50 * 5.00 * 0.1) / 1_000_000
+    // = (500 + 5000 + 62.5 + 25) / 1_000_000 = 0.0055875
+    expect(calculateCost(SAMPLE_USAGE, "claude-opus-4-8")).toBe(0.0055875);
+  });
+});
+
+// ─── claude-opus-4-7 ($5.00 input, $25.00 output) ────────────────────────────
+
+describe("claude-opus-4-7", () => {
+  test("returns correct USD for SAMPLE_USAGE (same rates as opus-4-8)", () => {
+    expect(calculateCost(SAMPLE_USAGE, "claude-opus-4-7")).toBe(0.0055875);
+  });
+});
+
+// ─── claude-opus-4-6 ($5.00 input, $25.00 output) ────────────────────────────
+
+describe("claude-opus-4-6", () => {
+  test("returns correct USD for SAMPLE_USAGE (same rates as opus-4-8)", () => {
+    expect(calculateCost(SAMPLE_USAGE, "claude-opus-4-6")).toBe(0.0055875);
+  });
+});
+
+// ─── claude-fable-5 ($10.00 input, $50.00 output) ────────────────────────────
+
+describe("claude-fable-5", () => {
+  test("returns correct USD for SAMPLE_USAGE", () => {
+    // (100 * 10.00 + 200 * 50.00 + 10 * 10.00 * 1.25 + 50 * 10.00 * 0.1) / 1_000_000
+    // = (1000 + 10000 + 125 + 50) / 1_000_000 = 0.011175
+    expect(calculateCost(SAMPLE_USAGE, "claude-fable-5")).toBe(0.011175);
+  });
+});
+
+// ─── cache multipliers ────────────────────────────────────────────────────────
+
+describe("cache multipliers", () => {
+  test("cache_creation_input_tokens uses 1.25x input rate", () => {
+    const usage: TokenUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+    };
+    // claude-sonnet-4-6 input = $3.00/M, cache write = 3.00 * 1.25 = $3.75/M
+    // 1_000_000 * 3.75 / 1_000_000 = 3.75
+    expect(calculateCost(usage, "claude-sonnet-4-6")).toBe(3.75);
+  });
+
+  test("cache_read_input_tokens uses 0.1x input rate", () => {
+    const usage: TokenUsage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 1_000_000,
+      cache_creation_input_tokens: 0,
+    };
+    // claude-sonnet-4-6 input = $3.00/M, cache read = 3.00 * 0.1 = $0.30/M
+    // 1_000_000 * 0.30 / 1_000_000 = 0.30
+    expect(calculateCost(usage, "claude-sonnet-4-6")).toBe(0.3);
+  });
+
+  test("input_tokens only (no cache) charges at base input rate", () => {
+    const usage: TokenUsage = {
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    };
+    // claude-haiku-4-5: $1.00/M input
+    expect(calculateCost(usage, "claude-haiku-4-5")).toBe(1.0);
+  });
+
+  test("output_tokens only charges at output rate", () => {
+    const usage: TokenUsage = {
+      input_tokens: 0,
+      output_tokens: 1_000_000,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    };
+    // claude-haiku-4-5: $5.00/M output
+    expect(calculateCost(usage, "claude-haiku-4-5")).toBe(5.0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `agent/src/pricing.ts`: per-model USD rate table (6 models) and `calculateCost(usage, model)` utility
- Wires `cost_usd: calculateCost(usage, resolvedModel)` into the `agent_token_usage` PostHog event in `forwardTokenUsage`
- 14 new unit tests in `pricing.unit.test.ts` verify correct USD values for all 6 models, unknown model (→ 0), and cache multipliers (write = 1.25×, read = 0.1×)

Part of CCT-1 (Cost Capture Tracking). CCT-2.1 (metrics queries + API handler) depends on this.

## Test plan

- [x] `bun test agent/src/pricing.unit.test.ts` — 14 tests, all pass
- [x] `bun test agent/src/posthog.unit.test.ts` — 20 tests, all pass (incl. new `cost_usd` assertion)
- [x] Full suite baseline unchanged (33 pre-existing failures, unrelated)
- [x] `bunx biome lint .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)