### PR TITLE
feat(check-strings): add bare vitals-os/VITALS_OS patterns and exclude planning dir

### DIFF
--- a/agent/src/config.unit.test.ts
+++ b/agent/src/config.unit.test.ts
@@ -3,7 +3,7 @@
  *
  * Strategy: call createConfig(agentHome) factory directly with a temp dir.
  * No mock.module() needed — the factory reads env vars at call time.
- * Uses SHIPWRIGHT_* env vars (not VITALS_OS_*).
+ * Uses SHIPWRIGHT_* env vars only.
  */
 
 import { afterAll, describe, expect, test } from "bun:test";

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -14,7 +14,7 @@ independent of `appVersion`. CI enforces this with
 
 ### Changed
 
-- Add bare `vitals-os/VITALS_OS` banned patterns and exclude planning dir from check-strings
+- Add bare platform-name banned-string patterns and exclude planning dir from check-strings
 
 ## [1.6.20] - 2026-06-24
 

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.19] - 2026-06-24
+
+### Changed
+
+- Scrubbed remaining internal platform references from CHANGELOG
+
 ## [1.6.18] - 2026-06-24
 
 ### Changed

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -66,8 +66,8 @@ independent of `appVersion`. CI enforces this with
 
 ### Removed
 
-- Deleted `ci/vitals-os-values.yaml` (internal CI install-test profile; no longer ships).
-- Scrubbed all internal `vitals-os` references from chart templates, tests, CHANGELOG, and docs; replaced with generic placeholders.
+- Deleted internal CI install-test config (no longer ships).
+- Scrubbed all internal platform references from chart templates, tests, CHANGELOG, and docs; replaced with generic placeholders.
 
 ## [1.6.8] - 2026-06-23
 

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "Add bare vitals-os/VITALS_OS banned patterns and exclude planning dir from check-strings"
+      description: "Add bare platform-name banned-string patterns and exclude planning dir from check-strings"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.18
+version: 1.6.19
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.18 triggered by release tag admin-v0.83.1"
+      description: "Scrubbed remaining internal platform references from CHANGELOG"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/metrics/src/api.auth-gate.integration.test.ts
+++ b/metrics/src/api.auth-gate.integration.test.ts
@@ -350,7 +350,7 @@ describe("dashboard HTML — no dead nav links", () => {
     expect(html.toLowerCase()).not.toContain("/time");
   });
 
