### PR TITLE
feat(admin): migrate runtime API to OpenAPIHono (OAS-2.1)

### DIFF
--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -19,7 +19,7 @@
  * two routes that need it.
  */
 
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { AgentCronJob } from "./agent-cron-jobs.ts";
 import type { AgentEnvBundle } from "./agent-envs.ts";
 import {
@@ -27,6 +27,12 @@ import {
   createAdminAuthMiddleware,
 } from "./api-auth.ts";
 import type { AgentTokenService } from "./agent-tokens.ts";
+import {
+  AgentConfigResponseSchema,
+  AgentCronJobSchema,
+  AgentIdParamSchema,
+  RuntimeErrorSchema,
+} from "./openapi-schemas.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -125,17 +131,71 @@ export interface AdminApiPaths {
   };
 }
 
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const getConfigRoute = createRoute({
+  method: "get",
+  path: "/:id/config",
+  tags: ["runtime"],
+  summary: "Get agent config bundle",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: AgentIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Agent config bundle",
+      content: { "application/json": { schema: AgentConfigResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: RuntimeErrorSchema } },
+    },
+    404: {
+      description: "Agent not found",
+      content: { "application/json": { schema: RuntimeErrorSchema } },
+    },
+  },
+});
+
+const getCronsRoute = createRoute({
+  method: "get",
+  path: "/:id/crons",
+  tags: ["runtime"],
+  summary: "List agent cron jobs",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: AgentIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Array of cron jobs",
+      content: {
+        "application/json": { schema: z.array(AgentCronJobSchema) },
+      },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: RuntimeErrorSchema } },
+    },
+    404: {
+      description: "Agent not found",
+      content: { "application/json": { schema: RuntimeErrorSchema } },
+    },
+  },
+});
+
 // ─── Factory ──────────────────────────────────────────────────────────────────
 
 /**
- * Creates the Hono runtime API app.
+ * Creates the OpenAPIHono runtime API app.
  *
  * Inject real services for production; inject mocks for tests.
  */
