### PR TITLE
feat(deploy): add bundle completeness gate to check-deploy and deploy.md

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -114,6 +114,41 @@ Task:   {task_id} — {task_title}  (or "standalone deploy" if no task found)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+### 2b. Bundle Completeness Check
+
+Before running pre-flight checks, verify that all tracked tasks on this PR's branch are
+at least `pr_open` (i.e., no bundle-mate is still `pending`, `in_progress`, or `blocked`).
+
+Get the PR's head branch name:
+
+```bash
+HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
+```
+
+Query the task store for tasks on this branch:
+
+```bash
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+BRANCH_TASKS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" query --branch "$HEAD_BRANCH" 2>/dev/null || echo "[]")
+```
+
+Check whether any task is incomplete (`pending`, `in_progress`, or `blocked`):
+
+```bash
+INCOMPLETE=$(echo "$BRANCH_TASKS" | jq '[.[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked")] | length')
+```
+
+**If `INCOMPLETE > 0`**: bundle-mates are not yet ready. Print and stop:
+
+```
+⏸ Bundle incomplete — {INCOMPLETE} task(s) on branch {HEAD_BRANCH} are not yet pr_open.
+  Waiting for all bundle-mates to reach pr_open before merging.
+  Re-run /shipwright:deploy once remaining tasks have open PRs.
+```
+
+**If `INCOMPLETE == 0`** (no tracked tasks, or all are `pr_open`/`approved`/`merged`/beyond):
+proceed to Step 3.
+
 ---
 
 ## Step 3: Pre-flight Checks (GitHub API — no local state)

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -16,6 +16,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -37,6 +38,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/example-branch",
     author: { login: "bodhi-agent" },
     reviewDecision: null,
     ...overrides,

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -28,6 +28,7 @@ import { createTaskStore, loadConfig } from "./create-task-store.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -67,6 +68,9 @@ interface Deps {
   reconcileStalePrOpenTasks?: () => Promise<void>;
   // Belt-and-suspenders: close open issues that have terminal status labels.
   cleanupStaleIssues?: () => Promise<void>;
+  // Returns true when all tasks on the branch are pr_open or beyond (or no tasks exist).
+  // When absent, the gate is skipped and the PR proceeds.
+  isBundleComplete?: (headRefName: string) => Promise<boolean>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -189,6 +193,11 @@ export async function run(deps: Deps): Promise<RunResult> {
         const ciRuns = await deps.fetchCiRuns(org, repoName, pr.headRefOid);
         if (!isCiGreen(ciRuns)) continue;
 
+        if (deps.isBundleComplete) {
+          const bundleComplete = await deps.isBundleComplete(pr.headRefName);
+          if (!bundleComplete) continue;
+        }
+
         return {
           exit: 0,
           output: "Deploy ready PRs via /shipwright:deploy",
@@ -210,6 +219,7 @@ export async function run(deps: Deps): Promise<RunResult> {
 interface GhPrListJson {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -265,7 +275,7 @@ async function buildProductionDeps(): Promise<Deps> {
         "--repo",
         repo,
         "--json",
-        "number,headRefOid,author,reviewDecision",
+        "number,headRefOid,headRefName,author,reviewDecision",
       ]);
     },
     fetchPrReviews: async (org: string, repo: string, pr: number) => {
@@ -368,6 +378,14 @@ async function buildProductionDeps(): Promise<Deps> {
           `[check-deploy] cleanup: closed ${closed} issue(s), ${plansClosed} plan(s), ${milestonesClosed} milestone(s)\n`,
         );
       }
+    },
+    isBundleComplete: async (headBranch: string) => {
+      const { config } = loadConfig();
+      const store = createTaskStore(config);
+      const branchTasks = await store.query({ branch: headBranch });
+      if (branchTasks.length === 0) return true;
+      const incomplete = ["pending", "in_progress", "blocked"];
+      return !branchTasks.some((t) => incomplete.includes(t.status ?? ""));
     },
   };
 }

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -17,6 +17,7 @@ import { run } from "./check-deploy.ts";
 interface GhPr {
   number: number;
   headRefOid: string;
+  headRefName: string;
   author: { login: string };
   reviewDecision: string | null;
 }
