### PR TITLE
fix(admin): parse plugin records as canonical claude install spec

### DIFF
--- a/admin/src/agent-plugins.ts
+++ b/admin/src/agent-plugins.ts
@@ -2,7 +2,10 @@
  * agent/src/agent-plugins.ts
  * AgentPluginService — CRUD for Claude Code plugins per agent.
  *
- * Each plugin is identified by its package name (e.g. "@shipwright/plugin").
+ * Each plugin is identified by its canonical Claude install spec — the string
+ * passed to `claude plugin install`: "<plugin>@<marketplace>" (e.g.
+ * "shipwright@shipwright"), or a bare "<plugin>" that defaults to the bundled
+ * "shipwright" marketplace.
  * The unique constraint on [agentId, name] prevents duplicates; add() uses
  * upsert so re-adding an existing plugin updates its version and re-enables it.
  */

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -239,7 +239,7 @@ function makeMockDeps(): AdminDeps {
         {
           id: PLUGIN_ID,
           agentId: AGENT_ID,
-          name: "@shipwright/plugin",
+          name: "shipwright@shipwright",
           version: "1.0.0",
           enabled: true,
           createdAt: new Date("2024-01-01"),
@@ -249,7 +249,7 @@ function makeMockDeps(): AdminDeps {
       add: async () => ({
         id: PLUGIN_ID,
         agentId: AGENT_ID,
-        name: "@shipwright/plugin",
+        name: "shipwright@shipwright",
         version: "1.0.0",
         enabled: true,
         createdAt: new Date("2024-01-01"),
@@ -704,7 +704,7 @@ describe("admin API — plugins", () => {
     const app = createAdminApp(makeMockDeps());
     const res = await app.request(`/agents/${AGENT_ID}/plugins`, {
       method: "POST",
-      body: JSON.stringify({ name: "@shipwright/plugin", version: "1.0.0" }),
+      body: JSON.stringify({ name: "shipwright@shipwright", version: "1.0.0" }),
       headers: {
         "Content-Type": "application/json",
         Cookie: `admin_session=${cookie}`,
@@ -727,7 +727,7 @@ describe("admin API — plugins", () => {
   it("PATCH /agents/:id/plugins?name=<name> updates version (200)", async () => {
     const app = createAdminApp(makeMockDeps());
     const res = await app.request(
-      `/agents/${AGENT_ID}/plugins?name=${encodeURIComponent("@shipwright/plugin")}`,
+      `/agents/${AGENT_ID}/plugins?name=${encodeURIComponent("shipwright@shipwright")}`,
       {
         method: "PATCH",
         body: JSON.stringify({ version: "2.0.0" }),
@@ -756,7 +756,7 @@ describe("admin API — plugins", () => {
   it("DELETE /agents/:id/plugins?name=<name> returns 204", async () => {
     const app = createAdminApp(makeMockDeps());
     const res = await app.request(
-      `/agents/${AGENT_ID}/plugins?name=${encodeURIComponent("@shipwright/plugin")}`,
+      `/agents/${AGENT_ID}/plugins?name=${encodeURIComponent("shipwright@shipwright")}`,
       {
         method: "DELETE",
         headers: { Cookie: `admin_session=${cookie}` },

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -485,8 +485,9 @@ export function createAdminApp(deps: AdminDeps): Hono<AdminAuthEnv> {
   });
 
   // PATCH /agents/:id/plugins?name=<name> — update plugin version (re-upsert)
-  // Uses a query param rather than a path segment to support scoped names like
-  // "@shipwright/plugin" which contain a literal "/" that breaks path matching.
+  // Uses a query param rather than a path segment because a canonical spec like
+  // "my-plugin@org/my-marketplace" can contain a literal "/" that breaks path
+  // matching.
   app.patch("/agents/:id/plugins", async (c) => {
     const agentId = c.req.param("id");
     const name = c.req.query("name");
@@ -499,8 +500,9 @@ export function createAdminApp(deps: AdminDeps): Hono<AdminAuthEnv> {
   });
 
   // DELETE /agents/:id/plugins?name=<name> — remove a plugin by name
-  // Uses a query param rather than a path segment to support scoped names like
-  // "@shipwright/plugin" which contain a literal "/" that breaks path matching.
+  // Uses a query param rather than a path segment because a canonical spec like
+  // "my-plugin@org/my-marketplace" can contain a literal "/" that breaks path
+  // matching.
   app.delete("/agents/:id/plugins", async (c) => {
     const agentId = c.req.param("id");
     const name = c.req.query("name");

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -152,7 +152,7 @@ function buildApp(opts?: {
           allowedTools: ["Read", "Write", "Bash"],
         };
   const plugins = opts?.plugins ?? [
-    makePlugin(KNOWN_AGENT_ID, "@shipwright/plugin"),
+    makePlugin(KNOWN_AGENT_ID, "shipwright@shipwright"),
   ];
   const crons = opts?.crons ?? [makeCron(KNOWN_AGENT_ID, "cron-1")];
 
@@ -195,16 +195,17 @@ describe("GET /:id/config (mounted as GET /agents/:id/config from root)", () => 
     });
     expect(body.allowedTools).toEqual(["Read", "Write", "Bash"]);
     expect(body.plugins).toEqual([
-      { marketplace: "shipwright", plugin: "@shipwright/plugin" },
+      { marketplace: "shipwright", plugin: "shipwright" },
     ]);
   });
 
-  test("derives marketplace from the plugin namespace, defaulting to shipwright", async () => {
+  test("parses the canonical plugin@marketplace spec, defaulting bare names to shipwright", async () => {
     const app = buildApp({
       plugins: [
-        makePlugin(KNOWN_AGENT_ID, "@vitals-os/plugin"),
-        makePlugin(KNOWN_AGENT_ID, "@shipwright/plugin"),
+        makePlugin(KNOWN_AGENT_ID, "time-tracker@acme"),
+        makePlugin(KNOWN_AGENT_ID, "shipwright@shipwright"),
         makePlugin(KNOWN_AGENT_ID, "unscoped-plugin"),
+        makePlugin(KNOWN_AGENT_ID, "my-plugin@org/my-marketplace"),
       ],
     });
     const res = await app.request(`/${KNOWN_AGENT_ID}/config`, {
@@ -214,9 +215,11 @@ describe("GET /:id/config (mounted as GET /agents/:id/config from root)", () => 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.plugins).toEqual([
-      { marketplace: "vitals-os", plugin: "@vitals-os/plugin" },
-      { marketplace: "shipwright", plugin: "@shipwright/plugin" },
+      { marketplace: "acme", plugin: "time-tracker" },
+      { marketplace: "shipwright", plugin: "shipwright" },
       { marketplace: "shipwright", plugin: "unscoped-plugin" },
+      // Splits on the first "@" so a marketplace can itself contain a "/".
+      { marketplace: "org/my-marketplace", plugin: "my-plugin" },
     ]);
   });
 
@@ -232,7 +235,7 @@ describe("GET /:id/config (mounted as GET /agents/:id/config from root)", () => 
     expect(body.allowedTools).toEqual([]);
     // plugins still returned (the agent has them)
     expect(body.plugins).toEqual([
-      { marketplace: "shipwright", plugin: "@shipwright/plugin" },
+      { marketplace: "shipwright", plugin: "shipwright" },
     ]);
   });
 

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -169,15 +169,17 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): Hono {
     const response: AgentConfigResponse = {
       env: bundle?.env ?? {},
       allowedTools: bundle?.allowedTools ?? [],
-      plugins: plugins.map((p) => ({
-        // Derive the marketplace from the plugin's namespace (scoped names like
-        // "@vitals-os/plugin" install from their own registry); default to
-        // "shipwright" for unscoped names.
-        marketplace: p.name.startsWith("@")
-          ? p.name.split("/")[0].slice(1)
-          : "shipwright",
-        plugin: p.name,
-      })),
+      plugins: plugins.map((p) => {
+        // The stored name is the canonical Claude plugin spec — exactly what
+        // you'd pass to `claude plugin install`: "<plugin>@<marketplace>"
+        // (e.g. "shipwright@shipwright"), or a bare "<plugin>" that defaults to
+        // the bundled "shipwright" marketplace. The harness reassembles
+        // "<plugin>@<marketplace>" from these two fields.
+        const at = p.name.indexOf("@");
+        return at === -1
+          ? { marketplace: "shipwright", plugin: p.name }
+          : { plugin: p.name.slice(0, at), marketplace: p.name.slice(at + 1) };
+      }),
     };
 
     return c.json(response, 200);

--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -285,20 +285,39 @@ curl -sf -X DELETE \
 
 Plugins installed on the agent determine which skills and commands are available.
 
+**`name` is the canonical Claude install spec** — exactly the string you'd pass to
+`claude plugin install`:
+
+- `"<plugin>@<marketplace>"` for a marketplace-scoped plugin (e.g. `"shipwright@shipwright"`,
+  `"my-plugin@my-marketplace"`). The config bundle splits on the first `@`, and the harness
+  reassembles `<plugin>@<marketplace>` to install it.
+- A bare `"<plugin>"` defaults to the bundled `shipwright` marketplace.
+
+Do **not** use an npm-scoped form like `@my-marketplace/my-plugin` — `claude plugin install`
+does not accept scoped plugin identifiers, and the agent would fail to install it.
+
 ```bash
 # List installed plugins
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins" | jq .
 
-# Install a plugin (or re-add to pin a specific version)
+# Install a plugin from the bundled shipwright marketplace (or re-add to pin a version)
 curl -sf -X POST \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins" \
   -d '{"name": "shipwright", "version": "4.27.2"}' | jq .
 
+# Install a plugin from a different marketplace baked into the agent image
+# (use the canonical "<plugin>@<marketplace>" spec)
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/plugins" \
+  -d '{"name": "my-plugin@my-marketplace"}' | jq .
+
 # Update a plugin version
-# name goes in the query param — scoped names like @scope/pkg contain "/" which breaks path matching
+# name goes in the query param — a spec like my-plugin@org/marketplace can contain "/" which breaks path matching
 curl -sf -X PATCH \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Problem

The agent config bundle derives `{marketplace, plugin}` from a stored plugin `name`, and the harness installs `` `${plugin}@${marketplace}` `` (`agent/src/setup.ts`). The old derivation (`admin/src/api.ts`) assumed an npm-scoped convention:

```js
marketplace: name.startsWith("@") ? name.split("/")[0].slice(1) : "shipwright",
plugin: name,   // ← kept the full scoped string
```

This is unreachable for any real plugin. Tracing every possible stored `name`:

| stored `name` | derived marketplace | derived plugin | install spec | valid? |
|---|---|---|---|---|
| `@scope/name` | `scope` | `@scope/name` | `@scope/name@scope` | ❌ `claude plugin install` rejects scoped ids |
| `name` | `shipwright` | `name` | `name@shipwright` | ❌ can't target another marketplace |

**No stored value could ever produce the correct `<plugin>@<marketplace>`** (e.g. `time-tracker@acme`).

## Fix

Store `name` as the exact string you'd pass to `claude plugin install` — the canonical spec — and parse on the first `@`:

- `"<plugin>@<marketplace>"` → `{ plugin, marketplace }`
- bare `"<plugin>"` → `{ plugin, marketplace: "shipwright" }`

Round-trips through the harness unchanged, and matches what operators actually type.

## Changes

- `admin/src/api.ts` — split on first `@`; bare name defaults to the shipwright marketplace
- `admin/src/api.smoke.test.ts` — assert canonical parsing, including a marketplace that itself contains `/` (`my-plugin@org/my-marketplace`)
- `admin/src/agents-api.{ts,smoke.test.ts}`, `admin/src/agent-plugins.ts` — align CRUD fixtures, comments, and JSDoc to the canonical convention
- `plugins/shipwright/skills/agent-admin/SKILL.md` — document the `name` format, add a marketplace-scoped install example, warn against the npm-scoped form

## Compatibility

No agent currently has a plugin record (verified against the deployed admin API across all agents), so there is no stored data to migrate.

## Verification

- `bunx biome lint .` — clean
- `bun test admin/` — 409 pass / 0 fail
- `task typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)