### PR TITLE
feat(github-adapter): HITL label support — setup, append, issueToTask, query filter

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -72,7 +72,7 @@ If any check fails (returns `[fail]`), the command exits with status code 1.
 
 ## GitHub backend
 
-The GitHub backend stores tasks as GitHub Issues. Each issue carries a `status:*` label that is the authoritative status, plus a fenced `shipwright` code block in the issue body containing the full task metadata JSON.
+The GitHub backend stores tasks as GitHub Issues. Each issue carries a `status:*` label that is the authoritative status, an optional `hitl` label to gate execution, and a fenced `shipwright` code block in the issue body containing the full task metadata JSON.
 
 ### Prerequisites
 
@@ -110,7 +110,7 @@ bun plugins/shipwright/scripts/task_store.ts setup
 bun plugins/shipwright/scripts/task_store.ts doctor
 ```
 
-The `setup` command creates all `status:*` labels (`status:pending`, `status:in_progress`, `status:pr_open`, etc.) using `--force` so it is safe to re-run.
+The `setup` command creates all `status:*` labels (`status:pending`, `status:in_progress`, `status:pr_open`, etc.) and the `hitl` label (human-in-the-loop, red color) using `--force` so it is safe to re-run.
 
 ### When to use
 
@@ -234,6 +234,16 @@ Example — limit to the current sprint and only pending tasks:
 }
 ```
 
+### Human-in-the-loop (HITL) filtering
+
+Tasks marked with the `hitl` label or field are automatically excluded from the ready task set. Use this to temporarily gate high-risk or uncertain tasks from automated execution — they will not be picked up by `resolveReadyTasks()` even when all dependencies are satisfied and status is `pending`.
+
+To mark a task as HITL:
+- **GitHub backend:** apply the `hitl` label to the issue
+- **Jira backend:** add `hitl: true` to the task metadata block, or use a custom JQL filter (see `readyJql` above) to exclude them
+
+HITL is a runtime flag — it does not affect `query()` filters or direct task lookup. Use `query(filters: { hitl: true })` to return only HITL tasks, or `query(filters: { hitl: false })` to return only non-HITL tasks.
+
 ### How task metadata is stored
 
 When Shipwright creates a Jira issue, it stores the full task JSON in an ADF `codeBlock` with `language: "shipwright"` in the issue description. A human-readable description paragraph appears above it. Issues without this block are ignored by the adapter.
@@ -271,7 +281,7 @@ The `task_store.ts` script provides several subcommands for manual interaction w
 | `setup` | Create `state/todos.json` if missing (JSON backend) or initialize GitHub/Jira labels and validation (GitHub/Jira backends) |
 | `doctor` | Validate configuration and print diagnostics (includes `backend:` line showing the active backend) |
 | `backend` | Print the active backend name: `json`, `github`, or `jira` (useful for scripts that need to detect the backend) |
-| `query` | Filter and return tasks as JSON array (supports `--status pending` and other filters) |
+| `query` | Filter and return tasks as JSON array (supports `--status pending`, `--assignee user`, `--hitl` and other filters) |
 | `append` | Append tasks from a JSON file (insert-only on GitHub adapter; upsert on JSON adapter) |
 | `update` | Write specific fields to a task by ID |
 | `repos` | Print all org/repo strings (one per line) |

--- a/plugins/shipwright/scripts/adapters/github.ts
+++ b/plugins/shipwright/scripts/adapters/github.ts
@@ -12,6 +12,7 @@
  * GH_CMD env var is used for the gh executable — inject a fake command for tests.
  */
 
