### PR TITLE
fix(provisioner): remove ownerReferences from provisioned agent resources

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -284,12 +284,6 @@ export function buildAgentDeploymentManifest(
                 periodSeconds: 10,
                 failureThreshold: 3,
               },
-              readinessProbe: {
-                httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
-                initialDelaySeconds: 10,
-                periodSeconds: 10,
-                failureThreshold: 3,
-              },
               securityContext: {
                 runAsNonRoot: true,
                 runAsUser: AGENT_RUN_AS,

--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -253,6 +253,7 @@ export function buildAgentDeploymentManifest(
             {
               name: AGENT_APP_NAME,
               image: `${opts.image}:${opts.imageTag}`,
+              ports: [{ containerPort: AGENT_HEALTH_PORT, protocol: "TCP" }],
               env: [
                 { name: "SHIPWRIGHT_AGENT_ID", value: opts.agentId },
                 { name: "SHIPWRIGHT_API_URL", value: opts.apiUrl },
@@ -273,8 +274,15 @@ export function buildAgentDeploymentManifest(
               ],
               livenessProbe: {
                 httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
+                initialDelaySeconds: 15,
+                periodSeconds: 30,
+                failureThreshold: 3,
+              },
+              readinessProbe: {
+                httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
                 initialDelaySeconds: 10,
-                periodSeconds: 15,
+                periodSeconds: 10,
+                failureThreshold: 3,
               },
               readinessProbe: {
                 httpGet: { path: "/health", port: AGENT_HEALTH_PORT },

--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -9,10 +9,6 @@
  * objects. The actual k8s API calls live in ./kubernetes-client.ts; this module
  * returns the same `KubernetesDeployment` / `KubernetesSecret` wire types so the
  * two stay structurally consistent.
- *
- * Garbage collection: each agent resource carries an `ownerReference` to the
- * admin Deployment. When the admin Deployment is deleted on uninstall,
- * Kubernetes cascade-deletes every owned agent Deployment + Secret.
  */
 
 import { createHash } from "node:crypto";
@@ -44,29 +40,6 @@ const INSTANCE_LABEL = "app.kubernetes.io/instance";
 const MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
 const AGENT_ID_LABEL = "shipwright.dev/agent-id";
 const AGENT_APP_NAME = "shipwright-agent";
-
-// ─── Owner reference (GC) ───────────────────────────────────────────────────
-
-interface OwnerReference {
-  apiVersion: string;
-  kind: string;
-  name: string;
-  uid: string;
-  controller: boolean;
-  blockOwnerDeletion: boolean;
-  [key: string]: unknown;
-}
-
-function adminOwnerReference(name: string, uid: string): OwnerReference {
-  return {
-    apiVersion: "apps/v1",
-    kind: "Deployment",
-    name,
-    uid,
-    controller: true,
-    blockOwnerDeletion: true,
-  };
-}
 
 // ─── Name sanitization ──────────────────────────────────────────────────────
 
@@ -124,8 +97,6 @@ export interface AgentPvcOpts {
   namespace: string;
   sizeGi: number;
   storageClassName?: string;
-  adminDeploymentName: string;
-  adminDeploymentUid: string;
 }
 
 export function buildAgentPvcManifest(opts: AgentPvcOpts): KubernetesPvc {
@@ -135,9 +106,6 @@ export function buildAgentPvcManifest(opts: AgentPvcOpts): KubernetesPvc {
     metadata: {
       name: opts.name,
       namespace: opts.namespace,
-      ownerReferences: [
-        adminOwnerReference(opts.adminDeploymentName, opts.adminDeploymentUid),
-      ],
     },
     spec: {
       accessModes: ["ReadWriteOnce"],
@@ -168,10 +136,6 @@ export interface AgentDeploymentOpts {
   secretName: string;
   /** Key within the Secret's data that holds the token. Defaults to "token". */
   tokenSecretKey?: string;
-  /** Admin Deployment name (ownerReference target for GC). */
-  adminDeploymentName: string;
-  /** Admin Deployment uid (ownerReference target for GC). */
-  adminDeploymentUid: string;
   /** Replica count. Defaults to 1. */
   replicas?: number;
   /**
@@ -260,9 +224,6 @@ export function buildAgentDeploymentManifest(
       name,
       namespace: opts.namespace,
       labels,
-      ownerReferences: [
-        adminOwnerReference(opts.adminDeploymentName, opts.adminDeploymentUid),
-      ],
     },
     spec: {
       replicas: opts.replicas ?? 1,
@@ -342,10 +303,6 @@ export interface AgentSecretOpts {
   token: string;
   /** Key under which the token is stored. Defaults to "token". */
   tokenKey?: string;
-  /** Admin Deployment name (ownerReference target for GC). */
-  adminDeploymentName: string;
-  /** Admin Deployment uid (ownerReference target for GC). */
-  adminDeploymentUid: string;
 }
 
 export function buildAgentSecretManifest(
@@ -359,9 +316,6 @@ export function buildAgentSecretManifest(
     metadata: {
       name: opts.name,
       namespace: opts.namespace,
-      ownerReferences: [
-        adminOwnerReference(opts.adminDeploymentName, opts.adminDeploymentUid),
-      ],
     },
     data: {
       [tokenKey]: Buffer.from(opts.token).toString("base64"),

--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -236,6 +236,7 @@ export function buildAgentDeploymentManifest(
         spec: {
           securityContext: {
             fsGroup: AGENT_RUN_AS,
+            fsGroupChangePolicy: "OnRootMismatch",
             runAsNonRoot: true,
             runAsUser: AGENT_RUN_AS,
           },

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -108,11 +108,37 @@ describe("buildAgentDeploymentManifest", () => {
     expect(mount?.name).toBe(vol?.name);
   });
 
-  it("defines a liveness probe on the health port 3459", () => {
+  it("sets strategy Recreate", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
-    const probe = d.spec.template.spec.containers[0].livenessProbe;
+    expect(d.spec.strategy).toEqual({ type: "Recreate" });
+  });
+
+  it("sets terminationGracePeriodSeconds to 120", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    expect(d.spec.template.spec.terminationGracePeriodSeconds).toBe(120);
+  });
+
+  it("declares a containerPort for the health port", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const ports = d.spec.template.spec.containers[0].ports ?? [];
+    expect(ports).toContainEqual({ containerPort: AGENT_HEALTH_PORT, protocol: "TCP" });
+  });
+
+  it("sets AGENT_HOME env var to the mount path", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const env = d.spec.template.spec.containers[0].env ?? [];
+    const agentHome = env.find((e) => e.name === "AGENT_HOME");
+    expect(agentHome?.value).toBe(AGENT_HOME_MOUNT_PATH);
+  });
+
+  it("defines liveness and readiness probes on the health port", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const c = d.spec.template.spec.containers[0];
     expect(AGENT_HEALTH_PORT).toBe(3459);
-    expect(probe?.httpGet?.port).toBe(3459);
+    expect(c.livenessProbe?.httpGet?.port).toBe(3459);
+    expect(c.livenessProbe?.failureThreshold).toBe(3);
+    expect(c.readinessProbe?.httpGet?.port).toBe(3459);
+    expect(c.readinessProbe?.failureThreshold).toBe(3);
   });
 
   it("applies a hardened security context (fsGroup, fsGroupChangePolicy, runAsNonRoot, runAsUser)", () => {

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -115,11 +115,12 @@ describe("buildAgentDeploymentManifest", () => {
     expect(probe?.httpGet?.port).toBe(3459);
   });
 
-  it("applies a hardened security context (fsGroup, runAsNonRoot, runAsUser)", () => {
+  it("applies a hardened security context (fsGroup, fsGroupChangePolicy, runAsNonRoot, runAsUser)", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
     const podSpec = d.spec.template.spec;
     expect(podSpec.securityContext).toMatchObject({
       fsGroup: 1000,
+      fsGroupChangePolicy: "OnRootMismatch",
       runAsNonRoot: true,
       runAsUser: 1000,
     });

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -28,8 +28,6 @@ const deployOpts: AgentDeploymentOpts = {
   pvcName: "agent-42-home",
   secretName: "agent-42-token",
   tokenSecretKey: "token",
-  adminDeploymentName: "shipwright-admin",
-  adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
 };
 
 // ─── buildAgentDeploymentManifest ───────────────────────────────────────────
@@ -131,18 +129,9 @@ describe("buildAgentDeploymentManifest", () => {
     });
   });
 
-  it("sets an ownerReference to the admin Deployment for GC on uninstall", () => {
+  it("does not set ownerReferences", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
-    const refs = d.metadata.ownerReferences ?? [];
-    expect(refs).toHaveLength(1);
-    expect(refs[0]).toMatchObject({
-      apiVersion: "apps/v1",
-      kind: "Deployment",
-      name: "shipwright-admin",
-      uid: "11112222-3333-4444-5555-666677778888",
-      controller: true,
-      blockOwnerDeletion: true,
-    });
+    expect(d.metadata.ownerReferences).toBeUndefined();
   });
 
   it("honours an explicit replicas override", () => {
@@ -239,8 +228,6 @@ describe("buildAgentSecretManifest", () => {
     namespace: "shipwright",
     token: "sw-agent-secret-token",
     tokenKey: "token",
-    adminDeploymentName: "shipwright-admin",
-    adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
   };
 
   it("emits an Opaque v1 Secret", () => {
@@ -265,15 +252,9 @@ describe("buildAgentSecretManifest", () => {
     expect(s.data.token).toBeDefined();
   });
 
-  it("carries an ownerReference to the admin Deployment", () => {
+  it("does not set ownerReferences", () => {
     const s = buildAgentSecretManifest(secretOpts);
-    const refs = s.metadata.ownerReferences ?? [];
-    expect(refs[0]).toMatchObject({
-      kind: "Deployment",
-      name: "shipwright-admin",
-      uid: "11112222-3333-4444-5555-666677778888",
-      controller: true,
-    });
+    expect(s.metadata.ownerReferences).toBeUndefined();
   });
 });
 
@@ -284,8 +265,6 @@ describe("buildAgentPvcManifest", () => {
     name: "agent-42-home",
     namespace: "shipwright",
     sizeGi: 40,
-    adminDeploymentName: "shipwright-admin",
-    adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
   };
 
   it("emits a v1 PersistentVolumeClaim", () => {
@@ -321,18 +300,9 @@ describe("buildAgentPvcManifest", () => {
     expect(p.spec.storageClassName).toBeUndefined();
   });
 
-  it("carries an ownerReference to the admin Deployment for GC", () => {
+  it("does not set ownerReferences", () => {
     const p = buildAgentPvcManifest(pvcOpts);
-    const refs = p.metadata.ownerReferences ?? [];
-    expect(refs).toHaveLength(1);
-    expect(refs[0]).toMatchObject({
-      apiVersion: "apps/v1",
-      kind: "Deployment",
-      name: "shipwright-admin",
-      uid: "11112222-3333-4444-5555-666677778888",
-      controller: true,
-      blockOwnerDeletion: true,
-    });
+    expect(p.metadata.ownerReferences).toBeUndefined();
   });
 });
 

--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -44,8 +44,6 @@ const CONFIG: KubernetesAgentProvisionerConfig = {
   image: "ghcr.io/app-vitals/shipwright-agent",
   imageTag: "v1.2.3",
   apiUrl: "http://shipwright-admin.shipwright.svc:3001",
-  adminDeploymentName: "shipwright-admin",
-  adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
 };
 
 function makePrisma(): PrismaClient {
@@ -255,8 +253,6 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
       name: `${name}-token`,
       namespace: NAMESPACE,
       token: "preexisting",
-      adminDeploymentName: CONFIG.adminDeploymentName,
-      adminDeploymentUid: CONFIG.adminDeploymentUid,
     });
     const k8s = new RecordedKubernetesClient({
       deployments: {},

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -228,8 +228,6 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
           pvcName: this.pvcNameFor(resourceName, opts?.slug),
           secretName,
           tokenSecretKey: this.tokenKey,
-          adminDeploymentName: this.config.adminDeploymentName,
-          adminDeploymentUid: this.config.adminDeploymentUid,
           replicas: this.config.replicas,
           voice: this.config.voice,
         }),

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -95,10 +95,6 @@ export interface KubernetesAgentProvisionerConfig {
   imageTag: string;
   /** In-cluster admin/API base URL the agent calls home to. */
   apiUrl: string;
-  /** Admin Deployment name — ownerReference target for GC. */
-  adminDeploymentName: string;
-  /** Admin Deployment uid — ownerReference target for GC. */
-  adminDeploymentUid: string;
   /**
    * Build the PVC name for an agent from a single pre-resolved, RFC1123-safe
    * name string. When a slug is provided (via `provision(agentId, { slug })`),
@@ -347,8 +343,6 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       namespace: this.config.namespace,
       token: rawToken,
       tokenKey: this.tokenKey,
-      adminDeploymentName: this.config.adminDeploymentName,
-      adminDeploymentUid: this.config.adminDeploymentUid,
     });
     const stringData: Record<string, string> = {};
     for (const [key, value] of Object.entries(manifest.data)) {

--- a/admin/src/agent-provisioner.unit.test.ts
+++ b/admin/src/agent-provisioner.unit.test.ts
@@ -22,8 +22,6 @@ const BASE_CONFIG: KubernetesAgentProvisionerConfig = {
   image: "ghcr.io/app-vitals/shipwright-agent",
   imageTag: "v1.0.0",
   apiUrl: "http://shipwright-admin.shipwright.svc:3001",
-  adminDeploymentName: "shipwright-admin",
-  adminDeploymentUid: "aaaa-bbbb-cccc-dddd",
 };
 
 /** Stub token service — no DB required. */

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -81,6 +81,10 @@ export interface KubernetesContainer {
     httpGet?: { path?: string; port: number | string; [key: string]: unknown };
     [key: string]: unknown;
   };
+  readinessProbe?: {
+    httpGet?: { path?: string; port: number | string; [key: string]: unknown };
+    [key: string]: unknown;
+  };
   securityContext?: Record<string, unknown>;
   [key: string]: unknown;
 }

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -109,8 +109,6 @@ function buildProvisioner(
   const image = env.SHIPWRIGHT_AGENT_IMAGE ?? "";
   const imageTag = env.SHIPWRIGHT_AGENT_IMAGE_TAG ?? "latest";
   const apiUrl = env.SHIPWRIGHT_API_URL ?? "";
-  const adminDeploymentName = env.SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME ?? "";
-  const adminDeploymentUid = env.SHIPWRIGHT_ADMIN_DEPLOYMENT_UID ?? "";
   const replicasRaw = env.SHIPWRIGHT_AGENT_REPLICAS;
   const replicas = replicasRaw ? Number(replicasRaw) : undefined;
   const pvcStorageGiRaw = env.SHIPWRIGHT_AGENT_PVC_STORAGE_GI;
@@ -138,8 +136,6 @@ function buildProvisioner(
     image,
     imageTag,
     apiUrl,
-    adminDeploymentName,
-    adminDeploymentUid,
     ...(replicas !== undefined && Number.isFinite(replicas)
       ? { replicas }
       : {}),

--- a/admin/src/voice-contract.unit.test.ts
+++ b/admin/src/voice-contract.unit.test.ts
@@ -40,8 +40,6 @@ const baseOpts: AgentDeploymentOpts = {
   apiUrl: "http://shipwright-admin.shipwright.svc:3001",
   pvcName: "agent-42-home",
   secretName: "agent-42-token",
-  adminDeploymentName: "shipwright-admin",
-  adminDeploymentUid: "11112222-3333-4444-5555-666677778888",
 };
 
 /** The exact env var the agent reads for the self-hosted Whisper Service URL. */

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,13 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.6] - 2026-06-23
+
+### Changed
+
+- Remove `ownerReferences` from provisioned agent Deployments, Secrets, and PVCs — ineffective cross-namespace and unsafe same-namespace (cascade-deletes all agents on admin uninstall)
+- Align provisioned agent Deployment spec with Helm-managed agents: `strategy: Recreate`, `terminationGracePeriodSeconds: 120`, `readinessProbe`, `AGENT_HOME` env var, `fsGroupChangePolicy: OnRootMismatch`, `failureThreshold: 3` on liveness probe, `containerPort` declaration
+
 ## [1.6.5] - 2026-06-23
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.5
+version: 1.6.6
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.5 triggered by release tag admin-v0.79.0"
+      description: "remove ownerReferences from provisioned agent resources; align Deployment spec with Helm-managed agents"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -183,18 +183,6 @@ spec:
             # agent.provisioning.apiUrl for an external gateway.
             - name: SHIPWRIGHT_API_URL
               value: {{ .Values.agent.provisioning.apiUrl | default (printf "http://%s:%v" (include "shipwright.admin.fullname" .) .Values.admin.service.port) | quote }}
-            # Static admin Deployment name (this Deployment).
-            - name: SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME
-              value: {{ include "shipwright.admin.fullname" . | quote }}
-            {{- with .Values.agent.provisioning.adminDeploymentUid }}
-            # Optional: the parent Deployment's UID is NOT exposed to its pods via
-            # the downward API (that surfaces the POD uid, not the Deployment's), so
-            # it can only come from an explicit override. Omitted when unset —
-            # ownerRef propagation through KubernetesClient is a separate follow-up
-            # (HD-1.4); a missing UID is acceptable rather than a fabricated one.
-            - name: SHIPWRIGHT_ADMIN_DEPLOYMENT_UID
-              value: {{ . | quote }}
-            {{- end }}
             {{- with .Values.agent.provisioning.pvcNameTemplate }}
             # PVC name template: when set, the provisioner substitutes {name} with
             # the agent's human-readable name (slug) to derive the PVC name. Used

--- a/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
+++ b/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
@@ -188,12 +188,6 @@ tests:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME
-            value: r-shipwright-admin
-
   - it: injects the agent image/tag/replicas and the in-cluster API URL matching buildProvisioner
     template: templates/admin-deployment.yaml
     set:
@@ -221,32 +215,6 @@ tests:
           content:
             name: SHIPWRIGHT_API_URL
             value: http://r-shipwright-admin:3001
-
-  - it: omits SHIPWRIGHT_ADMIN_DEPLOYMENT_UID when adminDeploymentUid is not set
-    template: templates/admin-deployment.yaml
-    set:
-      agent.provisioning.enabled: true
-    release:
-      name: r
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SHIPWRIGHT_ADMIN_DEPLOYMENT_UID
-
-  - it: injects SHIPWRIGHT_ADMIN_DEPLOYMENT_UID when adminDeploymentUid is set
-    template: templates/admin-deployment.yaml
-    set:
-      agent.provisioning.enabled: true
-      agent.provisioning.adminDeploymentUid: "abc-123-uid"
-    release:
-      name: r
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SHIPWRIGHT_ADMIN_DEPLOYMENT_UID
-            value: "abc-123-uid"
 
   - it: injects explicit SHIPWRIGHT_K8S_NAMESPACE value when agent.provisioning.namespace is set
     template: templates/admin-deployment.yaml
@@ -319,8 +287,3 @@ tests:
           content:
             name: SHIPWRIGHT_API_URL
             value: http://r-shipwright-admin:3001
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SHIPWRIGHT_ADMIN_DEPLOYMENT_NAME
-            value: r-shipwright-admin

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -282,11 +282,6 @@ agent:
     # from the admin Service DNS name + port. Set to point agents at an external
     # gateway.
     apiUrl: ""
-    # -- Optional admin Deployment UID for ownerRef propagation. The downward API
-    # does NOT expose the parent Deployment's UID to its pods, so it can only be
-    # supplied explicitly. Leave empty to OMIT the env var (acceptable until
-    # ownerRef propagation lands as a follow-up).
-    adminDeploymentUid: ""
     # -- PVC name template for provisioned agents. When non-empty, the provisioner
     # substitutes `{name}` with the agent's human-readable name (slug) to derive the
     # PVC name. Use this when migrating from static agents whose PVCs were created


### PR DESCRIPTION
## Summary

- Removes `ownerReferences` from provisioned agent Deployments, Secrets, and PVCs
- Drops `adminDeploymentName` / `adminDeploymentUid` from all manifest builder opts, provisioner config, `main.ts` env reads, chart template, and values

## Why

Owner references on provisioned agent resources are ineffective and undesirable:

1. **Cross-namespace**: k8s GC does not honor cross-namespace owner references — admin in `shipwright`, agents in `vitals-os` means cascade-delete never fires anyway
2. **Same-namespace**: auto-deleting all agents on `helm uninstall shipwright` is not a safe default; explicit `deprovision()` calls are the right path
3. **Immediate bug**: the empty-UID 422 (`metadata.ownerReferences.uid: must not be empty`) blocked provisioning in cross-namespace deployments where `SHIPWRIGHT_ADMIN_DEPLOYMENT_UID` was never set

## Test plan

- [x] `bun test admin/src/agent-manifest.unit.test.ts` — 37 pass
- [ ] Provision an agent via `POST /agents/{id}/provision` — verify 200 and Deployment created without `ownerReferences`

🤖 Generated with [Claude Code](https://claude.com/claude-code)