### PR TITLE
feat(task-store): add backend subcommand; update skills to use CLI

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -246,6 +246,26 @@ The `setup` command calls the Jira project API (`GET /rest/api/3/project/{key}`)
 
 ---
 
+## CLI Reference
+
+The `task_store.ts` script provides several subcommands for manual interaction with the task store.
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `setup` | Create `state/todos.json` if missing (JSON backend) or initialize GitHub/Jira labels and validation (GitHub/Jira backends) |
+| `doctor` | Validate configuration and print diagnostics (includes `backend:` line showing the active backend) |
+| `backend` | Print the active backend name: `json`, `github`, or `jira` (useful for scripts that need to detect the backend) |
+| `query` | Filter and return tasks as JSON array (supports `--status pending` and other filters) |
+| `append` | Append tasks from a JSON file (insert-only on GitHub adapter; upsert on JSON adapter) |
+| `update` | Write specific fields to a task by ID |
+| `repos` | Print all org/repo strings (one per line) |
+| `resolve-repo` | Print first org/repo (deprecated alias for `repos`) |
+| `cleanup` | Close open GitHub issues with terminal status labels (GitHub backend only) |
+
+---
+
 ## Troubleshooting
 
 ### Jira: 401 Unauthorized

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -4,7 +4,7 @@ description: Execute the next ready task from the queue — build feature, simpl
 
 # Dev Task
 
-Pick the next ready task from `state/todos.json`, build the feature, simplify, verify requirements, and ship a PR. Follow all steps in order.
+Pick the next ready task from the task store, build the feature, simplify, verify requirements, and ship a PR. Follow all steps in order.
 
 **This command runs autonomously. Do not pause for user input unless a build or test failure cannot be auto-resolved.**
 
