### PR TITLE
chore(chart): bump to 1.6.3 to fix duplicate release tag

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.3] - 2026-06-23
+
+### Fixed
+
+- bump chart version to 1.6.3 to resolve duplicate 1.6.2 release tag conflict
+
 ## [1.6.2] - 2026-06-23
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.2
+version: 1.6.3
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,9 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: fixed
-      description: "add serviceAccountName + taskStore.serviceAccount values to task-store Deployment for Workload Identity (TSS-4.2)"
-    - kind: changed
-      description: "auto-bump to chart v1.6.2 triggered by release tag metrics-v0.79.0"
+      description: "bump chart version to 1.6.3 to resolve duplicate 1.6.2 release tag conflict"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer


### PR DESCRIPTION
## Summary

- 1.6.2 was already released (triggered by `metrics-v0.79.0` auto-bump) before PR #589 merged with its own 1.6.2 bump
- `chart-releaser` failed with `tag already exists: shipwright-1.6.2`, leaving main red
- Bumps chart version to 1.6.3 and adds CHANGELOG entry

## Test plan

- [ ] CI passes (Chart Release workflow creates `shipwright-1.6.3` tag successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)