### PR TITLE
feat: emit cron_name in agent_token_usage events

### DIFF
--- a/agent/src/cron-handler.ts
+++ b/agent/src/cron-handler.ts
@@ -202,7 +202,7 @@ export async function handleCronRequest(
   if (workspace && metricsSnapshot) {
     await forwardNewMetrics(workspace, metricsSnapshot);
   }
-  await forwardTokenUsage(usage, "cron");
+  await forwardTokenUsage(usage, "cron", undefined, jobId);
 
   const { cleaned, markers } = parseMarkers(result);
   const isSilentMarker = markers.some((m) => m.type === "silent");

--- a/agent/src/posthog.ts
+++ b/agent/src/posthog.ts
@@ -166,6 +166,7 @@ export async function forwardTokenUsage(
   usage: TokenUsage | undefined,
   sessionType: SessionType,
   model?: string,
+  cronName?: string,
   fetchFn: typeof fetch = globalThis.fetch,
 ): Promise<void> {
   if (!usage) return;
@@ -194,6 +195,7 @@ export async function forwardTokenUsage(
       cache_creation_input_tokens: usage.cache_creation_input_tokens,
       model: resolvedModel,
       cost_usd: calculateCost(usage, resolvedModel),
+      ...(cronName !== undefined ? { cron_name: cronName } : {}),
     },
   };
 

--- a/agent/src/posthog.unit.test.ts
+++ b/agent/src/posthog.unit.test.ts
@@ -360,6 +360,7 @@ describe("forwardTokenUsage", () => {
       SAMPLE_USAGE,
       "slack_dm",
       "claude-sonnet-4-6",
+      undefined,
       mockFetch as unknown as typeof fetch,
     );
 
@@ -395,6 +396,7 @@ describe("forwardTokenUsage", () => {
       SAMPLE_USAGE,
       "cron",
       undefined,
+      undefined,
       mockFetch as unknown as typeof fetch,
     );
     expect(mockFetch).not.toHaveBeenCalled();
@@ -404,6 +406,7 @@ describe("forwardTokenUsage", () => {
     await forwardTokenUsage(
       undefined,
       "slack_mention",
+      undefined,
       undefined,
       mockFetch as unknown as typeof fetch,
     );
@@ -417,8 +420,41 @@ describe("forwardTokenUsage", () => {
         SAMPLE_USAGE,
         "slack_dm",
         undefined,
+        undefined,
         failFetch as unknown as typeof fetch,
       ),
     ).resolves.toBeUndefined();
+  });
+
+  test("includes cron_name in properties when cronName is provided", async () => {
+    await forwardTokenUsage(
+      SAMPLE_USAGE,
+      "cron",
+      undefined,
+      "shipwright-dev-task",
+      mockFetch as unknown as typeof fetch,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: { properties: Record<string, unknown> }[] };
+    expect(body.batch[0].properties.cron_name).toBe("shipwright-dev-task");
+  });
+
+  test("omits cron_name from properties when cronName is not provided", async () => {
+    await forwardTokenUsage(
+      SAMPLE_USAGE,
+      "cron",
+      undefined,
+      undefined,
+      mockFetch as unknown as typeof fetch,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { batch: { properties: Record<string, unknown> }[] };
+    expect(body.batch[0].properties).not.toHaveProperty("cron_name");
   });
 });


### PR DESCRIPTION
## Summary
- Add optional `cronName?: string` as 4th parameter to `forwardTokenUsage()` in `agent/src/posthog.ts`
- When `cronName` is provided, emit `cron_name` in PostHog `agent_token_usage` event properties; when absent, field is omitted entirely (not `null`)
- Update `cron-handler.ts` to pass `jobId` as the `cronName` argument so each cron job is identified in usage analytics

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `forwardTokenUsage(usage, 'cron', undefined, 'shipwright-dev-task')` emits `{ cron_name: 'shipwright-dev-task' }` | ✅ MET |
| 2 | `forwardTokenUsage(usage, 'cron')` emits without a `cron_name` field | ✅ MET |
| 3 | cron-handler.ts call passes `jobId` as the `cronName` arg | ✅ MET |
| 4 | Slack handler call signatures require no changes | ✅ MET |
| 5 | 2 new unit tests added + existing call sites updated | ✅ MET |

## Test Plan
- [x] 2 new unit tests in `posthog.unit.test.ts`: one asserting `cron_name` is present when arg supplied, one asserting absent when not
- [x] 4 existing `forwardTokenUsage` call sites updated to pass `undefined` for new `cronName` param before `fetchFn`
- [x] All 22 posthog unit tests pass; `posthog.ts` at 97.79% line coverage
- [x] Biome lint passes; agent typecheck clean

Generated with [Claude Code](https://claude.com/claude-code)
