### PR TITLE
docs(agent): pull repo before any work to prevent stale diffs

### DIFF
--- a/agent/workspace/CLAUDE.md.template
+++ b/agent/workspace/CLAUDE.md.template
@@ -43,6 +43,12 @@ stripped from the visible message before posting.
 `repos/<repo>` is always on `main`. Use for reading, research, and reference only.
 Never edit files in `repos/` directly.
 
+**Before any work on a repo** (planning, review, dev-task, patch, etc.) — pull first:
+```bash
+git -C repos/<repo> pull
+```
+This keeps the local ref current and prevents stale diffs.
+
 ### Worktrees
 
 All active work — features, bug fixes, reviewing a specific branch — happens in


### PR DESCRIPTION
## Summary

- Adds a \"pull first\" rule to `agent/workspace/CLAUDE.md.template` under the Repos section
- Mirrors the same fix already applied to this agent's own `CLAUDE.md`

## Context

During a review session, `git diff main...HEAD` in a worktree produced a massive diff that included commits already on `main` because the local `main` ref was stale (pointing to `gh-pages-update` instead of `origin/main`). This caused a completely wrong review that flagged changes not in the PR.

The fix: always `git -C repos/<repo> pull` before planning, review, dev-task, patch, or any operation that reads the repo state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)