### PR TITLE
feat(admin): add KubernetesAgentProvisioner + NoopAgentProvisioner (HD-1.3)

### DIFF
--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -178,6 +178,26 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
     ).rejects.toThrow();
   });
 
+  it("provision() rolls back the freshly-minted Secret when the Deployment already exists (409)", async () => {
+    const agentId = await createAgent();
+    const name = sanitizeAgentName(agentId);
+    // Seed ONLY the Deployment — the Secret does NOT pre-exist. This call mints
+    // a token and creates a new Secret, then hits a 409 on the Deployment. The
+    // orphaned Secret (carrying a fresh, unused token) must be rolled back.
+    const k8s = emptyClient();
+    await k8s.createDeployment(NAMESPACE, {
+      name,
+      image: `${CONFIG.image}:${CONFIG.imageTag}`,
+    });
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    // (a) Idempotent success — does NOT throw despite the Deployment conflict.
+    await expect(provisioner.provision(agentId)).resolves.toBeDefined();
+
+    // (b) The Secret created during THIS call was deleted, not left behind.
+    await expect(k8s.getSecret(NAMESPACE, `${name}-token`)).rejects.toThrow();
+  });
+
   it("provision() succeeds idempotently when both resources already exist", async () => {
     const agentId = await createAgent();
     const name = sanitizeAgentName(agentId);

--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -1,0 +1,256 @@
+/**
+ * admin/src/agent-provisioner.integration.test.ts
+ * Integration tests for KubernetesAgentProvisioner.
+ *
+ * Composes the REAL AgentTokenService against a real Postgres test DB with an
+ * injected in-memory KubernetesClient (RecordedKubernetesClient) standing in
+ * for the cluster. No globals are overridden — the fake is injected via the
+ * constructor.
+ *
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise (CI provides it).
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import {
+  buildAgentSecretManifest,
+  sanitizeAgentName,
+} from "./agent-manifest.ts";
+import {
+  type KubernetesAgentProvisionerConfig,
+  KubernetesAgentProvisioner,
+  NoopAgentProvisioner,
+} from "./agent-provisioner.ts";
+import { AgentTokenService } from "./agent-tokens.ts";
+import { ConflictError } from "./errors.ts";
+import {
+  type DeploymentSpec,
+  type KubernetesClient,
+  type KubernetesSecret,
+  RecordedKubernetesClient,
+  type SecretSpec,
+} from "./kubernetes-client.ts";
+
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+const NAMESPACE = "shipwright";
+
+const CONFIG: KubernetesAgentProvisionerConfig = {
+  namespace: NAMESPACE,
+  image: "ghcr.io/app-vitals/shipwright-agent",
+  imageTag: "v1.2.3",
+  apiUrl: "http://shipwright-admin.shipwright.svc:3001",
+  adminDeploymentName: "shipwright-admin",
+  adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
+};
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+function emptyClient(): RecordedKubernetesClient {
+  return new RecordedKubernetesClient({ deployments: {}, secrets: {} });
+}
+
+/** Decode the token value the Secret carries under the default "token" key. */
+function decodeSecretToken(secret: KubernetesSecret): string {
+  return Buffer.from(secret.data.token, "base64").toString("utf-8");
+}
+
+describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
+  let prisma: PrismaClient;
+  let tokens: AgentTokenService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    await prisma.agentToken.deleteMany();
+    await prisma.agentCronJob.deleteMany();
+    await prisma.agentTool.deleteMany();
+    await prisma.agentEnv.deleteMany();
+    await prisma.agent.deleteMany();
+    tokens = new AgentTokenService(prisma);
+  });
+
+  async function createAgent(name = "Test Agent"): Promise<string> {
+    const agent = await prisma.agent.create({ data: { name } });
+    return agent.id;
+  }
+
+  // ─── provision ──────────────────────────────────────────────────────────────
+
+  it("provision() mints a token, then creates the Secret and Deployment", async () => {
+    const agentId = await createAgent();
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    const result = await provisioner.provision(agentId);
+
+    const name = sanitizeAgentName(agentId);
+    expect(result.resourceName).toBe(name);
+    expect(result.secretName).toBe(`${name}-token`);
+    expect(result.deploymentName).toBe(name);
+    expect(result.rawToken).toBeDefined();
+
+    // Secret carries the minted token, and the token validates via the service.
+    const secret = await k8s.getSecret(NAMESPACE, `${name}-token`);
+    const carried = decodeSecretToken(secret);
+    expect(result.rawToken).toBeDefined();
+    expect(carried).toBe(result.rawToken as string);
+    const validated = await tokens.validate(carried);
+    expect(validated?.agentId).toBe(agentId);
+
+    // Deployment exists and points at the right image.
+    const dep = await k8s.getDeployment(NAMESPACE, name);
+    expect(dep.spec.template.spec.containers[0].image).toBe(
+      "ghcr.io/app-vitals/shipwright-agent:v1.2.3",
+    );
+  });
+
+  it("provision() creates the Secret BEFORE the Deployment (order)", async () => {
+    const agentId = await createAgent();
+    const order: string[] = [];
+    const recorded = emptyClient();
+    const ordered: KubernetesClient = {
+      createSecret: (ns: string, spec: SecretSpec) => {
+        order.push("secret");
+        return recorded.createSecret(ns, spec);
+      },
+      createDeployment: (ns: string, spec: DeploymentSpec) => {
+        order.push("deployment");
+        return recorded.createDeployment(ns, spec);
+      },
+      getSecret: (ns, n) => recorded.getSecret(ns, n),
+      getDeployment: (ns, n) => recorded.getDeployment(ns, n),
+      deleteSecret: (ns, n) => recorded.deleteSecret(ns, n),
+      deleteDeployment: (ns, n) => recorded.deleteDeployment(ns, n),
+    };
+    const provisioner = new KubernetesAgentProvisioner(ordered, tokens, CONFIG);
+
+    await provisioner.provision(agentId);
+    expect(order).toEqual(["secret", "deployment"]);
+  });
+
+  it("provision() is safe to retry (provision twice → no throw)", async () => {
+    const agentId = await createAgent();
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    await provisioner.provision(agentId);
+    // Second call hits ConflictError on both create calls; must not throw.
+    await expect(provisioner.provision(agentId)).resolves.toBeDefined();
+
+    const name = sanitizeAgentName(agentId);
+    // Resources still present after the retry.
+    await expect(
+      k8s.getSecret(NAMESPACE, `${name}-token`),
+    ).resolves.toBeDefined();
+    await expect(k8s.getDeployment(NAMESPACE, name)).resolves.toBeDefined();
+  });
+
+  // ─── failure / rollback ───────────────────────────────────────────────────────
+
+  it("provision() rolls back the Secret if Deployment creation fails", async () => {
+    const agentId = await createAgent();
+    const recorded = emptyClient();
+    const failing: KubernetesClient = {
+      createSecret: (ns, spec) => recorded.createSecret(ns, spec),
+      createDeployment: async () => {
+        throw new Error("simulated API server failure");
+      },
+      getSecret: (ns, n) => recorded.getSecret(ns, n),
+      getDeployment: (ns, n) => recorded.getDeployment(ns, n),
+      deleteSecret: (ns, n) => recorded.deleteSecret(ns, n),
+      deleteDeployment: (ns, n) => recorded.deleteDeployment(ns, n),
+    };
+    const provisioner = new KubernetesAgentProvisioner(failing, tokens, CONFIG);
+
+    await expect(provisioner.provision(agentId)).rejects.toThrow(
+      "simulated API server failure",
+    );
+
+    const name = sanitizeAgentName(agentId);
+    // Secret must have been cleaned up so a retry starts clean.
+    await expect(
+      recorded.getSecret(NAMESPACE, `${name}-token`),
+    ).rejects.toThrow();
+  });
+
+  it("provision() succeeds idempotently when both resources already exist", async () => {
+    const agentId = await createAgent();
+    const name = sanitizeAgentName(agentId);
+    // Pre-seed both resources as if a prior provision had completed.
+    const seededSecret = buildAgentSecretManifest({
+      name: `${name}-token`,
+      namespace: NAMESPACE,
+      token: "preexisting",
+      adminDeploymentName: CONFIG.adminDeploymentName,
+      adminDeploymentUid: CONFIG.adminDeploymentUid,
+    });
+    const k8s = new RecordedKubernetesClient({
+      deployments: {},
+      secrets: { [`${NAMESPACE}/${name}-token`]: seededSecret },
+    });
+    // Pre-create the deployment too.
+    await k8s.createDeployment(NAMESPACE, {
+      name,
+      image: `${CONFIG.image}:${CONFIG.imageTag}`,
+    });
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    await expect(provisioner.provision(agentId)).resolves.toBeDefined();
+  });
+
+  // ─── deprovision ──────────────────────────────────────────────────────────────
+
+  it("deprovision() deletes both the Deployment and the Secret", async () => {
+    const agentId = await createAgent();
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    await provisioner.provision(agentId);
+    await provisioner.deprovision(agentId);
+
+    const name = sanitizeAgentName(agentId);
+    await expect(k8s.getSecret(NAMESPACE, `${name}-token`)).rejects.toThrow();
+    await expect(k8s.getDeployment(NAMESPACE, name)).rejects.toThrow();
+  });
+
+  it("deprovision() tolerates already-absent resources (no throw)", async () => {
+    const agentId = await createAgent();
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    // Nothing provisioned — deprovision must be a no-op.
+    await expect(provisioner.deprovision(agentId)).resolves.toBeUndefined();
+    // And a second deprovision after a real one is still a no-op.
+    await provisioner.provision(agentId);
+    await provisioner.deprovision(agentId);
+    await expect(provisioner.deprovision(agentId)).resolves.toBeUndefined();
+  });
+});
+
+// ─── NoopAgentProvisioner (no DB required) ────────────────────────────────────
+
+describe("NoopAgentProvisioner", () => {
+  it("provision() returns derived names without touching any cluster", async () => {
+    const provisioner = new NoopAgentProvisioner();
+    const result = await provisioner.provision("agent_42");
+    const name = sanitizeAgentName("agent_42");
+    expect(result.resourceName).toBe(name);
+    expect(result.secretName).toBe(`${name}-token`);
+    expect(result.deploymentName).toBe(name);
+    expect(result.rawToken).toBeUndefined();
+  });
+
+  it("deprovision() resolves to nothing", async () => {
+    const provisioner = new NoopAgentProvisioner();
+    await expect(provisioner.deprovision("agent_42")).resolves.toBeUndefined();
+  });
+
+  it("ConflictError remains importable for typed-error narrowing", () => {
+    expect(new ConflictError().statusCode).toBe(409);
+  });
+});

