### PR TITLE
feat: add reinstall-after-sync flow (SMR-1.1)

### DIFF
--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -1179,6 +1179,8 @@ describe("admin UI — provision start form", () => {
     expect(upsertedAgentId).toBe(AGENT_ID);
     expect(envVars.SLACK_APP_ID).toBe("A_HAPPY");
     expect(envVars.SLACK_SIGNING_SECRET).toBe("ssec_happy");
+    expect(envVars.SLACK_CLIENT_ID).toBe("cid_happy");
+    expect(envVars.SLACK_CLIENT_SECRET).toBe("csec_happy");
     expect(envVars.GH_TOKEN).toBe("ghp_my_token");
   });
 
@@ -1802,5 +1804,73 @@ describe("admin UI — manifest sync route", () => {
       },
     });
     expect(res.status).toBe(403);
+  });
+
+  it("sync-manifest with SLACK_CLIENT_ID/SECRET/SIGNING_SECRET in env → 302 to slack.com/oauth/v2/authorize with provision state cookie set", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        agentEnvService: {
+          getByAgentId: async () => ({
+            SLACK_APP_ID: "A123456",
+            SLACK_CLIENT_ID: "my-client-id",
+            SLACK_CLIENT_SECRET: "my-client-secret",
+            SLACK_SIGNING_SECRET: "my-signing-secret",
+          }),
+          upsert: async () => {},
+          deleteKey: async () => {},
+          getConfigBundle: async () => null,
+        },
+        slackClient: {
+          updateAppManifest: async () => {},
+        },
+      }),
+    );
+    const body = new URLSearchParams({ xoxpToken: "xoxe.xoxp-valid-token" });
+    const res = await app.request(`/admin/agents/${AGENT_ID}/sync-manifest`, {
+      method: "POST",
+      body: body.toString(),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: `admin_session=${adminCookie}`,
+      },
+    });
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("slack.com/oauth/v2/authorize");
+    expect(location).toContain("client_id=my-client-id");
+    // Provision state cookie should be set
+    const setCookieHeader = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookieHeader).toContain("slack_provision_state=");
+  });
+
+  it("sync-manifest with no SLACK_CLIENT_ID in env (legacy agent) → 302 to ?success=manifest_synced", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        agentEnvService: {
+          getByAgentId: async () => ({
+            SLACK_APP_ID: "A123456",
+            // No SLACK_CLIENT_ID — legacy agent
+          }),
+          upsert: async () => {},
+          deleteKey: async () => {},
+          getConfigBundle: async () => null,
+        },
+        slackClient: {
+          updateAppManifest: async () => {},
+        },
+      }),
+    );
+    const body = new URLSearchParams({ xoxpToken: "xoxe.xoxp-valid-token" });
+    const res = await app.request(`/admin/agents/${AGENT_ID}/sync-manifest`, {
+      method: "POST",
+      body: body.toString(),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: `admin_session=${adminCookie}`,
+      },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("success=manifest_synced");
+    expect(res.headers.get("Set-Cookie") ?? "").not.toContain("slack_provision_state=");
   });
 });

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -1841,6 +1841,15 @@ describe("admin UI — manifest sync route", () => {
     // Provision state cookie should be set
     const setCookieHeader = res.headers.get("Set-Cookie") ?? "";
     expect(setCookieHeader).toContain("slack_provision_state=");
+    // Verify JWT payload — a bug encoding the wrong agentId or clientId
+    // would pass the presence check above but be caught here
+    const tokenMatch = setCookieHeader.match(/slack_provision_state=([^;]+)/);
+    expect(tokenMatch).not.toBeNull();
+    const jwtPayload = JSON.parse(
+      Buffer.from(tokenMatch?.[1].split(".")[1] ?? "", "base64url").toString(),
+    );
+    expect(jwtPayload.agentId).toBe(AGENT_ID);
+    expect(jwtPayload.clientId).toBe("my-client-id");
   });
 
   it("sync-manifest with no SLACK_CLIENT_ID in env (legacy agent) → 302 to ?success=manifest_synced", async () => {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -513,10 +513,13 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     const rawError = c.req.query("error") ?? undefined;
     const error = rawError ? (ERROR_MESSAGES[rawError] ?? rawError) : undefined;
     const newToken = c.req.query("newToken") ?? undefined;
+    const successParam = c.req.query("success");
     const successMsg =
-      c.req.query("success") === "manifest_synced"
+      successParam === "manifest_synced"
         ? "Manifest synced successfully."
-        : undefined;
+        : successParam === "reinstalled"
+          ? "Slack app reinstalled successfully."
+          : undefined;
 
     const [envVars, crons, tools, tokens, plugins, members] = await Promise.all([
       agentEnvService.getByAgentId(agentId).then((e) => e ?? {}),
@@ -887,6 +890,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     },
   );
 
+  // ─── Provisioning state constants ────────────────────────────────────────
+
+  const PROVISION_STATE_COOKIE = "slack_provision_state";
+  const PROVISION_STATE_TTL_SECONDS = 300; // 5 min
+
   // ─── Manifest sync ────────────────────────────────────────────────────────
 
   app.post("/admin/agents/:id/sync-manifest", requireAuth, async (c) => {
@@ -932,13 +940,68 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       );
     }
 
+    // If the agent has OAuth credentials stored, trigger a reinstall via Slack OAuth
+    const clientId = envVars.SLACK_CLIENT_ID;
+    const clientSecret = envVars.SLACK_CLIENT_SECRET;
+    const signingSecret = envVars.SLACK_SIGNING_SECRET;
+
+    if (clientId && clientSecret && signingSecret) {
+      // Sign a provision-state cookie so /provision/complete can exchange the code
+      const now = Math.floor(Date.now() / 1000);
+      const provisionToken = await sign(
+        {
+          agentId,
+          clientId,
+          clientSecret,
+          signingSecret,
+          appId,
+          iat: now,
+          exp: now + PROVISION_STATE_TTL_SECONDS,
+        },
+        sessionSecret,
+        "HS256",
+      );
+      setCookie(c, PROVISION_STATE_COOKIE, provisionToken, {
+        httpOnly: true,
+        maxAge: PROVISION_STATE_TTL_SECONDS,
+        sameSite: "Lax",
+        path: "/",
+        secure: appBaseUrl.startsWith("https://"),
+      });
+
+      // Build the Slack OAuth v2 authorize URL
+      const scopes = [
+        "app_mentions:read",
+        "assistant:write",
+        "channels:history",
+        "channels:read",
+        "chat:write",
+        "files:read",
+        "files:write",
+        "groups:history",
+        "im:history",
+        "im:write",
+        "mpim:history",
+        "reactions:read",
+        "reactions:write",
+        "users:read",
+      ].join(",");
+      const redirectUri = `${appBaseUrl}/admin/provision/complete`;
+      const oauthParams = new URLSearchParams({
+        client_id: clientId,
+        scope: scopes,
+        redirect_uri: redirectUri,
+      });
+      return c.redirect(
+        `https://slack.com/oauth/v2/authorize?${oauthParams.toString()}`,
+        302,
+      );
+    }
+
     return c.redirect(`/admin/agents/${agentId}?success=manifest_synced`, 302);
   });
 
   // ─── Provisioning flow ────────────────────────────────────────────────────
