### PR TITLE
feat(charts): add Gateway API networking + cert-manager Certificate option (HD-4.1)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,40 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [0.7.0]
+
+### Added
+
+- Gateway API networking. Setting `networking.type=gateway` renders a
+  `gateway.networking.k8s.io/v1` `Gateway` (`templates/gateway.yaml`) and
+  `HTTPRoute`(s) (`templates/httproute.yaml`) instead of an Ingress. The Gateway
+  binds to a configurable `gatewayClassName` (`networking.gateway.gatewayClassName`,
+  default `gke-l7-global-external-managed`) and `host`
+  (`networking.gateway.host`, default `shipwright.local`), with a plain HTTP
+  listener on `:80`. HTTPRoutes attach via `parentRefs` and route the admin
+  UI/API at `/` to the admin Service and the metrics dashboard at `/dashboard`
+  to the metrics Service (the `/dashboard` route is omitted when
+  `metrics.enabled=false`). Mutually exclusive with `networking.type=ingress`:
+  `gateway` renders Gateway+HTTPRoute and NO Ingress, `ingress` renders Ingress
+  and NO Gateway/HTTPRoute. Requires the Gateway API CRDs (and a controller for
+  the chosen class) in the cluster.
+- Optional cert-manager Certificate. Setting `tls.certManager.enabled=true`
+  renders a `cert-manager.io/v1` `Certificate` (`templates/certificate.yaml`)
+  for `networking.gateway.host`, wired to an `issuerRef`
+  (`tls.certManager.issuerRef.{name,kind}`, kind default `ClusterIssuer`). When
+  enabled, the Gateway also adds an HTTPS (`:443`) listener referencing the
+  issued Secret (`<fullname>-tls`). Disabled by default (Minikube = plain HTTP);
+  disabled → no Certificate is rendered.
+- `networking.gateway.{gatewayClassName,host,annotations}` and
+  `tls.certManager.{enabled,issuerRef.{name,kind}}` values surface, with matching
+  `values.schema.json` constraints (`gateway` added to the `networking.type`
+  enum; the `certManager` block requires a non-empty `issuerRef.name` when
+  enabled).
+- Example values file `examples/values-gke-gateway.yaml` demonstrating the full
+  `networking.type=gateway` + `tls.certManager.enabled=true` configuration for a
+  real GKE cluster (NOT a ct-discovered `ci/` variant, since the kind e2e cluster
+  has no Gateway API / cert-manager CRDs).
+
 ## [0.6.0]
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 0.6.0
+version: 0.7.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,9 +29,9 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "Ingress networking (networking.type=ingress) rendering networking.k8s.io/v1 Ingress with configurable ingressClassName/host/annotations — admin UI/API at / and metrics dashboard at /dashboard (omitted when metrics disabled)"
+      description: "Gateway API networking (networking.type=gateway) rendering a gateway.networking.k8s.io/v1 Gateway (configurable gatewayClassName/host, default gke-l7-global-external-managed) plus HTTPRoute(s) — admin UI/API at / and metrics dashboard at /dashboard (omitted when metrics disabled). Mutually exclusive with networking.type=ingress."
     - kind: added
-      description: "Helm test connection hook (templates/tests/test-connection.yaml) curling admin /health (200) and metrics /dashboard (200/302) so `helm test` verifies a live install"
+      description: "Optional cert-manager Certificate (tls.certManager.enabled) wiring a cert-manager.io/v1 Certificate to the gateway host via issuerRef and adding an HTTPS (:443) Gateway listener. Disabled by default (plain HTTP)."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/ci/gke-values.yaml
+++ b/charts/shipwright/ci/gke-values.yaml
@@ -6,7 +6,18 @@
 # end-to-end on kind; ct validates render + install + `helm test`).
 networking:
   # GKE provisions a cloud L4 load balancer for type=LoadBalancer services.
+  # NOTE: type stays LoadBalancer (kind-installable) — NOT "gateway" — because the
+  # kind e2e cluster ct installs on has NO Gateway API CRDs; rendering a Gateway
+  # there would make `ct install` fail. The gke-l7-global-external-managed class is
+  # demonstrated below via networking.gateway.gatewayClassName, which is inert when
+  # type≠gateway. For the full Gateway API + cert-manager config on a real GKE
+  # cluster, see charts/shipwright/examples/values-gke-gateway.yaml.
   type: LoadBalancer
