### PR TITLE
fix(ci): use VITALS_OS_DISPATCH_TOKEN for checkout in auto-bump-chart

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+        with:
           ref: main
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Pushes using the default `GITHUB_TOKEN` do not trigger downstream workflows. `auto-bump-chart.yml` pushes a branch and opens a PR — without a PAT on checkout, `chart-release.yml` won't fire after the bump PR merges.
- Adds `token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}` to `actions/checkout@v4`, matching the token already used for PR creation and auto-merge in this workflow.

## Test plan

- [ ] Merge this PR
- [ ] Push an image build tag (e.g. `agent-v*`) — confirm auto-bump PR is created, auto-merges, and `chart-release.yml` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)