### PR TITLE
ci: add chart-releaser workflow to publish the Helm chart on release (HD-6.1)

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -55,7 +55,7 @@ jobs:
           version: v3.18.6
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: charts
         env:

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,89 @@
+name: Chart Release
+
+# Publishes the Helm chart at charts/shipwright to a chart repository so it is
+# consumable via `helm repo add` (GitHub Pages, gh-pages branch).
+#
+# Kept SEPARATE from release.yml (the app's semantic-release): this workflow only
+# concerns the Helm chart artifact. Two concerns:
+#
+#   publish (push to main) — chart-releaser packages charts/ and, for any
+#     Chart.yaml `version` not already published, creates a GitHub Release with
+#     the .tgz attached and updates the gh-pages index.yaml. chart-releaser is
+#     idempotent: already-released versions are skipped, so the effective trigger
+#     is "a chart version bump landed on main" (HD-2.3's versioning discipline).
+#
+#   dry-run (pull_request) — validates that the chart packages and an index can
+#     be generated, WITHOUT publishing anything. This is the PR-time test for the
+#     publish path.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/shipwright/**"
+      - ".github/workflows/chart-release.yml"
+  pull_request:
+    paths:
+      - "charts/shipwright/**"
+      - ".github/workflows/chart-release.yml"
+
+# Least privilege at the workflow level; the publish job widens to contents:write.
+permissions:
+  contents: read
+
+jobs:
+  # Publish job — runs ONLY on push to main, never on pull_request.
+  publish:
+    name: chart-releaser (gh-pages)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create GitHub Releases + push to gh-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # chart-releaser needs full history to diff/tag
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.6
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Dry-run validation — runs ONLY on pull_request. Proves the chart packages and
+  # an index renders; publishes nothing (no gh-pages push, no GitHub Release).
+  dry-run:
+    name: package + index (dry run)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.6
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/shipwright
+
+      - name: Package chart (no publish)
+        run: helm package charts/shipwright -d .cr-release-packages
+
+      - name: Generate repo index (no publish)
+        run: helm repo index .cr-release-packages
+
+      - name: Show packaged artifacts
+        run: ls -la .cr-release-packages

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@
 
 Requires [Claude Code](https://www.anthropic.com/claude-code). Point it at your own repository — Shipwright is repo-agnostic.
 
+**Deploying the services to Kubernetes?** The `shipwright` Helm chart is published to a Helm repo on each chart version bump:
+
+```bash
+helm repo add shipwright https://app-vitals.github.io/shipwright
+helm install my-release shipwright/shipwright --namespace shipwright --create-namespace
+```
+
+See [`docs/helm-repo.md`](./docs/helm-repo.md) for the full flow and how publishing is triggered.
+
 ## Quickstart
 
 You can run the **metrics dashboard locally today** — **offline by default**, with **no PostHog key, no accounts, and no database**. One copy-paste prompt sequences the two execution contexts (terminal shell + an in-session slash command) and opens the dashboard.

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -1,0 +1,40 @@
+# Installing from the published Helm repo
+
+The `shipwright` chart (`charts/shipwright`) is published to a
+[GitHub Pages](https://pages.github.com/) Helm repository on every chart
+**version bump** that lands on `main`. The
+[`chart-release.yml`](../.github/workflows/chart-release.yml) workflow runs
+[chart-releaser](https://github.com/helm/chart-releaser-action), which packages
+the chart, attaches the `.tgz` to a GitHub Release, and updates the
+`index.yaml` on the `gh-pages` branch.
+
+> Publishing is keyed off `Chart.yaml`'s `version` (the
+> [versioning discipline](../charts/shipwright/CHANGELOG.md)). chart-releaser is
+> idempotent — it only releases versions it hasn't published before — so a
+> chart is published exactly when its version is bumped, never on a plain PR.
+
+## Add the repo and install
+
+```bash
+# Add the published Shipwright chart repository.
+helm repo add shipwright https://app-vitals.github.io/shipwright
+helm repo update
+
+# See the available chart versions.
+helm search repo shipwright --versions
+
+# Install into a dedicated namespace.
+helm install my-release shipwright/shipwright \
+  --namespace shipwright --create-namespace
+```
+
+To pin a specific chart version, pass `--version`:
+
+```bash
+helm install my-release shipwright/shipwright --version 0.2.0 \
+  --namespace shipwright --create-namespace
+```
+
+For values, the Bitnami PostgreSQL subchart caveat, and the image-override /
+mirror fallback, see the chart's own
+[README](../charts/shipwright/README.md).

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -13,6 +13,30 @@ the chart, attaches the `.tgz` to a GitHub Release, and updates the
 > idempotent — it only releases versions it hasn't published before — so a
 > chart is published exactly when its version is bumped, never on a plain PR.
 
+## First-time setup (one-time)
+
+Before the **first** chart release, the `gh-pages` branch must exist and GitHub
+Pages must be serving from it. The `chart-release.yml` workflow appends to an
+existing `gh-pages` branch — if it doesn't exist, the first publish silently
+no-ops and the `helm repo add` URL below 404s. Do this once:
+
+1. Create an orphan `gh-pages` branch:
+
+   ```bash
+   git checkout --orphan gh-pages
+   git rm -rf .
+   git commit --allow-empty -m "init gh-pages"
+   git push origin gh-pages
+   git checkout main
+   ```
+
+2. Enable GitHub Pages: **Settings → Pages → Source: "Deploy from a branch"**,
+   branch `gh-pages`, folder `/ (root)`.
+
+This is a one-time setup. After the first chart release, the
+`chart-release.yml` workflow maintains `index.yaml` on `gh-pages`
+automatically — no further manual steps.
+
 ## Add the repo and install
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.github/workflows/chart-release.yml` to publish the Helm chart on release, **separate** from the app's semantic-release:
  - **Publish job** (`push: main`, paths `charts/shipwright/**`): `helm/chart-releaser-action@v1.7.0` → gh-pages. Idempotent — releases only when `Chart.yaml` version is new (HD-2.3 discipline); packages the chart, attaches the `.tgz` to a GitHub Release, updates gh-pages `index.yaml`. Uses built-in `GITHUB_TOKEN`, `contents: write` scoped to the publish job.
  - **Dry-run job** (`pull_request`): `helm dependency build` + `helm package` + `helm repo index` — validates packaging without publishing.
- Docs: `docs/helm-repo.md` ("Installing from the published Helm repo") + a README note. Deliberately **outside** `charts/` so the version-increment gate isn't tripped (no chart-version bump needed for a docs/workflow change).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | On release, workflow packages + publishes the chart (gh-pages index + GitHub Release); documented `helm install` from published location | MET |
| 2 | Publishing triggers only on release/main-merge (not PRs); keys on Chart.yaml version + skips already-published | MET |
| 3 | PR dry-run validates cr package + index (no publish); no bun tests; none retired | MET |

## Test Plan
- `actionlint .github/workflows/chart-release.yml` → clean
- `helm package charts/shipwright -d /tmp/cr && helm repo index /tmp/cr` → `shipwright-0.2.0.tgz` + `index.yaml` (same steps the PR dry-run job runs)
- `ct lint --check-version-increment --target-branch main` → PASS ("no chart changes" — docs live outside charts/)
- check-strings + gitleaks clean; ci.yml / helm.yml / release.yml untouched
- [x] Pre-ship checks passing

Generated with [Claude Code](https://claude.com/claude-code)
