### PR TITLE
feat(admin): PVC lifecycle — KubernetesClient + manifest builder + provisioner (ALP-B.1)

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -18,6 +18,7 @@
 import { createHash } from "node:crypto";
 import type {
   KubernetesDeployment,
+  KubernetesPvc,
   KubernetesSecret,
 } from "./kubernetes-client.ts";
 
@@ -114,6 +115,39 @@ function cleanBase(id: string): string {
 
 function trimDashes(s: string): string {
   return s.replace(/^-+/, "").replace(/-+$/, "");
+}
+
+// ─── PVC builder ────────────────────────────────────────────────────────────
+
+export interface AgentPvcOpts {
+  name: string;
+  namespace: string;
+  sizeGi: number;
+  storageClassName?: string;
+  adminDeploymentName: string;
+  adminDeploymentUid: string;
+}
+
+export function buildAgentPvcManifest(opts: AgentPvcOpts): KubernetesPvc {
+  const manifest: KubernetesPvc = {
+    apiVersion: "v1",
+    kind: "PersistentVolumeClaim",
+    metadata: {
+      name: opts.name,
+      namespace: opts.namespace,
+      ownerReferences: [
+        adminOwnerReference(opts.adminDeploymentName, opts.adminDeploymentUid),
+      ],
+    },
+    spec: {
+      accessModes: ["ReadWriteOnce"],
+      resources: { requests: { storage: `${opts.sizeGi}Gi` } },
+    },
+  };
+  if (opts.storageClassName !== undefined) {
+    manifest.spec.storageClassName = opts.storageClassName;
+  }
+  return manifest;
 }
 
 // ─── Deployment builder ─────────────────────────────────────────────────────

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -9,8 +9,10 @@ import {
   AGENT_HEALTH_PORT,
   AGENT_HOME_MOUNT_PATH,
   type AgentDeploymentOpts,
+  type AgentPvcOpts,
   type AgentSecretOpts,
   buildAgentDeploymentManifest,
+  buildAgentPvcManifest,
   buildAgentSecretManifest,
   sanitizeAgentName,
 } from "./agent-manifest.ts";
@@ -191,6 +193,65 @@ describe("buildAgentSecretManifest", () => {
       name: "shipwright-admin",
       uid: "11112222-3333-4444-5555-666677778888",
       controller: true,
+    });
+  });
+});
+
+// ─── buildAgentPvcManifest ──────────────────────────────────────────────────
+
+describe("buildAgentPvcManifest", () => {
+  const pvcOpts: AgentPvcOpts = {
+    name: "agent-42-home",
+    namespace: "shipwright",
+    sizeGi: 40,
+    adminDeploymentName: "shipwright-admin",
+    adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
+  };
+
+  it("emits a v1 PersistentVolumeClaim", () => {
+    const p = buildAgentPvcManifest(pvcOpts);
+    expect(p.apiVersion).toBe("v1");
+    expect(p.kind).toBe("PersistentVolumeClaim");
+    expect(p.metadata.name).toBe("agent-42-home");
+    expect(p.metadata.namespace).toBe("shipwright");
+  });
+
+  it("sets accessModes to ReadWriteOnce", () => {
+    const p = buildAgentPvcManifest(pvcOpts);
+    expect(p.spec.accessModes).toEqual(["ReadWriteOnce"]);
+  });
+
+  it("sets storage to sizeGi Gi", () => {
+    const p = buildAgentPvcManifest(pvcOpts);
+    expect(p.spec.resources.requests.storage).toBe("40Gi");
+  });
+
+  it("honours a custom sizeGi", () => {
+    const p = buildAgentPvcManifest({ ...pvcOpts, sizeGi: 100 });
+    expect(p.spec.resources.requests.storage).toBe("100Gi");
+  });
+
+  it("includes storageClassName when provided", () => {
+    const p = buildAgentPvcManifest({ ...pvcOpts, storageClassName: "premium" });
+    expect(p.spec.storageClassName).toBe("premium");
+  });
+
+  it("omits storageClassName when not provided", () => {
+    const p = buildAgentPvcManifest(pvcOpts);
+    expect(p.spec.storageClassName).toBeUndefined();
+  });
+
+  it("carries an ownerReference to the admin Deployment for GC", () => {
+    const p = buildAgentPvcManifest(pvcOpts);
+    const refs = p.metadata.ownerReferences ?? [];
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      name: "shipwright-admin",
+      uid: "11112222-3333-4444-5555-666677778888",
+      controller: true,
+      blockOwnerDeletion: true,
     });
   });
 });

