### PR TITLE
feat(chart): admin.encryptionKeys, appBaseUrl/extraEnv, and GKE HealthCheckPolicy knobs

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,15 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.1.0]
+
+### Added
+
+- `admin.encryptionKeys` block: source `SHIPWRIGHT_ENCRYPTION_KEY` and `SHIPWRIGHT_SESSION_SECRET` from a pre-existing Secret instead of generating random values on a fresh namespace install. Set `admin.encryptionKeys.existingSecret` to the Secret name; `encryptionKeyRef` and `sessionSecretRef` select the keys within it (default to the env var names). When set, the chart-managed Secret omits these two keys entirely and the Deployment injects them via `secretKeyRef` against the caller-managed Secret. Default is empty — existing generate-on-install / reuse-on-upgrade behaviour is unchanged.
+- `admin.appBaseUrl`: sets `SHIPWRIGHT_ADMIN_APP_BASE_URL` in the admin container env when non-empty. Required when the admin service is behind a Gateway or Ingress so that OAuth redirect URIs reference the real public host rather than `localhost:3001`. Omitted from the env when left empty (default).
+- `admin.extraEnv`: list of Kubernetes `envVar` objects appended to the admin container env. Provides a generic passthrough for env vars not otherwise covered by chart values. Defaults to `[]` (no extra vars).
+- `networking.gateway.healthCheckPolicy.enabled`: when `true` and `networking.type=gateway`, renders a `networking.gke.io/v1 HealthCheckPolicy` for the admin Service and (when `metrics.enabled=true`) a second one for the metrics Service, both probing `/health` with 15 s interval / 5 s timeout / 1 healthy / 2 unhealthy thresholds. Without this the GKE Gateway controller default-probes `"/"` (both services → 404) and marks the backends UNHEALTHY, returning 503 on the external host. Disabled by default (`false`) so non-GKE Gateway installs are unaffected.
+
 ## [1.0.0]
 
 _First publicly published chart version. New features in this release: externalDatabase and cloudSqlProxy (SWD-1.x). Gateway API networking, cert-manager Certificate, agent-provisioning RBAC, and metrics.provider were shipped in 0.9.0/0.9.1._

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.0.0
+version: 1.1.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,9 +29,13 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "externalDatabase block: bring-your-own Postgres for the admin service (externalDatabase.existingSecret + adminUrlKey). Used when postgresql.enabled=false; the admin Deployment injects DATABASE_URL_SHIPWRIGHT_ADMIN from a user-managed Secret. Default off (existingSecret empty)."
+      description: "admin.encryptionKeys.existingSecret: source SHIPWRIGHT_ENCRYPTION_KEY and SHIPWRIGHT_SESSION_SECRET from a caller-managed Secret instead of generating random values on fresh namespace installs. The chart-managed Secret omits these keys when the knob is set; the Deployment references the external Secret via secretKeyRef. Fixes installs where generated random keys cannot decrypt existing encrypted-at-rest agent env."
     - kind: added
-      description: "cloudSqlProxy block: optional cloud-sql-proxy v2 sidecar for the admin pod. Renders only when cloudSqlProxy.enabled=true; defaults: image gcr.io/cloud-sql-connectors/cloud-sql-proxy:2, --private-ip + connectionName args, runAsNonRoot. Default off."
+      description: "admin.appBaseUrl: sets SHIPWRIGHT_ADMIN_APP_BASE_URL so OAuth redirect URIs use the real hostname instead of localhost:3001 when the admin is behind a Gateway or Ingress."
+    - kind: added
+      description: "admin.extraEnv: list of Kubernetes envVar objects appended to the admin container, providing a generic env passthrough for values not otherwise covered by chart knobs."
+    - kind: added
+      description: "networking.gateway.healthCheckPolicy.enabled: when true and networking.type=gateway, renders networking.gke.io/v1 HealthCheckPolicy resources for the admin and metrics Services probing /health. Fixes GKE Gateway deployments where the default probe to / (both services 404) marks backends UNHEALTHY and returns 503 externally. Disabled by default."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -78,6 +78,21 @@ spec:
                   name: {{ .Values.externalDatabase.existingSecret }}
                   key: {{ .Values.externalDatabase.adminUrlKey | default "DATABASE_URL_SHIPWRIGHT_ADMIN" }}
             {{- end }}
