### PR TITLE
feat(metrics): add per-agent cross-dimension token queries (ATB-2.1)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,7 +69,7 @@ All metric endpoints are `GET`, return JSON, and accept the same date-window que
 | GET | `/metrics/trends` | Time-series trends; supports `groupBy`. |
 | GET | `/metrics/features` | Per-feature task / CI / review breakdown. |
 | GET | `/metrics/queue` | Shipwright v3 queue metrics: funnel counts, block rate, avg cycle time (days), avg review findings. |
-| GET | `/metrics/tokens` | Token usage — totals, by agent, by session type, and trends; each group includes a `cost` field (USD). |
+| GET | `/metrics/tokens` | Token usage — totals, by agent, by session type, by agent + session type, by agent + cron, by agent + model, and trends; each group includes a `cost` field (USD). |
 | POST | `/batch/` | PostHog-shaped batch ingest — writes events to the local SQLite store. Only registered when `localStore` is injected via `MetricsDeps`; returns 404 otherwise. |
 | GET | `/dashboard` | Server-rendered dashboard HTML (session-gated). |
 | GET | `/dashboard/*` | Static dashboard assets (`styles.css`, `app.js`). |
@@ -116,7 +116,7 @@ The **dashboard** is protected by the session cookie middleware; an invalid/abse
 | `metrics/src/metrics-provider.ts` | `MetricsProvider` interface + `MetricQuery` / `MetricTable` types — the backend-agnostic read seam. |
 | `metrics/src/select-provider.ts` | Pure env-to-mode selector (`selectProviderMode()`) — maps env vars to `"fixtures" \| "posthog" \| "postgres" \| "sqlite"`. |
 | `metrics/src/providers/posthog-provider.ts` | `PostHogProvider` — implements `MetricsProvider` over a `PostHogClient` and HogQL query builders. |
-| `metrics/src/providers/sql-provider.ts` | `SqlEventStoreProvider` — shared aggregation engine; all 13 query kinds in TypeScript over any `SqlEventStore`. |
+| `metrics/src/providers/sql-provider.ts` | `SqlEventStoreProvider` — shared aggregation engine; all 16 query kinds in TypeScript over any `SqlEventStore`. |
 | `metrics/src/providers/sqlite-provider.ts` | `SqliteProvider` — thin wrapper adapting `LocalEventStore` to `SqlEventStoreProvider`. |
 | `metrics/src/providers/postgres-provider.ts` | `PostgresProvider` / `createPostgresEventStore()` — Postgres backend using `pg.Pool`; provisions DDL; wraps `SqlEventStoreProvider`. |
 | `metrics/src/queries.ts` | HogQL query builders (summary, trends, features, queue, tokens); used by `PostHogProvider`. |

--- a/docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md
+++ b/docs/superpowers/specs/2026-06-08-metrics-backend-interface-design.md
@@ -40,19 +40,22 @@ The fix is to move the seam **above** any query language: the API expresses *wha
 
 // What the dashboard/API asks for — query INTENT as data, not a query string.
 export type MetricQuery =
-  | { kind: "summary";            range: DateRange }
-  | { kind: "summaryCycleTime";   range: DateRange }
-  | { kind: "trends";             range: DateRange; groupBy: "hour" | "day" | "week" }
-  | { kind: "featuresTasks";      range: DateRange }
-  | { kind: "featuresCi";         range: DateRange }
-  | { kind: "featuresReviews";    range: DateRange }
-  | { kind: "queueFunnel";        range: DateRange }
-  | { kind: "queueCycleStarted";  range: DateRange }
-  | { kind: "queueCycleMerged";   range: DateRange }
-  | { kind: "tokensTotals";       range: DateRange }
-  | { kind: "tokensBySessionType"; range: DateRange }
-  | { kind: "tokensByAgent";      range: DateRange }
-  | { kind: "tokensTrends";       range: DateRange };
+  | { kind: "summary";                    range: DateRange }
+  | { kind: "summaryCycleTime";           range: DateRange }
+  | { kind: "trends";                     range: DateRange; groupBy: "hour" | "day" | "week" }
+  | { kind: "featuresTasks";              range: DateRange }
+  | { kind: "featuresCi";                 range: DateRange }
+  | { kind: "featuresReviews";            range: DateRange }
+  | { kind: "queueFunnel";                range: DateRange }
+  | { kind: "queueCycleStarted";          range: DateRange }
+  | { kind: "queueCycleMerged";           range: DateRange }
+  | { kind: "tokensTotals";               range: DateRange }
+  | { kind: "tokensBySessionType";        range: DateRange }
+  | { kind: "tokensByAgent";              range: DateRange }
+  | { kind: "tokensByAgentBySessionType"; range: DateRange }
+  | { kind: "tokensByAgentByCron";        range: DateRange }
+  | { kind: "tokensByAgentByModel";       range: DateRange }
+  | { kind: "tokensTrends";               range: DateRange };
 
 // The normalized result — today's HogQLResult shape, renamed to drop the vendor name.
 export type MetricTable = { columns: string[]; results: unknown[][]; types: string[] };

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -37,6 +37,9 @@ import {
   buildQueueFunnelQuery,
   buildSummaryCycleTimeQuery,
   buildSummaryQuery,
+  buildTokensByAgentByCronQuery,
+  buildTokensByAgentByModelQuery,
+  buildTokensByAgentBySessionTypeQuery,
   buildTokensByAgentQuery,
   buildTokensBySessionTypeQuery,
   buildTokensTotalsQuery,
@@ -86,6 +89,9 @@ export interface MetricsDeps {
   buildTokensBySessionTypeQueryFn?: typeof buildTokensBySessionTypeQuery;
   buildTokensByAgentQueryFn?: typeof buildTokensByAgentQuery;
   buildTokensTrendsQueryFn?: typeof buildTokensTrendsQuery;
+  buildTokensByAgentBySessionTypeQueryFn?: typeof buildTokensByAgentBySessionTypeQuery;
+  buildTokensByAgentByCronQueryFn?: typeof buildTokensByAgentByCronQuery;
+  buildTokensByAgentByModelQueryFn?: typeof buildTokensByAgentByModelQuery;
   dashboardDir?: string;
   sessionSecret?: string;
   /** Owner-gate: require OWNER role for session-cookie auth. Default false. */
@@ -340,6 +346,13 @@ function resolveProvider(
       deps?.buildTokensBySessionTypeQueryFn ?? buildTokensBySessionTypeQuery,
     tokensByAgent: deps?.buildTokensByAgentQueryFn ?? buildTokensByAgentQuery,
     tokensTrends: deps?.buildTokensTrendsQueryFn ?? buildTokensTrendsQuery,
+    tokensByAgentBySessionType:
+      deps?.buildTokensByAgentBySessionTypeQueryFn ??
+      buildTokensByAgentBySessionTypeQuery,
+    tokensByAgentByCron:
+      deps?.buildTokensByAgentByCronQueryFn ?? buildTokensByAgentByCronQuery,
+    tokensByAgentByModel:
+      deps?.buildTokensByAgentByModelQueryFn ?? buildTokensByAgentByModelQuery,
   });
 }
 