-  test("rendered HTML has no vitals-os platform links (/cal, /time, /billing)", async () => {
+  test("rendered HTML has no platform-specific links (/cal, /time, /billing)", async () => {
     const cookie = await makeSessionCookie();
     const deps: MetricsDeps = {
       sessionSecret: TEST_SESSION_SECRET,

--- a/plugins/shipwright/scripts/check-banned-strings.ts
+++ b/plugins/shipwright/scripts/check-banned-strings.ts
@@ -43,6 +43,8 @@ const BANNED_PATTERNS: string[] = [
   "vitals-os-" + "prod",
   "vitals-os-" + "staging",
   "vitals-os-" + "dev",
+  "vitals-" + "os",
+  "VITALS_" + "OS",
 ];
 
 /**
@@ -69,6 +71,7 @@ const EXCLUDED_DIRS: Set<string> = new Set([
   "build",
   "coverage",
   ".turbo",
+  "planning",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -137,15 +140,26 @@ function scanFile(root: string, filePath: string, hits: Hit[]): void {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    // Collect all matching patterns for this line, then report only the longest
+    // (most specific) match to avoid double-counting when a pattern is a substring
+    // of another (e.g., "vitals-os" is a substring of "vitals-os-prod").
+    const matchedPatterns: string[] = [];
     for (const pattern of BANNED_PATTERNS) {
       if (line.includes(pattern)) {
-        hits.push({
-          file: relPath,
-          lineNum: i + 1,
-          line,
-          pattern,
-        });
+        matchedPatterns.push(pattern);
       }
+    }
+    // Report the longest pattern (most specific)
+    if (matchedPatterns.length > 0) {
+      const longestPattern = matchedPatterns.reduce((a, b) =>
+        a.length > b.length ? a : b,
+      );
+      hits.push({
+        file: relPath,
+        lineNum: i + 1,
+        line,
+        pattern: longestPattern,
+      });
     }
   }
 }

--- a/plugins/shipwright/scripts/check-banned-strings.unit.test.ts
+++ b/plugins/shipwright/scripts/check-banned-strings.unit.test.ts
@@ -292,4 +292,16 @@ describe("scanForBannedStrings", () => {
     const hits = scanForBannedStrings(tmpDir);
     expect(hits).toEqual([]);
   });
+
+  test("dedup invariant: a line matching both 'vitals-os' and 'vitals-os-prod' reports exactly 1 hit with the longer pattern", () => {
+    // Use string concat so this test file is not itself flagged by the scanner.
+    writeFile(
+      tmpDir,
+      "config.ts",
+      "const env = 'vitals-os-" + "prod';\n",
+    );
+    const hits = scanForBannedStrings(tmpDir);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].pattern).toBe("vitals-os-" + "prod");
+  });
 });

--- a/plugins/shipwright/scripts/check-banned-strings.unit.test.ts
+++ b/plugins/shipwright/scripts/check-banned-strings.unit.test.ts
@@ -263,4 +263,33 @@ describe("scanForBannedStrings", () => {
       "vitals-os-prod",
     ]);
   });
+
+  test("detects bare 'vitals-os' in a file", () => {
+    writeFile(tmpDir, "config.ts", "const platform = 'vitals-os';\n");
+    const hits = scanForBannedStrings(tmpDir);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].pattern).toBe("vitals-os");
+    expect(hits[0].lineNum).toBe(1);
+    expect(hits[0].line).toContain("vitals-os");
+  });
+
+  test("detects 'VITALS_OS' in a file", () => {
+    writeFile(tmpDir, "env.ts", "const env = process.env.VITALS_OS;\n");
+    const hits = scanForBannedStrings(tmpDir);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].pattern).toBe("VITALS_OS");
+    expect(hits[0].lineNum).toBe(1);
+    expect(hits[0].line).toContain("VITALS_OS");
+  });
+
+  test("skips planning/ directory", () => {
+    mkdirSync(join(tmpDir, "planning"), { recursive: true });
+    writeFile(
+      tmpDir,
+      "planning/notes.md",
+      "We need to migrate off vitals-os completely.\n",
+    );
+    const hits = scanForBannedStrings(tmpDir);
+    expect(hits).toEqual([]);
+  });
 });

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -314,8 +314,8 @@ Possible reasons:
 1. The preCheck script returned non-zero — the cron was suppressed before Claude ran.
    Check logs/bodhi.log for "[preCheck]" lines around <time>.
 2. The cron was disabled at the time. Verify via:
-      curl -s -H "Authorization: Bearer $VITALS_OS_API_KEY" \
-        "$VITALS_OS_API_URL/accounts/agents/$VITALS_OS_AGENT_USER_ID/crons" | jq '.[] | select(.name | test("<name>"))'
+      curl -s -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+        "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons" | jq '.[] | select(.name | test("<name>"))'
 3. The cron fired in a different workspace — check if $AGENT_HOME differs.
 4. The ±90 minute search window was too narrow. Try a broader time range.
 ```


### PR DESCRIPTION
## Summary
- Add bare `vitals-os` and `VITALS_OS` to `BANNED_PATTERNS` — the existing patterns only caught qualified forms (`vitals-os-prod/staging/dev`, `app-vitals/vitals-os`); bare references slipped through
- Add `planning` to `EXCLUDED_DIRS` so local gitignored planning docs don't trip the scanner
- Add deduplication logic: when multiple patterns match a single line, report only the longest (most specific) match, preventing double-counts as `vitals-os` subsumes all `vitals-os-*` variants

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | BANNED_PATTERNS includes bare 'vitals-os' and 'VITALS_OS'; EXCLUDED_DIRS includes 'planning' | ✅ MET |
| 2 | task check-strings passes clean across the repo (scanner + test self-excluded by design) | ✅ MET |
| 3 | grep -rIn 'vitals-os' returns hits ONLY in check-banned-strings.ts and its test file | ✅ MET |
| 4 | Unit tests extended: bare 'vitals-os'/'VITALS_OS' flagged; scanner/test files excluded; no tests retired | ✅ MET |

## Test Plan
- [x] 24 unit tests passing (`bun test plugins/shipwright/scripts/check-banned-strings.unit.test.ts`)
- [x] 3 new tests: detects bare 'vitals-os', detects 'VITALS_OS', skips planning/ directory
- [x] All existing tests remain passing (deduplication logic preserves existing test expectations)
- [x] Biome lint clean

Generated with [Claude Code](https://claude.com/claude-code)
