### PR TITLE
fix(chart): grant patch/update on Deployments in agent-provisioner RBAC

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,15 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.14] - 2026-06-24
+
+### Fixed
+
+- agent-provisioner RBAC: grant `patch`/`update` on Deployments (apps) so the
+  reconcile path can strategic-merge-patch existing agent Deployments. Without
+  these verbs, `POST /agents/reconcile` returned 200 but every agent failed with
+  `cannot patch resource "deployments"` from the K8s API (SHI-1.3).
+
 ## [1.6.13] - 2026-06-24
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.13
+version: 1.6.14
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.6.13 triggered by release tag agent-v0.63.0"
+    - kind: fixed
+      description: "agent-provisioner RBAC: grant patch/update on Deployments so the reconcile path can update existing agent Deployments (SHI-1.3)"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/agent-provisioning-rbac.yaml
+++ b/charts/shipwright/templates/agent-provisioning-rbac.yaml
@@ -8,8 +8,10 @@
 # its own release namespace (e.g. provisioning agents into a dedicated target namespace).
 # A ClusterRole bound via ClusterRoleBinding is required to reach across namespace boundaries.
 # The verb set is exactly what the provisioner (HD-1.3 KubernetesAgentProvisioner /
-# HD-1.4 wiring) exercises: create + get + delete on Deployments (apps),
-# Secrets (core), and PersistentVolumeClaims (core).
+# HD-1.4 wiring) exercises: create + get + list + patch + update + delete on
+# Deployments (apps) — patch/update are required by the reconcile path, which
+# strategic-merge-patches existing Deployments — and create + get + delete on
+# Secrets (core) and PersistentVolumeClaims (core).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,7 +21,7 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "get", "list", "delete"]
+    verbs: ["create", "get", "list", "patch", "update", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "get", "delete"]
@@ -61,7 +63,7 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "get", "list", "delete"]
+    verbs: ["create", "get", "list", "patch", "update", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "get", "delete"]

--- a/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
+++ b/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
@@ -12,7 +12,7 @@ suite: agent-provisioning RBAC + admin env contract (HD-4.2 / K8S-NS-1.1)
 tests:
   # ── (a) enabled → RBAC + agent SA ────────────────────────────────────────────
   # Cross-namespace mode (agent.provisioning.namespace set) → ClusterRole + ClusterRoleBinding
-  - it: renders a cluster-scoped ClusterRole with exactly create/get/delete on Deployments, Secrets, and PVCs (cross-namespace mode)
+  - it: renders a cluster-scoped ClusterRole with create/get/list/patch/update/delete on Deployments and create/get/delete on Secrets and PVCs (cross-namespace mode)
     template: templates/agent-provisioning-rbac.yaml
     documentIndex: 0
     set:
@@ -34,7 +34,7 @@ tests:
           value: ["deployments"]
       - equal:
           path: rules[0].verbs
-          value: ["create", "get", "list", "delete"]
+          value: ["create", "get", "list", "patch", "update", "delete"]
       - equal:
           path: rules[1].apiGroups
           value: [""]
@@ -108,7 +108,7 @@ tests:
           value: ["deployments"]
       - equal:
           path: rules[0].verbs
-          value: ["create", "get", "list", "delete"]
+          value: ["create", "get", "list", "patch", "update", "delete"]
       - equal:
           path: rules[1].resources
           value: ["secrets"]


### PR DESCRIPTION
## What

The agent-provisioner `Role`/`ClusterRole` (`templates/agent-provisioning-rbac.yaml`) granted `create`/`get`/`list`/`delete` on Deployments but **not `patch`/`update`**. The reconcile path (`KubernetesAgentProvisioner.reconcile` → `patchDeployment`, strategic-merge-patch) needs `patch` to update existing agent Deployments.

## Symptom (how this surfaced)

`POST /agents/reconcile` against prod **authenticated fine** — HTTP 200, admin key with scope `*` → `isAdmin=true`. But every agent landed in the `failed[]` array:

```
deployments.apps "<id>" is forbidden: User
"system:serviceaccount:shipwright:shipwright" cannot patch resource
"deployments" in API group "apps" in the namespace "vitals-os"
```

The vitals-os `deploy.yml` "Reconcile agent deployments" step then `exit 1`s on `failed[].length > 0`, which **read as an admin-auth failure but was actually K8s RBAC**. New-agent provisioning (`create`) was unaffected; only reconcile of *existing* Deployments hit the missing verb.

## Change

- Add `patch` + `update` to the `deployments` verb set in **both** the cross-namespace `ClusterRole` and same-namespace `Role` branches.
- Update the helm-unittest assertions (`tests/agent_provisioning_rbac_test.yaml`) and the verb-set comment.
- Bump chart `1.6.13` → `1.6.14` (+ CHANGELOG + `artifacthub.io/changes`).

## Verification

`helm unittest charts/shipwright -f tests/agent_provisioning_rbac_test.yaml` → 12 passed.

## Follow-up (separate, in vitals-os)

Once `1.6.14` publishes to `app-vitals.github.io/shipwright`, bump the dependency in `infra/helm/shipwright-deploy/Chart.yaml` and re-vendor `charts/shipwright-1.6.14.tgz`, then deploy. That RoleBinding apply is what actually clears the prod reconcile failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)