### PR TITLE
feat(skills): add task-store skill

### DIFF
--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -358,8 +358,10 @@ shipwright/
 ├── skills/
 │   ├── agent-admin/
 │   │   └── SKILL.md             # Manage Shipwright agents — crons, env vars, tools, tokens, plugins
-│   └── review-staged/
-│       └── SKILL.md             # Conversational walkthrough of staged reviews
+│   ├── review-staged/
+│   │   └── SKILL.md             # Conversational walkthrough of staged reviews
+│   └── task-store/
+│       └── SKILL.md             # Query and update the task store — lifecycle invocations, env var config
 ├── references/
 │   ├── doc-refresh-recipe.md    # Shared staleness + section-rewrite recipe (research-docs + docs-refresher)
 │   ├── metrics-schema.md        # Metrics JSONL schema reference

--- a/plugins/shipwright/scripts/task_store.ts
+++ b/plugins/shipwright/scripts/task_store.ts
@@ -9,7 +9,7 @@
  *
  * Subcommands:
  *   query       Filter and return tasks as JSON array
- *   append      Upsert tasks from a JSON file (idempotent by id)
+ *   append      Append tasks from a JSON file (insert-only on GitHub adapter; upsert on JSON adapter)
  *   update      Write specific fields to a task by ID
  *   repos       Print all org/repo strings (one per line)
  *   resolve-repo  Print first org/repo (deprecated alias for repos)
