### PR TITLE
chore(chart): bump chart to 1.5.1 — task-store CLI consistency + doctor checks (TSD-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **HITL skill** (HIT-3.2): New `shipwright:hitl` skill provides human-in-the-loop task approval and lifecycle management. Allows humans to review, approve, or reject pending HITL tasks with full auditability.
 
+## [1.5.1] - 2026-06-17
+
+### Plugin — What's New
+
+#### Task Store (`plugins/shipwright/scripts/task_store.ts`)
+
+- **CLI-consistent skill invocation**: `plan-session`, `dev-task`, and `deploy` skills now invoke `task_store.ts` via the CLI directly, replacing inline script calls. Behavior is consistent across all three commands.
+- **Expanded `--doctor` checks**: five data-integrity checks now run under `--doctor`: orphaned tasks (no matching GitHub Issue), label drift (status label vs JSON mismatch), stale in-progress tasks (stuck > 24h), dependency cycles, and duplicate IDs. Duplicate IDs also trigger a warning in normal `query` output.
+
 ## [1.4.0] - 2026-06-17
 
 ### Chart — What's New

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.5.0
+version: 1.5.1
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,10 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "agent-provisioning-rbac: add PersistentVolumeClaims rule (create/get/delete) to the agent-provisioner Role so the provisioner can manage workspace PVCs alongside Deployments and Secrets."
+    - kind: changed
+      description: "task-store: plan-session, dev-task, and deploy skills now invoke the task_store CLI directly instead of inline scripts — consistent behavior across all three commands."
+    - kind: changed
+      description: "task-store-doctor: expanded --doctor output with 5 data-integrity checks (orphaned tasks, label drift, stale in-progress, dependency cycles, duplicate IDs) and a duplicate-ID warning appended to normal query output."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/tests/metadata_test.yaml
+++ b/charts/shipwright/tests/metadata_test.yaml
@@ -10,7 +10,7 @@ tests:
       - matchRegexRaw:
           pattern: Thank you for installing shipwright \(Shipwright Harness\)
       - matchRegexRaw:
-          pattern: chart version 1\.5\.0, app version 0\.1\.0
+          pattern: chart version 1\.5\.1, app version 0\.1\.0
 
   - it: surfaces the three configured service ports in NOTES
     asserts:


### PR DESCRIPTION
## Summary
- Bump `charts/shipwright/Chart.yaml` from `1.5.0` to `1.5.1` (patch version)
- Update `artifacthub.io/changes` annotation to document the task-store CLI consistency and expanded `--doctor` checks (TSD-3.1 + TSD-3.2)
- Add CHANGELOG entry for 1.5.1

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `Chart.yaml` version bumped (patch) | ✅ 1.5.0 → 1.5.1 |
| 2 | chart-release CI publishes new chart to GH Pages | ⏳ post-merge |
| 3 | New version visible in chart index | ⏳ post-merge |

## Test Plan
- [x] No code changes — Infra task (YAML + Markdown only)
- [x] `bunx biome lint .` — clean
- [x] Plugin tests (860) pass
- [x] Version bump verified in Chart.yaml

Generated with [Claude Code](https://claude.com/claude-code)
