### PR TITLE
fix(agent): skip @mention in threads where bot already has a session

### DIFF
--- a/agent/src/slack.integration.test.ts
+++ b/agent/src/slack.integration.test.ts
@@ -857,6 +857,26 @@ describe("app_mention handler", () => {
     expect(event.type).toBe("error");
     expect(event.error).toBe("oops");
   });
+
+  test("app_mention in active thread: runClaude not called when session exists", async () => {
+    // The fix: when thread_ts is set and getSessionFn returns a session, the
+    // app_mention handler returns early — the message handler already covers it
+    // and would double-respond otherwise.
+    createSlackApp({ getSessionFn: () => "sess-existing" });
+    const client = makeMockClient();
+    const say = makeSay();
+    await capturedMentionHandler?.({
+      event: {
+        text: "<@UBOT> follow-up in thread",
+        channel: "C999",
+        ts: "3.3",
+        thread_ts: "1.0",
+      },
+      say,
+      client,
+    });
+    expect(mockRunClaude).not.toHaveBeenCalled();
+  });
 });
 
 // ─── app_mention handler — file handling ─────────────────────────────────────

--- a/agent/src/slack.ts
+++ b/agent/src/slack.ts
@@ -500,6 +500,12 @@ export function createSlackApp(
     const sessionKey = getThreadKey(ev.channel, ev.thread_ts ?? ev.ts);
     const replyTs = ev.thread_ts ?? ev.ts;
 
+    // Drop @mention if bot is already participating in this thread —
+    // the message handler covers it and would double-respond otherwise.
+    if (ev.thread_ts && getSessionFn(sessionKey)) {
+      return;
+    }
+
     const setStatus = async (status: string) => {
       // biome-ignore lint/suspicious/noExplicitAny: Bolt types don't include Agents API yet
       await (client.assistant.threads as any)


### PR DESCRIPTION
## Summary

- When a user @mentions the agent in an active thread, both `app_mention` and `message` events fire — causing two responses
- Fix: add an early return in the `app_mention` handler if `ev.thread_ts` exists and `getSessionFn(sessionKey)` returns a session
- The `message` handler already has the same awareness (line 377-378) — this makes `app_mention` consistent with it

## Test plan

- [ ] 136 existing Slack integration tests pass unchanged
- [ ] Manual: @mention bot in an active thread → single response
- [ ] Manual: @mention bot to start a new thread → still responds (no session yet)
- [ ] Manual: @mention bot in a DM → still responds (`ev.thread_ts` is undefined in DMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)