### PR TITLE
feat(deploy): add bundle completeness gate to check-deploy and deploy.md

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -114,7 +114,7 @@ favors permissive: false positives are visible and self-correcting; false negati
 | Script | Guards | What it checks |
 |---|---|---|
 | `check-review.ts` | `review` cron | Open PRs with unreviewed commits (by headRefOid dedup against `state/reviews.json`); respects `allow_self_review` policy |
-| `check-deploy.ts` | `deploy` cron | Open PRs with `APPROVED` review decision and green CI; respects `allow_self_review` for self-authored PRs |
+| `check-deploy.ts` | `deploy` cron | Open PRs with `APPROVED` review decision, green CI, and bundle-mate task readiness (if any tasks share the branch); respects `allow_self_review` for self-authored PRs |
 | `check-dev-task.ts` | `dev-task` cron | Pending tasks with all dependencies satisfied (task store `ready: true` query) |
 | `check-patch.ts` | `patch` cron | Auto-updates BEHIND branches via `gh pr update-branch`; signals patch skill for unaddressed review findings, stuck-BEHIND branches (update-branch failures), merge conflicts, and failing CI; queries GitHub directly — does NOT read `state/reviews.json` |
 | `check-review-patch.ts` | `review-patch` cron | Delegates to `check-patch.ts` + `check-review.ts`; exits 0 if either exits 0, covering the full scope of the review-patch orchestrator (unaddressed findings, failing CI, BEHIND branches, merge conflicts, and unreviewed commits) |

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -114,6 +114,22 @@ Task:   {task_id} — {task_title}  (or "standalone deploy" if no task found)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+### 2b. Bundle Completeness Gate
+
+Before merging, verify that all other tasks sharing this PR's branch are at least at `pr_open` status. This prevents deploying a partial bundle when a companion task is still in development.
+
+Query the task store for tasks on this branch:
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" query --branch {headRefName}
+```
+
+If any returned task has status `pending`, `in_progress`, or `blocked`, skip this PR:
+```
+⏭ Bundle incomplete — skipping PR #{pr} (branch {headRefName} has tasks not yet at pr_open)
+```
+
+Proceed if the query returns no tasks, or all tasks are `pr_open` or beyond.
+
 ---
 
 ## Step 3: Pre-flight Checks (GitHub API — no local state)

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -16,6 +16,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -37,6 +38,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/sw-50-example",
     author: { login: "bodhi-agent" },
     reviewDecision: null,
     ...overrides,

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -28,6 +28,7 @@ import { createTaskStore, loadConfig } from "./create-task-store.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -67,6 +68,8 @@ interface Deps {
   reconcileStalePrOpenTasks?: () => Promise<void>;
   // Belt-and-suspenders: close open issues that have terminal status labels.
   cleanupStaleIssues?: () => Promise<void>;
+  // Bundle gate: returns false when bundle-mates on the same branch are not yet at pr_open.
+  isBundleComplete?: (headBranch: string) => Promise<boolean>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -189,6 +192,11 @@ export async function run(deps: Deps): Promise<RunResult> {
         const ciRuns = await deps.fetchCiRuns(org, repoName, pr.headRefOid);
         if (!isCiGreen(ciRuns)) continue;
 
+        if (deps.isBundleComplete !== undefined) {
+          const complete = await deps.isBundleComplete(pr.headRefName);
+          if (!complete) continue;
+        }
+
         return {
           exit: 0,
           output: "Deploy ready PRs via /shipwright:deploy",
@@ -210,6 +218,7 @@ export async function run(deps: Deps): Promise<RunResult> {
 interface GhPrListJson {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -265,7 +274,7 @@ async function buildProductionDeps(): Promise<Deps> {
         "--repo",
         repo,
         "--json",
-        "number,headRefOid,author,reviewDecision",
+        "number,headRefOid,headRefName,author,reviewDecision",
       ]);
     },
     fetchPrReviews: async (org: string, repo: string, pr: number) => {
@@ -368,6 +377,14 @@ async function buildProductionDeps(): Promise<Deps> {
           `[check-deploy] cleanup: closed ${closed} issue(s), ${plansClosed} plan(s), ${milestonesClosed} milestone(s)\n`,
         );
       }
+    },
+    isBundleComplete: async (headBranch: string) => {
+      const { config } = loadConfig();
+      const store = createTaskStore(config);
+      const tasks = await store.query({ branch: headBranch });
+      if (tasks.length === 0) return true;
+      const BLOCKING = new Set(["pending", "in_progress", "blocked"]);
+      return !tasks.some((t) => BLOCKING.has(t.status ?? ""));
     },
   };
 }

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -17,6 +17,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -44,6 +45,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/sw-50-example",
     author: { login: "bodhi-agent" },
     reviewDecision: "APPROVED",
     ...overrides,
@@ -59,6 +61,7 @@ interface MakeDepsOptions {
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
   clock?: () => string;
+  isBundleComplete?: (headBranch: string) => Promise<boolean>;
 }
 
 function makeDeps({
@@ -70,6 +73,7 @@ function makeDeps({
   currentUser = "bodhi-agent",
   isSelfReviewAllowed = true,
   clock,
+  isBundleComplete,
 }: MakeDepsOptions = {}) {
   return {
     getCurrentUser: () => currentUser,
@@ -91,6 +95,7 @@ function makeDeps({
       _org: string,
       _repo: string,
     ): Promise<WorkflowRun[]> => activeDeployRuns,
+    ...(isBundleComplete !== undefined ? { isBundleComplete } : {}),
   };
 }
 
@@ -377,5 +382,55 @@ describe("check-deploy (new behaviors)", () => {
     });
     expect(cleaned).toBe(true);
     expect(result.exit).toBe(1);
+  });
+
+  // ── Bundle completeness gate ───────────────────────────────────────────────────
+
+  test("isBundleComplete returns false → PR is skipped", async () => {
+    const pr = makeGhPr({
+      headRefOid: "sha50",
+      author: { login: "bodhi-agent" },
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        isBundleComplete: async () => false,
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.candidate).toBeNull();
+  });
+
+  test("isBundleComplete returns true → PR proceeds", async () => {
+    const pr = makeGhPr({
+      headRefOid: "sha50",
+      author: { login: "bodhi-agent" },
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        isBundleComplete: async () => true,
+      }),
+    );
+    expect(result.exit).toBe(0);
+  });
+
+  test("isBundleComplete absent → PR proceeds", async () => {
+    const pr = makeGhPr({
+      headRefOid: "sha50",
+      author: { login: "bodhi-agent" },
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+    );
+    expect(result.exit).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `headRefName` to the `GhPr` interface and `listOpenPrs` dep fetch so the branch name is available during PR qualification
- Introduces an injectable `isBundleComplete` dep that blocks deployment when any task on the same branch is `pending`, `in_progress`, or `blocked`; proceeds when no tasks exist or all are `pr_open` or beyond
- Adds Step 2b to `deploy.md` documenting the bundle completeness gate between the own-PR check and pre-flight

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GhPr` interface includes `headRefName`; `listOpenPrs` fetches it | ✅ MET |
| 2 | `isBundleComplete` dep wired into `run()` and called after CI check; PR skipped when false | ✅ MET |
| 3 | Production `buildProductionDeps` implements `isBundleComplete` via `store.query({ branch: headBranch })` | ✅ MET |
| 4 | New Step 2b present in `deploy.md` between Step 2a and Step 3 | ✅ MET |
| 5 | Holds merge when any task on the branch is pending \| in_progress \| blocked | ✅ MET |
| 6 | Proceeds when branch has no tracked tasks or all tasks are pr_open or beyond | ✅ MET |
| 7 | Test layer: unit (check-deploy.unit.test.ts). Three new cases: false→skip, true→proceed, absent→proceed | ✅ MET |
| 8 | No existing tests retired — net-new coverage only | ✅ MET |

## Test Plan
- [x] 22/22 unit tests passing (`bun test plugins/shipwright/scripts/check-deploy.unit.test.ts`)
- [x] Three new bundle gate cases: `isBundleComplete returns false → PR skipped`, `isBundleComplete returns true → PR proceeds`, `isBundleComplete absent → PR proceeds`
- [x] Biome lint: clean (298 files, no fixes needed)
- [x] Backward compatible — `isBundleComplete` is optional; existing deploy behavior unchanged when dep is absent

Generated with [Claude Code](https://claude.com/claude-code)
