### PR TITLE
feat(admin): add patchDeployment to KubernetesClient (SHI-1.2)

### DIFF
--- a/admin/src/agent-provisioner.integration.test.ts
+++ b/admin/src/agent-provisioner.integration.test.ts
@@ -149,6 +149,7 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
       deletePvc: (ns, n) => recorded.deletePvc(ns, n),
       deploymentExists: (ns, n) => recorded.deploymentExists(ns, n),
       listDeployments: (ns, sel) => recorded.listDeployments(ns, sel),
+      patchDeployment: (ns, n, p) => recorded.patchDeployment(ns, n, p),
     };
     const provisioner = new KubernetesAgentProvisioner(ordered, tokens, CONFIG);
 
@@ -211,6 +212,7 @@ describeOrSkip("KubernetesAgentProvisioner (integration)", () => {
       deletePvc: (ns, n) => recorded.deletePvc(ns, n),
       deploymentExists: (ns, n) => recorded.deploymentExists(ns, n),
       listDeployments: (ns, sel) => recorded.listDeployments(ns, sel),
+      patchDeployment: (ns, n, p) => recorded.patchDeployment(ns, n, p),
     };
     const provisioner = new KubernetesAgentProvisioner(failing, tokens, CONFIG);
 

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -193,6 +193,16 @@ export interface KubernetesClient {
   createPvc(namespace: string, spec: PvcSpec): Promise<KubernetesPvc>;
   getPvc(namespace: string, name: string): Promise<KubernetesPvc>;
   deletePvc(namespace: string, name: string): Promise<void>;
+  /**
+   * Apply a strategic merge patch to a named Deployment. The patch object is
+   * JSON-serialized and sent with Content-Type application/strategic-merge-patch+json.
+   * Typical use: update containers[0].image for a rolling restart.
+   */
+  patchDeployment(
+    namespace: string,
+    name: string,
+    patch: object,
+  ): Promise<void>;
 }
 
 // ─── Pure URL builders ────────────────────────────────────────────────────────
@@ -552,6 +562,23 @@ export class HttpKubernetesClient implements KubernetesClient {
     );
   }
 
