### PR TITLE
feat(charts): add helm test harness — task helm:* targets, unittest specs, kind ct CI (HD-2.2)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,84 @@
+name: Helm
+
+# Isolated from ci.yml (bun lint/typecheck/test). This workflow only gates the
+# Helm chart: fast no-cluster checks on every PR, plus a kind-based `ct install`
+# end-to-end job. Both jobs block merge on failure.
+on:
+  pull_request:
+    paths:
+      - "charts/**"
+      - "ct.yaml"
+      - ".github/workflows/helm.yml"
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - "ct.yaml"
+      - ".github/workflows/helm.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # Fast, no-cluster gate: lint + unit tests + schema validation.
+  helm-checks:
+    name: helm lint / unittest / validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
+
+      - name: Install kubeconform
+        uses: bmuschko/setup-kubeconform@v1
+        with:
+          kubeconform-version: 0.6.7
+
+      - name: helm lint
+        run: helm lint charts/shipwright
+
+      - name: helm unittest
+        run: helm unittest charts/shipwright
+
+      - name: kubeconform validate (strict, k8s + CRD schemas)
+        run: |
+          helm template shipwright charts/shipwright --namespace shipwright \
+            | kubeconform \
+                -strict \
+                -summary \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+  # End-to-end gate: spin a kind cluster and `ct install` the chart per ci/ values
+  # variant, running `helm test` against each install.
+  helm-e2e:
+    name: ct install (kind)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # ct needs full history to diff against target-branch
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+        with:
+          version: v3.12.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          version: v0.24.0
+
+      - name: ct install (per ci/ values variant, runs helm test)
+        run: ct install --config ct.yaml --charts charts/shipwright

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.16.4
+          # helm-unittest v1.x's plugin.yaml uses the `platformHooks` schema
+          # field, which Helm only understands from v3.18 onward. Keep this in
+          # step with the --version pin below.
+          version: v3.18.6
 
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -113,6 +113,41 @@ tasks:
           echo "WARNING: gitleaks not installed locally — skipping secret scan. CI enforces this gate."
         fi
 
+  helm:lint:
+    desc: "Helm chart lint (helm lint charts/shipwright)"
+    cmds:
+      - helm lint charts/shipwright
+
+  helm:unittest:
+    desc: "Helm unit tests (helm-unittest golden specs under charts/shipwright/tests/)"
+    cmds:
+      - helm unittest charts/shipwright
+
+  helm:validate:
+    desc: "Render templates and validate against k8s + CRD schemas (kubeconform, strict)"
+    cmds:
+      # The CRD schema-location uses kubeconform's own {{.Group}} placeholders;
+      # wrap the whole flag in a go-task string literal so go-task does not try
+      # to interpolate those braces.
+      - >-
+        helm template shipwright charts/shipwright --namespace shipwright
+        | kubeconform -strict -summary
+        -schema-location default
+        {{ printf "%s" "-schema-location" }}
+        {{ printf "%s" "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" }}
+
+  helm:check:
+    desc: "Local-runnable Helm gate: lint → unittest → validate (no cluster)"
+    cmds:
+      - task: helm:lint
+      - task: helm:unittest
+      - task: helm:validate
+
+  helm:e2e:
+    desc: "Helm end-to-end: ct install on a kind cluster (runs `helm test`). Requires kind + ct + a running Docker daemon."
+    cmds:
+      - ct install --config ct.yaml --charts charts/shipwright
+
   pre-public:
     desc: Full pre-public audit gate (check-strings + secret-scan). Run before making the repo public.
     cmds:

--- a/charts/shipwright/ci/eks-values.yaml
+++ b/charts/shipwright/ci/eks-values.yaml
@@ -1,0 +1,48 @@
+# ct-discovered values variant: EKS-flavored overrides.
+# Demonstrates AWS Elastic Kubernetes Service tuning — an external/NLB-style
+# LoadBalancer exposure, the EBS gp3 storage class for PVCs, and bearer-token
+# auth. As with the GKE variant, ct renders + installs this on the kind cluster
+# (the cloud LB/EBS are not provisioned on kind) to confirm the chart accepts
+# provider-flavored values and passes `helm test`.
+networking:
+  # EKS fronts type=LoadBalancer services with an AWS NLB/ELB.
+  type: LoadBalancer
+
+auth:
+  mode: bearer
+
+agent:
+  provisioning:
+    persistence:
+      enabled: true
+      size: 5Gi
+      # On real EKS you would set storageClass: gp3 (the EBS CSI gp3 class).
+      # Left empty here so `ct install` on a kind cluster binds the PVC against
+      # kind's default StorageClass — the cloud class name would never bind.
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+
+postgresql:
+  enabled: true
+  # Use the `bitnamilegacy` mirror — the default bitnami/postgresql tag is no
+  # longer publicly pullable (see README "Bitnami registry risk").
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+  auth:
+    database: shipwright_admin
+    username: shipwright
+    # CI-only literal; production should use auth.existingSecret.
+    password: ci-eks-postgres
+  primary:
+    persistence:
+      enabled: true
+      size: 10Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi

--- a/charts/shipwright/ci/gke-values.yaml
+++ b/charts/shipwright/ci/gke-values.yaml
@@ -1,0 +1,49 @@
+# ct-discovered values variant: GKE-flavored overrides.
+# Demonstrates how the chart is tuned for Google Kubernetes Engine — an internal
+# LoadBalancer for service exposure, the GKE default storage class for PVCs, and
+# session auth. ct renders + installs this variant on the kind cluster to prove
+# the templates accept provider-flavored values (the LB itself is not exercised
+# end-to-end on kind; ct validates render + install + `helm test`).
+networking:
+  # GKE provisions a cloud L4 load balancer for type=LoadBalancer services.
+  type: LoadBalancer
+
+auth:
+  mode: session
+
+agent:
+  provisioning:
+    persistence:
+      enabled: true
+      size: 5Gi
+      # On real GKE you would set storageClass: standard-rwo (the GKE default
+      # dynamic provisioner). Left empty here so `ct install` on a kind cluster
+      # binds the PVC against kind's default StorageClass — the cloud class name
+      # would never bind on kind.
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+
+postgresql:
+  enabled: true
+  # Use the `bitnamilegacy` mirror — the default bitnami/postgresql tag is no
+  # longer publicly pullable (see README "Bitnami registry risk").
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+  auth:
+    database: shipwright_admin
+    username: shipwright
+    # CI-only literal; production should use auth.existingSecret.
+    password: ci-gke-postgres
+  primary:
+    persistence:
+      enabled: true
+      size: 10Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi

--- a/charts/shipwright/ci/minikube-values.yaml
+++ b/charts/shipwright/ci/minikube-values.yaml
@@ -1,0 +1,43 @@
+# ct-discovered values variant: small/local (minikube / kind).
+# Keeps the install lightweight so `ct install` on a single-node kind cluster
+# can pull, schedule, and pass `helm test` quickly. Storage is ephemeral.
+networking:
+  type: ClusterIP
+
+auth:
+  mode: none
+
+agent:
+  provisioning:
+    persistence:
+      # No PVC churn on a throwaway local cluster.
+      enabled: false
+
+postgresql:
+  enabled: true
+  # Bitnami moved its public catalog behind "Bitnami Secure" in 2025, so the
+  # default docker.io/bitnami/postgresql tag is no longer publicly pullable.
+  # Point CI installs at the `bitnamilegacy` mirror (the fallback documented in
+  # the chart README "Bitnami registry risk" section) so `ct install` can pull.
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+  # Set an explicit password so the install is deterministic across CI re-runs
+  # (a Bitnami auto-generated password is fine for a throwaway cluster, but a
+  # fixed value keeps `helm test`/connectivity checks reproducible). This is a
+  # CI-only, non-secret literal for an ephemeral single-node cluster.
+  auth:
+    database: shipwright_admin
+    username: shipwright
+    password: ci-local-postgres
+  primary:
+    persistence:
+      # Ephemeral storage — no PVC on the local node.
+      enabled: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi

--- a/charts/shipwright/tests/image_defaults_test.yaml
+++ b/charts/shipwright/tests/image_defaults_test.yaml
@@ -1,0 +1,44 @@
+suite: default image repositories and pull policy
+# HD-2.1 set the PostgreSQL image coordinates (docker.io/bitnami/postgresql,
+# concrete tag — never `latest`) and the IfNotPresent default pull policy.
+# The shipwright service image repositories (shipwright-admin / -metrics /
+# -agent) live in values.yaml but have no consuming workload template until
+# HD-3.x, so they are guarded by values.schema.json `required: [repository]`
+# (see values_schema_test.yaml) rather than asserted on a rendered Deployment.
+# Here we assert the image facts that actually render today: the PostgreSQL
+# subchart's concrete image and pull policy.
+templates:
+  - charts/postgresql/templates/primary/statefulset.yaml
+tests:
+  - it: renders the bitnami/postgresql image from the docker.io registry
+    set:
+      postgresql.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^docker\\.io/bitnami/postgresql:"
+
+  - it: pins a concrete PostgreSQL image tag (never `latest`)
+    set:
+      postgresql.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ":latest$"
+
+  - it: defaults the PostgreSQL pull policy to IfNotPresent
+    set:
+      postgresql.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: repoints the image when global.imageRegistry overrides the registry
+    set:
+      postgresql.enabled: true
+      global.imageRegistry: my-mirror.example.com
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^my-mirror\\.example\\.com/bitnami/postgresql:"

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -1,0 +1,47 @@
+suite: chart metadata and NOTES rendering
+# Asserts the chart-level facts HD-2.1 established: NOTES.txt renders the chart
+# name/version, the configured service ports, and the networking/auth surface.
+# NOTES.txt is free text, so assertions use the *Raw matchers (no YAML path).
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: renders the Shipwright Harness banner with chart + app version
+    asserts:
+      - matchRegexRaw:
+          pattern: Thank you for installing shipwright \(Shipwright Harness\)
+      - matchRegexRaw:
+          pattern: chart version 0\.1\.0, app version 0\.1\.0
+
+  - it: surfaces the three configured service ports in NOTES
+    asserts:
+      - matchRegexRaw:
+          pattern: "admin:   3001"
+      - matchRegexRaw:
+          pattern: "metrics: 3460"
+      - matchRegexRaw:
+          pattern: "agent:   3000"
+
+  - it: reports the default networking exposure and auth mode
+    asserts:
+      - matchRegexRaw:
+          pattern: "Networking exposure type: ClusterIP"
+      - matchRegexRaw:
+          pattern: "Auth mode:                none"
+
+  - it: documents the PostgreSQL connection when the subchart is enabled
+    set:
+      postgresql.enabled: true
+    asserts:
+      - matchRegexRaw:
+          pattern: PostgreSQL \(Bitnami subchart\)
+      - matchRegexRaw:
+          pattern: database "shipwright_admin", user "shipwright"
+
+  - it: tells the operator to bring their own DB when PostgreSQL is disabled
+    set:
+      postgresql.enabled: false
+    asserts:
+      - matchRegexRaw:
+          pattern: PostgreSQL subchart is DISABLED
+      - matchRegexRaw:
+          pattern: external\s+DATABASE_URL_SHIPWRIGHT_ADMIN