--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -10,7 +10,7 @@
  * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise (CI provides it).
  */
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { PrismaClient } from "../prisma/client/index.js";
 import {
   buildAgentSecretManifest,
@@ -72,6 +72,10 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
     await prisma.agentEnv.deleteMany();
     await prisma.agent.deleteMany();
     tokens = new AgentTokenService(prisma);
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
   });
 
   async function createAgent(name = "Test Agent"): Promise<string> {

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -165,7 +165,13 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       );
     } catch (err) {
       if (isConflict(err)) {
-        // Already provisioned — idempotent success.
+        // Deployment already exists — idempotent success. But if we minted and
+        // created a NEW Secret in THIS call, the pre-existing Deployment isn't
+        // using it; roll the orphaned Secret (and its fresh token) back so we
+        // never leak it. Only ever delete a Secret THIS call created.
+        if (secretCreated) {
+          await this.deleteSecretBestEffort(secretName);
+        }
         return result;
       }
       if (secretCreated) {
@@ -190,9 +196,11 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
   // ─── Spec derivation (via the pure manifest builders) ─────────────────────
 
   private secretSpec(secretName: string, rawToken: string): SecretSpec {
-    // Build the canonical manifest (owner refs, encoding) for consistency, then
-    // hand the KubernetesClient the plain stringData it create-encodes itself.
-    buildAgentSecretManifest({
+    // The pure builder is the single source of truth for the Secret body (name,
+    // token key, base64 encoding). Derive the KubernetesClient SecretSpec from
+    // its output so the builder actually drives the secret — decoding `data`
+    // back to plain `stringData` since createSecret re-encodes it itself.
+    const manifest = buildAgentSecretManifest({
       name: secretName,
       namespace: this.config.namespace,
       token: rawToken,
@@ -200,7 +208,11 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       adminDeploymentName: this.config.adminDeploymentName,
       adminDeploymentUid: this.config.adminDeploymentUid,
     });
-    return { name: secretName, stringData: { [this.tokenKey]: rawToken } };
+    const stringData: Record<string, string> = {};
+    for (const [key, value] of Object.entries(manifest.data)) {
+      stringData[key] = Buffer.from(value, "base64").toString("utf-8");
+    }
+    return { name: manifest.metadata.name, stringData };
   }
 
   private deploymentSpec(

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -1,0 +1,273 @@
+/**
+ * admin/src/agent-provisioner.ts
+ *
+ * Provisions (and tears down) the Kubernetes resources backing a single
+ * Shipwright agent. This module COMPOSES three lower-level pieces:
+ *
+ *   - AgentTokenService (./agent-tokens.ts) — mints the scoped per-agent token.
+ *   - the pure manifest builders (./agent-manifest.ts) — shape the Secret +
+ *     Deployment wire objects (RFC1123 name derivation, owner references, env).
+ *   - a KubernetesClient (./kubernetes-client.ts) — performs the actual
+ *     namespace-scoped create/get/delete API calls.
+ *
+ * Provisioning order is token → Secret → Deployment: the Deployment references
+ * the Secret by name (`secretKeyRef`), so the Secret must exist first.
+ *
+ * Both operations are SAFE TO RETRY:
+ *   - provision() treats an already-existing Secret/Deployment (ConflictError /
+ *     409) as already-provisioned rather than failing, and if Deployment
+ *     creation fails after the Secret was created it best-effort deletes the
+ *     Secret so a retry starts from a clean slate.
+ *   - deprovision() deletes the Deployment then the Secret and swallows
+ *     NotFoundError (404) so tearing down an absent / half-absent agent is a
+ *     no-op rather than an error.
+ */
+
+import {
+  buildAgentDeploymentManifest,
+  buildAgentSecretManifest,
+  sanitizeAgentName,
+} from "./agent-manifest.ts";
+import type { AgentTokenService } from "./agent-tokens.ts";
+import { ConflictError, NotFoundError } from "./errors.ts";
+import type {
+  DeploymentSpec,
+  KubernetesClient,
+  SecretSpec,
+} from "./kubernetes-client.ts";
+
+// ─── Interface ──────────────────────────────────────────────────────────────
+
+/** Outcome of a successful (or already-satisfied) provision. */
+export interface ProvisionResult {
+  /** RFC1123 Kubernetes object name shared by the Secret + Deployment. */
+  resourceName: string;
+  /** Name of the per-agent Secret carrying the token. */
+  secretName: string;
+  /** Name of the per-agent Deployment. */
+  deploymentName: string;
+  /**
+   * The raw token minted for this provision, or `undefined` when the resources
+   * already existed (ConflictError) and no new token was issued.
+   */
+  rawToken?: string;
+}
+
+export interface AgentProvisioner {
+  /** Mint a token and create the agent's Secret + Deployment. Idempotent. */
+  provision(agentId: string): Promise<ProvisionResult>;
+  /** Delete the agent's Deployment + Secret. Tolerates already-absent. */
+  deprovision(agentId: string): Promise<void>;
+}
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+export interface KubernetesAgentProvisionerConfig {
+  /** Namespace the agent resources live in. */
+  namespace: string;
+  /** Agent container image (without tag). */
+  image: string;
+  /** Image tag, joined as `image:tag`. */
+  imageTag: string;
+  /** In-cluster admin/API base URL the agent calls home to. */
+  apiUrl: string;
+  /** Admin Deployment name — ownerReference target for GC. */
+  adminDeploymentName: string;
+  /** Admin Deployment uid — ownerReference target for GC. */
+  adminDeploymentUid: string;
+  /**
+   * Build the PVC name for an agent from its sanitized resource name.
+   * Defaults to `<name>-home`.
+   */
+  pvcName?: (resourceName: string) => string;
+  /**
+   * Build the Secret name from the sanitized resource name.
+   * Defaults to `<name>-token`.
+   */
+  secretName?: (resourceName: string) => string;
+  /** Key under which the token is stored in the Secret. Defaults to "token". */
+  tokenSecretKey?: string;
+  /** Replica count for the agent Deployment. Defaults to 1. */
+  replicas?: number;
+}
+
+function isConflict(err: unknown): boolean {
+  return err instanceof ConflictError;
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof NotFoundError;
+}
+
+// ─── Kubernetes implementation ──────────────────────────────────────────────
+
+export class KubernetesAgentProvisioner implements AgentProvisioner {
+  private readonly tokenKey: string;
+
+  constructor(
+    private readonly k8s: KubernetesClient,
+    private readonly tokens: AgentTokenService,
+    private readonly config: KubernetesAgentProvisionerConfig,
+  ) {
+    this.tokenKey = config.tokenSecretKey ?? "token";
+  }
+
+  private resourceName(agentId: string): string {
+    return sanitizeAgentName(agentId);
+  }
+
+  private secretNameFor(resourceName: string): string {
+    return this.config.secretName
+      ? this.config.secretName(resourceName)
+      : `${resourceName}-token`;
+  }
+
+  private pvcNameFor(resourceName: string): string {
+    return this.config.pvcName
+      ? this.config.pvcName(resourceName)
+      : `${resourceName}-home`;
+  }
+
+  async provision(agentId: string): Promise<ProvisionResult> {
+    const resourceName = this.resourceName(agentId);
+    const secretName = this.secretNameFor(resourceName);
+    const result: ProvisionResult = {
+      resourceName,
+      secretName,
+      deploymentName: resourceName,
+    };
+
+    // 1. Token — mint a fresh scoped token for this agent.
+    const { rawToken } = await this.tokens.create(agentId, "k8s-provision");
+    result.rawToken = rawToken;
+
+    // 2. Secret — must exist before the Deployment that references it.
+    //    A 409 means a prior (possibly partial) provision already created it;
+    //    treat as already-present and continue to the Deployment step.
+    let secretCreated = false;
+    try {
+      await this.k8s.createSecret(
+        this.config.namespace,
+        this.secretSpec(secretName, rawToken),
+      );
+      secretCreated = true;
+    } catch (err) {
+      if (!isConflict(err)) throw err;
+    }
+
+    // 3. Deployment. If creation fails AFTER we created the Secret in THIS call,
+    //    roll the Secret back (best-effort) so a retry starts clean and never
+    //    leaks a half-provisioned state.
+    try {
+      await this.k8s.createDeployment(
+        this.config.namespace,
+        this.deploymentSpec(agentId, resourceName, secretName),
+      );
+    } catch (err) {
+      if (isConflict(err)) {
+        // Already provisioned — idempotent success.
+        return result;
+      }
+      if (secretCreated) {
+        await this.deleteSecretBestEffort(secretName);
+      }
+      throw err;
+    }
+
+    return result;
+  }
+
+  async deprovision(agentId: string): Promise<void> {
+    const resourceName = this.resourceName(agentId);
+    const secretName = this.secretNameFor(resourceName);
+
+    // Delete the Deployment first (it depends on the Secret), then the Secret.
+    // Already-absent resources (404) are swallowed so teardown is idempotent.
+    await this.deleteDeploymentBestEffort(resourceName);
+    await this.deleteSecretBestEffort(secretName);
+  }
+
+  // ─── Spec derivation (via the pure manifest builders) ─────────────────────
+
+  private secretSpec(secretName: string, rawToken: string): SecretSpec {
+    // Build the canonical manifest (owner refs, encoding) for consistency, then
+    // hand the KubernetesClient the plain stringData it create-encodes itself.
+    buildAgentSecretManifest({
+      name: secretName,
+      namespace: this.config.namespace,
+      token: rawToken,
+      tokenKey: this.tokenKey,
+      adminDeploymentName: this.config.adminDeploymentName,
+      adminDeploymentUid: this.config.adminDeploymentUid,
+    });
+    return { name: secretName, stringData: { [this.tokenKey]: rawToken } };
+  }
+
+  private deploymentSpec(
+    agentId: string,
+    resourceName: string,
+    secretName: string,
+  ): DeploymentSpec {
+    const manifest = buildAgentDeploymentManifest({
+      agentId,
+      namespace: this.config.namespace,
+      image: this.config.image,
+      imageTag: this.config.imageTag,
+      apiUrl: this.config.apiUrl,
+      pvcName: this.pvcNameFor(resourceName),
+      secretName,
+      tokenSecretKey: this.tokenKey,
+      adminDeploymentName: this.config.adminDeploymentName,
+      adminDeploymentUid: this.config.adminDeploymentUid,
+      replicas: this.config.replicas,
+    });
+    const container = manifest.spec.template.spec.containers[0];
+    return {
+      name: resourceName,
+      image: container.image,
+      replicas: manifest.spec.replicas,
+      labels: manifest.spec.selector.matchLabels,
+      env: {
+        SHIPWRIGHT_AGENT_ID: agentId,
+        SHIPWRIGHT_API_URL: this.config.apiUrl,
+      },
+    };
+  }
+
+  private async deleteSecretBestEffort(name: string): Promise<void> {
+    try {
+      await this.k8s.deleteSecret(this.config.namespace, name);
+    } catch (err) {
+      if (!isNotFound(err)) throw err;
+    }
+  }
+
+  private async deleteDeploymentBestEffort(name: string): Promise<void> {
+    try {
+      await this.k8s.deleteDeployment(this.config.namespace, name);
+    } catch (err) {
+      if (!isNotFound(err)) throw err;
+    }
+  }
+}
+
+// ─── No-op implementation ─────────────────────────────────────────────────────
+
+/**
+ * No-op provisioner used when Kubernetes provisioning is disabled. Lets the
+ * admin service construct and run unchanged without a cluster.
+ */
+export class NoopAgentProvisioner implements AgentProvisioner {
+  async provision(agentId: string): Promise<ProvisionResult> {
+    const resourceName = sanitizeAgentName(agentId);
+    return {
+      resourceName,
+      secretName: `${resourceName}-token`,
+      deploymentName: resourceName,
+    };
+  }
+
+  async deprovision(_agentId: string): Promise<void> {
+    // intentionally a no-op
+  }
+}

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -137,22 +137,36 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       deploymentName: resourceName,
     };
 
-    // 1. Token — mint a fresh scoped token for this agent.
-    const { rawToken } = await this.tokens.create(agentId, "k8s-provision");
-    result.rawToken = rawToken;
-
-    // 2. Secret — must exist before the Deployment that references it.
-    //    A 409 means a prior (possibly partial) provision already created it;
-    //    treat as already-present and continue to the Deployment step.
+    // 1. Token — mint only when the Secret does NOT already exist. If the Secret
+    //    is already present (a prior provision completed or partially ran), we
+    //    skip minting so no orphaned token rows accumulate in the DB and the
+    //    returned rawToken correctly signals "use the existing credential" via
+    //    undefined. Only mint a fresh token when we're about to write a new Secret.
     let secretCreated = false;
+    let secretAlreadyExists = false;
     try {
-      await this.k8s.createSecret(
-        this.config.namespace,
-        this.secretSpec(secretName, rawToken),
-      );
-      secretCreated = true;
+      await this.k8s.getSecret(this.config.namespace, secretName);
+      secretAlreadyExists = true;
     } catch (err) {
-      if (!isConflict(err)) throw err;
+      if (!isNotFound(err)) throw err;
+    }
+
+    if (!secretAlreadyExists) {
+      const { rawToken } = await this.tokens.create(agentId, "k8s-provision");
+      result.rawToken = rawToken;
+
+      // 2. Secret — must exist before the Deployment that references it.
+      //    A 409 here is unexpected (we just confirmed it was absent), but treat
+      //    it as already-present and continue to the Deployment step.
+      try {
+        await this.k8s.createSecret(
+          this.config.namespace,
+          this.secretSpec(secretName, rawToken),
+        );
+        secretCreated = true;
+      } catch (err) {
+        if (!isConflict(err)) throw err;
+      }
     }
 
     // 3. Deployment. If creation fails AFTER we created the Secret in THIS call,

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -248,15 +248,16 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       replicas: this.config.replicas,
     });
     const container = manifest.spec.template.spec.containers[0];
+    // Pull the env entries directly from the manifest so the Deployment spec
+    // faithfully reflects what the pure builder produced — including the
+    // SHIPWRIGHT_AGENT_API_KEY valueFrom/secretKeyRef entry that cannot be
+    // expressed in the plain `env: Record<string, string>` map.
     return {
       name: resourceName,
       image: container.image,
       replicas: manifest.spec.replicas,
       labels: manifest.spec.selector.matchLabels,
-      env: {
-        SHIPWRIGHT_AGENT_ID: agentId,
-        SHIPWRIGHT_API_URL: this.config.apiUrl,
-      },
+      envVars: container.env,
     };
   }
 

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -40,6 +40,12 @@ export interface DeploymentSpec {
   labels?: Record<string, string>;
   /** Container environment variables (plain values). */
   env?: Record<string, string>;
+  /**
+   * Additional env vars expressed as full `KubernetesEnvVar` objects. Supports
+   * `valueFrom` entries (e.g. `secretKeyRef`) that cannot be expressed in the
+   * plain `env` map. Merged after the `env` entries in the container spec.
+   */
+  envVars?: KubernetesEnvVar[];
 }
 
 export interface SecretSpec {
@@ -170,9 +176,13 @@ export function deploymentBody(
   spec: DeploymentSpec,
 ): KubernetesDeployment {
   const labels = spec.labels ?? { app: spec.name };
-  const env = spec.env
+  const plainEnv: KubernetesEnvVar[] = spec.env
     ? Object.entries(spec.env).map(([name, value]) => ({ name, value }))
-    : undefined;
+    : [];
+  const env: KubernetesEnvVar[] | undefined =
+    plainEnv.length > 0 || (spec.envVars && spec.envVars.length > 0)
+      ? [...plainEnv, ...(spec.envVars ?? [])]
+      : undefined;
 
   return {
     apiVersion: "apps/v1",


### PR DESCRIPTION
## Summary
- Add `admin/src/agent-provisioner.ts`: an `AgentProvisioner` interface with two implementations.
  - **`KubernetesAgentProvisioner`**: `provision(agentId)` mints a scoped per-agent token (real `AgentTokenService`), then creates the per-agent **Secret** (carrying the token) and **Deployment** via the injected `KubernetesClient` — Secret-before-Deployment, retry-safe (409 ConflictError tolerated → already-provisioned), with **rollback** (if Deployment creation fails after the Secret was freshly created, the Secret is best-effort deleted so a retry starts clean). `deprovision(agentId)` deletes Deployment then Secret, tolerating already-absent (404).
  - **`NoopAgentProvisioner`**: no-ops, so the admin service runs unchanged when k8s provisioning is disabled.
- Composes HD-1.1 (`KubernetesClient`/`RecordedKubernetesClient`), HD-1.2 (`buildAgent*Manifest`, `sanitizeAgentName`), and the existing `AgentTokenService`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | provision() mints token, creates Secret then Deployment, retry-safe; deprovision() removes both, tolerates absent | MET |
| 2 | NoopAgentProvisioner no-ops the interface | MET |
| 3 | INTEGRATION tests (injected fake KubernetesClient + real AgentTokenService vs test Postgres): provision creates Secret+Deployment with minted token, deprovision deletes, failure/rollback path; none retired | MET |

## Test Plan
- 10 integration tests in `agent-provisioner.integration.test.ts` (provision Secret+Deployment carry the validated minted token; ordering; retry-safety; idempotent pre-existing; failure→Secret rollback; deprovision delete + absent-tolerant). 3 Noop tests run without a DB; 7 DB-backed tests guard on `DATABASE_URL_ADMIN_TEST` (same `describe.skip` pattern as the other admin integration tests) → run in CI's Postgres. Verified 10/0 locally against a real test DB.
- Biome lint clean; `@shipwright/admin` typecheck 0; check-strings + gitleaks clean.

## Known limitation (flagging for review)
The HD-1.2 manifest builders emit an `ownerReference` (for GC-cascade of agents on admin uninstall), but `KubernetesClient.createDeployment/createSecret` accept the simpler `DeploymentSpec`/`SecretSpec`, which don't carry ownerReferences — so the ownerRef is **not currently transmitted to the cluster**. Wiring it through would require extending the `KubernetesClient` create surface (HD-1.1 module), which is out of scope for this task. Flagging as a follow-up; HD-1.3's ACs (token + Secret/Deployment presence, retry, rollback) are fully met.

Generated with [Claude Code](https://claude.com/claude-code)
