### PR TITLE
fix(ci): use DISPATCH_TOKEN for chart bump PR creation and auto-merge

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -221,7 +221,7 @@ jobs:
         if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.new.outputs.version }}"
           CURRENT_VERSION="${{ steps.current.outputs.version }}"
@@ -257,7 +257,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           PR_URL="${{ steps.pr.outputs.pr_url }}"
           gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

`auto-bump-chart.yml` was changed in #633 to use `GITHUB_TOKEN` for PR creation and auto-merge. `GITHUB_TOKEN` creates PRs as `github-actions[bot]`, which requires a human CODEOWNERS review before auto-merge fires — blocking the automated chart bump flow.

Restores `DISPATCH_TOKEN` (PAT) for the `Open bump PR` and `Enable auto-merge` steps so chart bump PRs auto-merge without manual intervention, as they did before #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)