### PR TITLE
feat(agent): auto-discover baked marketplaces under convention root

### DIFF
--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -19,6 +19,7 @@ import {
 import { join } from "node:path";
 import type { AgentPlugin } from "@shipwright/admin";
 import {
+  discoverBakedMarketplaces,
   ensureAgentHome,
   ensureDotClaudeSymlink,
   findStalePluginSpecs,
@@ -1018,5 +1019,204 @@ describe("installPlugins", () => {
     // marketplace add + install + update = 3 calls (no uninstall)
     expect(calls).toHaveLength(3);
     expect(calls.every((c) => c.args[1] !== "uninstall")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverBakedMarketplaces
+// ---------------------------------------------------------------------------
+
+describe("discoverBakedMarketplaces", () => {
+  it("returns dirs that have .claude-plugin/marketplace.json", () => {
+    mkdirSync(testHome, { recursive: true });
+    const conventionRoot = join(testHome, "marketplaces");
+
+    // Create a valid marketplace dir
+    const validDir = join(conventionRoot, "my-marketplace");
+    mkdirSync(join(validDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(validDir, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "my-marketplace" }),
+      "utf8",
+    );
+
+    const result = discoverBakedMarketplaces(conventionRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(validDir);
+  });
+
+  it("skips dirs without .claude-plugin/marketplace.json", () => {
+    mkdirSync(testHome, { recursive: true });
+    const conventionRoot = join(testHome, "marketplaces");
+
+    // Valid dir
+    const validDir = join(conventionRoot, "valid-marketplace");
+    mkdirSync(join(validDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(validDir, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "valid-marketplace" }),
+      "utf8",
+    );
+
+    // Dir missing .claude-plugin/marketplace.json
+    const invalidDir = join(conventionRoot, "invalid-marketplace");
+    mkdirSync(join(invalidDir, ".claude-plugin"), { recursive: true });
+    // No marketplace.json — only a different file
+    writeFileSync(join(invalidDir, ".claude-plugin", "plugin.json"), "{}", "utf8");
+
+    // Dir with no .claude-plugin at all
+    const bareDir = join(conventionRoot, "bare-dir");
+    mkdirSync(bareDir, { recursive: true });
+
+    const result = discoverBakedMarketplaces(conventionRoot);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(validDir);
+  });
+
+  it("returns empty array when conventionRoot is absent", () => {
+    const result = discoverBakedMarketplaces(
+      join(testHome, "nonexistent-convention-root"),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when conventionRoot is empty", () => {
+    mkdirSync(testHome, { recursive: true });
+    const conventionRoot = join(testHome, "empty-marketplaces");
+    mkdirSync(conventionRoot, { recursive: true });
+
+    const result = discoverBakedMarketplaces(conventionRoot);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// installPlugins — extra marketplace discovery
+// ---------------------------------------------------------------------------
+
+describe("installPlugins — extra marketplace discovery", () => {
+  it("registers each discovered marketplace dir before plugin installs", async () => {
+    mkdirSync(testHome, { recursive: true });
+    const conventionRoot = join(testHome, "marketplaces");
+
+    // Create a baked marketplace dir
+    const extraMarketDir = join(conventionRoot, "vitals-os");
+    mkdirSync(join(extraMarketDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(extraMarketDir, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "vitals-os" }),
+      "utf8",
+    );
+
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const mockExec = async (
+      cmd: string,
+      args: string[],
+      _opts: { cwd: string },
+    ) => {
+      calls.push({ cmd, args });
+      return { stdout: "", exitCode: 0 };
+    };
+
+    await installPlugins(
+      mockExec,
+      testHome,
+      [],
+      "/repo/root",
+      join(testHome, "nonexistent.json"),
+      undefined, // use default discovery — pass conventionRoot via extraMarketplacesRoot
+      conventionRoot,
+    );
+
+    // Extra marketplace add must come BEFORE the /repo/root marketplace add and BEFORE plugin install
+    const addCalls = calls.filter((c) => c.args[1] === "marketplace");
+    expect(addCalls.length).toBeGreaterThanOrEqual(2);
+    expect(addCalls[0].args[3]).toBe(extraMarketDir);
+    expect(addCalls[1].args[3]).toBe("/repo/root");
+
+    // All install calls must come after all marketplace add calls
+    const installIdx = calls.findIndex((c) => c.args[1] === "install");
+    const lastAddIdx = calls.reduce((max, c, i) =>
+      c.args[1] === "marketplace" ? i : max, -1);
+    expect(installIdx).toBeGreaterThan(lastAddIdx);
+  });
+
+  it("skips dirs that do not have .claude-plugin/marketplace.json", async () => {
+    mkdirSync(testHome, { recursive: true });
+    const conventionRoot = join(testHome, "marketplaces");
+
+    // Valid dir
+    const validDir = join(conventionRoot, "valid");
+    mkdirSync(join(validDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(validDir, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "valid" }),
+      "utf8",
+    );
+
+    // Invalid dir (no marketplace.json)
+    const invalidDir = join(conventionRoot, "invalid");
+    mkdirSync(join(invalidDir, ".claude-plugin"), { recursive: true });
+
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const mockExec = async (
+      cmd: string,
+      args: string[],
+      _opts: { cwd: string },
+    ) => {
+      calls.push({ cmd, args });
+      return { stdout: "", exitCode: 0 };
+    };
+
+    await installPlugins(
+      mockExec,
+      testHome,
+      [],
+      "/repo/root",
+      join(testHome, "nonexistent.json"),
+      undefined,
+      conventionRoot,
+    );
+
+    const addCalls = calls.filter((c) => c.args[1] === "marketplace");
+    // Only valid + /repo/root = 2 adds (invalid dir excluded)
+    expect(addCalls).toHaveLength(2);
+    const addDirs = addCalls.map((c) => c.args[3]);
+    expect(addDirs).toContain(validDir);
+    expect(addDirs).not.toContain(invalidDir);
+    expect(addDirs).toContain("/repo/root");
+  });
+
+  it("is backward compatible when no extra marketplace dirs exist", async () => {
+    mkdirSync(testHome, { recursive: true });
+    const conventionRoot = join(testHome, "empty-marketplaces");
+    mkdirSync(conventionRoot, { recursive: true });
+
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const mockExec = async (
+      cmd: string,
+      args: string[],
+      _opts: { cwd: string },
+    ) => {
+      calls.push({ cmd, args });
+      return { stdout: "", exitCode: 0 };
+    };
+
+    await installPlugins(
+      mockExec,
+      testHome,
+      [],
+      "/repo/root",
+      join(testHome, "nonexistent.json"),
+      undefined,
+      conventionRoot,
+    );
+
+    // Only the /repo/root marketplace add — same as before this feature
+    const addCalls = calls.filter((c) => c.args[1] === "marketplace");
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0].args[3]).toBe("/repo/root");
+    // marketplace add + install + update = 3 calls total
+    expect(calls).toHaveLength(3);
   });
 });

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -13,6 +13,7 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -149,6 +150,66 @@ export function isNewWorkspace(home: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Baked marketplace discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Convention root for derived-image marketplaces:
+ *   /opt/shipwright/marketplaces/<name>/
+ *
+ * To ship a private marketplace with a derived image, place a directory
+ * containing `.claude-plugin/marketplace.json` under this root:
+ *
+ *   /opt/shipwright/marketplaces/
+ *     my-org-plugins/
+ *       .claude-plugin/
+ *         marketplace.json   ← required; triggers discovery
+ *         plugin.json        ← optional plugin metadata
+ *       ...
+ *
+ * The harness registers each discovered marketplace at boot via
+ * `claude plugin marketplace add <dir>` before the built-in shipwright
+ * marketplace. Plugin selection is still controlled by the AgentPlugin table —
+ * adding a marketplace makes its plugins available but does not install them.
+ *
+ * No env var, no DB table: marketplace availability is an IMAGE property.
+ */
+export const BAKED_MARKETPLACES_ROOT = "/opt/shipwright/marketplaces";
+
+/**
+ * Scans `conventionRoot` for directories that contain a
+ * `.claude-plugin/marketplace.json` file and returns their absolute paths.
+ *
+ * Returns an empty array when:
+ * - `conventionRoot` is an empty string
+ * - `conventionRoot` does not exist on disk
+ * - no subdirectory contains `.claude-plugin/marketplace.json`
+ *
+ * Non-throwing — all errors are handled internally.
+ */
+export function discoverBakedMarketplaces(conventionRoot: string): string[] {
+  if (!conventionRoot) return [];
+  if (!existsSync(conventionRoot)) return [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(conventionRoot);
+  } catch {
+    return [];
+  }
+
+  const result: string[] = [];
+  for (const entry of entries) {
+    const dirPath = join(conventionRoot, entry);
+    const marketplaceJson = join(dirPath, ".claude-plugin", "marketplace.json");
+    if (existsSync(marketplaceJson)) {
+      result.push(dirPath);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Plugin install
 // ---------------------------------------------------------------------------
 
@@ -215,6 +276,18 @@ export function findStalePluginSpecs(
  *
  * Install order: defaults first, then agent-specific plugins.
  * Update order: same.
+ *
+ * Marketplace registration order:
+ *   1. Extra baked marketplaces (discovered from `extraMarketplacesRoot` or
+ *      passed directly via `extraMarketplaceDirs`)
+ *   2. Built-in shipwright marketplace (`shipwrightRepoRoot`)
+ *
+ * @param extraMarketplaceDirs - Explicit list of extra marketplace dirs to
+ *   register. When provided, `extraMarketplacesRoot` is ignored. Useful for
+ *   tests that inject dirs directly without touching the filesystem.
+ * @param extraMarketplacesRoot - Convention root scanned by
+ *   `discoverBakedMarketplaces`. Defaults to `BAKED_MARKETPLACES_ROOT`
+ *   (/opt/shipwright/marketplaces). No-op when the path does not exist.
  */
 export async function installPlugins(
   execFn: ExecFn = defaultExec,
@@ -227,10 +300,34 @@ export async function installPlugins(
     "plugins",
     "installed_plugins.json",
   ),
+  extraMarketplaceDirs?: string[],
+  extraMarketplacesRoot: string = BAKED_MARKETPLACES_ROOT,
 ): Promise<void> {
   try {
-    // Register the local marketplace so `claude plugin install` can resolve
-    // plugins by name. Idempotent — safe to call on every startup.
+    // Determine which extra marketplace dirs to register.
+    // Explicit list (injected via tests) takes precedence over discovery.
+    const extraDirs =
+      extraMarketplaceDirs !== undefined
+        ? extraMarketplaceDirs
+        : discoverBakedMarketplaces(extraMarketplacesRoot);
+
+    // Register extra baked marketplaces BEFORE the built-in shipwright marketplace.
+    // Idempotent — safe to call on every startup.
+    for (const dir of extraDirs) {
+      const extraAdd = await execFn(
+        "claude",
+        ["plugin", "marketplace", "add", dir],
+        { cwd },
+      );
+      if (extraAdd.exitCode !== 0) {
+        console.warn(
+          `[agent] claude plugin marketplace add ${dir} exited ${extraAdd.exitCode}: ${extraAdd.stdout}`,
+        );
+      }
+    }
+
+    // Register the local (built-in) shipwright marketplace so `claude plugin install`
+    // can resolve plugins by name. Idempotent — safe to call on every startup.
     const add = await execFn(
       "claude",
       ["plugin", "marketplace", "add", shipwrightRepoRoot],

--- a/agent/src/setup.unit.test.ts
+++ b/agent/src/setup.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { installPlugins } from "./setup.ts";
+import { discoverBakedMarketplaces, installPlugins } from "./setup.ts";
 
 describe("installPlugins — local marketplace", () => {
   it("registers the marketplace before installing plugins", async () => {
@@ -106,5 +106,80 @@ describe("installPlugins — local marketplace", () => {
       "add",
       "/custom/repo/root",
     ]);
+  });
+
+  it("registers extra marketplaces before the /app marketplace", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const mockExec = async (
+      cmd: string,
+      args: string[],
+      _opts: { cwd: string },
+    ) => {
+      calls.push({ cmd, args });
+      return { stdout: "", exitCode: 0 };
+    };
+
+    // Pass a non-existent root so discoverBakedMarketplaces can't find dirs —
+    // we inject via extraMarketplaceDirs directly instead.
+    await installPlugins(
+      mockExec,
+      "/tmp/cwd",
+      [],
+      "/repo/root",
+      "/tmp/nonexistent-manifest.json",
+      ["/opt/shipwright/marketplaces/my-marketplace"],
+    );
+
+    // Extra marketplace add must come BEFORE the /repo/root marketplace add
+    const addCalls = calls.filter((c) => c.args[1] === "marketplace");
+    expect(addCalls[0].args[3]).toBe("/opt/shipwright/marketplaces/my-marketplace");
+    expect(addCalls[1].args[3]).toBe("/repo/root");
+  });
+
+  it("is a no-op when no extra marketplace dirs exist", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const mockExec = async (
+      cmd: string,
+      args: string[],
+      _opts: { cwd: string },
+    ) => {
+      calls.push({ cmd, args });
+      return { stdout: "", exitCode: 0 };
+    };
+
+    await installPlugins(
+      mockExec,
+      "/tmp/cwd",
+      [],
+      "/repo/root",
+      "/tmp/nonexistent-manifest.json",
+      [], // empty extra dirs
+    );
+
+    // Only the /repo/root marketplace add — no extra adds
+    const addCalls = calls.filter((c) => c.args[1] === "marketplace");
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0].args[3]).toBe("/repo/root");
+  });
+});
+
+describe("discoverBakedMarketplaces", () => {
+  it("returns dirs that have .claude-plugin/marketplace.json", () => {
+    // Since discoverBakedMarketplaces uses real fs, we test with a known-absent path
+    // The actual fs-based tests live in setup.integration.test.ts.
+    // This unit test verifies the function is exported and handles absent roots.
+    const result = discoverBakedMarketplaces("/tmp/nonexistent-convention-root-abc123");
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when conventionRoot is absent (empty string)", () => {
+    const result = discoverBakedMarketplaces("");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when conventionRoot does not exist", () => {
+    const result = discoverBakedMarketplaces("/opt/does-not-exist-xyz987");
+    expect(result).toEqual([]);
   });
 });

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -117,6 +117,28 @@ All child models cascade-delete with their `Agent`.
 | `SHIPWRIGHT_DEV_CHAT` | dev only | Set to `"true"` to enable the unauthenticated `POST /chat` endpoint (local dev convenience). Must **not** be set in production (`NODE_ENV=production`). |
 | `ADMIN_DEV_AUTH` | dev only | Set to `"true"` to enable `GET /admin/dev-login` (bypasses Google OAuth, mints a dev session). Hard-blocked when `NODE_ENV=production` by `dev-auth-guard.ts`. |
 
+## Baked marketplaces (derived images)
+
+A derived Docker image can ship additional Claude Code plugin marketplaces that are automatically registered at agent boot — no env var, no DB entry required. Marketplace availability is an **image property**; plugin selection remains in the AgentPlugin table as usual.
+
+**Convention root:** `/opt/shipwright/marketplaces/`
+
+Place one subdirectory per marketplace under the convention root. Each subdirectory must contain `.claude-plugin/marketplace.json` (the standard marketplace manifest). The harness calls `claude plugin marketplace add <dir>` for every discovered directory **before** registering the built-in shipwright marketplace, so derived-image plugins resolve correctly.
+
+```
+/opt/shipwright/marketplaces/
+  my-org-plugins/
+    .claude-plugin/
+      marketplace.json   ← required; triggers discovery
+      plugin.json        ← optional plugin metadata
+    plugins/
+      ...
+```
+
+Directories that do not contain `.claude-plugin/marketplace.json` are silently skipped. The registration call is idempotent and non-fatal — a missing directory or a non-zero exit from `claude` is logged as a warning and startup continues.
+
+The constant `BAKED_MARKETPLACES_ROOT` and function `discoverBakedMarketplaces()` in `agent/src/setup.ts` implement this behavior.
+
 ## Key Files
 
 | File | Purpose |


### PR DESCRIPTION
## Summary
- Adds `discoverBakedMarketplaces()` to `agent/src/setup.ts` that scans `/opt/shipwright/marketplaces/` for dirs containing `.claude-plugin/marketplace.json` and returns their paths
- Extends `installPlugins()` to register discovered extra marketplaces before the built-in shipwright marketplace, enabling derived images to ship private plugins without modifying the base image
- Documents the convention root in `agent/src/setup.ts` (JSDoc block with example layout) and `docs/agent.md` (new "Baked marketplaces" section)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Globs /opt/shipwright/marketplaces/, runs `marketplace add <dir>` before plugin install; idempotent + non-fatal | ✅ MET |
| 2 | Existing /app marketplace registration preserved; no-op when empty/absent | ✅ MET |
| 3 | Convention root documented in code comment + agent README | ✅ MET |
| 4 | Unit + integration tests; marketplace add asserted BEFORE plugin install; no tests retired | ✅ MET |
| 5 | Safe to deploy standalone; merge triggers build-agent.yml | ✅ MET |

## Test Plan
- 79 tests pass (setup.unit.test.ts + setup.integration.test.ts)
- `discoverBakedMarketplaces`: 4 integration tests with real tmpdir (valid dirs found, invalid skipped, absent root, empty root)
- `installPlugins — extra marketplace discovery`: 3 integration tests including ordering assertion (extra adds come before built-in add, which comes before plugin install)
- `discoverBakedMarketplaces` unit: 3 tests for absent/empty root handling
- `installPlugins` unit: 2 new tests (ordering when extra dirs injected; no-op with empty list)
- Pre-existing 7 failures in agent/src/ are unrelated (missing hono package, slack mock issues)
- [x] Biome lint: clean
- [x] Coverage: 91.56% (above 90% threshold)

Generated with [Claude Code](https://claude.com/claude-code)
