### PR TITLE
fix(agent): guard Slack startup on credentials, serve dev /chat in offline mode

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -29,10 +29,11 @@ import {
   markSlackDisconnected,
   startHealthServer,
 } from "./health.ts";
+import { createComposedApp } from "./run-agent.ts";
 import { createFileSessionStore, threadKey } from "./sessions.ts";
 import { ensureAgentHome, installPlugins, runMiseStartup } from "./setup.ts";
 import { HttpShipwrightRuntimeClient } from "./shipwright-runtime-client.ts";
-import { createSlackApp } from "./slack.ts";
+import { createSlackApp, hasSlackCredentials } from "./slack.ts";
 import { sendBackOnlineDm } from "./startup-dm.ts";
 import { resolveDisplayName } from "./users.ts";
 import { synthesizeSpeech } from "./voice.ts";
@@ -262,34 +263,61 @@ if (runtimeClient && agentId) {
   console.log("[agent] cron sync started (60s interval)");
 }
 
-// ─── Step 7: Slack Bolt Socket Mode ──────────────────────────────────────────
+// ─── Step 7: Slack Bolt Socket Mode (only when credentials present) ───────────
+// Bolt's Socket Mode throws "Must provide an App-Level Token" if constructed
+// without an appToken, so the agent runs Slack ONLY when both tokens are present.
+// Absent creds → offline mode: skip Slack, keep health green, interact via /chat.
 
-const app = createSlackApp(
-  runner,
-  markdownToSlack,
-  threadKey,
-  undefined, // appFactory — default Bolt App
-  {
-    botToken: config.slack.botToken ?? "",
-    appToken: config.slack.appToken ?? "",
-    signingSecret: config.slack.signingSecret ?? "",
-  },
-  analytics.track,
-  undefined, // fileDownloaderFn — default
-  config.voice,
-  undefined, // transcribeAudioFn — default
-  synthesizeSpeech,
-  (userId, client) => resolveDisplayName(userId, client),
-  undefined, // botUserId — resolved by Bolt
-  undefined, // conversationsRepliesFn — default
-  (key) => sessions.get(key),
-);
+const slackAppConfig = {
+  botToken: config.slack.botToken ?? "",
+  appToken: config.slack.appToken ?? "",
+  signingSecret: config.slack.signingSecret ?? "",
+};
 
-await app.start();
-markSlackConnected();
-console.log("[agent] Slack app started — running");
+let app: ReturnType<typeof createSlackApp> | undefined;
 
-await sendBackOnlineDm(slack, config.owner.user);
+if (hasSlackCredentials(slackAppConfig)) {
+  app = createSlackApp(
+    runner,
+    markdownToSlack,
+    threadKey,
+    undefined, // appFactory — default Bolt App
+    slackAppConfig,
+    analytics.track,
+    undefined, // fileDownloaderFn — default
+    config.voice,
+    undefined, // transcribeAudioFn — default
+    synthesizeSpeech,
+    (userId, client) => resolveDisplayName(userId, client),
+    undefined, // botUserId — resolved by Bolt
+    undefined, // conversationsRepliesFn — default
+    (key) => sessions.get(key),
+  );
+
+  await app.start();
+  markSlackConnected();
+  console.log("[agent] Slack app started — running");
+
+  await sendBackOnlineDm(slack, config.owner.user);
+} else {
+  console.warn(
+    "[agent] Slack credentials absent (need SLACK_BOT_TOKEN + SLACK_APP_TOKEN) — " +
+      "skipping Slack startup. Offline mode: use the dev /chat endpoint to interact.",
+  );
+}
+
+// ─── Step 7b: Dev-only /chat transport ────────────────────────────────────────
+// DEFAULT-DENY: only when SHIPWRIGHT_DEV_CHAT=true (a CI/doctor guard forbids
+// this in production — see chat-guard.ts). Reuses the same Claude runner as
+// Slack so local chat exercises the identical code path.
+if (process.env.SHIPWRIGHT_DEV_CHAT === "true") {
+  const chatPort = Number(process.env.PORT ?? 3000);
+  const chatApp = createComposedApp({ devChat: true, chatRunner: runner });
+  Bun.serve({ fetch: chatApp.fetch, port: chatPort });
+  console.warn(
+    `[agent] SHIPWRIGHT_DEV_CHAT=true — dev /chat endpoint on port ${chatPort} (must NOT be used in production)`,
+  );
+}
 
 // ─── Step 8: Graceful shutdown ────────────────────────────────────────────────
 
@@ -308,18 +336,21 @@ async function shutdown(signal: string) {
   }
   cronTasks.clear();
 
