### PR TITLE
fix(plugin): use version-aware resolution for plugin script lookup

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.28.1",
+  "version": "4.28.2",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.28.1
+# Shipwright v4.28.2
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -38,7 +38,7 @@ AGENT_LOGIN=$(gh api user --jq '.login')
 
 Resolve the configured repos:
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 REPOS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos)
 ```
 
@@ -121,7 +121,7 @@ beyond (i.e., no bundle-mates are still in flight). This prevents deploying a PR
 sibling tasks on the same branch are still being developed or are blocked.
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
 BRANCH_TASKS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" query --branch "$HEAD_BRANCH" 2>/dev/null || echo '[]')
 INCOMPLETE_TASKS=$(echo "$BRANCH_TASKS" | jq '[.[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked") | {id, status}]')

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -19,7 +19,7 @@ Auto-detect the project toolchain (run once, reuse throughout). Skip this step u
 **First, check for an interrupted task** — if a prior session left a task `in_progress`, resume it:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" query --status in_progress ${CURRENT_USER:+--assignee "$CURRENT_USER"}
 ```
@@ -35,7 +35,7 @@ Record `task_started_at` (current ISO timestamp) for metrics.
 **If no in_progress task**, pick the next ready pending task:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" query --ready ${CURRENT_USER:+--assignee "$CURRENT_USER"}
 ```
@@ -123,7 +123,7 @@ If the task's current status is already `in_progress`:
 ### Mark In-Progress
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set startedAt={ISO timestamp} --set status=in_progress
 ```
 
@@ -451,7 +451,7 @@ Store these counts for use in Step 10b metrics.
 If any criterion is PARTIAL or NOT MET after the fix loop, mark the task blocked via task_store.ts, then fire `shipwright_task_blocked`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set blockedReason=requirements_not_met --set status=blocked
 ```
 
@@ -677,7 +677,7 @@ If PR creation fails, OR if CI checks fail after max retries (Step 9b.5), after 
 This cleanup ensures no orphaned PRs or branches are left behind. Mark the task blocked via task_store.ts, then fire `shipwright_task_blocked`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set blockedReason=pr_creation_failed --set status=blocked
 ```
 
@@ -868,7 +868,7 @@ Failing checks:
 Run PR Failure Cleanup (Step 9) and stop. Mark the task blocked via task_store.ts, then fire `shipwright_task_blocked`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set blockedReason=ci_max_retries_exhausted --set status=blocked
 ```
 
@@ -883,7 +883,7 @@ POSTHOG_SCRIPT=$(find ~/.claude/plugins/cache -name "posthog_send.py" -path "*/s
 ### 10a. Update Queue
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set pr={pr_number} --set prCreatedAt={ISO timestamp} --set status=pr_open
 ```
 