@@ -138,7 +138,7 @@ POSTHOG_SCRIPT=$(find ~/.claude/plugins/cache -name "posthog_send.py" -path "*/s
 
 ## Step 3: Build Feature-Dev Prompt
 
-Construct the implementation prompt from the task fields in `state/todos.json`:
+Construct the implementation prompt from the task fields in the task store:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -601,7 +601,7 @@ gh pr list --head {branch} --state open --json number,url
 
 **If a PR already exists** (bundled task — joining an existing PR):
 - The push above added the commits to the existing branch/PR — no new PR needed
-- Set `pr: {existing-pr-number}` and `prCreatedAt: "{ISO timestamp}"` in todos.json for this task
+- Set `pr: {existing-pr-number}` and `prCreatedAt: "{ISO timestamp}"` in the task store for this task
 - Print the existing PR URL
 - Skip to the `shipwright_pr_created` PostHog event below (still fire it so metrics are captured)
 

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -36,18 +36,18 @@ This is the engineering planning pass. The product spec (what and why) is alread
 
 ## Phase-0: Backend Setup (GitHub only)
 
-If `SHIPWRIGHT_CONFIG` is set, read the config file and check the `taskStore` field.
-When `taskStore` is `"github"`, run the task store setup before any context loading:
+Detect the active backend and, when it is `"github"`, run the task store setup before any context loading:
 
 ```bash
 PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
-[ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" setup
+PHASE0_BACKEND=$([ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" backend 2>/dev/null || echo "json")
+[ "$PHASE0_BACKEND" = "github" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" setup
 ```
 
-If the command exits non-zero, print the error and **stop** — a misconfigured board means
+If the `setup` command exits non-zero, print the error and **stop** — a misconfigured board means
 tasks written in Step 6 won't land on the board and the queue will be out of sync.
 
-If `SHIPWRIGHT_CONFIG` is not set, or `taskStore` is `"json"` (the default), skip this step.
+If the active backend is `"json"` (the default), skip this step.
 
 ---
 
@@ -255,16 +255,7 @@ A task on its own branch is unaffected. This ensures a `haiku`-scored task bundl
 The code path depends on `taskStore` in `SHIPWRIGHT_CONFIG`. Read it the same way Phase-0 does:
 
 ```bash
-SHIPWRIGHT_CONFIG_VALUE=$(python3 -c "
-import os, json
-cfg_path = os.environ.get('SHIPWRIGHT_CONFIG', '')
-if cfg_path:
-    with open(cfg_path) as f:
-        cfg = json.load(f)
-    print(cfg.get('taskStore', 'json'))
-else:
-    print('json')
-" 2>/dev/null || echo "json")
+SHIPWRIGHT_CONFIG_VALUE=$(bun "$PLUGIN_SCRIPTS/task_store.ts" backend 2>/dev/null || echo "json")
 ```
 
 **Branch gate — choose exactly one path based on `SHIPWRIGHT_CONFIG_VALUE`:**
@@ -317,32 +308,12 @@ bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks-{session}.json
 **Step 6a — Read owner/repo from config:**
 
 ```bash
-SHIPWRIGHT_OWNER=$(python3 -c "
-import os, json, sys
-cfg_path = os.environ.get('SHIPWRIGHT_CONFIG', '')
-with open(cfg_path) as f:
-    cfg = json.load(f)
-val = cfg.get('github', {}).get('owner', '')
-if not val:
-    print('ERROR: github.owner not configured in SHIPWRIGHT_CONFIG', file=sys.stderr)
-    sys.exit(1)
-print(val)
-")
-
-SHIPWRIGHT_REPO=$(python3 -c "
-import os, json, sys
-cfg_path = os.environ.get('SHIPWRIGHT_CONFIG', '')
-with open(cfg_path) as f:
-    cfg = json.load(f)
-val = cfg.get('github', {}).get('repo', '')
-if not val:
-    print('ERROR: github.repo not configured in SHIPWRIGHT_CONFIG', file=sys.stderr)
-    sys.exit(1)
-print(val)
-")
+SHIPWRIGHT_REPO_FULL=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos 2>/dev/null | head -1)
+SHIPWRIGHT_OWNER=$(echo "$SHIPWRIGHT_REPO_FULL" | cut -d'/' -f1)
+SHIPWRIGHT_REPO=$(echo "$SHIPWRIGHT_REPO_FULL" | cut -d'/' -f2)
 ```
 
-If either command exits non-zero (i.e. the `github` key or its `owner`/`repo` sub-keys are missing from `SHIPWRIGHT_CONFIG`), stop immediately. Add `github: {owner: "...", repo: "..."}` to your config file before retrying.
+If `SHIPWRIGHT_REPO_FULL` is empty (i.e. `repos` returned no output), stop immediately. Ensure `github.owner` and `github.repo` are configured in the active task store config before retrying.
 
 **Step 6b — Create a parent GitHub Issue for the plan:**
 

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -40,7 +40,8 @@ Detect the active backend and, when it is `"github"`, run the task store setup b
 
 ```bash
 PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
-PHASE0_BACKEND=$([ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" backend 2>/dev/null || echo "json")
+PHASE0_BACKEND=$([ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" backend 2>/dev/null)
+PHASE0_BACKEND=${PHASE0_BACKEND:-json}
 [ "$PHASE0_BACKEND" = "github" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" setup
 ```
 
@@ -309,6 +310,7 @@ bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks-{session}.json
 
 ```bash
 SHIPWRIGHT_REPO_FULL=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos 2>/dev/null | head -1)
+[ -z "$SHIPWRIGHT_REPO_FULL" ] && { echo 'ERROR: repos returned no output — ensure github.owner and github.repo are set in .shipwright.json' >&2; false; }
 SHIPWRIGHT_OWNER=$(echo "$SHIPWRIGHT_REPO_FULL" | cut -d'/' -f1)
 SHIPWRIGHT_REPO=$(echo "$SHIPWRIGHT_REPO_FULL" | cut -d'/' -f2)
 ```

--- a/plugins/shipwright/scripts/task_store.backend.unit.test.ts
+++ b/plugins/shipwright/scripts/task_store.backend.unit.test.ts
@@ -8,27 +8,17 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cmdBackend } from "./task_store";
+import { getBackend } from "./task_store";
 import { loadConfig } from "./create-task-store";
 
