### PR TITLE
feat(metrics): hierarchical per-agent token breakdown UI (ATB-2.2)

### DIFF
--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -325,27 +325,15 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
             <div class="kpi-meta">total cost (USD)</div>
           </div>
         </div>
-        <div class="token-breakdown-grid">
-          <div class="quality-panel">
-            <h3 class="panel-title">By Session Type</h3>
-            <table class="token-table" id="token-session-table">
-              <thead>
-                <tr><th>Session Type</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-session-tbody"></tbody>
-            </table>
-            <p id="token-session-empty" class="empty-state" style="display:none">No data</p>
-          </div>
-          <div class="quality-panel">
-            <h3 class="panel-title">By Agent</h3>
-            <table class="token-table" id="token-agent-table">
-              <thead>
-                <tr><th>Agent</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-agent-tbody"></tbody>
-            </table>
-            <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
-          </div>
+        <div class="quality-panel">
+          <h3 class="panel-title">By Agent</h3>
+          <table class="token-table" id="token-agent-table">
+            <thead>
+              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
+            </thead>
+            <tbody id="token-agent-tbody"></tbody>
+          </table>
+          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
         </div>
         <div class="token-trends-section">
           <div class="token-trends-toggles" role="group" aria-label="Token series">
@@ -767,27 +755,15 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
             <div class="kpi-meta">total cost (USD)</div>
           </div>
         </div>
-        <div class="token-breakdown-grid">
-          <div class="quality-panel">
-            <h3 class="panel-title">By Session Type</h3>
-            <table class="token-table" id="token-session-table">
-              <thead>
-                <tr><th>Session Type</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-session-tbody"></tbody>
-            </table>
-            <p id="token-session-empty" class="empty-state" style="display:none">No data</p>
-          </div>
-          <div class="quality-panel">
-            <h3 class="panel-title">By Agent</h3>
-            <table class="token-table" id="token-agent-table">
-              <thead>
-                <tr><th>Agent</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-agent-tbody"></tbody>
-            </table>
-            <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
-          </div>
+        <div class="quality-panel">
+          <h3 class="panel-title">By Agent</h3>
+          <table class="token-table" id="token-agent-table">
+            <thead>
+              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
+            </thead>
+            <tbody id="token-agent-tbody"></tbody>
+          </table>
+          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
         </div>
         <div class="token-trends-section">
           <div class="token-trends-toggles" role="group" aria-label="Token series">
@@ -1209,27 +1185,15 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
             <div class="kpi-meta">total cost (USD)</div>
           </div>
         </div>
-        <div class="token-breakdown-grid">
-          <div class="quality-panel">
-            <h3 class="panel-title">By Session Type</h3>
-            <table class="token-table" id="token-session-table">
-              <thead>
-                <tr><th>Session Type</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-session-tbody"></tbody>
-            </table>
-            <p id="token-session-empty" class="empty-state" style="display:none">No data</p>
-          </div>
-          <div class="quality-panel">
-            <h3 class="panel-title">By Agent</h3>
-            <table class="token-table" id="token-agent-table">
-              <thead>
-                <tr><th>Agent</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-agent-tbody"></tbody>
-            </table>
-            <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
-          </div>
+        <div class="quality-panel">
+          <h3 class="panel-title">By Agent</h3>
+          <table class="token-table" id="token-agent-table">
+            <thead>
+              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
+            </thead>
+            <tbody id="token-agent-tbody"></tbody>
+          </table>
+          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
         </div>
         <div class="token-trends-section">
           <div class="token-trends-toggles" role="group" aria-label="Token series">
@@ -1651,27 +1615,15 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
             <div class="kpi-meta">total cost (USD)</div>
           </div>
         </div>
-        <div class="token-breakdown-grid">
-          <div class="quality-panel">
-            <h3 class="panel-title">By Session Type</h3>
-            <table class="token-table" id="token-session-table">
-              <thead>
-                <tr><th>Session Type</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-session-tbody"></tbody>
-            </table>
-            <p id="token-session-empty" class="empty-state" style="display:none">No data</p>
-          </div>
-          <div class="quality-panel">
-            <h3 class="panel-title">By Agent</h3>
-            <table class="token-table" id="token-agent-table">
-              <thead>
-                <tr><th>Agent</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-agent-tbody"></tbody>
-            </table>
-            <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
-          </div>
+        <div class="quality-panel">
+          <h3 class="panel-title">By Agent</h3>
+          <table class="token-table" id="token-agent-table">
+            <thead>
+              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
+            </thead>
+            <tbody id="token-agent-tbody"></tbody>
+          </table>
+          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
         </div>
         <div class="token-trends-section">
           <div class="token-trends-toggles" role="group" aria-label="Token series">

