### PR TITLE
fix(admin): redirect GET / → /admin/login

### DIFF
--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -524,10 +524,21 @@ function buildCombinedApp() {
   });
 
   const root = new Hono();
+  root.get("/health", (c) => c.json({ status: "ok" }));
+  root.get("/", (c) => c.redirect("/admin/login", 302));
   root.route("/agents", runtimeApp);
   root.route("/", adminApp);
   return root;
 }
+
+describe("root redirect — GET / → 302 /admin/login", () => {
+  test("GET / returns 302 with Location /admin/login", async () => {
+    const root = buildCombinedApp();
+    const res = await root.request("/", { redirect: "manual" });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin/login");
+  });
+});
 
 describe("combined server — regression guard: runtime middleware must not block admin CRUD", () => {
   test("POST /agents/:id/envs with admin key reaches admin handler (201, not 401)", async () => {

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -534,7 +534,7 @@ function buildCombinedApp() {
 describe("root redirect — GET / → 302 /admin/login", () => {
   test("GET / returns 302 with Location /admin/login", async () => {
     const root = buildCombinedApp();
-    const res = await root.request("/", { redirect: "manual" });
+    const res = await root.request("/");
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe("/admin/login");
   });

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -177,6 +177,9 @@ async function startServer(): Promise<void> {
   // 1. Health check — no auth
   root.get("/health", (c) => c.json({ status: "ok" }));
 
+  // Redirect bare root to the login page — no handler exists at "/" otherwise.
+  root.get("/", (c) => c.redirect("/admin/login", 302));
+
   // 2. Runtime API — admin key | per-agent bearer | session JWT
   //    Mounted via root.route("/agents", runtimeApp). Hono v4 strips the prefix
   //    before dispatching, so runtimeApp routes are registered as /:id/config


### PR DESCRIPTION
## Summary

- `GET /` on the bare hostname returned 404 because no Hono route handled it
- Adds `root.get("/", (c) => c.redirect("/admin/login", 302))` immediately after the health-check route in `admin/src/main.ts`
- Updates `buildCombinedApp()` in the smoke test to mirror the new route, adds assertion for 302 + `Location: /admin/login`

Closes #443.

## Test plan

- [ ] `bun test admin/src/api.smoke.test.ts` — 14 pass, 0 fail (verified locally)
- [ ] CI passes
- [ ] After image release + deploy bump: `curl -s -o /dev/null -w '%{http_code}' https://shipwright.vitals-os.com/` returns 302