### PR TITLE
fix(deploy): check any self-review for APPROVE, not just the first

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.27.3",
+  "version": "4.27.4",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.27.3
+# Shipwright v4.27.4
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -55,7 +55,7 @@ For each PR, check in order:
    by `AGENT_LOGIN` has a body where `trimStart().startsWith("APPROVE")`:
    ```bash
    gh pr view {pr} --repo {org}/{repo} --json reviews \
-     --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | .body] | first'
+     --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | .body] | any(startswith("APPROVE"))'
    ```
    Skip if neither source shows approval.
 


### PR DESCRIPTION
## Summary

- The deploy scan used `| first` to get a self-review body, so PRs with multiple self-reviews (e.g. a COMMENT finding then an APPROVE) always evaluated the earliest review and silently skipped the PR
- Changed to `| any(startswith("APPROVE"))` — matches the intent already stated in the prose above the command
- Bumps plugin to 4.27.4

## Root cause

PR #1529 (vitals-os) had two self-reviews from the agent: the first was a `COMMENT —` finding, the second was `APPROVE — Both prior findings resolved`. The scan picked the COMMENT, failed the approval check, and skipped the PR at every deploy cron (5pm and 5:30pm PDT on Jun 16).

## Test plan
- [ ] Deploy cron picks up vitals-os #1529 after this ships
- [ ] PRs with a single APPROVE review continue to deploy normally
- [ ] PRs with only COMMENT reviews are still skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)