@@ -44,6 +45,7 @@ function makeGhPr(overrides: Partial<GhPr> = {}): GhPr {
   return {
     number: 50,
     headRefOid: "sha50",
+    headRefName: "feat/example-branch",
     author: { login: "bodhi-agent" },
     reviewDecision: "APPROVED",
     ...overrides,
@@ -59,6 +61,7 @@ interface MakeDepsOptions {
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
   clock?: () => string;
+  isBundleComplete?: (headRefName: string) => Promise<boolean>;
 }
 
 function makeDeps({
@@ -70,12 +73,14 @@ function makeDeps({
   currentUser = "bodhi-agent",
   isSelfReviewAllowed = true,
   clock,
+  isBundleComplete,
 }: MakeDepsOptions = {}) {
   return {
     getCurrentUser: () => currentUser,
     isSelfReviewAllowed,
     repos,
     clock,
+    isBundleComplete,
     listOpenPrs: async (repo: string) => prs[repo] ?? [],
     fetchCiRuns: async (
       _org: string,
@@ -377,5 +382,55 @@ describe("check-deploy (new behaviors)", () => {
     });
     expect(cleaned).toBe(true);
     expect(result.exit).toBe(1);
+  });
+
+  // ── Bundle completeness gate ──────────────────────────────────────────────────
+
+  test("bundle gate: skips PR when isBundleComplete returns false", async () => {
+    const pr = makeGhPr({
+      headRefName: "feat/bundle-branch",
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        isBundleComplete: async (_branch: string) => false,
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.candidate).toBeNull();
+  });
+
+  test("bundle gate: proceeds when isBundleComplete returns true", async () => {
+    const pr = makeGhPr({
+      headRefName: "feat/bundle-branch",
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        isBundleComplete: async (_branch: string) => true,
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
+  });
+
+  test("bundle gate: proceeds when isBundleComplete is absent (dep not injected)", async () => {
+    const pr = makeGhPr({
+      headRefName: "feat/bundle-branch",
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        prs: { "acme/example-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        // isBundleComplete intentionally omitted
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `headRefName` to the `GhPr` interface and `listOpenPrs` to fetch it from GitHub
- Wires injectable `isBundleComplete` dep into the PR qualification loop in `check-deploy.ts` after the CI check — skips a PR when any tracked task on the branch is still `pending`, `in_progress`, or `blocked`
- Adds Step 2b to `deploy.md` between Step 2a and Step 3 to document the bundle completeness hold

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GhPr` includes `headRefName`; `listOpenPrs` fetches it | ✅ MET |
| 2 | `isBundleComplete` wired after CI check; PR skipped when false | ✅ MET |
| 3 | Production `buildProductionDeps` implements `isBundleComplete` via `store.query({ branch })` | ✅ MET |
| 4 | New Step 2b in `deploy.md` between Step 2a and Step 3 | ✅ MET |
| 5 | Holds when any task is `pending`/`in_progress`/`blocked` | ✅ MET |
| 6 | Proceeds when no tracked tasks or all tasks are `pr_open`+  | ✅ MET |
| 7 | Three new unit tests in `check-deploy.unit.test.ts` | ✅ MET |
| 8 | No existing tests retired — net-new coverage only | ✅ MET |

## Test Plan
- [x] 22 unit tests pass (19 pre-existing + 3 new bundle gate cases)
- [x] false→skip: `isBundleComplete` returns false → PR is skipped (exit 1, candidate null)
- [x] true→proceed: `isBundleComplete` returns true → PR qualifies (exit 0)
- [x] absent→proceed: dep not injected → PR qualifies (exit 0, gate is no-op)
- [x] Typecheck clean (`tsc --noEmit` passes in plugin package)
- [x] Biome lint clean

Generated with [Claude Code](https://claude.com/claude-code)
