### PR TITLE
docs(task-store): document 5 doctor data checks and append duplicate-ID warning

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -42,19 +42,23 @@ token scope: N/A (JSON backend)
 [ok]  storage: /path/to/state/todos.json present
 [ok]  data: duplicate-ids — No duplicate IDs found
 [ok]  data: dangling-deps — All dependencies resolve
+[ok]  data: cross-repo-orphans — All repos are valid
 ```
 
 The `doctor` command runs two categories of checks:
 
 1. **Config/storage checks** — verifies the backend is configured correctly and accessible
 2. **Data integrity checks** — audits task metadata for structural issues:
-   - `duplicate-ids` — no task ID appears twice
-   - `dangling-deps` — all task dependencies reference existing tasks
-   - `zero-status-label` (GitHub only) — all shipwright-managed issues have a `status:*` label
-   - `stale-pr` (GitHub only) — tasks in `pr_open` or `approved` status have merged PRs
-   - `cross-repo-orphans` — all cross-repo task references point to valid repositories
 
-If any check fails (returns `[fail]`), the command exits with status code 1.
+| Check | Level | Applies to | Trigger condition |
+|-------|-------|-----------|-------------------|
+| `duplicate-ids` | `fail` | all backends | Two or more tasks share the same `id` |
+| `dangling-deps` | `fail` | all backends | A task's `dependencies` reference an `id` that doesn't exist |
+| `cross-repo-orphans` | `warn` | all backends | A task's `repo` field doesn't match the adapter's configured repo |
+| `zero-status-label` | `fail` | GitHub only | A GitHub issue has a shipwright code block but no `status:*` label |
+| `stale-pr` | `fail` | GitHub only | A task in `pr_open` or `approved` status has a PR that is already merged |
+
+Any check that returns `[fail]` causes the command to exit with status code 1. Results with `[warn]` severity are printed but do not cause a non-zero exit.
 
 ### When to use
 
@@ -272,7 +276,7 @@ The `task_store.ts` script provides several subcommands for manual interaction w
 | `doctor` | Validate configuration and print diagnostics (includes `backend:` line showing the active backend) |
 | `backend` | Print the active backend name: `json`, `github`, or `jira` (useful for scripts that need to detect the backend) |
 | `query` | Filter and return tasks as JSON array (supports `--status pending` and other filters) |
-| `append` | Append tasks from a JSON file (insert-only on GitHub adapter; upsert on JSON adapter) |
+| `append` | Append tasks from a JSON file (insert-only on GitHub adapter; upsert on JSON adapter). GitHub backend warns to stderr when a duplicate task ID is skipped: `warn: task '{id}' already exists in GitHub — skipped` |
 | `update` | Write specific fields to a task by ID |
 | `repos` | Print all org/repo strings (one per line) |
 | `resolve-repo` | Print first org/repo (deprecated alias for `repos`) |

--- a/plugins/shipwright/references/task-store.md
+++ b/plugins/shipwright/references/task-store.md
@@ -129,9 +129,12 @@ Idempotently upsert tasks from a JSON file (matched by `id`).
 ts-store append <file>
 ```
 
-- If a task with the same `id` already exists, it is updated with the fields
-  from the file. Fields not present in the file are left unchanged.
-- If the task does not exist, it is inserted.
+- **JSON backend:** If a task with the same `id` already exists, it is updated with the
+  fields from the file. Fields not present in the file are left unchanged. If the task
+  does not exist, it is inserted (upsert behavior).
+- **GitHub backend:** Insert-only. If a task with a matching `id` already exists in the
+  GitHub store, it is skipped and a warning is emitted to stderr: `warn: task '{id}'
+  already exists in GitHub — skipped`. New tasks are inserted normally.
 
 **Return shape:** Summary object.
 
@@ -210,11 +213,23 @@ misconfiguration.
 ts-store doctor
 ```
 
-Checks performed:
+**Config and storage checks:**
 - Config file present and valid JSON
 - Required fields populated for the active backend
 - Auth token present and `gh auth status` succeeds
 - For GitHub backend: all 6 status labels exist in the configured repository
+
+**Data integrity checks:**
+
+| Check | Level | Applies to | Trigger condition |
+|-------|-------|-----------|-------------------|
+| `duplicate-ids` | `fail` | all backends | Two or more tasks share the same `id` |
+| `dangling-deps` | `fail` | all backends | A task's `dependencies` reference an `id` that doesn't exist |
+| `cross-repo-orphans` | `warn` | all backends | A task's `repo` field doesn't match the adapter's configured repo |
+| `zero-status-label` | `fail` | GitHub only | A GitHub issue has a shipwright code block but no `status:*` label |
+| `stale-pr` | `fail` | GitHub only | A task in `pr_open` or `approved` status has a PR that is already merged |
+
+Any check that returns `[fail]` causes the command to exit with code 1. Results with `[warn]` severity are printed but do not cause a non-zero exit.
 
 **Return shape:** Diagnostic lines printed to stdout/stderr; exit code `0`
 (healthy) or `1` (misconfigured).
@@ -228,6 +243,9 @@ Checks performed:
 [ok]  label: status:approved
 [ok]  label: status:merged
 [ok]  label: status:blocked
+[ok]  data: duplicate-ids — No duplicate IDs found
+[ok]  data: dangling-deps — All dependencies resolve
+[ok]  data: cross-repo-orphans — All repos are valid
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Documents all 5 new data integrity checks added in TSD-2.1 in both `docs/task-store.md` and `plugins/shipwright/references/task-store.md`
- Each check now shows its name, severity level (`fail` or `warn`), which backends it applies to, and the trigger condition
- Clarifies exit-code behavior: `[fail]` causes exit 1; `[warn]` is informational only
- Adds note to the `append` section in both docs: the GitHub backend emits a warning to stderr (`warn: task '{id}' already exists in GitHub — skipped`) when a duplicate task ID is skipped

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | docs/task-store.md doctor section lists all 5 checks with level and trigger | ✅ MET |
| 2 | plugins/shipwright/references/task-store.md doctor section updated to match | ✅ MET |
| 3 | append section in both docs notes the duplicate-ID warning behavior | ✅ MET |
| 4 | No code changes in this task | ✅ MET |
| 5 | No tests needed — docs-only change | ✅ MET |

## Test Plan
- [x] Docs-only change — no tests required
- [x] Both files verified against actual implementation in `audit.ts` and `github.ts`

Generated with [Claude Code](https://claude.com/claude-code)