--- a/metrics/src/dashboard/app.js
+++ b/metrics/src/dashboard/app.js
@@ -314,43 +314,14 @@
       $("token-cost").textContent = "$0.00";
       return;
     }
-    const { totals, bySessionType, byAgent } = res.data;
+    const { totals, byAgent, byAgentCron, byAgentModel, byAgentSessionType } =
+      res.data;
     $("token-input").textContent = fmtTokens(totals.input);
     $("token-output").textContent = fmtTokens(totals.output);
     $("token-cache").textContent = fmtTokens(
       (totals.cacheRead || 0) + (totals.cacheCreation || 0),
     );
     $("token-cost").textContent = fmtCost(totals.cost);
-
-    const sessionTbody = $("token-session-tbody");
-    const sessionEmpty = $("token-session-empty");
-    if (sessionTbody) {
-      sessionTbody.innerHTML = "";
-      if (!bySessionType || bySessionType.length === 0) {
-        if (sessionEmpty) sessionEmpty.style.display = "";
-      } else {
-        if (sessionEmpty) sessionEmpty.style.display = "none";
-        for (const row of bySessionType) {
-          const tr = document.createElement("tr");
-          const tdType = document.createElement("td");
-          const tdInput = document.createElement("td");
-          const tdOutput = document.createElement("td");
-          const tdCost = document.createElement("td");
-          const tdTotal = document.createElement("td");
-          tdType.textContent = row.sessionType;
-          tdInput.textContent = fmtTokens(row.input);
-          tdOutput.textContent = fmtTokens(row.output);
-          tdCost.textContent = fmtCost(row.cost);
-          tdTotal.textContent = fmtTokens(row.total);
-          tr.appendChild(tdType);
-          tr.appendChild(tdInput);
-          tr.appendChild(tdOutput);
-          tr.appendChild(tdCost);
-          tr.appendChild(tdTotal);
-          sessionTbody.appendChild(tr);
-        }
-      }
-    }
 
     const agentTbody = $("token-agent-tbody");
     const agentEmpty = $("token-agent-empty");
@@ -360,24 +331,87 @@
         if (agentEmpty) agentEmpty.style.display = "";
       } else {
         if (agentEmpty) agentEmpty.style.display = "none";
-        for (const row of byAgent) {
-          const tr = document.createElement("tr");
-          const tdAgent = document.createElement("td");
-          const tdInput = document.createElement("td");
-          const tdOutput = document.createElement("td");
-          const tdCost = document.createElement("td");
-          const tdTotal = document.createElement("td");
-          tdAgent.textContent = row.agentName ?? row.agentId;
-          tdInput.textContent = fmtTokens(row.input);
-          tdOutput.textContent = fmtTokens(row.output);
-          tdCost.textContent = fmtCost(row.cost);
-          tdTotal.textContent = fmtTokens(row.total);
-          tr.appendChild(tdAgent);
-          tr.appendChild(tdInput);
-          tr.appendChild(tdOutput);
-          tr.appendChild(tdCost);
-          tr.appendChild(tdTotal);
-          agentTbody.appendChild(tr);
+        for (const agent of byAgent) {
+          const agentCronRows = (byAgentCron || []).filter(
+            (r) => r.agentId === agent.agentId,
+          );
+          const agentSessionRows = (byAgentSessionType || []).filter(
+            (r) => r.agentId === agent.agentId,
+          );
+          const agentModelRows = (byAgentModel || []).filter(
+            (r) => r.agentId === agent.agentId,
+          );
+
+          const cronTotal = agentCronRows.reduce(
+            (sum, r) => sum + (r.total || 0),
+            0,
+          );
+          let dmTotal;
+          if (agentSessionRows.length > 0) {
+            dmTotal = agentSessionRows
+              .filter((r) => r.sessionType !== "cron")
+              .reduce((sum, r) => sum + (r.total || 0), 0);
+          } else {
+            dmTotal = (agent.total || 0) - cronTotal;
+          }
+
+          const agentLabel =
+            agent.agentName ?? agent.agentId.slice(0, 8);
+
+          // Agent header row
+          const headerTr = document.createElement("tr");
+          headerTr.className = "agent-header-row";
+          const cells = [
+            agentLabel,
+            fmtTokens(cronTotal),
+            fmtTokens(dmTotal),
+            fmtTokens(agent.total),
+            fmtCost(agent.cost),
+          ];
+          for (const text of cells) {
+            const td = document.createElement("td");
+            td.textContent = text;
+            headerTr.appendChild(td);
+          }
+          agentTbody.appendChild(headerTr);
+
+          // Cron sub-rows
+          for (const cronRow of agentCronRows) {
+            const tr = document.createElement("tr");
+            tr.className = "agent-cron-row";
+            const cronCells = [
+              `› ${cronRow.cronName}`,
+              fmtTokens(cronRow.total),
+              "--",
+              fmtTokens(cronRow.total),
+              fmtCost(cronRow.cost),
+            ];
+            for (const text of cronCells) {
+              const td = document.createElement("td");
+              td.textContent = text;
+              tr.appendChild(td);
+            }
+            agentTbody.appendChild(tr);
+          }
+
+          // Model sub-rows
+          for (const modelRow of agentModelRows) {
+            const tr = document.createElement("tr");
+            tr.className = "agent-model-row";
+            const modelCells = [
+              `◦ ${modelRow.model}`,
+              "--",
+              "--",
+              fmtTokens(modelRow.total),
+              fmtCost(modelRow.cost),
+            ];
+            for (const text of modelCells) {
+              const td = document.createElement("td");
+              td.textContent = text;
+              tr.appendChild(td);
+            }
+            agentTbody.appendChild(tr);
+          }
         }
       }
     }

