### PR TITLE
feat: add PVC name template support to K8s provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+#### `AgentProvisioner.reconcile()` interface change
+
+- **`reconcile(agentIds: string[])` → `reconcile(agents: Array<{ id: string; slug?: string }>)`**: The `AgentProvisioner` interface's `reconcile()` method now accepts structured agent objects instead of raw ID strings. This is a **compile-time breaking change** for any code that implements or calls `AgentProvisioner` directly.
+
+  **Why**: The new `slug` field enables PVC name templates to use a human-readable agent slug instead of the raw agent ID, supporting custom PVC naming conventions (e.g. per-client storage naming).
+
+  **Migration**: callers passing a `string[]` must change to `agents.map(id => ({ id }))`. The `slug` field is optional — existing callers that do not need custom PVC naming can omit it.
+
+  ```ts
+  // Before
+  await provisioner.reconcile(["agent-id-1", "agent-id-2"]);
+
+  // After
+  await provisioner.reconcile([{ id: "agent-id-1" }, { id: "agent-id-2" }]);
+
+  // With optional slug for custom PVC naming
+  await provisioner.reconcile([{ id: "agent-id-1", slug: "my-agent" }]);
+  ```
+
 ## [4.28.0] - 2026-06-17
 
 ### Plugin — What's New

--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -273,7 +273,7 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
     const provisioner = new KubernetesAgentProvisioner(k8s, tokens, CONFIG);
 
     // Agent exists in DB, but no k8s Deployment provisioned yet.
-    const result = await provisioner.reconcile([agentId]);
+    const result = await provisioner.reconcile([{ id: agentId }]);
 
     expect(result.orphans).toEqual([]);
     expect(result.recreated).toEqual([agentId]);
@@ -313,9 +313,68 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
     await provisioner.provision(agentId);
 
     // Now reconcile — should be a clean no-op.
-    const result = await provisioner.reconcile([agentId]);
+    const result = await provisioner.reconcile([{ id: agentId }]);
     expect(result.recreated).toEqual([]);
     expect(result.orphans).toEqual([]);
+  });
+
+  // ─── PVC name template ───────────────────────────────────────────────────────
+
+  it("provision() uses slug for PVC name when pvcName template is configured", async () => {
+    const agentId = await createAgent("OkWOW Agent");
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, {
+      ...CONFIG,
+      pvcName: (name) => `vitals-os-agent-${name}-home`,
+    });
+
+    await provisioner.provision(agentId, { slug: "okwow" });
+
+    // PVC must use the slug, not the sanitized agentId.
+    await expect(
+      k8s.getPvc(NAMESPACE, "vitals-os-agent-okwow-home"),
+    ).resolves.toBeDefined();
+    // Default-named PVC must NOT exist.
+    const resourceName = sanitizeAgentName(agentId);
+    await expect(
+      k8s.getPvc(NAMESPACE, `vitals-os-agent-${resourceName}-home`),
+    ).rejects.toThrow();
+  });
+
+  it("provision() falls back to resourceName when slug is absent and pvcName is configured", async () => {
+    const agentId = await createAgent("FallbackAgent");
+    const k8s = emptyClient();
+    const resourceName = sanitizeAgentName(agentId);
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, {
+      ...CONFIG,
+      pvcName: (name) => `vitals-os-agent-${name}-home`,
+    });
+
+    // Call provision() with no opts — slug is absent.
+    await provisioner.provision(agentId);
+
+    // PVC must use the sanitized resourceName (not a slug).
+    await expect(
+      k8s.getPvc(NAMESPACE, `vitals-os-agent-${resourceName}-home`),
+    ).resolves.toBeDefined();
+  });
+
+  it("reconcile() uses slug for PVC name when template is configured", async () => {
+    const agentId = await createAgent("ReconcileSlugAgent");
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, {
+      ...CONFIG,
+      pvcName: (name) => `vitals-os-agent-${name}-home`,
+    });
+
+    // Agent exists in DB, no k8s Deployment — reconcile should provision it.
+    const result = await provisioner.reconcile([{ id: agentId, slug: "okwow" }]);
+
+    expect(result.recreated).toEqual([agentId]);
+    // PVC must use the slug passed through reconcile.
+    await expect(
+      k8s.getPvc(NAMESPACE, "vitals-os-agent-okwow-home"),
+    ).resolves.toBeDefined();
   });
 
   // ─── deprovision ──────────────────────────────────────────────────────────────