+import { resolveRepos } from "../check-helpers.ts";
 import { resolveReadyTasks } from "../store.ts";
 import type {
   QueryFilters,
@@ -20,7 +21,6 @@ import type {
   TaskStore,
   TaskStoreConfig,
 } from "../store.ts";
-import { resolveRepos } from "../check-helpers.ts";
 import {
   type AuditResult,
   checkCrossRepoOrphans,
@@ -699,9 +699,7 @@ export class GitHubTaskStore implements TaskStore {
 
     const g = this.config.github;
     if (g) {
-      results.push(
-        ...checkCrossRepoOrphans(tasks, `${g.owner}/${g.repo}`),
-      );
+      results.push(...checkCrossRepoOrphans(tasks, `${g.owner}/${g.repo}`));
     }
 
     // ── 3. Zero-label check (wide fetch) ────────────────────────────────────

--- a/plugins/shipwright/scripts/adapters/github.ts
+++ b/plugins/shipwright/scripts/adapters/github.ts
@@ -146,6 +146,11 @@ function issueToTask(issue: GhIssue): TaskWithMeta {
     task._labelStatus = labelStatus;
   }
 
+  // hitl label is authoritative — set task.hitl when the label is present
+  if (issue.labels.some((lbl) => lbl.name === "hitl")) {
+    task.hitl = true;
+  }
+
   // Fall back to GitHub issue assignee when not set in the YAML block
   if (task.assignee === undefined && issue.assignees?.[0]) {
     task.assignee = issue.assignees[0].login;
@@ -326,6 +331,13 @@ export class GitHubTaskStore implements TaskStore {
       // ready path above.
       tasks = tasks.filter((t) => t.assignee === filters.assignee);
     }
+    if (filters.hitl !== undefined) {
+      if (filters.hitl) {
+        tasks = tasks.filter((t) => t.hitl === true);
+      } else {
+        tasks = tasks.filter((t) => t.hitl !== true);
+      }
+    }
 
     return tasks.map(stripInternal);
   }
@@ -397,6 +409,10 @@ export class GitHubTaskStore implements TaskStore {
 
       if (assignee) {
         createArgs.push("--assignee", assignee);
+      }
+
+      if (task.hitl === true) {
+        createArgs.push("--label", "hitl");
       }
 
       await this.runGh(createArgs);
@@ -494,6 +510,31 @@ export class GitHubTaskStore implements TaskStore {
           String(issueNumber),
           "--repo",
           this.repoFlag,
+        ]);
+      }
+    }
+
+    // Manage hitl label when hitl field is explicitly set or cleared
+    if (fields.hitl !== undefined && issueNumber !== undefined) {
+      if (fields.hitl) {
+        await this.runGh([
+          "issue",
+          "edit",
+          String(issueNumber),
+          "--repo",
+          this.repoFlag,
+          "--add-label",
+          "hitl",
+        ]);
+      } else {
+        await this.runGh([
+          "issue",
+          "edit",
+          String(issueNumber),
+          "--repo",
+          this.repoFlag,
+          "--remove-label",
+          "hitl",
         ]);
       }
     }
@@ -741,6 +782,16 @@ export class GitHubTaskStore implements TaskStore {
         "--force",
       ]);
     }