--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -26,8 +26,10 @@ import { ConflictError } from "./errors.ts";
 import {
   type DeploymentSpec,
   type KubernetesClient,
+  type KubernetesPvc,
   type KubernetesSecret,
   RecordedKubernetesClient,
+  type PvcSpec,
   type SecretSpec,
 } from "./kubernetes-client.ts";
 
@@ -52,7 +54,7 @@ function makePrisma(): PrismaClient {
 }
 
 function emptyClient(): RecordedKubernetesClient {
-  return new RecordedKubernetesClient({ deployments: {}, secrets: {} });
+  return new RecordedKubernetesClient({ deployments: {}, secrets: {}, pvcs: {} });
 }
 
 /** Decode the token value the Secret carries under the default "token" key. */
@@ -126,15 +128,37 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
         order.push("deployment");
         return recorded.createDeployment(ns, spec);
       },
+      createPvc: (ns: string, spec: PvcSpec) => {
+        order.push("pvc");
+        return recorded.createPvc(ns, spec);
+      },
       getSecret: (ns, n) => recorded.getSecret(ns, n),
       getDeployment: (ns, n) => recorded.getDeployment(ns, n),
+      getPvc: (ns, n) => recorded.getPvc(ns, n),
       deleteSecret: (ns, n) => recorded.deleteSecret(ns, n),
       deleteDeployment: (ns, n) => recorded.deleteDeployment(ns, n),
+      deletePvc: (ns, n) => recorded.deletePvc(ns, n),
     };
     const provisioner = new KubernetesAgentProvisioner(ordered, tokens, CONFIG);
 
     await provisioner.provision(agentId);
