### PR TITLE
feat(admin): wire selfHosted through agent API layer

### DIFF
--- a/admin/prisma/migrations/20260624000000_add_agent_self_hosted/migration.sql
+++ b/admin/prisma/migrations/20260624000000_add_agent_self_hosted/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Agent" ADD COLUMN "selfHosted" BOOLEAN NOT NULL DEFAULT false;

--- a/admin/prisma/schema.prisma
+++ b/admin/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Agent {
   slackId         String?  @unique
   slackBotToken   String?  // AES-256-GCM encrypted at the service layer
   anthropicApiKey String?  // AES-256-GCM encrypted at the service layer
+  selfHosted      Boolean  @default(false)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -283,23 +283,47 @@ function makeMockDeps(): AdminDeps {
     prisma: {
       agent: {
         create: async (args: {
-          data: { name: string; slackId: string | null };
+          data: { name: string; slackId: string | null; selfHosted?: boolean };
         }) => ({
           id: "agent-new-id",
           name: args.data.name,
           slackId: args.data.slackId,
+          selfHosted: args.data.selfHosted ?? false,
           createdAt: new Date("2024-01-01"),
           updatedAt: new Date("2024-01-01"),
         }),
         findUnique: async (args: { where: { id: string } }) =>
           args.where.id === AGENT_ID
-            ? { id: AGENT_ID, name: "Existing Agent" }
+            ? {
+                id: AGENT_ID,
+                name: "Existing Agent",
+                slackId: null,
+                selfHosted: false,
+                createdAt: new Date("2024-01-01"),
+                updatedAt: new Date("2024-01-01"),
+              }
             : null,
-        findMany: async () => [{ id: AGENT_ID }, { id: "agent-other-id" }],
+        findMany: async () => [
+          { id: AGENT_ID, name: "Existing Agent", selfHosted: false },
+          { id: "agent-other-id", name: "Other Agent", selfHosted: false },
+        ],
         delete: async (args: { where: { id: string } }) => ({
           id: args.where.id,
           name: "Existing Agent",
           slackId: null,
+          selfHosted: false,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        }),
+        update: async (args: {
+          where: { id: string };
+          data: { selfHosted?: boolean };
+          select?: Record<string, boolean>;
+        }) => ({
+          id: args.where.id,
+          name: "Existing Agent",
+          slackId: null,
+          selfHosted: args.data.selfHosted ?? false,
           createdAt: new Date("2024-01-01"),
           updatedAt: new Date("2024-01-01"),
         }),
@@ -1290,5 +1314,292 @@ describe("admin API — provision agent", () => {
       deploymentName: AGENT_ID,
     });
     expect(provisioner.provisioned).toEqual([AGENT_ID]);
+  });
+
+  it("POST /agents/:id/provision on self-hosted agent returns 200 { skipped: true } without calling provisioner", async () => {
+    const cookie = await makeSessionCookie();
+    const provisioner = new RecordingProvisioner();
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      provisioner,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findUnique: async (args: { where: { id: string } }) =>
+            args.where.id === AGENT_ID
+              ? {
+                  id: AGENT_ID,
+                  name: "Self-Hosted Agent",
+                  selfHosted: true,
+                }
+              : null,
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}/provision`, {
+      method: "POST",
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ skipped: true, reason: "self-hosted" });
+    expect(provisioner.provisioned).toEqual([]);
+  });
+});
+
+// ─── selfHosted field smoke tests ─────────────────────────────────────────────
+
+describe("admin API — selfHosted field", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  it("POST /agents with selfHosted:true stores and returns flag (201)", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          create: async (args: {
+            data: { name: string; slackId: string | null; selfHosted: boolean };
+          }) => ({
+            id: "agent-new-id",
+            name: args.data.name,
+            slackId: args.data.slackId,
+            selfHosted: args.data.selfHosted,
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          }),
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Self-Hosted Agent", selfHosted: true }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.selfHosted).toBe(true);
+  });
+
+  it("POST /agents without selfHosted defaults to false (201)", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          create: async (args: {
+            data: { name: string; slackId: string | null; selfHosted: boolean };
+          }) => ({
+            id: "agent-new-id",
+            name: args.data.name,
+            slackId: args.data.slackId,
+            selfHosted: args.data.selfHosted ?? false,
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          }),
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Regular Agent" }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.selfHosted).toBe(false);
+  });
+
+  it("GET /agents includes selfHosted in response", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findMany: async () => [
+            { id: AGENT_ID, name: "Existing Agent", selfHosted: false },
+            { id: "agent-other-id", name: "Other Agent", selfHosted: true },
+          ],
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0].selfHosted).toBeDefined();
+    expect(typeof body[0].selfHosted).toBe("boolean");
+  });
+
+  it("GET /agents/:id returns full agent record with selfHosted", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findUnique: async (args: { where: { id: string } }) =>
+            args.where.id === AGENT_ID
+              ? {
+                  id: AGENT_ID,
+                  name: "Existing Agent",
+                  slackId: null,
+                  selfHosted: false,
+                  createdAt: new Date("2024-01-01"),
+                  updatedAt: new Date("2024-01-01"),
+                }
+              : null,
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(AGENT_ID);
+    expect(typeof body.selfHosted).toBe("boolean");
+  });
+
+  it("GET /agents/:id unknown id → 404", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request("/agents/does-not-exist", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /agents/:id with {selfHosted: true} updates flag and returns 200", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findUnique: async (args: { where: { id: string } }) =>
+            args.where.id === AGENT_ID
+              ? {
+                  id: AGENT_ID,
+                  name: "Existing Agent",
+                  slackId: null,
+                  selfHosted: false,
+                  createdAt: new Date("2024-01-01"),
+                  updatedAt: new Date("2024-01-01"),
+                }
+              : null,
+          update: async (args: {
+            where: { id: string };
+            data: { selfHosted?: boolean };
+          }) => ({
+            id: args.where.id,
+            name: "Existing Agent",
+            slackId: null,
+            selfHosted: args.data.selfHosted ?? false,
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          }),
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ selfHosted: true }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.selfHosted).toBe(true);
+  });
+
+  it("PATCH /agents/:id unknown id → 404", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request("/agents/does-not-exist", {
+      method: "PATCH",
+      body: JSON.stringify({ selfHosted: true }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /agents/reconcile excludes self-hosted agents and response includes updated field", async () => {
+    const provisioner = new RecordingProvisioner();
+    provisioner.reconcileResult = {
+      recreated: [],
+      updated: [],
+      orphans: [],
+      failed: [],
+    };
+
+    // Track which agents are passed to reconcile
+    const agentsPassed: Array<{ id: string; slug?: string }> = [];
+    const trackingProvisioner: AdminDeps["provisioner"] = {
+      async provision(agentId, opts) {
+        return provisioner.provision(agentId, opts);
+      },
+      async deprovision(agentId) {
+        return provisioner.deprovision(agentId);
+      },
+      async reconcile(agents) {
+        agentsPassed.push(...agents);
+        return provisioner.reconcileResult;
+      },
+    };
+
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      provisioner: trackingProvisioner,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findMany: async () => [
+            { id: AGENT_ID, name: "Regular Agent", selfHosted: false },
+            { id: "self-hosted-id", name: "Self-Hosted Agent", selfHosted: true },
+          ],
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents/reconcile", {
+      method: "POST",
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Response must include updated field
+    expect(body).toHaveProperty("updated");
+    expect(Array.isArray(body.updated)).toBe(true);
+    // Self-hosted agent must NOT be passed to the provisioner
+    expect(agentsPassed.map((a) => a.id)).not.toContain("self-hosted-id");
+    // Regular agent IS passed
+    expect(agentsPassed.map((a) => a.id)).toContain(AGENT_ID);
   });
 });

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -1118,12 +1118,12 @@ describe("admin API — POST /agents/reconcile", () => {
     expect(res.status).toBe(403);
   });
 
-  it("POST /agents/reconcile with admin session → calls reconcile and returns { recreated, orphans }", async () => {
+  it("POST /agents/reconcile with admin session → calls reconcile and returns { recreated, updated, orphans }", async () => {
     const cookie = await makeSessionCookie();
     const provisioner = new RecordingProvisioner();
     provisioner.reconcileResult = {
       recreated: ["agent-abc"],
-      updated: [],
+      updated: ["agent-stale"],
       orphans: ["agent-orphan"],
       failed: [],
     };
@@ -1137,6 +1137,7 @@ describe("admin API — POST /agents/reconcile", () => {
     const body = await res.json();
     expect(body).toMatchObject({
       recreated: ["agent-abc"],
+      updated: ["agent-stale"],
       orphans: ["agent-orphan"],
     });
   });

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -55,6 +55,7 @@ import {
   EnvKeyParamSchema,
   ErrorSchema,
   OkSchema,
+  PatchAgentBodySchema,
   PatchAgentCronJobBodySchema,
   PatchAgentPluginBodySchema,
   PatchAgentToolBodySchema,
@@ -136,6 +137,24 @@ const ProvisionAgentResultSchema = z
   })
   .openapi("ProvisionAgentResult");
 
+const ProvisionSkippedResultSchema = z
+  .object({
+    skipped: z.literal(true),
+    reason: z.string(),
+  })
+  .openapi("ProvisionSkippedResult");
+
+const GetAgentResultSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    slackId: z.string().nullable().optional(),
+    selfHosted: z.boolean(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .openapi("GetAgentResult");
+
 const CronWrapperSchema = z
   .object({ cron: AgentCronJobSchema })
   .openapi("CronWrapper");
@@ -202,8 +221,12 @@ const provisionAgentRoute = createRoute({
   request: { params: AgentIdParamSchema },
   responses: {
     200: {
-      description: "Agent provisioned (or already-provisioned — idempotent)",
-      content: { "application/json": { schema: ProvisionAgentResultSchema } },
+      description: "Agent provisioned (or already-provisioned — idempotent), or skipped for self-hosted agents",
+      content: {
+        "application/json": {
+          schema: z.union([ProvisionAgentResultSchema, ProvisionSkippedResultSchema]),
+        },
+      },
     },
     403: { description: "Forbidden", ...jsonError },
     404: { description: "Agent not found", ...jsonError },
@@ -219,6 +242,40 @@ const listAgentsRoute = createRoute({
       content: { "application/json": { schema: z.array(AgentSummarySchema) } },
     },
     403: { description: "Forbidden", ...jsonError },
+  },
+});
+
+const getAgentRoute = createRoute({
+  method: "get",
+  path: "/agents/{id}",
+  request: { params: AgentIdParamSchema },
+  responses: {
+    200: {
+      description: "Full agent record",
+      content: { "application/json": { schema: GetAgentResultSchema } },
+    },
+    403: { description: "Forbidden", ...jsonError },
+    404: { description: "Agent not found", ...jsonError },
+  },
+});
+
+const patchAgentRoute = createRoute({
+  method: "patch",
+  path: "/agents/{id}",
+  request: {
+    params: AgentIdParamSchema,
+    body: {
+      content: { "application/json": { schema: PatchAgentBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Agent updated",
+      content: { "application/json": { schema: GetAgentResultSchema } },
+    },
+    400: { description: "Bad request", ...jsonError },
+    403: { description: "Forbidden", ...jsonError },
+    404: { description: "Agent not found", ...jsonError },
   },
 });
 
@@ -577,7 +634,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     }
     const body = c.req.valid("json");
     const agent = await prisma.agent.create({
-      data: { name: body.name, slackId: body.slackId ?? null },
+      data: { name: body.name, slackId: body.slackId ?? null, selfHosted: body.selfHosted ?? false },
     });
 
     // Provision the backing workload AFTER the row exists (the provisioner
@@ -585,18 +642,21 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     // roll the agent row back so we never leave a half-created agent with no
     // workload — then surface the failure as a 5xx via onError. The Noop
     // provisioner never throws, preserving today's create behavior exactly.
-    try {
-      await provisioner.provision(agent.id, { slug: agent.name });
-    } catch (err) {
-      await prisma.agent
-        .delete({ where: { id: agent.id } })
-        .catch((cleanupErr) => {
-          console.error(
-            "[agents-api] failed to roll back agent after provision error:",
-            cleanupErr,
-          );
-        });
-      throw err;
+    // Self-hosted agents manage their own workload — skip provisioning.
+    if (!agent.selfHosted) {
+      try {
+        await provisioner.provision(agent.id, { slug: agent.name });
+      } catch (err) {
+        await prisma.agent
+          .delete({ where: { id: agent.id } })
+          .catch((cleanupErr) => {
+            console.error(
+              "[agents-api] failed to roll back agent after provision error:",
+              cleanupErr,
+            );
+          });
+        throw err;
+      }
     }
 
     return c.json(
@@ -604,6 +664,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
         id: agent.id,
         name: agent.name,
         slackId: agent.slackId,
+        selfHosted: agent.selfHosted,
         createdAt: agent.createdAt.toISOString(),
         updatedAt: agent.updatedAt.toISOString(),
       },
@@ -618,8 +679,10 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
         "Only admin bearers and session users can reconcile agents",
       );
     }
-    const agents = await prisma.agent.findMany({ select: { id: true, name: true } });
-    const result = await provisioner.reconcile(agents.map((a) => ({ id: a.id, slug: a.name })));
+    const agents = await prisma.agent.findMany({ select: { id: true, name: true, selfHosted: true } });
+    // Self-hosted agents manage their own workloads — exclude them from K8s reconciliation.
+    const managedAgents = agents.filter((a) => !a.selfHosted);
+    const result = await provisioner.reconcile(managedAgents.map((a) => ({ id: a.id, slug: a.name })));
     return c.json(result, 200);
   });
 
@@ -635,10 +698,14 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
 
     const agent = await prisma.agent.findUnique({
       where: { id: agentId },
-      select: { id: true, name: true },
+      select: { id: true, name: true, selfHosted: true },
     });
     if (!agent) {
       throw new NotFoundError(`agent ${agentId} not found`);
+    }
+
+    if (agent.selfHosted) {
+      return c.json({ skipped: true as const, reason: "self-hosted" }, 200);
     }
 
     const { resourceName, secretName, deploymentName } = await provisioner.provision(
@@ -646,6 +713,64 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       { slug: agent.name },
     );
     return c.json({ resourceName, secretName, deploymentName }, 200);
+  });
+
+  // GET /agents/:id — get full agent record including selfHosted
+  app.openapi(getAgentRoute, async (c) => {
+    if (c.get("isAdmin") !== true) {
+      throw new ForbiddenError("Admin access required to get agent");
+    }
+    const { id: agentId } = c.req.valid("param");
+    const agent = await prisma.agent.findUnique({
+      where: { id: agentId },
+      select: { id: true, name: true, slackId: true, selfHosted: true, createdAt: true, updatedAt: true },
+    });
+    if (!agent) {
+      throw new NotFoundError(`agent ${agentId} not found`);
+    }
+    return c.json(
+      {
+        id: agent.id,
+        name: agent.name,
+        slackId: agent.slackId,
+        selfHosted: agent.selfHosted,
+        createdAt: agent.createdAt.toISOString(),
+        updatedAt: agent.updatedAt.toISOString(),
+      },
+      200,
+    );
+  });
+
+  // PATCH /agents/:id — update agent fields (currently: selfHosted)
+  app.openapi(patchAgentRoute, async (c) => {
+    if (c.get("isAdmin") !== true) {
+      throw new ForbiddenError("Admin access required to update agent");
+    }
+    const { id: agentId } = c.req.valid("param");
+    const body = c.req.valid("json");
+    const existing = await prisma.agent.findUnique({
+      where: { id: agentId },
+      select: { id: true },
+    });
+    if (!existing) {
+      throw new NotFoundError(`agent ${agentId} not found`);
+    }
+    const agent = await prisma.agent.update({
+      where: { id: agentId },
+      data: { selfHosted: body.selfHosted },
+      select: { id: true, name: true, slackId: true, selfHosted: true, createdAt: true, updatedAt: true },
+    });
+    return c.json(
+      {
+        id: agent.id,
+        name: agent.name,
+        slackId: agent.slackId,
+        selfHosted: agent.selfHosted,
+        createdAt: agent.createdAt.toISOString(),
+        updatedAt: agent.updatedAt.toISOString(),
+      },
+      200,
+    );
   });
 
   // DELETE /agents/:id — delete an agent and tear down its workload (admin only)
@@ -676,13 +801,13 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     return c.body(null, 204);
   });
 
-  // GET /agents — list all agents (id + name) for metrics name resolution.
+  // GET /agents — list all agents (id + name + selfHosted) for metrics name resolution.
   app.openapi(listAgentsRoute, async (c) => {
     if (c.get("isAdmin") !== true) {
       throw new ForbiddenError("Admin access required to list agents");
     }
     const agents = await prisma.agent.findMany({
-      select: { id: true, name: true },
+      select: { id: true, name: true, selfHosted: true },
       orderBy: { name: "asc" },
     });
     return c.json(agents, 200);

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -659,17 +659,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       }
     }
 
-    return c.json(
-      {
-        id: agent.id,
-        name: agent.name,
-        slackId: agent.slackId,
-        selfHosted: agent.selfHosted,
-        createdAt: agent.createdAt.toISOString(),
-        updatedAt: agent.updatedAt.toISOString(),
-      },
-      201,
-    );
+    return c.json(serializeAgent(agent), 201);
   });
 
   // POST /agents/reconcile — reconcile K8s Deployment state against the DB (admin only)
@@ -728,17 +718,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     if (!agent) {
       throw new NotFoundError(`agent ${agentId} not found`);
     }
-    return c.json(
-      {
-        id: agent.id,
-        name: agent.name,
-        slackId: agent.slackId,
-        selfHosted: agent.selfHosted,
-        createdAt: agent.createdAt.toISOString(),
-        updatedAt: agent.updatedAt.toISOString(),
-      },
-      200,
-    );
+    return c.json(serializeAgent(agent), 200);
   });
 
   // PATCH /agents/:id — update agent fields (currently: selfHosted)
@@ -760,17 +740,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       data: { selfHosted: body.selfHosted },
       select: { id: true, name: true, slackId: true, selfHosted: true, createdAt: true, updatedAt: true },
     });
-    return c.json(
-      {
-        id: agent.id,
-        name: agent.name,
-        slackId: agent.slackId,
-        selfHosted: agent.selfHosted,
-        createdAt: agent.createdAt.toISOString(),
-        updatedAt: agent.updatedAt.toISOString(),
-      },
-      200,
-    );
+    return c.json(serializeAgent(agent), 200);
   });
 
   // DELETE /agents/:id — delete an agent and tear down its workload (admin only)
@@ -1104,4 +1074,22 @@ function serializePlugin(plugin: {
     createdAt: plugin.createdAt.toISOString(),
     updatedAt: plugin.updatedAt.toISOString(),
   } as z.infer<typeof AgentPluginSchema>;
+}
+
+function serializeAgent(agent: {
+  id: string;
+  name: string;
+  slackId: string | null | undefined;
+  selfHosted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}): z.infer<typeof GetAgentResultSchema> {
+  return {
+    id: agent.id,
+    name: agent.name,
+    slackId: agent.slackId,
+    selfHosted: agent.selfHosted,
+    createdAt: agent.createdAt.toISOString(),
+    updatedAt: agent.updatedAt.toISOString(),
+  };
 }

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -39,6 +39,7 @@ export const AgentSchema = z
       .nullable()
       .optional()
       .openapi({ example: "U0AALR8M69X" }),
+    selfHosted: z.boolean().openapi({ example: false }),
     createdAt: z
       .string()
       .datetime()
@@ -57,6 +58,7 @@ export const AgentSummarySchema = z
   .object({
     id: z.string().openapi({ example: "clx1234567890" }),
     name: z.string().openapi({ example: "Bodhi" }),
+    selfHosted: z.boolean().openapi({ example: false }),
   })
   .openapi("AgentSummary");
 
@@ -64,8 +66,15 @@ export const CreateAgentBodySchema = z
   .object({
     name: z.string().min(1).openapi({ example: "Bodhi" }),
     slackId: z.string().optional().openapi({ example: "U0AALR8M69X" }),
+    selfHosted: z.boolean().optional().openapi({ example: false }),
   })
   .openapi("CreateAgentBody");
+
+export const PatchAgentBodySchema = z
+  .object({
+    selfHosted: z.boolean().optional().openapi({ example: false }),
+  })
+  .openapi("PatchAgentBody");
 
 // ─── AgentCronJob ─────────────────────────────────────────────────────────────
 

--- a/admin/src/openapi-schemas.unit.test.ts
+++ b/admin/src/openapi-schemas.unit.test.ts
@@ -27,6 +27,7 @@ const validAgent = {
   id: "cuid1",
   name: "Bodhi",
   slackId: "U01234567",
+  selfHosted: false,
   createdAt: now,
   updatedAt: now,
 };

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -48,10 +48,10 @@ Mounted at `/agents/*` (unified with the runtime API surface). Auth: **admin key
 
 | Resource | Endpoints |
 |---|---|
-| Agents | `POST /agents` (admin-only: creates agent, returns `{id, name, slackId, createdAt}` with `201`) |
+| Agents | `POST /agents` (admin-only: creates agent, returns `{id, name, slackId, selfHosted, createdAt, updatedAt}` with `201`), `GET /agents/:id` (admin-only: fetches agent record), `GET /agents` (admin-only: lists agents), `PATCH /agents/:id` (admin-only: updates agent fields like `selfHosted`), `POST /agents/:id/provision` (admin-only: provisions a managed agent or returns `{skipped: true, reason: "self-hosted"}` for self-hosted agents) |
 | Envs | `POST` / `GET` / `PATCH` `/agents/:id/envs`, `DELETE /agents/:id/envs/:key` |
 | Crons | `POST` `/agents/:id/crons`, `PATCH` / `DELETE` `/agents/:id/crons/:cronId`, `POST /agents/:id/crons/reconcile` |
-| Reconciliation | `POST /agents/reconcile` (admin-only: reconciles K8s Deployments against all known agents; returns `{recreated: string[], updated: string[], orphans: string[], failed: Array<{agentId, error}>}`) |
+| Reconciliation | `POST /agents/reconcile` (admin-only: reconciles K8s Deployments against all managed (non-self-hosted) agents; returns `{recreated: string[], updated: string[], orphans: string[], failed: Array<{agentId, error}>}`) |
 | Tools | `POST` / `GET` `/agents/:id/tools`, `PATCH` / `DELETE` `/agents/:id/tools/:toolId` |
 | Tokens | `POST` / `GET` `/agents/:id/tokens`, `DELETE /agents/:id/tokens/:tokenId` |
 | Plugins | `POST` / `GET` / `PATCH` `/agents/:id/plugins`, `DELETE /agents/:id/plugins` |
@@ -84,7 +84,7 @@ Each REPL session generates a single `session` UUID so successive messages resum
 
 | Model | Owns | Notable fields |
 |---|---|---|
-| `Agent` | The runner identity | `name`, `slackId` (unique), `slackBotToken` / `anthropicApiKey` (AES-256-GCM encrypted). |
+| `Agent` | The runner identity | `name`, `slackId` (unique), `selfHosted` (boolean; when true, agent manages its own workload and skips K8s provisioning), `slackBotToken` / `anthropicApiKey` (AES-256-GCM encrypted). |
 | `AgentEnv` | Key/value env store | `key`, `value` (encrypted); unique per `[agentId, key]`. |
 | `AgentCronJob` | Scheduled prompts | `schedule` (cron expr), `prompt`, `channel` **xor** `user`, `silent`, `enabled`, `preCheck`, `name`/`system` (system-cron key). |
 | `AgentTool` | Allowed tool patterns | `pattern` (e.g. `Read`, `Bash`), `enabled`; unique per `[agentId, pattern]`. |

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -304,7 +304,7 @@ Setting `agent.provisioning.enabled=true` switches the admin service to the
 - `POST /agents` creates a per-agent **PersistentVolumeClaim** (for persistent
   agent home storage), mints a scoped per-agent token, creates a per-agent
   **Secret** (carrying the token), and a per-agent **Deployment** (referencing
-  both), in that order. All operations are idempotent and safe to retry.
+  both), in that order. All operations are idempotent and safe to retry. **Exception:** if the agent is marked `selfHosted: true`, provisioning is skipped — the agent is expected to manage its own workload.
 - `DELETE /agents/:id` deletes the agent's Deployment then its Secret,
   tolerating already-absent resources. The **PVC is intentionally left behind**
   (data safety policy) — cluster admins may clean it up manually once its data


### PR DESCRIPTION
## Summary
- Add `selfHosted` boolean field to the `Agent` model (Prisma schema + migration)
- Expose `selfHosted` across all agent CRUD endpoints: `POST /agents`, `GET /agents`, new `GET /agents/:id`, new `PATCH /agents/:id`
- Gate K8s provisioning on `selfHosted`: `POST /agents/reconcile` excludes self-hosted agents; `POST /agents/:id/provision` returns `{ skipped: true, reason: "self-hosted" }` for self-hosted agents

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `POST /agents` with `{ selfHosted: true }` stores and returns the flag | MET |
| 2 | `GET /agents` includes `selfHosted` for every agent | MET |
| 3 | New `GET /agents/:id` returns full record including `selfHosted` | MET |
| 4 | New `PATCH /agents/:id` updates `selfHosted` and returns updated record | MET |
| 5 | `POST /agents/reconcile` excludes self-hosted agents; response includes `updated` | MET |
| 6 | `POST /agents/:id/provision` returns `200 { skipped: true, reason: "self-hosted" }` | MET |
| 7 | Smoke tests added for all scenarios; old reconcile test updated to assert `updated` | MET |

## Test Plan
- 9 new smoke tests covering all new routes and behaviors
- `openapi-schemas.unit.test.ts` fixture updated with `selfHosted` field
- Full suite: 2625 pass, 0 fail (2735 tests total including 110 skipped integration/e2e)
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — all 5 packages clean

Generated with [Claude Code](https://claude.com/claude-code)