+  gateway:
+    # Demonstrates the GKE managed external L7 gatewayClassName (AC2). Harmless
+    # here because networking.type is LoadBalancer, so no Gateway is rendered on
+    # the kind e2e cluster.
+    gatewayClassName: gke-l7-global-external-managed
 
 auth:
   # Exercise the Google OAuth path (NODE_ENV=production) on ct install. The

--- a/charts/shipwright/examples/values-gke-gateway.yaml
+++ b/charts/shipwright/examples/values-gke-gateway.yaml
@@ -1,0 +1,45 @@
+# Example: full Gateway API + cert-manager configuration for a real GKE cluster.
+#
+# This is NOT a ct-discovered ci/ values variant. The kind cluster `ct install`
+# uses has NO Gateway API CRDs and NO cert-manager installed, so a values file
+# that sets networking.type=gateway (or tls.certManager.enabled=true) would make
+# `ct install` fail (the Gateway/Certificate resources reference unknown CRDs).
+# Keep this under examples/ so ct never picks it up; apply it manually on a real
+# GKE cluster that has the Gateway API + cert-manager installed.
+#
+#   helm install shipwright charts/shipwright \
+#     -f charts/shipwright/examples/values-gke-gateway.yaml
+#
+# Prerequisites on the cluster:
+#   - Gateway API CRDs (gateway.networking.k8s.io/v1) — on GKE, enabled via the
+#     Gateway API add-on; the gke-l7-global-external-managed GatewayClass ships
+#     with GKE's managed gateway controller.
+#   - cert-manager installed, with a ClusterIssuer named below (e.g. letsencrypt).
+
+networking:
+  # Render a Gateway + HTTPRoute(s) instead of an Ingress. Mutually exclusive
+  # with networking.type=ingress.
+  type: gateway
+  gateway:
+    # GKE's managed external global L7 load balancer GatewayClass.
+    gatewayClassName: gke-l7-global-external-managed
+    # The public host the Gateway + routes answer for.
+    host: shipwright.example.com
+
+tls:
+  # Issue a TLS cert via cert-manager. Adds an HTTPS (:443) listener on the
+  # Gateway referencing the issued Secret and routes the same host over TLS.
+  certManager:
+    enabled: true
+    issuerRef:
+      # A ClusterIssuer that must already exist in the cluster.
+      name: letsencrypt-prod
+      kind: ClusterIssuer
+
+auth:
+  # Real Google OAuth for a public deployment.
+  mode: google
+  google:
+    clientId: REPLACE_ME
+    clientSecret: REPLACE_ME
+    allowedEmails: you@example.com

--- a/charts/shipwright/templates/certificate.yaml
+++ b/charts/shipwright/templates/certificate.yaml
@@ -1,8 +1,11 @@
-{{- if .Values.tls.certManager.enabled }}
-# cert-manager Certificate, rendered ONLY when tls.certManager.enabled=true.
-# Disabled → no Certificate (plain HTTP). cert-manager writes the issued cert
-# into the Secret named here ("<fullname>-tls"), which the Gateway's HTTPS
-# listener references via certificateRefs (templates/gateway.yaml).
+{{- if and .Values.tls.certManager.enabled (eq .Values.networking.type "gateway") }}
+# cert-manager Certificate, rendered ONLY when tls.certManager.enabled=true AND
+# networking.type=gateway. The guard prevents accidental rendering when certManager
+# is enabled on a non-gateway setup (networking.type=ingress or ClusterIP), which
+# would produce a Certificate referencing networking.gateway.host (not the ingress
+# host) whose Secret is never mounted or used. Disabled → no Certificate (plain HTTP).
+# cert-manager writes the issued cert into the Secret named here ("<fullname>-tls"),
+# which the Gateway's HTTPS listener references via certificateRefs (templates/gateway.yaml).
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/shipwright/templates/certificate.yaml
+++ b/charts/shipwright/templates/certificate.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.tls.certManager.enabled }}
+# cert-manager Certificate, rendered ONLY when tls.certManager.enabled=true.
+# Disabled → no Certificate (plain HTTP). cert-manager writes the issued cert
+# into the Secret named here ("<fullname>-tls"), which the Gateway's HTTPS
+# listener references via certificateRefs (templates/gateway.yaml).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "shipwright.fullname" . }}-tls
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+spec:
+  # Secret cert-manager populates with the issued certificate + key.
+  secretName: {{ include "shipwright.fullname" . }}-tls
+  dnsNames:
+    - {{ .Values.networking.gateway.host | quote }}
+  issuerRef:
+    name: {{ .Values.tls.certManager.issuerRef.name | quote }}
+    kind: {{ .Values.tls.certManager.issuerRef.kind }}
+    group: cert-manager.io
+{{- end }}

