### PR TITLE
feat(check-dev-task): HITL pending notification + hitlNotifiedAt stamp (HIT-2.1)

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -244,6 +244,8 @@ To mark a task as HITL:
 
 HITL is a runtime flag — it does not affect `query()` filters or direct task lookup. Use `query(filters: { hitl: true })` to return only HITL tasks, or `query(filters: { hitl: false })` to return only non-HITL tasks.
 
+**Notification workflow:** When `check-dev-task.ts` finds pending HITL tasks that have not been notified (no `hitlNotifiedAt` timestamp), it returns exit code 0 with a notification message listing the tasks. The notification should be posted to the configured channel, and then each task's `hitlNotifiedAt` field should be stamped with the current timestamp using the task store update command to prevent duplicate notifications. The field format is an ISO 8601 timestamp string (e.g., `"2026-06-17T10:00:00Z"`).
+
 ### How task metadata is stored
 
 When Shipwright creates a Jira issue, it stores the full task JSON in an ADF `codeBlock` with `language: "shipwright"` in the issue description. A human-readable description paragraph appears above it. Issues without this block are ignored by the adapter.

--- a/plugins/shipwright/scripts/check-dev-task.test.ts
+++ b/plugins/shipwright/scripts/check-dev-task.test.ts
@@ -36,6 +36,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
 interface MakeDepsOptions {
   readyTasks?: Task[];
   inProgressTasks?: Task[];
+  hitlPendingTasks?: Task[];
   resetCalls?: string[];
   stampCalls?: string[];
   clock?: Clock;
@@ -50,12 +51,14 @@ function makeDeps(options: MakeDepsOptions | Task[] = {}) {
 
   const readyTasks = opts.readyTasks ?? [];
   const inProgressTasks = opts.inProgressTasks ?? [];
+  const hitlPendingTasks = opts.hitlPendingTasks ?? [];
   const resetCalls = opts.resetCalls ?? [];
   const clock = opts.clock ?? FixedClock("2026-05-31T16:00:00Z");
 
   return {
     getReadyTasks: async (): Promise<Task[]> => readyTasks,
     getInProgressTasks: async (): Promise<Task[]> => inProgressTasks,
+    getHitlPendingTasks: async (): Promise<Task[]> => hitlPendingTasks,
     resetTask: async (id: string): Promise<Task> => {
       resetCalls.push(id);
       return makeTask({ id, status: "pending" });
@@ -219,5 +222,87 @@ describe("check-dev-task", () => {
 
     expect(resetCalls).toContain("SWC-2.6");
     expect(result.exit).toBe(1);
+  });
+
+  // ─── HITL pending notification ────────────────────────────────────────────
+
+  test("exits 0 with HITL notification when only HITL tasks pending (no ready work)", async () => {
+    const hitlTask1 = makeTask({
+      id: "HIT-3.1",
+      title: "Review architecture decision",
+      status: "pending",
+      hitl: true,
+    });
+    const hitlTask2 = makeTask({
+      id: "HIT-3.2",
+      title: "Approve deployment plan",
+      status: "pending",
+      hitl: true,
+    });
+
+    const result = await run(
+      makeDeps({
+        readyTasks: [],
+        hitlPendingTasks: [hitlTask1, hitlTask2],
+      }),
+    );
+
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("HIT-3.1");
+    expect(result.output).toContain("HIT-3.2");
+    expect(result.output).toContain("Review architecture decision");
+    expect(result.output).toContain("Approve deployment plan");
+  });
+
+  test("exits 0 with standard dev-task prompt when both ready and HITL tasks exist", async () => {
+    const regularTask = makeTask({ id: "SWC-4.1", title: "Regular task" });
+    const hitlTask = makeTask({
+      id: "HIT-4.1",
+      title: "Human review needed",
+      status: "pending",
+      hitl: true,
+    });
+
+    const result = await run(
+      makeDeps({
+        readyTasks: [regularTask],
+        hitlPendingTasks: [hitlTask],
+      }),
+    );
+
+    expect(result.exit).toBe(0);
+    expect(result.output.toLowerCase()).toContain("dev-task");
+  });
+
+  test("excludes HITL tasks with hitlNotifiedAt from notification", async () => {
+    const hitlTaskWithNotifiedAt = makeTask({
+      id: "HIT-5.1",
+      title: "Already notified task",
+      status: "pending",
+      hitl: true,
+      hitlNotifiedAt: "2026-06-17T10:00:00Z",
+    });
+
+    const result = await run(
+      makeDeps({
+        readyTasks: [],
+        hitlPendingTasks: [hitlTaskWithNotifiedAt],
+      }),
+    );
+
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when no ready tasks and no un-notified HITL tasks", async () => {
+    const result = await run(
+      makeDeps({
+        readyTasks: [],
+        hitlPendingTasks: [],
+      }),
+    );
+
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
   });
 });

--- a/plugins/shipwright/scripts/check-dev-task.ts
+++ b/plugins/shipwright/scripts/check-dev-task.ts
@@ -31,6 +31,7 @@ const STALE_THRESHOLD_MS = 4 * 60 * 60 * 1000; // 4 hours
 interface Deps {
   getReadyTasks: () => Promise<Task[]>;
   getInProgressTasks: () => Promise<Task[]>;
+  getHitlPendingTasks: () => Promise<Task[]>;
   resetTask: (id: string) => Promise<Task>;
   stampTask: (id: string, startedAt: string) => Promise<Task>;
   clock: Clock;
@@ -63,6 +64,21 @@ export async function run(deps: Deps): Promise<RunResult> {
       exit: 0,
       output:
         "Pick the next ready task from the task store and execute via /shipwright:dev-task",
+    };
+  }
+
+  const hitlPendingTasks = await deps.getHitlPendingTasks();
+  const unnotifiedHitlTasks = hitlPendingTasks.filter(
+    (t) => t.hitlNotifiedAt === undefined,
+  );
+
+  if (unnotifiedHitlTasks.length > 0) {
+    const taskList = unnotifiedHitlTasks
+      .map((t) => `  - ${t.id}: ${t.title}`)
+      .join("\n");
+    return {
+      exit: 0,
+      output: `The following tasks require human-in-the-loop action. Post a notification in the channel listing these tasks and ask for human attention, then stamp hitlNotifiedAt on each using the task store update command:\n${taskList}`,
     };
   }
 
@@ -99,6 +115,8 @@ function buildProductionDeps(): Deps {
   return {
     getReadyTasks: () => store.query({ ready: true, assignee }),
     getInProgressTasks: () => store.query({ status: "in_progress", assignee }),
+    getHitlPendingTasks: () =>
+      store.query({ status: "pending", hitl: true, assignee }),
     resetTask: (id) =>
       store.update(id, { status: "pending", startedAt: undefined }),
     stampTask: (id, startedAt) => store.update(id, { startedAt }),


### PR DESCRIPTION
## Summary
- Adds `getHitlPendingTasks` to the `Deps` interface, querying `{ status: pending, hitl: true, assignee }` from the task store
- Updates `run()` logic: when no automated tasks are ready but un-notified HITL tasks exist, exits 0 with a prompt instructing the bot to notify the channel and stamp `hitlNotifiedAt` on each task
- Wires `getHitlPendingTasks` in `buildProductionDeps` with the correct query parameters

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | With only pending HITL tasks (no non-HITL ready work): exits 0, output names task IDs and titles | MET |
| 2 | With both HITL and non-HITL ready tasks: exits 0 with standard dev-task prompt | MET |
| 3 | HITL tasks with a non-null hitlNotifiedAt are excluded from the notification prompt | MET |
| 4 | No ready tasks and no un-notified HITL tasks: exits 1 (no behavior change) | MET |
| 5 | 4 unit tests added to check-dev-task.test.ts; no existing tests retired | MET |

## Test Plan
- 15 unit tests passing (11 existing + 4 new covering all HITL notification scenarios)
- No regressions against main (same 2 pre-existing failures: Playwright missing + admin smoke test errors)
- Full typecheck passes

Generated with [Claude Code](https://claude.com/claude-code)