+    await this.runGh([
+      "label",
+      "create",
+      "hitl",
+      "--repo",
+      this.repoFlag,
+      "--color",
+      "B60205",
+      "--force",
+    ]);
   }
 
   async resolveRepo(): Promise<string> {

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -2888,6 +2888,7 @@ process.exit(0);
   });
 
   test("only calls ensureMilestone once per session when batch has multiple tasks with same session", async () => {
+
     const milestonesGetFile = path.join(tmpDir, "milestone-batch-gets.txt");
     const scriptPath = path.join(tmpDir, "milestone-batch-gh");
     const script = `#!/usr/bin/env bun
@@ -2952,5 +2953,159 @@ process.exit(0);
     const getsContent = await Bun.file(milestonesGetFile).text();
     const getCount = getsContent.trim().split("\n").filter(Boolean).length;
     expect(getCount).toBe(1);
+  });
+});
+
+// ─── HITL label support (HIT-1.2) ────────────────────────────────────────────
+
+describe("GitHubTaskStore HITL label support", () => {
+  test("setup() creates hitl label via --force", async () => {
+    const captureScript = path.join(tmpDir, "hitl-setup-gh");
+    const callsFile = path.join(tmpDir, "hitl-setup-calls.txt");
+    const script = `#!/usr/bin/env bun
+import { argv } from "process";
+import { appendFileSync } from "fs";
+appendFileSync(${JSON.stringify(callsFile)}, argv.slice(2).join("|") + "\\n");
+process.exit(0);
+`;
+    await writeFile(captureScript, script, { mode: 0o755 });
+    process.env.GH_CMD = captureScript;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    await adapter.setup();
+
+    const calls = (await Bun.file(callsFile).text())
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.split("|"));
+
+    const hitlLabelCall = calls.find(
+      (c) => c[0] === "label" && c[1] === "create" && c[2] === "hitl",
+    );
+    expect(hitlLabelCall).toBeDefined();
+    expect(hitlLabelCall).toContain("--force");
+    expect(hitlLabelCall).toContain("--color");
+    expect(hitlLabelCall).toContain("B60205");
+  });
+
+  test("append() adds --label hitl when task.hitl is true", async () => {
+    const argsFile = path.join(tmpDir, "hitl-append-args.json");
+    const captureScript = path.join(tmpDir, "hitl-append-gh");
+    const script = `#!/usr/bin/env bun
+import { argv } from "process";
+import { writeFileSync } from "fs";
+const args = argv.slice(2);
+
+if (args[0] === "issue" && args[1] === "list") {
+  console.log("[]");
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "user") {
+  console.log("test-user");
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1].includes("milestones")) {
+  console.log("[]");
+  process.exit(0);
+}
+
+if (args[0] === "label" && args[1] === "create") {
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "create") {
+  writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(args));
+  console.log("https://github.com/test-owner/test-repo/issues/42");
+  process.exit(0);
+}
+
+process.exit(0);
+`;
+    await writeFile(captureScript, script, { mode: 0o755 });
+    process.env.GH_CMD = captureScript;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    await adapter.append([
+      {
+        id: "HIT-A.1",
+        title: "HITL task",
+        status: "pending",
+        hitl: true,
+        session: "hitl-test",
+      },
+    ]);
+
+    const createArgs = JSON.parse(await Bun.file(argsFile).text()) as string[];
+    expect(createArgs).toContain("--label");
+    expect(createArgs).toContain("hitl");
+  });
+
+  test("issueToTask() sets hitl: true when hitl label is present on the issue", async () => {
+    const baseIssue = makeIssue(1, "HIT-B.1: HITL task", "pending", {
+      id: "HIT-B.1",
+      title: "HITL task",
+      status: "pending",
+    });
+    const issueWithHitlLabel = {
+      ...baseIssue,
+      labels: [...baseIssue.labels, { name: "hitl" }],
+    };
+
+    const issueWithoutHitlLabel = makeIssue(2, "HIT-B.2: Normal task", "pending", {
+      id: "HIT-B.2",
+      title: "Normal task",
+      status: "pending",
+    });
+
+    const fakeGh = await writeFakeGh(tmpDir, {
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
+        [issueWithHitlLabel, issueWithoutHitlLabel],
+    });
+    process.env.GH_CMD = fakeGh;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    const tasks = await adapter.query({});
+
+    const hitlTask = tasks.find((t) => t.id === "HIT-B.1");
+    const normalTask = tasks.find((t) => t.id === "HIT-B.2");
+
+    expect(hitlTask?.hitl).toBe(true);
+    expect(normalTask?.hitl).toBeUndefined();
+  });
+
+  test("query({ hitl: true }) returns only hitl tasks; query({ hitl: false }) excludes them", async () => {
+    const baseIssue = makeIssue(1, "HIT-C.1: HITL task", "pending", {
+      id: "HIT-C.1",
+      title: "HITL task",
+      status: "pending",
+    });
+    const hitlIssue = {
+      ...baseIssue,
+      labels: [...baseIssue.labels, { name: "hitl" }],
+    };
+    const normalIssue = makeIssue(2, "HIT-C.2: Normal task", "pending", {
+      id: "HIT-C.2",
+      title: "Normal task",
+      status: "pending",
+    });
+
+    const fakeGh = await writeFakeGh(tmpDir, {
+      "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":
+        [hitlIssue, normalIssue],
+    });
+    process.env.GH_CMD = fakeGh;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+
+    const hitlOnly = await adapter.query({ hitl: true });
+    expect(hitlOnly).toHaveLength(1);
+    expect(hitlOnly[0].id).toBe("HIT-C.1");
+
+    const nonHitlOnly = await adapter.query({ hitl: false });
+    expect(nonHitlOnly).toHaveLength(1);
+    expect(nonHitlOnly[0].id).toBe("HIT-C.2");
   });
 });

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -136,7 +136,9 @@ describe("GitHubTaskStore.resolveRepos", () => {
   });
 
   test("merges config repo with workspace repos, config repo first, no duplicates", async () => {
-    const reposDir = await mkdtemp(path.join(tmpdir(), "shipwright-test-repos-"));
+    const reposDir = await mkdtemp(
+      path.join(tmpdir(), "shipwright-test-repos-"),
+    );
     try {
       // Create a fake git repo that resolveRepos can scan
       const repoDir = path.join(reposDir, "other-repo");
@@ -2888,7 +2890,6 @@ process.exit(0);
   });
 
   test("only calls ensureMilestone once per session when batch has multiple tasks with same session", async () => {
-
     const milestonesGetFile = path.join(tmpDir, "milestone-batch-gets.txt");
     const scriptPath = path.join(tmpDir, "milestone-batch-gh");
     const script = `#!/usr/bin/env bun
