### PR TITLE
fix(ci): add fetch_all_tags: true to all image build workflows

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -24,6 +24,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: "admin-v"
           default_bump: patch
+          fetch_all_tags: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -24,6 +24,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: "agent-v"
           default_bump: patch
+          fetch_all_tags: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -24,6 +24,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: "metrics-v"
           default_bump: patch
+          fetch_all_tags: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
## Summary

- Adds `fetch_all_tags: true` to the `github-tag-action` step in `build-admin.yml`, `build-agent.yml`, and `build-metrics.yml`

## Problem

Without this flag, `github-tag-action` can't see existing `admin-v*` / `agent-v*` / `metrics-v*` tags. It falls back to base version `0.0.0`, then tries to create `0.0.1` — which already exists from a prior run. Results in `Reference already exists` error on every push to main. The admin and chart-release workflows have been red since the SWD-1.4 merge.

The chart-release failure (missing `gh-pages` branch) was fixed separately by creating the orphan branch directly.

## Test plan

- [ ] Merge and verify `Build and Push Admin Image` run completes successfully on main
- [ ] Verify chart-release run also passes (gh-pages branch now exists)
- [ ] Confirm new `admin-v*` tag is created correctly based on latest existing tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)