--- a/plugins/shipwright/commands/hitl.md
+++ b/plugins/shipwright/commands/hitl.md
@@ -35,7 +35,7 @@ Example: /shipwright:hitl HIT-3.1
 Resolve the task store script and query by ID:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 TASK_JSON=$(bun "$PLUGIN_SCRIPTS/task_store.ts" query --id "$TASK_ID" 2>/dev/null)
 ```
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -33,7 +33,7 @@ CURRENT_USER=$(gh api /user -q '.login')
 Resolve the list of repos to scan. Use the same resolver as other shipwright commands:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 REPOS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos)
 ```
 

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -39,7 +39,7 @@ This is the engineering planning pass. The product spec (what and why) is alread
 Detect the active backend and, when it is `"github"`, run the task store setup before any context loading:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 PHASE0_BACKEND=$([ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" backend 2>/dev/null)
 PHASE0_BACKEND=${PHASE0_BACKEND:-json}
 [ "$PHASE0_BACKEND" = "github" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" setup
@@ -58,7 +58,7 @@ If the active backend is `"json"` (the default), skip this step.
 2. Glob the repo structure to understand the codebase layout
 3. Check for any existing tasks in this session to avoid duplicates:
    ```bash
-   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
    [ -n "$PLUGIN_SCRIPTS" ] && bun "$PLUGIN_SCRIPTS/task_store.ts" query --session {session}
    ```
    The output is a JSON array. If non-empty, print the existing task IDs and skip re-adding them.
@@ -368,7 +368,7 @@ Set `"hitl": true` (and include the `## Human steps` section in `description`) f
 Append them to `state/todos.json` via task_store.ts (idempotent by id — safe to re-run):
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks-{session}.json
 ```
 
@@ -472,7 +472,7 @@ jq --arg src "$PARENT_REF" \
 **Step 6d — Append tasks to the store:**
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks-{session}-linked.json
 ```
 

--- a/plugins/shipwright/commands/refresh-plan.md
+++ b/plugins/shipwright/commands/refresh-plan.md
@@ -21,7 +21,7 @@ Follow all steps in order.
 5. Query task_store for live statuses:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 bun "$PLUGIN_SCRIPTS/task_store.ts" query --session $ARGUMENTS
 ```
 

--- a/plugins/shipwright/commands/research-docs.md
+++ b/plugins/shipwright/commands/research-docs.md
@@ -93,7 +93,7 @@ For any module that has no corresponding doc (identified by scanning for modules
 Do NOT generate the doc automatically. Instead, write a follow-on task via `task_store.ts append`:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 # Write task JSON to temp file, then:
 bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/missing-docs-tasks.json
 ```

--- a/plugins/shipwright/commands/review-patch.md
+++ b/plugins/shipwright/commands/review-patch.md
@@ -30,7 +30,7 @@ Store `START_TIME` — it is used in every subsequent iteration to check elapsed
 Resolve the plugin scripts directory from the cache:
 
 ```bash
-CHECK_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "check-patch.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+CHECK_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "check-patch.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 ```
 
 Run both prechecks to determine if there is anything to do:

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -104,7 +104,7 @@ processed or skipped, continue to Step 3b.
 If `review_external_prs` is true, resolve the configured repos and fetch open PRs for each:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 REPOS=$(bun "$PLUGIN_SCRIPTS/task_store.ts" repos)
 ```
 
@@ -636,7 +636,7 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
 1. Parse the argument: extract `org`, `repo`, and `pr` number. For bare numbers,
    infer `org/repo` via:
    ```bash
-   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+   PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
    bun "$PLUGIN_SCRIPTS/task_store.ts" repos | head -1
    ```
    Fall back to the current workspace repo if the command fails.

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -135,7 +135,7 @@ If `--queue` was passed, run this workflow instead of Steps 6a-6e.
 ### 6q.1 Locate task_store.ts
 
 ```bash
-TASK_STORE_DIR=$(find ~/.claude/plugins/cache -maxdepth 6 -name "task_store.ts" -path "*/shipwright/*" | sort -V | tail -1 | xargs dirname 2>/dev/null)
+TASK_STORE_DIR=$(find ~/.claude/plugins/cache -maxdepth 6 -name "task_store.ts" -path "*/shipwright/*" | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 ```
 
 If `TASK_STORE_DIR` is empty, print:

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -72,7 +72,7 @@ If none of the above resolve, the JSON backend is used by default.
 Resolve once at the start of any task store operation and reuse within the same step:
 
 ```bash
-PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null)
+PLUGIN_SCRIPTS=$(find ~/.claude/plugins/cache -maxdepth 5 -name "task_store.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2- | xargs dirname 2>/dev/null)
 ```
 
 Then invoke as:


### PR DESCRIPTION
## Summary

- `sort -V` on full paths sorted by publisher prefix (`vitals-os` > `shipwright` alphabetically), causing an older plugin version (4.26.8) to win over a newer one (4.28.0) when multiple marketplace publishers are installed
- Fix: pipe through `awk -F/ '{print $(NF-2), $0}'` to prepend the version segment before sorting, so the highest version always wins regardless of publisher
- Applied to all 22 occurrences across 10 command/skill files (`task_store.ts` × 21, `check-patch.ts` × 1)

## Test plan

- [ ] On an agent with both `vitals-os/shipwright` and `shipwright/shipwright` installed, `PLUGIN_SCRIPTS` resolves to the highest version from either publisher
- [ ] `task_store.ts append` with `acceptanceCriteria` stores a proper array (not a stringified array)
- [ ] All existing command flows (dev-task, review, deploy, patch, plan-session) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)