### PR TITLE
docs: relocate changelog prose to docs/migration.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking Changes
-
-#### `AgentProvisioner.reconcile()` interface change
-
-- **`reconcile(agentIds: string[])` → `reconcile(agents: Array<{ id: string; slug?: string }>)`**: The `AgentProvisioner` interface's `reconcile()` method now accepts structured agent objects instead of raw ID strings. This is a **compile-time breaking change** for any code that implements or calls `AgentProvisioner` directly.
-
-  **Why**: The new `slug` field enables PVC name templates to use a human-readable agent slug instead of the raw agent ID, supporting custom PVC naming conventions (e.g. per-client storage naming).
-
-  **Migration**: callers passing a `string[]` must change to `agents.map(id => ({ id }))`. The `slug` field is optional — existing callers that do not need custom PVC naming can omit it.
-
-  ```ts
-  // Before
-  await provisioner.reconcile(["agent-id-1", "agent-id-2"]);
-
-  // After
-  await provisioner.reconcile([{ id: "agent-id-1" }, { id: "agent-id-2" }]);
-
-  // With optional slug for custom PVC naming
-  await provisioner.reconcile([{ id: "agent-id-1", slug: "my-agent" }]);
-  ```
+<!-- This section is managed by @semantic-release/changelog. Do not edit by hand. -->
 
 ## [4.28.0] - 2026-06-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,3 +155,4 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/agent.md** — Shipwright agent (C): runtime + admin CRUD APIs, the six-model Prisma store, and encryption/env notes
 - **docs/deploy-kubernetes.md** — Kubernetes deployment guide: Minikube / GKE (Gateway API + cert-manager) / EKS (ALB), the agent runtime-provisioning RBAC model, and auth modes
 - **docs/test-readiness/test-system.md** — the authoritative test blueprint: layer matrix, boundary rules, per-component budgets, CI pipeline shape, and the full isolation contract
+- **docs/migration.md** — breaking changes and migration steps across versions (e.g. `AgentProvisioner.reconcile()` interface change)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,24 @@
+# Migration Guide
+
+Durable notes for breaking changes and the steps needed to migrate across versions.
+
+---
+
+## `AgentProvisioner.reconcile()` interface change
+
+- **`reconcile(agentIds: string[])` → `reconcile(agents: Array<{ id: string; slug?: string }>)`**: The `AgentProvisioner` interface's `reconcile()` method now accepts structured agent objects instead of raw ID strings. This is a **compile-time breaking change** for any code that implements or calls `AgentProvisioner` directly.
+
+  **Why**: The new `slug` field enables PVC name templates to use a human-readable agent slug instead of the raw agent ID, supporting custom PVC naming conventions (e.g. per-client storage naming).
+
+  **Migration**: callers passing a `string[]` must change to `agents.map(id => ({ id }))`. The `slug` field is optional — existing callers that do not need custom PVC naming can omit it.
+
+  ```ts
+  // Before
+  await provisioner.reconcile(["agent-id-1", "agent-id-2"]);
+
+  // After
+  await provisioner.reconcile([{ id: "agent-id-1" }, { id: "agent-id-2" }]);
+
+  // With optional slug for custom PVC naming
+  await provisioner.reconcile([{ id: "agent-id-1", slug: "my-agent" }]);
+  ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,7 +4,7 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
-## `AgentProvisioner.reconcile()` interface change
+## `AgentProvisioner.reconcile()` interface change _(v4.29.0)_
 
 - **`reconcile(agentIds: string[])` → `reconcile(agents: Array<{ id: string; slug?: string }>)`**: The `AgentProvisioner` interface's `reconcile()` method now accepts structured agent objects instead of raw ID strings. This is a **compile-time breaking change** for any code that implements or calls `AgentProvisioner` directly.
 


### PR DESCRIPTION
## Summary

- Moves the hand-written `AgentProvisioner.reconcile()` breaking-change and migration notes from `CHANGELOG.md [Unreleased]` into a new durable `docs/migration.md`
- Resets `CHANGELOG.md [Unreleased]` to an empty, machine-owned section so `@semantic-release/changelog` is the sole owner going forward
- Migration prose preserved verbatim under a clear heading in `docs/migration.md`

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `docs/migration.md` exists with relocated `AgentProvisioner.reconcile()` prose | ✅ MET |
| 2 | `CHANGELOG.md [Unreleased]` normalized/empty and clearly machine-owned | ✅ MET |
| 3 | semantic-release dry-run parses without conflict | ⏭ Verified in REL-2.3 |
| 4 | No tests — documentation content move with no executable logic | ✅ MET |

## Test Plan

- [x] `docs/migration.md` created with exact prose from `CHANGELOG.md [Unreleased]`
- [x] `CHANGELOG.md [Unreleased]` contains only the `@semantic-release/changelog` ownership comment
- [x] No executable logic changed — documentation-only move

Generated with [Claude Code](https://claude.com/claude-code)