@@ -747,13 +760,23 @@ export function createMetricsHandlers(
     const startMs = Date.now();
 
     try {
-      const [totalsResult, bySessionTypeResult, byAgentResult, trendsResult] =
-        await Promise.all([
-          provider.query({ kind: "tokensTotals", range: dateRange }),
-          provider.query({ kind: "tokensBySessionType", range: dateRange }),
-          provider.query({ kind: "tokensByAgent", range: dateRange }),
-          provider.query({ kind: "tokensTrends", range: dateRange }),
-        ]);
+      const [
+        totalsResult,
+        bySessionTypeResult,
+        byAgentResult,
+        trendsResult,
+        byAgentBySessionTypeResult,
+        byAgentByCronResult,
+        byAgentByModelResult,
+      ] = await Promise.all([
+        provider.query({ kind: "tokensTotals", range: dateRange }),
+        provider.query({ kind: "tokensBySessionType", range: dateRange }),
+        provider.query({ kind: "tokensByAgent", range: dateRange }),
+        provider.query({ kind: "tokensTrends", range: dateRange }),
+        provider.query({ kind: "tokensByAgentBySessionType", range: dateRange }),
+        provider.query({ kind: "tokensByAgentByCron", range: dateRange }),
+        provider.query({ kind: "tokensByAgentByModel", range: dateRange }),
+      ]);
 
       const totalsRow = rowToObject(totalsResult) ?? {};
       const totals = {
@@ -814,9 +837,52 @@ export function createMetricsHandlers(
         cost: toNum(row.cost_usd),
       }));
 
+      const byAgentSessionType = resultToRows(byAgentBySessionTypeResult).map(
+        (row) => ({
+          agentId: String(row.agent_id ?? ""),
+          sessionType: String(row.session_type ?? ""),
+          input: toNum(row.input_tokens),
+          output: toNum(row.output_tokens),
+          cacheRead: toNum(row.cache_read_input_tokens),
+          cacheCreation: toNum(row.cache_creation_input_tokens),
+          total: toNum(row.total_tokens),
+          cost: toNum(row.cost_usd),
+        }),
+      );
+
+      const byAgentCron = resultToRows(byAgentByCronResult).map((row) => ({
+        agentId: String(row.agent_id ?? ""),
+        cronName: String(row.cron_name ?? ""),
+        input: toNum(row.input_tokens),
+        output: toNum(row.output_tokens),
+        cacheRead: toNum(row.cache_read_input_tokens),
+        cacheCreation: toNum(row.cache_creation_input_tokens),
+        total: toNum(row.total_tokens),
+        cost: toNum(row.cost_usd),
+      }));
+
+      const byAgentModel = resultToRows(byAgentByModelResult).map((row) => ({
+        agentId: String(row.agent_id ?? ""),
+        model: String(row.model ?? ""),
+        input: toNum(row.input_tokens),
+        output: toNum(row.output_tokens),
+        cacheRead: toNum(row.cache_read_input_tokens),
+        cacheCreation: toNum(row.cache_creation_input_tokens),
+        total: toNum(row.total_tokens),
+        cost: toNum(row.cost_usd),
+      }));
+
       return c.json(
         wrapResponse(
-          { totals, bySessionType, byAgent, trends },
+          {
+            totals,
+            bySessionType,
+            byAgent,
+            trends,
+            byAgentSessionType,
+            byAgentCron,
+            byAgentModel,
+          },
           {
             dateRange: dateRangeMeta,
             generatedAt: new Date().toISOString(),

--- a/metrics/src/metrics-provider.ts
+++ b/metrics/src/metrics-provider.ts
@@ -29,7 +29,10 @@ export type MetricQuery =
   | { kind: "tokensTotals"; range: QueryDateRange }
   | { kind: "tokensBySessionType"; range: QueryDateRange }
   | { kind: "tokensByAgent"; range: QueryDateRange }
-  | { kind: "tokensTrends"; range: QueryDateRange };
+  | { kind: "tokensTrends"; range: QueryDateRange }
+  | { kind: "tokensByAgentBySessionType"; range: QueryDateRange }
+  | { kind: "tokensByAgentByCron"; range: QueryDateRange }
+  | { kind: "tokensByAgentByModel"; range: QueryDateRange };
 
 export type MetricQueryKind = MetricQuery["kind"];
 

--- a/metrics/src/providers/posthog-provider.ts
+++ b/metrics/src/providers/posthog-provider.ts
@@ -14,7 +14,7 @@ import type {
 } from "../metrics-provider.ts";
 import type { QueryDateRange, TrendsGroupBy } from "../queries.ts";
 
-/** The 13 HogQL builders, keyed by MetricQuery kind. */
+/** The 16 HogQL builders, keyed by MetricQuery kind. */
 export interface BuilderFns {
   summary: (range: QueryDateRange) => string;
   summaryCycleTime: (range: QueryDateRange) => string;
@@ -29,6 +29,9 @@ export interface BuilderFns {
   tokensBySessionType: (range: QueryDateRange) => string;
   tokensByAgent: (range: QueryDateRange) => string;
   tokensTrends: (range: QueryDateRange) => string;
+  tokensByAgentBySessionType: (range: QueryDateRange) => string;
+  tokensByAgentByCron: (range: QueryDateRange) => string;
+  tokensByAgentByModel: (range: QueryDateRange) => string;
 }
 
 export class PostHogProvider implements MetricsProvider {
@@ -71,6 +74,12 @@ export class PostHogProvider implements MetricsProvider {
         return b.tokensByAgent(q.range);
       case "tokensTrends":
         return b.tokensTrends(q.range);
+      case "tokensByAgentBySessionType":
+        return b.tokensByAgentBySessionType(q.range);
+      case "tokensByAgentByCron":
+        return b.tokensByAgentByCron(q.range);
+      case "tokensByAgentByModel":
+        return b.tokensByAgentByModel(q.range);
     }
   }
 }

--- a/metrics/src/providers/posthog-provider.unit.test.ts
+++ b/metrics/src/providers/posthog-provider.unit.test.ts
@@ -52,6 +52,9 @@ function sentinelBuilders() {
       tokensBySessionType: (_r: QueryDateRange) => "S:tsession",
       tokensByAgent: (_r: QueryDateRange) => "S:tagent",
       tokensTrends: (_r: QueryDateRange) => "S:ttrends",
+      tokensByAgentBySessionType: (_r: QueryDateRange) => "S:tagent_session",
+      tokensByAgentByCron: (_r: QueryDateRange) => "S:tagent_cron",
+      tokensByAgentByModel: (_r: QueryDateRange) => "S:tagent_model",
     },
   };
 }
@@ -72,6 +75,18 @@ const cases: Array<{ q: MetricQuery; expected: string }> = [
   },
   { q: { kind: "tokensByAgent", range: "today" }, expected: "S:tagent" },
   { q: { kind: "tokensTrends", range: "today" }, expected: "S:ttrends" },
+  {
+    q: { kind: "tokensByAgentBySessionType", range: "today" },
+    expected: "S:tagent_session",
+  },
+  {
+    q: { kind: "tokensByAgentByCron", range: "today" },
+    expected: "S:tagent_cron",
+  },
+  {
+    q: { kind: "tokensByAgentByModel", range: "today" },
+    expected: "S:tagent_model",
+  },
 ];
 
 describe("PostHogProvider routing", () => {

--- a/metrics/src/providers/sql-provider.ts
+++ b/metrics/src/providers/sql-provider.ts
@@ -163,6 +163,12 @@ export class SqlEventStoreProvider implements MetricsProvider {
         return this.tokensGrouped(win, "agent_id");
       case "tokensTrends":
         return this.tokensTrends(win);
+      case "tokensByAgentBySessionType":
+        return this.tokensGrouped2(win, "agent_id", "session_type");
+      case "tokensByAgentByCron":
+        return this.tokensGroupedCron(win);
+      case "tokensByAgentByModel":
+        return this.tokensGrouped2(win, "agent_id", "model");
     }
   }
 
@@ -579,6 +585,85 @@ export class SqlEventStoreProvider implements MetricsProvider {
       })
       .sort((a, b) => Number(b[5]) - Number(a[5]));
     return table(this.tokenColumns(prop), rows);
+  }
+
+  private async tokensGrouped2(
+    win: { from: string; to: string },
+    prop1: string,
+    prop2: string,
+  ): Promise<MetricTable> {
+    const events = await this.events("agent_token_usage", win);
+    const groups = new Map<string, SqlStoredEvent[]>();
+    for (const e of events) {
+      const v1 = e.properties[prop1];
+      const v2 = e.properties[prop2];
+      const k1 = typeof v1 === "string" ? v1 : String(v1 ?? "");
+      const k2 = typeof v2 === "string" ? v2 : String(v2 ?? "");
+      const key = `${k1}\x00${k2}`;
+      const arr = groups.get(key) ?? [];
+      arr.push(e);
+      groups.set(key, arr);
+    }
+    const rows = [...groups.entries()]
+      .map(([key, group]) => {
+        const [k1, k2] = key.split("\x00", 2);
+        const t = this.tokenSumRow(group);
+        return [
+          k1,
+          k2,
+          t.input,
+          t.output,
+          t.cacheRead,
+          t.cacheCreation,
+          t.total,
+          sum(group.map((e) => num(e.properties.cost_usd))),
+        ];
+      })
+      .sort((a, b) => Number(b[6]) - Number(a[6]));
+    return table([prop1, prop2, ...this.tokenColumns()], rows);
+  }
+
+  private async tokensGroupedCron(win: {
+    from: string;
+    to: string;
+  }): Promise<MetricTable> {
+    const events = await this.events("agent_token_usage", win);
+    const filtered = events.filter(
+      (e) =>
+        e.properties.session_type === "cron" &&
+        e.properties.cron_name != null &&
+        e.properties.cron_name !== "",
+    );
+    const groups = new Map<string, SqlStoredEvent[]>();
+    for (const e of filtered) {
+      const agentId = e.properties.agent_id;
+      const cronName = e.properties.cron_name;
+      const k1 =
+        typeof agentId === "string" ? agentId : String(agentId ?? "");
+      const k2 =
+        typeof cronName === "string" ? cronName : String(cronName ?? "");
+      const key = `${k1}\x00${k2}`;
+      const arr = groups.get(key) ?? [];
+      arr.push(e);
+      groups.set(key, arr);
+    }
+    const rows = [...groups.entries()]
+      .map(([key, group]) => {
+        const [k1, k2] = key.split("\x00", 2);
+        const t = this.tokenSumRow(group);
+        return [
+          k1,
+          k2,
+          t.input,
+          t.output,
+          t.cacheRead,
+          t.cacheCreation,
+          t.total,
+          sum(group.map((e) => num(e.properties.cost_usd))),
+        ];
+      })
+      .sort((a, b) => Number(b[6]) - Number(a[6]));
+    return table(["agent_id", "cron_name", ...this.tokenColumns()], rows);
   }
 
   private async tokensTrends(win: {

--- a/metrics/src/providers/sql-provider.ts
+++ b/metrics/src/providers/sql-provider.ts
@@ -620,7 +620,7 @@ export class SqlEventStoreProvider implements MetricsProvider {
         ];
       })
       .sort((a, b) => Number(b[6]) - Number(a[6]));
