### PR TITLE
feat(deploy): add bundle completeness gate to check-deploy and deploy.md

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -114,6 +114,45 @@ Task:   {task_id} — {task_title}  (or "standalone deploy" if no task found)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+### 2b. Bundle Completeness Gate
+
+<!-- Added 2026-06-16: prevents partial bundle deployments when bundle-mates
+     on the same branch are still pending/in_progress/blocked. -->
+
+Fetch the head branch name for the PR:
+
+```bash
+HEAD_REF=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
+```
+
+Query the task store for all tasks tracked against that branch:
+
+```bash
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+BUNDLE_TASKS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" query --branch "$HEAD_REF")
+```
+
+Filter for incomplete bundle-mates — any task with status `pending`, `in_progress`, or `blocked`:
+
+```bash
+INCOMPLETE=$(echo "$BUNDLE_TASKS" | jq '[.[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked")]')
+INCOMPLETE_COUNT=$(echo "$INCOMPLETE" | jq 'length')
+```
+
+**If `INCOMPLETE_COUNT > 0`**, bundle-mates are still in flight — hold the merge and stop:
+
+```
+✗ Bundle gate: {INCOMPLETE_COUNT} task(s) on branch {HEAD_REF} are not yet ready.
+  Holding merge until all bundle-mates reach pr_open or beyond.
+
+  Incomplete tasks:
+    {for each: "  - {id}: {title} [{status}]"}
+
+  Re-run /shipwright:deploy once all bundle tasks have open PRs.
+```
+
+**If `INCOMPLETE_COUNT == 0`** (no tasks found on the branch, or all tasks are `pr_open`, `approved`, `merged`, `deployed`, or `done`): proceed to Step 3.
+
 ---
 
 ## Step 3: Pre-flight Checks (GitHub API — no local state)

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -16,6 +16,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -37,6 +38,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/example-branch",
     author: { login: "bodhi-agent" },
     reviewDecision: null,
     ...overrides,

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -28,6 +28,7 @@ import { createTaskStore, loadConfig } from "./create-task-store.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -67,6 +68,9 @@ interface Deps {
   reconcileStalePrOpenTasks?: () => Promise<void>;
   // Belt-and-suspenders: close open issues that have terminal status labels.
   cleanupStaleIssues?: () => Promise<void>;
+  // Bundle completeness gate: returns false when bundle-mates on the same branch
+  // have incomplete tasks (pending | in_progress | blocked). Absent → skip gate.
+  isBundleComplete?: (headRefName: string) => Promise<boolean>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -189,6 +193,11 @@ export async function run(deps: Deps): Promise<RunResult> {
         const ciRuns = await deps.fetchCiRuns(org, repoName, pr.headRefOid);
         if (!isCiGreen(ciRuns)) continue;
 
+        if (deps.isBundleComplete) {
+          const bundleOk = await deps.isBundleComplete(pr.headRefName);
+          if (!bundleOk) continue;
+        }
+
         return {
           exit: 0,
           output: "Deploy ready PRs via /shipwright:deploy",
@@ -210,6 +219,7 @@ export async function run(deps: Deps): Promise<RunResult> {
 interface GhPrListJson {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -265,7 +275,7 @@ async function buildProductionDeps(): Promise<Deps> {
         "--repo",
         repo,
         "--json",
-        "number,headRefOid,author,reviewDecision",
+        "number,headRefOid,headRefName,author,reviewDecision",
       ]);
     },
     fetchPrReviews: async (org: string, repo: string, pr: number) => {
@@ -368,6 +378,17 @@ async function buildProductionDeps(): Promise<Deps> {
           `[check-deploy] cleanup: closed ${closed} issue(s), ${plansClosed} plan(s), ${milestonesClosed} milestone(s)\n`,
         );
       }
+    },
+    // Bundle completeness gate: holds merge when any task on the branch is
+    // pending | in_progress | blocked (added 2026-06-16 to prevent partial
+    // bundle deployments when bundle-mates are still in flight).
+    isBundleComplete: async (headRefName: string) => {
+      const { config } = loadConfig();
+      const store = createTaskStore(config);
+      const tasks = await store.query({ branch: headRefName });
+      if (tasks.length === 0) return true; // no tracked tasks → OK
+      const incomplete = ["pending", "in_progress", "blocked"];
+      return !tasks.some((t) => incomplete.includes(t.status ?? ""));
     },
   };
 }

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -17,6 +17,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -44,6 +45,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/example-branch",
     author: { login: "bodhi-agent" },
     reviewDecision: "APPROVED",
     ...overrides,
