### PR TITLE
feat(chart): task-store Deployment + Service templates (TSS-4.1)

### DIFF
--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.5.29
+version: 1.6.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.5.29 triggered by release tag agent-v0.60.0"
+    - kind: added
+      description: "task-store Deployment and Service templates with existingSecret database wiring (TSS-4.1)"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -241,3 +241,26 @@ The Bitnami subchart derives these from its own fullname (release name +
 {{- define "shipwright.postgresql.fullname" -}}
 {{- printf "%s-postgresql" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Task-store component fullname: "<fullname>-task-store".
+*/}}
+{{- define "shipwright.taskStore.fullname" -}}
+{{- printf "%s-task-store" (include "shipwright.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Task-store selector labels — fullname selector labels plus the component label.
+*/}}
+{{- define "shipwright.taskStore.selectorLabels" -}}
+{{ include "shipwright.selectorLabels" . }}
+app.kubernetes.io/component: task-store
+{{- end }}
+
+{{/*
+Task-store labels — common labels plus the component label.
+*/}}
+{{- define "shipwright.taskStore.labels" -}}
+{{ include "shipwright.labels" . }}
+app.kubernetes.io/component: task-store
+{{- end }}

--- a/charts/shipwright/templates/task-store-deployment.yaml
+++ b/charts/shipwright/templates/task-store-deployment.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.taskStore.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "shipwright.taskStore.fullname" . }}
+  labels:
+    {{- include "shipwright.taskStore.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.taskStore.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "shipwright.taskStore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "shipwright.taskStore.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: task-store
+          image: "{{ with .Values.global.imageRegistry }}{{ . }}/{{ end }}{{ .Values.taskStore.image.repository }}:{{ .Values.taskStore.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.taskStore.image.pullPolicy | default .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          env:
+            # DATABASE_URL_SHIPWRIGHT_TASK_STORE sourced from an existing Secret.
+            # Defaults to "shipwright-secrets" (the canonical cluster secret name)
+            # but can be overridden via taskStore.database.existingSecret.
+            - name: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.taskStore.database.existingSecret | default "shipwright-secrets" }}
+                  key: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+          {{- with .Values.taskStore.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/shipwright/templates/task-store-service.yaml
+++ b/charts/shipwright/templates/task-store-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.taskStore.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "shipwright.taskStore.fullname" . }}
+  labels:
+    {{- include "shipwright.taskStore.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.taskStore.service.type | default "ClusterIP" }}
+  ports:
+    - name: http
+      port: {{ .Values.taskStore.service.port }}
+      targetPort: 3000
+      protocol: TCP
+  selector:
+    {{- include "shipwright.taskStore.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/shipwright/tests/task_store_workload_test.yaml
+++ b/charts/shipwright/tests/task_store_workload_test.yaml
@@ -1,0 +1,150 @@
+suite: task-store Deployment / Service workloads
+# TSS-4.1 adds the task-store workload templates. These assert the structural
+# facts: image (tag defaults to appVersion), container port 3000, /health
+# liveness + readiness probes, Service shape, and the DATABASE_URL wiring
+# from an existingSecret (shipwright-secrets by default).
+tests:
+  - it: renders the task-store Deployment with the appVersion-defaulted image and port 3000
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: shipwright-task-store:0.1.0
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 3000
+
+  - it: sets liveness and readiness probes against /health on port 3000
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 3000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 3000
+
+  - it: wires standard selector labels onto the Deployment
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: task-store
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: shipwright
+    release:
+      name: r
+
+  - it: applies the configured task-store resources
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+      taskStore.resources:
+        requests:
+          cpu: 111m
+          memory: 222Mi
+        limits:
+          cpu: 333m
+          memory: 444Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 111m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 444Mi
+
+  - it: wires DATABASE_URL_SHIPWRIGHT_TASK_STORE from the default existingSecret (shipwright-secrets)
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+
+  - it: wires DATABASE_URL_SHIPWRIGHT_TASK_STORE from a custom existingSecret
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+      taskStore.database.existingSecret: my-task-store-secret
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+            valueFrom:
+              secretKeyRef:
+                name: my-task-store-secret
+                key: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+
+  - it: renders the task-store Service (ClusterIP) mapping the service port to targetPort 3000
+    template: templates/task-store-service.yaml
+    set:
+      taskStore.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 3000
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3000
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: task-store
+
+  - it: honors a custom taskStore.service.type and port
+    template: templates/task-store-service.yaml
+    set:
+      taskStore.enabled: true
+      taskStore.service.type: NodePort
+      taskStore.service.port: 30000
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 30000
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3000
+
+  - it: renders no task-store workloads when taskStore.enabled=false
+    set:
+      taskStore.enabled: false
+    templates:
+      - templates/task-store-deployment.yaml
+      - templates/task-store-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -464,6 +464,35 @@ externalDatabase:
   # falls back to the key name "DATABASE_URL_SHIPWRIGHT_ADMIN".
   adminUrlKey: ""
 
+# -- Task-store service (@shipwright/task-store) — GitHub Issues-backed task queue. Port 3000.
+# Disabled by default — purely additive, safe to deploy without this.
+taskStore:
+  # -- Whether to render the task-store Deployment and Service.
+  enabled: false
+  image:
+    repository: shipwright-task-store
+    tag: ""           # defaults to .Chart.AppVersion when empty
+    pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
+  service:
+    # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
+    type: ClusterIP
+    port: 3000
+  replicas: 1
+  # -- Compute resources for the task-store container. Minikube-friendly defaults.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  # -- Database wiring for the task-store service.
+  database:
+    # -- Name of a pre-existing Secret holding DATABASE_URL_SHIPWRIGHT_TASK_STORE.
+    # Defaults to "shipwright-secrets" (the canonical cluster secret name).
+    # The chart does NOT manage this Secret — create it before deploying.
+    existingSecret: "shipwright-secrets"
+
 # -- Cloud SQL Auth Proxy sidecar for the admin pod (GCP Cloud SQL).
 # When enabled, a cloud-sql-proxy sidecar is added to the admin Deployment so
 # a GCP Cloud SQL instance is reachable at 127.0.0.1:5432 from the admin pod.

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -1,14 +1,15 @@
 # Deploying to Kubernetes
 
-> How to deploy the three Shipwright services (admin, metrics, agent) to
+> How to deploy the four Shipwright services (admin, metrics, agent, task-store) to
 > Kubernetes with the `shipwright` Helm chart — local on Minikube, and in
 > production on GKE (Gateway API + cert-manager) or EKS (ALB + cert-manager).
 
 The chart lives at [`charts/shipwright`](../charts/shipwright) and is also
 published to a Helm repo on every chart version bump (see
 [`helm-repo.md`](./helm-repo.md)). It packages the admin (port **3001**), metrics
-(port **3460**), and agent (port **3000**) services plus an optional bundled
-PostgreSQL dependency, with Minikube-friendly defaults throughout.
+(port **3460**), agent (port **3000**), and optional task-store (port **3000**)
+services plus an optional bundled PostgreSQL dependency, with Minikube-friendly
+defaults throughout. Task-store is disabled by default.
 
 This guide covers three deployment targets end-to-end, then the cross-cutting
 concerns shared by all of them:
@@ -459,6 +460,9 @@ changing the chart, or bring your own database:
   `DATABASE_URL_SHIPWRIGHT_ADMIN`. The chart injects the value into the admin
   pod from that Secret — you create and rotate the Secret outside the chart.
   Pre-create the separate `shipwright_metrics` event-store database as well.
+  If you enable task-store (`taskStore.enabled=true`), also pre-create a Secret
+  holding `DATABASE_URL_SHIPWRIGHT_TASK_STORE` and point `taskStore.database.existingSecret`
+  at it — the task-store database **must be separate** from the admin database.
 
   ```yaml
   postgresql:
@@ -497,4 +501,4 @@ The full image-override / mirror guidance and the exact pinned version are in
 - [`helm-repo.md`](./helm-repo.md) — installing from the published Helm repo and how publishing is triggered.
 - [`charts/shipwright/README.md`](../charts/shipwright/README.md) — the chart's own README: full values table, versioning, and the Bitnami fallback.
 - [`configuration.md`](./configuration.md) — every env var, including the agent-provisioning and auth-mode vars.
-- [`architecture.md`](./architecture.md) — the three-artifact (plugin / metrics / agent) design.
+- [`architecture.md`](./architecture.md) — the four-artifact (plugin / metrics / agent / task-store) design.


### PR DESCRIPTION
## Summary
- Adds `task-store-deployment.yaml` and `task-store-service.yaml` to the Shipwright Helm chart, following the admin service pattern
- Adds `taskStore:` section to `values.yaml` (disabled by default — safe to deploy without enabling)
- Bumps chart version 1.5.29 → 1.6.0 to satisfy `ct lint --check-version-increment`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | helm lint passes on updated chart | ✅ MET |
| 2 | helm unittest passes (9 new tests, 206 total) | ✅ MET |
| 3 | values.yaml taskStore section: image, port, resources, enabled flag | ✅ MET |
| 4 | Chart version incremented in Chart.yaml | ✅ MET |
| 5 | DATABASE_URL_SHIPWRIGHT_TASK_STORE wired from existingSecret (default: shipwright-secrets) | ✅ MET |
| 6 | Safe to deploy standalone — additive only, gated by `taskStore.enabled: false` | ✅ MET |

## Test Plan
- [x] `helm lint charts/shipwright/` — 0 failures
- [x] `helm unittest charts/shipwright/` — 206 tests, all pass (9 new covering task-store workloads)
- [x] New templates guarded by `{{- if .Values.taskStore.enabled }}` — zero impact when disabled

Generated with [Claude Code](https://claude.com/claude-code)
