### PR TITLE
feat(chart): auth.google.existingSecret — source Google OAuth creds from external Secret (1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-16
+
+### Chart — What's New
+
+#### Helm Chart (`charts/shipwright`)
+
+- **Google OAuth bring-your-own Secret** (`auth.google.existingSecret`): source `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` from a caller-managed Secret instead of inline Helm values. The chart-managed admin Secret omits these keys when the knob is set; the Deployment sources them via `secretKeyRef`. Allows fully secret-free helm installs when combined with `admin.encryptionKeys.existingSecret`.
+
 ## [chart-1.0.0] - 2026-06-14
 
 ### Chart — What's New

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.1.0
+version: 1.2.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,13 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "admin.encryptionKeys.existingSecret: source SHIPWRIGHT_ENCRYPTION_KEY and SHIPWRIGHT_SESSION_SECRET from a caller-managed Secret instead of generating random values on fresh namespace installs. The chart-managed Secret omits these keys when the knob is set; the Deployment references the external Secret via secretKeyRef. Fixes installs where generated random keys cannot decrypt existing encrypted-at-rest agent env."
-    - kind: added
-      description: "admin.appBaseUrl: sets SHIPWRIGHT_ADMIN_APP_BASE_URL so OAuth redirect URIs use the real hostname instead of localhost:3001 when the admin is behind a Gateway or Ingress."
-    - kind: added
-      description: "admin.extraEnv: list of Kubernetes envVar objects appended to the admin container, providing a generic env passthrough for values not otherwise covered by chart knobs."
-    - kind: added
-      description: "networking.gateway.healthCheckPolicy.enabled: when true and networking.type=gateway, renders networking.gke.io/v1 HealthCheckPolicy resources for the admin and metrics Services probing /health. Fixes GKE Gateway deployments where the default probe to / (both services 404) marks backends UNHEALTHY and returns 503 externally. Disabled by default."
+      description: "auth.google.existingSecret: source GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and SHIPWRIGHT_ADMIN_ALLOWED_EMAILS from a caller-managed Secret instead of inline Helm values. The chart-managed admin Secret omits these keys when the knob is set; the Deployment sources them via secretKeyRef. Allows fully secret-free helm installs when combined with admin.encryptionKeys.existingSecret."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -120,6 +120,24 @@ spec:
             # auth.mode=google — real Google OAuth. Production hardening on.
             - name: NODE_ENV
               value: "production"
+            {{- if .Values.auth.google.existingSecret }}
+            # auth.google.existingSecret: source all three OAuth vars from caller-managed Secret.
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.google.existingSecret }}
+                  key: {{ .Values.auth.google.clientIdRef | default "GOOGLE_CLIENT_ID" }}
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.google.existingSecret }}
+                  key: {{ .Values.auth.google.clientSecretRef | default "GOOGLE_CLIENT_SECRET" }}
+            - name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.google.existingSecret }}
+                  key: {{ .Values.auth.google.allowedEmailsRef | default "SHIPWRIGHT_ADMIN_ALLOWED_EMAILS" }}
+            {{- else }}
             - name: GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -132,6 +150,7 @@ spec:
                   key: GOOGLE_CLIENT_SECRET
             - name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
               value: {{ .Values.auth.google.allowedEmails | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.agent.provisioning.enabled }}
             # ── Agent-provisioning env contract (HD-4.2) ──────────────────────

--- a/charts/shipwright/templates/admin-secret.yaml
+++ b/charts/shipwright/templates/admin-secret.yaml
@@ -79,8 +79,9 @@ data:
   {{- $dbUrl := printf "postgresql://%s:%s@%s:5432/%s" $pgUser $pgPassword $pgHost $pgDb }}
   DATABASE_URL_SHIPWRIGHT_ADMIN: {{ $dbUrl | b64enc | quote }}
 {{- end }}