-    expect(order).toEqual(["secret", "deployment"]);
+    expect(order).toEqual(["pvc", "secret", "deployment"]);
+  });
+
+  it("deprovision() deletes Deployment and Secret but leaves PVC", async () => {
+    const agentId = await createAgent();
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
+
+    await provisioner.provision(agentId);
+    await provisioner.deprovision(agentId);
+
+    const name = sanitizeAgentName(agentId);
+    // Deployment and Secret must be gone
+    await expect(k8s.getDeployment(NAMESPACE, name)).rejects.toThrow();
+    await expect(k8s.getSecret(NAMESPACE, `${name}-token`)).rejects.toThrow();
+    // PVC must still be present (data safety)
+    await expect(k8s.getPvc(NAMESPACE, `${name}-home`)).resolves.toBeDefined();
   });
 
   it("provision() is safe to retry (provision twice → no throw)", async () => {
@@ -160,14 +184,17 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
     const agentId = await createAgent();
     const recorded = emptyClient();
     const failing: KubernetesClient = {
+      createPvc: (ns, spec) => recorded.createPvc(ns, spec),
       createSecret: (ns, spec) => recorded.createSecret(ns, spec),
       createDeployment: async () => {
         throw new Error("simulated API server failure");
       },
       getSecret: (ns, n) => recorded.getSecret(ns, n),
       getDeployment: (ns, n) => recorded.getDeployment(ns, n),
+      getPvc: (ns, n) => recorded.getPvc(ns, n),
       deleteSecret: (ns, n) => recorded.deleteSecret(ns, n),
       deleteDeployment: (ns, n) => recorded.deleteDeployment(ns, n),
+      deletePvc: (ns, n) => recorded.deletePvc(ns, n),
     };
     const provisioner = new KubernetesAgentProvisioner(failing, tokens, CONFIG);
 

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -25,7 +25,6 @@
 
 import {
   buildAgentDeploymentManifest,
-  buildAgentPvcManifest,
   buildAgentSecretManifest,
   sanitizeAgentName,
 } from "./agent-manifest.ts";
@@ -227,16 +226,9 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
   // ─── Spec derivation (via the pure manifest builders) ─────────────────────
 
   private pvcSpec(pvcName: string): PvcSpec {
-    const manifest = buildAgentPvcManifest({
+    return {
       name: pvcName,
       namespace: this.config.namespace,
-      sizeGi: this.config.pvcStorageGi ?? 40,
-      adminDeploymentName: this.config.adminDeploymentName,
-      adminDeploymentUid: this.config.adminDeploymentUid,
-    });
-    return {
-      name: manifest.metadata.name,
-      namespace: manifest.metadata.namespace,
       storageGi: this.config.pvcStorageGi ?? 40,
     };
   }

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -25,6 +25,7 @@
 
 import {
   buildAgentDeploymentManifest,
+  buildAgentPvcManifest,
   buildAgentSecretManifest,
   sanitizeAgentName,
 } from "./agent-manifest.ts";
@@ -33,6 +34,7 @@ import { ConflictError, NotFoundError } from "./errors.ts";
 import type {
   DeploymentSpec,
   KubernetesClient,
+  PvcSpec,
   SecretSpec,
 } from "./kubernetes-client.ts";
 
@@ -89,6 +91,8 @@ export interface KubernetesAgentProvisionerConfig {
   tokenSecretKey?: string;
   /** Replica count for the agent Deployment. Defaults to 1. */
   replicas?: number;
+  /** Storage size in Gi for the agent home PVC. Defaults to 40. */
+  pvcStorageGi?: number;
 }
 
 function isConflict(err: unknown): boolean {
@@ -131,13 +135,26 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
   async provision(agentId: string): Promise<ProvisionResult> {
     const resourceName = this.resourceName(agentId);
     const secretName = this.secretNameFor(resourceName);
+    const pvcName = this.pvcNameFor(resourceName);
     const result: ProvisionResult = {
       resourceName,
       secretName,
       deploymentName: resourceName,
     };
 
-    // 1. Token — mint only when the Secret does NOT already exist. If the Secret
+    // 1. PVC — must exist before the Deployment that mounts it. A 409 means the
+    //    PVC already exists from a prior provision; treat as idempotent success.
+    //    On any subsequent failure, do NOT delete the PVC (data safety policy).
+    try {
+      await this.k8s.createPvc(
+        this.config.namespace,
+        this.pvcSpec(pvcName),
+      );
+    } catch (err) {
+      if (!isConflict(err)) throw err;
+    }
+
+    // 2. Token — mint only when the Secret does NOT already exist. If the Secret
     //    is already present (a prior provision completed or partially ran), we
     //    skip minting so no orphaned token rows accumulate in the DB and the
     //    returned rawToken correctly signals "use the existing credential" via
@@ -155,7 +172,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       const { rawToken } = await this.tokens.create(agentId, "k8s-provision");
       result.rawToken = rawToken;
 
-      // 2. Secret — must exist before the Deployment that references it.
+      // 3. Secret — must exist before the Deployment that references it.
       //    A 409 here is unexpected (we just confirmed it was absent), but treat
       //    it as already-present and continue to the Deployment step.
       try {
@@ -169,9 +186,9 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       }
     }
 
-    // 3. Deployment. If creation fails AFTER we created the Secret in THIS call,
+    // 4. Deployment. If creation fails AFTER we created the Secret in THIS call,
     //    roll the Secret back (best-effort) so a retry starts clean and never
-    //    leaks a half-provisioned state.
+    //    leaks a half-provisioned state. The PVC is NOT rolled back (data safety).
     try {
       await this.k8s.createDeployment(
         this.config.namespace,
@@ -208,6 +225,21 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
   }
 
   // ─── Spec derivation (via the pure manifest builders) ─────────────────────
+
+  private pvcSpec(pvcName: string): PvcSpec {
+    const manifest = buildAgentPvcManifest({
+      name: pvcName,
+      namespace: this.config.namespace,
+      sizeGi: this.config.pvcStorageGi ?? 40,
+      adminDeploymentName: this.config.adminDeploymentName,
+      adminDeploymentUid: this.config.adminDeploymentUid,
+    });
+    return {
+      name: manifest.metadata.name,
+      namespace: manifest.metadata.namespace,
+      storageGi: this.config.pvcStorageGi ?? 40,
+    };
+  }
 
   private secretSpec(secretName: string, rawToken: string): SecretSpec {
     // The pure builder is the single source of truth for the Secret body (name,

--- a/admin/src/fixtures/k8s-cassette.json
+++ b/admin/src/fixtures/k8s-cassette.json
@@ -155,5 +155,34 @@
       "status": "Success",
       "details": { "name": "agent-secret", "kind": "secrets" }
     }
+  },
+  "createPvc_success": {
+    "status": 201,
+    "body": {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": { "name": "agent-abc-home", "namespace": "shipwright" },
+      "spec": { "accessModes": ["ReadWriteOnce"], "resources": { "requests": { "storage": "40Gi" } } },
+      "status": { "phase": "Pending" }
+    }
+  },
+  "getPvc_success": {
+    "status": 200,
+    "body": {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": { "name": "agent-abc-home", "namespace": "shipwright" },
+      "spec": { "accessModes": ["ReadWriteOnce"], "resources": { "requests": { "storage": "40Gi" } } },
+      "status": { "phase": "Bound" }
+    }
+  },
+  "deletePvc_success": { "status": 200, "body": {} },
+  "createPvc_409": {
+    "status": 409,
+    "body": { "message": "persistentvolumeclaims \"agent-abc-home\" already exists", "reason": "AlreadyExists", "code": 409 }
+  },
+  "getPvc_404": {
+    "status": 404,
+    "body": { "message": "persistentvolumeclaims \"missing\" not found", "reason": "NotFound", "code": 404 }
   }
 }

--- a/admin/src/kubernetes-client.integration.test.ts
+++ b/admin/src/kubernetes-client.integration.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./errors.ts";
 import {
   HttpKubernetesClient,
+  type KubernetesPvc,
   type KubernetesClient,
   RecordedKubernetesClient,
 } from "./kubernetes-client.ts";
@@ -396,6 +397,68 @@ describe("HttpKubernetesClient — token rotation", () => {
   });
 });
 
+// ─── PVCs: success + error paths ────────────────────────────────────────────
+
+describe("HttpKubernetesClient — PVCs", () => {
+  it("createPvc POSTs to the persistentvolumeclaims collection", async () => {
+    const { client, lastRequest } = makeClient("createPvc_success");
+    const result = await client.createPvc("shipwright", {
+      name: "agent-abc-home",
+      namespace: "shipwright",
+      storageGi: 40,
+    });
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe(
+      "https://kubernetes.default.svc/api/v1/namespaces/shipwright/persistentvolumeclaims",
+    );
+    expect(req.auth).toBe("Bearer test-sa-token");
+    expect(result.metadata.name).toBe("agent-abc-home");
+  });
+
+  it("getPvc GETs the named resource", async () => {
+    const { client, lastRequest } = makeClient("getPvc_success");
+    const result = await client.getPvc("shipwright", "agent-abc-home");
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.url).toBe(
+      "https://kubernetes.default.svc/api/v1/namespaces/shipwright/persistentvolumeclaims/agent-abc-home",
+    );
+    expect(result.metadata.name).toBe("agent-abc-home");
+  });
+
+  it("deletePvc DELETEs the named resource", async () => {
+    const { client, lastRequest } = makeClient("deletePvc_success");
+    await client.deletePvc("shipwright", "agent-abc-home");
+
+    const req = lastRequest();
+    expect(req.method).toBe("DELETE");
+    expect(req.url).toBe(
+      "https://kubernetes.default.svc/api/v1/namespaces/shipwright/persistentvolumeclaims/agent-abc-home",
+    );
+  });
+
+  it("createPvc maps 409 to ConflictError", async () => {
+    const { client } = makeClient("createPvc_409");
+    await expect(
+      client.createPvc("shipwright", {
+        name: "agent-abc-home",
+        namespace: "shipwright",
+        storageGi: 40,
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("getPvc maps 404 to NotFoundError", async () => {
+    const { client } = makeClient("getPvc_404");
+    await expect(
+      client.getPvc("shipwright", "missing"),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
 // ─── RecordedKubernetesClient (in-memory double) ────────────────────────────
 
 describe("RecordedKubernetesClient", () => {
@@ -405,6 +468,9 @@ describe("RecordedKubernetesClient", () => {
     },
     secrets: {
       "shipwright/agent-secret": cassette.getSecret_success?.body as never,
+    },
+    pvcs: {
+      "shipwright/agent-abc-home": cassette.getPvc_success?.body as never,
     },
   });
 

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -129,6 +129,31 @@ export interface KubernetesSecret {
   [key: string]: unknown;
 }
 
+export interface PvcSpec {
+  name: string;
+  namespace: string;
+  storageGi: number;
+  storageClassName?: string;
+}
+
+export interface KubernetesPvc {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    ownerReferences?: Array<Record<string, unknown>>;
+    [key: string]: unknown;
+  };
+  spec: {
+    accessModes: string[];
+    resources: { requests: { storage: string } };
+    storageClassName?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
 // ─── Interface ──────────────────────────────────────────────────────────────
 
 export interface KubernetesClient {
@@ -141,6 +166,9 @@ export interface KubernetesClient {
   createSecret(namespace: string, spec: SecretSpec): Promise<KubernetesSecret>;
   getSecret(namespace: string, name: string): Promise<KubernetesSecret>;
   deleteSecret(namespace: string, name: string): Promise<void>;
+  createPvc(namespace: string, spec: PvcSpec): Promise<KubernetesPvc>;
+  getPvc(namespace: string, name: string): Promise<KubernetesPvc>;
+  deletePvc(namespace: string, name: string): Promise<void>;
 }
 
 // ─── Pure URL builders ────────────────────────────────────────────────────────
@@ -166,6 +194,16 @@ export function secretUrl(
   name?: string,
 ): string {
   const base = `${trimTrailingSlash(apiServer)}/api/v1/namespaces/${namespace}/secrets`;
+  return name ? `${base}/${name}` : base;
+}
+
+/** `/api/v1/namespaces/{ns}/persistentvolumeclaims[/{name}]` */
+export function pvcUrl(
+  apiServer: string,
+  namespace: string,
+  name?: string,
+): string {
+  const base = `${trimTrailingSlash(apiServer)}/api/v1/namespaces/${namespace}/persistentvolumeclaims`;
   return name ? `${base}/${name}` : base;
 }
 
@@ -227,6 +265,22 @@ export function secretBody(
     metadata: { name: spec.name, namespace },
     data,
   };
+}
+
+export function pvcBody(namespace: string, spec: PvcSpec): KubernetesPvc {
+  const body: KubernetesPvc = {
+    apiVersion: "v1",
+    kind: "PersistentVolumeClaim",
+    metadata: { name: spec.name, namespace },
+    spec: {
+      accessModes: ["ReadWriteOnce"],
+      resources: { requests: { storage: `${spec.storageGi}Gi` } },
+    },
+  };
+  if (spec.storageClassName !== undefined) {
+    body.spec.storageClassName = spec.storageClassName;
+  }
+  return body;
 }
 
 // ─── In-cluster config loading ────────────────────────────────────────────────
@@ -463,6 +517,28 @@ export class HttpKubernetesClient implements KubernetesClient {
       headers: this.authHeaders(),
     });
   }
+
+  async createPvc(namespace: string, spec: PvcSpec): Promise<KubernetesPvc> {
+    return this.request<KubernetesPvc>(pvcUrl(this.apiServer, namespace), {
+      method: "POST",
+      headers: this.authHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify(pvcBody(namespace, spec)),
+    });
+  }
+
+  async getPvc(namespace: string, name: string): Promise<KubernetesPvc> {
+    return this.request<KubernetesPvc>(pvcUrl(this.apiServer, namespace, name), {
+      method: "GET",
+      headers: this.authHeaders(),
+    });
+  }
+
+  async deletePvc(namespace: string, name: string): Promise<void> {
+    await this.request<unknown>(pvcUrl(this.apiServer, namespace, name), {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+  }
 }
 
 // ─── RecordedKubernetesClient (in-memory double) ──────────────────────────────
@@ -472,6 +548,8 @@ export interface KubernetesCassette {
   deployments: Record<string, KubernetesDeployment>;
   /** Pre-seeded secrets keyed by `${namespace}/${name}`. */
   secrets: Record<string, KubernetesSecret>;
+  /** Pre-seeded PVCs keyed by `${namespace}/${name}`. */
+  pvcs?: Record<string, KubernetesPvc>;
 }
 
 /**
@@ -482,10 +560,12 @@ export interface KubernetesCassette {
 export class RecordedKubernetesClient implements KubernetesClient {
   private readonly deployments: Map<string, KubernetesDeployment>;
   private readonly secrets: Map<string, KubernetesSecret>;
+  private readonly pvcs: Map<string, KubernetesPvc>;
 
   constructor(cassette: KubernetesCassette) {
     this.deployments = new Map(Object.entries(cassette.deployments));
     this.secrets = new Map(Object.entries(cassette.secrets));
+    this.pvcs = new Map(Object.entries(cassette.pvcs ?? {}));
   }
 
   private static key(namespace: string, name: string): string {
@@ -555,5 +635,33 @@ export class RecordedKubernetesClient implements KubernetesClient {
       throw new NotFoundError(`secrets "${name}" not found`);
     }
     this.secrets.delete(key);
+  }
+
+  async createPvc(namespace: string, spec: PvcSpec): Promise<KubernetesPvc> {
+    const key = RecordedKubernetesClient.key(namespace, spec.name);
+    if (this.pvcs.has(key)) {
+      throw new ConflictError(
+        `persistentvolumeclaims "${spec.name}" already exists`,
+      );
+    }
+    const pvc = pvcBody(namespace, spec);
+    this.pvcs.set(key, pvc);
+    return pvc;
+  }
+
+  async getPvc(namespace: string, name: string): Promise<KubernetesPvc> {
+    const pvc = this.pvcs.get(RecordedKubernetesClient.key(namespace, name));
+    if (!pvc) {
+      throw new NotFoundError(`persistentvolumeclaims "${name}" not found`);
+    }
+    return pvc;
+  }
+
+  async deletePvc(namespace: string, name: string): Promise<void> {
+    const key = RecordedKubernetesClient.key(namespace, name);
+    if (!this.pvcs.has(key)) {
+      throw new NotFoundError(`persistentvolumeclaims "${name}" not found`);
+    }
+    this.pvcs.delete(key);
   }
 }

--- a/admin/src/kubernetes-client.unit.test.ts
+++ b/admin/src/kubernetes-client.unit.test.ts
@@ -6,8 +6,15 @@
 
 import { describe, expect, it } from "bun:test";
 import {
+  ConflictError,
+  NotFoundError,
+} from "./errors.ts";
+import {
+  RecordedKubernetesClient,
   deploymentBody,
   deploymentUrl,
+  pvcBody,
+  pvcUrl,
   secretBody,
   secretUrl,
 } from "./kubernetes-client.ts";
@@ -108,6 +115,133 @@ describe("deploymentBody", () => {
       { name: "FOO", value: "bar" },
       { name: "BAZ", value: "qux" },
     ]);
+  });
+});
+
+// ─── URL building: PVCs ─────────────────────────────────────────────────────
+
+describe("pvcUrl", () => {
+  const api = "https://kubernetes.default.svc";
+
+  it("builds a collection URL (create/list) with no name", () => {
+    expect(pvcUrl(api, "shipwright")).toBe(
+      "https://kubernetes.default.svc/api/v1/namespaces/shipwright/persistentvolumeclaims",
+    );
+  });
+
+  it("builds a resource URL (get/delete) with a name", () => {
+    expect(pvcUrl(api, "shipwright", "agent-abc-home")).toBe(
+      "https://kubernetes.default.svc/api/v1/namespaces/shipwright/persistentvolumeclaims/agent-abc-home",
+    );
+  });
+
+  it("strips a trailing slash from the api server", () => {
+    expect(pvcUrl("https://k8s.local/", "ns", "name")).toBe(
+      "https://k8s.local/api/v1/namespaces/ns/persistentvolumeclaims/name",
+    );
+  });
+});
+
+// ─── Request body shaping: PVCs ──────────────────────────────────────────────
+
+describe("pvcBody", () => {
+  it("shapes a PVC manifest with v1/PersistentVolumeClaim and ReadWriteOnce", () => {
+    const body = pvcBody("shipwright", {
+      name: "agent-abc-home",
+      namespace: "shipwright",
+      storageGi: 40,
+    });
+
+    expect(body.apiVersion).toBe("v1");
+    expect(body.kind).toBe("PersistentVolumeClaim");
+    expect(body.metadata.name).toBe("agent-abc-home");
+    expect(body.metadata.namespace).toBe("shipwright");
+    expect(body.spec.accessModes).toEqual(["ReadWriteOnce"]);
+    expect(body.spec.resources.requests.storage).toBe("40Gi");
+  });
+
+  it("includes storageClassName when provided", () => {
+    const body = pvcBody("shipwright", {
+      name: "agent-abc-home",
+      namespace: "shipwright",
+      storageGi: 20,
+      storageClassName: "standard",
+    });
+
+    expect(body.spec.storageClassName).toBe("standard");
+  });
+
+  it("omits storageClassName when not provided", () => {
+    const body = pvcBody("shipwright", {
+      name: "agent-abc-home",
+      namespace: "shipwright",
+      storageGi: 40,
+    });
+
+    expect(body.spec.storageClassName).toBeUndefined();
+  });
+});
+
+// ─── RecordedKubernetesClient: PVC CRUD ──────────────────────────────────────
+
+describe("RecordedKubernetesClient — PVCs", () => {
+  it("createPvc records and returns the PVC", async () => {
+    const rec = new RecordedKubernetesClient({ deployments: {}, secrets: {}, pvcs: {} });
+    const created = await rec.createPvc("ns", {
+      name: "agent-abc-home",
+      namespace: "ns",
+      storageGi: 40,
+    });
+    expect(created.metadata.name).toBe("agent-abc-home");
+    expect(created.spec.accessModes).toEqual(["ReadWriteOnce"]);
+    expect(created.spec.resources.requests.storage).toBe("40Gi");
+
+    const fetched = await rec.getPvc("ns", "agent-abc-home");
+    expect(fetched.metadata.name).toBe("agent-abc-home");
+  });
+
+  it("createPvc throws ConflictError on duplicate", async () => {
+    const rec = new RecordedKubernetesClient({ deployments: {}, secrets: {}, pvcs: {} });
+    await rec.createPvc("ns", { name: "dup", namespace: "ns", storageGi: 40 });
+    await expect(
+      rec.createPvc("ns", { name: "dup", namespace: "ns", storageGi: 40 }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it("getPvc throws NotFoundError for missing PVC", async () => {
+    const rec = new RecordedKubernetesClient({ deployments: {}, secrets: {}, pvcs: {} });
+    await expect(rec.getPvc("ns", "missing")).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("deletePvc removes the PVC", async () => {
+    const rec = new RecordedKubernetesClient({ deployments: {}, secrets: {}, pvcs: {} });
+    await rec.createPvc("ns", { name: "p", namespace: "ns", storageGi: 40 });
+    await rec.deletePvc("ns", "p");
+    await expect(rec.getPvc("ns", "p")).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("deletePvc throws NotFoundError for missing PVC", async () => {
+    const rec = new RecordedKubernetesClient({ deployments: {}, secrets: {}, pvcs: {} });
+    await expect(rec.deletePvc("ns", "missing")).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("getPvc returns a pre-seeded PVC from the cassette", async () => {
+    const seeded = {
+      apiVersion: "v1" as const,
+      kind: "PersistentVolumeClaim" as const,
+      metadata: { name: "agent-abc-home", namespace: "shipwright" },
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        resources: { requests: { storage: "40Gi" } },
+      },
+    };
+    const rec = new RecordedKubernetesClient({
+      deployments: {},
+      secrets: {},
+      pvcs: { "shipwright/agent-abc-home": seeded },
+    });
+    const fetched = await rec.getPvc("shipwright", "agent-abc-home");
+    expect(fetched.metadata.name).toBe("agent-abc-home");
   });
 });
 

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -113,6 +113,8 @@ function buildProvisioner(
   const adminDeploymentUid = env.SHIPWRIGHT_ADMIN_DEPLOYMENT_UID ?? "";
   const replicasRaw = env.SHIPWRIGHT_AGENT_REPLICAS;
   const replicas = replicasRaw ? Number(replicasRaw) : undefined;
+  const pvcStorageGiRaw = env.SHIPWRIGHT_AGENT_PVC_STORAGE_GI;
+  const pvcStorageGi = pvcStorageGiRaw ? Number(pvcStorageGiRaw) : undefined;
 
   // Agent-voice (STT/TTS) env flowed into provisioned agent pods. The chart's
   // voice Secret + Whisper Service URL land in the admin's env when
@@ -139,6 +141,9 @@ function buildProvisioner(
     adminDeploymentUid,
     ...(replicas !== undefined && Number.isFinite(replicas)
       ? { replicas }
+      : {}),
+    ...(pvcStorageGi !== undefined && Number.isFinite(pvcStorageGi)
+      ? { pvcStorageGi }
       : {}),
     ...(Object.keys(voice).length > 0 ? { voice } : {}),
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,13 +146,14 @@ Controls how the admin service provisions the Kubernetes workload backing each a
 
 | Name | Type | Default | Description |
 |---|---|---|---|
-| `SHIPWRIGHT_K8S_PROVISIONING` | `string` | — | Set to `enabled` to provision a real Kubernetes Secret + Deployment per agent via `KubernetesAgentProvisioner`. Any other value (or unset) selects the no-op provisioner, preserving DB-only create/delete behavior. |
-| `SHIPWRIGHT_K8S_NAMESPACE` | `string` | `default` | Namespace the per-agent Secret + Deployment are created in. Only read when provisioning is enabled. |
+| `SHIPWRIGHT_K8S_PROVISIONING` | `string` | — | Set to `enabled` to provision a real Kubernetes PersistentVolumeClaim + Secret + Deployment per agent via `KubernetesAgentProvisioner`. Any other value (or unset) selects the no-op provisioner, preserving DB-only create/delete behavior. |
+| `SHIPWRIGHT_K8S_NAMESPACE` | `string` | `default` | Namespace the per-agent PersistentVolumeClaim, Secret, and Deployment are created in. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_IMAGE` | `string` | — | Agent container image (without tag) used for the provisioned Deployment. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_IMAGE_TAG` | `string` | `latest` | Image tag joined as `image:tag` for the provisioned Deployment. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME` | `string` | — | Name of the admin Deployment, used as the `ownerReference` target so per-agent resources are garbage-collected with the admin Deployment. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_ADMIN_DEPLOYMENT_UID` | `string` | — | UID of the admin Deployment, paired with `SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME` for the `ownerReference`. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_REPLICAS` | `number` | `1` | Replica count for the provisioned agent Deployment. Only read when provisioning is enabled. |
+| `SHIPWRIGHT_AGENT_PVC_STORAGE_GI` | `number` | `40` | Storage size in Gi for the per-agent persistent home directory (PVC). Only read when provisioning is enabled. Must be large enough to hold mise caches and workspace files across pod restarts. |
 
 ### Workspace and tooling
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -300,18 +300,22 @@ to spin up real agent workloads.
 Setting `agent.provisioning.enabled=true` switches the admin service to the
 **Kubernetes** provisioner. Then:
 
-- `POST /agents` mints a scoped per-agent token, creates a per-agent **Secret**
-  (carrying the token) and a per-agent **Deployment** (referencing that Secret),
-  in that order. Both operations are idempotent and safe to retry.
+- `POST /agents` creates a per-agent **PersistentVolumeClaim** (for persistent
+  agent home storage), mints a scoped per-agent token, creates a per-agent
+  **Secret** (carrying the token), and a per-agent **Deployment** (referencing
+  both), in that order. All operations are idempotent and safe to retry.
 - `DELETE /agents/:id` deletes the agent's Deployment then its Secret,
-  tolerating already-absent resources.
+  tolerating already-absent resources. The **PVC is intentionally left behind**
+  (data safety policy) — cluster admins may clean it up manually once its data
+  has been exported if needed.
 
 ### What the chart renders when provisioning is enabled
 
 - A **namespace-scoped `Role`** (not a `ClusterRole`) named
   `<admin>-agent-provisioner` granting `create`, `get`, and `delete` on
-  `Deployments` (`apps`) and `Secrets` (core) — exactly the verbs the
-  provisioner exercises, least-privilege and scoped to the release namespace.
+  `PersistentVolumeClaims` (core), `Deployments` (`apps`), and `Secrets` (core)
+  — exactly the verbs the provisioner exercises, least-privilege and scoped to
+  the release namespace.
 - A **`RoleBinding`** binding that Role to the **admin ServiceAccount**.
 - A separate **agent ServiceAccount** that provisioned agent pods run as
   (distinct from the admin SA).


### PR DESCRIPTION
## Summary
- Adds `PvcSpec`, `KubernetesPvc`, `pvcUrl()`, `pvcBody()`, and `createPvc/getPvc/deletePvc` to the Kubernetes client interface and both implementations
- Adds `buildAgentPvcManifest()` pure builder to `agent-manifest.ts` (ReadWriteOnce, configurable size, ownerReference for GC)
- Wires `provision()` to create PVC → Secret → Deployment in order; PVC is never deleted on failure or deprovision (data safety policy)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | KubernetesClient interface + both impls have createPvc/getPvc/deletePvc | ✅ MET |
| 2 | buildAgentPvcManifest() pure function with ReadWriteOnce, storage size, ownerRef | ✅ MET |
| 3 | provision() PVC→Secret→Deployment order; 409 idempotent; PVC NOT deleted on failure | ✅ MET |
| 4 | deprovision() deletes Deployment + Secret, NOT PVC (data safety) | ✅ MET |
| 5 | Unit + integration tests for PVC CRUD, manifest shape, provisioner ordering | ✅ MET |
| 6 | Safe to deploy standalone (additive only; requires ALP-A.1 RBAC in prod) | ✅ MET |

## Test Plan
- [x] `bun test admin/src/kubernetes-client.unit.test.ts` — pvcUrl, pvcBody, RecordedKubernetesClient PVC CRUD
- [x] `bun test admin/src/kubernetes-client.integration.test.ts` — HttpKubernetesClient PVC methods via cassette
- [x] `bun test admin/src/agent-manifest.unit.test.ts` — buildAgentPvcManifest shape
- [x] `bun test admin/src/agent-provisioner.integration.test.ts` — PVC→Secret→Deployment ordering; deprovision data-safety
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Lint clean (`bunx biome lint .`)

**Deploy note:** this PR requires ALP-A.1 (RBAC rule for PVCs in agent-provisioning role) to be applied to the cluster before the PVC creation path will succeed in prod. Code can be reviewed independently.

Generated with [Claude Code](https://claude.com/claude-code)
