### PR TITLE
feat(chart): metrics.sessionSecret.existingSecret to share admin's session secret

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,18 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.3.0]
+
+### Added
+
+- `metrics.sessionSecret.existingSecret`: source the metrics service's `SHIPWRIGHT_SESSION_SECRET` from a caller-managed Secret instead of the chart-generated random. Point it at the same Secret the admin uses (`admin.encryptionKeys.existingSecret`) so admin-minted dashboard session JWTs validate at the metrics service when both sit behind a shared Gateway — a mismatch returns 401 on the dashboard's metrics view. `sessionSecretRef` selects the key within that Secret (defaults to `SHIPWRIGHT_SESSION_SECRET`). When set, the chart-managed metrics Secret omits `SHIPWRIGHT_SESSION_SECRET` and the Deployment injects it via `secretKeyRef` against the caller-managed Secret. Default empty preserves the existing generate-on-install / reuse-on-upgrade behaviour — purely additive.
+
+## [1.2.0]
+
+### Added
+
+- `auth.google.existingSecret`: source `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` from a caller-managed Secret instead of inline Helm values. The chart-managed admin Secret omits these keys when the knob is set; the Deployment sources them via `secretKeyRef`. Allows fully secret-free helm installs when combined with `admin.encryptionKeys.existingSecret`.
+
 ## [1.1.0]
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.2.0
+version: 1.3.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "auth.google.existingSecret: source GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and SHIPWRIGHT_ADMIN_ALLOWED_EMAILS from a caller-managed Secret instead of inline Helm values. The chart-managed admin Secret omits these keys when the knob is set; the Deployment sources them via secretKeyRef. Allows fully secret-free helm installs when combined with admin.encryptionKeys.existingSecret."
+      description: "metrics.sessionSecret.existingSecret: source the metrics service's SHIPWRIGHT_SESSION_SECRET from a caller-managed Secret instead of the chart-generated random. Point it at the same Secret the admin uses (admin.encryptionKeys.existingSecret) so admin-minted dashboard session JWTs validate at the metrics service when both sit behind a shared Gateway — a mismatch 401s the dashboard's metrics view. The chart-managed metrics Secret omits SHIPWRIGHT_SESSION_SECRET when the knob is set; the Deployment sources it via secretKeyRef. Default empty preserves the generate-on-install / reuse-on-upgrade behaviour."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/README.md
+++ b/charts/shipwright/README.md
@@ -97,6 +97,7 @@ environment, set `postgresql.auth.existingSecret` to a pre-created Secret (or se
 | `metrics.image.tag` | `""` | Metrics image tag (defaults to chart `appVersion`). |
 | `metrics.service.port` | `3460` | Metrics service port. |
 | `metrics.replicas` | `1` | Metrics replica count. |
+| `metrics.sessionSecret.existingSecret` | `""` | Source the metrics `SHIPWRIGHT_SESSION_SECRET` from a pre-created Secret. Point at the admin's Secret so admin-minted dashboard JWTs validate (a mismatch 401s the dashboard). Empty = chart-generated. |
 | `agent.enabled` | `true` | Toggle the agent service (port **3000**). |
 | `agent.image.repository` | `shipwright-agent` | Agent image repo. |
 | `agent.image.tag` | `""` | Agent image tag (defaults to chart `appVersion`). |

--- a/charts/shipwright/templates/metrics-deployment.yaml
+++ b/charts/shipwright/templates/metrics-deployment.yaml
@@ -56,13 +56,26 @@ spec:
             # Bind the metrics dashboard to the chart-standard port 3460.
             - name: METRICS_API_PORT
               value: "3460"
-            # Signs the dashboard session JWT. Generated into the metrics Secret
-            # on first install and preserved across `helm upgrade`.
+            # Signs/validates the dashboard session JWT. MUST match the admin's
+            # SHIPWRIGHT_SESSION_SECRET so admin-minted sessions validate at the
+            # metrics service when both sit behind a shared Gateway — otherwise the
+            # dashboard's metrics view 401s. When metrics.sessionSecret.existingSecret
+            # is set, source it from that caller-managed Secret (point it at the same
+            # Secret the admin uses); otherwise use the chart-generated metrics Secret
+            # (generate on first install, reuse on upgrade).
+            {{- if .Values.metrics.sessionSecret.existingSecret }}
+            - name: SHIPWRIGHT_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.metrics.sessionSecret.existingSecret }}
+                  key: {{ .Values.metrics.sessionSecret.sessionSecretRef | default "SHIPWRIGHT_SESSION_SECRET" }}
+            {{- else }}
             - name: SHIPWRIGHT_SESSION_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "shipwright.metrics.secretName" . }}
                   key: SHIPWRIGHT_SESSION_SECRET
+            {{- end }}
             {{- if .Values.postgresql.enabled }}
             # Assembled in the metrics Secret so the Postgres password is never in
             # plaintext Deployment env. Targets the bundled PostgreSQL in postgres

