### PR TITLE
fix(deploy): watch post-merge CI when no Deploy workflow fires

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -277,7 +277,20 @@ Use `-` for runs not yet seen.
   {name}: success
   ...
 ```
-Compute `pipeline_minutes = elapsed`. Update the task store and fire `shipwright_task_deployed` with `canary_result="no_pipeline"` and `pipeline_minutes={pipeline_minutes}`. Print the handoff block (Step 9) with `Pipeline: post-merge CI ({pipeline_minutes}m)`. Stop.
+Compute `pipeline_minutes = elapsed`. Update the task store — skip if deploy-only mode:
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id "$TASK_ID" \
+  --set status=deployed \
+  --set deployedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+Fire `shipwright_task_deployed` — skip if deploy-only mode:
+```bash
+POSTHOG_SCRIPT=$(find ~/.claude/plugins/cache -name "posthog_send.py" -path "*/shipwright/*" 2>/dev/null | head -1)
+[ -n "$POSTHOG_SCRIPT" ] && [ -n "$TASK_ID" ] && python3 "$POSTHOG_SCRIPT" shipwright_task_deployed \
+  --project {repo} --task "$TASK_ID" \
+  canary_result=no_pipeline pipeline_minutes={pipeline_minutes}
+```
+Print the handoff block (Step 9) with `Pipeline: post-merge CI ({pipeline_minutes}m)`. Stop.
 
 **Any run fails** (`conclusion == "failure"` on any run):
 ```
@@ -297,7 +310,20 @@ Stop.
 ⚠ Post-merge CI still pending after 10 minutes — marking deployed.
   Check manually: gh api repos/{org}/{repo}/actions/runs?head_sha={SQUASH_SHA}
 ```
-Update the task store to `status=deployed` and fire `shipwright_task_deployed` with `canary_result="no_pipeline"` and `pipeline_minutes=10`. Print the handoff block (Step 9) with `Pipeline: post-merge CI (pending at timeout)`. Stop.
+Update the task store to `status=deployed` — skip if deploy-only mode:
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id "$TASK_ID" \
+  --set status=deployed \
+  --set deployedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+Fire `shipwright_task_deployed` — skip if deploy-only mode:
+```bash
+POSTHOG_SCRIPT=$(find ~/.claude/plugins/cache -name "posthog_send.py" -path "*/shipwright/*" 2>/dev/null | head -1)
+[ -n "$POSTHOG_SCRIPT" ] && [ -n "$TASK_ID" ] && python3 "$POSTHOG_SCRIPT" shipwright_task_deployed \
+  --project {repo} --task "$TASK_ID" \
+  canary_result=no_pipeline pipeline_minutes=10
+```
+Print the handoff block (Step 9) with `Pipeline: post-merge CI (pending at timeout)`. Stop.
 
 ---
 

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -245,17 +245,61 @@ gh api "repos/$REPO/actions/runs?per_page=50" \
 ```
 
 - **Deploy workflow appears**: Break the 5-minute poll early and proceed to the main pipeline watch (Step 5b).
