### PR TITLE
fix(plugin): validate branch field and document required task fields

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.28.2",
+  "version": "4.28.3",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.28.3",
+  "version": "4.28.4",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.28.2
+# Shipwright v4.28.3
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -1,4 +1,4 @@
-# Shipwright v4.28.3
+# Shipwright v4.28.4
 
 A structured dev pipeline plugin for Claude Code. Plan sessions, execute tasks, run autonomous dev loops, perform multi-agent code reviews, and conduct integrated project research — for any software project.
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -44,6 +44,16 @@ The command returns `pending` shipwright tasks whose dependencies are all satisf
 
 If the output is an empty JSON array (`[]`), respond `[silent]` and stop.
 
+**Validate required fields.** If the selected task has no `branch` field (null, undefined, or empty string), do not proceed. Post:
+
+```
+⚠ Task {id} has no branch field set. Set it with:
+  bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set branch=feat/{id-lowercase}
+Then re-run /shipwright:dev-task.
+```
+
+Respond `[silent]` and stop. A missing branch cannot be recovered from at runtime — worktree creation will fail silently if attempted.
+
 Print:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -52,7 +52,13 @@ If the output is an empty JSON array (`[]`), respond `[silent]` and stop.
 Then re-run /shipwright:dev-task.
 ```
 
-Respond `[silent]` and stop. A missing branch cannot be recovered from at runtime — worktree creation will fail silently if attempted.
+Before stopping, mark the task blocked so the cron does not keep re-queuing it:
+
+```bash
+bun "$PLUGIN_SCRIPTS/task_store.ts" update --id {id} --set status=blocked
+```
+
+Post the message above and stop. A missing branch cannot be recovered from at runtime — worktree creation will fail silently if attempted.
 
 Print:
 ```

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -154,6 +154,19 @@ bun "$PLUGIN_SCRIPTS/task_store.ts" append --file /tmp/new-tasks.json
 # Returns: { "inserted": N, "updated": N }
 ```
 
+**Required fields for every task** — omitting these causes silent failures downstream:
+
+| Field | Why required |
+|---|---|
+| `id` | Stable key; used by dependency resolution and all `update` calls |
+| `title` | Required by schema |
+| `status` | Must be `"pending"` on creation |
+| `repo` | Routes `dev-task` to the correct worktree |
+| `branch` | `dev-task` creates the worktree from this; absent → task is skipped with an error |
+| `assignee` | Without it, any agent can pick up the task; with it, only that agent will |
+
+Convention: `branch` = `feat/{id-lowercase}` (e.g. `feat/she-pvc-name-template`).
+
 Backend note: the GitHub adapter is insert-only — existing tasks (matched by `id`) are
 never updated via `append`. Use `update` for targeted field changes on existing
 GitHub-backed tasks. The JSON adapter upserts (idempotent by `id`).


### PR DESCRIPTION
## Summary

- **`dev-task.md`**: After picking a task in Step 1, validate that `branch` is set. If missing, post a clear error with the fix command and stop — prevents the silent worktree failure that caused tasks to stay `pending` indefinitely while the cron kept silently completing.
- **`task-store/SKILL.md`**: Document the required fields for `append` in a table, with `branch` called out explicitly (and the convention for generating its value).

## Background

A task created without a `branch` field caused `dev-task` to attempt `git worktree add ... -b ""`, failing silently. The cron's preCheck kept finding the task (correct), but the session always exited `[silent]` without progressing the task. This adds an early-exit guard with a clear, actionable error message.

## Test plan
- [ ] Create a task without `branch` and run `/shipwright:dev-task` — should post the error message and stop
- [ ] Create a task with `branch` set — should proceed normally through worktree creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)