+            {{- if .Values.admin.encryptionKeys.existingSecret }}
+            # admin.encryptionKeys.existingSecret: source these two keys from a
+            # caller-managed Secret so they survive across fresh namespace installs
+            # without generating random values that can't decrypt existing data.
+            - name: SHIPWRIGHT_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.admin.encryptionKeys.existingSecret }}
+                  key: {{ .Values.admin.encryptionKeys.sessionSecretRef | default "SHIPWRIGHT_SESSION_SECRET" }}
+            - name: SHIPWRIGHT_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.admin.encryptionKeys.existingSecret }}
+                  key: {{ .Values.admin.encryptionKeys.encryptionKeyRef | default "SHIPWRIGHT_ENCRYPTION_KEY" }}
+            {{- else }}
             - name: SHIPWRIGHT_SESSION_SECRET
               valueFrom:
                 secretKeyRef:
@@ -88,6 +103,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "shipwright.admin.secretName" . }}
                   key: SHIPWRIGHT_ENCRYPTION_KEY
+            {{- end }}
+            {{- if .Values.admin.appBaseUrl }}
+            # admin.appBaseUrl: public host for OAuth redirect URIs so they use
+            # the real hostname instead of localhost:3001 behind a Gateway.
+            - name: SHIPWRIGHT_ADMIN_APP_BASE_URL
+              value: {{ .Values.admin.appBaseUrl | quote }}
+            {{- end }}
             {{- if or (eq .Values.auth.mode "open") (eq .Values.auth.mode "none") }}
             # auth.mode=open (or deprecated alias "none") — dev auth, NO OAuth.
             # Insecure: do not expose publicly. NODE_ENV is intentionally NOT set
@@ -148,6 +170,11 @@ spec:
             - name: SHIPWRIGHT_ADMIN_DEPLOYMENT_UID
               value: {{ . | quote }}
             {{- end }}
+            {{- end }}
+            {{- with .Values.admin.extraEnv }}
+            # admin.extraEnv: caller-supplied env vars appended last so they can
+            # override anything above if needed.
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.admin.resources }}
           resources:

--- a/charts/shipwright/templates/admin-secret.yaml
+++ b/charts/shipwright/templates/admin-secret.yaml
@@ -2,21 +2,28 @@
 {{- /*
   Chart-managed admin Secret.
 
-  Holds the admin session/encryption keys, and — when the bundled PostgreSQL
-  subchart is enabled — the fully-assembled DATABASE_URL_SHIPWRIGHT_ADMIN so the
-  Postgres password never appears in plaintext Deployment env.
+  Holds the admin session/encryption keys (unless admin.encryptionKeys.existingSecret
+  is set — then the Deployment references that external Secret directly and those keys
+  are omitted here), and — when the bundled PostgreSQL subchart is enabled — the
+  fully-assembled DATABASE_URL_SHIPWRIGHT_ADMIN so the Postgres password never appears
+  in plaintext Deployment env.
 
-  Persistence idiom (survives `helm upgrade`): look up the already-installed
-  Secret and reuse its (already base64-encoded) values; only generate fresh
-  random material on first install. NOTE: `helm template` and helm-unittest do
-  NOT execute `lookup`, so they always take the generate branch — that is
-  expected. On a live install/upgrade the lookup finds the prior Secret and the
-  generated values stay stable.
+  Persistence idiom for chart-generated keys (survives `helm upgrade`): look up the
+  already-installed Secret and reuse its (already base64-encoded) values; only generate
+  fresh random material on first install. NOTE: `helm template` and helm-unittest do NOT
+  execute `lookup`, so they always take the generate branch — that is expected. On a
+  live install/upgrade the lookup finds the prior Secret and the generated values stay
+  stable.
+
+  When admin.encryptionKeys.existingSecret is set the generate/lookup path is skipped
+  entirely and no key material is written here — the Deployment uses secretKeyRef
+  against the caller-managed Secret for those two vars.
 */}}
 {{- $secretName := include "shipwright.admin.secretName" . }}
 {{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 {{- $sessionSecret := "" }}
 {{- $encryptionKey := "" }}
+{{- if not .Values.admin.encryptionKeys.existingSecret }}
 {{- if and $existing $existing.data (index $existing.data "SHIPWRIGHT_SESSION_SECRET") }}
 {{- $sessionSecret = index $existing.data "SHIPWRIGHT_SESSION_SECRET" }}
 {{- else }}
@@ -27,6 +34,7 @@
 {{- else }}
 {{- $encryptionKey = (randAlphaNum 32 | b64enc) }}
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -35,9 +43,13 @@ metadata:
     {{- include "shipwright.admin.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if not .Values.admin.encryptionKeys.existingSecret }}
   # Generated on first install, reused on upgrade via the lookup idiom above.
+  # Omitted when admin.encryptionKeys.existingSecret is set — the Deployment
+  # sources these vars from the caller-managed Secret instead.
   SHIPWRIGHT_SESSION_SECRET: {{ $sessionSecret | quote }}
   SHIPWRIGHT_ENCRYPTION_KEY: {{ $encryptionKey | quote }}
+{{- end }}
 {{- if .Values.postgresql.enabled }}
   {{- /*
     Assemble DATABASE_URL_SHIPWRIGHT_ADMIN here so the Postgres password is not

--- a/charts/shipwright/templates/healthcheckpolicy.yaml
+++ b/charts/shipwright/templates/healthcheckpolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and (eq .Values.networking.type "gateway") .Values.networking.gateway.healthCheckPolicy.enabled }}
+{{- /*
+  GKE HealthCheckPolicies for the admin and metrics Services.
+
+  The GKE Gateway controller default-probes "/" — both services return 404 there —
+  and marks each backend UNHEALTHY, returning 503 on the external host. These
+  policies steer the probe to /health (both services respond 200) and fix that.
+
+  Only rendered when:
+    networking.type=gateway           (GKE Gateway API path)
+    networking.gateway.healthCheckPolicy.enabled=true   (opt-in; off by default)
+
+  The networking.gke.io/v1 API is GKE-specific. Do not enable this on other
+  Gateway controllers (Istio, Cilium, etc.) that don't support it.
+*/}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "shipwright.admin.fullname" . }}
+  labels:
+    {{- include "shipwright.admin.labels" . | nindent 4 }}
+spec:
+  default:
+    checkIntervalSec: 15
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 2
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /health
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "shipwright.admin.fullname" . }}
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "shipwright.metrics.fullname" . }}
+  labels:
+    {{- include "shipwright.metrics.labels" . | nindent 4 }}
+spec:
+  default:
+    checkIntervalSec: 15
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 2
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /health
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "shipwright.metrics.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/shipwright/tests/admin_secret_test.yaml
+++ b/charts/shipwright/tests/admin_secret_test.yaml
@@ -35,6 +35,17 @@ tests:
       - isNotEmpty:
           path: data.SHIPWRIGHT_ENCRYPTION_KEY
 
