### PR TITLE
feat(plan-session): add complexity scoring and model tier assignment

### DIFF
--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -187,7 +187,7 @@ Assign a complexity score (1–5) and model tier to every task:
 **Tie-breaking rules:**
 - New abstraction required (interface, base class, shared module) → bump up one tier
 - Pure modification of existing code (no new patterns) → stay at current tier
-- When uncertain, prefer the lower tier — the executor escalates automatically on BLOCKED
+- When uncertain, prefer the lower tier — the planner can escalate in a follow-up plan revision if execution is blocked
 
 **Bundle inheritance:** When tasks share a branch, all tasks in the bundle inherit the highest model tier among them. A haiku-tier task bundled with a sonnet-tier task runs at sonnet.
 

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -169,6 +169,27 @@ For each task:
 - **Branch**: `feat/{id-lowered-dashes}-{first-3-words-kebab}` — or a shared branch name for bundled tasks (see below)
 - **Layer**: API | Frontend | Database | Shared | Background | CLI
 - **Hours**: rough estimate (1-8h; break tasks larger than 8h)
+- **Complexity**: integer 1–5 — use the scoring table below
+- **Model**: `haiku` | `sonnet` | `opus` — derived from complexity score (see table)
+
+### Complexity and Model Scoring
+
+Assign a complexity score (1–5) and model tier to every task:
+
+| Score | Signal | Model |
+|-------|--------|-------|
+| 1 | Single file, config/copy change, no logic, unit tests only | `haiku` |
+| 2 | 1–2 files, straightforward logic, unit tests only | `haiku` |
+| 3 | 2–5 files, standard feature, integration tests | `sonnet` |
+| 4 | 5+ files, cross-layer, new patterns, integration + smoke tests | `sonnet` |
+| 5 | Architectural, cross-layer, new abstraction, migration, or perf-sensitive | `opus` |
+
+**Tie-breaking rules:**
+- New abstraction required (interface, base class, shared module) → bump up one tier
+- Pure modification of existing code (no new patterns) → stay at current tier
+- When uncertain, prefer the lower tier — the executor escalates automatically on BLOCKED
+
+**Bundle inheritance:** When tasks share a branch, all tasks in the bundle inherit the highest model tier among them. A haiku-tier task bundled with a sonnet-tier task runs at sonnet.
 
 ### Bundles
 
@@ -265,7 +286,9 @@ Write the new tasks to a temp file `/tmp/new-tasks-{session}.json` as a JSON arr
     "status": "pending",
     "pr": null,
     "addedAt": "{ISO timestamp}",
-    "hours": 2
+    "hours": 2,
+    "complexity": {complexity},
+    "model": "{model}"
   }
 ]
 ```
@@ -374,7 +397,9 @@ Write the tasks to `/tmp/new-tasks-{session}.json`. Set `source` to `"gh:{owner}
     "status": "pending",
     "pr": null,
     "addedAt": "{ISO timestamp}",
-    "hours": 2
+    "hours": 2,
+    "complexity": {complexity},
+    "model": "{model}"
   }
 ]
 ```

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -242,6 +242,16 @@ Present the task list and dependency map as a first pass. The engineer reviews a
 
 Once the task breakdown is approved, write each task to the task store via `task_store.ts`.
 
+### Bundle Model Inheritance (Pre-Write)
+
+Before constructing any JSON, apply bundle inheritance to the full task list:
+
+1. Group planned tasks by `branch`.
+2. For each group with more than one task (a bundle), find the highest model tier present: `opus` > `sonnet` > `haiku`.
+3. Set every task in that bundle to the highest tier before writing.
+
+A task on its own branch is unaffected. This ensures a `haiku`-scored task bundled with a `sonnet`-scored task is written as `model: "sonnet"`.
+
 The code path depends on `taskStore` in `SHIPWRIGHT_CONFIG`. Read it the same way Phase-0 does:
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds **Complexity** (1–5) and **Model** (haiku/sonnet/opus) fields to the Step 5 task breakdown field list in `plan-session.md`
- Adds a **heuristics table** mapping complexity score to signal patterns and model tier, plus tie-breaking rules and bundle inheritance rule
- Updates both **Path A and Path B** Step 6 JSON templates to include `"complexity"` and `"model"` fields in generated task JSON

## Complexity Scoring Heuristic

| Score | Signal | Model |
|-------|--------|-------|
| 1 | Single file, config/copy change, no logic | `haiku` |
| 2 | 1–2 files, straightforward logic, unit tests only | `haiku` |
| 3 | 2–5 files, standard feature, integration tests | `sonnet` |
| 4 | 5+ files, cross-layer, new patterns | `sonnet` |
| 5 | Architectural, new abstraction, migration, perf-sensitive | `opus` |

## Test plan

- [ ] 553 existing tests pass — no new tests needed (pure markdown edit)
- [ ] Biome format issues in `create-task-store.unit.test.ts` and `check-deploy.ts` are pre-existing on `main` (not introduced by this PR)
- [ ] `plan-session` invocations now emit `complexity` and `model` in task JSON, enabling downstream routing in `dev-task` (DM-1.3)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)