@@ -367,7 +426,10 @@ describe("NoopAgentProvisioner", () => {
 
   it("reconcile() returns empty arrays (no-op)", async () => {
     const provisioner = new NoopAgentProvisioner();
-    const result = await provisioner.reconcile(["agent_42", "agent_99"]);
+    const result = await provisioner.reconcile([
+      { id: "agent_42" },
+      { id: "agent_99" },
+    ]);
     expect(result).toEqual({ recreated: [], orphans: [], failed: [] });
   });
 

--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -359,6 +359,28 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
     ).resolves.toBeDefined();
   });
 
+  it("provision() sanitizes an unsafe slug before passing to pvcName template", async () => {
+    const agentId = await createAgent("Uppercase Spaces Agent");
+    const k8s = emptyClient();
+    const provisioner = new KubernetesAgentProvisioner(k8s, tokens, {
+      ...CONFIG,
+      pvcName: (name) => `vitals-os-agent-${name}-home`,
+    });
+
+    // slug contains uppercase and spaces — must be RFC1123 sanitized.
+    await provisioner.provision(agentId, { slug: "My Agent" });
+
+    // sanitizeAgentName("My Agent") → "my-agent-<hash>" (lossy path → hash suffix)
+    const sanitized = sanitizeAgentName("My Agent");
+    await expect(
+      k8s.getPvc(NAMESPACE, `vitals-os-agent-${sanitized}-home`),
+    ).resolves.toBeDefined();
+    // Raw unsanitized PVC name must NOT exist.
+    await expect(
+      k8s.getPvc(NAMESPACE, "vitals-os-agent-My Agent-home"),
+    ).rejects.toThrow();
+  });
+
   it("reconcile() uses slug for PVC name when template is configured", async () => {
     const agentId = await createAgent("ReconcileSlugAgent");
     const k8s = emptyClient();

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -71,7 +71,7 @@ export interface ReconcileResult {
 
 export interface AgentProvisioner {
   /** Mint a token and create the agent's Secret + Deployment. Idempotent. */
-  provision(agentId: string): Promise<ProvisionResult>;
+  provision(agentId: string, opts?: { slug?: string }): Promise<ProvisionResult>;
   /** Delete the agent's Deployment + Secret. Tolerates already-absent. */
   deprovision(agentId: string): Promise<void>;
   /**
@@ -79,7 +79,7 @@ export interface AgentProvisioner {
    * Re-provisions agents whose Deployments are missing; surfaces orphaned
    * Deployments that have no corresponding agent.
    */
-  reconcile(agentIds: string[]): Promise<ReconcileResult>;
+  reconcile(agents: Array<{ id: string; slug?: string }>): Promise<ReconcileResult>;
 }
 
 // ─── Configuration ──────────────────────────────────────────────────────────
@@ -152,16 +152,17 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       : `${resourceName}-token`;
   }
 
-  private pvcNameFor(resourceName: string): string {
-    return this.config.pvcName
-      ? this.config.pvcName(resourceName)
-      : `${resourceName}-home`;
+  private pvcNameFor(resourceName: string, slug?: string): string {
+    if (this.config.pvcName) {
+      return this.config.pvcName(slug ?? resourceName);
+    }
+    return `${resourceName}-home`;
   }
 
-  async provision(agentId: string): Promise<ProvisionResult> {
+  async provision(agentId: string, opts?: { slug?: string }): Promise<ProvisionResult> {
     const resourceName = this.resourceName(agentId);
     const secretName = this.secretNameFor(resourceName);
-    const pvcName = this.pvcNameFor(resourceName);
+    const pvcName = this.pvcNameFor(resourceName, opts?.slug);
     const result: ProvisionResult = {
       resourceName,
       secretName,
@@ -218,7 +219,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     try {
       await this.k8s.createDeployment(
         this.config.namespace,
-        this.deploymentSpec(agentId, resourceName, secretName),
+        this.deploymentSpec(agentId, resourceName, secretName, opts?.slug),
       );
     } catch (err) {
       if (isConflict(err)) {
@@ -250,7 +251,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     await this.deleteSecretBestEffort(secretName);
   }
 
-  async reconcile(agentIds: string[]): Promise<ReconcileResult> {
+  async reconcile(agents: Array<{ id: string; slug?: string }>): Promise<ReconcileResult> {
     const labelSelector =
       "app.kubernetes.io/name=shipwright-agent,app.kubernetes.io/managed-by=shipwright-admin";
 
@@ -261,11 +262,11 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     );
     const k8sNameSet = new Set(k8sNames);
 
-    // Build a map from sanitized resource name → original agentId, and track
+    // Build a map from sanitized resource name → original agent entry, and track
     // the full set of expected k8s names.
-    const expectedNames = new Map<string, string>(); // resourceName → agentId
-    for (const agentId of agentIds) {
-      expectedNames.set(this.resourceName(agentId), agentId);
+    const expectedNames = new Map<string, { id: string; slug?: string }>(); // resourceName → agent
+    for (const agent of agents) {
+      expectedNames.set(this.resourceName(agent.id), agent);
     }
 
     const recreated: string[] = [];
@@ -275,15 +276,15 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     // Recreate Deployments that should exist but are missing in k8s.
     // Each provision() call is wrapped in try/catch so a single transient K8s
     // error does not abort the loop — the remaining agents are always checked.
-    for (const [resourceName, agentId] of expectedNames) {
+    for (const [resourceName, agent] of expectedNames) {
       if (!k8sNameSet.has(resourceName)) {
         // provision() is idempotent — it handles ConflictError on Secret/Deployment.
         try {
-          await this.provision(agentId);
-          recreated.push(agentId);
+          await this.provision(agent.id, { slug: agent.slug });
+          recreated.push(agent.id);
         } catch (err) {
           failed.push({
-            agentId,
+            agentId: agent.id,
             error: err instanceof Error ? err.message : String(err),
           });
         }
@@ -334,6 +335,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     agentId: string,
     resourceName: string,
     secretName: string,
+    slug?: string,
   ): DeploymentSpec {
     const manifest = buildAgentDeploymentManifest({
       agentId,
@@ -341,7 +343,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       image: this.config.image,
       imageTag: this.config.imageTag,
       apiUrl: this.config.apiUrl,
-      pvcName: this.pvcNameFor(resourceName),
+      pvcName: this.pvcNameFor(resourceName, slug),
       secretName,
       tokenSecretKey: this.tokenKey,
       adminDeploymentName: this.config.adminDeploymentName,
@@ -387,7 +389,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
  * admin service construct and run unchanged without a cluster.
  */
 export class NoopAgentProvisioner implements AgentProvisioner {
-  async provision(agentId: string): Promise<ProvisionResult> {
+  async provision(agentId: string, _opts?: { slug?: string }): Promise<ProvisionResult> {
     const resourceName = sanitizeAgentName(agentId);
     return {
       resourceName,
@@ -400,7 +402,7 @@ export class NoopAgentProvisioner implements AgentProvisioner {
     // intentionally a no-op
   }
 
-  async reconcile(_agentIds: string[]): Promise<ReconcileResult> {
+  async reconcile(_agents: Array<{ id: string; slug?: string }>): Promise<ReconcileResult> {
     return { recreated: [], orphans: [], failed: [] };
   }
 }

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -154,7 +154,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
 
   private pvcNameFor(resourceName: string, slug?: string): string {
     if (this.config.pvcName) {
-      return this.config.pvcName(slug ?? resourceName);
+      return this.config.pvcName(slug ? sanitizeAgentName(slug) : resourceName);
     }
     return `${resourceName}-home`;
   }

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -34,7 +34,7 @@ class RecordingProvisioner implements AgentProvisioner {
 
   constructor(private readonly onProvision?: (agentId: string) => void) {}
 
-  async provision(agentId: string): Promise<ProvisionResult> {
+  async provision(agentId: string, _opts?: { slug?: string }): Promise<ProvisionResult> {
     this.onProvision?.(agentId);
     this.provisioned.push(agentId);
     return {
@@ -49,7 +49,7 @@ class RecordingProvisioner implements AgentProvisioner {
   }
 
   async reconcile(
-    _agentIds: string[],
+    _agents: Array<{ id: string; slug?: string }>,
   ): Promise<{
     recreated: string[];
     orphans: string[];

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -563,7 +563,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     // workload — then surface the failure as a 5xx via onError. The Noop
     // provisioner never throws, preserving today's create behavior exactly.
     try {
-      await provisioner.provision(agent.id);
+      await provisioner.provision(agent.id, { slug: agent.name });
     } catch (err) {
       await prisma.agent
         .delete({ where: { id: agent.id } })
@@ -595,8 +595,8 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
         "Only admin bearers and session users can reconcile agents",
       );
     }
-    const agents = await prisma.agent.findMany({ select: { id: true } });
-    const result = await provisioner.reconcile(agents.map((a) => a.id));
+    const agents = await prisma.agent.findMany({ select: { id: true, name: true } });
+    const result = await provisioner.reconcile(agents.map((a) => ({ id: a.id, slug: a.name })));
     return c.json(result, 200);
   });
 

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -115,6 +115,7 @@ function buildProvisioner(
   const replicas = replicasRaw ? Number(replicasRaw) : undefined;
   const pvcStorageGiRaw = env.SHIPWRIGHT_AGENT_PVC_STORAGE_GI;
   const pvcStorageGi = pvcStorageGiRaw ? Number(pvcStorageGiRaw) : undefined;
+  const pvcNameTemplate = env.SHIPWRIGHT_AGENT_PVC_NAME_TEMPLATE;
 
   // Agent-voice (STT/TTS) env flowed into provisioned agent pods. The chart's
   // voice Secret + Whisper Service URL land in the admin's env when
@@ -146,6 +147,9 @@ function buildProvisioner(
       ? { pvcStorageGi }
       : {}),
     ...(Object.keys(voice).length > 0 ? { voice } : {}),
+    ...(pvcNameTemplate
+      ? { pvcName: (name: string) => pvcNameTemplate.replace("{name}", name) }
+      : {}),
   });
 }
 

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.5.24] - 2026-06-20
+
+### Added
+
+- `agent.provisioning.pvcNameTemplate`: optional PVC name template for provisioned agent home directories; `{name}` is replaced with the agent slug at provision time
+
 ## [1.5.23] - 2026-06-20
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.5.23
+version: 1.5.24
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.5.23 triggered by release tag agent-v0.57.0"
+    - kind: added
+      description: "agent.provisioning.pvcNameTemplate: optional PVC name template for provisioned agent home directories"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -195,6 +195,10 @@ spec:
             - name: SHIPWRIGHT_ADMIN_DEPLOYMENT_UID
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.agent.provisioning.pvcNameTemplate }}
+            - name: SHIPWRIGHT_AGENT_PVC_NAME_TEMPLATE
+              value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.agent.voice.enabled }}
             # ── Agent-voice env contract (CV-1.1) ─────────────────────────────

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -258,6 +258,7 @@
                 },
                 "apiUrl": { "type": "string" },
                 "adminDeploymentUid": { "type": "string" },
+                "pvcNameTemplate": { "type": "string" },
                 "pvc": {
                   "type": "object",
                   "additionalProperties": false,

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -287,6 +287,10 @@ agent:
     # supplied explicitly. Leave empty to OMIT the env var (acceptable until
     # ownerRef propagation lands as a follow-up).
     adminDeploymentUid: ""
+    # -- PVC name template for provisioned agent home directories.
+    # When set, replaces {name} with the agent slug (e.g. `vitals-os-agent-{name}-home`).
+    # When empty (default), PVC is named `{sanitizedAgentId}-home`.
+    pvcNameTemplate: ""
     # -- Provisioned workspace PVCs: created per-agent when the provisioner spins
     # up a new agent pod. These settings are surfaced for the agent manifest
     # builder's future use. NOTE: buildProvisioner does not read these as env

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -154,7 +154,7 @@ The constant `BAKED_MARKETPLACES_ROOT` and function `discoverBakedMarketplaces()
 | `admin/src/admin-ui-pages.ts` | Page rendering functions (`renderLoginPage`, `renderAgentsPage`, `renderAgentDetailPage`, `renderProvision*`). |
 | `admin/src/admin-ui-styles.ts` | Shared CSS helpers (`baseStyles`, `escapeHtml`, `renderAdminToolbar`). |
 | `admin/src/google-auth-client.ts` | `GoogleAuthClient` interface + `HttpGoogleAuthClient` — typed Google OAuth2 token exchange and user profile lookup; injected into the admin UI for testability. |
-| `admin/src/slack-provisioning-client.ts` | `SlackProvisioningClient` interface + `HttpSlackProvisioningClient` — drives the one-time Slack app creation and OAuth flow. `createAppManifest()` returns `appId`, `oauthRedirectUrl`, `clientId`, `clientSecret`, and `signingSecret` from the `apps.manifest.create` response. `exchangeOAuthCode()` exchanges the Slack OAuth callback code for a bot token via `oauth.v2.access`. |
+| `admin/src/slack-provisioning-client.ts` | `SlackProvisioningClient` interface + `HttpSlackProvisioningClient` — drives the one-time Slack app creation and OAuth flow. `createAppManifest()` returns `appId`, `oauthRedirectUrl`, `clientId`, `clientSecret`, and `signingSecret` from the `apps.manifest.create` response. `exchangeOAuthCode()` exchanges the Slack OAuth callback code for a bot token via `oauth.v2.access`. Also exports `buildAgentManifest(appName, redirectUri?)` — constructs per-agent Slack app manifests via the Manifest API shape — and `AGENT_BOT_SCOPES` — the canonical bot scope list used by both provisioning and sync-manifest OAuth flows. |
 | `admin/src/agent-envs.ts` | Env service — encrypted key/value store + config bundle assembly. |
 | `admin/src/agent-cron-jobs.ts` | Cron service + system-cron reconciliation. |
 | `admin/src/agent-tools.ts` / `agent-tokens.ts` / `agent-plugins.ts` | Per-resource service classes. |
@@ -182,7 +182,6 @@ The constant `BAKED_MARKETPLACES_ROOT` and function `discoverBakedMarketplaces()
 | `agent/src/cron-handler.ts` | Cron runtime: `handleCronRequest()` — runs a cron prompt through Claude and posts the result to Slack. Supports `preCheck` scripts, `silent` suppression, channel vs. DM delivery, and `onPost`/`onSession` callbacks. |
 | `agent/src/slack.ts` | Slack event handler: `createSlackApp()` — Bolt-based Socket Mode app handling DMs, `app_mention`, `reaction_added`, file attachments, and voice transcription. |
 | `agent/src/health.ts` | Health server: `startHealthServer(port, summarize?, cronDeps?, clock?, graceMs?)` — K8s liveness probe server. `GET /health` returns `{ ok: true, slack: "connected"\|"disconnected" }` (200) or `{ ok: false, slack: "disconnected" }` (500) when the Slack socket has been continuously down longer than `graceMs` (default 90 s). `GET /stats` returns an `AnalyticsSummary` when a `summarize` function is injected (404 otherwise). `POST /cron` dispatches cron prompts via `cron-handler.ts`. Exports `slackState`, `markSlackConnected()`, and `markSlackDisconnected(clock)` for Slack socket lifecycle wiring. |
-| `agent/src/slack-manifest.ts` | Typed Slack app manifest builder (`buildManifest()`) — constructs per-agent Slack app manifests via the Manifest API shape. |
 | `admin/prisma/schema.prisma` | The six-model schema (`DATABASE_URL_SHIPWRIGHT_ADMIN`). |
 
 ## Testing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,7 @@ Controls how the admin service provisions the Kubernetes workload backing each a
 | `SHIPWRIGHT_ADMIN_DEPLOYMENT_UID` | `string` | — | UID of the admin Deployment, paired with `SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME` for the `ownerReference`. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_REPLICAS` | `number` | `1` | Replica count for the provisioned agent Deployment. Only read when provisioning is enabled. |
 | `SHIPWRIGHT_AGENT_PVC_STORAGE_GI` | `number` | `40` | Storage size in Gi for the per-agent persistent home directory (PVC). Only read when provisioning is enabled. Must be large enough to hold mise caches and workspace files across pod restarts. |
+| `SHIPWRIGHT_AGENT_PVC_NAME_TEMPLATE` | `string` | — | PVC name template for provisioned agent home directories. When set, `{name}` is replaced with the agent slug to derive the PVC name (e.g. `vitals-os-agent-{name}-home` → `vitals-os-agent-okwow-home`). When unset, PVC is named `{sanitizedAgentId}-home` (default). Only read when provisioning is enabled. |
 
 ### Workspace and tooling
 


### PR DESCRIPTION
## Summary
- Adds `SHIPWRIGHT_AGENT_PVC_NAME_TEMPLATE` env var to the admin provisioner so PVC names can be derived from an agent slug rather than the sanitized agent ID
- Wires the slug (agent name) through `provision()` and `reconcile()` so pre-existing PVCs (e.g. `vitals-os-agent-okwow-home`) are correctly referenced when migrating static agents to dynamic provisioning
- Adds Helm chart value `agent.provisioning.pvcNameTemplate` that flows the template to the admin Deployment

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Default behaviour unchanged: no template → PVC named `{sanitizedAgentId}-home` | ✅ MET |
| 2 | Template `vitals-os-agent-{name}-home` + slug `okwow` → `vitals-os-agent-okwow-home` | ✅ MET |
| 3 | Reconcile respects the template when re-provisioning missing Deployments | ✅ MET |
| 4 | Tests cover both default and templated PVC name paths | ✅ MET |

## Breaking Changes

`AgentProvisioner.reconcile()` parameter type changes from `string[]` to `Array<{ id: string; slug?: string }>`. This is a compile-time breaking change for external implementers. Runtime callers passing `{ id }` objects work without modification; callers using bare string arrays must update to pass `{ id: agentId }` objects.

## Test Plan
- 4 new integration tests in `agent-provisioner.integration.test.ts`: slug-based PVC name, fallback-to-resourceName, sanitized unsafe slug, reconcile with slug
- Updated existing reconcile tests to use new `Array<{id, slug?}>` signature
- All 59 smoke tests pass; 2985 unit tests pass; 2 pre-existing Playwright failures (no `@playwright/test` on Pi) unrelated
- [x] `bunx biome lint .` — no issues
- [x] `bun run --filter='*' typecheck` — all pass

Generated with [Claude Code](https://claude.com/claude-code)