-    return table([prop1, prop2, ...this.tokenColumns()], rows);
+    return table([prop1, prop2, ...this.tokenColumns(), "cost_usd"], rows);
   }
 
   private async tokensGroupedCron(win: {
@@ -663,7 +663,7 @@ export class SqlEventStoreProvider implements MetricsProvider {
         ];
       })
       .sort((a, b) => Number(b[6]) - Number(a[6]));
-    return table(["agent_id", "cron_name", ...this.tokenColumns()], rows);
+    return table(["agent_id", "cron_name", ...this.tokenColumns(), "cost_usd"], rows);
   }
 
   private async tokensTrends(win: {

--- a/metrics/src/providers/sql-provider.unit.test.ts
+++ b/metrics/src/providers/sql-provider.unit.test.ts
@@ -115,6 +115,9 @@ beforeEach(() => {
     cache_creation_input_tokens: 100,
     session_type: "cron",
     agent_id: "agent-a",
+    cron_name: "daily-report",
+    model: "claude-sonnet-4-5",
+    cost_usd: 0.01,
   });
   seed("agent_token_usage", "2026-06-03T09:00:00.000Z", {
     input_tokens: 2000,
@@ -123,6 +126,8 @@ beforeEach(() => {
     cache_creation_input_tokens: 150,
     session_type: "slack_dm",
     agent_id: "agent-b",
+    model: "claude-opus-4-5",
+    cost_usd: 0.05,
   });
 });
 
@@ -238,5 +243,44 @@ describe("SqlEventStoreProvider.tokens", () => {
     expect(all.length).toBeGreaterThanOrEqual(2);
     const total = all.reduce((acc, x) => acc + Number(x.input_tokens ?? 0), 0);
     expect(total).toBe(3000);
+  });
+
+  test("tokensByAgentBySessionType — columns include cost_usd and values are correct", async () => {
+    const table = await q({ kind: "tokensByAgentBySessionType", range: RANGE });
+    expect(table.columns).toContain("cost_usd");
+    expect(table.columns).toContain("agent_id");
+    expect(table.columns).toContain("session_type");
+    const all = rows(table);
+    const agentA = all.find((x) => x.agent_id === "agent-a" && x.session_type === "cron");
+    expect(agentA).toBeDefined();
+    expect(Number(agentA?.input_tokens)).toBe(1000);
+    expect(Number(agentA?.cost_usd)).toBeCloseTo(0.01);
+  });
+
+  test("tokensByAgentByCron — columns include cost_usd; only cron events included", async () => {
+    const table = await q({ kind: "tokensByAgentByCron", range: RANGE });
+    expect(table.columns).toContain("cost_usd");
+    expect(table.columns).toContain("agent_id");
+    expect(table.columns).toContain("cron_name");
+    const all = rows(table);
+    // Only the cron event (agent-a / daily-report) qualifies
+    expect(all).toHaveLength(1);
+    const r = all[0];
+    expect(r?.agent_id).toBe("agent-a");
+    expect(r?.cron_name).toBe("daily-report");
+    expect(Number(r?.input_tokens)).toBe(1000);
+    expect(Number(r?.cost_usd)).toBeCloseTo(0.01);
+  });
+
+  test("tokensByAgentByModel — columns include cost_usd and values are correct", async () => {
+    const table = await q({ kind: "tokensByAgentByModel", range: RANGE });
+    expect(table.columns).toContain("cost_usd");
+    expect(table.columns).toContain("agent_id");
+    expect(table.columns).toContain("model");
+    const all = rows(table);
+    const agentB = all.find((x) => x.agent_id === "agent-b");
+    expect(agentB).toBeDefined();
+    expect(Number(agentB?.input_tokens)).toBe(2000);
+    expect(Number(agentB?.cost_usd)).toBeCloseTo(0.05);
   });
 });

