### PR TITLE
feat(charts): chart versioning discipline + ct version-increment CI gate (HD-2.3)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # ct --check-version-increment diffs against target-branch
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -43,8 +45,22 @@ jobs:
         with:
           kubeconform-version: 0.6.7
 
+      - name: Set up chart-testing
+        # Installs the `ct` binary plus its yamllint + yamale dependencies.
+        uses: helm/chart-testing-action@v2
+        with:
+          version: v3.12.0
+
       - name: helm lint
         run: helm lint charts/shipwright
+
+      - name: ct lint (enforces chart version-increment)
+        # Fails any PR that modifies charts/shipwright/** without bumping
+        # Chart.yaml `version`. NOTE: the version-increment check only fires in
+        # ct's *changed-chart detection* mode — passing `--charts` would bypass
+        # detection and silently skip the bump check. So we rely on `chart-dirs`
+        # + `target-branch` from ct.yaml to let ct diff against main itself.
+        run: ct lint --config ct.yaml --check-version-increment --target-branch main
 
       - name: helm unittest
         run: helm unittest charts/shipwright

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the **shipwright** Helm chart are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this chart adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The chart `version` (in `Chart.yaml`) is bumped on **every** chart change,
+independent of `appVersion`. CI enforces this with
+`ct lint --check-version-increment`. Each release here must mirror the
+`artifacthub.io/changes` annotation in `Chart.yaml`.
+
+## [0.2.0]
+
+### Added
+
+- `CHANGELOG.md` (keep-a-changelog) documenting chart versions.
+- `artifacthub.io/changes` annotation in `Chart.yaml` mirroring this changelog.
+- `ct` version-increment CI gate (`ct lint --check-version-increment`) wired into
+  the Helm workflow — any PR touching `charts/shipwright/**` that does not bump
+  the chart `version` now fails CI.
+
+### Changed
+
+- Documented the chart versioning discipline in the chart `README.md`
+  ("Versioning" section) and `CONTRIBUTING.md`.
+
+## [0.1.0]
+
+### Added
+
+- Initial chart scaffold: values surface, helpers, NOTES, `values.schema.json`,
+  and the pinned Bitnami PostgreSQL dependency (HD-2.1).
+- Helm test harness: `task helm:*` targets, helm-unittest specs, and the
+  kind-based `ct install` CI workflow (HD-2.2).