@@ -3054,11 +3055,16 @@ process.exit(0);
       labels: [...baseIssue.labels, { name: "hitl" }],
     };
 
-    const issueWithoutHitlLabel = makeIssue(2, "HIT-B.2: Normal task", "pending", {
-      id: "HIT-B.2",
-      title: "Normal task",
-      status: "pending",
-    });
+    const issueWithoutHitlLabel = makeIssue(
+      2,
+      "HIT-B.2: Normal task",
+      "pending",
+      {
+        id: "HIT-B.2",
+        title: "Normal task",
+        status: "pending",
+      },
+    );
 
     const fakeGh = await writeFakeGh(tmpDir, {
       "issue list --repo test-owner/test-repo --state all --json number,title,body,labels,state,url,milestone,assignees --limit 500":

--- a/plugins/shipwright/scripts/adapters/github.unit.test.ts
+++ b/plugins/shipwright/scripts/adapters/github.unit.test.ts
@@ -3114,4 +3114,106 @@ process.exit(0);
     expect(nonHitlOnly).toHaveLength(1);
     expect(nonHitlOnly[0].id).toBe("HIT-C.2");
   });
+
+  test("update(id, { hitl: true }) calls gh issue edit --add-label hitl", async () => {
+    const issues = [
+      makeIssue(42, "HIT-D.1: HITL task", "pending", {
+        id: "HIT-D.1",
+        title: "HITL task",
+        status: "pending",
+      }),
+    ];
+
+    const editsFile = path.join(tmpDir, "hitl-add-edits.txt");
+    const scriptPath = path.join(tmpDir, "hitl-add-gh");
+    const script = `#!/usr/bin/env bun
+import { argv } from "process";
+import { appendFileSync } from "fs";
+const args = argv.slice(2);
+
+if (args[0] === "issue" && args[1] === "list") {
+  console.log(${JSON.stringify(JSON.stringify(issues))});
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "edit") {
+  appendFileSync(${JSON.stringify(editsFile)}, args.join("|") + "\\n");
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "close") {
+  process.exit(0);
+}
+
+process.exit(0);
+`;
+    await writeFile(scriptPath, script, { mode: 0o755 });
+    process.env.GH_CMD = scriptPath;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    await adapter.update("HIT-D.1", { hitl: true });
+
+    const edits = (await Bun.file(editsFile).text())
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.split("|"));
+
+    const hitlEdit = edits.find(
+      (e) => e.includes("--add-label") && e.includes("hitl"),
+    );
+    expect(hitlEdit).toBeDefined();
+    expect(hitlEdit).not.toContain("--remove-label");
+  });
+
+  test("update(id, { hitl: false }) calls gh issue edit --remove-label hitl", async () => {
+    const issues = [
+      makeIssue(43, "HIT-D.2: HITL task", "pending", {
+        id: "HIT-D.2",
+        title: "HITL task",
+        status: "pending",
+      }),
+    ];
+
+    const editsFile = path.join(tmpDir, "hitl-remove-edits.txt");
+    const scriptPath = path.join(tmpDir, "hitl-remove-gh");
+    const script = `#!/usr/bin/env bun
+import { argv } from "process";
+import { appendFileSync } from "fs";
+const args = argv.slice(2);
+
+if (args[0] === "issue" && args[1] === "list") {
+  console.log(${JSON.stringify(JSON.stringify(issues))});
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "edit") {
+  appendFileSync(${JSON.stringify(editsFile)}, args.join("|") + "\\n");
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "close") {
+  process.exit(0);
+}
+
+process.exit(0);
+`;
+    await writeFile(scriptPath, script, { mode: 0o755 });
+    process.env.GH_CMD = scriptPath;
+
+    const adapter = new GitHubTaskStore(CONFIG);
+    await adapter.update("HIT-D.2", { hitl: false });
+
+    const edits = (await Bun.file(editsFile).text())
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.split("|"));
+
+    const hitlEdit = edits.find(
+      (e) => e.includes("--remove-label") && e.includes("hitl"),
+    );
+    expect(hitlEdit).toBeDefined();
+    expect(hitlEdit).not.toContain("--add-label");
+  });
 });