--- a/metrics/src/queries.ts
+++ b/metrics/src/queries.ts
@@ -371,6 +371,78 @@ ORDER BY total_tokens DESC`;
 }
 
 /**
+ * Token usage by agent and session type: aggregates grouped by agent_id + session_type.
+ */
+export function buildTokensByAgentBySessionTypeQuery(
+  dateRange: QueryDateRange,
+): string {
+  const dateFilter = buildDateFilter(dateRange);
+  return `SELECT
+  properties.agent_id AS agent_id,
+  properties.session_type AS session_type,
+  sum(properties.input_tokens) AS input_tokens,
+  sum(properties.output_tokens) AS output_tokens,
+  sum(properties.cache_read_input_tokens) AS cache_read_input_tokens,
+  sum(properties.cache_creation_input_tokens) AS cache_creation_input_tokens,
+  sum(properties.input_tokens) + sum(properties.output_tokens) + sum(properties.cache_read_input_tokens) + sum(properties.cache_creation_input_tokens) AS total_tokens,
+  sum(properties.cost_usd) AS cost_usd
+FROM events
+WHERE event = 'agent_token_usage'
+  AND ${dateFilter}
+GROUP BY agent_id, session_type
+ORDER BY total_tokens DESC`;
+}
+
+/**
+ * Token usage by agent and cron name: aggregates grouped by agent_id + cron_name.
+ * Restricted to cron session types with a non-null cron_name.
+ */
+export function buildTokensByAgentByCronQuery(
+  dateRange: QueryDateRange,
+): string {
+  const dateFilter = buildDateFilter(dateRange);
+  return `SELECT
+  properties.agent_id AS agent_id,
+  properties.cron_name AS cron_name,
+  sum(properties.input_tokens) AS input_tokens,
+  sum(properties.output_tokens) AS output_tokens,
+  sum(properties.cache_read_input_tokens) AS cache_read_input_tokens,
+  sum(properties.cache_creation_input_tokens) AS cache_creation_input_tokens,
+  sum(properties.input_tokens) + sum(properties.output_tokens) + sum(properties.cache_read_input_tokens) + sum(properties.cache_creation_input_tokens) AS total_tokens,
+  sum(properties.cost_usd) AS cost_usd
+FROM events
+WHERE event = 'agent_token_usage'
+  AND properties.session_type = 'cron'
+  AND isNotNull(properties.cron_name)
+  AND ${dateFilter}
+GROUP BY agent_id, cron_name
+ORDER BY total_tokens DESC`;
+}
+
+/**
+ * Token usage by agent and model: aggregates grouped by agent_id + model.
+ */
+export function buildTokensByAgentByModelQuery(
+  dateRange: QueryDateRange,
+): string {
+  const dateFilter = buildDateFilter(dateRange);
+  return `SELECT
+  properties.agent_id AS agent_id,
+  properties.model AS model,
+  sum(properties.input_tokens) AS input_tokens,
+  sum(properties.output_tokens) AS output_tokens,
+  sum(properties.cache_read_input_tokens) AS cache_read_input_tokens,
+  sum(properties.cache_creation_input_tokens) AS cache_creation_input_tokens,
+  sum(properties.input_tokens) + sum(properties.output_tokens) + sum(properties.cache_read_input_tokens) + sum(properties.cache_creation_input_tokens) AS total_tokens,
+  sum(properties.cost_usd) AS cost_usd
+FROM events
+WHERE event = 'agent_token_usage'
+  AND ${dateFilter}
+GROUP BY agent_id, model
+ORDER BY total_tokens DESC`;
+}
+
+/**
  * Token usage daily trends: time-series token sums grouped by day (LA timezone).
  */
 export function buildTokensTrendsQuery(dateRange: QueryDateRange): string {

--- a/metrics/src/schemas.ts
+++ b/metrics/src/schemas.ts
@@ -194,12 +194,54 @@ const TokenTrendSchema = z
   })
   .openapi("TokenTrend");
 
+const TokensByAgentBySessionTypeSchema = z
+  .object({
+    agentId: z.string(),
+    sessionType: z.string(),
+    input: z.number(),
+    output: z.number(),
+    cacheRead: z.number(),
+    cacheCreation: z.number(),
+    total: z.number(),
+    cost: z.number(),
+  })
+  .openapi("TokensByAgentBySessionType");
+
+const TokensByAgentByCronSchema = z
+  .object({
+    agentId: z.string(),
+    cronName: z.string(),
+    input: z.number(),
+    output: z.number(),
+    cacheRead: z.number(),
+    cacheCreation: z.number(),
+    total: z.number(),
+    cost: z.number(),
+  })
+  .openapi("TokensByAgentByCron");
+
+const TokensByAgentByModelSchema = z
+  .object({
+    agentId: z.string(),
+    model: z.string(),
+    input: z.number(),
+    output: z.number(),
+    cacheRead: z.number(),
+    cacheCreation: z.number(),
+    total: z.number(),
+    cost: z.number(),
+  })
+  .openapi("TokensByAgentByModel");
+
 export const TokensResultSchema = z
   .object({
     totals: TokenTotalsSchema,
     bySessionType: z.array(TokensBySessionTypeSchema),
     byAgent: z.array(TokensByAgentSchema),
     trends: z.array(TokenTrendSchema),
+    byAgentSessionType: z.array(TokensByAgentBySessionTypeSchema),
+    byAgentCron: z.array(TokensByAgentByCronSchema),
+    byAgentModel: z.array(TokensByAgentByModelSchema),
   })
   .openapi("TokensResult");
 

--- a/metrics/src/tokens-api.integration.test.ts
+++ b/metrics/src/tokens-api.integration.test.ts
@@ -31,11 +31,33 @@ function makeMockClient(
   bySessionTypeResult: HogQLResult,
   byAgentResult: HogQLResult,
   trendsResult: HogQLResult,
+  byAgentBySessionTypeResult?: HogQLResult,
+  byAgentByCronResult?: HogQLResult,
+  byAgentByModelResult?: HogQLResult,
 ) {
   return {
     query: async (hogql: string): Promise<HogQLResult> => {
+      // More specific patterns first to avoid GROUP BY agent_id ambiguity
+      if (hogql.includes("agent_id, session_type"))
+        return (
+          byAgentBySessionTypeResult ??
+          makeResult(byAgentBySessionTypeColumns, [])
+        );
+      if (
+        hogql.includes("agent_id, cron_name") ||
+        hogql.includes("isNotNull(properties.cron_name)")
+      )
+        return byAgentByCronResult ?? makeResult(byAgentByCronColumns, []);
+      if (hogql.includes("agent_id, model"))
+        return byAgentByModelResult ?? makeResult(byAgentByModelColumns, []);
       if (hogql.includes("GROUP BY session_type")) return bySessionTypeResult;
-      if (hogql.includes("GROUP BY agent_id")) return byAgentResult;
+      if (
+        hogql.includes("GROUP BY agent_id") &&
+        !hogql.includes("session_type") &&
+        !hogql.includes("cron_name") &&
+        !hogql.includes(", model")
+      )
+        return byAgentResult;
       if (hogql.includes("GROUP BY period")) return trendsResult;
       return totalsResult;
     },
@@ -93,6 +115,50 @@ const trendsRows = [
   ["2026-04-02", 700, 350, 140, 70, 1260, 0.35],
 ];
 
+const byAgentBySessionTypeColumns = [
+  "agent_id",
+  "session_type",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+  "cost_usd",
+];
+const byAgentBySessionTypeRows = [
+  ["agent-abc123", "slack_dm", 400, 200, 80, 40, 720, 0.2],
+  ["agent-abc123", "cron", 600, 300, 120, 60, 1080, 0.3],
+];
+
+const byAgentByCronColumns = [
+  "agent_id",
+  "cron_name",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+  "cost_usd",
+];
+const byAgentByCronRows = [
+  ["agent-abc123", "daily-report", 600, 300, 120, 60, 1080, 0.3],
+];
+
+const byAgentByModelColumns = [
+  "agent_id",
+  "model",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "total_tokens",
+  "cost_usd",
+];
+const byAgentByModelRows = [
+  ["agent-abc123", "claude-sonnet-4-6", 700, 350, 140, 70, 1260, 0.35],
+  ["agent-abc123", "claude-opus-4-6", 300, 150, 60, 30, 540, 0.15],
+];
+
 function makeTestApp(
   accountsClient: AccountsClient = makeAccountsClientMock(async () => []),
   deps?: Partial<MetricsDeps>,
@@ -102,6 +168,9 @@ function makeTestApp(
     makeResult(bySessionTypeColumns, bySessionTypeRows),
     makeResult(byAgentColumns, byAgentRows),
     makeResult(trendsColumns, trendsRows),
+    makeResult(byAgentBySessionTypeColumns, byAgentBySessionTypeRows),
+    makeResult(byAgentByCronColumns, byAgentByCronRows),
+    makeResult(byAgentByModelColumns, byAgentByModelRows),
   );
   return createMetricsApp(apiKeys, accountsClient, { postHogClient, ...deps });
 }
@@ -194,6 +263,36 @@ describe("GET /metrics/tokens?preset=7d — happy path", () => {
     expect(body.data.trends[0].cost).toBe(0.15);
     expect(body.data.trends[1].date).toBe("2026-04-02");
 
+    // data.byAgentSessionType
+    expect(body.data).toHaveProperty("byAgentSessionType");
+    expect(Array.isArray(body.data.byAgentSessionType)).toBe(true);
+    expect(body.data.byAgentSessionType).toHaveLength(2);
+    expect(body.data.byAgentSessionType[0].agentId).toBe("agent-abc123");
+    expect(body.data.byAgentSessionType[0].sessionType).toBe("slack_dm");
+    expect(body.data.byAgentSessionType[0].input).toBe(400);
+    expect(body.data.byAgentSessionType[0].total).toBe(720);
+    expect(body.data.byAgentSessionType[0].cost).toBe(0.2);
+
+    // data.byAgentCron
+    expect(body.data).toHaveProperty("byAgentCron");
+    expect(Array.isArray(body.data.byAgentCron)).toBe(true);
+    expect(body.data.byAgentCron).toHaveLength(1);
+    expect(body.data.byAgentCron[0].agentId).toBe("agent-abc123");
+    expect(body.data.byAgentCron[0].cronName).toBe("daily-report");
+    expect(body.data.byAgentCron[0].input).toBe(600);
+    expect(body.data.byAgentCron[0].total).toBe(1080);
+    expect(body.data.byAgentCron[0].cost).toBe(0.3);
+
+    // data.byAgentModel
+    expect(body.data).toHaveProperty("byAgentModel");
+    expect(Array.isArray(body.data.byAgentModel)).toBe(true);
+    expect(body.data.byAgentModel).toHaveLength(2);
+    expect(body.data.byAgentModel[0].agentId).toBe("agent-abc123");
+    expect(body.data.byAgentModel[0].model).toBe("claude-sonnet-4-6");
+    expect(body.data.byAgentModel[0].input).toBe(700);
+    expect(body.data.byAgentModel[0].total).toBe(1260);
+    expect(body.data.byAgentModel[0].cost).toBe(0.35);
+
     // meta
     expect(body.meta).toHaveProperty("dateRange");
     expect(body.meta.dateRange).toHaveProperty("from");
@@ -265,12 +364,15 @@ describe("GET /metrics/tokens — custom date range", () => {
 // ─── GET /metrics/tokens — empty results ─────────────────────────────────────
 
 describe("GET /metrics/tokens — empty results", () => {
-  test("empty PostHog results return zero totals", async () => {
+  test("empty PostHog results return zero totals and empty arrays", async () => {
     const emptyClient = makeMockClient(
       makeResult(totalsColumns, []),
       makeResult(bySessionTypeColumns, []),
       makeResult(byAgentColumns, []),
       makeResult(trendsColumns, []),
+      makeResult(byAgentBySessionTypeColumns, []),
+      makeResult(byAgentByCronColumns, []),
+      makeResult(byAgentByModelColumns, []),
     );
     const app = createMetricsApp(
       apiKeys,
@@ -290,6 +392,10 @@ describe("GET /metrics/tokens — empty results", () => {
     expect(body.data.bySessionType).toHaveLength(0);
     expect(body.data.byAgent).toHaveLength(0);
     expect(body.data.trends).toHaveLength(0);
+    // New fields must be empty arrays, not 500
+    expect(body.data.byAgentSessionType).toHaveLength(0);
+    expect(body.data.byAgentCron).toHaveLength(0);
+    expect(body.data.byAgentModel).toHaveLength(0);
   });
 });
 

--- a/metrics/src/tokens-queries.unit.test.ts
+++ b/metrics/src/tokens-queries.unit.test.ts
@@ -8,6 +8,9 @@ import { describe, expect, it } from "bun:test";
 import {
   DENYLIST,
   type QueryDateRange,
+  buildTokensByAgentByCronQuery,
+  buildTokensByAgentByModelQuery,
+  buildTokensByAgentBySessionTypeQuery,
   buildTokensByAgentQuery,
   buildTokensBySessionTypeQuery,
   buildTokensTotalsQuery,
@@ -347,6 +350,197 @@ describe("buildTokensTrendsQuery", () => {
   });
 });
 
+// ─── buildTokensByAgentBySessionTypeQuery ────────────────────────────────────
+
+describe("buildTokensByAgentBySessionTypeQuery", () => {
+  it("filters to agent_token_usage event", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain(`event = '${TOKEN_EVENT}'`);
+  });
+
+  it("groups by agent_id and session_type", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("GROUP BY agent_id, session_type");
+  });
+
+  it("selects agent_id column", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("agent_id");
+  });
+
+  it("selects session_type column", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("session_type");
+  });
+
+  it("selects input_tokens", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("input_tokens");
+  });
+
+  it("selects total_tokens", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("total_tokens");
+  });
+
+  it("selects cost_usd", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("cost_usd");
+  });
+
+  it("queries from events table", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("FROM events");
+  });
+
+  it("applies 7d date filter", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain(
+      "timestamp >= toStartOfDay(now() - interval 7 day, 'America/Los_Angeles')",
+    );
+  });
+
+  it("references agent_id and session_type properties", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("properties.agent_id");
+    expect(query).toContain("properties.session_type");
+  });
+
+  it("uses sum() aggregates", () => {
+    const query = buildTokensByAgentBySessionTypeQuery("7d");
+    expect(query).toContain("sum(");
+  });
+});
+
+// ─── buildTokensByAgentByCronQuery ────────────────────────────────────────────
+
+describe("buildTokensByAgentByCronQuery", () => {
+  it("filters to agent_token_usage event", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain(`event = '${TOKEN_EVENT}'`);
+  });
+
+  it("groups by agent_id and cron_name", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("GROUP BY agent_id, cron_name");
+  });
+
+  it("filters to session_type = cron", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("session_type");
+    expect(query).toContain("'cron'");
+  });
+
+  it("filters to non-null cron_name via isNotNull", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("isNotNull(properties.cron_name)");
+  });
+
+  it("selects agent_id column", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("agent_id");
+  });
+
+  it("selects cron_name column", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("cron_name");
+  });
+
+  it("selects total_tokens", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("total_tokens");
+  });
+
+  it("selects cost_usd", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("cost_usd");
+  });
+
+  it("queries from events table", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("FROM events");
+  });
+
+  it("applies 7d date filter", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain(
+      "timestamp >= toStartOfDay(now() - interval 7 day, 'America/Los_Angeles')",
+    );
+  });
+
+  it("references cron_name property", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("properties.cron_name");
+  });
+
+  it("uses sum() aggregates", () => {
+    const query = buildTokensByAgentByCronQuery("7d");
+    expect(query).toContain("sum(");
+  });
+});
+
+// ─── buildTokensByAgentByModelQuery ──────────────────────────────────────────
+
+describe("buildTokensByAgentByModelQuery", () => {
+  it("filters to agent_token_usage event", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain(`event = '${TOKEN_EVENT}'`);
+  });
+
+  it("groups by agent_id and model", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("GROUP BY agent_id, model");
+  });
+
+  it("selects agent_id column", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("agent_id");
+  });
+
+  it("selects model column", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("model");
+  });
+
+  it("selects input_tokens", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("input_tokens");
+  });
+
+  it("selects total_tokens", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("total_tokens");
+  });
+
+  it("selects cost_usd", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("cost_usd");
+  });
+
+  it("queries from events table", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("FROM events");
+  });
+
+  it("applies 7d date filter", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain(
+      "timestamp >= toStartOfDay(now() - interval 7 day, 'America/Los_Angeles')",
+    );
+  });
+
+  it("references agent_id and model properties", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("properties.agent_id");
+    expect(query).toContain("properties.model");
+  });
+
+  it("uses sum() aggregates", () => {
+    const query = buildTokensByAgentByModelQuery("7d");
+    expect(query).toContain("sum(");
+  });
+});
+
 // ─── cost_usd select assertions ──────────────────────────────────────────────
 
 describe("cost_usd select — all 4 token query builders", () => {
@@ -376,6 +570,12 @@ describe("HogQL denylist guard — token queries (TU-2.1)", () => {
       ["buildTokensBySessionTypeQuery", buildTokensBySessionTypeQuery],
       ["buildTokensByAgentQuery", buildTokensByAgentQuery],
       ["buildTokensTrendsQuery", buildTokensTrendsQuery],
+      [
+        "buildTokensByAgentBySessionTypeQuery",
+        buildTokensByAgentBySessionTypeQuery,
+      ],
+      ["buildTokensByAgentByCronQuery", buildTokensByAgentByCronQuery],
+      ["buildTokensByAgentByModelQuery", buildTokensByAgentByModelQuery],
     ];
 
   const DATE_RANGE: QueryDateRange = { from: "2026-01-01", to: "2026-03-31" };
@@ -401,6 +601,9 @@ describe("Direct typed prop rule — token properties referenced directly", () =
     buildTokensBySessionTypeQuery,
     buildTokensByAgentQuery,
     buildTokensTrendsQuery,
+    buildTokensByAgentBySessionTypeQuery,
+    buildTokensByAgentByCronQuery,
+    buildTokensByAgentByModelQuery,
   ];
 
   it("no toString() round-trips on numeric token properties", () => {
@@ -427,6 +630,12 @@ describe("PST timezone anchor — token queries", () => {
       ["buildTokensBySessionTypeQuery", buildTokensBySessionTypeQuery],
       ["buildTokensByAgentQuery", buildTokensByAgentQuery],
       ["buildTokensTrendsQuery", buildTokensTrendsQuery],
+      [
+        "buildTokensByAgentBySessionTypeQuery",
+        buildTokensByAgentBySessionTypeQuery,
+      ],
+      ["buildTokensByAgentByCronQuery", buildTokensByAgentByCronQuery],
+      ["buildTokensByAgentByModelQuery", buildTokensByAgentByModelQuery],
     ];
 
   for (const [name, builder] of tokenBuilders) {
@@ -441,5 +650,21 @@ describe("PST timezone anchor — token queries", () => {
       expect(query).not.toMatch(/(?<!OfDay\()\btoday\(\)/);
       expect(query).not.toMatch(/now\(\) - interval \d+ day(?!,)/);
     }
+  });
+});
+
+// ─── cost_usd select assertions — new cross-dimension builders ────────────────
+
+describe("cost_usd select — new cross-dimension builders", () => {
+  it("buildTokensByAgentBySessionTypeQuery selects cost_usd", () => {
+    expect(buildTokensByAgentBySessionTypeQuery("7d")).toContain("cost_usd");
+  });
+
+  it("buildTokensByAgentByCronQuery selects cost_usd", () => {
+    expect(buildTokensByAgentByCronQuery("7d")).toContain("cost_usd");
+  });
+
+  it("buildTokensByAgentByModelQuery selects cost_usd", () => {
+    expect(buildTokensByAgentByModelQuery("7d")).toContain("cost_usd");
   });
 });


### PR DESCRIPTION
## Summary
- Adds 3 new HogQL query builders (`buildTokensByAgentBySessionTypeQuery`, `buildTokensByAgentByCronQuery`, `buildTokensByAgentByModelQuery`) to `metrics/src/queries.ts`
- Wires all three through `MetricQuery` union, `PostHogProvider`, `SqlEventStoreProvider`, schemas, and `api.ts` `handleTokens` (7 parallel queries total)
- `byAgentCron` is correctly filtered to `session_type = 'cron' AND isNotNull(properties.cron_name)` at both the HogQL and SQL provider layers

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | GET /metrics/tokens?preset=7d includes `data.byAgentSessionType`, `data.byAgentCron`, `data.byAgentModel` | MET |
| 2 | `byAgentCron` rows filtered to cron session_type + non-null cron_name | MET |
| 3 | Empty arrays for all three new fields when no data — no 500 | MET |
| 4 | `TokensResultSchema` validates all three new fields | MET |
| 5 | Unit: 3 suites in `tokens-queries.unit.test.ts` | MET |
| 6 | Integration: mock dispatch updated + happy-path + empty-results assertions | MET |

## Test Plan
- [x] 150 unit + integration tests pass for new query builders and API endpoint
- [x] 711 total metrics tests pass, 0 failures
- [x] Biome lint: no issues
- [x] TypeScript typecheck passes for `@shipwright/metrics`
- [x] Coverage on changed files: queries.ts 100%, api.ts 98.5%, posthog-provider.ts 100%, sql-provider.ts 97.7%, schemas.ts 100%
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
