### PR TITLE
fix(dev-task): reduce stale in_progress reset threshold to 45 minutes

### DIFF
--- a/plugins/shipwright/scripts/check-dev-task.test.ts
+++ b/plugins/shipwright/scripts/check-dev-task.test.ts
@@ -114,14 +114,14 @@ describe("check-dev-task", () => {
 
   // ─── Stale in_progress guard ──────────────────────────────────────────────
 
-  test("resets in_progress task older than 4 hours to pending", async () => {
+  test("resets in_progress task older than 45 minutes to pending", async () => {
     const resetCalls: string[] = [];
     const clock = FixedClock("2026-05-31T16:00:00Z");
-    // 4 hours and 1 second ago — just over the threshold
+    // 45 minutes and 1 second ago — just over the threshold
     const staleTask = makeTask({
       id: "SWC-2.1",
       status: "in_progress",
-      startedAt: "2026-05-31T11:59:59Z",
+      startedAt: "2026-05-31T15:14:59Z",
     });
 
     await run(
@@ -135,14 +135,14 @@ describe("check-dev-task", () => {
     expect(resetCalls).toContain("SWC-2.1");
   });
 
-  test("does not reset in_progress task newer than 4 hours", async () => {
+  test("does not reset in_progress task newer than 45 minutes", async () => {
     const resetCalls: string[] = [];
     const clock = FixedClock("2026-05-31T16:00:00Z");
-    // 1 hour ago — well within the threshold
+    // 40 minutes ago — well within the threshold
     const freshTask = makeTask({
       id: "SWC-2.2",
       status: "in_progress",
-      startedAt: "2026-05-31T15:00:00Z",
+      startedAt: "2026-05-31T15:20:00Z",
     });
 
     await run(
@@ -163,7 +163,7 @@ describe("check-dev-task", () => {
     const taskWithoutStartedAt = makeTask({
       id: "SWC-2.3",
       status: "in_progress",
-      // no startedAt — conservative: stamp now, reset 4 hours later
+      // no startedAt — conservative: stamp now, reset 45 minutes later
     });
 
     await run(
@@ -185,7 +185,7 @@ describe("check-dev-task", () => {
     const staleTask = makeTask({
       id: "SWC-2.4",
       status: "in_progress",
-      startedAt: "2026-05-31T11:59:59Z",
+      startedAt: "2026-05-31T15:14:59Z",
     });
     const readyTask = makeTask({ id: "SWC-2.5" });
 
@@ -208,7 +208,7 @@ describe("check-dev-task", () => {
     const staleTask = makeTask({
       id: "SWC-2.6",
       status: "in_progress",
-      startedAt: "2026-05-31T11:59:59Z",
+      startedAt: "2026-05-31T15:14:59Z",
     });
 
     const result = await run(

--- a/plugins/shipwright/scripts/check-dev-task.ts
+++ b/plugins/shipwright/scripts/check-dev-task.ts
@@ -6,7 +6,7 @@
  *
  * Queries the task store for ready tasks and prints a prompt if any exist.
  * Before checking ready tasks, guards against stale in_progress tasks:
- *   - Tasks with startedAt older than 4 hours are reset to pending.
+ *   - Tasks with startedAt older than 45 minutes are reset to pending.
  *   - Tasks with no startedAt are stamped with the current time so they age
  *     out naturally on the next run (conservative — avoids disrupting tasks
  *     legitimately set to in_progress outside of dev-task).
@@ -24,7 +24,7 @@ import type { Task } from "./store.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const STALE_THRESHOLD_MS = 4 * 60 * 60 * 1000; // 4 hours
+const STALE_THRESHOLD_MS = 45 * 60 * 1000; // 45 minutes
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Reduces `STALE_THRESHOLD_MS` in `check-dev-task.ts` from 4 hours to 45 minutes
- Sessions time out after 30 minutes, so 4 hours meant stuck tasks sat for up to 4 runs before auto-recovery
- Updates test descriptions and fixed timestamps accordingly (all 15 tests pass)

## Test plan

- [x] `bun test plugins/shipwright/scripts/check-dev-task.test.ts` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)