### PR TITLE
fix(agent): pass env: process.env to cron preCheck spawn

### DIFF
--- a/agent/src/cron-handler.integration.test.ts
+++ b/agent/src/cron-handler.integration.test.ts
@@ -570,6 +570,39 @@ describe("handleCronRequest — preCheck", () => {
     expect(runArg).toContain("precheck prompt");
   });
 
+  test("preCheck inherits runtime process.env mutations (env: process.env passthrough)", async () => {
+    // config-sync mutates process.env at runtime (Object.assign every 60s). The
+    // preCheck child must see those mutations, not a Bun-startup snapshot —
+    // regression for a rotated SHIPWRIGHT_TASK_STORE_TOKEN causing 401s until
+    // the pod restarted. The probe key is absent from the process's boot env, so
+    // without env: process.env the child reads "MISSING".
+    const key = "CRON_PRECHECK_ENV_PROBE";
+    process.env[key] = "runtime-value";
+    try {
+      const script = join(tmpDir, "check.ts");
+      writeFileSync(
+        script,
+        `console.log(process.env.${key} ?? "MISSING"); process.exit(0);`,
+      );
+
+      await handleCronRequest(
+        {
+          jobId: "j1",
+          prompt: "original",
+          channel: "C-TEST",
+          preCheck: script,
+        },
+        deps,
+      );
+
+      expect(mockRunner).toHaveBeenCalledTimes(1);
+      const runArg = (mockRunner.mock.calls as unknown as string[][])[0][0];
+      expect(runArg).toContain("runtime-value");
+    } finally {
+      delete process.env[key];
+    }
+  });
+
   test("runs preCheck with cwd = workspace (resolves state relative to workspace)", async () => {
     // Mirrors check-dev-task.ts → JsonTaskStore(process.cwd()) reading
     // `state/todos.json`. The file lives in the workspace; the preCheck must run

--- a/agent/src/cron-handler.ts
+++ b/agent/src/cron-handler.ts
@@ -149,6 +149,13 @@ export async function handleCronRequest(
     // run, which is already rooted at the workspace.
     const checkProc = Bun.spawn(["bun", scriptPath], {
       ...(workspace ? { cwd: workspace } : {}),
+      // env: process.env is required — Bun.spawn otherwise snapshots env at Bun
+      // startup and misses runtime mutations from config-sync (index.ts does
+      // Object.assign(process.env, bundle.env) every 60s). Without this, a
+      // preCheck reads boot-time credentials — e.g. a rotated
+      // SHIPWRIGHT_TASK_STORE_TOKEN — and fails (401) until the pod restarts.
+      // Mirrors setup.ts defaultExec, which documents the same gotcha.
+      env: process.env,
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## Problem

Warchild's `shipwright-dev-task` cron fired on schedule but its preCheck crashed every tick:

```
[agent:cron] preCheck for job "…" crashed (exit 2):
  error: task-store GET /tasks?status=in_progress → 401 — session suppressed
```

So the dev-task session never ran — even though interactive `/shipwright:dev-task` worked fine.

## Root cause

`cron-handler.ts` spawned the preCheck without an explicit `env`:

```ts
const checkProc = Bun.spawn(["bun", scriptPath], {
  ...(workspace ? { cwd: workspace } : {}),
  stdout: "pipe", stderr: "pipe",
});
```

**Bun snapshots the environment at process startup for spawns that omit `env`** — runtime `process.env` mutations are invisible to the child. config-sync applies the agent's dynamic env via `Object.assign(process.env, bundle.env)` every 60s (`index.ts`), so after a per-agent `SHIPWRIGHT_TASK_STORE_TOKEN` rotation:

- config-sync updated `process.env` (prod log: `[config-sync] updated: SHIPWRIGHT_TASK_STORE_TOKEN` at 08:06),
- but the preCheck child kept reading the **boot-time** token (seeded at 07:36) → 401 on every tick until the pod restarted.

The cron **job** runner was unaffected — it already passes `env: process.env`. And `setup.ts` `defaultExec` already documents this exact gotcha:

```ts
// env: process.env is required — Bun.spawn otherwise snapshots env at Bun
// startup and misses runtime mutations (MISE_CACHE_DIR, etc.).
```

The preCheck spawn just missed it.

Empirically confirmed on Bun 1.3.11:
```
no-env  child sees: <undefined>          # Bun.spawn without env
env=process.env child sees: new-value    # Bun.spawn with env: process.env
```

## Fix

Pass `env: process.env` to the preCheck spawn. config-sync updates now reach preChecks without a pod restart.

## Test

Adds a regression test: a preCheck that echoes a `process.env` key set at runtime (absent from the test process's boot env). It reads `MISSING` (boot snapshot) and **fails without the fix**; reads the runtime value and passes with it. Verified by reverting the source change — the test fails as expected.

## Notes

- Prod stopgap already applied: the affected agent was restarted so its boot env re-seeded the rotated token. This PR removes the need for that going forward.
- Follow-up worth considering: a shared `spawnInheritingEnv` helper so `env: process.env` can't be forgotten again (this is the 2nd site to hit it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)