### PR TITLE
docs: clarify agent token scoping applies to all task-store endpoints

### DIFF
--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -31,6 +31,8 @@ Both env vars are provisioned automatically by the agent harness:
 | `SHIPWRIGHT_TASK_STORE_URL` | Base URL of the task store service |
 | `SHIPWRIGHT_TASK_STORE_TOKEN` | Bearer token for this agent |
 
+The bearer token scopes all API operations to the calling agent's own tasks automatically — the same token that authenticates you also filters results. No `?assignee=` parameter is needed on any endpoint.
+
 Verify the service is reachable before doing anything:
 
 ```bash
@@ -176,6 +178,8 @@ Branch statuses: `blocked`, `cancelled`, `deploying`, `deployed`
 | `POST` | `/tasks/:id/release` | Unclaim → `pending` |
 | `POST` | `/tasks/:id/complete` | Mark `done` |
 | `POST` | `/tasks/:id/fail` | Mark `blocked` |
+
+> **Scoping:** All endpoints automatically scope to the calling agent's tasks via the bearer token. Admin tokens see all agents' tasks.
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarifies that agent bearer token scoping applies to **all** task-store API endpoints, not just `?ready=true`
- Adds a scoping note in the Authentication section so the contract is visible at first read
- Adds a scoping callout in the Full API reference table for quick reference

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Authentication section explains bearer token scopes all API operations | ✅ MET |
| 2 | `?ready=true` semantics section keeps per-token explanation | ✅ MET |
| 3 | Full API reference table has scoping note | ✅ MET |
| 4 | Existing examples and commands unchanged | ✅ MET |

## Test Plan
- [x] Docs-only change — no code modified
- [x] Diff reviewed: additions only, no existing content removed

Generated with [Claude Code](https://claude.com/claude-code)