-function captureStdout(fn: () => void): string {
-  const chunks: string[] = [];
-  const orig = process.stdout.write.bind(process.stdout);
-  // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
-  (process.stdout as any).write = (chunk: string) => { chunks.push(chunk); return true; };
-  try { fn(); } finally {
-    // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
-    (process.stdout as any).write = orig;
-  }
-  return chunks.join("");
-}
-
-describe("cmdBackend", () => {
+describe("getBackend", () => {
   let isolatedDir: string;
   const origTaskStore = process.env.SHIPWRIGHT_TASK_STORE;
   const origConfig = process.env.SHIPWRIGHT_CONFIG;
   const origGhOwner = process.env.SHIPWRIGHT_GITHUB_OWNER;
   const origGhRepo = process.env.SHIPWRIGHT_GITHUB_REPO;
+  const origJiraUrl = process.env.JIRA_BASE_URL;
+  const origJiraKey = process.env.JIRA_PROJECT_KEY;
 
   beforeEach(() => {
     isolatedDir = mkdtempSync(join(tmpdir(), "sw-backend-test-"));
@@ -40,6 +30,10 @@ describe("cmdBackend", () => {
     delete process.env.SHIPWRIGHT_GITHUB_OWNER;
     // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
     delete process.env.SHIPWRIGHT_GITHUB_REPO;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.JIRA_BASE_URL;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.JIRA_PROJECT_KEY;
   });
 
   afterEach(() => {
@@ -68,47 +62,42 @@ describe("cmdBackend", () => {
       // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
       delete process.env.SHIPWRIGHT_GITHUB_REPO;
     }
+    if (origJiraUrl !== undefined) {
+      process.env.JIRA_BASE_URL = origJiraUrl;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.JIRA_BASE_URL;
+    }
+    if (origJiraKey !== undefined) {
+      process.env.JIRA_PROJECT_KEY = origJiraKey;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.JIRA_PROJECT_KEY;
+    }
   });
 
-  test("no config (JSON default) → prints 'json'", () => {
+  test("no config (JSON default) → returns 'json'", () => {
     const { config } = loadConfig(isolatedDir);
-    expect(captureStdout(() => cmdBackend(config))).toBe("json\n");
+    expect(getBackend(config)).toBe("json");
   });
 
-  test("SHIPWRIGHT_TASK_STORE=github → prints 'github'", () => {
+  test("SHIPWRIGHT_TASK_STORE=github → returns 'github'", () => {
     process.env.SHIPWRIGHT_TASK_STORE = "github";
     process.env.SHIPWRIGHT_GITHUB_OWNER = "my-org";
     process.env.SHIPWRIGHT_GITHUB_REPO = "my-repo";
     const { config } = loadConfig(isolatedDir);
-    expect(captureStdout(() => cmdBackend(config))).toBe("github\n");
+    expect(getBackend(config)).toBe("github");
   });
 
-  test("SHIPWRIGHT_TASK_STORE=jira → prints 'jira'", () => {
+  test("SHIPWRIGHT_TASK_STORE=jira → returns 'jira'", () => {
     process.env.SHIPWRIGHT_TASK_STORE = "jira";
     process.env.JIRA_BASE_URL = "https://example.atlassian.net";
     process.env.JIRA_PROJECT_KEY = "SHIP";
-    const origJiraUrl = process.env.JIRA_BASE_URL;
-    const origJiraKey = process.env.JIRA_PROJECT_KEY;
     const { config } = loadConfig(isolatedDir);
-    try {
-      expect(captureStdout(() => cmdBackend(config))).toBe("jira\n");
-    } finally {
-      if (origJiraUrl !== undefined) {
-        process.env.JIRA_BASE_URL = origJiraUrl;
-      } else {
-        // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
-        delete process.env.JIRA_BASE_URL;
-      }
-      if (origJiraKey !== undefined) {
-        process.env.JIRA_PROJECT_KEY = origJiraKey;
-      } else {
-        // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
-        delete process.env.JIRA_PROJECT_KEY;
-      }
-    }
+    expect(getBackend(config)).toBe("jira");
   });
 
-  test(".shipwright.json with github backend → prints 'github'", () => {
+  test(".shipwright.json with github backend → returns 'github'", () => {
     writeFileSync(
       join(isolatedDir, ".shipwright.json"),
       JSON.stringify({
@@ -117,6 +106,6 @@ describe("cmdBackend", () => {
       }),
     );
     const { config } = loadConfig(isolatedDir);
-    expect(captureStdout(() => cmdBackend(config))).toBe("github\n");
+    expect(getBackend(config)).toBe("github");
   });
 });

--- a/plugins/shipwright/scripts/task_store.backend.unit.test.ts
+++ b/plugins/shipwright/scripts/task_store.backend.unit.test.ts
@@ -11,6 +11,18 @@ import { join } from "node:path";
 import { cmdBackend } from "./task_store";
 import { loadConfig } from "./create-task-store";
 
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
+  (process.stdout as any).write = (chunk: string) => { chunks.push(chunk); return true; };
+  try { fn(); } finally {
+    // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
+    (process.stdout as any).write = orig;
+  }
+  return chunks.join("");
+}
+
 describe("cmdBackend", () => {
   let isolatedDir: string;
   const origTaskStore = process.env.SHIPWRIGHT_TASK_STORE;
@@ -60,20 +72,7 @@ describe("cmdBackend", () => {
 
   test("no config (JSON default) → prints 'json'", () => {
     const { config } = loadConfig(isolatedDir);
-    const output: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
-    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
-      output.push(chunk);
-      return true;
-    };
-    try {
-      cmdBackend(config);
-    } finally {
-      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
-      (process.stdout as any).write = origWrite;
-    }
-    expect(output.join("")).toBe("json\n");
+    expect(captureStdout(() => cmdBackend(config))).toBe("json\n");
   });
 
   test("SHIPWRIGHT_TASK_STORE=github → prints 'github'", () => {
@@ -81,20 +80,7 @@ describe("cmdBackend", () => {
     process.env.SHIPWRIGHT_GITHUB_OWNER = "my-org";
     process.env.SHIPWRIGHT_GITHUB_REPO = "my-repo";
     const { config } = loadConfig(isolatedDir);
-    const output: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
-    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
-      output.push(chunk);
-      return true;
-    };
-    try {
-      cmdBackend(config);
-    } finally {
-      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
-      (process.stdout as any).write = origWrite;
-    }
-    expect(output.join("")).toBe("github\n");
+    expect(captureStdout(() => cmdBackend(config))).toBe("github\n");
   });
 
   test("SHIPWRIGHT_TASK_STORE=jira → prints 'jira'", () => {
@@ -104,18 +90,9 @@ describe("cmdBackend", () => {
     const origJiraUrl = process.env.JIRA_BASE_URL;
     const origJiraKey = process.env.JIRA_PROJECT_KEY;
     const { config } = loadConfig(isolatedDir);
-    const output: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
-    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
-      output.push(chunk);
-      return true;
-    };
     try {
-      cmdBackend(config);
+      expect(captureStdout(() => cmdBackend(config))).toBe("jira\n");
     } finally {
-      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
-      (process.stdout as any).write = origWrite;
       if (origJiraUrl !== undefined) {
         process.env.JIRA_BASE_URL = origJiraUrl;
       } else {
@@ -129,7 +106,6 @@ describe("cmdBackend", () => {
         delete process.env.JIRA_PROJECT_KEY;
       }
     }
-    expect(output.join("")).toBe("jira\n");
   });
 
   test(".shipwright.json with github backend → prints 'github'", () => {
@@ -141,19 +117,6 @@ describe("cmdBackend", () => {
       }),
     );
     const { config } = loadConfig(isolatedDir);
-    const output: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
-    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
-      output.push(chunk);
-      return true;
-    };
-    try {
-      cmdBackend(config);
-    } finally {
-      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
-      (process.stdout as any).write = origWrite;
-    }
-    expect(output.join("")).toBe("github\n");
+    expect(captureStdout(() => cmdBackend(config))).toBe("github\n");
   });
 });

--- a/plugins/shipwright/scripts/task_store.backend.unit.test.ts
+++ b/plugins/shipwright/scripts/task_store.backend.unit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * plugins/shipwright/scripts/task_store.backend.unit.test.ts
+ *
+ * Unit tests for the `backend` subcommand helper in task_store.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cmdBackend } from "./task_store";
+import { loadConfig } from "./create-task-store";
+
+describe("cmdBackend", () => {
+  let isolatedDir: string;
+  const origTaskStore = process.env.SHIPWRIGHT_TASK_STORE;
+  const origConfig = process.env.SHIPWRIGHT_CONFIG;
+  const origGhOwner = process.env.SHIPWRIGHT_GITHUB_OWNER;
+  const origGhRepo = process.env.SHIPWRIGHT_GITHUB_REPO;
+
+  beforeEach(() => {
+    isolatedDir = mkdtempSync(join(tmpdir(), "sw-backend-test-"));
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_TASK_STORE;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_CONFIG;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_GITHUB_OWNER;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_GITHUB_REPO;
+  });
+
+  afterEach(() => {
+    rmSync(isolatedDir, { recursive: true, force: true });
+    if (origTaskStore !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE = origTaskStore;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_TASK_STORE;
+    }
+    if (origConfig !== undefined) {
+      process.env.SHIPWRIGHT_CONFIG = origConfig;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_CONFIG;
+    }
+    if (origGhOwner !== undefined) {
+      process.env.SHIPWRIGHT_GITHUB_OWNER = origGhOwner;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_GITHUB_OWNER;
+    }
+    if (origGhRepo !== undefined) {
+      process.env.SHIPWRIGHT_GITHUB_REPO = origGhRepo;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_GITHUB_REPO;
+    }
+  });
+
+  test("no config (JSON default) → prints 'json'", () => {
+    const { config } = loadConfig(isolatedDir);
+    const output: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
+    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
+      output.push(chunk);
+      return true;
+    };
+    try {
+      cmdBackend(config);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
+      (process.stdout as any).write = origWrite;
+    }
+    expect(output.join("")).toBe("json\n");
+  });
+
+  test("SHIPWRIGHT_TASK_STORE=github → prints 'github'", () => {
+    process.env.SHIPWRIGHT_TASK_STORE = "github";
+    process.env.SHIPWRIGHT_GITHUB_OWNER = "my-org";
+    process.env.SHIPWRIGHT_GITHUB_REPO = "my-repo";
+    const { config } = loadConfig(isolatedDir);
+    const output: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
+    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
+      output.push(chunk);
+      return true;
+    };
+    try {
+      cmdBackend(config);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
+      (process.stdout as any).write = origWrite;
+    }
+    expect(output.join("")).toBe("github\n");
+  });
+
+  test("SHIPWRIGHT_TASK_STORE=jira → prints 'jira'", () => {
+    process.env.SHIPWRIGHT_TASK_STORE = "jira";
+    process.env.JIRA_BASE_URL = "https://example.atlassian.net";
+    process.env.JIRA_PROJECT_KEY = "SHIP";
+    const origJiraUrl = process.env.JIRA_BASE_URL;
+    const origJiraKey = process.env.JIRA_PROJECT_KEY;
+    const { config } = loadConfig(isolatedDir);
+    const output: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
+    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
+      output.push(chunk);
+      return true;
+    };
+    try {
+      cmdBackend(config);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
+      (process.stdout as any).write = origWrite;
+      if (origJiraUrl !== undefined) {
+        process.env.JIRA_BASE_URL = origJiraUrl;
+      } else {
+        // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+        delete process.env.JIRA_BASE_URL;
+      }
+      if (origJiraKey !== undefined) {
+        process.env.JIRA_PROJECT_KEY = origJiraKey;
+      } else {
+        // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+        delete process.env.JIRA_PROJECT_KEY;
+      }
+    }
+    expect(output.join("")).toBe("jira\n");
+  });
+
+  test(".shipwright.json with github backend → prints 'github'", () => {
+    writeFileSync(
+      join(isolatedDir, ".shipwright.json"),
+      JSON.stringify({
+        taskStore: "github",
+        github: { owner: "example-org", repo: "example-repo" },
+      }),
+    );
+    const { config } = loadConfig(isolatedDir);
+    const output: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: intercepting stdout.write for test assertion
+    (process.stdout as any).write = (chunk: string, ...rest: unknown[]) => {
+      output.push(chunk);
+      return true;
+    };
+    try {
+      cmdBackend(config);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring original stdout.write
+      (process.stdout as any).write = origWrite;
+    }
+    expect(output.join("")).toBe("github\n");
+  });
+});

--- a/plugins/shipwright/scripts/task_store.ts
+++ b/plugins/shipwright/scripts/task_store.ts
@@ -15,6 +15,7 @@
  *   resolve-repo  Print first org/repo (deprecated alias for repos)
  *   setup       Create state/todos.json if missing
  *   doctor      Validate config and print diagnostics
+ *   backend     Print the active backend name ("json", "github", "jira")
  *
  * Environment:
  *   SHIPWRIGHT_CONFIG   Path to JSON config file (optional)
@@ -99,6 +100,7 @@ function printUsageAndExit(): never {
       "  setup         Create state/todos.json if missing",
       "  cleanup       Close open GitHub issues with terminal status labels",
       "  doctor        Validate config and print diagnostics",
+      "  backend       Print the active backend name (json, github, jira)",
       "",
     ].join("\n"),
   );
@@ -309,6 +311,10 @@ async function cmdCleanup(adapter: TaskStore): Promise<void> {
   );
 }
 
+export function cmdBackend(config: import("./store").TaskStoreConfig): void {
+  process.stdout.write(`${config.taskStore ?? "json"}\n`);
+}
+
 function cmdDoctor(
   adapter: TaskStore,
   config: import("./store").TaskStoreConfig,
@@ -334,6 +340,7 @@ const SUBCOMMANDS = new Set([
   "setup",
   "cleanup",
   "doctor",
+  "backend",
 ]);
 
 async function main(): Promise<void> {
@@ -373,10 +380,15 @@ async function main(): Promise<void> {
     case "doctor":
       cmdDoctor(adapter, config, configSource);
       break;
+    case "backend":
+      cmdBackend(config);
+      break;
   }
 }
 
-main().catch((e: unknown) => {
-  process.stderr.write(`error: ${String(e)}\n`);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(1);
+  });
+}

--- a/plugins/shipwright/scripts/task_store.ts
+++ b/plugins/shipwright/scripts/task_store.ts
@@ -311,8 +311,12 @@ async function cmdCleanup(adapter: TaskStore): Promise<void> {
   );
 }
 
+export function getBackend(config: import("./store").TaskStoreConfig): string {
+  return config.taskStore ?? "json";
+}
+
 export function cmdBackend(config: import("./store").TaskStoreConfig): void {
-  process.stdout.write(`${config.taskStore ?? "json"}\n`);
+  process.stdout.write(`${getBackend(config)}\n`);
 }
 
 function cmdDoctor(


### PR DESCRIPTION
## Summary
- Add `backend` subcommand to `task_store.ts` — prints active backend name (`json`, `github`, `jira`) without inline python3 config parsing
- Guard `main()` with `import.meta.main` so `task_store.ts` is importable in tests without auto-executing
- Replace all inline `python3 -c "import os, json..."` blocks in `plan-session.md` with clean CLI calls (`bun task_store.ts backend`, `bun task_store.ts repos | head -1`)
- Update `dev-task.md` references from `state/todos.json` to generic "task store" language

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | plan-session: python3 SHIPWRIGHT_CONFIG_VALUE block replaced with `bun task_store.ts backend` | ✅ MET |
| 2 | plan-session: python3 OWNER/REPO blocks replaced with `bun task_store.ts repos \| head -1 \| cut` | ✅ MET |
| 3 | plan-session: Phase-0 uses `backend` subcommand for GitHub detection | ✅ MET |
| 4 | dev-task: `state/todos.json` references updated to "task store" | ✅ MET |
| 5 | `backend` subcommand added to task_store.ts, registered in SUBCOMMANDS | ✅ MET |
| 6 | `import.meta.main` guard added to enable test imports | ✅ MET |
| 7 | 4 unit tests covering json/github/jira backends and .shipwright.json detection | ✅ MET |

## Test Plan
- [x] `bun test plugins/shipwright/scripts/task_store.backend.unit.test.ts` — 4 pass
- [x] `bun test plugins/shipwright/scripts/` — 570 pass, 0 fail
- [x] `bunx biome lint plugins/shipwright/` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
