### PR TITLE
fix(ci): restore dispatch pipeline broken by #633

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -23,18 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate app token for tag push
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Bump version and push tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "admin-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -27,7 +27,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "admin-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -28,7 +28,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "agent-v"
           default_bump: patch
           fetch_all_tags: true
@@ -55,7 +55,7 @@ jobs:
 
       - name: Dispatch agent-released to downstream
         env:
-          GH_TOKEN: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           NEW_TAG: ${{ steps.tag.outputs.new_tag }}
           DISPATCH_REPO: ${{ vars.CHART_DISPATCH_REPO }}
         run: |

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -24,18 +24,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate app token for tag push
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Bump version and push tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "agent-v"
           default_bump: patch
           fetch_all_tags: true
@@ -59,3 +52,14 @@ jobs:
       - name: Push Docker image
         run: |
           docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }}
+
+      - name: Dispatch agent-released to downstream
+        env:
+          GH_TOKEN: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          DISPATCH_REPO: ${{ vars.CHART_DISPATCH_REPO }}
+        run: |
+          [ -z "$DISPATCH_REPO" ] && echo "CHART_DISPATCH_REPO not configured, skipping" && exit 0
+          printf '{"event_type":"shipwright-agent-released","client_payload":{"base_tag":"%s"}}' "$NEW_TAG" \
+            | gh api "repos/$DISPATCH_REPO/dispatches" --method POST --input -
+          echo "Dispatched shipwright-agent-released with base_tag: ${NEW_TAG}"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -23,18 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate app token for tag push
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Bump version and push tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "metrics-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -27,7 +27,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "metrics-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -23,18 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate app token for tag push
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Bump version and push tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
           tag_prefix: "task-store-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -27,7 +27,7 @@ jobs:
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "task-store-v"
           default_bump: patch
           fetch_all_tags: true

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Notify downstream of chart release
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           DISPATCH_REPO: ${{ vars.CHART_DISPATCH_REPO }}
         run: |
           [ -z "$DISPATCH_REPO" ] && echo "CHART_DISPATCH_REPO not configured, skipping" && exit 0

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -61,6 +61,19 @@ jobs:
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify downstream of chart release
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.VITALS_OS_DISPATCH_TOKEN }}
+          DISPATCH_REPO: ${{ vars.CHART_DISPATCH_REPO }}
+        run: |
+          [ -z "$DISPATCH_REPO" ] && echo "CHART_DISPATCH_REPO not configured, skipping" && exit 0
+          CHART_VERSION=$(grep '^version:' charts/shipwright/Chart.yaml | sed 's/^version: //')
+          [ -z "$CHART_VERSION" ] && echo "Error: could not parse chart version" && exit 1
+          echo "Chart version: $CHART_VERSION"
+          printf '{"event_type":"shipwright-chart-released","client_payload":{"chart_version":"%s"}}' "$CHART_VERSION" \
+            | gh api "repos/$DISPATCH_REPO/dispatches" --method POST --input -
+
   # Dry-run validation — runs ONLY on pull_request. Proves the chart packages and
   # an index renders; publishes nothing (no gh-pages push, no GitHub Release).
   dry-run:


### PR DESCRIPTION
## Summary

- Removes the broken `create-github-app-token` step from all 4 build workflows — `RELEASE_APP_ID`/`RELEASE_APP_PRIVATE_KEY` were never configured as repo secrets, causing immediate failure on every build
- Replaces with `VITALS_OS_DISPATCH_TOKEN` directly (already exists, a PAT — pushes tags that correctly trigger `auto-bump-chart`)
- Restores `Dispatch agent-released to downstream` step in `build-agent.yml` (drives vitals-os agent image build)
- Restores `Notify downstream of chart release` step in `chart-release.yml` (drives image bump + deploy)

Both dispatch steps were removed in #633 without a replacement, silently killing the downstream pipeline. The dispatch target remains configurable via `CHART_DISPATCH_REPO`.

## Test plan

- [ ] Push a change to `agent/` on main — `Build and Push Agent Image` should succeed, push a tag, and dispatch `shipwright-agent-released`
- [ ] Confirm `auto-bump-chart` fires on the new `agent-v*` tag
- [ ] After chart bump merges, confirm `chart-release.yml` publishes and dispatches `shipwright-chart-released` downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)