### PR TITLE
fix(admin): wire fetchTaskStoreTasks + releaseTask into admin UI

### DIFF
--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -251,6 +251,33 @@ async function startServer(): Promise<void> {
   root.route("/", adminApiApp);
 
   // 4. Admin UI — /admin/* — session JWT
+  const taskStoreUrl = process.env.SHIPWRIGHT_TASK_STORE_URL;
+  const taskStoreAdminToken = process.env.SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN;
+  const taskStoreFetchers =
+    taskStoreUrl && taskStoreAdminToken
+      ? {
+          fetchTaskStoreTasks: async (params: URLSearchParams) => {
+            const url = `${taskStoreUrl}/tasks${params.size > 0 ? `?${params}` : ""}`;
+            const res = await fetch(url, {
+              headers: { Authorization: `Bearer ${taskStoreAdminToken}` },
+            });
+            if (!res.ok)
+              throw new Error(`task-store GET /tasks → ${res.status}`);
+            return res.json();
+          },
+          releaseTask: async (id: string) => {
+            const res = await fetch(`${taskStoreUrl}/tasks/${id}/release`, {
+              method: "POST",
+              headers: { Authorization: `Bearer ${taskStoreAdminToken}` },
+            });
+            if (!res.ok)
+              throw new Error(
+                `task-store POST /tasks/${id}/release → ${res.status}`,
+              );
+          },
+        }
+      : {};
+
   const adminUIApp = createAdminUIApp({
     prisma: prisma as never,
     agentEnvService,
@@ -267,6 +294,7 @@ async function startServer(): Promise<void> {
     slackClient,
     appBaseUrl,
     devAuthEnabled: isDevAuthAllowed(process.env),
+    ...taskStoreFetchers,
   });
   root.route("/", adminUIApp);
 


### PR DESCRIPTION
## Summary

- `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN` were wired into the admin pod in vitals-os PR #1738, but `main.ts` only used them for `buildProvisioner` — never for the task-list UI
- `createAdminUIApp` received no `fetchTaskStoreTasks`, so the `/admin/tasks` page always rendered in degraded mode with "Task store unavailable — data shown may be stale or empty."
- This constructs both fetchers from the env vars and passes them to `createAdminUIApp`

## Test plan

- [ ] 563 admin unit tests pass (`bun test admin/src/`)
- [ ] After deploy: open `/admin/tasks` — degraded notice should be gone, tasks list should populate
- [ ] `kubectl exec` into admin pod, confirm `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN` are set (landed via vitals-os PR #1738)

🤖 Generated with [Claude Code](https://claude.com/claude-code)