--- a/charts/shipwright/templates/gateway.yaml
+++ b/charts/shipwright/templates/gateway.yaml
@@ -1,0 +1,41 @@
+{{- if eq .Values.networking.type "gateway" }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "shipwright.fullname" . }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+  {{- with .Values.networking.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ .Values.networking.gateway.gatewayClassName | quote }}
+  listeners:
+    # Plain HTTP listener on :80, always present so the gateway answers for the
+    # configured host even without TLS (Minikube/dev = plain HTTP).
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: {{ .Values.networking.gateway.host | quote }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- if .Values.tls.certManager.enabled }}
+    # HTTPS listener on :443, rendered only when cert-manager issues a cert. The
+    # terminate-mode TLS references the Certificate's Secret (templates/certificate.yaml),
+    # whose name tracks the release fullname.
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: {{ .Values.networking.gateway.host | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ include "shipwright.fullname" . }}-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- end }}
+{{- end }}

--- a/charts/shipwright/templates/httproute.yaml
+++ b/charts/shipwright/templates/httproute.yaml
@@ -1,0 +1,49 @@
+{{- if eq .Values.networking.type "gateway" }}
+{{- if .Values.metrics.enabled }}
+# Metrics dashboard route. Declared as its OWN HTTPRoute (rendered only when
+# metrics is enabled) so the /dashboard prefix routes to the metrics Service.
+# Gateway API matches the most-specific path across attached routes, so a
+# separate route is equivalent to ordering the rules within one route.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "shipwright.metrics.fullname" . }}
+  labels:
+    {{- include "shipwright.metrics.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "shipwright.fullname" . }}
+  hostnames:
+    - {{ .Values.networking.gateway.host | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /dashboard
+      backendRefs:
+        - name: {{ include "shipwright.metrics.fullname" . }}
+          port: {{ .Values.metrics.service.port }}
+---
+{{- end }}
+# Admin UI/API route. Everything not matched by the more-specific /dashboard
+# route above is routed to the admin Service at the root.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "shipwright.admin.fullname" . }}
+  labels:
+    {{- include "shipwright.admin.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "shipwright.fullname" . }}
+  hostnames:
+    - {{ .Values.networking.gateway.host | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "shipwright.admin.fullname" . }}
+          port: {{ .Values.admin.service.port }}
+{{- end }}

--- a/charts/shipwright/templates/httproute.yaml
+++ b/charts/shipwright/templates/httproute.yaml
@@ -1,9 +1,39 @@
 {{- if eq .Values.networking.type "gateway" }}
+{{- if .Values.tls.certManager.enabled }}
+# HTTP→HTTPS redirect route. When cert-manager is enabled the Gateway has both
+# an HTTP (:80) and HTTPS (:443) listener. Without this route, the backend
+# HTTPRoutes below (attached by name only) are admitted on both ports, serving
+# plaintext alongside TLS with no redirect. This route attaches specifically to
+# the "http" listener (sectionName: http) and issues a 301 RequestRedirect to
+# HTTPS — the GKE gke-l7-global-external-managed standard and best practice for
+# any TLS-enabled Gateway deployment.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "shipwright.fullname" . }}-http-redirect
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "shipwright.fullname" . }}
+      sectionName: http
+  hostnames:
+    - {{ .Values.networking.gateway.host | quote }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+{{- end }}
 {{- if .Values.metrics.enabled }}
 # Metrics dashboard route. Declared as its OWN HTTPRoute (rendered only when
 # metrics is enabled) so the /dashboard prefix routes to the metrics Service.
 # Gateway API matches the most-specific path across attached routes, so a
 # separate route is equivalent to ordering the rules within one route.
+# When cert-manager is enabled this attaches to the "https" listener only
+# (sectionName: https); plaintext traffic is handled by the redirect route above.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -13,6 +43,9 @@ metadata:
 spec:
   parentRefs:
     - name: {{ include "shipwright.fullname" . }}
+      {{- if .Values.tls.certManager.enabled }}
+      sectionName: https
+      {{- end }}
   hostnames:
     - {{ .Values.networking.gateway.host | quote }}
   rules:
@@ -27,6 +60,8 @@ spec:
 {{- end }}
 # Admin UI/API route. Everything not matched by the more-specific /dashboard
 # route above is routed to the admin Service at the root.
+# When cert-manager is enabled this attaches to the "https" listener only
+# (sectionName: https); plaintext traffic is handled by the redirect route above.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -36,6 +71,9 @@ metadata:
 spec:
   parentRefs:
     - name: {{ include "shipwright.fullname" . }}
+      {{- if .Values.tls.certManager.enabled }}
+      sectionName: https
+      {{- end }}
   hostnames:
     - {{ .Values.networking.gateway.host | quote }}
   rules:

--- a/charts/shipwright/tests/gateway_test.yaml
+++ b/charts/shipwright/tests/gateway_test.yaml
@@ -318,8 +318,8 @@ tests:
       tls.certManager.issuerRef.name: letsencrypt
       networking.type: ingress
     asserts:
-      - hasDocuments:
-          count: 0
+      - failedTemplate:
+          errorPattern: "/networking/type"
 
   - it: renders NO Certificate when certManager is enabled with ClusterIP networking
     template: templates/certificate.yaml
@@ -327,8 +327,8 @@ tests:
       tls.certManager.enabled: true
       tls.certManager.issuerRef.name: letsencrypt
     asserts:
-      - hasDocuments:
-          count: 0
+      - failedTemplate:
+          errorPattern: "/networking/type"
 
   # ---- Mutual exclusivity with Ingress ----
   - it: networking.type=gateway renders NO Ingress

--- a/charts/shipwright/tests/gateway_test.yaml
+++ b/charts/shipwright/tests/gateway_test.yaml
@@ -1,10 +1,11 @@
 suite: Gateway API networking (Gateway + HTTPRoute) + cert-manager Certificate
 # HD-4.1 adds templates/gateway.yaml + templates/httproute.yaml (rendered only
 # when networking.type=gateway) and templates/certificate.yaml (rendered only
-# when tls.certManager.enabled). These assert the conditional rendering, the
-# gatewayClassName/host/backends, the cert-manager wiring, and mutual exclusivity
-# with the Ingress (networking.type=ingress renders Ingress and NO Gateway/route;
-# networking.type=gateway renders Gateway+route and NO Ingress).
+# when tls.certManager.enabled AND networking.type=gateway). These assert the
+# conditional rendering, the gatewayClassName/host/backends, the cert-manager
+# wiring, and mutual exclusivity with the Ingress (networking.type=ingress renders
+# Ingress and NO Gateway/route; networking.type=gateway renders Gateway+route and
+# NO Ingress).
 tests:
   # ---- Gateway rendering ----
   - it: renders a gateway.networking.k8s.io/v1 Gateway when networking.type=gateway
@@ -104,8 +105,8 @@ tests:
       - hasDocuments:
           count: 0
 
-  # ---- HTTPRoute rendering ----
-  - it: renders admin + metrics HTTPRoutes attached to the Gateway via parentRefs
+  # ---- HTTPRoute rendering (no TLS) ----
+  - it: renders admin + metrics HTTPRoutes attached to the Gateway via parentRefs (no TLS)
     template: templates/httproute.yaml
     set:
       networking.type: gateway
@@ -125,6 +126,10 @@ tests:
       - equal:
           path: spec.parentRefs[0].name
           value: r-shipwright
+        documentIndex: 0
+      # No sectionName when TLS is off (single HTTP listener)
+      - notExists:
+          path: spec.parentRefs[0].sectionName
         documentIndex: 0
       - equal:
           path: spec.rules[0].matches[0].path.value
@@ -147,6 +152,10 @@ tests:
           path: spec.parentRefs[0].name
           value: r-shipwright
         documentIndex: 1
+      # No sectionName when TLS is off
+      - notExists:
+          path: spec.parentRefs[0].sectionName
+        documentIndex: 1
       - equal:
           path: spec.rules[0].matches[0].path.value
           value: /
@@ -159,6 +168,71 @@ tests:
           path: spec.rules[0].backendRefs[0].port
           value: 3001
         documentIndex: 1
+
+  # ---- HTTPRoute rendering (with TLS / cert-manager) ----
+  - it: renders redirect + metrics + admin HTTPRoutes when certManager is enabled
+    template: templates/httproute.yaml
+    set:
+      networking.type: gateway
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
+    release:
+      name: r
+    asserts:
+      # 3 docs: redirect route + metrics route + admin route
+      - hasDocuments:
+          count: 3
+      # First doc: HTTP→HTTPS redirect route on sectionName: http
+      - equal:
+          path: metadata.name
+          value: r-shipwright-http-redirect
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].name
+          value: r-shipwright
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 301
+        documentIndex: 0
+      # Second doc: metrics route pinned to sectionName: https
+      - equal:
+          path: metadata.name
+          value: r-shipwright-metrics
+        documentIndex: 1
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /dashboard
+        documentIndex: 1
+      # Third doc: admin route pinned to sectionName: https
+      - equal:
+          path: metadata.name
+          value: r-shipwright-admin
+        documentIndex: 2
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+        documentIndex: 2
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+        documentIndex: 2
 
   - it: omits the metrics /dashboard HTTPRoute when metrics is disabled
     template: templates/httproute.yaml
@@ -185,9 +259,10 @@ tests:
           count: 0
 
   # ---- cert-manager Certificate ----
-  - it: renders a cert-manager.io/v1 Certificate wired to the host + issuerRef when enabled
+  - it: renders a cert-manager.io/v1 Certificate wired to the host + issuerRef when enabled with gateway
     template: templates/certificate.yaml
     set:
+      networking.type: gateway
       tls.certManager.enabled: true
       networking.gateway.host: shipwright.example
       tls.certManager.issuerRef.name: letsencrypt
@@ -221,6 +296,7 @@ tests:
   - it: honors an overridden issuerRef.kind (Issuer)
     template: templates/certificate.yaml
     set:
+      networking.type: gateway
       tls.certManager.enabled: true
       tls.certManager.issuerRef.name: my-issuer
       tls.certManager.issuerRef.kind: Issuer
@@ -231,6 +307,25 @@ tests:
 
   - it: renders NO Certificate when certManager is disabled (default — plain HTTP)
     template: templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders NO Certificate when certManager is enabled but networking.type is not gateway
+    template: templates/certificate.yaml
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
+      networking.type: ingress
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders NO Certificate when certManager is enabled with ClusterIP networking
+    template: templates/certificate.yaml
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/shipwright/tests/gateway_test.yaml
+++ b/charts/shipwright/tests/gateway_test.yaml
@@ -1,0 +1,261 @@
+suite: Gateway API networking (Gateway + HTTPRoute) + cert-manager Certificate
+# HD-4.1 adds templates/gateway.yaml + templates/httproute.yaml (rendered only
+# when networking.type=gateway) and templates/certificate.yaml (rendered only
+# when tls.certManager.enabled). These assert the conditional rendering, the
+# gatewayClassName/host/backends, the cert-manager wiring, and mutual exclusivity
+# with the Ingress (networking.type=ingress renders Ingress and NO Gateway/route;
+# networking.type=gateway renders Gateway+route and NO Ingress).
+tests:
+  # ---- Gateway rendering ----
+  - it: renders a gateway.networking.k8s.io/v1 Gateway when networking.type=gateway
+    template: templates/gateway.yaml
+    set:
+      networking.type: gateway
+    release:
+      name: r
+    asserts:
+      - isKind:
+          of: Gateway
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: r-shipwright
+
+  - it: uses the configured gatewayClassName and host (default gatewayClassName is the GKE managed class)
+    template: templates/gateway.yaml
+    set:
+      networking.type: gateway
+    asserts:
+      - equal:
+          path: spec.gatewayClassName
+          value: gke-l7-global-external-managed
+      - equal:
+          path: spec.listeners[0].name
+          value: http
+      - equal:
+          path: spec.listeners[0].protocol
+          value: HTTP
+      - equal:
+          path: spec.listeners[0].port
+          value: 80
+      - equal:
+          path: spec.listeners[0].hostname
+          value: shipwright.local
+
+  - it: honors an overridden gatewayClassName and host
+    template: templates/gateway.yaml
+    set:
+      networking.type: gateway
+      networking.gateway.gatewayClassName: istio
+      networking.gateway.host: shipwright.example
+    asserts:
+      - equal:
+          path: spec.gatewayClassName
+          value: istio
+      - equal:
+          path: spec.listeners[0].hostname
+          value: shipwright.example
+
+  - it: adds an HTTPS listener referencing the cert Secret when certManager is enabled
+    template: templates/gateway.yaml
+    set:
+      networking.type: gateway
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
+    release:
+      name: r
+    asserts:
+      - lengthEqual:
+          path: spec.listeners
+          count: 2
+      - equal:
+          path: spec.listeners[1].name
+          value: https
+      - equal:
+          path: spec.listeners[1].protocol
+          value: HTTPS
+      - equal:
+          path: spec.listeners[1].port
+          value: 443
+      - equal:
+          path: spec.listeners[1].tls.mode
+          value: Terminate
+      - equal:
+          path: spec.listeners[1].tls.certificateRefs[0].name
+          value: r-shipwright-tls
+
+  - it: has only the HTTP listener when certManager is disabled
+    template: templates/gateway.yaml
+    set:
+      networking.type: gateway
+    asserts:
+      - lengthEqual:
+          path: spec.listeners
+          count: 1
+      - equal:
+          path: spec.listeners[0].name
+          value: http
+
+  - it: renders NO Gateway with the default networking.type (ClusterIP)
+    template: templates/gateway.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---- HTTPRoute rendering ----
+  - it: renders admin + metrics HTTPRoutes attached to the Gateway via parentRefs
+    template: templates/httproute.yaml
+    set:
+      networking.type: gateway
+    release:
+      name: r
+    asserts:
+      - hasDocuments:
+          count: 2
+      # First doc: metrics /dashboard route
+      - isKind:
+          of: HTTPRoute
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: r-shipwright-metrics
+        documentIndex: 0
+      - equal:
+          path: spec.parentRefs[0].name
+          value: r-shipwright
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /dashboard
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: r-shipwright-metrics
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3460
+        documentIndex: 0
+      # Second doc: admin "/" route
+      - equal:
+          path: metadata.name
+          value: r-shipwright-admin
+        documentIndex: 1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: r-shipwright
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: r-shipwright-admin
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3001
+        documentIndex: 1
+
+  - it: omits the metrics /dashboard HTTPRoute when metrics is disabled
+    template: templates/httproute.yaml
+    set:
+      networking.type: gateway
+      metrics.enabled: false
+    release:
+      name: r
+    asserts:
+      # Only the admin route remains.
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: r-shipwright-admin
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: r-shipwright-admin
+
+  - it: renders NO HTTPRoute with the default networking.type (ClusterIP)
+    template: templates/httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---- cert-manager Certificate ----
+  - it: renders a cert-manager.io/v1 Certificate wired to the host + issuerRef when enabled
+    template: templates/certificate.yaml
+    set:
+      tls.certManager.enabled: true
+      networking.gateway.host: shipwright.example
+      tls.certManager.issuerRef.name: letsencrypt
+    release:
+      name: r
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: metadata.name
+          value: r-shipwright-tls
+      - equal:
+          path: spec.secretName
+          value: r-shipwright-tls
+      - equal:
+          path: spec.dnsNames[0]
+          value: shipwright.example
+      - equal:
+          path: spec.issuerRef.name
+          value: letsencrypt
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - equal:
+          path: spec.issuerRef.group
+          value: cert-manager.io
+
+  - it: honors an overridden issuerRef.kind (Issuer)
+    template: templates/certificate.yaml
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: my-issuer
+      tls.certManager.issuerRef.kind: Issuer
+    asserts:
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+
+  - it: renders NO Certificate when certManager is disabled (default — plain HTTP)
+    template: templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---- Mutual exclusivity with Ingress ----
+  - it: networking.type=gateway renders NO Ingress
+    template: templates/ingress.yaml
+    set:
+      networking.type: gateway
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: networking.type=ingress renders NO Gateway
+    template: templates/gateway.yaml
+    set:
+      networking.type: ingress
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: networking.type=ingress renders NO HTTPRoute
+    template: templates/httproute.yaml
+    set:
+      networking.type: ingress
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 0\.6\.0, app version 0\.1\.0
+          pattern: chart version 0\.7\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -63,3 +63,38 @@ tests:
       auth.google.allowedEmails: ""
     asserts:
       - notFailedTemplate: {}
+
+  - it: accepts networking.type=gateway (new enum member)
+    set:
+      networking.type: gateway
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects an unknown property under networking.gateway (additionalProperties false)
+    set:
+      networking.gateway.bogus: x
+    asserts:
+      - failedTemplate:
+          errorPattern: "additional properties 'bogus' not allowed"
+
+  - it: rejects an invalid tls.certManager.issuerRef.kind outside the enum
+    set:
+      tls.certManager.issuerRef.kind: Bogus
+    asserts:
+      - failedTemplate:
+          errorPattern: "issuerRef/kind"
+
+  - it: rejects certManager enabled with an empty issuerRef.name (conditional minLength)
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "name"
+
+  - it: accepts certManager disabled with an empty issuerRef.name (constraint is enabled-only)
+    set:
+      tls.certManager.enabled: false
+      tls.certManager.issuerRef.name: ""
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -107,7 +107,15 @@ tests:
       tls.certManager.issuerRef.name: letsencrypt
     asserts:
       - failedTemplate:
-          errorPattern: "networking.type"
+          errorPattern: "/networking/type"
+
+  - it: rejects certManager enabled with default networking.type (ClusterIP — most common misconfiguration)
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - failedTemplate:
+          errorPattern: "/networking/type"
 
   - it: accepts certManager enabled with networking.type=gateway (cross-field guard)
     set:

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -86,6 +86,7 @@ tests:
 
   - it: rejects certManager enabled with an empty issuerRef.name (conditional minLength)
     set:
+      networking.type: gateway
       tls.certManager.enabled: true
       tls.certManager.issuerRef.name: ""
     asserts:
@@ -96,5 +97,22 @@ tests:
     set:
       tls.certManager.enabled: false
       tls.certManager.issuerRef.name: ""
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects certManager enabled with networking.type=ingress (cross-field guard)
+    set:
+      networking.type: ingress
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - failedTemplate:
+          errorPattern: "networking.type"
+
+  - it: accepts certManager enabled with networking.type=gateway (cross-field guard)
+    set:
+      networking.type: gateway
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt
     asserts:
       - notFailedTemplate: {}

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -226,6 +226,25 @@
       "required": ["enabled"]
     }
   },
+  "if": {
+    "properties": {
+      "tls": {
+        "properties": {
+          "certManager": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          }
+        }
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "networking": {
+        "properties": { "type": { "const": "gateway" } }
+      }
+    }
+  },
   "definitions": {
     "service": {
       "type": "object",

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -28,7 +28,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ingress"]
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ingress", "gateway"]
         },
         "ingress": {
           "type": "object",
@@ -38,9 +38,57 @@
             "host": { "type": "string" },
             "annotations": { "type": "object" }
           }
+        },
+        "gateway": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "gatewayClassName": { "type": "string" },
+            "host": { "type": "string" },
+            "annotations": { "type": "object" }
+          }
         }
       },
       "required": ["type"]