+  - it: omits SHIPWRIGHT_SESSION_SECRET and SHIPWRIGHT_ENCRYPTION_KEY when encryptionKeys.existingSecret is set
+    set:
+      admin.encryptionKeys.existingSecret: my-keys-secret
+      admin.encryptionKeys.encryptionKeyRef: SHIPWRIGHT_ENCRYPTION_KEY
+      admin.encryptionKeys.sessionSecretRef: SHIPWRIGHT_SESSION_SECRET
+    asserts:
+      - notExists:
+          path: data.SHIPWRIGHT_SESSION_SECRET
+      - notExists:
+          path: data.SHIPWRIGHT_ENCRYPTION_KEY
+
   - it: assembles DATABASE_URL_SHIPWRIGHT_ADMIN into the Secret when postgresql is enabled
     set:
       postgresql.enabled: true

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -91,6 +91,115 @@ tests:
     release:
       name: r
 
+  # ── admin.encryptionKeys.existingSecret ──────────────────────────────────
+
+  - it: sources SHIPWRIGHT_SESSION_SECRET and SHIPWRIGHT_ENCRYPTION_KEY from existingSecret when set
+    template: templates/admin-deployment.yaml
+    set:
+      admin.encryptionKeys.existingSecret: my-keys-secret
+      admin.encryptionKeys.encryptionKeyRef: SHIPWRIGHT_ENCRYPTION_KEY
+      admin.encryptionKeys.sessionSecretRef: SHIPWRIGHT_SESSION_SECRET
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-keys-secret
+                key: SHIPWRIGHT_SESSION_SECRET
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-keys-secret
+                key: SHIPWRIGHT_ENCRYPTION_KEY
+
+  - it: sources session+encryption keys from the chart-managed Secret by default (no existingSecret)
+    template: templates/admin-deployment.yaml
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: SHIPWRIGHT_SESSION_SECRET
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: SHIPWRIGHT_ENCRYPTION_KEY
+
+  # ── admin.appBaseUrl ──────────────────────────────────────────────────────
+
+  - it: injects SHIPWRIGHT_ADMIN_APP_BASE_URL when admin.appBaseUrl is set
+    template: templates/admin-deployment.yaml
+    set:
+      admin.appBaseUrl: "https://shipwright.example.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_APP_BASE_URL
+            value: "https://shipwright.example.com"
+
+  - it: omits SHIPWRIGHT_ADMIN_APP_BASE_URL when admin.appBaseUrl is empty (default)
+    template: templates/admin-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_APP_BASE_URL
+
+  # ── admin.extraEnv ────────────────────────────────────────────────────────
+
+  - it: appends admin.extraEnv entries to the container env
+    template: templates/admin-deployment.yaml
+    set:
+      admin.extraEnv:
+        - name: MY_CUSTOM_VAR
+          value: "hello"
+        - name: FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: MY_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_CUSTOM_VAR
+            value: "hello"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FROM_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: MY_KEY
+
+  - it: renders no extra env vars when admin.extraEnv is empty (default)
+    template: templates/admin-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_CUSTOM_VAR
+
+  # ── service / serviceaccount ──────────────────────────────────────────────
+
   - it: renders the admin Service (ClusterIP) mapping the service port to targetPort 3001
     template: templates/admin-service.yaml
     asserts:

--- a/charts/shipwright/tests/healthcheckpolicy_test.yaml
+++ b/charts/shipwright/tests/healthcheckpolicy_test.yaml
@@ -1,0 +1,116 @@
+suite: GKE HealthCheckPolicy (networking.gke.io/v1)
+# HK-1.3: render HealthCheckPolicy resources for the admin and metrics Services
+# when networking.type=gateway AND networking.gateway.healthCheckPolicy.enabled=true.
+# Without these the GKE Gateway default-probes "/" (both services 404) and returns
+# 503 externally. Disabled by default so non-GKE installs are unaffected.
+templates:
+  - templates/healthcheckpolicy.yaml
+release:
+  name: r
+  namespace: shipwright
+tests:
+  - it: renders NO HealthCheckPolicy by default (disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders NO HealthCheckPolicy when networking.type=gateway but healthCheckPolicy.enabled=false
+    set:
+      networking.type: gateway
+      networking.gateway.healthCheckPolicy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders NO HealthCheckPolicy when healthCheckPolicy.enabled=true but networking.type is not gateway
+    set:
+      networking.type: ClusterIP
+      networking.gateway.healthCheckPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders admin + metrics HealthCheckPolicies when gateway + enabled
+    set:
+      networking.type: gateway
+      networking.gateway.healthCheckPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      # First doc: admin HealthCheckPolicy
+      - isAPIVersion:
+          of: networking.gke.io/v1
+        documentIndex: 0
+      - isKind:
+          of: HealthCheckPolicy
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: r-shipwright-admin
+        documentIndex: 0
+      - equal:
+          path: spec.default.config.type
+          value: HTTP
+        documentIndex: 0
+      - equal:
+          path: spec.default.config.httpHealthCheck.requestPath
+          value: /health
+        documentIndex: 0
+      - equal:
+          path: spec.targetRef.kind
+          value: Service
+        documentIndex: 0
+      - equal:
+          path: spec.targetRef.name
+          value: r-shipwright-admin
+        documentIndex: 0
+      # Second doc: metrics HealthCheckPolicy
+      - isAPIVersion:
+          of: networking.gke.io/v1
+        documentIndex: 1
+      - isKind:
+          of: HealthCheckPolicy
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: r-shipwright-metrics
+        documentIndex: 1
+      - equal:
+          path: spec.default.config.httpHealthCheck.requestPath
+          value: /health
+        documentIndex: 1
+      - equal:
+          path: spec.targetRef.name
+          value: r-shipwright-metrics
+        documentIndex: 1
+
+  - it: renders only the admin HealthCheckPolicy when metrics is disabled
+    set:
+      networking.type: gateway
+      networking.gateway.healthCheckPolicy.enabled: true
+      metrics.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: r-shipwright-admin
+
+  - it: probe params are 15s interval, 5s timeout, 1 healthy threshold, 2 unhealthy threshold
+    set:
+      networking.type: gateway
+      networking.gateway.healthCheckPolicy.enabled: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.default.checkIntervalSec
+          value: 15
+      - equal:
+          path: spec.default.timeoutSec
+          value: 5
+      - equal:
+          path: spec.default.healthyThreshold
+          value: 1
+      - equal:
+          path: spec.default.unhealthyThreshold
+          value: 2

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 1\.0\.0, app version 0\.1\.0
+          pattern: chart version 1\.1\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -45,7 +45,14 @@
           "properties": {
             "gatewayClassName": { "type": "string" },
             "host": { "type": "string" },
-            "annotations": { "type": "object" }
+            "annotations": { "type": "object" },
+            "healthCheckPolicy": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            }
           }
         }
       },