--- a/charts/shipwright/templates/metrics-secret.yaml
+++ b/charts/shipwright/templates/metrics-secret.yaml
@@ -13,14 +13,21 @@
   fresh random material on first install. NOTE: `helm template` and helm-unittest
   do NOT execute `lookup`, so they always take the generate branch — that is
   expected.
+
+  When metrics.sessionSecret.existingSecret is set the generate/lookup path is
+  skipped and no session key is written here — the Deployment sources
+  SHIPWRIGHT_SESSION_SECRET via secretKeyRef against the caller-managed Secret
+  (point it at the admin's Secret so admin-minted dashboard JWTs validate).
 */}}
 {{- $secretName := include "shipwright.metrics.secretName" . }}
 {{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 {{- $sessionSecret := "" }}
+{{- if not .Values.metrics.sessionSecret.existingSecret }}
 {{- if and $existing $existing.data (index $existing.data "SHIPWRIGHT_SESSION_SECRET") }}
 {{- $sessionSecret = index $existing.data "SHIPWRIGHT_SESSION_SECRET" }}
 {{- else }}
 {{- $sessionSecret = (randAlphaNum 32 | b64enc) }}
+{{- end }}
 {{- end }}
 apiVersion: v1
 kind: Secret
@@ -30,8 +37,12 @@ metadata:
     {{- include "shipwright.metrics.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if not .Values.metrics.sessionSecret.existingSecret }}
   # Generated on first install, reused on upgrade via the lookup idiom above.
+  # Omitted when metrics.sessionSecret.existingSecret is set — the Deployment
+  # sources SHIPWRIGHT_SESSION_SECRET from the caller-managed Secret instead.
   SHIPWRIGHT_SESSION_SECRET: {{ $sessionSecret | quote }}
+{{- end }}
 {{- if .Values.postgresql.enabled }}
   {{- /*
     Assemble METRICS_DATABASE_URL here so the Postgres password is not rendered

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 1\.2\.0, app version 0\.1\.0
+          pattern: chart version 1\.3\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/charts/shipwright/tests/metrics_secret_test.yaml
+++ b/charts/shipwright/tests/metrics_secret_test.yaml
@@ -68,6 +68,31 @@ tests:
       - notExists:
           path: data.METRICS_DATABASE_URL
 
+  - it: omits the session secret when metrics.sessionSecret.existingSecret is set
+    # The Deployment sources SHIPWRIGHT_SESSION_SECRET from the caller-managed
+    # Secret instead, so the chart-managed Secret must not write its own random
+    # (which would never be used and would mask the intended shared value).
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: testpw
+      metrics.sessionSecret.existingSecret: shipwright-secrets
+    asserts:
+      - notExists:
+          path: data.SHIPWRIGHT_SESSION_SECRET
+      # DB URL assembly is unaffected by the session-secret knob.
+      - isNotEmpty:
+          path: data.METRICS_DATABASE_URL
+
+  - it: renders an empty-data metrics Secret when existingSecret is set and postgres is disabled
+    set:
+      postgresql.enabled: false
+      metrics.sessionSecret.existingSecret: shipwright-secrets
+    asserts:
+      - notExists:
+          path: data.SHIPWRIGHT_SESSION_SECRET
+      - notExists:
+          path: data.METRICS_DATABASE_URL
+
   - it: renders no metrics Secret when metrics is disabled
     set:
       metrics.enabled: false

--- a/charts/shipwright/tests/metrics_workload_test.yaml
+++ b/charts/shipwright/tests/metrics_workload_test.yaml
@@ -57,6 +57,49 @@ tests:
                 name: r-shipwright-metrics
                 key: SHIPWRIGHT_SESSION_SECRET
 
+  - it: sources SHIPWRIGHT_SESSION_SECRET from a caller-managed Secret when metrics.sessionSecret.existingSecret is set
+    # Point metrics at the same Secret the admin uses so admin-minted dashboard
+    # JWTs validate at the metrics service (shared-Gateway dashboards).
+    template: templates/metrics-deployment.yaml
+    release:
+      name: r
+    set:
+      metrics.sessionSecret.existingSecret: shipwright-secrets
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: SHIPWRIGHT_SESSION_SECRET
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-metrics
+                key: SHIPWRIGHT_SESSION_SECRET
+
+  - it: honors a custom metrics.sessionSecret.sessionSecretRef key
+    template: templates/metrics-deployment.yaml
+    release:
+      name: r
+    set:
+      metrics.sessionSecret.existingSecret: shipwright-secrets
+      metrics.sessionSecret.sessionSecretRef: MY_SESSION_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: MY_SESSION_KEY
+
   - it: wires the ServiceAccount and standard selector labels onto the Deployment
     template: templates/metrics-deployment.yaml
     asserts:

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -189,6 +189,34 @@ tests:
       - failedTemplate:
           errorPattern: "key"
 
+  - it: accepts sessionSecret with sessionSecretRef set and existingSecret empty (guard is existingSecret-triggered)
+    set:
+      metrics.sessionSecret.sessionSecretRef: SHIPWRIGHT_SESSION_SECRET
+      metrics.sessionSecret.existingSecret: ""
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: accepts sessionSecret with sessionSecretRef set and a non-empty existingSecret
+    set:
+      metrics.sessionSecret.sessionSecretRef: SHIPWRIGHT_SESSION_SECRET
+      metrics.sessionSecret.existingSecret: shipwright-secrets
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: accepts sessionSecret with no ref and an empty existingSecret (guard never triggers)
+    set:
+      metrics.sessionSecret.existingSecret: ""
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects sessionSecret with existingSecret set but sessionSecretRef empty (conditional minLength)
+    set:
+      metrics.sessionSecret.existingSecret: shipwright-secrets
+      metrics.sessionSecret.sessionSecretRef: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "sessionSecretRef"
+
   - it: accepts google mode with existingSecret set and empty clientId (existingSecret bypasses inline-field requirement)
     set:
       auth.mode: google

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -160,6 +160,22 @@
                 "name": { "type": "string" }
               }
             },
+            "sessionSecret": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "existingSecret":   { "type": "string" },
+                "sessionSecretRef": { "type": "string" }
+              },
+              "if": {
+                "properties": { "existingSecret": { "type": "string", "minLength": 1 } },
+                "required": ["existingSecret"]
+              },
+              "then": {
+                "properties": { "sessionSecretRef": { "type": "string", "minLength": 1 } },
+                "required": ["sessionSecretRef"]
+              }
+            },
             "provider": {
               "type": "object",
               "additionalProperties": false,

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -193,6 +193,18 @@ metrics:
     # bring your own Postgres (postgresql.enabled=false), pre-create this database
     # or point METRICS_DATABASE_URL at it yourself.
     name: shipwright_metrics
+  # -- Stable session secret via an existing Secret. When existingSecret is
+  # non-empty, SHIPWRIGHT_SESSION_SECRET (signs/validates the dashboard session
+  # JWT) is sourced from that pre-existing Secret instead of the chart-generated
+  # random. Point this at the SAME Secret the admin uses (admin.encryptionKeys.
+  # existingSecret) so admin-minted sessions validate at the metrics service when
+  # both sit behind a shared Gateway — a mismatch 401s the dashboard's metrics
+  # view. Leave empty to use the chart-managed Secret (generate on first install,
+  # reuse on upgrade via lookup).
+  sessionSecret:
+    existingSecret: ""
+    # -- Key in existingSecret that holds SHIPWRIGHT_SESSION_SECRET.
+    sessionSecretRef: SHIPWRIGHT_SESSION_SECRET
   # -- Provider and environment surface for the metrics dashboard.
   # All fields are optional and additive — defaults preserve the existing
   # SQLite / bundled-PostgreSQL fallback behavior unchanged.


### PR DESCRIPTION
## Problem

The metrics Deployment hardcodes `SHIPWRIGHT_SESSION_SECRET` to the chart-generated `<release>-metrics` Secret (lookup-or-`randAlphaNum`), with **no override**. When the admin sources its session secret from a caller-managed Secret via `admin.encryptionKeys.existingSecret` (the recommended prod posture — see the 1.1.0 encryption-key feature), metrics ends up holding a **different random**.

The metrics dashboard validates the admin-signed session JWT with `SHIPWRIGHT_SESSION_SECRET`. A mismatch means metrics rejects every admin-minted session → **401 on the dashboard's metrics view** when admin + metrics sit behind a shared Gateway. We hit exactly this in prod (admin on the canonical GCP secret `a10724…`, metrics on a chart-generated random `633c5b…`).

## Change

Add `metrics.sessionSecret.existingSecret` (+ `sessionSecretRef`), mirroring the existing `admin.encryptionKeys` idiom:

- **`templates/metrics-deployment.yaml`** — if/else: when set, source `SHIPWRIGHT_SESSION_SECRET` via `secretKeyRef` against the caller-managed Secret; else the chart-managed metrics Secret (unchanged default).
- **`templates/metrics-secret.yaml`** — gate the generate/lookup and the `data` key on the knob, so the chart doesn't write an unused random when the value is externally supplied.
- **`values.yaml`** — `metrics.sessionSecret` block (default empty).

Point it at the same Secret the admin uses and admin-minted dashboard JWTs validate at metrics.

## Compatibility

Purely additive. Default empty preserves the generate-on-install / reuse-on-upgrade behaviour exactly.

## Tests

- `helm unittest charts/shipwright`: **178 passed** (added workload cases for the external + custom-`sessionSecretRef` paths, and secret cases for key-omission + empty-data-when-postgres-disabled).
- `helm lint`: clean.
- `Chart.yaml` `1.2.0 → 1.3.0` (+ artifacthub annotation); `CHANGELOG.md` `[1.3.0]` (and backfilled the missing `[1.2.0]` entry whose only record was the annotation); README values row; metadata version-pin test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)