### PR TITLE
feat(task-store): agent token scoping

### DIFF
--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -226,6 +226,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
       if (this.config.taskStore) {
         const { id, rawToken } = await this.config.taskStore.mintToken(
           `agent:${agentId}`,
+          agentId,
         );
         tsTokenId = id;
         tsRawToken = rawToken;

--- a/admin/src/agent-provisioner.unit.test.ts
+++ b/admin/src/agent-provisioner.unit.test.ts
@@ -403,19 +403,19 @@ describe("KubernetesAgentProvisioner.reconcile() — template respected", () => 
  */
 function stubTaskStore(opts?: { throwOnMint?: boolean }): {
   client: TaskStoreProvisioningClient;
-  minted: Array<{ label: string; id: string }>;
+  minted: Array<{ label: string; agentId: string | undefined; id: string }>;
   revoked: string[];
 } {
-  const minted: Array<{ label: string; id: string }> = [];
+  const minted: Array<{ label: string; agentId: string | undefined; id: string }> = [];
   const revoked: string[] = [];
   let seq = 0;
 
   const client: TaskStoreProvisioningClient = {
-    async mintToken(label: string) {
+    async mintToken(label: string, agentId?: string) {
       if (opts?.throwOnMint) throw new Error("mint failed");
       seq++;
       const id = `ts-tok-${seq}`;
-      minted.push({ label, id });
+      minted.push({ label, agentId, id });
       return { id, rawToken: `raw-ts-token-${seq}` };
     },
     async revokeToken(id: string) {
@@ -446,6 +446,7 @@ describe("KubernetesAgentProvisioner — task-store token minting", () => {
 
     expect(minted).toHaveLength(1);
     expect(minted[0].label).toBe(`agent:${AGENT_ID}`);
+    expect(minted[0].agentId).toBe(AGENT_ID);
   });
 
   it("provision() does NOT mint a task-store token when taskStore is not configured", async () => {

--- a/admin/src/task-store-provisioning-client.ts
+++ b/admin/src/task-store-provisioning-client.ts
@@ -13,11 +13,17 @@
 
 export interface TaskStoreProvisioningClient {
   /**
-   * Mint a new task-store token with the given label. Returns the token `id`
-   * (needed to revoke it on rollback) and the `rawToken` (stored in the agent
-   * Secret and later used by the agent to authenticate with the task store).
+   * Mint a new task-store token. Returns the token `id` (needed to revoke it
+   * on rollback) and the `rawToken` (stored in the agent Secret and later used
+   * by the agent to authenticate with the task store).
+   *
+   * Pass `agentId` to create a scoped agent token — the task store will scope
+   * all reads and writes to tasks assigned to this agent. Omit for admin tokens.
    */
-  mintToken(label: string): Promise<{ id: string; rawToken: string }>;
+  mintToken(
+    label: string,
+    agentId?: string,
+  ): Promise<{ id: string; rawToken: string }>;
 
   /**
    * Revoke a previously-minted task-store token. Called as part of the rollback
@@ -46,14 +52,17 @@ export class HttpTaskStoreProvisioningClient
     private readonly adminToken: string,
   ) {}
 
-  async mintToken(label: string): Promise<{ id: string; rawToken: string }> {
+  async mintToken(
+    label: string,
+    agentId?: string,
+  ): Promise<{ id: string; rawToken: string }> {
     const res = await fetch(`${this.baseUrl}/tokens`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.adminToken}`,
       },
-      body: JSON.stringify({ label }),
+      body: JSON.stringify({ label, ...(agentId ? { agentId } : {}) }),
     });
     if (!res.ok) {
       throw new Error(
@@ -89,7 +98,10 @@ export class HttpTaskStoreProvisioningClient
 export class NoopTaskStoreProvisioningClient
   implements TaskStoreProvisioningClient
 {
-  async mintToken(_label: string): Promise<{ id: string; rawToken: string }> {
+  async mintToken(
+    _label: string,
+    _agentId?: string,
+  ): Promise<{ id: string; rawToken: string }> {
     return { id: "", rawToken: "" };
   }
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -19,9 +19,8 @@ Auto-detect the project toolchain (run once, reuse throughout). Skip this step u
 **First, check for an interrupted task** — if a prior session left a task `in_progress`, resume it:
 
 ```bash
-CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress${CURRENT_USER:+&assignee=$CURRENT_USER}" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq .
 ```
 
 If the result is a non-empty array, use the first task returned. The Step 2 orphan check will clean up any stale branch/PR from the prior session before restarting. Print:
@@ -35,9 +34,8 @@ Record `task_started_at` (current ISO timestamp) for metrics.
 **If no in_progress task**, pick the next ready pending task:
 
 ```bash
-CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true${CURRENT_USER:+&assignee=$CURRENT_USER}" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq .
 ```
 
 The command returns `pending` shipwright tasks whose dependencies are all satisfied, sorted by `addedAt`. Pick the first result.

--- a/plugins/shipwright/scripts/check-dev-task.ts
+++ b/plugins/shipwright/scripts/check-dev-task.ts
@@ -87,50 +87,17 @@ export async function run(deps: Deps): Promise<RunResult> {
 
 // ─── Production deps ──────────────────────────────────────────────────────────
 
-function resolveGhUser(): string | undefined {
-  // GraphQL viewer works under both PAT and GitHub App installation tokens.
-  // REST /user 403s under installation tokens. Same "name[bot]" → "app/name"
-  // normalisation as getCurrentUser() in check-helpers.ts.
-  const proc = Bun.spawnSync(
-    ["gh", "api", "graphql", "-f", "query=query{viewer{login}}"],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  if (proc.exitCode !== 0) return undefined;
-  try {
-    const data = JSON.parse(proc.stdout.toString()) as {
-      data: { viewer: { login: string } };
-    };
-    const login = data.data.viewer.login;
-    return login.endsWith("[bot]") ? `app/${login.slice(0, -5)}` : login;
-  } catch {
-    return undefined;
-  }
-}
-
 function buildProductionDeps(): Deps {
   const client = createTaskStoreClient();
-  const assignee = resolveGhUser();
 
   return {
-    getReadyTasks: () =>
-      client.query(
-        assignee
-          ? new URLSearchParams({ ready: "true", assignee })
-          : new URLSearchParams({ ready: "true" }),
-      ),
+    getReadyTasks: () => client.query(new URLSearchParams({ ready: "true" })),
     getInProgressTasks: () =>
-      client.query(
-        assignee
-          ? new URLSearchParams({ status: "in_progress", assignee })
-          : new URLSearchParams({ status: "in_progress" }),
-      ),
+      client.query(new URLSearchParams({ status: "in_progress" })),
     getHitlPendingTasks: () =>
-      client.query(
-        assignee
-          ? new URLSearchParams({ status: "pending", hitl: "true", assignee })
-          : new URLSearchParams({ status: "pending", hitl: "true" }),
-      ),
-    resetTask: (id) => client.update(id, { status: "pending", startedAt: null }),
+      client.query(new URLSearchParams({ status: "pending", hitl: "true" })),
+    resetTask: (id) =>
+      client.update(id, { status: "pending", startedAt: null }),
     stampTask: (id, startedAt) => client.update(id, { startedAt }),
     clock: SystemClock(),
   };

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -40,30 +40,20 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 
 ---
 
-## Resolve your assignee
-
-Always resolve the current GitHub user before querying. Pass it to every query:
-
-```bash
-CURRENT_USER=$(gh api graphql -f "query=query{viewer{login}}" --jq '.data.viewer.login' 2>/dev/null)
-```
-
----
-
 ## Standard lifecycle
 
 ### Pick next task
 
-Check for an interrupted task first, then fall back to the next ready one:
+The API scopes results to the calling agent automatically via the bearer token — no assignee parameter needed. Check for an interrupted task first, then fall back to the next ready one:
 
 ```bash
 # 1. Resume interrupted task (in_progress assigned to you)
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&assignee=$CURRENT_USER" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq .
 
 # 2. If empty, pick next ready task
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true&assignee=$CURRENT_USER" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq .
 ```
 
 Both return a JSON array. Use the first element.
@@ -132,7 +122,7 @@ curl -sf -X POST \
 | `status` | Must be `"pending"` on creation |
 | `repo` | Routes `dev-task` to the correct worktree |
 | `branch` | `dev-task` creates the worktree from this; absent → task is skipped |
-| `assignee` | Without it, any agent can pick up the task |
+| `assignee` | Agent ID of the agent that should own this task |
 
 Convention: `branch` = `feat/{id-lowercase}` (e.g. `feat/tss-x-1-my-task`).
 
@@ -141,10 +131,10 @@ Convention: `branch` = `feat/{id-lowercase}` (e.g. `feat/tss-x-1-my-task`).
 ## `?ready=true` semantics
 
 When `?ready=true` is set, `?status` and `?id` filters are ignored. Only
-`?assignee` and `?session` apply as post-filters.
+`?session` applies as a post-filter.
 
-- `?assignee` — filter by GitHub login; pass `$CURRENT_USER`.
-  Unassigned tasks (no `assignee` field) are included — available to any agent.
+- Agent tokens: results are automatically scoped to the calling agent's tasks.
+- Admin tokens: results include all agents' tasks.
 - `?session` — filter by planning session slug. Omit to return ready tasks across all sessions.
 
 A task is ready when:
@@ -159,7 +149,7 @@ When `?ready=true` returns `[]`:
 
 | Likely cause | How to check |
 |---|---|
-| Wrong assignee | Re-run without `?assignee` to see the full ready set |
+| No tasks assigned to this agent | Use an admin token to see all ready tasks |
 | Deps not satisfied | Query `?status=pending` — tasks present but blocked on deps |
 | Queue empty | No pending tasks exist at all |
 

--- a/task-store/prisma/migrations/20260623000000_task_token_agent_id/migration.sql
+++ b/task-store/prisma/migrations/20260623000000_task_token_agent_id/migration.sql
@@ -1,0 +1,3 @@
+-- Add agentId to TaskToken.
+-- null = admin token (unrestricted); set = agent token scoped to that agent ID.
+ALTER TABLE "TaskToken" ADD COLUMN "agentId" TEXT;

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -100,6 +100,7 @@ model TaskToken {
   id        String    @id @default(cuid())
   token     String    @unique // SHA-256 hash of the raw token (hex)
   label     String?
+  agentId   String?   // null = admin token; set = agent token scoped to this agent
   createdAt DateTime  @default(now())
   revokedAt DateTime?
 }

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -355,4 +355,41 @@ describe("task-store API (smoke)", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("GET /tasks/:id returns 200 when agent token reads an unassigned task", async () => {
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      // Task has no assignee — should be accessible to any agent token.
+      taskService: fakeTaskService({
+        getResult: makeTask({ id: "task-1", assignee: null }),
+      }),
+    });
+    const res = await app.request("/tasks/task-1", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("PATCH /tasks/:id with agent token pins assignee to the agent's ID", async () => {
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      // Task is owned by agent-1 (the token's agent).
+      taskService: fakeTaskService({
+        getResult: makeTask({ id: "task-1", assignee: "agent-1" }),
+      }),
+    });
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      // Attempt to reassign to a different agent.
+      body: JSON.stringify({ assignee: "agent-2", status: "in_progress" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task;
+    // Assignee must be pinned back to agent-1, not agent-2.
+    expect(body.assignee).toBe("agent-1");
+  });
 });

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -392,4 +392,58 @@ describe("task-store API (smoke)", () => {
     // Assignee must be pinned back to agent-1, not agent-2.
     expect(body.assignee).toBe("agent-1");
   });
+
+  it("GET /tasks?ready=true with agent token forwards agentId to listReady", async () => {
+    let capturedAgentId: string | undefined = undefined;
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async listReady(agentId?: string) {
+        capturedAgentId = agentId;
+        return [];
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      taskService: spyTaskService,
+    });
+
+    const res = await app.request("/tasks?ready=true", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    // The token's agentId ("agent-1") must be forwarded to listReady.
+    expect(capturedAgentId).toBe("agent-1");
+  });
+
+  it("GET /tasks?status=in_progress with agent token ignores caller-supplied ?assignee", async () => {
+    let capturedAssignee: string | undefined = undefined;
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async list(opts) {
+        capturedAssignee = opts.assignee;
+        return [];
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      taskService: spyTaskService,
+    });
+
+    // Caller tries to supply ?assignee=other-agent to peek at another agent's tasks.
+    const res = await app.request(
+      "/tasks?status=in_progress&assignee=other-agent",
+      {
+        headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    // Token's agentId must win; caller-supplied assignee must be ignored.
+    expect(capturedAssignee).toBe("agent-1");
+  });
 });

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Task } from "./index.ts";
-import type { TaskServiceLike } from "./task-service.ts";
+import type { TaskListFilters, TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
 // ─── Fakes ────────────────────────────────────────────────────────────────────
@@ -430,12 +430,12 @@ describe("task-store API (smoke)", () => {
   });
 
   it("GET /tasks?ready=true with agent token forwards agentId to listReady", async () => {
-    let capturedAgentId: string | undefined = undefined;
+    const capturedArgs: Array<string | undefined> = [];
 
     const spyTaskService: TaskServiceLike = {
       ...fakeTaskService(),
       async listReady(agentId?: string) {
-        capturedAgentId = agentId;
+        capturedArgs.push(agentId);
         return [];
       },
     };
@@ -451,16 +451,16 @@ describe("task-store API (smoke)", () => {
 
     expect(res.status).toBe(200);
     // The token's agentId ("agent-1") must be forwarded to listReady.
-    expect(capturedAgentId).toBe("agent-1");
+    expect(capturedArgs[0]).toBe("agent-1");
   });
 
   it("GET /tasks?status=in_progress with agent token ignores caller-supplied ?assignee", async () => {
-    let capturedAssignee: string | undefined = undefined;
+    const capturedAssignees: Array<string | undefined> = [];
 
     const spyTaskService: TaskServiceLike = {
       ...fakeTaskService(),
-      async list(opts) {
-        capturedAssignee = opts.assignee;
+      async list(opts?) {
+        capturedAssignees.push(opts?.assignee);
         return [];
       },
     };
@@ -480,6 +480,6 @@ describe("task-store API (smoke)", () => {
 
     expect(res.status).toBe(200);
     // Token's agentId must win; caller-supplied assignee must be ignored.
-    expect(capturedAssignee).toBe("agent-1");
+    expect(capturedAssignees[0]).toBe("agent-1");
   });
 });

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -22,6 +22,7 @@ import type { TokenServiceLike } from "./token-service.ts";
 // ─── Fakes ────────────────────────────────────────────────────────────────────
 
 const VALID_TOKEN = "valid-token";
+const AGENT_TOKEN = "agent-token";
 
 function fakeTokenService(): TokenServiceLike {
   return {
@@ -40,6 +41,34 @@ function fakeTokenService(): TokenServiceLike {
     },
     async validate(raw: string) {
       return raw === VALID_TOKEN ? { id: "tok-1", agentId: null } : null;
+    },
+    async revoke() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+  };
+}
+
+/** Token service that validates AGENT_TOKEN as a scoped agent-1 token. */
+function fakeAgentTokenService(): TokenServiceLike {
+  return {
+    async create(label?: string) {
+      return {
+        token: {
+          id: "tok-2",
+          token: "hash",
+          label: label ?? null,
+          agentId: "agent-1",
+          createdAt: new Date(),
+          revokedAt: null,
+        },
+        rawToken: "raw",
+      };
+    },
+    async validate(raw: string) {
+      return raw === AGENT_TOKEN ? { id: "tok-2", agentId: "agent-1" } : null;
     },
     async revoke() {
       return null;
@@ -281,5 +310,49 @@ describe("task-store API (smoke)", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as { rawToken: string };
     expect(body.rawToken).toBe("raw");
+  });
+
+  // ─── Agent token scoping ──────────────────────────────────────────────────
+
+  it("POST /tasks with agent token forces assignee to the agent's ID", async () => {
+    const app = makeApp({ tokenService: fakeAgentTokenService() });
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ title: "New task", status: "pending" }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Task;
+    expect(body.assignee).toBe("agent-1");
+  });
+
+  it("GET /tasks/:id returns 403 when agent token tries to read a task owned by a different agent", async () => {
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      // Task is owned by agent-2, not agent-1.
+      taskService: fakeTaskService({
+        getResult: makeTask({ id: "task-1", assignee: "agent-2" }),
+      }),
+    });
+    const res = await app.request("/tasks/task-1", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /tokens returns 403 for an agent token (admin-only route)", async () => {
+    const app = makeApp({ tokenService: fakeAgentTokenService() });
+    const res = await app.request("/tokens", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ label: "ci" }),
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -31,6 +31,7 @@ function fakeTokenService(): TokenServiceLike {
           id: "tok-1",
           token: "hash",
           label: label ?? null,
+          agentId: null,
           createdAt: new Date(),
           revokedAt: null,
         },
@@ -38,7 +39,7 @@ function fakeTokenService(): TokenServiceLike {
       };
     },
     async validate(raw: string) {
-      return raw === VALID_TOKEN ? { id: "tok-1" } : null;
+      return raw === VALID_TOKEN ? { id: "tok-1", agentId: null } : null;
     },
     async revoke() {
       return null;

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -356,10 +356,10 @@ describe("task-store API (smoke)", () => {
     expect(res.status).toBe(403);
   });
 
-  it("GET /tasks/:id returns 200 when agent token reads an unassigned task", async () => {
+  it("GET /tasks/:id returns 403 when agent token reads an unassigned task", async () => {
     const app = makeApp({
       tokenService: fakeAgentTokenService(),
-      // Task has no assignee — should be accessible to any agent token.
+      // Unassigned tasks are not accessible to agent tokens — only admins.
       taskService: fakeTaskService({
         getResult: makeTask({ id: "task-1", assignee: null }),
       }),
@@ -367,7 +367,7 @@ describe("task-store API (smoke)", () => {
     const res = await app.request("/tasks/task-1", {
       headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
   });
 
   it("PATCH /tasks/:id with agent token pins assignee to the agent's ID", async () => {

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -130,14 +130,16 @@ function fakeTaskService(
   opts: {
     getResult?: Task | null;
     claimThrows?: Error;
+    listResult?: Task[];
+    listReadyResult?: Task[];
   } = {},
 ): TaskServiceLike {
   return {
     async list() {
-      return [];
+      return opts.listResult ?? [];
     },
     async listReady() {
-      return [];
+      return opts.listReadyResult ?? [];
     },
     async get(id: string) {
       if ("getResult" in opts) return opts.getResult ?? null;
@@ -368,6 +370,40 @@ describe("task-store API (smoke)", () => {
       headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
     });
     expect(res.status).toBe(403);
+  });
+
+  it("GET /tasks?ready=true with agent token returns only the agent's ready tasks", async () => {
+    const ownedTask = makeTask({ id: "task-1", assignee: "agent-1" });
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      taskService: fakeTaskService({ listReadyResult: [ownedTask] }),
+    });
+    const res = await app.request("/tasks?ready=true", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task[];
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("task-1");
+  });
+
+  it("GET /tasks?status=in_progress with agent token scopes to the agent's tasks", async () => {
+    const ownedTask = makeTask({
+      id: "task-2",
+      assignee: "agent-1",
+      status: "in_progress",
+    });
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      taskService: fakeTaskService({ listResult: [ownedTask] }),
+    });
+    const res = await app.request("/tasks?status=in_progress", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task[];
+    expect(body).toHaveLength(1);
+    expect(body[0].assignee).toBe("agent-1");
   });
 
   it("PATCH /tasks/:id with agent token pins assignee to the agent's ID", async () => {

--- a/task-store/src/auth.ts
+++ b/task-store/src/auth.ts
@@ -13,7 +13,13 @@
 import type { MiddlewareHandler } from "hono";
 import type { TokenServiceLike } from "./token-service.ts";
 
-export type TaskStoreAuthEnv = { Variables: { tokenId: string } };
+export type TaskStoreAuthEnv = {
+  Variables: {
+    tokenId: string;
+    /** null = admin token (unrestricted); set = agent token scoped to this agent. */
+    agentId: string | null;
+  };
+};
 
 export function createBearerAuthMiddleware(deps: {
   tokenService: Pick<TokenServiceLike, "validate">;
@@ -44,6 +50,7 @@ export function createBearerAuthMiddleware(deps: {
     }
 
     c.set("tokenId", result.id);
+    c.set("agentId", result.agentId);
     return next();
   };
 }

--- a/task-store/src/errors.ts
+++ b/task-store/src/errors.ts
@@ -45,3 +45,10 @@ export class UnauthorizedError extends ApiError {
     this.name = "UnauthorizedError";
   }
 }
+
+export class ForbiddenError extends ApiError {
+  constructor(message = "Forbidden") {
+    super(403, message);
+    this.name = "ForbiddenError";
+  }
+}

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -53,7 +53,7 @@ async function requireOwnership(
 ) {
   const task = await taskService.get(id);
   if (!task) throw new NotFoundError("task not found");
-  if (agentId !== null && task.assignee !== agentId) {
+  if (agentId !== null && task.assignee !== null && task.assignee !== agentId) {
     throw new ForbiddenError("task belongs to a different agent");
   }
   return task;
@@ -131,7 +131,7 @@ export function createTasksRoutes(
     const agentId = c.get("agentId");
     const task = await taskService.get(c.req.param("id"));
     if (!task) throw new NotFoundError("task not found");
-    if (agentId !== null && task.assignee !== agentId) {
+    if (agentId !== null && task.assignee !== null && task.assignee !== agentId) {
       throw new ForbiddenError("task belongs to a different agent");
     }
     return c.json(task, 200);
@@ -144,7 +144,7 @@ export function createTasksRoutes(
     const body = await readJson(c);
     // Prevent agent tokens from reassigning tasks outside their ownership scope.
     if (agentId !== null) {
-      body.assignee = undefined;
+      body.assignee = agentId;
     }
     const updated = await taskService.update(
       c.req.param("id"),

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -53,7 +53,7 @@ async function requireOwnership(
 ) {
   const task = await taskService.get(id);
   if (!task) throw new NotFoundError("task not found");
-  if (agentId !== null && task.assignee !== null && task.assignee !== agentId) {
+  if (agentId !== null && task.assignee !== agentId) {
     throw new ForbiddenError("task belongs to a different agent");
   }
   return task;
@@ -131,7 +131,7 @@ export function createTasksRoutes(
     const agentId = c.get("agentId");
     const task = await taskService.get(c.req.param("id"));
     if (!task) throw new NotFoundError("task not found");
-    if (agentId !== null && task.assignee !== null && task.assignee !== agentId) {
+    if (agentId !== null && task.assignee !== agentId) {
       throw new ForbiddenError("task belongs to a different agent");
     }
     return c.json(task, 200);

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -5,6 +5,12 @@
  * Returns a Hono sub-app mounted at /tasks by app.ts. Auth is applied by the
  * parent app, so these handlers assume the caller is already authenticated.
  *
+ * Agent tokens (agentId set) are scoped to their own tasks:
+ *   - reads return only tasks where assignee === agentId
+ *   - writes are blocked on tasks owned by other agents (403)
+ *   - creates force assignee = agentId
+ * Admin tokens (agentId null) have no restrictions.
+ *
  * Routes:
  *   GET    /tasks               list (?status, ?session, ?assignee, ?pr, ?branch, ?ready=true)
  *   POST   /tasks               create one (409 if id exists)
@@ -20,7 +26,8 @@
  */
 
 import { Hono } from "hono";
-import { BadRequestError, NotFoundError } from "../errors.ts";
+import type { TaskStoreAuthEnv } from "../auth.ts";
+import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.ts";
 import type { Prisma } from "../index.ts";
 import type { TaskServiceLike } from "../task-service.ts";
 
@@ -38,19 +45,39 @@ async function readJson(c: {
   }
 }
 
-export function createTasksRoutes(taskService: TaskServiceLike): Hono {
-  const app = new Hono();
+/** Fetch a task and enforce agent ownership. Throws 404 or 403 as appropriate. */
+async function requireOwnership(
+  taskService: TaskServiceLike,
+  id: string,
+  agentId: string | null,
+) {
+  const task = await taskService.get(id);
+  if (!task) throw new NotFoundError("task not found");
+  if (agentId !== null && task.assignee !== agentId) {
+    throw new ForbiddenError("task belongs to a different agent");
+  }
+  return task;
+}
+
+export function createTasksRoutes(
+  taskService: TaskServiceLike,
+): Hono<TaskStoreAuthEnv> {
+  const app = new Hono<TaskStoreAuthEnv>();
 
   // ─── List ──────────────────────────────────────────────────────────────────
   app.get("/", async (c) => {
+    const agentId = c.get("agentId");
+
     if (c.req.query("ready") === "true") {
-      return c.json(await taskService.listReady(), 200);
+      return c.json(await taskService.listReady(agentId ?? undefined), 200);
     }
+
     const prRaw = c.req.query("pr");
     const tasks = await taskService.list({
       status: c.req.query("status"),
       session: c.req.query("session"),
-      assignee: c.req.query("assignee"),
+      // Agent tokens always scope to their own tasks; ignore any provided ?assignee.
+      assignee: agentId ?? c.req.query("assignee"),
       claimedBy: c.req.query("claimedBy"),
       pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
       branch: c.req.query("branch"),
@@ -60,6 +87,7 @@ export function createTasksRoutes(taskService: TaskServiceLike): Hono {
 
   // ─── Create ────────────────────────────────────────────────────────────────
   app.post("/", async (c) => {
+    const agentId = c.get("agentId");
     const body = await readJson(c);
     if (typeof body.title !== "string" || !body.title) {
       throw new BadRequestError("title is required");
@@ -67,12 +95,17 @@ export function createTasksRoutes(taskService: TaskServiceLike): Hono {
     if (typeof body.status !== "string" || !body.status) {
       throw new BadRequestError("status is required");
     }
+    // Agent tokens force assignee to their own ID.
+    if (agentId !== null) {
+      body.assignee = agentId;
+    }
     const created = await taskService.create(body as Prisma.TaskCreateInput);
     return c.json(created, 201);
   });
 
   // ─── Bulk insert ───────────────────────────────────────────────────────────
   app.post("/bulk", async (c) => {
+    const agentId = c.get("agentId");
     let body: unknown;
     try {
       body = await c.req.json();
@@ -82,19 +115,32 @@ export function createTasksRoutes(taskService: TaskServiceLike): Hono {
     if (!Array.isArray(body)) {
       throw new BadRequestError("body must be a JSON array of tasks");
     }
-    const result = await taskService.bulk(body as Prisma.TaskCreateInput[]);
+    const tasks =
+      agentId !== null
+        ? (body as Record<string, unknown>[]).map((t) => ({
+            ...t,
+            assignee: agentId,
+          }))
+        : body;
+    const result = await taskService.bulk(tasks as Prisma.TaskCreateInput[]);
     return c.json(result, 200);
   });
 
   // ─── Get one ───────────────────────────────────────────────────────────────
   app.get("/:id", async (c) => {
+    const agentId = c.get("agentId");
     const task = await taskService.get(c.req.param("id"));
     if (!task) throw new NotFoundError("task not found");
+    if (agentId !== null && task.assignee !== agentId) {
+      throw new ForbiddenError("task belongs to a different agent");
+    }
     return c.json(task, 200);
   });
 
   // ─── Update ────────────────────────────────────────────────────────────────
   app.patch("/:id", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     const body = await readJson(c);
     const updated = await taskService.update(
       c.req.param("id"),
@@ -105,12 +151,16 @@ export function createTasksRoutes(taskService: TaskServiceLike): Hono {
 
   // ─── Delete ────────────────────────────────────────────────────────────────
   app.delete("/:id", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     await taskService.remove(c.req.param("id"));
     return c.body(null, 204);
   });
 
   // ─── Claim (atomic) ────────────────────────────────────────────────────────
   app.post("/:id/claim", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     const body = await readJson(c);
     const claimedBy = body.claimedBy;
     if (typeof claimedBy !== "string" || !claimedBy) {
@@ -122,18 +172,24 @@ export function createTasksRoutes(taskService: TaskServiceLike): Hono {
 
   // ─── Heartbeat ─────────────────────────────────────────────────────────────
   app.post("/:id/heartbeat", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     const task = await taskService.heartbeat(c.req.param("id"));
     return c.json(task, 200);
   });
 
   // ─── Complete ──────────────────────────────────────────────────────────────
   app.post("/:id/complete", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     const task = await taskService.complete(c.req.param("id"));
     return c.json(task, 200);
   });
 
   // ─── Fail ──────────────────────────────────────────────────────────────────
   app.post("/:id/fail", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     const body = await readJson(c);
     const reason = typeof body.reason === "string" ? body.reason : undefined;
     const task = await taskService.fail(c.req.param("id"), reason);
@@ -142,6 +198,8 @@ export function createTasksRoutes(taskService: TaskServiceLike): Hono {
 
   // ─── Release ───────────────────────────────────────────────────────────────
   app.post("/:id/release", async (c) => {
+    const agentId = c.get("agentId");
+    await requireOwnership(taskService, c.req.param("id"), agentId);
     const task = await taskService.release(c.req.param("id"));
     return c.json(task, 200);
   });

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -142,6 +142,10 @@ export function createTasksRoutes(
     const agentId = c.get("agentId");
     await requireOwnership(taskService, c.req.param("id"), agentId);
     const body = await readJson(c);
+    // Prevent agent tokens from reassigning tasks outside their ownership scope.
+    if (agentId !== null) {
+      body.assignee = undefined;
+    }
     const updated = await taskService.update(
       c.req.param("id"),
       body as Prisma.TaskUpdateInput,

--- a/task-store/src/routes/tokens.ts
+++ b/task-store/src/routes/tokens.ts
@@ -1,9 +1,9 @@
 /**
  * task-store/src/routes/tokens.ts
- * Token management routes.
+ * Token management routes — admin tokens only.
  *
  * Returns a Hono sub-app mounted at /tokens by app.ts. Auth is applied by the
- * parent app.
+ * parent app. All routes here require an admin token (agentId === null).
  *
  * Routes:
  *   GET    /tokens       list (hash + metadata, never raw values)
@@ -12,11 +12,22 @@
  */
 
 import { Hono } from "hono";
-import { NotFoundError } from "../errors.ts";
+import type { TaskStoreAuthEnv } from "../auth.ts";
+import { ForbiddenError, NotFoundError } from "../errors.ts";
 import type { TokenServiceLike } from "../token-service.ts";
 
-export function createTokensRoutes(tokenService: TokenServiceLike): Hono {
-  const app = new Hono();
+export function createTokensRoutes(
+  tokenService: TokenServiceLike,
+): Hono<TaskStoreAuthEnv> {
+  const app = new Hono<TaskStoreAuthEnv>();
+
+  // All token management requires an admin token.
+  app.use("*", async (c, next) => {
+    if (c.get("agentId") !== null) {
+      throw new ForbiddenError("token management requires an admin token");
+    }
+    return next();
+  });
 
   // ─── List ──────────────────────────────────────────────────────────────────
   app.get("/", async (c) => {
@@ -27,13 +38,18 @@ export function createTokensRoutes(tokenService: TokenServiceLike): Hono {
   // ─── Create ────────────────────────────────────────────────────────────────
   app.post("/", async (c) => {
     let label: string | undefined;
+    let agentId: string | undefined;
     try {
-      const body = (await c.req.json()) as { label?: unknown };
+      const body = (await c.req.json()) as {
+        label?: unknown;
+        agentId?: unknown;
+      };
       if (typeof body.label === "string") label = body.label;
+      if (typeof body.agentId === "string") agentId = body.agentId;
     } catch {
-      // No body / invalid JSON → create an unlabeled token.
+      // No body / invalid JSON → create an unlabeled admin token.
     }
-    const { token, rawToken } = await tokenService.create(label);
+    const { token, rawToken } = await tokenService.create(label, agentId);
     // The raw token is returned exactly once, here.
     return c.json({ ...token, rawToken }, 201);
   });

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -30,10 +30,12 @@ export interface TaskListFilters {
 /** The subset of TaskService the routes depend on. */
 export interface TaskServiceLike {
   list(filters?: TaskListFilters): Promise<Task[]>;
-  listReady(): Promise<Task[]>;
+  listReady(agentId?: string): Promise<Task[]>;
   get(id: string): Promise<Task | null>;
   create(data: Prisma.TaskCreateInput): Promise<Task>;
-  bulk(tasks: Prisma.TaskCreateInput[]): Promise<{ inserted: number; updated: number }>;
+  bulk(
+    tasks: Prisma.TaskCreateInput[],
+  ): Promise<{ inserted: number; updated: number }>;
   update(id: string, data: Prisma.TaskUpdateInput): Promise<Task>;
   remove(id: string): Promise<void>;
   claim(id: string, claimedBy: string): Promise<Task>;
@@ -72,9 +74,13 @@ export class TaskService implements TaskServiceLike {
    * The task-store has no GitHub access, so cross-branch pr_open deps are never
    * treated as merged (isPrMerged resolves to false).
    */
-  async listReady(): Promise<Task[]> {
+  async listReady(agentId?: string): Promise<Task[]> {
+    // Load all tasks so dependency resolution sees the full graph, then filter
+    // the result set to the caller's agent if one is specified.
     const tasks = await this.prisma.task.findMany();
-    return resolveReadyTasks(tasks, async () => false);
+    const ready = await resolveReadyTasks(tasks, async () => false);
+    if (agentId) return ready.filter((t) => t.assignee === agentId);
+    return ready;
   }
 
   async get(id: string): Promise<Task | null> {

--- a/task-store/src/token-service.ts
+++ b/task-store/src/token-service.ts
@@ -15,11 +15,16 @@ export type { TaskToken };
 export interface TaskTokenValidated {
   /** The TaskToken row id. */
   id: string;
+  /** null = admin token; set = agent token scoped to this agent ID. */
+  agentId: string | null;
 }
 
 /** The subset of TaskTokenService the auth middleware and routes depend on. */
 export interface TokenServiceLike {
-  create(label?: string): Promise<{ token: TaskToken; rawToken: string }>;
+  create(
+    label?: string,
+    agentId?: string,
+  ): Promise<{ token: TaskToken; rawToken: string }>;
   validate(raw: string): Promise<TaskTokenValidated | null>;
   revoke(tokenId: string): Promise<TaskToken | null>;
   list(): Promise<TaskToken[]>;
@@ -45,11 +50,12 @@ export class TaskTokenService implements TokenServiceLike {
    */
   async create(
     label?: string,
+    agentId?: string,
   ): Promise<{ token: TaskToken; rawToken: string }> {
     const rawToken = generateRawToken();
     const hashed = hashToken(rawToken);
     const token = await this.prisma.taskToken.create({
-      data: { token: hashed, label: label ?? null },
+      data: { token: hashed, label: label ?? null, agentId: agentId ?? null },
     });
     return { token, rawToken };
   }
@@ -65,7 +71,7 @@ export class TaskTokenService implements TokenServiceLike {
       where: { token: hashed },
     });
     if (!record || record.revokedAt !== null) return null;
-    return { id: record.id };
+    return { id: record.id, agentId: record.agentId };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `agentId String?` to `TaskToken` — `null` = admin token, set = agent token scoped to that agent
- Agent tokens can only create, read, and update tasks where `assignee === agentId`; creates auto-set `assignee`
- Admin tokens retain unrestricted access to all tasks and token management
- Token management routes (`/tokens`) are now admin-only

## Changes

- **Schema + migration**: `agentId` column on `TaskToken`
- **`token-service`**: `create(label?, agentId?)` stores it; `validate()` returns `{ id, agentId }`
- **`auth`**: middleware exposes `agentId` on Hono context (`null` for admin)
- **`task routes`**: ownership enforced on all CRUD + action endpoints; `POST /tasks` and `POST /tasks/bulk` force `assignee = agentId` for agent tokens
- **`token routes`**: 403 for any agent token
- **`task-service`**: `listReady(agentId?)` filters results post-dependency-resolution (full graph still used for dep checking)
- **`errors`**: `ForbiddenError` (403) added

## Test plan

- [x] All existing smoke tests pass with updated fakes (`agentId: null` for admin tokens)
- [ ] Integration: verify agent token sees only its tasks, admin sees all, cross-agent PATCH returns 403
- [ ] Existing admin tokens (`agentId null` in DB) continue to work without migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)