-
-  const PROVISION_STATE_COOKIE = "slack_provision_state";
-  const PROVISION_STATE_TTL_SECONDS = 300; // 5 min
 
   app.get("/admin/provision", requireAuth, async (c) => {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
@@ -1084,6 +1147,8 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       ...existing,
       SLACK_APP_ID: appId,
       SLACK_SIGNING_SECRET: signingSecret,
+      SLACK_CLIENT_ID: clientId,
+      SLACK_CLIENT_SECRET: clientSecret,
     };
 
     if (ghAuthMode === "pat") {
@@ -1211,6 +1276,15 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       ...existing,
       SLACK_BOT_TOKEN: botToken,
     });
+
+    // If SLACK_APP_TOKEN is already set this is a reinstall (not fresh provisioning).
+    // Skip the xapp-token page and redirect directly to the agent detail page.
+    if (existing.SLACK_APP_TOKEN) {
+      return c.redirect(
+        `/admin/agents/${provisionState.agentId}?success=reinstalled`,
+        302,
+      );
+    }
 
     // Render xapp-token page
     return html(

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -40,7 +40,10 @@ import { ForbiddenError, UnprocessableEntityError } from "./errors.ts";
 import type { GoogleAuthClient } from "./google-auth-client.ts";
 import type { AgentProvisioner } from "./agent-provisioner.ts";
 import type { AppManifest } from "./slack-provisioning-client.ts";
-import { buildAgentManifest } from "./slack-provisioning-client.ts";
+import {
+  AGENT_BOT_SCOPES,
+  buildAgentManifest,
+} from "./slack-provisioning-client.ts";
 
 type AdminUIEnv = { Variables: { userEmail: string; isAdmin: boolean } };
 
@@ -969,23 +972,10 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         secure: appBaseUrl.startsWith("https://"),
       });
 
-      // Build the Slack OAuth v2 authorize URL
-      const scopes = [
-        "app_mentions:read",
-        "assistant:write",
-        "channels:history",
-        "channels:read",
-        "chat:write",
-        "files:read",
-        "files:write",
-        "groups:history",
-        "im:history",
-        "im:write",
-        "mpim:history",
-        "reactions:read",
-        "reactions:write",
-        "users:read",
-      ].join(",");
+      // Build the Slack OAuth v2 authorize URL — use the canonical scope list
+      // exported from slack-provisioning-client.ts so this stays in sync with
+      // what buildAgentManifest declares.
+      const scopes = AGENT_BOT_SCOPES.join(",");
       const redirectUri = `${appBaseUrl}/admin/provision/complete`;
       const oauthParams = new URLSearchParams({
         client_id: clientId,

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -349,6 +349,57 @@ describe("GET /admin/provision/complete — OAuth callback", () => {
   });
 });
 