-- **No Deploy workflow after 5 minutes**: The repo has no deploy pipeline. Mark the task complete:
-  - Print: `⏭  No Deploy workflow triggered — repo has no pipeline. Marking task deployed.`
-  - If a task was found (not deploy-only mode): update via the task store — `status=deployed`, `deployedAt={now ISO timestamp}`:
-    ```bash
-    bun "$PLUGIN_SCRIPTS/task_store.ts" update --id "$TASK_ID" \
-      --set status=deployed \
-      --set deployedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    ```
-    Also fire `shipwright_task_deployed` with `canary_result="no_pipeline"` and `pipeline_minutes=0`. Skip both if no task was found.
-  - Print the handoff block (Step 9) with `Pipeline: no pipeline`
-  - Stop.
+- **No Deploy workflow after 5 minutes**: The repo has no deploy pipeline. Print:
+  ```
+  ⏭  No Deploy workflow triggered — watching post-merge CI runs on {SQUASH_SHA[0..7]}
+  ```
+  Then proceed to Step 5c to watch post-merge CI and build runs before marking the task deployed.
+
+### 5c. Post-Merge CI Watch (no Deploy pipeline)
+
+Poll for CI and build runs on `SQUASH_SHA` for up to **10 minutes** (poll every 30 seconds, up to 20 polls):
+
+```bash
+REPO="{org}/{repo}"
+gh api "repos/$REPO/actions/runs?per_page=50" \
+  --jq "[.workflow_runs[] | select(.head_sha == \"$SQUASH_SHA\") | {id, name, status, conclusion}]"
+```
+
+Print progress on each poll:
+```
+[{elapsed}m] {name}: {status}/{conclusion} | {name}: {status}/{conclusion} | ...
+```
+
+Use `-` for runs not yet seen.
+
+**Terminal conditions:**
+
+**All runs completed successfully** (`conclusion == "success"` for every run seen):
+```
+✓ Post-merge CI passed ({elapsed}m)
+  {name}: success
+  {name}: success
+  ...
+```
+Compute `pipeline_minutes = elapsed`. Update the task store and fire `shipwright_task_deployed` with `canary_result="no_pipeline"` and `pipeline_minutes={pipeline_minutes}`. Print the handoff block (Step 9) with `Pipeline: post-merge CI ({pipeline_minutes}m)`. Stop.
+
+**Any run fails** (`conclusion == "failure"` on any run):
+```
+✗ Post-merge CI failed — {name}
+  Logs: gh run view {id} --log --failed
+```
+Update via task store — skip if deploy-only mode:
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id "$TASK_ID" \
+  --set status=blocked \
+  --set note="Post-merge CI failed — run ID: {id}"
+```
+Stop.
+
+**Budget exhausted (10 minutes)** with runs still pending:
+```
+⚠ Post-merge CI still pending after 10 minutes — marking deployed.
+  Check manually: gh api repos/{org}/{repo}/actions/runs?head_sha={SQUASH_SHA}
+```
+Update the task store to `status=deployed` and fire `shipwright_task_deployed` with `canary_result="no_pipeline"` and `pipeline_minutes=10`. Print the handoff block (Step 9) with `Pipeline: post-merge CI (pending at timeout)`. Stop.
+
+---
 
 ### 5b. Monitor Pipeline (Deploy → Canary → Promote)
 

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -270,7 +270,7 @@ Use `-` for runs not yet seen.
 
 **Terminal conditions:**
 
-**All runs completed successfully** (`conclusion == "success"` for every run seen):
+**All runs completed successfully** (at least one run must be seen, AND `conclusion == "success"` for every run seen):
 ```
 ✓ Post-merge CI passed ({elapsed}m)
   {name}: success


### PR DESCRIPTION
## Summary

- When `/shipwright:deploy` finds no `Deploy` workflow after 5 minutes, it now enters a new **Step 5c** that polls all GHA runs on the squash SHA for up to 10 minutes
- Reports CI/build progress on each poll tick
- Marks deployed on success, blocked on failure, and deployed-with-warning on timeout
- Removes the immediate "no pipeline, marking deployed" shortcut that skipped post-merge validation entirely

## Motivation

Repos like `app-vitals/shipwright` don't have a Deploy/Canary/Promote workflow but do run CI and image builds on push to main — these are meaningful signals that the merge landed cleanly. Surfaced during a deploy of PR #416 where all four post-merge runs (CI + 3 image builds) passed but were silently ignored.

## Test plan

- [ ] Deploy to a repo with a Deploy pipeline — confirm 5c is never entered (5b handles it)
- [ ] Deploy to a repo without a Deploy pipeline — confirm 5c polls and reports runs
- [ ] Verify success path marks deployed and shows `Pipeline: post-merge CI (Nm)` in handoff
- [ ] Verify failure path marks blocked and prints log command

🤖 Generated with [Claude Code](https://claude.com/claude-code)