### PR TITLE
fix(patch): include workspace/repos in GitHub adapter resolveRepos

### DIFF
--- a/plugins/shipwright/scripts/adapters/github.ts
+++ b/plugins/shipwright/scripts/adapters/github.ts
@@ -20,6 +20,7 @@ import type {
   TaskStore,
   TaskStoreConfig,
 } from "../store.ts";
+import { resolveRepos } from "../check-helpers.ts";
 import { warnMissingFields } from "./validation.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -633,6 +634,8 @@ export class GitHubTaskStore implements TaskStore {
   async resolveRepos(): Promise<string[]> {
     const g = this.config.github;
     if (!g?.owner || !g?.repo) return [];
-    return [`${g.owner}/${g.repo}`];
+    const primary = `${g.owner}/${g.repo}`;
+    const scanned = resolveRepos(process.cwd());
+    return [primary, ...scanned.filter((r) => r !== primary)];
   }
 }

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -152,8 +152,7 @@ describe("GitHubTaskStore.resolveRepos", () => {
         expect(repos[0]).toBe("test-owner/test-repo");
         expect(repos).toContain("test-owner/other-repo");
       } finally {
-        if (prev === undefined) delete process.env.SHIPWRIGHT_REPOS_DIR;
-        else process.env.SHIPWRIGHT_REPOS_DIR = prev;
+        process.env.SHIPWRIGHT_REPOS_DIR = prev;
       }
     } finally {
       await rm(reposDir, { recursive: true, force: true });

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -123,7 +123,7 @@ describe("GitHubTaskStore.resolveRepo", () => {
 // ─── resolveRepos ────────────────────────────────────────────────────────────
 
 describe("GitHubTaskStore.resolveRepos", () => {
-  test("returns config repo as single-element array", async () => {
+  test("returns config repo when no workspace repos dir exists", async () => {
     const adapter = new GitHubTaskStore(CONFIG);
     const repos = await adapter.resolveRepos();
     expect(repos).toEqual(["test-owner/test-repo"]);
@@ -133,6 +133,31 @@ describe("GitHubTaskStore.resolveRepos", () => {
     const adapter = new GitHubTaskStore({ taskStore: "github" });
     const repos = await adapter.resolveRepos();
     expect(repos).toEqual([]);
+  });
+
+  test("merges config repo with workspace repos, config repo first, no duplicates", async () => {
+    const reposDir = await mkdtemp(path.join(tmpdir(), "shipwright-test-repos-"));
+    try {
+      // Create a fake git repo that resolveRepos can scan
+      const repoDir = path.join(reposDir, "other-repo");
+      await Bun.write(
+        path.join(repoDir, ".git", "config"),
+        '[remote "origin"]\n\turl = https://github.com/test-owner/other-repo.git\n',
+      );
+      const prev = process.env.SHIPWRIGHT_REPOS_DIR;
+      process.env.SHIPWRIGHT_REPOS_DIR = reposDir;
+      try {
+        const adapter = new GitHubTaskStore(CONFIG);
+        const repos = await adapter.resolveRepos();
+        expect(repos[0]).toBe("test-owner/test-repo");
+        expect(repos).toContain("test-owner/other-repo");
+      } finally {
+        if (prev === undefined) delete process.env.SHIPWRIGHT_REPOS_DIR;
+        else process.env.SHIPWRIGHT_REPOS_DIR = prev;
+      }
+    } finally {
+      await rm(reposDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- `check-patch.ts` uses `resolveAllRepos` (check-helpers), which unions the primary repo with everything under `workspace/repos/`
- The patch and deploy skills call `task_store.ts repos` → `GitHubTaskStore.resolveRepos`, which returned **only** the primary repo from `shipwright.config.json`
- Since that return is non-empty, the `resolveReposForStore` fallback to `workspace/repos/` never fired
- Net effect: check-patch detects failing CI in a workspace repo (e.g. `bodhi`), triggers the cron, but the patch skill scans only the primary repo, finds nothing, and exits silently

Fix: `GitHubTaskStore.resolveRepos` now merges the primary repo with any repos scanned from `workspace/repos/` (matching the logic in `check-helpers.resolveAllRepos`). Primary repo is always first; duplicates are filtered.

## Test plan

- [ ] Existing 76 unit tests pass
- [ ] New test: `merges config repo with workspace repos, config repo first, no duplicates` — creates a fake git repo under a temp `SHIPWRIGHT_REPOS_DIR` and verifies both repos appear in the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)