@@ -92,7 +92,7 @@ function printUsageAndExit(): never {
       "",
       "Subcommands:",
       "  query         Filter and return tasks as JSON array",
-      "  append        Upsert tasks from a JSON file (idempotent by id)",
+      "  append        Append tasks from a JSON file (insert-only on GitHub adapter; upsert on JSON adapter)",
       "  update        Write specific fields to a task by ID",
       "  repos         Print all org/repo strings (one per line)",
       "  resolve-repo  Print first org/repo (deprecated alias for repos)",

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -3,32 +3,15 @@ name: task-store
 description: >
   Query and update the Shipwright task store — pick the next ready task, mark status
   transitions, and append new tasks. Use whenever you need to read from or write to
-  the task queue. Covers agent env var configuration, script resolution, standard
-  lifecycle invocations, and common failure modes.
+  the task queue. Covers script resolution, standard lifecycle invocations, and common
+  failure modes.
 ---
 
 # Task Store — Skill
 
 Use this skill to interact with the Shipwright task store. The task store is a CLI
-(`task_store.ts`) that abstracts over JSON-file and GitHub Issues backends. For agents,
-the backend is selected via environment variables — no config file needed.
-
----
-
-## Configuration (agents)
-
-Agents configure the task store via env vars. These take highest precedence and bypass
-config file discovery entirely.
-
-| Variable | Required | Description |
-|---|---|---|
-| `SHIPWRIGHT_TASK_STORE` | Yes | Backend selector: `github`, `json`, or `jira` |
-| `SHIPWRIGHT_GITHUB_OWNER` | If `github` | GitHub org or user that owns the task repo |
-| `SHIPWRIGHT_GITHUB_REPO` | If `github` | GitHub repo name where issues are created |
-| `GH_TOKEN` | If `github` | GitHub token with `repo` scope |
-
-For local Claude Code sessions, the backend is configured via `.shipwright.json` — see
-`references/task-store.md` for that path.
+(`task_store.ts`) that abstracts over JSON-file and GitHub Issues backends. The backend
+is selected via `.shipwright.json` — see `references/task-store.md` for the config schema.
 
 ---
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: task-store
+description: >
+  Query and update the Shipwright task store — pick the next ready task, mark status
+  transitions, and append new tasks. Use whenever you need to read from or write to
+  the task queue. Covers agent env var configuration, script resolution, standard
+  lifecycle invocations, and common failure modes.
+---
+
+# Task Store — Skill
+
+Use this skill to interact with the Shipwright task store. The task store is a CLI
+(`task_store.ts`) that abstracts over JSON-file and GitHub Issues backends. For agents,
+the backend is selected via environment variables — no config file needed.
+
+---
+
+## Configuration (agents)
+
+Agents configure the task store via env vars. These take highest precedence and bypass
+config file discovery entirely.
+
+| Variable | Required | Description |
+|---|---|---|
+| `SHIPWRIGHT_TASK_STORE` | Yes | Backend selector: `github`, `json`, or `jira` |
+| `SHIPWRIGHT_GITHUB_OWNER` | If `github` | GitHub org or user that owns the task repo |
+| `SHIPWRIGHT_GITHUB_REPO` | If `github` | GitHub repo name where issues are created |
+| `GH_TOKEN` | If `github` | GitHub token with `repo` scope |
+
+For local Claude Code sessions, the backend is configured via `.shipwright.json` — see
+`references/task-store.md` for that path.
+
+---
+
+## Locate the script
+
+Resolve once at the start of any task store operation and reuse within the same step:
+
+```bash
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+```
+
+Then invoke as:
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" <subcommand> [flags]
+```
+
+---
+
+## Resolve your assignee
+
+Always resolve the current GitHub user before querying. Pass it to every `query` call:
+
+```bash
+CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
+```
+
+---
+
+## Standard lifecycle
+
+### Pick next task
+
+Check for an interrupted task first, then fall back to the next ready one:
+
+```bash
+# 1. Resume interrupted task (in_progress assigned to you)
+bun "$PLUGIN_SCRIPTS/task_store.ts" query --status in_progress --assignee "$CURRENT_USER"
+
+# 2. If empty, pick next ready task
+bun "$PLUGIN_SCRIPTS/task_store.ts" query --ready --assignee "$CURRENT_USER"
+```
+
+Both return a JSON array sorted by `addedAt`. Use the first element.
+
+### Start a task
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} \
+  --set status=in_progress \
+  --set startedAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+
+### Open a PR
+
+Must set `pr` and `prCreatedAt` together with the status:
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} \
+  --set status=pr_open \
+  --set pr={pr_number} \
+  --set prCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+
+### Mark blocked
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} \
+  --set status=blocked \
+  --set blockedReason="{reason}" \
+  --set blockedAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+
+### Mark merged / done
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} \
+  --set status=merged \
+  --set mergedAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+
+### Append new tasks
+
+Write tasks to a temp file, then upsert (idempotent by `id`):
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks.json
+# Returns: { "inserted": N, "updated": N }
+```
+
+---
+
+## `--ready` flag semantics
+
+When `--ready` is set, `--status`, `--id`, and `--pr` are **ignored**. Only
+`--assignee` and `--session` apply as post-filters.
+
+A task is ready when:
+- `status === "pending"`, AND
+- all `dependencies` are satisfied (merged, or same branch with `pr_open`/`approved`)
+
+---
+
+## Empty results
+
+When `query --ready` returns `[]`:
+
+| Likely cause | How to check |
+|---|---|
+| Wrong assignee | Re-run without `--assignee` to see the full ready set |
+| Deps not satisfied | Query `--status pending` — tasks present but blocked on deps |
+| Queue empty | No pending tasks exist at all |
+
+If `PLUGIN_SCRIPTS` resolves to empty, the plugin is not installed in the cache. Stop
+and report the missing plugin rather than retrying.
+
+---
+
+## Task status values
+
+`pending` → `in_progress` → `pr_open` → `approved` → `merged`
+
+Branch statuses: `blocked`, `cancelled`, `deploying`, `deployed`
+
+---
+
+## Reference
+
+Full schema: `references/todos-schema.md`
+Backend contract and GitHub data model: `references/task-store.md`

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -45,7 +45,17 @@ The script walks up from the current directory looking for `.shipwright.json`. E
 { "taskStore": "github", "github": { "owner": "app-vitals", "repo": "shipwright" } }
 ```
 
-If neither env vars nor a config file are found, the JSON backend is used by default.
+### Option C — `SHIPWRIGHT_CONFIG` env var (explicit file path)
+
+When no `.shipwright.json` is found by walk-up, `SHIPWRIGHT_CONFIG` is consulted next.
+Use this in CI or non-standard workspace layouts where the config file lives outside
+the working directory:
+
+```bash
+export SHIPWRIGHT_CONFIG=/path/to/.shipwright.json
+```
+
+If none of the above resolve, the JSON backend is used by default.
 
 ---
 
@@ -143,7 +153,10 @@ bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks.json
 When `--ready` is set, `--status`, `--id`, and `--pr` are **ignored**. Only
 `--assignee` and `--session` apply as post-filters.
 
-- `--assignee` — filter by GitHub login (pass `$CURRENT_USER`)
+- `--assignee` — filter by GitHub login (pass `$CURRENT_USER`).
+  Backend note: the GitHub adapter includes unassigned tasks (`assignee` field absent) —
+  they are available to any agent. The JSON adapter uses strict equality — unassigned
+  tasks are excluded; omit `--assignee` to see them.
 - `--session` — filter by planning session slug (the `session` field stamped on each task
   during `plan-session`). Omit to return ready tasks across all sessions.
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -11,7 +11,41 @@ description: >
 
 Use this skill to interact with the Shipwright task store. The task store is a CLI
 (`task_store.ts`) that abstracts over JSON-file and GitHub Issues backends. The backend
-is selected via `.shipwright.json` — see `references/task-store.md` for the config schema.
+is selected via env vars or `.shipwright.json` — see `references/task-store.md` for the config schema.
+
+---
+
+## Configure the backend
+
+The backend is resolved in this order (first match wins):
+
+### Option A — env vars (preferred for agents)
+
+Set `SHIPWRIGHT_TASK_STORE` to select the backend. No config file required.
+
+**GitHub Issues backend:**
+
+```bash
+export SHIPWRIGHT_TASK_STORE=github
+export SHIPWRIGHT_GITHUB_OWNER=<org-or-user>   # e.g. app-vitals
+export SHIPWRIGHT_GITHUB_REPO=<repo-name>       # e.g. shipwright
+```
+
+**JSON file backend (local fallback):**
+
+```bash
+export SHIPWRIGHT_TASK_STORE=json
+```
+
+### Option B — `.shipwright.json` config file
+
+The script walks up from the current directory looking for `.shipwright.json`. Example:
+
+```json
+{ "taskStore": "github", "github": { "owner": "app-vitals", "repo": "shipwright" } }
+```
+
+If neither env vars nor a config file are found, the JSON backend is used by default.
 
 ---
 
@@ -108,6 +142,10 @@ bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks.json
 
 When `--ready` is set, `--status`, `--id`, and `--pr` are **ignored**. Only
 `--assignee` and `--session` apply as post-filters.
+
+- `--assignee` — filter by GitHub login (pass `$CURRENT_USER`)
+- `--session` — filter by planning session slug (the `session` field stamped on each task
+  during `plan-session`). Omit to return ready tasks across all sessions.
 
 A task is ready when:
 - `status === "pending"`, AND

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -139,12 +139,16 @@ bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} \
 
 ### Append new tasks
 
-Write tasks to a temp file, then upsert (idempotent by `id`):
+Write tasks to a temp file, then append:
 
 ```bash
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks.json
 # Returns: { "inserted": N, "updated": N }
 ```
+
+Backend note: the GitHub adapter is insert-only — existing tasks (matched by `id`) are
+never updated via `append`. Use `update` for targeted field changes on existing
+GitHub-backed tasks. The JSON adapter upserts (idempotent by `id`).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `plugins/shipwright/skills/task-store/SKILL.md` — a concise agent-focused reference for interacting with the Shipwright task store
- Updates `README.md` directory tree to list the new skill

## What's in the skill

- **Env var config** as the primary path for agents (`SHIPWRIGHT_TASK_STORE`, `SHIPWRIGHT_GITHUB_OWNER`, `SHIPWRIGHT_GITHUB_REPO`) — no config file needed
- **Script resolution** via `find ~/.claude/plugins/cache`
- **Assignee resolution** — always look up current GitHub user before querying
- **Standard lifecycle invocations** — resume, start, pr-open, blocked, merged — with correct field combos for each status transition
- **`--ready` flag semantics** — which filters are ignored, which post-filter applies
- **Empty result diagnosis** — wrong assignee vs deps unsatisfied vs empty queue

## Test plan

- [ ] Install plugin and verify `/task-store` skill is discoverable
- [ ] Confirm env var config section matches `create-task-store.ts` precedence order
- [ ] Confirm lifecycle invocations match `dev-task.md` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)