### PR TITLE
fix(chart): add task-store to GKE HealthCheckPolicy subchart

### DIFF
--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.14
+version: 1.6.15
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: fixed
-      description: "agent-provisioner RBAC: grant patch/update on Deployments so the reconcile path can update existing agent Deployments (SHI-1.3)"
+      description: "chart: add task-store to GKE HealthCheckPolicy so the GKE Gateway probes /health instead of / (which 404s)"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/healthcheckpolicy.yaml
+++ b/charts/shipwright/templates/healthcheckpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if and (eq .Values.networking.type "gateway") .Values.networking.gateway.healthCheckPolicy.enabled }}
 {{- /*
-  GKE HealthCheckPolicies for the admin and metrics Services.
+  GKE HealthCheckPolicies for the admin, metrics, and task-store Services.
 
   The GKE Gateway controller default-probes "/" — both services return 404 there —
   and marks each backend UNHEALTHY, returning 503 on the external host. These
@@ -55,5 +55,28 @@ spec:
     group: ""
     kind: Service
     name: {{ include "shipwright.metrics.fullname" . }}
+{{- end }}
+{{- if .Values.taskStore.enabled }}
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "shipwright.taskStore.fullname" . }}
+  labels:
+    {{- include "shipwright.taskStore.labels" . | nindent 4 }}
+spec:
+  default:
+    checkIntervalSec: 15
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 2
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /health
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "shipwright.taskStore.fullname" . }}
 {{- end }}
 {{- end }}

--- a/charts/shipwright/tests/healthcheckpolicy_test.yaml
+++ b/charts/shipwright/tests/healthcheckpolicy_test.yaml
@@ -1,5 +1,5 @@
 suite: GKE HealthCheckPolicy (networking.gke.io/v1)
-# HK-1.3: render HealthCheckPolicy resources for the admin and metrics Services
+# HK-1.3: render HealthCheckPolicy resources for the admin, metrics, and task-store Services
 # when networking.type=gateway AND networking.gateway.healthCheckPolicy.enabled=true.
 # Without these the GKE Gateway default-probes "/" (both services 404) and returns
 # 503 externally. Disabled by default so non-GKE installs are unaffected.
@@ -30,7 +30,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders admin + metrics HealthCheckPolicies when gateway + enabled
+  - it: renders admin + metrics HealthCheckPolicies when gateway + enabled (taskStore off by default)
     set:
       networking.type: gateway
       networking.gateway.healthCheckPolicy.enabled: true
@@ -84,17 +84,72 @@ tests:
           value: r-shipwright-metrics
         documentIndex: 1
 
-  - it: renders only the admin HealthCheckPolicy when metrics is disabled
+  - it: renders admin + metrics + task-store HealthCheckPolicies when all enabled
+    set:
+      networking.type: gateway
+      networking.gateway.healthCheckPolicy.enabled: true
+      taskStore.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+      # Third doc: task-store HealthCheckPolicy
+      - isAPIVersion:
+          of: networking.gke.io/v1
+        documentIndex: 2
+      - isKind:
+          of: HealthCheckPolicy
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: r-shipwright-task-store
+        documentIndex: 2
+      - equal:
+          path: spec.default.config.type
+          value: HTTP
+        documentIndex: 2
+      - equal:
+          path: spec.default.config.httpHealthCheck.requestPath
+          value: /health
+        documentIndex: 2
+      - equal:
+          path: spec.targetRef.kind
+          value: Service
+        documentIndex: 2
+      - equal:
+          path: spec.targetRef.name
+          value: r-shipwright-task-store
+        documentIndex: 2
+
+  - it: renders only the admin HealthCheckPolicy when metrics and taskStore are disabled
     set:
       networking.type: gateway
       networking.gateway.healthCheckPolicy.enabled: true
       metrics.enabled: false
+      taskStore.enabled: false
     asserts:
       - hasDocuments:
           count: 1
       - equal:
           path: metadata.name
           value: r-shipwright-admin
+
+  - it: renders admin + task-store when metrics disabled but taskStore enabled
+    set:
+      networking.type: gateway
+      networking.gateway.healthCheckPolicy.enabled: true
+      metrics.enabled: false
+      taskStore.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: r-shipwright-admin
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: r-shipwright-task-store
+        documentIndex: 1
 
   - it: probe params are 15s interval, 5s timeout, 1 healthy threshold, 2 unhealthy threshold
     set:


### PR DESCRIPTION
## Summary

- Adds a `HealthCheckPolicy` resource for the `task-store` Service in `charts/shipwright/templates/healthcheckpolicy.yaml`
- Gated on `taskStore.enabled` (defaults `false`) — no impact on existing installs
- Task-store exposes `GET /health` (unauthenticated, returns 200) — same probe path as admin and metrics

## Test plan

- [ ] `helm template` with `taskStore.enabled=true` + gateway conditions renders 3 `HealthCheckPolicy` docs
- [ ] `helm template` with default values (taskStore off) still renders 2 docs — no regression
- [ ] Helm unittest suite updated with 3 new cases: all-enabled, metrics-off+taskStore-on, admin-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)