+  async patchDeployment(
+    namespace: string,
+    name: string,
+    patch: object,
+  ): Promise<void> {
+    await this.request<void>(
+      deploymentUrl(this.apiServer, namespace, name),
+      {
+        method: "PATCH",
+        headers: this.authHeaders({
+          "Content-Type": "application/strategic-merge-patch+json",
+        }),
+        body: JSON.stringify(patch),
+      },
+    );
+  }
+
   async createSecret(
     namespace: string,
     spec: SecretSpec,
@@ -700,6 +727,35 @@ export class RecordedKubernetesClient implements KubernetesClient {
       throw new NotFoundError(`deployments.apps "${name}" not found`);
     }
     this.deployments.delete(key);
+  }
+
+  async patchDeployment(
+    namespace: string,
+    name: string,
+    patch: object,
+  ): Promise<void> {
+    const key = RecordedKubernetesClient.key(namespace, name);
+    const dep = this.deployments.get(key);
+    if (!dep) {
+      throw new NotFoundError(`deployments.apps "${name}" not found`);
+    }
+    const p = patch as {
+      spec?: {
+        template?: {
+          spec?: {
+            containers?: Array<{ name: string; image: string }>;
+          };
+        };
+      };
+    };
+    const newImage = p.spec?.template?.spec?.containers?.[0]?.image;
+    const existing = dep.spec.template.spec.containers[0];
+    if (newImage !== undefined && existing !== undefined) {
+      dep.spec.template.spec.containers[0] = {
+        ...existing,
+        image: newImage,
+      };
+    }
   }
 
   async createSecret(

--- a/admin/src/kubernetes-client.unit.test.ts
+++ b/admin/src/kubernetes-client.unit.test.ts
@@ -332,7 +332,7 @@ describe("HttpKubernetesClient.patchDeployment()", () => {
     const client = new HttpKubernetesClient({
       apiServer,
       token: "test-token",
-      fetchFn: fetchFn as typeof fetch,
+      fetchFn: fetchFn as unknown as typeof fetch,
     });
 
     await expect(

--- a/admin/src/kubernetes-client.unit.test.ts
+++ b/admin/src/kubernetes-client.unit.test.ts
@@ -10,6 +10,7 @@ import {
   NotFoundError,
 } from "./errors.ts";
 import {
+  HttpKubernetesClient,
   RecordedKubernetesClient,
   deploymentBody,
   deploymentUrl,
@@ -242,6 +243,159 @@ describe("RecordedKubernetesClient — PVCs", () => {
     });
     const fetched = await rec.getPvc("shipwright", "agent-abc-home");
     expect(fetched.metadata.name).toBe("agent-abc-home");
+  });
+});
+
+// ─── HttpKubernetesClient: patchDeployment ───────────────────────────────────
+
+describe("HttpKubernetesClient.patchDeployment()", () => {
+  const apiServer = "https://kubernetes.default.svc";
+  const namespace = "shipwright";
+  const name = "agent-abc";
+  const patch = {
+    spec: {
+      template: {
+        spec: {
+          containers: [{ name: "agent-abc", image: "ghcr.io/example/agent:v2" }],
+        },
+      },
+    },
+  };
+
+  it("sends PATCH to deploymentUrl(apiServer, namespace, name)", async () => {
+    let capturedUrl: string | undefined;
+    let capturedMethod: string | undefined;
+
+    const fetchFn = async (url: string | URL | Request, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedMethod = init?.method;
+      return new Response(null, { status: 200 });
+    };
+
+    const client = new HttpKubernetesClient({
+      apiServer,
+      token: "test-token",
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    await client.patchDeployment(namespace, name, patch);
+
+    expect(capturedUrl).toBe(deploymentUrl(apiServer, namespace, name));
+    expect(capturedMethod).toBe("PATCH");
+  });
+
+  it("sends Content-Type: application/strategic-merge-patch+json", async () => {
+    let capturedHeaders: HeadersInit | undefined;
+
+    const fetchFn = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = init?.headers;
+      return new Response(null, { status: 200 });
+    };
+
+    const client = new HttpKubernetesClient({
+      apiServer,
+      token: "test-token",
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    await client.patchDeployment(namespace, name, patch);
+
+    const headers = capturedHeaders as Record<string, string>;
+    expect(headers["Content-Type"]).toBe(
+      "application/strategic-merge-patch+json",
+    );
+  });
+
+  it("sends the patch object as JSON body", async () => {
+    let capturedBody: string | undefined;
+
+    const fetchFn = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(null, { status: 200 });
+    };
+
+    const client = new HttpKubernetesClient({
+      apiServer,
+      token: "test-token",
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    await client.patchDeployment(namespace, name, patch);
+
+    expect(capturedBody).toBe(JSON.stringify(patch));
+  });
+
+  it("throws NotFoundError on 404", async () => {
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ message: "not found" }), { status: 404 });
+
+    const client = new HttpKubernetesClient({
+      apiServer,
+      token: "test-token",
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    await expect(
+      client.patchDeployment(namespace, name, patch),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+// ─── RecordedKubernetesClient: patchDeployment ───────────────────────────────
+
+describe("RecordedKubernetesClient.patchDeployment()", () => {
+  const makeDeployment = (image: string) => ({
+    apiVersion: "apps/v1" as const,
+    kind: "Deployment" as const,
+    metadata: { name: "agent-abc", namespace: "shipwright" },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: "agent-abc" } },
+      template: {
+        metadata: { labels: { app: "agent-abc" } },
+        spec: {
+          containers: [{ name: "agent-abc", image }],
+        },
+      },
+    },
+  });
+
+  it("updates containers[0].image from the patch payload", async () => {
+    const rec = new RecordedKubernetesClient({
+      deployments: { "shipwright/agent-abc": makeDeployment("ghcr.io/example/agent:v1") },
+      secrets: {},
+    });
+
+    await rec.patchDeployment("shipwright", "agent-abc", {
+      spec: {
+        template: {
+          spec: {
+            containers: [{ name: "agent-abc", image: "ghcr.io/example/agent:v2" }],
+          },
+        },
+      },
+    });
+
+    const dep = await rec.getDeployment("shipwright", "agent-abc");
+    expect(dep.spec.template.spec.containers[0]?.image).toBe(
+      "ghcr.io/example/agent:v2",
+    );
+  });
+
+  it("throws NotFoundError when the deployment does not exist", async () => {
+    const rec = new RecordedKubernetesClient({ deployments: {}, secrets: {} });
+
+    await expect(
+      rec.patchDeployment("shipwright", "agent-abc", {
+        spec: {
+          template: {
+            spec: {
+              containers: [{ name: "agent-abc", image: "ghcr.io/example/agent:v2" }],
+            },
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `patchDeployment(namespace, name, patch)` to the `KubernetesClient` interface with strategic merge patch semantics
- Implements in `HttpKubernetesClient` — PATCH to deployment URL with `Content-Type: application/strategic-merge-patch+json`
- Implements in `RecordedKubernetesClient` — mutates `containers[0].image` from the patch payload, throws `NotFoundError` when deployment not found

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `patchDeployment(namespace, name, patch)` added to `KubernetesClient` interface | ✅ MET |
| 2 | `HttpKubernetesClient.patchDeployment()` sends PATCH with `Content-Type: application/strategic-merge-patch+json` | ✅ MET |
| 3 | `RecordedKubernetesClient.patchDeployment()` mutates `containers[0].image` from patch payload | ✅ MET |
| 4 | `RecordedKubernetesClient.patchDeployment()` throws `NotFoundError` when deployment not found | ✅ MET |
| 5 | Unit tests in `kubernetes-client.unit.test.ts` for URL construction and stub behaviour | ✅ MET |

## Test Plan
- [x] 6 new unit tests: HTTP PATCH URL/method, content-type header, JSON body, 404 error mapping; RecordedClient image mutation and NotFoundError
- [x] 30 total unit tests pass (`bun test admin/src/kubernetes-client.unit.test.ts`)
- [x] Biome lint clean
- [ ] Integration tests for image-update flow covered by SHI-1.3 (depends on this PR)

Generated with [Claude Code](https://claude.com/claude-code)
