### PR TITLE
fix(ci): use SHIPWRIGHT_DISPATCH_TOKEN for image release tags

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -21,7 +21,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
           tag_prefix: "admin-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -21,7 +21,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
           tag_prefix: "agent-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -21,7 +21,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
           tag_prefix: "metrics-v"
           default_bump: patch
           fetch_all_tags: true


### PR DESCRIPTION
## Problem

The deployment pipeline from shipwright → vitals-os was silently broken. The chain:

```
build-{agent,admin,metrics}.yml pushes tag
  → auto-bump-chart.yml bumps Chart.yaml, opens PR
    → chart-release.yml publishes chart + dispatches to vitals-os
      → bump-shipwright-chart.yml opens vitals-os bump PR
```

...never started. All three build workflows used `GITHUB_TOKEN` to push their image release tags (`agent-v*`, `admin-v*`, `metrics-v*`). GitHub's anti-recursion guard blocks `GITHUB_TOKEN`-triggered pushes from firing other workflow runs, so `auto-bump-chart.yml` never saw the tags.

Evidence: no `chore/chart-v*` branches ever existed on origin; chart is still at 1.5.1 despite 14+ commits of image builds since `auto-bump-chart.yml` was added.

## Fix

Swap `github_token` from `GITHUB_TOKEN` → `SHIPWRIGHT_DISPATCH_TOKEN` in the tag action for all three build workflows. `SHIPWRIGHT_DISPATCH_TOKEN` is a fine-grained PAT with `Contents: Read and Write` on this repo — tag pushes from it are attributed to a user identity, which GitHub does allow to trigger downstream tag-push workflows.

## Changed

- `.github/workflows/build-agent.yml`
- `.github/workflows/build-admin.yml`
- `.github/workflows/build-metrics.yml`