### PR TITLE
feat(admin): add pure agent Kubernetes manifest builders (HD-1.2)

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -1,0 +1,263 @@
+/**
+ * admin/src/agent-manifest.ts
+ *
+ * Pure builders for the Kubernetes manifests that provision a single Shipwright
+ * agent: a per-agent Deployment, its Opaque token Secret, and the RFC1123 name
+ * derivation that ties them together.
+ *
+ * These functions are PURE — no fs, no network, no clock. They only shape wire
+ * objects. The actual k8s API calls live in ./kubernetes-client.ts; this module
+ * returns the same `KubernetesDeployment` / `KubernetesSecret` wire types so the
+ * two stay structurally consistent.
+ *
+ * Garbage collection: each agent resource carries an `ownerReference` to the
+ * admin Deployment. When the admin Deployment is deleted on uninstall,
+ * Kubernetes cascade-deletes every owned agent Deployment + Secret.
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  KubernetesDeployment,
+  KubernetesSecret,
+} from "./kubernetes-client.ts";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Agent health/liveness port (matches the agent's `SHIPWRIGHT_HEALTH_PORT`). */
+export const AGENT_HEALTH_PORT = 3459;
+
+/** Where the agent's persistent home volume is mounted in the container. */
+export const AGENT_HOME_MOUNT_PATH = "/data/agent-home";
+
+/** Non-root uid/gid the agent runs as (matches the agent image). */
+const AGENT_RUN_AS = 1000;
+
+/** RFC1123 label length cap. */
+const MAX_NAME_LEN = 63;
+
+/** Length of the appended disambiguation hash suffix. */
+const HASH_SUFFIX_LEN = 8;
+
+const NAME_LABEL = "app.kubernetes.io/name";
+const INSTANCE_LABEL = "app.kubernetes.io/instance";
+const MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
+const AGENT_ID_LABEL = "shipwright.dev/agent-id";
+const AGENT_APP_NAME = "shipwright-agent";
+
+// ─── Owner reference (GC) ───────────────────────────────────────────────────
+
+interface OwnerReference {
+  apiVersion: string;
+  kind: string;
+  name: string;
+  uid: string;
+  controller: boolean;
+  blockOwnerDeletion: boolean;
+  [key: string]: unknown;
+}
+
+function adminOwnerReference(name: string, uid: string): OwnerReference {
+  return {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    name,
+    uid,
+    controller: true,
+    blockOwnerDeletion: true,
+  };
+}
+
+// ─── Name sanitization ──────────────────────────────────────────────────────
+
+/**
+ * Derive an RFC1123-compliant, collision-resistant Kubernetes object name from
+ * an arbitrary agent id.
+ *
+ * RFC1123 labels must be lowercase alphanumerics or `-`, start/end alphanumeric,
+ * and be ≤63 chars.
+ *
+ * Collision strategy: sanitization is inherently lossy — `agent_1`, `agent.1`,
+ * and `Agent-1` all reduce to the same `agent-1` base, and long ids must be
+ * truncated. Whenever the cleaned base is NOT a byte-for-byte match of the
+ * original id (i.e. any lowercasing, char replacement, collapsing, trimming, or
+ * truncation happened), we append `-<8-hex>` where the hex is the leading bytes
+ * of `sha256(originalId)`. The hash is over the FULL original id, so two ids
+ * that share a cleaned prefix still get distinct suffixes. A lossless id (already
+ * valid RFC1123) is returned unchanged. The base is truncated as needed so that
+ * `base + "-" + suffix` still fits within 63 chars.
+ */
+export function sanitizeAgentName(id: string): string {
+  const base = cleanBase(id);
+
+  // Lossless: the id was already a valid RFC1123 label — return as-is.
+  if (base === id && base.length > 0 && base.length <= MAX_NAME_LEN) {
+    return base;
+  }
+
+  const suffix = createHash("sha256")
+    .update(id)
+    .digest("hex")
+    .slice(0, HASH_SUFFIX_LEN);
+
+  // Reserve room for "-" + suffix, then re-trim any dash exposed at the new end.
+  const room = MAX_NAME_LEN - (suffix.length + 1);
+  const truncated = trimDashes(base.slice(0, Math.max(0, room)));
+  const prefix = truncated.length > 0 ? `${truncated}-` : "";
+  return `${prefix}${suffix}`;
+}
+
+/** Lowercase, replace invalid runs with a single dash, trim dash padding. */
+function cleanBase(id: string): string {
+  const lowered = id.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  return trimDashes(lowered);
+}
+
+function trimDashes(s: string): string {
+  return s.replace(/^-+/, "").replace(/-+$/, "");
+}
+
+// ─── Deployment builder ─────────────────────────────────────────────────────
+
+export interface AgentDeploymentOpts {
+  /** Original agent id (used verbatim in env + label, sanitized for the name). */
+  agentId: string;
+  namespace: string;
+  /** Agent container image (without tag). */
+  image: string;
+  /** Image tag, joined as `image:tag`. */
+  imageTag: string;
+  /** In-cluster admin/API base URL the agent calls home to. */
+  apiUrl: string;
+  /** Name of the pre-provisioned PersistentVolumeClaim for the agent home. */
+  pvcName: string;
+  /** Name of the Secret holding the per-agent token. */
+  secretName: string;
+  /** Key within the Secret's data that holds the token. Defaults to "token". */
+  tokenSecretKey?: string;
+  /** Admin Deployment name (ownerReference target for GC). */
+  adminDeploymentName: string;
+  /** Admin Deployment uid (ownerReference target for GC). */
+  adminDeploymentUid: string;
+  /** Replica count. Defaults to 1. */
+  replicas?: number;
+}
+
+export function buildAgentDeploymentManifest(
+  opts: AgentDeploymentOpts,
+): KubernetesDeployment {
+  const name = sanitizeAgentName(opts.agentId);
+  const tokenKey = opts.tokenSecretKey ?? "token";
+  const volumeName = "agent-home";
+
+  const labels: Record<string, string> = {
+    [NAME_LABEL]: AGENT_APP_NAME,
+    [INSTANCE_LABEL]: name,
+    [MANAGED_BY_LABEL]: "shipwright-admin",
+    [AGENT_ID_LABEL]: opts.agentId,
+  };
+
+  // Selectors are immutable post-create and must not include volatile values;
+  // the instance label is the stable per-agent identity.
+  const selectorLabels: Record<string, string> = {
+    [NAME_LABEL]: AGENT_APP_NAME,
+    [INSTANCE_LABEL]: name,
+  };
+
+  return {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: {
+      name,
+      namespace: opts.namespace,
+      labels,
+      ownerReferences: [
+        adminOwnerReference(opts.adminDeploymentName, opts.adminDeploymentUid),
+      ],
+    },
+    spec: {
+      replicas: opts.replicas ?? 1,
+      selector: { matchLabels: selectorLabels },
+      template: {
+        metadata: { labels: selectorLabels },
+        spec: {
+          securityContext: {
+            fsGroup: AGENT_RUN_AS,
+            runAsNonRoot: true,
+            runAsUser: AGENT_RUN_AS,
+          },
+          volumes: [
+            {
+              name: volumeName,
+              persistentVolumeClaim: { claimName: opts.pvcName },
+            },
+          ],
+          containers: [
+            {
+              name: AGENT_APP_NAME,
+              image: `${opts.image}:${opts.imageTag}`,
+              env: [
+                { name: "SHIPWRIGHT_AGENT_ID", value: opts.agentId },
+                { name: "SHIPWRIGHT_API_URL", value: opts.apiUrl },
+                {
+                  name: "SHIPWRIGHT_AGENT_API_KEY",
+                  valueFrom: {
+                    secretKeyRef: { name: opts.secretName, key: tokenKey },
+                  },
+                },
+              ],
+              volumeMounts: [
+                { name: volumeName, mountPath: AGENT_HOME_MOUNT_PATH },
+              ],
+              livenessProbe: {
+                httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
+                initialDelaySeconds: 10,
+                periodSeconds: 15,
+              },
+              securityContext: {
+                runAsNonRoot: true,
+                runAsUser: AGENT_RUN_AS,
+                allowPrivilegeEscalation: false,
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+// ─── Secret builder ─────────────────────────────────────────────────────────
+
+export interface AgentSecretOpts {
+  name: string;
+  namespace: string;
+  /** Plaintext per-agent token; base64-encoded into the Secret's `data`. */
+  token: string;
+  /** Key under which the token is stored. Defaults to "token". */
+  tokenKey?: string;
+  /** Admin Deployment name (ownerReference target for GC). */
+  adminDeploymentName: string;
+  /** Admin Deployment uid (ownerReference target for GC). */
+  adminDeploymentUid: string;
+}
+
+export function buildAgentSecretManifest(
+  opts: AgentSecretOpts,
+): KubernetesSecret {
+  const tokenKey = opts.tokenKey ?? "token";
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    type: "Opaque",
+    metadata: {
+      name: opts.name,
+      namespace: opts.namespace,
+      ownerReferences: [
+        adminOwnerReference(opts.adminDeploymentName, opts.adminDeploymentUid),
+      ],
+    },
+    data: {
+      [tokenKey]: Buffer.from(opts.token).toString("base64"),
+    },
+  };
+}

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -1,0 +1,281 @@
+/**
+ * admin/src/agent-manifest.unit.test.ts
+ * Unit tests for the pure agent Kubernetes manifest builders. No I/O, no
+ * network, no fs — these assert wire-shape only.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  AGENT_HEALTH_PORT,
+  AGENT_HOME_MOUNT_PATH,
+  type AgentDeploymentOpts,
+  type AgentSecretOpts,
+  buildAgentDeploymentManifest,
+  buildAgentSecretManifest,
+  sanitizeAgentName,
+} from "./agent-manifest.ts";
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+const deployOpts: AgentDeploymentOpts = {
+  agentId: "agent_42",
+  namespace: "shipwright",
+  image: "ghcr.io/app-vitals/shipwright-agent",
+  imageTag: "v1.2.3",
+  apiUrl: "http://shipwright-admin.shipwright.svc:3001",
+  pvcName: "agent-42-home",
+  secretName: "agent-42-token",
+  tokenSecretKey: "token",
+  adminDeploymentName: "shipwright-admin",
+  adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
+};
+
+// ─── buildAgentDeploymentManifest ───────────────────────────────────────────
+
+describe("buildAgentDeploymentManifest", () => {
+  it("emits a valid apps/v1 Deployment", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    expect(d.apiVersion).toBe("apps/v1");
+    expect(d.kind).toBe("Deployment");
+    expect(d.metadata.namespace).toBe("shipwright");
+    expect(d.spec.replicas).toBe(1);
+  });
+
+  it("derives a sanitized RFC1123 metadata name from the agent id", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    expect(d.metadata.name).toBe(sanitizeAgentName("agent_42"));
+    expect(d.metadata.name).not.toContain("_");
+  });
+
+  it("joins image and tag", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    expect(d.spec.template.spec.containers[0].image).toBe(
+      "ghcr.io/app-vitals/shipwright-agent:v1.2.3",
+    );
+  });
+
+  it("sets labels and matching selector/template labels", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const name = sanitizeAgentName("agent_42");
+    expect(d.metadata.labels).toMatchObject({
+      "app.kubernetes.io/name": "shipwright-agent",
+      "app.kubernetes.io/instance": name,
+      "shipwright.dev/agent-id": "agent_42",
+    });
+    // selector must match the pod template labels (else 0 pods scheduled)
+    expect(d.spec.selector.matchLabels).toEqual(
+      d.spec.template.metadata.labels,
+    );
+    expect(d.spec.selector.matchLabels).toMatchObject({
+      "app.kubernetes.io/instance": name,
+    });
+  });
+
+  it("sets the required env vars including a secretKeyRef token", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const env = d.spec.template.spec.containers[0].env ?? [];
+    const byName = new Map(env.map((e) => [e.name, e]));
+
+    expect(byName.get("SHIPWRIGHT_AGENT_ID")?.value).toBe("agent_42");
+    expect(byName.get("SHIPWRIGHT_API_URL")?.value).toBe(
+      "http://shipwright-admin.shipwright.svc:3001",
+    );
+
+    const tokenEnv = byName.get("SHIPWRIGHT_AGENT_API_KEY");
+    expect(tokenEnv).toBeDefined();
+    expect(tokenEnv?.value).toBeUndefined();
+    expect(tokenEnv?.valueFrom?.secretKeyRef).toEqual({
+      name: "agent-42-token",
+      key: "token",
+    });
+  });
+
+  it("mounts a PVC volume at the agent home path", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const podSpec = d.spec.template.spec;
+
+    const vol = podSpec.volumes?.find(
+      (v) => v.persistentVolumeClaim?.claimName === "agent-42-home",
+    );
+    expect(vol).toBeDefined();
+
+    const mount = podSpec.containers[0].volumeMounts?.find(
+      (m) => m.mountPath === AGENT_HOME_MOUNT_PATH,
+    );
+    expect(mount).toBeDefined();
+    expect(AGENT_HOME_MOUNT_PATH).toBe("/data/agent-home");
+    // volume name and mount name must agree
+    expect(mount?.name).toBe(vol?.name);
+  });
+
+  it("defines a liveness probe on the health port 3459", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const probe = d.spec.template.spec.containers[0].livenessProbe;
+    expect(AGENT_HEALTH_PORT).toBe(3459);
+    expect(probe?.httpGet?.port).toBe(3459);
+  });
+
+  it("applies a hardened security context (fsGroup, runAsNonRoot, runAsUser)", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const podSpec = d.spec.template.spec;
+    expect(podSpec.securityContext).toMatchObject({
+      fsGroup: 1000,
+      runAsNonRoot: true,
+      runAsUser: 1000,
+    });
+    expect(podSpec.containers[0].securityContext).toMatchObject({
+      runAsNonRoot: true,
+      runAsUser: 1000,
+    });
+  });
+
+  it("sets an ownerReference to the admin Deployment for GC on uninstall", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const refs = d.metadata.ownerReferences ?? [];
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      name: "shipwright-admin",
+      uid: "11112222-3333-4444-5555-666677778888",
+      controller: true,
+      blockOwnerDeletion: true,
+    });
+  });
+
+  it("honours an explicit replicas override", () => {
+    const d = buildAgentDeploymentManifest({ ...deployOpts, replicas: 0 });
+    expect(d.spec.replicas).toBe(0);
+  });
+});
+
+// ─── buildAgentSecretManifest ───────────────────────────────────────────────
+
+describe("buildAgentSecretManifest", () => {
+  const secretOpts: AgentSecretOpts = {
+    name: "agent-42-token",
+    namespace: "shipwright",
+    token: "sw-agent-secret-token",
+    tokenKey: "token",
+    adminDeploymentName: "shipwright-admin",
+    adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
+  };
+
+  it("emits an Opaque v1 Secret", () => {
+    const s = buildAgentSecretManifest(secretOpts);
+    expect(s.apiVersion).toBe("v1");
+    expect(s.kind).toBe("Secret");
+    expect(s.type).toBe("Opaque");
+    expect(s.metadata.name).toBe("agent-42-token");
+    expect(s.metadata.namespace).toBe("shipwright");
+  });
+
+  it("base64-encodes the token under the configured key in data", () => {
+    const s = buildAgentSecretManifest(secretOpts);
+    expect(s.data.token).toBe(
+      Buffer.from("sw-agent-secret-token").toString("base64"),
+    );
+  });
+
+  it("defaults the token key to 'token'", () => {
+    const { tokenKey: _omit, ...rest } = secretOpts;
+    const s = buildAgentSecretManifest(rest);
+    expect(s.data.token).toBeDefined();
+  });
+
+  it("carries an ownerReference to the admin Deployment", () => {
+    const s = buildAgentSecretManifest(secretOpts);
+    const refs = s.metadata.ownerReferences ?? [];
+    expect(refs[0]).toMatchObject({
+      kind: "Deployment",
+      name: "shipwright-admin",
+      uid: "11112222-3333-4444-5555-666677778888",
+      controller: true,
+    });
+  });
+});
+
+// ─── sanitizeAgentName ──────────────────────────────────────────────────────
+
+const RFC1123 = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+describe("sanitizeAgentName", () => {
+  it("lowercases uppercase characters (lossy → hash suffix)", () => {
+    expect(sanitizeAgentName("AgentFoo")).toMatch(RFC1123);
+    expect(sanitizeAgentName("AgentFoo")).toMatch(/^agentfoo-[a-z0-9]+$/);
+  });
+
+  it("replaces underscores and dots with dashes (lossy → hash suffix)", () => {
+    // The cleaned base is "agent-42-beta", then a short hash of the original id
+    // is appended so distinct originals never collide.
+    expect(sanitizeAgentName("agent_42.beta")).toMatch(
+      /^agent-42-beta-[a-z0-9]+$/,
+    );
+  });
+
+  it("collapses runs of invalid characters into a single dash", () => {
+    expect(sanitizeAgentName("a___b")).toMatch(/^a-b-[a-z0-9]+$/);
+  });
+
+  it("strips leading and trailing non-alphanumerics", () => {
+    expect(sanitizeAgentName("__agent__")).toMatch(/^agent-[a-z0-9]+$/);
+    expect(sanitizeAgentName("-.-foo-.-")).toMatch(/^foo-[a-z0-9]+$/);
+  });
+
+  it("leaves an already-RFC1123 id unchanged (lossless → no hash suffix)", () => {
+    expect(sanitizeAgentName("agent-42")).toBe("agent-42");
+    expect(sanitizeAgentName("a1")).toBe("a1");
+  });
+
+  it("always produces an RFC1123-compliant label", () => {
+    for (const id of [
+      "Agent_42",
+      "___",
+      "UPPER.Case_ID",
+      "a".repeat(200),
+      "weird@@chars!!here",
+      "123start",
+    ]) {
+      const out = sanitizeAgentName(id);
+      expect(out.length).toBeGreaterThan(0);
+      expect(out.length).toBeLessThanOrEqual(63);
+      expect(out).toMatch(RFC1123);
+    }
+  });
+
+  it("never exceeds 63 characters even for very long ids", () => {
+    const out = sanitizeAgentName("agent-".repeat(50));
+    expect(out.length).toBeLessThanOrEqual(63);
+    expect(out).toMatch(RFC1123);
+  });
+
+  it("appends a hash suffix when the id is truncated (collision resistance)", () => {
+    const longA = `${"x".repeat(100)}aaaa`;
+    const longB = `${"x".repeat(100)}bbbb`;
+    const a = sanitizeAgentName(longA);
+    const b = sanitizeAgentName(longB);
+    // Truncation alone would collide on the shared prefix; the hash suffix
+    // derived from the full original id keeps them distinct.
+    expect(a).not.toBe(b);
+    expect(a).toMatch(RFC1123);
+    expect(b).toMatch(RFC1123);
+  });
+
+  it("disambiguates ids that sanitize to the same label", () => {
+    // "agent_1" and "agent.1" both naively map to "agent-1"; the hash suffix
+    // from the distinct originals keeps the k8s names unique.
+    const a = sanitizeAgentName("agent_1");
+    const b = sanitizeAgentName("agent.1");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a non-empty fallback when nothing alphanumeric remains", () => {
+    const out = sanitizeAgentName("___");
+    expect(out.length).toBeGreaterThan(0);
+    expect(out).toMatch(RFC1123);
+  });
+
+  it("is deterministic for a given id", () => {
+    expect(sanitizeAgentName("agent_42")).toBe(sanitizeAgentName("agent_42"));
+  });
+});

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -50,6 +50,35 @@ export interface SecretSpec {
 
 // ─── Resource bodies (k8s wire shapes) ──────────────────────────────────────
 
+/** A single container env var: either a literal value or a `valueFrom` source. */
+export interface KubernetesEnvVar {
+  name: string;
+  value?: string;
+  valueFrom?: {
+    secretKeyRef?: { name: string; key: string };
+    configMapKeyRef?: { name: string; key: string };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface KubernetesContainer {
+  name: string;
+  image: string;
+  env?: KubernetesEnvVar[];
+  volumeMounts?: Array<{
+    name: string;
+    mountPath: string;
+    [key: string]: unknown;
+  }>;
+  livenessProbe?: {
+    httpGet?: { path?: string; port: number | string; [key: string]: unknown };
+    [key: string]: unknown;
+  };
+  securityContext?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 export interface KubernetesDeployment {
   apiVersion: string;
   kind: string;
@@ -57,6 +86,7 @@ export interface KubernetesDeployment {
     name: string;
     namespace: string;
     labels?: Record<string, string>;
+    ownerReferences?: Array<Record<string, unknown>>;
     [key: string]: unknown;
   };
   spec: {
@@ -65,11 +95,14 @@ export interface KubernetesDeployment {
     template: {
       metadata: { labels: Record<string, string> };
       spec: {
-        containers: Array<{
+        containers: KubernetesContainer[];
+        volumes?: Array<{
           name: string;
-          image: string;
-          env?: Array<{ name: string; value: string }>;
+          persistentVolumeClaim?: { claimName: string };
+          [key: string]: unknown;
         }>;
+        securityContext?: Record<string, unknown>;
+        [key: string]: unknown;
       };
     };
   };
@@ -83,6 +116,7 @@ export interface KubernetesSecret {
   metadata: {
     name: string;
     namespace: string;
+    ownerReferences?: Array<Record<string, unknown>>;
     [key: string]: unknown;
   };
   data: Record<string, string>;


### PR DESCRIPTION
## Summary
- Add `admin/src/agent-manifest.ts` — pure (no-I/O) Kubernetes manifest builders for agent provisioning:
  - `buildAgentDeploymentManifest(opts)` — apps/v1 Deployment: agent image+tag, env (`SHIPWRIGHT_AGENT_ID`, in-cluster `SHIPWRIGHT_API_URL`, per-agent token via `secretKeyRef`), PVC mount at `/data/agent-home`, liveness probe on `SHIPWRIGHT_HEALTH_PORT` 3459, `securityContext` (fsGroup/runAsUser 1000, runAsNonRoot), and an `ownerReference` to the admin Deployment so agents are GC'd on uninstall.
  - `buildAgentSecretManifest(opts)` — Opaque Secret carrying the minted agent token.
  - `sanitizeAgentName(id)` — RFC1123-safe, collision-resistant name (lowercase + normalize; appends `sha256(id)[:8]` whenever the transform is lossy, so `agent_1`/`agent.1`/`Agent-1` don't collide).
- Additively widens the `KubernetesDeployment`/`KubernetesSecret` wire types in `kubernetes-client.ts` (optional `valueFrom`, `volumeMounts`, `livenessProbe`, `securityContext`, `volumes`, `ownerReferences`) so a full pod spec is typeable — existing `deploymentBody`/`secretBody` + all client tests unchanged and passing.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Deployment with required env, PVC, liveness probe :3459, fsGroup:1000, runAsNonRoot, ownerReference to admin Deployment | MET |
| 2 | Secret carries agent token; sanitizeAgentName is RFC1123-compliant + collision-resistant | MET |
| 3 | UNIT tests only (manifest shape, labels/selectors, env, ownerReference, name-sanitization edge cases); no tests retired | MET |

## Test Plan
- 25 new unit tests in `agent-manifest.unit.test.ts` (Deployment/Secret shape, env, secretKeyRef, PVC, probe:3459, securityContext, ownerReference, replicas; sanitize: uppercase/underscores/dots, length>63, trim, collisions, determinism)
- `kubernetes-client` tests still pass (40/0) confirming the type widening is additive
- Full `bun test` → no new failures (only the 2 known-pre-existing `task_store.test.ts` env failures)
- typecheck/Biome clean; check-strings + gitleaks clean
- [x] Pre-ship checks passing

Generated with [Claude Code](https://claude.com/claude-code)
