### PR TITLE
feat(deploy): add bundle completeness gate to check-deploy and deploy.md

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -114,6 +114,31 @@ Task:   {task_id} — {task_title}  (or "standalone deploy" if no task found)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+### 2b. Bundle Completeness Gate
+
+Before merging, verify that all tracked tasks on this PR's branch are ready — none may be
+pending, in_progress, or blocked (bundle-mates that haven't shipped yet).
+
+Fetch the PR's head branch name and query the task store for tasks on that branch:
+
+```bash
+HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
+bun "$PLUGIN_SCRIPTS/task_store.ts" query --branch "$HEAD_BRANCH"
+```
+
+**If no tasks are tracked on this branch:** the bundle is complete — proceed.
+
+**If any task has status `pending`, `in_progress`, or `blocked`:** the bundle is NOT
+complete. Skip this PR silently and stop:
+
+```
+⏸  Bundle incomplete — branch {HEAD_BRANCH} has tasks that are not yet ready to merge.
+   Re-run /shipwright:deploy once all bundle-mates have reached pr_open or beyond.
+```
+
+**If all tasks are `pr_open`, `approved`, `merged`, `deploying`, `deployed`, `done`, or
+`cancelled`:** the bundle is complete — proceed to Step 3.
+
 ---
 
 ## Step 3: Pre-flight Checks (GitHub API — no local state)

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -16,6 +16,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -37,6 +38,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/default-branch",
     author: { login: "bodhi-agent" },
     reviewDecision: null,
     ...overrides,

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -28,6 +28,7 @@ import { createTaskStore, loadConfig } from "./create-task-store.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -67,6 +68,8 @@ interface Deps {
   reconcileStalePrOpenTasks?: () => Promise<void>;
   // Belt-and-suspenders: close open issues that have terminal status labels.
   cleanupStaleIssues?: () => Promise<void>;
+  // Bundle completeness gate: returns false when bundle-mates are still pending/in_progress/blocked.
+  isBundleComplete?: (headBranch: string) => Promise<boolean>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -189,6 +192,11 @@ export async function run(deps: Deps): Promise<RunResult> {
         const ciRuns = await deps.fetchCiRuns(org, repoName, pr.headRefOid);
         if (!isCiGreen(ciRuns)) continue;
 
+        if (deps.isBundleComplete) {
+          const bundleOk = await deps.isBundleComplete(pr.headRefName);
+          if (!bundleOk) continue;
+        }
+
         return {
           exit: 0,
           output: "Deploy ready PRs via /shipwright:deploy",
@@ -210,6 +218,7 @@ export async function run(deps: Deps): Promise<RunResult> {
 interface GhPrListJson {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -265,7 +274,7 @@ async function buildProductionDeps(): Promise<Deps> {
         "--repo",
         repo,
         "--json",
-        "number,headRefOid,author,reviewDecision",
+        "number,headRefOid,headRefName,author,reviewDecision",
       ]);
     },
     fetchPrReviews: async (org: string, repo: string, pr: number) => {
@@ -368,6 +377,15 @@ async function buildProductionDeps(): Promise<Deps> {
           `[check-deploy] cleanup: closed ${closed} issue(s), ${plansClosed} plan(s), ${milestonesClosed} milestone(s)\n`,
         );
       }
+    },
+    isBundleComplete: async (headBranch: string) => {
+      if (!headBranch) return true;
+      const { config } = loadConfig();
+      const store = createTaskStore(config);
+      const tasks = await store.query({ branch: headBranch });
+      if (tasks.length === 0) return true;
+      const BLOCKING_STATUSES = new Set(["pending", "in_progress", "blocked"]);
+      return !tasks.some((t) => BLOCKING_STATUSES.has(t.status));
     },
   };
 }

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -17,6 +17,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -44,6 +45,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/default-branch",
     author: { login: "bodhi-agent" },
     reviewDecision: "APPROVED",
     ...overrides,
@@ -377,5 +379,45 @@ describe("check-deploy (new behaviors)", () => {
     });
     expect(cleaned).toBe(true);
     expect(result.exit).toBe(1);
+  });
+
+  // ── Bundle gate ───────────────────────────────────────────────────────────────
+
+  test("bundle gate: skips PR when isBundleComplete returns false", async () => {
+    const pr = makeGhPr({ reviewDecision: "APPROVED", headRefName: "feat/my-feature" });
+    const result = await run({
+      ...makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+      isBundleComplete: async (_branch: string) => false,
+    });
+    expect(result.exit).toBe(1);
+    expect(result.candidate).toBeNull();
+  });
+
+  test("bundle gate: proceeds when isBundleComplete returns true", async () => {
+    const pr = makeGhPr({ reviewDecision: "APPROVED", headRefName: "feat/my-feature" });
+    const result = await run({
+      ...makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+      isBundleComplete: async (_branch: string) => true,
+    });
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
+  });
+
+  test("bundle gate: proceeds when isBundleComplete is absent (backward compat)", async () => {
+    const pr = makeGhPr({ reviewDecision: "APPROVED" });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `headRefName` to the `GhPr` interface and `listOpenPrs` production dep fetch so branch name is available during the PR qualification loop
- Wires a new optional `isBundleComplete` dep into `run()` (called after CI check) — holds deploy when any task on the PR's branch is `pending`, `in_progress`, or `blocked`; proceeds when no tasks exist or all are `pr_open` or beyond
- Adds Step 2b (Bundle Completeness Gate) to `deploy.md` between Step 2a and Step 3

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GhPr` interface includes `headRefName`; `listOpenPrs` fetches it | ✅ MET |
| 2 | `isBundleComplete` dep wired into `run()` after CI check; PR skipped when false | ✅ MET |
| 3 | Production `buildProductionDeps` implements `isBundleComplete` via `store.query({ branch })` | ✅ MET |
| 4 | New Step 2b present in `deploy.md` between Step 2a and Step 3 | ✅ MET |
| 5 | Holds merge when any task is `pending` \| `in_progress` \| `blocked` | ✅ MET |
| 6 | Proceeds when branch has no tracked tasks or all tasks are `pr_open` or beyond | ✅ MET |
| 7 | Unit tests: three new cases (false→skip, true→proceed, absent→proceed) | ✅ MET |
| 8 | No existing tests retired — net-new coverage only | ✅ MET |

## Test Plan
- [x] 22 unit tests pass in `check-deploy.unit.test.ts` (19 pre-existing + 3 new bundle gate cases)
- [x] 37 total tests pass across both check-deploy test files
- [x] Plugin typecheck passes (`@shipwright/plugin typecheck: Exited with code 0`)
- [x] Biome lint clean (61 files, no fixes applied)
- [x] Backward compatible: `isBundleComplete` is optional; existing calls without it proceed unchanged

Generated with [Claude Code](https://claude.com/claude-code)