@@ -99,7 +106,47 @@
         "name": { "type": "string" }
       }
     },
-    "admin": { "$ref": "#/definitions/service" },
+    "admin": {
+      "allOf": [
+        { "$ref": "#/definitions/service" },
+        {
+          "type": "object",
+          "properties": {
+            "encryptionKeys": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "existingSecret":   { "type": "string" },
+                "encryptionKeyRef": { "type": "string" },
+                "sessionSecretRef": { "type": "string" }
+              },
+              "if": {
+                "properties": { "existingSecret": { "type": "string", "minLength": 1 } },
+                "required": ["existingSecret"]
+              },
+              "then": {
+                "properties": {
+                  "encryptionKeyRef": { "type": "string", "minLength": 1 },
+                  "sessionSecretRef": { "type": "string", "minLength": 1 }
+                },
+                "required": ["encryptionKeyRef", "sessionSecretRef"]
+              }
+            },
+            "appBaseUrl": { "type": "string" },
+            "extraEnv": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
     "metrics": {
       "allOf": [
         { "$ref": "#/definitions/service" },

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -60,6 +60,13 @@ networking:
     host: shipwright.local
     # -- Extra annotations for the Gateway (controller-specific).
     annotations: {}
+    # -- GKE HealthCheckPolicy. When enabled, renders a networking.gke.io/v1
+    # HealthCheckPolicy for the admin and metrics Services so the GKE load
+    # balancer probes /health instead of the default "/". Without this, both
+    # services answer "/" with 404 and the backend is marked UNHEALTHY (external
+    # 503). Only applies when networking.type=gateway.
+    healthCheckPolicy:
+      enabled: false
 
 # -- TLS / certificate management for the gateway/ingress host.
 tls:
@@ -118,6 +125,29 @@ admin:
     annotations: {}
     # -- Name of the admin ServiceAccount. Generated if empty and create=true.
     name: ""
+  # -- Stable encryption and session keys via an existing Secret.
+  # When existingSecret is non-empty, SHIPWRIGHT_ENCRYPTION_KEY and
+  # SHIPWRIGHT_SESSION_SECRET are sourced from that pre-existing Secret instead
+  # of being generated/reused by the chart. Set this on fresh namespace installs
+  # where those keys must match previously-encrypted data — a fresh install
+  # without this generates random keys that cannot decrypt existing agent env
+  # (caused the 2026-06-16 prod outage). Leave empty to use the chart-managed
+  # Secret (generate on first install, reuse on upgrade via lookup).
+  encryptionKeys:
+    existingSecret: ""
+    # -- Key in existingSecret that holds SHIPWRIGHT_ENCRYPTION_KEY.
+    encryptionKeyRef: SHIPWRIGHT_ENCRYPTION_KEY
+    # -- Key in existingSecret that holds SHIPWRIGHT_SESSION_SECRET.
+    sessionSecretRef: SHIPWRIGHT_SESSION_SECRET
+  # -- Public base URL for the admin service (sets SHIPWRIGHT_ADMIN_APP_BASE_URL).
+  # Required when the admin service is behind a Gateway or Ingress so that OAuth
+  # redirect URIs use the public host instead of localhost:3001. Leave empty to
+  # omit the env var.
+  appBaseUrl: ""
+  # -- Extra environment variables injected into the admin container.
+  # List of Kubernetes envVar objects (name/value or name/valueFrom). Use for
+  # env vars not otherwise covered by chart values.
+  extraEnv: []
 
 # -- Metrics dashboard (@shipwright/metrics) — event-store-backed service. Port 3460.
 # In postgres mode it reads/writes an `events` table in the bundled PostgreSQL and


### PR DESCRIPTION
## Summary

Three chart knobs that retire the post-deploy hacks added in **app-vitals/vitals-os#1523** after the 2026-06-16 prod outage. Each section below describes the gap, the vitals-os workaround that currently compensates, and the new chart value that replaces it.

---

### 1. `admin.encryptionKeys.existingSecret` — stable encryption/session keys across installs

**Gap:** The chart's `admin-secret.yaml` only reuse-or-generates `SHIPWRIGHT_ENCRYPTION_KEY` and `SHIPWRIGHT_SESSION_SECRET` — there is no way to inject pre-existing values. A fresh namespace install mints random keys that cannot decrypt agent env already stored encrypted-at-rest, causing uniform `invalid_auth` on every agent.

**vitals-os workaround (retire this):** The "Pin shipwright-admin encryption keys" step in `.github/workflows/deploy.yml` — fetches both keys from GCP Secret Manager, compares to live values in the `shipwright-admin` Secret, and patches + restarts the admin Deployment when they differ.

**New knob:**
```yaml
admin:
  encryptionKeys:
    existingSecret: shipwright-secrets          # pre-existing Secret name
    encryptionKeyRef: SHIPWRIGHT_ENCRYPTION_KEY # key within that Secret
    sessionSecretRef: SHIPWRIGHT_SESSION_SECRET  # key within that Secret
```
When set, the chart-managed Secret **omits** these keys entirely, and the Deployment sources them via `secretKeyRef` against the caller-managed Secret. Default is empty (existing behaviour: chart generates/reuses via lookup).

---

### 2. `admin.appBaseUrl` + `admin.extraEnv` — public base URL and env passthrough

**Gap:** The admin container has no way to receive `SHIPWRIGHT_ADMIN_APP_BASE_URL` or other arbitrary env vars from chart values. Without the public base URL, OAuth redirect URIs use `localhost:3001` and login fails behind the GKE Gateway.

**vitals-os workaround (retire this):** The "Set shipwright-admin public base URL" step in `.github/workflows/deploy.yml` — runs `kubectl set env` after every install to inject `SHIPWRIGHT_ADMIN_APP_BASE_URL` and then waits for rollout.

**New knobs:**
```yaml
admin:
  appBaseUrl: "https://shipwright.vitals-os.com"  # sets SHIPWRIGHT_ADMIN_APP_BASE_URL
  extraEnv: []                                      # arbitrary envVar objects
```
`extraEnv` is appended last in the container env list, so it can override earlier entries if needed.

---

### 3. `networking.gateway.healthCheckPolicy.enabled` — GKE HealthCheckPolicy for /health

**Gap:** The chart renders no `networking.gke.io/v1 HealthCheckPolicy`. The GKE Gateway controller default-probes `"/"` — both the admin and metrics services return 404 there — and marks the backends UNHEALTHY, returning 503 on the external host.

**vitals-os workaround (retire this):** `infra/helm/shipwright-deploy/templates/healthcheckpolicy.yaml` in the vitals-os umbrella chart — a separate template that creates HealthCheckPolicies for both services, targeting `/health`.

**New knob:**
```yaml
networking:
  type: gateway
  gateway:
    healthCheckPolicy:
      enabled: true   # default: false
```
When `networking.type=gateway` AND `enabled=true`, renders `networking.gke.io/v1 HealthCheckPolicy` resources for the admin Service (and metrics if `metrics.enabled=true`), probing `/health` with 15s interval / 5s timeout / 1-healthy / 2-unhealthy thresholds. Disabled by default so non-GKE Gateway installs are unaffected.

---

## Validation

- `helm lint` — clean (0 failures)
- `helm template` — verified all three new knobs render correctly
- New helm-unittest tests added: `admin_secret_test.yaml` (existingSecret omits keys), `admin_workload_test.yaml` (secretKeyRef, appBaseUrl, extraEnv), `healthcheckpolicy_test.yaml` (new file, 6 cases)

## Test plan

- [ ] `helm lint charts/shipwright` passes
- [ ] `helm unittest charts/shipwright` passes (once runner has the plugin)
- [ ] `helm template` with `admin.encryptionKeys.existingSecret` set: admin-secret has no SESSION/ENCRYPTION keys; Deployment uses the external secret refs
- [ ] `helm template` with `admin.appBaseUrl` set: `SHIPWRIGHT_ADMIN_APP_BASE_URL` appears in the Deployment env
- [ ] `helm template` with `networking.type=gateway` + `healthCheckPolicy.enabled=true`: two HealthCheckPolicies rendered with `/health` probe path
- [ ] After merging: update `app-vitals/vitals-os` to set these three knobs in `values-prod.yaml` and remove the three workaround steps from `deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)