--- a/charts/shipwright/CONTRIBUTING.md
+++ b/charts/shipwright/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to the shipwright Helm chart
+
+This note covers the rules specific to the chart under `charts/shipwright/`. For
+repo-wide conventions (Conventional Commits, tests-with-code, license), see the
+[root `CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+## Versioning discipline (enforced by CI)
+
+Every change under `charts/shipwright/**` **must bump the chart `version`** in
+`Chart.yaml`. This is a hard CI gate, not a convention:
+
+- The Helm workflow (`.github/workflows/helm.yml`) runs
+  `ct lint --check-version-increment`, which diffs the chart against `main` and
+  **fails the PR** if the chart changed but `version` did not increase.
+- `ct.yaml` sets `check-version-increment: true`.
+
+When you change the chart:
+
+1. **Bump `version`** in `Chart.yaml` (SemVer — patch/minor/major as
+   appropriate). `appVersion` only changes when the deployed Shipwright app
+   release changes.
+2. **Add a `CHANGELOG.md` entry** for the new version (keep-a-changelog style:
+   `Added` / `Changed` / `Fixed` / `Removed`).
+3. **Mirror it in `artifacthub.io/changes`** in `Chart.yaml` (Artifact Hub
+   list-of-changes format: `- kind: added|changed|fixed|removed` +
+   `description:`). Keep the annotation and the CHANGELOG in sync.
+
+## Validate locally before pushing
+
+```bash
+helm lint charts/shipwright
+task helm:unittest                                # helm-unittest specs
+# Detection mode — no --charts, so ct diffs against main and runs the
+# version-bump check (passing --charts bypasses detection and the bump check):
+ct lint --config ct.yaml --check-version-increment --target-branch main
+```
+
+`ct lint` also runs `yamllint` and `yamale` schema validation; install them with
+`brew install yamllint yamale` (or `pip install yamllint yamale`) if missing.

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -6,7 +6,9 @@ description: >-
   optional PostgreSQL dependency for Kubernetes (Minikube-friendly defaults).
 type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
-version: 0.1.0
+# See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
+# via `ct lint --check-version-increment`.
+version: 0.2.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -23,6 +25,17 @@ maintainers:
 # License: MIT (chart + application).
 annotations:
   licenses: MIT
+  # Artifact Hub change log for this release. Must mirror the matching version
+  # entry in CHANGELOG.md (keep the two in sync on every bump).
+  artifacthub.io/changes: |
+    - kind: added
+      description: CHANGELOG.md (keep-a-changelog) documenting chart versions
+    - kind: added
+      description: artifacthub.io/changes annotation mirroring the CHANGELOG
+    - kind: added
+      description: ct version-increment CI gate — chart changes must bump version
+    - kind: changed
+      description: documented the chart versioning discipline in README + CONTRIBUTING
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/README.md
+++ b/charts/shipwright/README.md
@@ -13,6 +13,25 @@ Minikube-friendly defaults.
 
 License: **MIT**.
 
+## Versioning
+
+This chart follows [Semantic Versioning](https://semver.org). The chart
+`version` in `Chart.yaml` is bumped on **every** chart change, independent of
+`appVersion` (which tracks the Shipwright application release the chart deploys
+by default).
+
+**On any change under `charts/shipwright/**`:**
+
+1. Bump `version` in `Chart.yaml` (patch / minor / major per the nature of the
+   change).
+2. Add a matching entry to [`CHANGELOG.md`](./CHANGELOG.md) (keep-a-changelog
+   style).
+3. Mirror that entry in the `artifacthub.io/changes` annotation in `Chart.yaml`.
+
+CI enforces step 1: the Helm workflow runs
+`ct lint --check-version-increment`, which fails any PR that modifies the chart
+without bumping `version`. See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
 ## Quick start (Minikube)
 
 ```bash

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 0\.1\.0, app version 0\.1\.0
+          pattern: chart version 0\.2\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/ct.yaml
+++ b/ct.yaml
@@ -19,6 +19,8 @@ chart-repos: []
 # Single maintainer/org chart — don't enforce the maintainers list.
 validate-maintainers: false
 
-# Don't gate on a chart-version bump for every change (the CLI task and CI invoke
-# ct with --charts explicitly, so changed-chart detection is bypassed anyway).
-check-version-increment: false
+# Gate on a chart-version bump for every chart change. `ct lint
+# --check-version-increment` diffs charts/shipwright/** against target-branch and
+# fails any PR that modifies the chart without bumping Chart.yaml `version`. See
+# charts/shipwright/CHANGELOG.md and the README "Versioning" section.
+check-version-increment: true


### PR DESCRIPTION
## Summary
- Establish Helm chart version discipline: bump `Chart.yaml` version 0.1.0 → **0.2.0**, add `charts/shipwright/CHANGELOG.md` (keep-a-changelog), and an `artifacthub.io/changes` annotation matching the changelog.
- Wire **`ct lint --check-version-increment`** into the `helm-checks` CI job (via `helm/chart-testing-action`): any PR that edits `charts/shipwright/**` without bumping the chart version now fails CI.
- Document the rule in the chart README ("Versioning") and a chart-local `CONTRIBUTING.md`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | CHANGELOG.md exists + Chart.yaml `artifacthub.io/changes` annotation matches it | MET |
| 2 | CI fails an un-bumped chart change (`ct lint --check-version-increment`) and passes when bumped; rule documented in README/CONTRIBUTING | MET |
| 3 | Gate is self-testing (no new bun tests); no tests retired | MET |

## Test Plan
- `ct lint --check-version-increment --target-branch main` **with** the 0.2.0 bump → PASS (`Old: 0.1.0 / New: 0.2.0 / Chart version ok`)
- Reverting to 0.1.0 → **FAIL** (`chart version not ok. Needs a version bump!`) — gate proven both directions
- `helm lint` ✓, `helm:unittest` 19/19 ✓ (version pin updated), `actionlint` clean, `ci.yml` untouched
- gitleaks + check-strings clean
- [x] Pre-ship checks passing

> Note: `ct`'s `--check-version-increment` only fires in changed-chart **detection** mode — passing `--charts` silently skips it. The CI step uses detection mode (chart-dirs/target-branch via ct.yaml) so the gate genuinely enforces.

Generated with [Claude Code](https://claude.com/claude-code)