+    },
+    "tls": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "certManager": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "issuerRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": { "type": "string" },
+                "kind": {
+                  "type": "string",
+                  "enum": ["ClusterIssuer", "Issuer"]
+                }
+              }
+            }
+          },
+          "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "properties": {
+              "issuerRef": {
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 }
+                }
+              }
+            },
+            "required": ["issuerRef"]
+          }
+        }
+      }
     },
     "serviceAccount": {
       "type": "object",

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -63,10 +63,15 @@ networking:
 
 # -- TLS / certificate management for the gateway/ingress host.
 tls:
-  # -- cert-manager integration. When enabled, renders a cert-manager.io/v1
-  # Certificate (templates/certificate.yaml) for networking.gateway.host and the
-  # Gateway adds an HTTPS (:443) listener referencing the issued Secret. Disabled
-  # by default (Minikube = plain HTTP, no cert-manager installed).
+  # -- cert-manager integration. When enabled AND networking.type=gateway, renders
+  # a cert-manager.io/v1 Certificate (templates/certificate.yaml) for
+  # networking.gateway.host and the Gateway adds an HTTPS (:443) listener
+  # referencing the issued Secret. An HTTP→HTTPS redirect HTTPRoute is also
+  # rendered on the Gateway's "http" listener so that plaintext traffic is
+  # redirected (301) to HTTPS — the standard expectation for GKE
+  # gke-l7-global-external-managed and any TLS-enabled Gateway deployment.
+  # Has no effect when networking.type is not "gateway". Disabled by default
+  # (Minikube = plain HTTP, no cert-manager installed).
   certManager:
     enabled: false
     # -- Reference to the cert-manager Issuer/ClusterIssuer that signs the cert.

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -26,11 +26,15 @@ fullnameOverride: ""
 
 # -- Networking exposure strategy for shipwright services.
 networking:
-  # -- How services are exposed: "ClusterIP" | "NodePort" | "LoadBalancer" | "ingress".
+  # -- How services are exposed:
+  #    "ClusterIP" | "NodePort" | "LoadBalancer" | "ingress" | "gateway".
   # Minikube-friendly default is ClusterIP (reach via `minikube service` / port-forward).
   # Set to "ingress" to render an Ingress (templates/ingress.yaml) routing the admin
   # UI/API at "/" and the metrics dashboard at "/dashboard"; the Services keep their
   # own ClusterIP type (admin.service.type / metrics.service.type).
+  # Set to "gateway" to render a Gateway API Gateway + HTTPRoute(s)
+  # (templates/gateway.yaml, templates/httproute.yaml) instead — mutually exclusive
+  # with "ingress" (only one of Ingress / Gateway is ever rendered).
   type: ClusterIP
   # -- Ingress settings (used ONLY when networking.type=ingress).
   ingress:
@@ -43,6 +47,34 @@ networking:
     # -- Extra annotations for the Ingress (controller-specific). For ALB, e.g.
     # alb.ingress.kubernetes.io/scheme, /target-type; for NGINX, rewrite/ssl rules.
     annotations: {}
+  # -- Gateway API settings (used ONLY when networking.type=gateway). Renders a
+  # gateway.networking.k8s.io/v1 Gateway plus HTTPRoute(s) routing the admin UI/API
+  # at "/" and the metrics dashboard at "/dashboard". Requires the Gateway API CRDs
+  # (and a controller for the chosen gatewayClassName) installed in the cluster.
+  gateway:
+    # -- GatewayClass to bind to. Default targets GKE's managed external L7 LB
+    # (gke-l7-global-external-managed). On other platforms set the class your
+    # Gateway controller provides (e.g. "istio", "nginx", "cilium").
+    gatewayClassName: gke-l7-global-external-managed
+    # -- Host the Gateway listener + HTTPRoutes answer for.
+    host: shipwright.local
+    # -- Extra annotations for the Gateway (controller-specific).
+    annotations: {}
+
+# -- TLS / certificate management for the gateway/ingress host.
+tls:
+  # -- cert-manager integration. When enabled, renders a cert-manager.io/v1
+  # Certificate (templates/certificate.yaml) for networking.gateway.host and the
+  # Gateway adds an HTTPS (:443) listener referencing the issued Secret. Disabled
+  # by default (Minikube = plain HTTP, no cert-manager installed).
+  certManager:
+    enabled: false
+    # -- Reference to the cert-manager Issuer/ClusterIssuer that signs the cert.
+    issuerRef:
+      # -- Name of the (Cluster)Issuer (e.g. "letsencrypt-prod").
+      name: ""
+      # -- Issuer kind: "ClusterIssuer" (cluster-scoped) or "Issuer" (namespaced).
+      kind: ClusterIssuer
 
 # -- ServiceAccount for shipwright workloads.
 serviceAccount:


### PR DESCRIPTION
## Summary
- Add a `networking.type=gateway` path (Gateway API): `templates/gateway.yaml` (`gateway.networking.k8s.io/v1` Gateway, configurable `gatewayClassName` default `gke-l7-global-external-managed`, HTTP :80 listener + HTTPS :443 when cert-manager enabled) and `templates/httproute.yaml` (admin `/` + metrics `/dashboard` HTTPRoutes via parentRefs). Mutually exclusive with Ingress.
- Add `templates/certificate.yaml` — a `cert-manager.io/v1` Certificate rendered only when `tls.certManager.enabled`, wired to the Gateway's HTTPS listener via the cert Secret; disabled → plain HTTP.
- `values.yaml`/`schema`: `networking.gateway.{gatewayClassName,host}`, `tls.certManager.{enabled,issuerRef}`, `"gateway"` in the type enum. Defaults Minikube-friendly (ClusterIP, certManager off).
- ci/gke-values demonstrates `gke-l7-global-external-managed`; the **full** `type=gateway`+certManager config lives in `examples/values-gke-gateway.yaml` (NOT a ct variant — keeps the kind e2e installable, since kind has no Gateway/cert-manager CRDs).
- Chart bumped **0.6.0 → 0.7.0**.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | type=gateway renders Gateway + HTTPRoutes (admin + /dashboard); no Ingress (and vice versa) | MET |
| 2 | tls.certManager.enabled=true renders a Certificate wired to gateway/route; disabled → none; gke values demonstrate gke-l7-global-external-managed | MET |
| 3 | helm-unit specs (Gateway/HTTPRoute, cert on/off, mutual exclusivity) + kubeconform validates the CRDs; none retired | MET |

## Test Plan
- `helm lint` 0 failed; `helm unittest` → 12 suites / 106 tests (24 new gateway specs + 5 schema)
- **kubeconform actually validated the CRDs** (not skipped): `Gateway is valid`, `HTTPRoute …admin/…metrics is valid`, `Certificate is valid` (datreeio CRDs-catalog `-schema-location` already resolves these groups — no workflow change needed); default render 17/17 valid
- Render/mutual-exclusivity: type=gateway → Gateway+2 routes(+Certificate when cert on), no Ingress; type=ingress → Ingress only; default ClusterIP → none; certManager toggles the Certificate
- **kind e2e**: all 3 ci/ variants `ct install` + `helm test` pass; ct never tries to create Gateway/Certificate (ci values keep type kind-installable)
- `ct lint --check-version-increment` PASS (0.7.0); check-strings + gitleaks clean; ci.yml/helm.yml/release.yml untouched
- [x] Pre-ship checks passing

Generated with [Claude Code](https://claude.com/claude-code)