-export function createAgentRuntimeApp(deps: AgentRuntimeDeps): Hono {
+export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
   const { agentEnvService, agentCronJobService, prisma } = deps;
 
-  const app = new Hono();
+  const app = new OpenAPIHono();
 
   // Auth middleware — applied per-route, NOT as app.use("*").
   // See file-level comment for why global middleware is avoided here.
@@ -148,11 +208,10 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): Hono {
   // ─── GET /:id/config ─────────────────────────────────────────────────────
   //     Reachable from root as GET /agents/:id/config (Hono v4 strips prefix)
 
-  app.get("/:id/config", requireAuth, async (c) => {
-    const id = c.req.param("id");
-    if (!id) {
-      return c.json({ error: "Not found" }, 404);
-    }
+  app.use("/:id/config", requireAuth);
+
+  app.openapi(getConfigRoute, async (c) => {
+    const { id } = c.req.valid("param");
 
     // Check agent existence
     const agent = await prisma.agent.findUnique({ where: { id } });
@@ -188,11 +247,10 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): Hono {
   // ─── GET /:id/crons ──────────────────────────────────────────────────────
   //     Reachable from root as GET /agents/:id/crons (Hono v4 strips prefix)
 
-  app.get("/:id/crons", requireAuth, async (c) => {
-    const id = c.req.param("id");
-    if (!id) {
-      return c.json({ error: "Not found" }, 404);
-    }
+  app.use("/:id/crons", requireAuth);
+
+  app.openapi(getCronsRoute, async (c) => {
+    const { id } = c.req.valid("param");
 
     // Check agent existence
     const agent = await prisma.agent.findUnique({ where: { id } });

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -322,3 +322,27 @@ export const EnvKeyParamSchema = z.object({
 export const PluginNameQuerySchema = z.object({
   name: z.string().openapi({ example: "@shipwright/plugin" }),
 });
+
+// ─── AgentConfig (runtime GET /agents/:id/config response) ───────────────────
+
+export const AgentConfigPluginSchema = z
+  .object({
+    marketplace: z.string().openapi({ example: "shipwright" }),
+    plugin: z.string().openapi({ example: "shipwright" }),
+  })
+  .openapi("AgentConfigPlugin");
+
+export const AgentConfigResponseSchema = z
+  .object({
+    env: z.record(z.string()).openapi({ example: { SLACK_BOT_TOKEN: "xoxb-..." } }),
+    allowedTools: z.array(z.string()).openapi({ example: ["Read", "Write"] }),
+    plugins: z.array(AgentConfigPluginSchema),
+  })
+  .openapi("AgentConfigResponse");
+
+// Simple error shape for runtime API responses (no status field)
+export const RuntimeErrorSchema = z
+  .object({
+    error: z.string().openapi({ example: "Not found" }),
+  })
+  .openapi("RuntimeError");

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -145,10 +145,10 @@ The constant `BAKED_MARKETPLACES_ROOT` and function `discoverBakedMarketplaces()
 | File | Purpose |
 |---|---|
 | `admin/src/main.ts` | Standalone admin service entrypoint — runs `prisma migrate deploy`, constructs all services, and mounts health + runtime API + admin CRUD API + admin UI. Dockerfile `ENTRYPOINT`. |
-| `admin/src/api.ts` | Runtime API factory `createAgentRuntimeApp()` (DI for services). |
+| `admin/src/api.ts` | Runtime API factory `createAgentRuntimeApp()` (OpenAPIHono app with OAS 2.1 route definitions; DI for services). |
 | `admin/src/agents-api.ts` | Admin CRUD factory `createAdminApp()`. |
 | `admin/src/api-auth.ts` | Combined admin auth middleware (`createAdminAuthMiddleware()`) and env-key parser (`parseAdminApiKeys()`) — bearer check order: env API keys (scope enforcement), then DB token via `agentTokenService`; bearer path does not fall through to session cookie on failure. |
-| `admin/src/openapi-schemas.ts` | Zod schemas for the admin API — entity types (Agent, AgentCronJob, AgentTool, AgentToken, AgentPlugin), request bodies, and common error shapes (Error, Ok). Imported by route migrations (OAS-2.1, OAS-2.2); `z` imported from `@hono/zod-openapi` for `.openapi()` metadata support. |
+| `admin/src/openapi-schemas.ts` | Zod schemas for the admin and runtime APIs — entity types (Agent, AgentCronJob, AgentTool, AgentToken, AgentPlugin), request bodies, runtime response shapes (AgentConfigResponse, RuntimeError), and common error shapes (Error, Ok). Imported by route migrations (OAS-2.1, OAS-2.2); `z` imported from `@hono/zod-openapi` for `.openapi()` metadata support. |
 | `admin/src/admin-ui.ts` | Admin UI factory `createAdminUIApp()` — server-rendered Hono app (login, agent list/detail, Slack provisioning) with POST mutation routes for cron jobs, tools, and tokens (create/toggle/delete/revoke). Accepts `devAuthEnabled` in `AdminUIDeps`; when true, registers `GET /admin/dev-login` (dev auto-login). |
 | `admin/src/dev-auth-guard.ts` | `isDevAuthAllowed(env)` — pure predicate over an injected env object (`DevAuthGuardEnv`). Returns `true` only when `ADMIN_DEV_AUTH=true` and `NODE_ENV !== "production"`. Mirrors the `chat-guard.ts` safety pattern. |
 | `admin/src/admin-ui-pages.ts` | Page rendering functions (`renderLoginPage`, `renderAgentsPage`, `renderAgentDetailPage`, `renderProvision*`). |


### PR DESCRIPTION
## Summary
- Migrates `admin/src/api.ts` from plain `Hono` to `OpenAPIHono` from `@hono/zod-openapi`
- Replaces both route handlers (`GET /:id/config`, `GET /:id/crons`) with `createRoute()` + `app.openapi()` using Zod schemas from OAS-1.1
- Adds `AgentConfigResponseSchema`, `AgentConfigPluginSchema`, and `RuntimeErrorSchema` to `openapi-schemas.ts`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `admin/src/api.ts` uses `OpenAPIHono` from `@hono/zod-openapi` | ✅ MET |
| 2 | Both routes registered via `createRoute()` + `app.openapi()` with Zod schemas | ✅ MET |
| 3 | `RuntimeApiPaths` and `AdminApiPaths` exports retained unchanged | ✅ MET |
| 4 | Existing `api.smoke.test.ts` passes unchanged — route contracts identical | ✅ MET |
| 5 | `bun test --filter admin` passes; `bun run typecheck` passes | ✅ MET |

## Test Plan
- [x] `bun test admin/src/api.smoke.test.ts` — 14/14 pass (unchanged)
- [x] `bun test --filter admin` — 521 pass, 0 fail
- [x] `bun run --filter='*' typecheck` — all 4 packages clean
- [x] `bunx biome lint .` — 298 files, no issues

Generated with [Claude Code](https://claude.com/claude-code)