-  // Close the Slack socket (bounded — don't let Bolt hang indefinitely)
-  try {
-    await Promise.race([
-      app.stop(),
-      new Promise<void>((resolve) => setTimeout(resolve, 15_000)),
-    ]);
-    console.log("[agent] Slack app stopped");
-  } catch (err) {
-    console.error(
-      "[agent] app.stop() failed:",
-      err instanceof Error ? err.message : String(err),
-    );
+  // Close the Slack socket (bounded — don't let Bolt hang indefinitely).
+  // Skipped entirely when Slack never started (offline mode).
+  if (app) {
+    try {
+      await Promise.race([
+        app.stop(),
+        new Promise<void>((resolve) => setTimeout(resolve, 15_000)),
+      ]);
+      console.log("[agent] Slack app stopped");
+    } catch (err) {
+      console.error(
+        "[agent] app.stop() failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   }
 
   console.log("[agent] shutdown complete");

--- a/agent/src/slack.ts
+++ b/agent/src/slack.ts
@@ -80,6 +80,21 @@ interface SlackConfig {
   signingSecret: string;
 }
 
+/**
+ * Whether the agent has the credentials required to start its Slack Bolt App.
+ *
+ * Bolt's Socket Mode constructor throws "Must provide an App-Level Token" when
+ * `appToken` is empty, so the agent must skip Slack startup (offline mode)
+ * unless BOTH the bot token and the app-level token are present. Whitespace-only
+ * values are treated as absent.
+ */
+export function hasSlackCredentials(cfg: {
+  botToken: string;
+  appToken: string;
+}): boolean {
+  return cfg.botToken.trim() !== "" && cfg.appToken.trim() !== "";
+}
+
 type AppFactory = (cfg: {
   token: string;
   appToken: string;

--- a/agent/src/slack.unit.test.ts
+++ b/agent/src/slack.unit.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for pure helpers in agent/src/slack.ts.
+ *
+ * hasSlackCredentials gates whether the agent boots its Slack Bolt App. Bolt's
+ * Socket Mode throws "Must provide an App-Level Token" when constructed without
+ * a non-empty appToken, so the agent must only call createSlackApp when both the
+ * bot token and the app-level token are present. Absent creds → offline mode.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { hasSlackCredentials } from "./slack.ts";
+
+describe("hasSlackCredentials", () => {
+  test("true when both bot and app tokens are non-empty", () => {
+    expect(
+      hasSlackCredentials({ botToken: "xoxb-1", appToken: "xapp-1" }),
+    ).toBe(true);
+  });
+
+  test("false when app token is missing (the Socket Mode requirement)", () => {
+    expect(hasSlackCredentials({ botToken: "xoxb-1", appToken: "" })).toBe(
+      false,
+    );
+  });
+
+  test("false when bot token is missing", () => {
+    expect(hasSlackCredentials({ botToken: "", appToken: "xapp-1" })).toBe(
+      false,
+    );
+  });
+
+  test("false when both are empty (offline dev default)", () => {
+    expect(hasSlackCredentials({ botToken: "", appToken: "" })).toBe(false);
+  });
+
+  test("treats whitespace-only tokens as absent", () => {
+    expect(hasSlackCredentials({ botToken: "  ", appToken: "  " })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The Docker agent crashed on startup when no Slack credentials were configured: `index.ts` built a Slack Bolt **Socket Mode** app unconditionally, and Bolt throws `Must provide an App-Level Token` when `appToken` is empty → process exits → `--rm` discards the container. The local dev stack hit this because `dev-agent`'s config has no `SLACK_*` vars. A latent second gap: the dev `/chat` server was never spawned in the container (only `index.ts` runs), so there was no offline interaction path either.

This makes the agent **offline-first**, matching the repo's "everything runs offline by default" principle.

## Changes
- `slack.ts` — new pure `hasSlackCredentials()` predicate (both bot + app token required).
- `index.ts` — start Slack **only** when credentials are present; otherwise log an offline warning and skip. Guarded `app.stop()` in shutdown. Added an in-process dev `/chat` server (port 3000) behind the existing `SHIPWRIGHT_DEV_CHAT` gate, reusing the same Claude runner.
- `slack.unit.test.ts` — 5 unit tests for the predicate.

No health-server change needed: a socket that never connects leaves `downSince === null`, so `/health` stays `200 {slack:"disconnected"}`.

## Verification
- typecheck clean · biome clean · **676/676** agent tests pass
- Rebuilt image runs without crashing; logs `offline mode`, `/chat` returns `{"result":"PONG"}`, `/health` returns `{"ok":true,"slack":"disconnected"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)