### PR TITLE
fix(check-deploy): match **APPROVE** markdown bold in self-review body check

### DIFF
--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -160,6 +160,31 @@ describe("check-deploy", () => {
     expect(result.exit).toBe(1);
   });
 
+  test("exits 0 when self-review body uses markdown bold (**APPROVE**)", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: null,
+    });
+    const reviews: GhReview[] = [
+      {
+        author: { login: "bodhi-agent" },
+        body: "**APPROVE** — All acceptance criteria met.",
+        state: "COMMENTED",
+      },
+    ];
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        isSelfReviewAllowed: true,
+        prs: { "acme/example-repo": [pr] },
+        reviews: { 50: reviews },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
   test("exits 1 when self-review allowed but no APPROVE in review body", async () => {
     const pr = makeGhPr({
       author: { login: "bodhi-agent" },

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -93,7 +93,10 @@ function isActiveRun(run: WorkflowRun, now: string): boolean {
 function hasSelfApproveReview(reviews: GhReview[], userLogin: string): boolean {
   return reviews.some(
     (r) =>
-      r.author.login === userLogin && r.body.trimStart().startsWith("APPROVE"),
+      r.author.login === userLogin &&
+      // Strip leading markdown bold markers (**) before checking — the review
+      // skill posts "**APPROVE**" but the body must still be treated as APPROVE.
+      r.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE"),
   );
 }
 


### PR DESCRIPTION
## Summary

- `hasSelfApproveReview` was calling `startsWith("APPROVE")` on the review body
- The review skill posts verdicts as `**APPROVE** — ...` (markdown bold), so the leading `**` caused the check to fail
- PR #416 was silently skipped every deploy tick because of this mismatch — preCheck exited 1, no session created, no deploy

## Fix

Strip leading `*` characters before the prefix check:
```ts
r.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE")
```

Added a test case for the `**APPROVE**` body format in `check-deploy.test.ts`.

## Test plan

- [x] `bun test check-deploy.test.ts check-deploy.unit.test.ts` — 34 pass
- [x] New test: `exits 0 when self-review body uses markdown bold (**APPROVE**)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)