+describe("GET /admin/provision/complete — reinstall path (SLACK_APP_TOKEN already set)", () => {
+  let sessionCookie: string;
+
+  beforeAll(async () => {
+    sessionCookie = await makeSessionCookie();
+  });
+
+  it("valid state cookie + code param + SLACK_APP_TOKEN already in env → 302 to ?success=reinstalled", async () => {
+    const state: MockState = {
+      upsertCalls: [],
+      reconcileCalls: [],
+      createTokenCalls: [],
+    };
+    const deps = makeMockDeps(state, {
+      agentEnvService: {
+        // Existing env already has SLACK_APP_TOKEN — reinstall path
+        getByAgentId: async () => ({
+          SLACK_BOT_TOKEN: "xoxb-old-bot-token",
+          SLACK_APP_TOKEN: "xapp-existing-app-token",
+        }),
+        upsert: async (agentId: string, env: Record<string, string>) => {
+          state.upsertCalls.push({ agentId, env });
+        },
+        deleteKey: async () => {},
+        getConfigBundle: async () => null,
+      },
+    });
+    const app = createAdminUIApp(deps);
+
+    const provisionState = await makeProvisionStateCookie();
+
+    const res = await app.request(
+      "/admin/provision/complete?code=valid-oauth-code",
+      {
+        headers: {
+          Cookie: `admin_session=${sessionCookie}; ${PROVISION_STATE_COOKIE}=${provisionState}`,
+        },
+      },
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("success=reinstalled");
+    expect(location).toContain(`/admin/agents/${AGENT_ID}`);
+
+    // SLACK_BOT_TOKEN should still have been stored (new token)
+    const storedEnv = state.upsertCalls[state.upsertCalls.length - 1]?.env;
+    expect(storedEnv).toHaveProperty("SLACK_BOT_TOKEN", "xoxb-mock-bot-token");
+  });
+});
+
 describe("POST /admin/provision/complete — removed route", () => {
   let sessionCookie: string;
 

--- a/admin/src/slack-provisioning-client.ts
+++ b/admin/src/slack-provisioning-client.ts
@@ -109,7 +109,28 @@ export interface SlackProvisioningClient {
  * and subsequent manifest syncs (omit redirectUri to keep localhost default).
  * Socket Mode and the full event/assistant config are always applied — there
  * is no separate "provisioning-only" manifest.
+ *
+ * The canonical bot scope list is exported as `AGENT_BOT_SCOPES` so that other
+ * code paths (e.g. the sync-manifest reinstall OAuth URL) can stay in sync
+ * without duplicating the array.
  */
+export const AGENT_BOT_SCOPES: string[] = [
+  "app_mentions:read",
+  "assistant:write",
+  "channels:history",
+  "channels:read",
+  "chat:write",
+  "files:read",
+  "files:write",
+  "groups:history",
+  "im:history",
+  "im:write",
+  "mpim:history",
+  "reactions:read",
+  "reactions:write",
+  "users:read",
+];
+
 export function buildAgentManifest(
   appName: string,
   redirectUri?: string,
@@ -137,22 +158,7 @@ export function buildAgentManifest(
     },
     oauth_config: {
       scopes: {
-        bot: [
-          "app_mentions:read",
-          "assistant:write",
-          "channels:history",
-          "channels:read",
-          "chat:write",
-          "files:read",
-          "files:write",
-          "groups:history",
-          "im:history",
-          "im:write",
-          "mpim:history",
-          "reactions:read",
-          "reactions:write",
-          "users:read",
-        ],
+        bot: AGENT_BOT_SCOPES,
       },
       ...(redirectUri !== undefined ? { redirect_urls: [redirectUri] } : {}),
     },


### PR DESCRIPTION
## Summary
- Extends `sync-manifest` route to trigger a full Slack OAuth reinstall after updating the manifest, reusing the existing `provision/complete` flow
- `provision/start` now persists `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET` to the agent env alongside `SLACK_APP_ID` so they're available for the reinstall path
- `provision/complete` detects reinstalls (when `SLACK_APP_TOKEN` is already set) and redirects to `?success=reinstalled` instead of rendering the xapp-token page

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | provision/start upserts SLACK_CLIENT_ID and SLACK_CLIENT_SECRET alongside SLACK_APP_ID | MET |
| 2 | Smoke: sync-manifest with creds in env → 302 to slack.com/oauth/v2/authorize + provision cookie | MET |
| 3 | Smoke: sync-manifest without SLACK_CLIENT_ID (legacy agent) → 302 to ?success=manifest_synced | MET |
| 4 | Smoke: provision/complete with SLACK_APP_TOKEN in env → 302 to ?success=reinstalled | MET |
| 5 | Smoke tests only; existing provision/complete tests remain green | MET |

## Test Plan
- [x] 75 smoke tests pass across `admin-ui.smoke.test.ts` and `provision-callback.smoke.test.ts`
- [x] Biome lint clean
- [x] All 4 packages typecheck clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
