### PR TITLE
feat(agent-admin): add scope boundary and API reference, bump to v4.28.1

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.27.4
+# Shipwright v4.28.1
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -380,6 +380,9 @@ the live `/doc` endpoint on a running admin service:
 open "$SHIPWRIGHT_API_URL/doc"
 ```
 
+> **Note:** The `/doc` endpoint is not yet wired in the production admin service — it is a
+> planned follow-up. Use `admin/openapi.json` as the schema reference in the meantime.
+
 ---
 
 ## Safety Rules

--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -11,6 +11,9 @@ description: >
 Use this skill to configure and manage Shipwright agents via the admin API. Covers cron jobs,
 env vars, tool permissions, API tokens, and plugins for any agent — including yourself.
 
+**Scope boundary:** For delivery pipeline work (planning, code tasks, reviews, deploys) use the
+task-store, dev-task, review, or deploy skills. This skill is for agent lifecycle management only.
+
 ---
 
 ## Authentication
@@ -364,6 +367,18 @@ The metrics service exposes PostHog-backed pipeline data. Endpoints require Bear
 
 For structured analysis, use `/shipwright:metrics` instead — it handles PostHog queries,
 local JSONL fallback, trends, and produces a formatted report.
+
+---
+
+## API Reference
+
+The full admin API schema is committed to the repository at `admin/openapi.json`. For
+interactive schema exploration (endpoints, request/response shapes, validation rules), access
+the live `/doc` endpoint on a running admin service:
+
+```bash
+open "$SHIPWRIGHT_API_URL/doc"
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Added scope boundary sentence to `agent-admin` SKILL.md distinguishing it from dev-task/review/deploy skills
- Added API Reference section pointing to `admin/openapi.json` and the live `/doc` endpoint
- Bumped plugin version to v4.28.1 (patch) across plugin.json and plugins/shipwright/README.md

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Skill name and description frontmatter unchanged | ✅ MET |
| 2 | Scope boundary sentence near top | ✅ MET |
| 3 | API Reference section with admin/openapi.json and /doc | ✅ MET |
| 4 | All existing curl examples present and unchanged | ✅ MET |
| 5 | Plugin version bumped (patch) in plugin.json and plugins README | ✅ MET |

## Test Plan
- [x] No existing tests modified — doc-only change
- [x] Biome lint passes on changed files
- [x] 37 pre-existing test failures confirmed as baseline (not regressions from this PR)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
