### PR TITLE
feat(chart): add PVC rule to agent-provisioner Role, bump to 1.5.0 (ALP-A.1)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.4.0]
+
+### Added
+
+- `agent-provisioning-rbac`: added a `persistentvolumeclaims` rule (`create`/`get`/`delete`) to the `agent-provisioner` Role, giving the provisioner the permissions it needs to manage workspace PVCs alongside Deployments and Secrets. Additive — no existing rules changed. ALP-A.2 in vitals-os bumps the subchart dependency to pick this up.
+
 ## [1.3.0]
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.3.0
+version: 1.4.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "metrics.sessionSecret.existingSecret: source the metrics service's SHIPWRIGHT_SESSION_SECRET from a caller-managed Secret instead of the chart-generated random. Point it at the same Secret the admin uses (admin.encryptionKeys.existingSecret) so admin-minted dashboard session JWTs validate at the metrics service when both sit behind a shared Gateway — a mismatch 401s the dashboard's metrics view. The chart-managed metrics Secret omits SHIPWRIGHT_SESSION_SECRET when the knob is set; the Deployment sources it via secretKeyRef. Default empty preserves the generate-on-install / reuse-on-upgrade behaviour."
+      description: "agent-provisioning-rbac: add PersistentVolumeClaims rule (create/get/delete) to the agent-provisioner Role so the provisioner can manage workspace PVCs alongside Deployments and Secrets."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/agent-provisioning-rbac.yaml
+++ b/charts/shipwright/templates/agent-provisioning-rbac.yaml
@@ -3,11 +3,11 @@
 # false → this file renders nothing and the admin service stays in Noop mode).
 #
 # Namespace-scoped Role (NOT a ClusterRole): the admin service provisions agent