-{{- if eq .Values.auth.mode "google" }}
-  {{- /* Google OAuth client credentials kept in the Secret, not Deployment env. */}}
+{{- if and (eq .Values.auth.mode "google") (not .Values.auth.google.existingSecret) }}
+  {{- /* Google OAuth client credentials — omitted when auth.google.existingSecret is set
+       (the Deployment sources them from the caller-managed Secret via secretKeyRef). */}}
   GOOGLE_CLIENT_ID: {{ .Values.auth.google.clientId | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.auth.google.clientSecret | b64enc | quote }}
 {{- end }}

--- a/charts/shipwright/tests/admin_secret_test.yaml
+++ b/charts/shipwright/tests/admin_secret_test.yaml
@@ -92,3 +92,16 @@ tests:
           path: data.GOOGLE_CLIENT_ID
       - notExists:
           path: data.GOOGLE_CLIENT_SECRET
+
+  - it: omits GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET when auth.google.existingSecret is set
+    set:
+      auth.mode: google
+      auth.google.existingSecret: my-google-secret
+      auth.google.clientIdRef: GOOGLE_CLIENT_ID
+      auth.google.clientSecretRef: GOOGLE_CLIENT_SECRET
+      auth.google.allowedEmailsRef: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+    asserts:
+      - notExists:
+          path: data.GOOGLE_CLIENT_ID
+      - notExists:
+          path: data.GOOGLE_CLIENT_SECRET

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -141,6 +141,76 @@ tests:
                 name: r-shipwright-admin
                 key: SHIPWRIGHT_ENCRYPTION_KEY
 
+  # ── auth.google.existingSecret ───────────────────────────────────────────
+
+  - it: sources GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and SHIPWRIGHT_ADMIN_ALLOWED_EMAILS from existingSecret when set
+    template: templates/admin-deployment.yaml
+    set:
+      auth.mode: google
+      auth.google.existingSecret: my-google-secret
+      auth.google.clientIdRef: GOOGLE_CLIENT_ID
+      auth.google.clientSecretRef: GOOGLE_CLIENT_SECRET
+      auth.google.allowedEmailsRef: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-google-secret
+                key: GOOGLE_CLIENT_ID
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-google-secret
+                key: GOOGLE_CLIENT_SECRET
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+            valueFrom:
+              secretKeyRef:
+                name: my-google-secret
+                key: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+
+  - it: sources Google OAuth from the chart-managed Secret by default (no existingSecret)
+    template: templates/admin-deployment.yaml
+    set:
+      auth.mode: google
+      auth.google.clientId: cid
+      auth.google.clientSecret: csec
+      auth.google.allowedEmails: dev@example.com
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: GOOGLE_CLIENT_ID
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: GOOGLE_CLIENT_SECRET
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+            value: "dev@example.com"
+
   # ── admin.appBaseUrl ──────────────────────────────────────────────────────
 
   - it: injects SHIPWRIGHT_ADMIN_APP_BASE_URL when admin.appBaseUrl is set

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 1\.1\.0, app version 0\.1\.0
+          pattern: chart version 1\.2\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -188,3 +188,24 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "key"
+
+  - it: accepts google mode with existingSecret set and empty clientId (existingSecret bypasses inline-field requirement)
+    set:
+      auth.mode: google
+      auth.google.existingSecret: my-google-secret
+      auth.google.clientId: ""
+      auth.google.clientSecret: ""
+      auth.google.allowedEmails: ""
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects google mode with existingSecret empty and empty clientId (existing enforcement still holds)
+    set:
+      auth.mode: google
+      auth.google.existingSecret: ""
+      auth.google.clientId: ""
+      auth.google.clientSecret: csec
+      auth.google.allowedEmails: user@example.com
+    asserts:
+      - failedTemplate:
+          errorPattern: "clientId"

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -281,9 +281,13 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "clientId": { "type": "string" },
-            "clientSecret": { "type": "string" },
-            "allowedEmails": { "type": "string" }
+            "existingSecret":  { "type": "string" },
+            "clientIdRef":     { "type": "string" },
+            "clientSecretRef": { "type": "string" },
+            "allowedEmailsRef":{ "type": "string" },
+            "clientId":        { "type": "string" },
+            "clientSecret":    { "type": "string" },
+            "allowedEmails":   { "type": "string" }
           }
         }
       },
