### PR TITLE
fix(admin): correct Metrics toolbar link default from /sw/dashboard to /dashboard

### DIFF
--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -280,6 +280,6 @@ export function renderAdminToolbar(userName: string, activePath = ""): string {
     userName,
     activePath,
     logoutAction: "/admin/logout",
-    metricsUrl: process.env.METRICS_DASHBOARD_URL ?? "/sw/dashboard",
+    metricsUrl: process.env.METRICS_DASHBOARD_URL ?? "/dashboard",
   });
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,6 +136,7 @@ Provide either the GitHub App vars (recommended) or `GH_TOKEN` (PAT). App auth i
 | `SHIPWRIGHT_ENCRYPTION_KEY` | `string` | — | 64-char hex (32 bytes) for AES-256-GCM encryption of secrets at rest. **If unset, secrets are stored in plain text** — always set this in any real deployment. |
 | `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` | `string` | — | Comma-separated list of Google email addresses permitted to log in to the admin UI. |
 | `SHIPWRIGHT_ADMIN_APP_BASE_URL` | `string` | `http://localhost:{PORT}` | Public base URL of the admin service, used to construct the Google OAuth redirect URI. |
+| `METRICS_DASHBOARD_URL` | `string` | `/dashboard` | URL for the "Metrics" toolbar link in the admin UI. Defaults to `/dashboard` (same-host relative path, suitable when the ingress routes `/dashboard` to the metrics service on the same public hostname). Set to an absolute URL when the metrics service runs on a different host or port (e.g. in local dev: `http://localhost:3460/dashboard`). |
 | `GOOGLE_CLIENT_ID` | `string` | — | Google OAuth 2.0 client ID. Required for the admin UI login flow. |
 | `GOOGLE_CLIENT_SECRET` | `string` | — | Google OAuth 2.0 client secret. Required for the admin UI login flow. |
 

--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -9,7 +9,7 @@ export interface ShipwrightToolbarOptions {
   activePath: string;
   /** Form action for the sign-out button (differs per service). */
   logoutAction: string;
-  /** Full URL of the metrics dashboard. Defaults to "/sw/dashboard". */
+  /** Full URL of the metrics dashboard. Defaults to "/dashboard". */
   metricsUrl?: string;
   /** Base URL of the admin service. Defaults to empty string (same origin). */
   adminBaseUrl?: string;

--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -128,7 +128,7 @@ export function renderShipwrightToolbar(
   opts: ShipwrightToolbarOptions,
 ): string {
   const { userName, activePath, logoutAction } = opts;
-  const metricsUrl = opts.metricsUrl ?? "/sw/dashboard";
+  const metricsUrl = opts.metricsUrl ?? "/dashboard";
   const adminBase = opts.adminBaseUrl ?? "";
   const active = (prefix: string) =>
     activePath.startsWith(prefix) ? " active" : "";

--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -176,8 +176,8 @@ export const STACK_PANES: Pane[] = [
       SHIPWRIGHT_ADMIN_API_KEYS: `dev-agent:${DUMMY_AGENT_API_KEY}:dev-agent`,
       ADMIN_DEV_AUTH: "true",
       // Point the admin toolbar's "Metrics" link at the running metrics
-      // dashboard (:3460). Without this it falls back to /sw/dashboard on the
-      // admin host (:3001) and 404s.
+      // dashboard (:3460). Without this it uses the same-host relative /dashboard,
+      // which in dev points to :3001 instead of the metrics service on :3460.
       METRICS_DASHBOARD_URL: `http://localhost:${METRICS_PORT}/dashboard`,
     },
   },

--- a/scripts/dev-tmux.unit.test.ts
+++ b/scripts/dev-tmux.unit.test.ts
@@ -473,8 +473,8 @@ describe("admin pane — dev auth", () => {
   });
 
   test("admin pane points the toolbar Metrics link at the running metrics dashboard", () => {
-    // Without this the toolbar's Metrics link falls back to /sw/dashboard on the
-    // admin host (:3001), which 404s — the dashboard actually lives on :3460.
+    // Without this the toolbar's Metrics link uses the same-host relative /dashboard,
+    // which in dev points to :3001 instead of the metrics service on :3460.
     const admin = STACK_PANES.find((p) => p.label === "admin") as Pane;
     expect(admin.env?.METRICS_DASHBOARD_URL).toBe(
       `http://localhost:${METRICS_PORT}/dashboard`,


### PR DESCRIPTION
## Summary

- The admin toolbar's **Metrics** link was using `/sw/dashboard` as its default — a path that doesn't exist. The metrics service serves at `/dashboard` on the same public host.
- Fixed the default in both `renderAdminToolbar()` (`admin/src/admin-ui-styles.ts`) and the shared `renderShipwrightToolbar()` (`lib/web/toolbar.ts`).
- Documented `METRICS_DASHBOARD_URL` in `docs/configuration.md` — same-host deployments need no change; set it to an absolute URL when the metrics service is on a different host/port (as in local dev via `task stack`, which already sets `http://localhost:3460/dashboard`).

## No new env var needed for production

The umbrella chart (`infra/helm/shipwright-deploy`) does **not** need a new value. The default `/dashboard` resolves correctly on the shared ingress host. The existing `METRICS_DASHBOARD_URL` override remains available if ever needed.

## Test plan

- [x] Existing `dev-tmux.unit.test.ts` (63 tests) passes — verifies local dev still gets the correct absolute URL override
- [x] No changes to metrics service asset paths (`/sw/dashboard/styles.css`, `/sw/dashboard/app.js`) — those are internal and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)