### PR TITLE
feat(audit): add audit engine with pure check functions (TSD-1.1)

### DIFF
--- a/plugins/shipwright/scripts/adapters/audit.ts
+++ b/plugins/shipwright/scripts/adapters/audit.ts
@@ -12,6 +12,11 @@ export interface AuditResult {
   message: string;
 }
 
+/**
+ * Detects duplicate task IDs within the provided `tasks` slice.
+ * Callers are responsible for passing the full set if cross-scope detection is needed —
+ * duplicates that span filtered subsets will not be surfaced.
+ */
 export function checkDuplicateIds(tasks: Task[]): AuditResult[] {
   const idCounts = new Map<string, number>();
 
@@ -75,6 +80,10 @@ export function checkDanglingDeps(
   return failures;
 }
 
+/**
+ * Returns warn for each task whose repo doesn't match configuredRepo.
+ * Tasks with no `repo` field are skipped — only explicit mismatches are flagged.
+ */
 export function checkCrossRepoOrphans(
   tasks: Task[],
   configuredRepo: string,

--- a/plugins/shipwright/scripts/adapters/audit.ts
+++ b/plugins/shipwright/scripts/adapters/audit.ts
@@ -1,0 +1,146 @@
+/**
+ * plugins/shipwright/scripts/adapters/audit.ts
+ *
+ * Pure, I/O-free audit check functions for task integrity.
+ * All functions are synchronous, pure, and suitable for validation pipelines.
+ */
+
+import type { Task } from "../store";
+
+/**
+ * Result of an audit check.
+ *
+ * level: 'ok' when check passes, 'warn' for non-blocking issues, 'fail' for blocking issues
+ * check: machine-readable check identifier (e.g. 'duplicate-ids')
+ * message: human-readable message explaining the result
+ */
+export interface AuditResult {
+  level: "ok" | "warn" | "fail";
+  check: string;
+  message: string;
+}
+
+/**
+ * Check for duplicate task IDs.
+ *
+ * Returns a single 'ok' result if no duplicates exist.
+ * Returns one 'fail' result per duplicated ID, including count of occurrences.
+ *
+ * @param tasks Task array to check
+ * @returns Array of AuditResult objects
+ */
+export function checkDuplicateIds(tasks: Task[]): AuditResult[] {
+  const idCounts = new Map<string, number>();
+
+  for (const task of tasks) {
+    idCounts.set(task.id, (idCounts.get(task.id) ?? 0) + 1);
+  }
+
+  const failures: AuditResult[] = [];
+  for (const [id, count] of idCounts.entries()) {
+    if (count > 1) {
+      failures.push({
+        level: "fail",
+        check: "duplicate-ids",
+        message: `ID '${id}' appears ${count} times in task list`,
+      });
+    }
+  }
+
+  if (failures.length === 0) {
+    return [
+      {
+        level: "ok",
+        check: "duplicate-ids",
+        message: "No duplicate IDs found",
+      },
+    ];
+  }
+
+  return failures;
+}
+
+/**
+ * Check for dangling task dependencies.
+ *
+ * For each task, ensures all dependency IDs are in the allKnownIds set.
+ * Returns a single 'ok' result if all dependencies resolve.
+ * Returns one 'fail' result per dangling dependency reference.
+ *
+ * @param tasks Task array to check
+ * @param allKnownIds Set of all known task IDs in the system
+ * @returns Array of AuditResult objects
+ */
+export function checkDanglingDeps(
+  tasks: Task[],
+  allKnownIds: Set<string>,
+): AuditResult[] {
+  const failures: AuditResult[] = [];
+
+  for (const task of tasks) {
+    if (!task.dependencies) continue;
+    for (const depId of task.dependencies) {
+      if (!allKnownIds.has(depId)) {
+        failures.push({
+          level: "fail",
+          check: "dangling-deps",
+          message: `Task '${task.id}' depends on unknown ID '${depId}'`,
+        });
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    return [
+      {
+        level: "ok",
+        check: "dangling-deps",
+        message: "No dangling dependencies",
+      },
+    ];
+  }
+
+  return failures;
+}
+
+/**
+ * Check for cross-repo orphaned tasks.
+ *
+ * For each task with a repo field, verifies it matches the configured repo.
+ * Tasks without a repo field are skipped (not considered orphans).
+ * Returns a single 'ok' result if all tasks match or have no repo field.
+ * Returns one 'warn' result per task with a mismatched repo.
+ *
+ * @param tasks Task array to check
+ * @param configuredRepo The expected repo in 'owner/repo' format
+ * @returns Array of AuditResult objects
+ */
+export function checkCrossRepoOrphans(
+  tasks: Task[],
+  configuredRepo: string,
+): AuditResult[] {
+  const warnings: AuditResult[] = [];
+
+  for (const task of tasks) {
+    if (!task.repo) continue;
+    if (task.repo !== configuredRepo) {
+      warnings.push({
+        level: "warn",
+        check: "cross-repo-orphans",
+        message: `Task '${task.id}' uses repo '${task.repo}', expected '${configuredRepo}'`,
+      });
+    }
+  }
+
+  if (warnings.length === 0) {
+    return [
+      {
+        level: "ok",
+        check: "cross-repo-orphans",
+        message: "No cross-repo orphans",
+      },
+    ];
+  }
+
+  return warnings;
+}

--- a/plugins/shipwright/scripts/adapters/audit.ts
+++ b/plugins/shipwright/scripts/adapters/audit.ts
@@ -2,33 +2,16 @@
  * plugins/shipwright/scripts/adapters/audit.ts
  *
  * Pure, I/O-free audit check functions for task integrity.
- * All functions are synchronous, pure, and suitable for validation pipelines.
  */
 
 import type { Task } from "../store";
 
-/**
- * Result of an audit check.
- *
- * level: 'ok' when check passes, 'warn' for non-blocking issues, 'fail' for blocking issues
- * check: machine-readable check identifier (e.g. 'duplicate-ids')
- * message: human-readable message explaining the result
- */
 export interface AuditResult {
   level: "ok" | "warn" | "fail";
   check: string;
   message: string;
 }
 
-/**
- * Check for duplicate task IDs.
- *
- * Returns a single 'ok' result if no duplicates exist.
- * Returns one 'fail' result per duplicated ID, including count of occurrences.
- *
- * @param tasks Task array to check
- * @returns Array of AuditResult objects
- */
 export function checkDuplicateIds(tasks: Task[]): AuditResult[] {
   const idCounts = new Map<string, number>();
 
@@ -60,17 +43,6 @@ export function checkDuplicateIds(tasks: Task[]): AuditResult[] {
   return failures;
 }
 
-/**
- * Check for dangling task dependencies.
- *
- * For each task, ensures all dependency IDs are in the allKnownIds set.
- * Returns a single 'ok' result if all dependencies resolve.
- * Returns one 'fail' result per dangling dependency reference.
- *
- * @param tasks Task array to check
- * @param allKnownIds Set of all known task IDs in the system
- * @returns Array of AuditResult objects
- */
 export function checkDanglingDeps(
   tasks: Task[],
   allKnownIds: Set<string>,
@@ -103,18 +75,6 @@ export function checkDanglingDeps(
   return failures;
 }
 
-/**
- * Check for cross-repo orphaned tasks.
- *
- * For each task with a repo field, verifies it matches the configured repo.
- * Tasks without a repo field are skipped (not considered orphans).
- * Returns a single 'ok' result if all tasks match or have no repo field.
- * Returns one 'warn' result per task with a mismatched repo.
- *
- * @param tasks Task array to check
- * @param configuredRepo The expected repo in 'owner/repo' format
- * @returns Array of AuditResult objects
- */
 export function checkCrossRepoOrphans(
   tasks: Task[],
   configuredRepo: string,

--- a/plugins/shipwright/scripts/adapters/audit.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/audit.unit.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for plugins/shipwright/scripts/adapters/audit.ts
+ *
+ * Pure unit tests for the audit check functions.
+ * No I/O required — all pure functions with pure test data.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Task } from "../store";
+import {
+  checkCrossRepoOrphans,
+  checkDanglingDeps,
+  checkDuplicateIds,
+} from "./audit";
+
+describe("checkDuplicateIds", () => {
+  test("returns ok when no duplicate IDs", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending" },
+      { id: "T-2", title: "Task 2", status: "pending" },
+      { id: "T-3", title: "Task 3", status: "pending" },
+    ];
+    const result = checkDuplicateIds(tasks);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+    expect(result[0].check).toBe("duplicate-ids");
+    expect(result[0].message).toContain("No duplicate IDs");
+  });
+
+  test("returns fail for each duplicated ID", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending" },
+      { id: "T-1", title: "Task 1 duplicate", status: "pending" },
+      { id: "T-2", title: "Task 2", status: "pending" },
+      { id: "T-2", title: "Task 2 duplicate", status: "pending" },
+    ];
+    const result = checkDuplicateIds(tasks);
+    const failures = result.filter((r) => r.level === "fail");
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures.some((f) => f.message.includes("T-1"))).toBe(true);
+    expect(failures.some((f) => f.message.includes("T-2"))).toBe(true);
+  });
+
+  test("returns fail with duplicate count in message", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending" },
+      { id: "T-1", title: "Task 1 copy 1", status: "pending" },
+      { id: "T-1", title: "Task 1 copy 2", status: "pending" },
+    ];
+    const result = checkDuplicateIds(tasks);
+    const failure = result.find((r) => r.level === "fail" && r.message.includes("T-1"));
+    expect(failure).toBeDefined();
+    expect(failure?.message).toContain("3");
+  });
+
+  test("returns empty list for empty task list", () => {
+    const tasks: Task[] = [];
+    const result = checkDuplicateIds(tasks);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  test("returns fail with check='duplicate-ids'", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending" },
+      { id: "T-1", title: "Task 1 duplicate", status: "pending" },
+    ];
+    const result = checkDuplicateIds(tasks);
+    const failures = result.filter((r) => r.level === "fail");
+    expect(failures.every((f) => f.check === "duplicate-ids")).toBe(true);
+  });
+});
+
+describe("checkDanglingDeps", () => {
+  test("returns ok when all dependencies are known", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending", dependencies: ["T-2"] },
+      { id: "T-2", title: "Task 2", status: "pending" },
+    ];
+    const allKnownIds = new Set(["T-1", "T-2"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+    expect(result[0].check).toBe("dangling-deps");
+    expect(result[0].message).toContain("No dangling dependencies");
+  });
+
+  test("returns fail when a dependency ID is unknown", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        dependencies: ["UNKNOWN-DEP"],
+      },
+    ];
+    const allKnownIds = new Set(["T-1"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    const failures = result.filter((r) => r.level === "fail");
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures[0].message).toContain("UNKNOWN-DEP");
+  });
+
+  test("returns one fail per dangling dependency", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        dependencies: ["UNKNOWN-1", "UNKNOWN-2"],
+      },
+    ];
+    const allKnownIds = new Set(["T-1"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    const failures = result.filter((r) => r.level === "fail");
+    expect(failures).toHaveLength(2);
+    const messages = failures.map((f) => f.message);
+    expect(messages.some((m) => m.includes("UNKNOWN-1"))).toBe(true);
+    expect(messages.some((m) => m.includes("UNKNOWN-2"))).toBe(true);
+  });
+
+  test("returns fail for multiple tasks with dangling deps", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        dependencies: ["UNKNOWN-1"],
+      },
+      {
+        id: "T-2",
+        title: "Task 2",
+        status: "pending",
+        dependencies: ["UNKNOWN-2"],
+      },
+    ];
+    const allKnownIds = new Set(["T-1", "T-2"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    const failures = result.filter((r) => r.level === "fail");
+    expect(failures.length).toBe(2);
+  });
+
+  test("ignores tasks with no dependencies", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending" },
+      { id: "T-2", title: "Task 2", status: "pending", dependencies: [] },
+    ];
+    const allKnownIds = new Set(["T-1", "T-2"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  test("returns fail with check='dangling-deps'", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending", dependencies: ["UNKNOWN"] },
+    ];
+    const allKnownIds = new Set(["T-1"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    const failures = result.filter((r) => r.level === "fail");
+    expect(failures.every((f) => f.check === "dangling-deps")).toBe(true);
+  });
+
+  test("handles empty task list", () => {
+    const result = checkDanglingDeps([], new Set());
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  test("returns ok when no tasks have dangling deps", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        dependencies: ["T-2", "T-3"],
+      },
+      { id: "T-2", title: "Task 2", status: "pending" },
+      { id: "T-3", title: "Task 3", status: "pending" },
+    ];
+    const allKnownIds = new Set(["T-1", "T-2", "T-3"]);
+    const result = checkDanglingDeps(tasks, allKnownIds);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+});
+
+describe("checkCrossRepoOrphans", () => {
+  test("returns ok when all tasks match configured repo", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending", repo: "acme/repo" },
+      { id: "T-2", title: "Task 2", status: "pending", repo: "acme/repo" },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+    expect(result[0].check).toBe("cross-repo-orphans");
+    expect(result[0].message).toContain("No cross-repo orphans");
+  });
+
+  test("returns warn for each task with mismatched repo", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending", repo: "acme/repo" },
+      {
+        id: "T-2",
+        title: "Task 2",
+        status: "pending",
+        repo: "other/repo",
+      },
+      {
+        id: "T-3",
+        title: "Task 3",
+        status: "pending",
+        repo: "another/repo",
+      },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    const warnings = result.filter((r) => r.level === "warn");
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.some((w) => w.message.includes("T-2"))).toBe(true);
+    expect(warnings.some((w) => w.message.includes("T-3"))).toBe(true);
+  });
+
+  test("skips tasks without repo field", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending", repo: "acme/repo" },
+      { id: "T-2", title: "Task 2", status: "pending" },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  test("returns warn with task ID in message", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        repo: "other/repo",
+      },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    const warnings = result.filter((r) => r.level === "warn");
+    expect(warnings[0].message).toContain("T-1");
+  });
+
+  test("returns warn with check='cross-repo-orphans'", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        repo: "other/repo",
+      },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    const warnings = result.filter((r) => r.level === "warn");
+    expect(warnings.every((w) => w.check === "cross-repo-orphans")).toBe(true);
+  });
+
+  test("handles empty task list", () => {
+    const result = checkCrossRepoOrphans([], "acme/repo");
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  test("returns ok when no mismatches", () => {
+    const tasks: Task[] = [
+      { id: "T-1", title: "Task 1", status: "pending", repo: "acme/repo" },
+      { id: "T-2", title: "Task 2", status: "pending", repo: "acme/repo" },
+      { id: "T-3", title: "Task 3", status: "pending" },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  test("handles case sensitivity in repo names", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-1",
+        title: "Task 1",
+        status: "pending",
+        repo: "ACME/Repo",
+      },
+    ];
+    const result = checkCrossRepoOrphans(tasks, "acme/repo");
+    const warnings = result.filter((r) => r.level === "warn");
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/shipwright/scripts/adapters/audit.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/audit.unit.test.ts
@@ -1,10 +1,3 @@
-/**
- * Tests for plugins/shipwright/scripts/adapters/audit.ts
- *
- * Pure unit tests for the audit check functions.
- * No I/O required — all pure functions with pure test data.
- */
-
 import { describe, expect, test } from "bun:test";
 import type { Task } from "../store";
 import {
@@ -53,7 +46,7 @@ describe("checkDuplicateIds", () => {
     expect(failure?.message).toContain("3");
   });
 
-  test("returns empty list for empty task list", () => {
+  test("returns ok for empty task list", () => {
     const tasks: Task[] = [];
     const result = checkDuplicateIds(tasks);
     expect(result).toHaveLength(1);
@@ -161,7 +154,7 @@ describe("checkDanglingDeps", () => {
     expect(failures.every((f) => f.check === "dangling-deps")).toBe(true);
   });
 
-  test("handles empty task list", () => {
+  test("returns ok for empty task list", () => {
     const result = checkDanglingDeps([], new Set());
     expect(result).toHaveLength(1);
     expect(result[0].level).toBe("ok");
@@ -259,7 +252,7 @@ describe("checkCrossRepoOrphans", () => {
     expect(warnings.every((w) => w.check === "cross-repo-orphans")).toBe(true);
   });
 
-  test("handles empty task list", () => {
+  test("returns ok for empty task list", () => {
     const result = checkCrossRepoOrphans([], "acme/repo");
     expect(result).toHaveLength(1);
     expect(result[0].level).toBe("ok");


### PR DESCRIPTION
## Summary
- Add `AuditResult` type and three pure, I/O-free audit check functions in `plugins/shipwright/scripts/adapters/audit.ts`
- `checkDuplicateIds` — returns fail per duplicated task ID, ok when all unique
- `checkDanglingDeps` — returns fail per dep reference not in the known-IDs set, ok when all resolved
- `checkCrossRepoOrphans` — returns warn per task whose repo doesn't match the configured repo, ok otherwise

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | checkDuplicateIds returns fail when any id appears >1 time, ok otherwise | ✅ MET |
| 2 | checkDanglingDeps returns one fail per dep reference not in allKnownIds | ✅ MET |
| 3 | checkCrossRepoOrphans returns warn for each task with mismatched repo | ✅ MET |
| 4 | audit.unit.test.ts covers all three functions with ok/warn/fail — no mocks | ✅ MET |
| 5 | No existing tests retired — new module only | ✅ MET |

## Test Plan
- 21 unit tests covering ok, warn, and fail paths for all three functions
- 100% line and function coverage on audit.ts
- [x] Biome lint passing
- [x] TypeScript typecheck passing

Generated with [Claude Code](https://claude.com/claude-code)