--- a/metrics/src/dashboard/dashboard-page.ts
+++ b/metrics/src/dashboard/dashboard-page.ts
@@ -236,27 +236,15 @@ export function renderDashboardPage(opts: DashboardPageOptions): string {
             <div class="kpi-meta">total cost (USD)</div>
           </div>
         </div>
-        <div class="token-breakdown-grid">
-          <div class="quality-panel">
-            <h3 class="panel-title">By Session Type</h3>
-            <table class="token-table" id="token-session-table">
-              <thead>
-                <tr><th>Session Type</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-session-tbody"></tbody>
-            </table>
-            <p id="token-session-empty" class="empty-state" style="display:none">No data</p>
-          </div>
-          <div class="quality-panel">
-            <h3 class="panel-title">By Agent</h3>
-            <table class="token-table" id="token-agent-table">
-              <thead>
-                <tr><th>Agent</th><th>Input</th><th>Output</th><th>Cost ($)</th><th>Total</th></tr>
-              </thead>
-              <tbody id="token-agent-tbody"></tbody>
-            </table>
-            <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
-          </div>
+        <div class="quality-panel">
+          <h3 class="panel-title">By Agent</h3>
+          <table class="token-table" id="token-agent-table">
+            <thead>
+              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
+            </thead>
+            <tbody id="token-agent-tbody"></tbody>
+          </table>
+          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
         </div>
         <div class="token-trends-section">
           <div class="token-trends-toggles" role="group" aria-label="Token series">

--- a/metrics/src/dashboard/dashboard-page.unit.test.ts
+++ b/metrics/src/dashboard/dashboard-page.unit.test.ts
@@ -78,10 +78,10 @@ describe("renderDashboardPage — Token Usage section", () => {
     expect(html).toContain('id="token-cache"');
   });
 
-  test("includes session type breakdown table", () => {
+  test("does not include session type breakdown table", () => {
     const html = renderDashboardPage(BASE_OPTS);
-    expect(html).toContain('id="token-session-table"');
-    expect(html).toContain('id="token-session-tbody"');
+    expect(html).not.toContain('id="token-session-table"');
+    expect(html).not.toContain('id="token-session-tbody"');
   });
 
   test("includes agent breakdown table", () => {
@@ -282,22 +282,8 @@ describe("renderDashboardPage — info icons: approved copy", () => {
   });
 });
 
-describe("renderDashboardPage — TK-1.1 token table input/output columns", () => {
-  test("session type table has Input and Output column headers", () => {
-    const html = renderDashboardPage(BASE_OPTS);
-    const tokenSection = html.slice(
-      html.indexOf('aria-label="Token usage"'),
-      html.indexOf('aria-label="Feature breakdown"'),
-    );
-    const sessionTable = tokenSection.slice(
-      tokenSection.indexOf('id="token-session-table"'),
-      tokenSection.indexOf('id="token-agent-table"'),
-    );
-    expect(sessionTable).toContain("<th>Input</th>");
-    expect(sessionTable).toContain("<th>Output</th>");
-  });
-
-  test("agent table has Input and Output column headers", () => {
+describe("renderDashboardPage — TK-1.1 token table columns", () => {
+  test("agent table does not have Input or Output column headers (replaced by Cron/DM)", () => {
     const html = renderDashboardPage(BASE_OPTS);
     const tokenSection = html.slice(
       html.indexOf('aria-label="Token usage"'),
@@ -306,22 +292,8 @@ describe("renderDashboardPage — TK-1.1 token table input/output columns", () =
     const agentTable = tokenSection.slice(
       tokenSection.indexOf('id="token-agent-table"'),
     );
-    expect(agentTable).toContain("<th>Input</th>");
-    expect(agentTable).toContain("<th>Output</th>");
-  });
-
-  test("session type table Total column is labeled 'Total' not 'Total Tokens'", () => {
-    const html = renderDashboardPage(BASE_OPTS);
-    const tokenSection = html.slice(
-      html.indexOf('aria-label="Token usage"'),
-      html.indexOf('aria-label="Feature breakdown"'),
-    );
-    const sessionTable = tokenSection.slice(
-      tokenSection.indexOf('id="token-session-table"'),
-      tokenSection.indexOf('id="token-agent-table"'),
-    );
-    expect(sessionTable).not.toContain("<th>Total Tokens</th>");
-    expect(sessionTable).toContain("<th>Total</th>");
+    expect(agentTable).not.toContain("<th>Input</th>");
+    expect(agentTable).not.toContain("<th>Output</th>");
   });
 
   test("agent table Total column is labeled 'Total' not 'Total Tokens'", () => {
@@ -421,16 +393,9 @@ describe("renderDashboardPage — CCT-2.2 cost KPI and table columns", () => {
     expect(html).toContain("Total Cost");
   });
 
-  test("session type table has Cost ($) column header", () => {
+  test("session type table is absent (removed in ATB-2.2)", () => {
     const html = renderDashboardPage(BASE_OPTS);
-    const tokenStart = html.indexOf('aria-label="Token usage"');
-    const tokenEnd = html.indexOf("</section>", tokenStart);
-    const tokenSection = html.slice(tokenStart, tokenEnd);
-    const sessionTable = tokenSection.slice(
-      tokenSection.indexOf('id="token-session-table"'),
-      tokenSection.indexOf('id="token-agent-table"'),
-    );
-    expect(sessionTable).toContain("<th>Cost ($)</th>");
+    expect(html).not.toContain('id="token-session-table"');
   });
 
   test("agent table has Cost ($) column header", () => {
@@ -464,6 +429,28 @@ describe("renderDashboardPage — basePath", () => {
   test("prefixes the app script src with basePath", () => {
     const html = renderDashboardPage({ userName: "Alice", basePath: "/sw" });
     expect(html).toContain('src="/sw/dashboard/app.js"');
+  });
+});
+
+describe("renderDashboardPage — ATB-2.2 hierarchical token breakdown", () => {
+  test("By Session Type panel is removed", () => {
+    const html = renderDashboardPage(BASE_OPTS);
+    expect(html).not.toContain("By Session Type");
+  });
+
+  test("agent table has Agent Cron DM/Mention Total Cost columns", () => {
+    const html = renderDashboardPage(BASE_OPTS);
+    const tokenStart = html.indexOf('aria-label="Token usage"');
+    const tokenEnd = html.indexOf("</section>", tokenStart);
+    const tokenSection = html.slice(tokenStart, tokenEnd);
+    const agentTable = tokenSection.slice(
+      tokenSection.indexOf('id="token-agent-table"'),
+    );
+    expect(agentTable).toContain("<th>Agent</th>");
+    expect(agentTable).toContain("<th>Cron</th>");
+    expect(agentTable).toContain("<th>DM/Mention</th>");
+    expect(agentTable).toContain("<th>Total</th>");
+    expect(agentTable).toContain("<th>Cost ($)</th>");
   });
 });
 


### PR DESCRIPTION
## Summary
- Replaces the two-panel token breakdown layout (By Session Type + By Agent) with a single hierarchical agent table
- Agent header rows show Cron | DM/Mention | Total | Cost ($) columns, with cron sub-rows (› prefix) and model sub-rows (◦ prefix) nested underneath
- Removes the By Session Type panel entirely; agentName displayed with truncated agentId fallback

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Agent header rows: Agent \| Cron \| DM/Mention \| Total \| Cost ($) | ✅ MET |
| 2 | Cron sub-rows with › prefix under each agent with cron usage | ✅ MET |
| 3 | Model sub-rows with ◦ prefix under each agent | ✅ MET |
| 4 | By Session Type panel removed | ✅ MET |
| 5 | Empty state when byAgent is empty | ✅ MET |
| 6 | agentName displayed when present; truncated agentId fallback | ✅ MET |
| 7 | E2E assertions referencing old panel title updated | ✅ MET |

## Test Plan
- [x] 68/68 unit tests in dashboard-page.unit.test.ts pass
- [x] 730/730 full metrics test suite passes
- [x] Biome lint clean (64 files)
- [x] Snapshots regenerated for new table structure
- [x] Tests for session-type panel flipped to assert absence

Generated with [Claude Code](https://claude.com/claude-code)
