### PR TITLE
fix(agent): set safe.directory on every startup to survive PVC uid mismatch

### DIFF
--- a/agent/src/setup-github-auth.integration.test.ts
+++ b/agent/src/setup-github-auth.integration.test.ts
@@ -135,11 +135,17 @@ describe("setupGitHubAuth — App path", () => {
       ],
       { stdio: "inherit", env: expectedEnv },
     );
+    // safe.directory always set unconditionally
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["config", "--global", "safe.directory", "*"],
+      { stdio: "inherit", env: expect.any(Object) },
+    );
     // No `gh auth setup-git` invocation on the App path anymore
     for (const call of spawnSync.mock.calls) {
       expect(call[0]).not.toBe("gh");
     }
-    expect(spawnSync).toHaveBeenCalledTimes(3);
+    expect(spawnSync).toHaveBeenCalledTimes(4);
     expect(startBackgroundRefresh).toHaveBeenCalledTimes(1);
   });
 
@@ -232,7 +238,12 @@ describe("setupGitHubAuth — PAT path", () => {
 
     await setupGitHubAuth(deps);
 
-    expect(spawnSync).toHaveBeenCalledTimes(1);
+    expect(spawnSync).toHaveBeenCalledTimes(2);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["config", "--global", "safe.directory", "*"],
+      { stdio: "inherit", env: expect.any(Object) },
+    );
     expect(spawnSync).toHaveBeenCalledWith("gh", ["auth", "setup-git"], {
       stdio: "inherit",
       env: expect.objectContaining({ GH_TOKEN: "ghp_test_pat" }),
@@ -268,7 +279,13 @@ describe("setupGitHubAuth — no auth configured", () => {
 
     await setupGitHubAuth(deps);
 
-    expect(spawnSync).not.toHaveBeenCalled();
+    // safe.directory is set even when no auth is configured
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["config", "--global", "safe.directory", "*"],
+      { stdio: "inherit", env: expect.any(Object) },
+    );
     expect(createTokenManager).not.toHaveBeenCalled();
     expect(getBotIdentity).not.toHaveBeenCalled();
     expect(writeToken).not.toHaveBeenCalled();
@@ -294,7 +311,13 @@ describe("setupGitHubAuth — no auth configured", () => {
 
     await setupGitHubAuth(deps);
 
-    expect(spawnSync).not.toHaveBeenCalled();
+    // safe.directory is set even with incomplete GH_APP_* vars
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["config", "--global", "safe.directory", "*"],
+      { stdio: "inherit", env: expect.any(Object) },
+    );
     expect(createTokenManager).not.toHaveBeenCalled();
     expect(getBotIdentity).not.toHaveBeenCalled();
     expect(writeToken).not.toHaveBeenCalled();

--- a/agent/src/setup-github-auth.integration.test.ts
+++ b/agent/src/setup-github-auth.integration.test.ts
@@ -170,9 +170,14 @@ describe("setupGitHubAuth — App path", () => {
     });
 
     expect(errorSpy).toHaveBeenCalled();
-    const firstCall = errorSpy.mock.calls[0]?.[0] as string;
-    expect(firstCall).toContain("git config");
-    expect(firstCall).toContain("status 1");
+    // call[0] = safe.directory failure (fires first, unconditionally)
+    const safeDirectoryCall = errorSpy.mock.calls[0]?.[0] as string;
+    expect(safeDirectoryCall).toContain("safe.directory");
+    expect(safeDirectoryCall).toContain("status 1");
+    // call[1] = credential helper failure (the actual subject of this test)
+    const credHelperCall = errorSpy.mock.calls[1]?.[0] as string;
+    expect(credHelperCall).toContain("credential");
+    expect(credHelperCall).toContain("status 1");
   });
 
   test("background refresh callback rewrites the token file only — no env mutation, no further spawnSync calls", async () => {

--- a/agent/src/setup-github-auth.ts
+++ b/agent/src/setup-github-auth.ts
@@ -61,6 +61,16 @@ export async function setupGitHubAuth(deps: GitHubAuthDeps): Promise<void> {
     logger,
   } = deps;
 
+  // Repos on the PVC may be owned by root (uid 0) while the agent runs as uid 1000.
+  // Set safe.directory unconditionally so git can operate on them regardless of auth path.
+  runOrWarn(
+    spawnSync,
+    "git",
+    ["config", "--global", "safe.directory", "*"],
+    env,
+    logger,
+  );
+
   const appId = env.GH_APP_ID;
   const installationId = env.GH_APP_INSTALLATION_ID;
   const privateKey = env.GH_APP_PRIVATE_KEY;


### PR DESCRIPTION
## Summary

- PVC-mounted repos may be owned by root (uid 0) while the agent runs as uid 1000
- Git's `safe.directory` check blocks all git operations in that case
- The previous band-aid lived in `/home/bun/.gitconfig`, but the startup sequence's `git config --global` calls for credential helper / user.name / user.email rewrite that file on every pod restart, wiping the fix
- This adds `git config --global safe.directory '*'` unconditionally at the top of `setupGitHubAuth`, before any auth-path branching, so it survives every restart regardless of which auth method is configured

## Test plan

- [ ] All 6 `setup-github-auth.integration.test.ts` tests updated and passing
- [ ] Biome lint clean on changed files
- [ ] Deploy to an agent with a PVC, confirm git operations work after a pod restart without manual `.gitconfig` edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)