### PR TITLE
chore: remove arc-queue-probe from SYSTEM_CRONS

### DIFF
--- a/admin/src/system-crons.ts
+++ b/admin/src/system-crons.ts
@@ -94,12 +94,4 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
     silent: true,
     enabled: false,
   },
-  {
-    name: "arc-queue-probe",
-    schedule: "0 9 * * *",
-    prompt:
-      "Run `bun scripts/arc-queue-probe.ts --repo example-org/my-project --hours 24 --out state/arc-queue-time.jsonl --trend` and share the summary. Use [silent] if gh is unavailable or returns no ARC jobs.",
-    silent: true,
-    enabled: false,
-  },
 ] as const;

--- a/admin/src/system-crons.unit.test.ts
+++ b/admin/src/system-crons.unit.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { SYSTEM_CRONS } from "./system-crons.ts";
 
 describe("SYSTEM_CRONS", () => {
-  test("exports exactly eleven crons", () => {
-    expect(SYSTEM_CRONS).toHaveLength(11);
+  test("exports exactly ten crons", () => {
+    expect(SYSTEM_CRONS).toHaveLength(10);
   });
 
-  test("cron names are the eleven expected crons", () => {
+  test("cron names are the ten expected crons", () => {
     const names = SYSTEM_CRONS.map((c) => c.name);
     expect(names).toContain("shipwright-dev-task");
     expect(names).toContain("shipwright-patch");
@@ -18,7 +18,6 @@ describe("SYSTEM_CRONS", () => {
     expect(names).toContain("learn-dream");
     expect(names).toContain("dependabot-triage");
     expect(names).toContain("entropy-patrol-maintenance");
-    expect(names).toContain("arc-queue-probe");
   });
 
   test("all crons have silent: true", () => {
@@ -169,8 +168,7 @@ describe("SYSTEM_CRONS", () => {
         c.name !== "shipwright-docs-freshness" &&
         c.name !== "learn-dream" &&
         c.name !== "dependabot-triage" &&
-        c.name !== "entropy-patrol-maintenance" &&
-        c.name !== "arc-queue-probe",
+        c.name !== "entropy-patrol-maintenance",
     );
     for (const cron of pollingCrons) {
       expect(cron.schedule).toBe("*/30 * * * *");
@@ -240,28 +238,6 @@ describe("SYSTEM_CRONS", () => {
     expect(cron?.prompt).toContain("/shipwright:entropy-fix");
     expect(cron?.prompt).not.toContain("entropy-patrol:");
     expect(cron?.prompt).toContain("entropy-patrol-last-run.json");
-  });
-
-  // ── arc-queue-probe ─────────────────────────────────────────────────────────
-
-  test("arc-queue-probe has schedule 0 9 * * *", () => {
-    const cron = SYSTEM_CRONS.find((c) => c.name === "arc-queue-probe");
-    expect(cron?.schedule).toBe("0 9 * * *");
-  });
-
-  test("arc-queue-probe has enabled: false", () => {
-    const cron = SYSTEM_CRONS.find((c) => c.name === "arc-queue-probe");
-    expect(cron?.enabled).toBe(false);
-  });
-
-  test("arc-queue-probe has no preCheck", () => {
-    const cron = SYSTEM_CRONS.find((c) => c.name === "arc-queue-probe");
-    expect(cron?.preCheck).toBeUndefined();
-  });
-
-  test("arc-queue-probe prompt contains the script invocation", () => {
-    const cron = SYSTEM_CRONS.find((c) => c.name === "arc-queue-probe");
-    expect(cron?.prompt).toContain("bun scripts/arc-queue-probe.ts");
   });
 
   // ── No old plugin-prefix refs anywhere in prompts ──────────────────────────


### PR DESCRIPTION
## Summary

- Removes `arc-queue-probe` from `SYSTEM_CRONS` — it's a vitals-os-specific cron that monitors ARC runner queue times for that platform's infra
- Shipwright has no ARC runners or `arc-queue-probe` script, so it doesn't belong here
- Updates the unit test count (11 → 10) and removes the arc-queue-probe test block

🤖 Generated with [Claude Code](https://claude.com/claude-code)