### PR TITLE
feat(charts): add Ingress networking + helm test connection hook (HD-3.3)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,25 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [0.6.0]
+
+### Added
+
+- Ingress networking. Setting `networking.type=ingress` renders a
+  `networking.k8s.io/v1` `Ingress` (`templates/ingress.yaml`) with a configurable
+  `ingressClassName` (`networking.ingress.className`, default `nginx`), `host`
+  (`networking.ingress.host`, default `shipwright.local`), and controller-specific
+  `annotations` (`networking.ingress.annotations`, default `{}`). Rules route the
+  admin UI/API at `/` to the admin Service and the metrics dashboard at `/dashboard`
+  to the metrics Service (`pathType: Prefix`). The `/dashboard` path is omitted when
+  `metrics.enabled=false`. No Ingress is rendered for any other `networking.type`
+  (the default stays `ClusterIP`, so the Ingress is OFF by default).
+- Helm test connection hook (`templates/tests/test-connection.yaml`). A
+  `helm.sh/hook: test` Pod using the public, pinned `curlimages/curl` image curls
+  the admin Service `/health` (must return 200) and, when `metrics.enabled`, the
+  metrics Service `/dashboard` (accepts 200 or 302), exiting non-zero on failure so
+  `helm test` fails loudly. This is the smoke check `ct install` runs in the e2e job.
+
 ## [0.5.0]
 
 ### Fixed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 0.5.0
+version: 0.6.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,10 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "initdb DB name now tracks metrics.database.name overrides — moved CREATE DATABASE into a parent-chart ConfigMap rendered with the shipwright.metrics.databaseName helper; postgresql.primary.initdb.scriptsConfigMap wired via tpl"
+    - kind: added
+      description: "Ingress networking (networking.type=ingress) rendering networking.k8s.io/v1 Ingress with configurable ingressClassName/host/annotations — admin UI/API at / and metrics dashboard at /dashboard (omitted when metrics disabled)"
+    - kind: added
+      description: "Helm test connection hook (templates/tests/test-connection.yaml) curling admin /health (200) and metrics /dashboard (200/302) so `helm test` verifies a live install"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/ingress.yaml
+++ b/charts/shipwright/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if eq .Values.networking.type "ingress" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "shipwright.fullname" . }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+  {{- with .Values.networking.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.networking.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.networking.ingress.host | quote }}
+      http:
+        paths:
+          {{- if .Values.metrics.enabled }}
+          # Metrics dashboard. Declared BEFORE the admin "/" catch-all so the
+          # more-specific /dashboard prefix wins (ingress controllers match the
+          # longest prefix, but ordering keeps intent explicit). Omitted entirely
+          # when metrics is disabled.
+          - path: /dashboard
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "shipwright.metrics.fullname" . }}
+                port:
+                  name: http
+          {{- end }}
+          # Admin UI/API at the root. Everything not matched by a more-specific
+          # path above is routed to the admin service.
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "shipwright.admin.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/shipwright/templates/tests/test-connection.yaml
+++ b/charts/shipwright/templates/tests/test-connection.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.admin.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "shipwright.fullname" . }}-test-connection
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test-connection
+  annotations:
+    # Marks this Pod as a Helm test hook: it only runs on `helm test`, never on
+    # install/upgrade. Deleted after the test run unless it fails (kept for debug).
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  # A failed test Pod should surface immediately, not be retried into a
+  # CrashLoopBackOff that masks the failure from `helm test`.
+  restartPolicy: Never
+  containers:
+    - name: curl
+      # Small, public, pinned curl image (no first-party build needed).
+      image: curlimages/curl:8.11.1
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          # Admin /health MUST return 200.
+          ADMIN_URL="http://{{ include "shipwright.admin.fullname" . }}:{{ .Values.admin.service.port }}/health"
+          echo "GET ${ADMIN_URL} (expect 200)"
+          admin_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 --retry 5 --retry-delay 3 --retry-connrefused "${ADMIN_URL}")"
+          echo "admin /health -> ${admin_code}"
+          if [ "${admin_code}" != "200" ]; then
+            echo "FAIL: admin /health returned ${admin_code}, expected 200" >&2
+            exit 1
+          fi
+          {{- if .Values.metrics.enabled }}
+          # Metrics /dashboard MUST return 200 or 302 (auth/redirect tolerated).
+          METRICS_URL="http://{{ include "shipwright.metrics.fullname" . }}:{{ .Values.metrics.service.port }}/dashboard"
+          echo "GET ${METRICS_URL} (expect 200 or 302)"
+          metrics_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 --retry 5 --retry-delay 3 --retry-connrefused "${METRICS_URL}")"
+          echo "metrics /dashboard -> ${metrics_code}"
+          if [ "${metrics_code}" != "200" ] && [ "${metrics_code}" != "302" ]; then
+            echo "FAIL: metrics /dashboard returned ${metrics_code}, expected 200 or 302" >&2
+            exit 1
+          fi
+          {{- end }}
+          echo "OK: connection checks passed"
+{{- end }}

