### PR TITLE
fix(task-store): don't strip the status label when re-applying the current status

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.27.2",
+  "version": "4.27.3",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.27.2
+# Shipwright v4.27.3
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/scripts/adapters/github.ts
+++ b/plugins/shipwright/scripts/adapters/github.ts
@@ -457,10 +457,19 @@ export class GitHubTaskStore implements TaskStore {
         "--add-label",
         newLabel,
       ];
-      // Only remove the old label if it was actually present on the issue.
-      // Attempting to remove a label that isn't there causes gh to error,
-      // which leaves the issue with no status label and invisible to fetchAllIssues.
-      if (targetTask._labelStatus !== undefined) {
+      // Only remove the old label if it was actually present on the issue AND
+      // differs from the one we're adding. Two failure modes otherwise:
+      //   1. _labelStatus === undefined: removing a label that isn't there makes
+      //      gh error, leaving the issue with no status label.
+      //   2. _labelStatus === newStatus (re-applying the current status): a single
+      //      `gh issue edit --add-label X --remove-label X` nets to a REMOVAL, so
+      //      the issue ends up with no status label.
+      // Either way the issue becomes invisible to fetchAllIssues (orphaned) and can
+      // only be recovered by manually re-adding the label.
+      if (
+        targetTask._labelStatus !== undefined &&
+        targetTask._labelStatus !== newStatus
+      ) {
         editArgs.push(
           "--remove-label",
           `${STATUS_LABEL_PREFIX}${targetTask._labelStatus}`,

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -2139,7 +2139,6 @@ process.exit(0);
 // ─── GitHubTaskStore.update field enforcement warnings ────────────────────────
 
 describe("GitHubTaskStore.update field enforcement warnings", () => {
-
   test("warns when prCreatedAt missing on pr_open transition", async () => {
     const issues = [
       makeIssue(1, "TSR-W.1: Task", "in_progress", {
@@ -2490,7 +2489,12 @@ process.exit(0);
         model: modelValue,
       };
       const issues = [
-        makeIssue(20 + idx, `${id}: Task ${modelValue}`, "pending", originalTask),
+        makeIssue(
+          20 + idx,
+          `${id}: Task ${modelValue}`,
+          "pending",
+          originalTask,
+        ),
       ];
 
       const fakeGh = await writeFakeGh(tmpDir, {
@@ -2695,6 +2699,43 @@ process.exit(0);
     expect(labelEdit).toContain("--remove-label");
     expect(labelEdit).toContain("status:in_progress");
   });
+
+  test("update() does NOT remove the label when new status equals current status", async () => {
+    // Regression: re-applying the current status must not emit
+    // `--add-label status:X --remove-label status:X` in one gh call — gh nets that
+    // to a removal, leaving the issue with no status label (orphaned).
+    const issues = [
+      makeIssue(101, "LSG-3.1: Task", "pr_open", {
+        id: "LSG-3.1",
+        title: "Task",
+        status: "pr_open",
+      }),
+    ];
+
+    const { scriptPath, editsFile } = await makeEditCaptureScript(
+      tmpDir,
+      "same-status-test-gh",
+      issues,
+    );
+    process.env.GH_CMD = scriptPath;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    await adapter.update("LSG-3.1", { status: "pr_open", pr: 1509 });
+
+    const edits = (await Bun.file(editsFile).text())
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line: string) => line.split("|"));
+
+    const labelEdit = edits.find(
+      (e: string[]) =>
+        e.includes("--add-label") && e.includes("status:pr_open"),
+    );
+    expect(labelEdit).toBeDefined();
+    // new === old (pr_open) → must NOT pair the add with a same-label remove
+    expect(labelEdit).not.toContain("--remove-label");
+  });
 });
 
 // ─── GitHubTaskStore.append — ensureMilestone ────────────────────────────────
@@ -2864,9 +2905,24 @@ process.exit(0);
 
     const adapter = new GitHubTaskStore(CONFIG);
     await adapter.append([
-      { id: "TSR-9.3", title: "Task 1", status: "pending", session: "batch-session" },
-      { id: "TSR-9.4", title: "Task 2", status: "pending", session: "batch-session" },
-      { id: "TSR-9.5", title: "Task 3", status: "pending", session: "batch-session" },
+      {
+        id: "TSR-9.3",
+        title: "Task 1",
+        status: "pending",
+        session: "batch-session",
+      },
+      {
+        id: "TSR-9.4",
+        title: "Task 2",
+        status: "pending",
+        session: "batch-session",
+      },
+      {
+        id: "TSR-9.5",
+        title: "Task 3",
+        status: "pending",
+        session: "batch-session",
+      },
     ]);
 
     const getsContent = await Bun.file(milestonesGetFile).text();

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -13,6 +13,14 @@ Use this skill to interact with the Shipwright task store. The task store is a C
 (`task_store.ts`) that abstracts over JSON-file and GitHub Issues backends. The backend
 is selected via env vars or `.shipwright.json` — see **Configure the backend** below for the config schema.
 
+> **The CLI is the only interface.** Always go through `task_store.ts`
+> (`query` / `update` / `append`) — never open, `cat`, or edit a file to read or change tasks.
+> The store's underlying persistence is private to the backend (a local file for the JSON
+> backend; issues for the GitHub backend) and is not a supported entry point; reaching for it
+> bypasses validation and the status-label↔body sync, and is the most common way tasks get
+> orphaned. The unit you work with is the **task** (see
+> [task-schema.md](references/task-schema.md)).
+
 ---
 
 ## Configure the backend
@@ -226,6 +234,8 @@ This skill is the **canonical reference for the task lifecycle** — `dev-task`,
 `review` all drive the store through the same `update` transitions documented above. You should
 not need to read those command files to operate the queue.
 
-- Task schema + field validation: the plugin's `scripts/adapters/validation.ts`
-- GitHub backend data model (labels + body JSON block): `scripts/adapters/github.ts`
+- **Task schema** (all fields + per-status required fields): [task-schema.md](references/task-schema.md)
 - Backend selection / config schema: see **Configure the backend** above.
+- Maintainer-only (do **not** operate on these directly — use the CLI): field validation lives in
+  `scripts/adapters/validation.ts`; the GitHub persistence model (status label + body JSON block) in
+  `scripts/adapters/github.ts`.

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 Use this skill to interact with the Shipwright task store. The task store is a CLI
 (`task_store.ts`) that abstracts over JSON-file and GitHub Issues backends. The backend
-is selected via env vars or `.shipwright.json` — see `references/task-store.md` for the config schema.
+is selected via env vars or `.shipwright.json` — see **Configure the backend** below for the config schema.
 
 ---
 
@@ -193,7 +193,39 @@ Branch statuses: `blocked`, `cancelled`, `deploying`, `deployed`
 
 ---
 
+## How status is stored — always transition via `update`
+
+On a GitHub-backed task, status lives in **two** places, kept in sync by the CLI:
+- the `status:<value>` **label** on the issue — what `query --status` / `--ready` filter on, and
+- the `"status"` field in the issue body's ` ```shipwright ` JSON block — the full task record.
+
+**Always change status with `task_store.ts update --set status=…`** (the lifecycle commands
+above). It rewrites the body JSON and swaps the label in a single call. Do **not** hand-edit
+the label with `gh issue edit` or edit the body JSON directly — the two drift apart and the
+task misbehaves.
+
+**Orphan gotcha:** a task with **no `status:*` label** is invisible to the store —
+`fetchAllIssues` filters by that label, so `query --id` returns `[]` and `update` reports
+`task not found`. If a task gets orphaned (label removed out-of-band), the CLI can't heal it
+because it can't enumerate a label-less issue. Recover by re-adding the label, then resume
+with `update`:
+
+```bash
+gh issue edit {issue-number} --repo {owner}/{repo} --add-label status:{current-status}
+```
+
+> Pre-4.27.3 adapters could orphan a task *themselves*: re-applying the current status issued
+> `gh issue edit --add-label status:X --remove-label status:X`, which gh nets to a removal.
+> Fixed in 4.27.3 (the swap now skips `--remove-label` when new == old).
+
+---
+
 ## Reference
 
-Full schema: `references/todos-schema.md`
-Backend contract and GitHub data model: `references/task-store.md`
+This skill is the **canonical reference for the task lifecycle** — `dev-task`, `patch`, and
+`review` all drive the store through the same `update` transitions documented above. You should
+not need to read those command files to operate the queue.
+
+- Task schema + field validation: the plugin's `scripts/adapters/validation.ts`
+- GitHub backend data model (labels + body JSON block): `scripts/adapters/github.ts`
+- Backend selection / config schema: see **Configure the backend** above.

--- a/plugins/shipwright/skills/task-store/references/task-schema.md
+++ b/plugins/shipwright/skills/task-store/references/task-schema.md
@@ -1,0 +1,76 @@
+# Task schema
+
+The task store exposes one object type — the **Task**. This is the **backend-agnostic**
+contract: the same shape whether the backend is GitHub Issues, Jira, or the local JSON file.
+
+> **Operate the store only through `task_store.ts` (`query` / `update` / `append`).**
+> The `Task` below is the contract you read and write; *how* it is persisted — a local file,
+> GitHub issues, Jira — is the backend's business, not yours. Editing the underlying storage
+> directly bypasses validation, the status-label↔body sync, and the backend abstraction, and
+> is the most common way tasks get corrupted or orphaned.
+
+## Fields
+
+### Identity & content
+| field | type | notes |
+|---|---|---|
+| `id` | string **(required)** | Stable task id, e.g. `SWD-2.2`. `append` matches on this; never reuse. |
+| `title` | string **(required)** | One-line summary. |
+| `status` | enum **(required)** | See lifecycle below. |
+| `description` | string | Full task description. |
+| `acceptanceCriteria` | string[] | Checklist of done conditions. |
+| `note` | string | Freeform note. |
+
+### Planning & routing
+| field | type | notes |
+|---|---|---|
+| `session` | string | Planning-session slug; groups tasks (a milestone / `session:` label on GitHub). |
+| `repo` | string | Source repo the task targets; routes `/dev-task` to the right tree. |
+| `layer` | string | `Shared`, `API`, `Database`, `Agent`, `CLI`, `Web`. |
+| `dependencies` | string[] | Task ids that must be satisfied before this is `--ready`. |
+| `branch` | string | Feature branch; used for same-branch dependency satisfaction. |
+| `assignee` | string | GitHub login of the owner. |
+| `hours` | number | Estimate. |
+| `complexity` | number (1–5) | Planning / model-selection hint; out-of-range warns. |
+| `model` | `haiku` \| `sonnet` \| `opus` | Tier hint for model selection (no auto-mapping to a full model id). |
+| `priority` / `size` / `type` | string | Optional planning metadata. |
+
+### Lifecycle timestamps & PR linkage
+| field | type | set when |
+|---|---|---|
+| `addedAt` | ISO string | task created |
+| `startedAt` | ISO string | → `in_progress` |
+| `pr` | number | → `pr_open` (PR number) |
+| `prUrl` | string | → `pr_open` (alternative to `pr`) |
+| `prCreatedAt` | ISO string | → `pr_open` |
+| `ciFixAttempts` | number | before `pr_open` → `approved` / `merged` |
+| `mergedAt` | ISO string | → `merged` |
+| `blockedAt` / `blockedReason` | ISO string / string | → `blocked` |
+| `cancelledAt` / `deployingAt` / `completedAt` | ISO string | corresponding status |
+| `mergeCommit` | string | merge commit SHA |
+| `source` / `issue` | string | backend tracking ref (e.g. `gh:owner/repo#123`) |
+
+> **Legacy duplicates** appear in older records: `prNumber` (≈ `pr`), `prOpenedAt`
+> (≈ `prCreatedAt`). Prefer `pr` / `prCreatedAt`; readers should tolerate both.
+
+## Status lifecycle
+
+`pending → in_progress → pr_open → approved → merged → deploying → deployed`
+
+Terminal: `merged`, `done`, `deployed`, `cancelled`. Paused: `blocked`.
+
+A task is **`--ready`** when `status === "pending"` AND every id in `dependencies` is satisfied
+(the dependency is `merged`, or on the same `branch` with `pr_open` / `approved`).
+
+## Required fields per transition
+
+`warnMissingFields` (in `scripts/adapters/validation.ts`) *warns* (never blocks) when these are
+absent — set them in the **same `update`** that changes status:
+
+| transition | must set |
+|---|---|
+| → `in_progress` | `model` (soft — recommended) |
+| → `pr_open` | `pr` (or `prUrl`) **and** `prCreatedAt` |
+| `pr_open` → `approved` / `merged` | `ciFixAttempts` |
+
+The exact `update --set …` invocations for each transition are in `SKILL.md` (Standard lifecycle).


### PR DESCRIPTION
## Summary

Fixes a latent bug in the GitHub task-store adapter that **orphans tasks** (makes them invisible to `query`/`update`), and hardens the `task-store` skill so the lifecycle is self-documenting and agents stop reaching for the backing store file.

## The bug

`GitHubTaskStore.update()` swaps status labels with a single call:
`gh issue edit --add-label status:<new> --remove-label status:<old>`. When **new === old** (re-applying the current status — e.g. updating a `pr_open` task to `pr_open` to set `pr`), gh adds and removes the *same* label in one invocation and nets to a **removal**. The issue is left with no `status:*` label; `fetchAllIssues` filters by that label, so the task is no longer enumerable → `query --id` returns `[]` and `update` throws `task not found`. Recovery required manually re-adding the label.

The prior guard only skipped `--remove-label` when there was *no* prior label (`_labelStatus === undefined`); it didn't handle `_labelStatus === newStatus`. Hit live while moving SWD-2.2 (vitals-os#1509) onto a `pr_open` record.

## Fix

Skip `--remove-label` when `_labelStatus === newStatus` (re-adding an already-present label is an idempotent no-op). Regression test added asserting a same-status update emits `--add-label` without a paired same-label `--remove-label`.

## Docs / skill

- **`references/task-schema.md`** — adds the canonical, backend-agnostic Task schema (every field + per-status required fields), restoring the previously-dangling reference link.
- **Self-sufficient lifecycle** — the skill now documents the label↔body model, the orphan gotcha + recovery, and every status transition, and is marked the canonical reference (no need to read `dev-task.md`).
- **"CLI is the only interface"** — reframed positively to steer agents off the backing store, *without* naming the store file (so it doesn't reinforce the file-reaching tendency it discourages). Dropped the "todos" concept (→ "task" / "task schema").

## Test Plan
- [x] `bun test github.unit.test.ts` → 75 pass (incl. new regression test)
- [x] `biome lint` + `tsc --noEmit` clean

Version bump handled by semantic-release (`fix:` → patch / 4.27.3).