--- a/charts/shipwright/tests/postgresql_dependency_test.yaml
+++ b/charts/shipwright/tests/postgresql_dependency_test.yaml
@@ -1,0 +1,55 @@
+suite: PostgreSQL subchart conditional rendering
+# HD-2.1 wired the Bitnami PostgreSQL subchart behind `postgresql.enabled`
+# (condition in Chart.yaml). These tests assert the subchart's StatefulSet renders
+# (and is correctly named) when enabled. The *absence* of the subchart when
+# disabled is asserted structurally below via documentSelector, and at the NOTES
+# level in metadata_test.yaml ("PostgreSQL subchart is DISABLED").
+tests:
+  - it: renders the PostgreSQL StatefulSet when postgresql.enabled=true
+    templates:
+      - charts/postgresql/templates/primary/statefulset.yaml
+    set:
+      postgresql.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - matchRegex:
+          path: metadata.name
+          pattern: -postgresql$
+
+  - it: renders the PostgreSQL StatefulSet under default values (enabled by default)
+    templates:
+      - charts/postgresql/templates/primary/statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+
+  - it: renders no PostgreSQL StatefulSet when postgresql.enabled=false
+    # When the subchart condition is false Helm does not load the subchart
+    # templates at all; skipEmptyTemplates lets us assert that scoped emptiness.
+    templates:
+      - charts/postgresql/templates/primary/statefulset.yaml
+    set:
+      postgresql.enabled: false
+    documentSelector:
+      path: kind
+      value: StatefulSet
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the PostgreSQL primary Service when enabled
+    templates:
+      - charts/postgresql/templates/primary/svc.yaml
+    set:
+      postgresql.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -1,0 +1,48 @@
+suite: values.schema.json guard behavior
+# HD-2.1 shipped values.schema.json. The `service` definition marks
+# `enabled`, `image`, and `service` as required (and image.repository within it).
+# Helm validates values against this schema BEFORE template execution, so an
+# override that violates a `required`/`enum` constraint must fail the render.
+# Schema-validation errors are matched with failedTemplate.errorPattern (the
+# errorMessage matcher only covers in-template render errors).
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: renders cleanly with the default (schema-valid) values
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects an admin service whose required `service` block is removed
+    set:
+      admin.service: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "at '/admin': missing property 'service'"
+
+  - it: rejects a service image missing the required `repository`
+    set:
+      metrics.image.repository: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "at '/metrics/image': missing property 'repository'"
+
+  - it: rejects an unknown property on a service image (additionalProperties false)
+    set:
+      admin.image.bogus: x
+    asserts:
+      - failedTemplate:
+          errorPattern: "additional properties 'bogus' not allowed"
+
+  - it: rejects an invalid networking.type outside the allowed enum
+    set:
+      networking.type: Bogus
+    asserts:
+      - failedTemplate:
+          errorPattern: "/networking/type"
+
+  - it: rejects an unknown auth.mode outside the allowed enum
+    set:
+      auth.mode: superuser
+    asserts:
+      - failedTemplate:
+          errorPattern: "/auth/mode"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,24 @@
+# chart-testing (ct) configuration.
+# https://github.com/helm/chart-testing
+#
+# Single-chart repo: charts live under charts/, the only chart is
+# charts/shipwright. ct discovers the per-environment values variants under
+# charts/shipwright/ci/*-values.yaml and installs the chart once per variant on
+# the kind cluster, then runs `helm test`.
+
+# Branch ct diffs against to decide which charts changed.
+target-branch: main
+
+# Where charts live (relative to repo root).
+chart-dirs:
+  - charts
+
+# This is a leaf application chart; no remote chart repositories to add.
+chart-repos: []
+
+# Single maintainer/org chart — don't enforce the maintainers list.
+validate-maintainers: false
+
+# Don't gate on a chart-version bump for every change (the CLI task and CI invoke
+# ct with --charts explicitly, so changed-chart detection is bypassed anyway).
+check-version-increment: false


### PR DESCRIPTION
## Summary
- Add the Helm chart test harness: go-task targets `helm:lint`, `helm:unittest`, `helm:validate`, `helm:e2e` (+ a `helm:check` local group).
- 19 helm-unittest specs (4 suites) covering chart metadata/NOTES, postgresql subchart enable/disable, values.schema.json guards, and image defaults.
- `ci/` values variants (minikube/gke/eks) + `ct.yaml` for chart-testing `ct install`.
- New **isolated** CI workflow `.github/workflows/helm.yml` (separate from `ci.yml`/bun): `helm-checks` job (lint + unittest + kubeconform on every PR) and `helm-e2e` job (kind + chart-testing `ct install`). Both block merge. Action versions pinned.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `task helm:lint/unittest/validate` run + pass locally; `task helm:e2e` installs on kind + runs helm test | MET |
| 2 | CI runs local helm checks on every PR + separate kind `ct` install job; ci/ values (minikube/gke/eks) committed | MET |
| 3 | Establishes helm-unit / helm-integration / helm-e2e layers for later chart tasks; no tests retired | MET |

## Test Plan
- `task helm:lint` → 0 failed
- `task helm:unittest` → 4 suites / 19 tests pass
- `task helm:validate` → kubeconform: 7 resources valid, 0 invalid
- `task helm:e2e` → ran on a real kind cluster; `ct install` all 3 ci/ variants succeeded (applied the documented `bitnamilegacy` image fallback)
- gitleaks secret-scan + check-strings: clean; `ci.yml` untouched
- [x] Pre-ship checks passing

> Bundles with HD-2.3 (same branch). Note: helm-unittest specs are `*_test.yaml` under `charts/` — Bun's runner ignores them, keeping the bun pipeline isolated.

Generated with [Claude Code](https://claude.com/claude-code)