--- a/charts/shipwright/tests/ingress_test.yaml
+++ b/charts/shipwright/tests/ingress_test.yaml
@@ -1,0 +1,167 @@
+suite: Ingress networking + helm test connection hook
+# HD-3.3 adds templates/ingress.yaml (rendered only when networking.type=ingress)
+# and templates/tests/test-connection.yaml (a helm.sh/hook: test Pod). These
+# assert the conditional rendering, the className/host/backends/paths, and the
+# hook annotation.
+tests:
+  - it: renders a networking.k8s.io/v1 Ingress when networking.type=ingress
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+    release:
+      name: r
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: r-shipwright
+
+  - it: uses the configured ingressClassName and host
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.className: alb
+      networking.ingress.host: shipwright.example.com
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: alb
+      - equal:
+          path: spec.rules[0].host
+          value: shipwright.example.com
+
+  - it: applies configured ingress annotations
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.annotations:
+        alb.ingress.kubernetes.io/scheme: internet-facing
+    asserts:
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/scheme"]
+          value: internet-facing
+
+  - it: routes / to the admin Service (port http) and /dashboard to the metrics Service (port http)
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+    release:
+      name: r
+    asserts:
+      # /dashboard -> metrics (declared first so the more-specific prefix wins)
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /dashboard
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: r-shipwright-metrics
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http
+      # / -> admin
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: r-shipwright-admin
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.port.name
+          value: http
+
+  - it: omits the /dashboard path when metrics is disabled
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      metrics.enabled: false
+    release:
+      name: r
+    asserts:
+      # Only the admin "/" path remains.
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: r-shipwright-admin
+
+  - it: renders NO Ingress with the default networking.type (ClusterIP)
+    template: templates/ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders NO Ingress for NodePort / LoadBalancer
+    template: templates/ingress.yaml
+    set:
+      networking.type: LoadBalancer
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the helm test connection Pod with the test hook annotation
+    template: templates/tests/test-connection.yaml
+    release:
+      name: r
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: r-shipwright-test-connection
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: spec.restartPolicy
+          value: Never
+      - matchRegex:
+          path: spec.containers[0].image
+          pattern: "^curlimages/curl:"
+
+  - it: curls admin /health and metrics /dashboard in the hook command
+    template: templates/tests/test-connection.yaml
+    release:
+      name: r
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "http://r-shipwright-admin:3001/health"
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "http://r-shipwright-metrics:3460/dashboard"
+
+  - it: omits the metrics /dashboard check in the hook when metrics is disabled
+    template: templates/tests/test-connection.yaml
+    set:
+      metrics.enabled: false
+    release:
+      name: r
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "http://r-shipwright-admin:3001/health"
+      - notMatchRegex:
+          path: spec.containers[0].command[2]
+          pattern: /dashboard
+
+  - it: renders no test-connection Pod when admin is disabled
+    template: templates/tests/test-connection.yaml
+    set:
+      admin.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 0\.5\.0, app version 0\.1\.0
+          pattern: chart version 0\.6\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -28,7 +28,16 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ingress"]
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "className": { "type": "string" },
+            "host": { "type": "string" },
+            "annotations": { "type": "object" }
+          }
         }
       },
       "required": ["type"]

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -26,9 +26,23 @@ fullnameOverride: ""
 
 # -- Networking exposure strategy for shipwright services.
 networking:
-  # -- How services are exposed: "ClusterIP" | "NodePort" | "LoadBalancer".
+  # -- How services are exposed: "ClusterIP" | "NodePort" | "LoadBalancer" | "ingress".
   # Minikube-friendly default is ClusterIP (reach via `minikube service` / port-forward).
+  # Set to "ingress" to render an Ingress (templates/ingress.yaml) routing the admin
+  # UI/API at "/" and the metrics dashboard at "/dashboard"; the Services keep their
+  # own ClusterIP type (admin.service.type / metrics.service.type).
   type: ClusterIP
+  # -- Ingress settings (used ONLY when networking.type=ingress).
+  ingress:
+    # -- IngressClass to use: "nginx" for the Minikube/NGINX ingress addon,
+    # "alb" for the AWS Load Balancer Controller on EKS, etc.
+    className: nginx
+    # -- Host the Ingress answers for. Minikube-friendly default; for the NGINX
+    # addon add it to /etc/hosts pointing at `minikube ip`.
+    host: shipwright.local
+    # -- Extra annotations for the Ingress (controller-specific). For ALB, e.g.
+    # alb.ingress.kubernetes.io/scheme, /target-type; for NGINX, rewrite/ssl rules.
+    annotations: {}
 
 # -- ServiceAccount for shipwright workloads.
 serviceAccount:


### PR DESCRIPTION
## Summary
- Add `templates/ingress.yaml` — a `networking.k8s.io/v1` Ingress rendered ONLY when `networking.type == "ingress"` (new option alongside ClusterIP/NodePort/LoadBalancer; default stays ClusterIP so Ingress is off by default). Configurable `ingressClassName` (nginx/alb), `host`, and `annotations`. Routes `/` → admin Service and `/dashboard` → metrics Service (the /dashboard path is omitted when `metrics.enabled=false`); `pathType: Prefix`, named `http` ports.
- Add `templates/tests/test-connection.yaml` — a `helm.sh/hook: test` Pod (pinned `curlimages/curl:8.11.1`) that curls admin `/health` (must 200) and, when metrics enabled, metrics `/dashboard` (200/302); `set -eu` + explicit non-zero exit so `helm test` fails loudly.
- `values.yaml`/`values.schema.json`: `networking.ingress.{className,host,annotations}` + `"ingress"` in the type enum.
- Chart bumped **0.5.0 → 0.6.0** (CHANGELOG + artifacthub annotation).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | networking.type=ingress renders Ingress w/ className/host + correct admin + /dashboard backends/paths; no Ingress for other types | MET |
| 2 | helm test runs the connection Pod, succeeds against a live install (ct install e2e) | MET |
| 3 | helm-unit golden specs (className/host/paths, conditional rendering) + kubeconform; test-connection is the helm-e2e smoke; none retired | MET |

## Test Plan
- `helm lint` 0 failed; `helm unittest` → 11 suites / 86 tests (11 new ingress specs); `kubeconform` 18/18 valid (Ingress validates as networking.k8s.io/v1)
- Render checks: `--set networking.type=ingress` → Ingress (className=nginx, host=shipwright.local, /→admin, /dashboard→metrics); default ClusterIP → no Ingress; `metrics.enabled=false` → no /dashboard path
- **Live kind e2e `helm test` PASS**: connection Pod logs `admin /health -> 200`, `metrics /dashboard -> 302`, `OK: connection checks passed`; `kubectl get ingress` shows the nginx/shipwright.local rule
- `ct lint --check-version-increment` PASS (0.6.0); check-strings + gitleaks clean; ci.yml/helm.yml/release.yml untouched
- [x] Pre-ship checks passing

Generated with [Claude Code](https://claude.com/claude-code)