@@ -59,6 +61,7 @@ interface MakeDepsOptions {
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
   clock?: () => string;
+  isBundleComplete?: (headRefName: string) => Promise<boolean>;
 }
 
 function makeDeps({
@@ -70,12 +73,14 @@ function makeDeps({
   currentUser = "bodhi-agent",
   isSelfReviewAllowed = true,
   clock,
+  isBundleComplete,
 }: MakeDepsOptions = {}) {
   return {
     getCurrentUser: () => currentUser,
     isSelfReviewAllowed,
     repos,
     clock,
+    isBundleComplete,
     listOpenPrs: async (repo: string) => prs[repo] ?? [],
     fetchCiRuns: async (
       _org: string,
@@ -377,5 +382,61 @@ describe("check-deploy (new behaviors)", () => {
     });
     expect(cleaned).toBe(true);
     expect(result.exit).toBe(1);
+  });
+
+  // ── Bundle completeness gate ──────────────────────────────────────────────────
+
+  test("isBundleComplete returns false → PR is skipped", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: "APPROVED",
+      headRefName: "feat/my-bundle-branch",
+    });
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        isBundleComplete: async (_headRefName: string) => false,
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.candidate).toBeNull();
+  });
+
+  test("isBundleComplete returns true → PR proceeds", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: "APPROVED",
+      headRefName: "feat/my-bundle-branch",
+    });
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        isBundleComplete: async (_headRefName: string) => true,
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
+  });
+
+  test("isBundleComplete absent → PR proceeds (no bundle tracking)", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: "APPROVED",
+      headRefName: "feat/my-bundle-branch",
+    });
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        // no isBundleComplete in deps
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `headRefName` to `GhPr` interface and `listOpenPrs` dep fetch in `check-deploy.ts`
- Introduces injectable `isBundleComplete` dep that holds the deploy cron when any task on the PR's branch is `pending | in_progress | blocked`
- Adds Step 2b "Bundle Completeness Gate" to `deploy.md` between Step 2a and Step 3

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GhPr` interface includes `headRefName`; `listOpenPrs` fetches it | ✅ MET |
| 2 | `isBundleComplete` dep wired into `run()` and called after CI check; PR skipped when false | ✅ MET |
| 3 | Production `buildProductionDeps` implements `isBundleComplete` using `store.query({ branch })` | ✅ MET |
| 4 | New Step 2b present in `deploy.md` between Step 2a and Step 3 | ✅ MET |
| 5 | Holds merge when any task on the branch is pending \| in_progress \| blocked | ✅ MET |
| 6 | Proceeds when branch has no tracked tasks or all tasks are pr_open or beyond | ✅ MET |
| 7 | Three new unit tests: false→skip, true→proceed, absent→proceed | ✅ MET |
| 8 | No existing tests retired — net-new coverage only | ✅ MET |

## Test Plan
- [x] 22 unit tests pass (`bun test plugins/shipwright/scripts/check-deploy.unit.test.ts`)
- [x] Biome lint clean on changed files
- [x] No existing tests retired (net-new: 3 bundle gate cases)
- [x] Pre-existing suite failures on main are unrelated (47 fail on main, same on branch)

Generated with [Claude Code](https://claude.com/claude-code)