-# Deployments + Secrets only within its own release namespace, so a Role bound by
-# a RoleBinding is the least-privilege fit — no cluster-wide grant. The verb set
-# is exactly what the provisioner (HD-1.3 KubernetesAgentProvisioner / HD-1.4
-# wiring) exercises: create + get + delete on Deployments (apps) and
-# Secrets (core).
+# Deployments + Secrets + PVCs only within its own release namespace, so a Role
+# bound by a RoleBinding is the least-privilege fit — no cluster-wide grant. The
+# verb set is exactly what the provisioner (HD-1.3 KubernetesAgentProvisioner /
+# HD-1.4 wiring) exercises: create + get + delete on Deployments (apps),
+# Secrets (core), and PersistentVolumeClaims (core).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -20,6 +20,9 @@ rules:
     verbs: ["create", "get", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["create", "get", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
     verbs: ["create", "get", "delete"]
 ---
 # RoleBinding granting the admin ServiceAccount the Role above, scoped to the

--- a/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
+++ b/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
@@ -8,7 +8,7 @@ suite: agent-provisioning RBAC + admin env contract (HD-4.2)
 #       carries NO provisioning env (admin stays in Noop mode)
 tests:
   # ── (a) enabled → RBAC + agent SA ────────────────────────────────────────────
-  - it: renders a namespace-scoped Role with exactly create/get/delete on Deployments and Secrets
+  - it: renders a namespace-scoped Role with exactly create/get/delete on Deployments, Secrets, and PVCs
     template: templates/agent-provisioning-rbac.yaml
     documentIndex: 0
     set:
@@ -38,6 +38,15 @@ tests:
           value: ["secrets"]
       - equal:
           path: rules[1].verbs
+          value: ["create", "get", "delete"]
+      - equal:
+          path: rules[2].apiGroups
+          value: [""]
+      - equal:
+          path: rules[2].resources
+          value: ["persistentvolumeclaims"]
+      - equal:
+          path: rules[2].verbs
           value: ["create", "get", "delete"]
 
   - it: binds the Role to the admin ServiceAccount via a namespace-scoped RoleBinding

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 1\.3\.0, app version 0\.1\.0
+          pattern: chart version 1\.4\.0, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,8 +146,8 @@ Controls how the admin service provisions the Kubernetes workload backing each a
 
 | Name | Type | Default | Description |
 |---|---|---|---|
-| `SHIPWRIGHT_K8S_PROVISIONING` | `string` | — | Set to `enabled` to provision a real Kubernetes Secret + Deployment per agent via `KubernetesAgentProvisioner`. Any other value (or unset) selects the no-op provisioner, preserving DB-only create/delete behavior. |
-| `SHIPWRIGHT_K8S_NAMESPACE` | `string` | `default` | Namespace the per-agent Secret + Deployment are created in. Only read when provisioning is enabled. |
+| `SHIPWRIGHT_K8S_PROVISIONING` | `string` | — | Set to `enabled` to provision a real Kubernetes Secret + PersistentVolumeClaim + Deployment per agent via `KubernetesAgentProvisioner`. Any other value (or unset) selects the no-op provisioner, preserving DB-only create/delete behavior. |
+| `SHIPWRIGHT_K8S_NAMESPACE` | `string` | `default` | Namespace the per-agent Secret, PersistentVolumeClaim, and Deployment are created in. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_IMAGE` | `string` | — | Agent container image (without tag) used for the provisioned Deployment. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_IMAGE_TAG` | `string` | `latest` | Image tag joined as `image:tag` for the provisioned Deployment. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME` | `string` | — | Name of the admin Deployment, used as the `ownerReference` target so per-agent resources are garbage-collected with the admin Deployment. Only read when provisioning is enabled. |

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -301,17 +301,19 @@ Setting `agent.provisioning.enabled=true` switches the admin service to the
 **Kubernetes** provisioner. Then:
 
 - `POST /agents` mints a scoped per-agent token, creates a per-agent **Secret**
-  (carrying the token) and a per-agent **Deployment** (referencing that Secret),
-  in that order. Both operations are idempotent and safe to retry.
-- `DELETE /agents/:id` deletes the agent's Deployment then its Secret,
+  (carrying the token), a per-agent **PersistentVolumeClaim** (for durable
+  storage), and a per-agent **Deployment** (referencing the Secret and PVC),
+  in that order. All operations are idempotent and safe to retry.
+- `DELETE /agents/:id` deletes the agent's Deployment, PVC, then its Secret,
   tolerating already-absent resources.
 
 ### What the chart renders when provisioning is enabled
 
 - A **namespace-scoped `Role`** (not a `ClusterRole`) named
   `<admin>-agent-provisioner` granting `create`, `get`, and `delete` on
-  `Deployments` (`apps`) and `Secrets` (core) — exactly the verbs the
-  provisioner exercises, least-privilege and scoped to the release namespace.
+  `Deployments` (`apps`), `Secrets` (core), and `PersistentVolumeClaims`
+  (core) — exactly the verbs the provisioner exercises, least-privilege and
+  scoped to the release namespace.
 - A **`RoleBinding`** binding that Role to the **admin ServiceAccount**.
 - A separate **agent ServiceAccount** that provisioned agent pods run as
   (distinct from the admin SA).


### PR DESCRIPTION
## Summary
- Add `persistentvolumeclaims` (create/get/delete) as a third rule to the `agent-provisioner` Role in `agent-provisioning-rbac.yaml`
- Update Helm unit test to assert `rules[2]` for PVCs alongside existing `rules[0]` (Deployments) and `rules[1]` (Secrets) assertions
- Bump chart version `1.3.0 → 1.4.0` with CHANGELOG entry and updated `artifacthub.io/changes` annotation

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Role has three rules: deployments/secrets/pvcs each with create/get/delete | ✅ MET |
| 2 | RoleBinding and agent.provisioning.enabled gate unchanged | ✅ MET |
| 3 | Helm test asserts rules[2] for persistentvolumeclaims | ✅ MET |
| 4 | Chart version bumped to 1.4.0 | ✅ MET |
| 5 | Safe to deploy standalone: no — requires ALP-A.2 in vitals-os | ℹ️ UNVERIFIABLE (process note) |

## Test Plan
- [x] `helm unittest . --file tests/agent_provisioning_rbac_test.yaml` — 11/11 pass
- [x] Pre-existing test failures (gateway, metadata, values_schema) are on main and unrelated to this change
- [x] Additive change — no existing rules modified

> **Note**: This PR is not safe to deploy standalone. ALP-A.2 in vitals-os must bump the shipwright subchart dependency to 1.4.0 before the cluster sees the new PVC rule.

Generated with [Claude Code](https://claude.com/claude-code)