--- a/plugins/shipwright/scripts/store.ts
+++ b/plugins/shipwright/scripts/store.ts
@@ -123,6 +123,16 @@ export interface Task {
    * 1 = trivial, 5 = highest complexity. Used for planning and model selection heuristics.
    */
   complexity?: number;
+
+  /**
+   * When true, this task requires human-in-the-loop execution and must not be
+   * picked up by the automated dev-task executor. resolveReadyTasks excludes
+   * hitl tasks from the ready set.
+   */
+  hitl?: boolean;
+
+  /** ISO timestamp set when the agent first notified humans about this HITL task. */
+  hitlNotifiedAt?: string;
 }
 
 // ─── QueryFilters ─────────────────────────────────────────────────────────────
@@ -148,6 +158,9 @@ export interface QueryFilters {
 
   /** Filter tasks by GitHub login of the assigned developer. */
   assignee?: string;
+
+  /** When true, return only hitl tasks; when false, exclude hitl tasks. */
+  hitl?: boolean;
 }
 
 // ─── TaskStoreConfig ──────────────────────────────────────────────────────────
@@ -214,6 +227,7 @@ export async function resolveReadyTasks(
 
   for (const task of tasks) {
     if (task.status !== "pending") continue;
+    if (task.hitl === true) continue;
 
     let ready = true;
     for (const depId of task.dependencies ?? []) {


### PR DESCRIPTION
## Summary

Implements HIT-1.2: GitHub adapter HITL label lifecycle management.

- `setup()` creates the `hitl` label (red `#B60205`) idempotently via `--force`
- `issueToTask()` sets `task.hitl = true` when the `hitl` label is present on the issue
- `append()` applies `--label hitl` when `task.hitl === true` at issue creation time
- `query({ hitl: true/false })` filters tasks by HITL status in the non-ready path
- `update()` manages `hitl` label add/remove when `fields.hitl` is explicitly set or cleared
- `resolveReadyTasks()` in `store.ts` skips `task.hitl === true` tasks from the ready set (HIT-1.1 prerequisite bundled in this PR since HIT-1.1's code was never merged to main)
- 4 unit tests covering all four behaviors using fake-gh fixtures

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `setup()` creates hitl label idempotently via `--force` | ✅ MET |
| 2 | `append()` adds `--label hitl` when `task.hitl === true` | ✅ MET |
| 3 | `issueToTask()` sets `task.hitl = true` when hitl label present | ✅ MET |
| 4 | `query({ hitl: true })` returns only hitl tasks; `query({ hitl: false })` excludes them | ✅ MET |
| 5 | 4 unit tests at unit layer, no existing tests retired | ✅ MET |

## Test plan

- [x] `bun test plugins/shipwright/scripts/adapters/github.unit.test.ts` — 80/80 pass
- [x] `bun test plugins/shipwright/` — 837/837 pass
- [x] `bunx biome check` — clean (import order + formatting auto-fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)