### PR TITLE
fix(ci): scope build triggers to module paths instead of paths-ignore

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -3,9 +3,12 @@ name: Build and Push Admin Image
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "charts/**"
-      - "CHANGELOG.md"
+    paths:
+      - "admin/**"
+      - "lib/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/build-admin.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -3,9 +3,13 @@ name: Build and Push Agent Image
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "charts/**"
-      - "CHANGELOG.md"
+    paths:
+      - "agent/**"
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/build-agent.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -3,9 +3,12 @@ name: Build and Push Metrics Image
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "charts/**"
-      - "CHANGELOG.md"
+    paths:
+      - "metrics/**"
+      - "lib/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/build-metrics.yml"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Replaces the broad `paths-ignore` (from #515) with positive `paths` filters so each build workflow only fires on changes relevant to that module.

| Workflow | Paths |
|---|---|
| `build-admin.yml` | `admin/**`, `lib/**`, root deps |
| `build-metrics.yml` | `metrics/**`, `lib/**`, root deps |
| `build-agent.yml` | `agent/**`, `plugins/**`, `.claude-plugin/**`, root deps |

`plugins/**` does not affect admin or metrics. `lib/**` is shared and affects admin + metrics (both use `COPY . .`). The agent Dockerfile explicitly copies `agent/`, `plugins/`, and `.claude-plugin/` — lib source is not in its build context.

## Why positive paths over paths-ignore

`paths-ignore` only excluded chart bumps and CHANGELOG — any other cross-module change (e.g. editing `admin/` code) would still rebuild all three images unnecessarily. Positive filters are explicit about what triggers each build.