### PR TITLE
fix(ci): correct dispatch token secret name to VITALS_OS_DISPATCH_TOKEN

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -21,7 +21,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "admin-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -21,7 +21,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "agent-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -21,7 +21,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "metrics-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -19,7 +19,7 @@ name: Chart Release
 #     publish path.
 #
 # Required secrets / variables:
-#   - SHIPWRIGHT_DISPATCH_TOKEN: GitHub PAT with `repo` scope on the dispatch target.
+#   - VITALS_OS_DISPATCH_TOKEN: GitHub PAT with `repo` scope on the dispatch target.
 #     Used to emit repository_dispatch events. The step is continue-on-error: true so a
 #     missing or invalid token does not block chart publishing.
 #   - CHART_DISPATCH_REPO (repository variable): owner/repo to receive the dispatch event
@@ -73,7 +73,7 @@ jobs:
       - name: Notify downstream of chart release
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.SHIPWRIGHT_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           DISPATCH_REPO: ${{ vars.CHART_DISPATCH_REPO }}
         run: |
           [ -z "$DISPATCH_REPO" ] && echo "CHART_DISPATCH_REPO not configured, skipping" && exit 0


### PR DESCRIPTION
`SHIPWRIGHT_DISPATCH_TOKEN` doesn't exist — the actual secret is `VITALS_OS_DISPATCH_TOKEN` (renamed in workflow files by `7b1b8d6` but the GitHub secret was never renamed).

**Impact:**
- Build workflows failing with `Parameter token or opts.auth is required` since #505 merged
- `chart-release.yml` dispatch to vitals-os has been silently failing since `7b1b8d6` (`continue-on-error: true` was hiding it)

**Fix:** rename all four references across `build-agent.yml`, `build-admin.yml`, `build-metrics.yml`, and `chart-release.yml`.