@@ -295,11 +299,18 @@
       "then": {
         "properties": {
           "google": {
-            "required": ["clientId", "clientSecret", "allowedEmails"],
-            "properties": {
-              "clientId":      { "type": "string", "minLength": 1 },
-              "clientSecret":  { "type": "string", "minLength": 1 },
-              "allowedEmails": { "type": "string", "minLength": 1 }
+            "if": {
+              "properties": { "existingSecret": { "type": "string", "minLength": 1 } },
+              "required": ["existingSecret"]
+            },
+            "then": {},
+            "else": {
+              "required": ["clientId", "clientSecret", "allowedEmails"],
+              "properties": {
+                "clientId":      { "type": "string", "minLength": 1 },
+                "clientSecret":  { "type": "string", "minLength": 1 },
+                "allowedEmails": { "type": "string", "minLength": 1 }
+              }
             }
           }
         }

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -301,7 +301,18 @@ auth:
   mode: open
   # -- Google OAuth settings (used only when auth.mode=google).
   google:
-    # -- Google OAuth client ID.
+    # -- Name of an existing Secret holding Google OAuth credentials and the
+    # allowed-emails list. When set, clientId/clientSecret/allowedEmails below
+    # are ignored and the Deployment sources those three vars via secretKeyRef
+    # from this Secret. Leave empty to use the inline values below.
+    existingSecret: ""
+    # -- Key in existingSecret for GOOGLE_CLIENT_ID.
+    clientIdRef: GOOGLE_CLIENT_ID
+    # -- Key in existingSecret for GOOGLE_CLIENT_SECRET.
+    clientSecretRef: GOOGLE_CLIENT_SECRET
+    # -- Key in existingSecret for SHIPWRIGHT_ADMIN_ALLOWED_EMAILS.
+    allowedEmailsRef: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+    # -- Google OAuth client ID (used when existingSecret is empty).
     clientId: ""
     # -- Google OAuth client secret (kept in the chart-managed admin Secret).
     clientSecret: ""


### PR DESCRIPTION
## Summary

- Adds `auth.google.existingSecret` (+ `clientIdRef` / `clientSecretRef` / `allowedEmailsRef`) under `auth.google` in `values.yaml` — mirrors the `admin.encryptionKeys.existingSecret` pattern from #391 exactly
- `admin-secret.yaml`: skips writing `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` when `existingSecret` is set (same as the encryptionKeys path)
- `admin-deployment.yaml`: when `existingSecret` is set, sources all three vars (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`) via `secretKeyRef` from the named Secret; falls back to existing behavior when unset
- `values.schema.json`: the `auth.google` if/then is refactored to allow empty `clientId` / `clientSecret` / `allowedEmails` when `existingSecret` is non-empty — fixes the downstream deploy failure where schema validation rejected empty values
- Tests added for both `existingSecret` set and unset paths in `admin_secret_test.yaml` and `admin_workload_test.yaml`; `metadata_test.yaml` updated for 1.2.0

## Motivation

With this knob, a downstream consumer (e.g. vitals-os) can deploy the admin with **no secret values on the Helm command line** — everything sourced from SecretSync'd Secrets:

```
auth.google.existingSecret: shipwright-secrets   # already materialized via SecretSync
admin.encryptionKeys.existingSecret: shipwright-secrets
admin.appBaseUrl: https://...
```

Combined with `admin.encryptionKeys.existingSecret` from #391, this enables a pure-Helm deploy with zero `gcloud`/`kubectl` post-steps.

## Backward compatibility

When `auth.google.existingSecret` is empty (the default), behavior is identical to 1.1.0. Existing installs require no changes.

## Test plan

- [ ] `helm unittest` passes for all new test cases (admin_secret, admin_workload, metadata)
- [ ] `helm template` with `existingSecret` set renders all three vars as `secretKeyRef` against the named Secret, and the chart-managed admin Secret omits `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`
- [ ] `helm template` with `existingSecret` unset and inline values set behaves identically to 1.1.0
- [ ] `ct lint` passes (version bump 1.1.0 → 1.2.0 included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)