### PR TITLE
feat(task-store): state filter, pagination, and status dropdown fix

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -894,7 +894,7 @@ export function renderTasksPage(
     limit: 50,
     page: 1,
   },
-  opts?: { error?: string },
+  opts?: { error?: string; agentFilterActive?: boolean },
 ): string {
   const errorHtml = opts?.error
     ? `<div class="alert alert-error">${escapeHtml(opts.error)}</div>`
@@ -902,6 +902,10 @@ export function renderTasksPage(
 
   const degradedHtml = degraded
     ? `<div class="alert alert-warning">Task store unavailable — data shown may be stale or empty.</div>`
+    : "";
+
+  const agentFilterHtml = opts?.agentFilterActive
+    ? `<div class="alert alert-warning">Showing up to 500 results — agent name filter is applied client-side and may not reflect all matching tasks.</div>`
     : "";
 
   const statusBadgeClass = (s: string) => {
@@ -1033,6 +1037,7 @@ export function renderTasksPage(
     </div>
     ${errorHtml}
     ${degradedHtml}
+    ${agentFilterHtml}
     <div class="card" style="margin-bottom:16px">
       <form method="GET" action="/admin/tasks" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
         ${filters.state && !filters.status ? `<input type="hidden" name="state" value="${escapeHtml(filters.state)}" />` : ""}

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -879,10 +879,21 @@ export function renderProvisionPasteForm(
 
 export function renderTasksPage(
   tasks: TaskItem[],
-  filters: { status?: string; session?: string; repo?: string; agent?: string },
+  filters: {
+    status?: string;
+    state?: "open" | "closed";
+    session?: string;
+    repo?: string;
+    agent?: string;
+  },
   degraded: boolean,
   userName: string,
   agentNames: Record<string, string> = {},
+  pagination: { total: number; limit: number; page: number } = {
+    total: 0,
+    limit: 50,
+    page: 1,
+  },
   opts?: { error?: string },
 ): string {
   const errorHtml = opts?.error
@@ -892,6 +903,15 @@ export function renderTasksPage(
   const degradedHtml = degraded
     ? `<div class="alert alert-warning">Task store unavailable — data shown may be stale or empty.</div>`
     : "";
+
+  const statusBadgeClass = (s: string) => {
+    if (s === "in_progress" || s === "pr_open" || s === "approved")
+      return "badge-blue";
+    if (s === "done" || s === "deployed" || s === "merged")
+      return "badge-green";
+    if (s === "blocked" || s === "cancelled") return "badge-red";
+    return "badge-gray";
+  };
 
   const rows =
     tasks.length === 0
@@ -905,7 +925,7 @@ export function renderTasksPage(
             return `<tr>
     <td class="mono" style="font-size:11px"><a href="/admin/tasks/${escapeHtml(t.id)}" style="color:#6366f1;text-decoration:none" title="View details">${escapeHtml(t.id)}</a></td>
     <td><a href="/admin/tasks/${escapeHtml(t.id)}" style="color:inherit;text-decoration:none">${escapeHtml(t.title)}</a></td>
-    <td><span class="badge ${t.status === "in_progress" ? "badge-blue" : t.status === "done" ? "badge-green" : "badge-gray"}">${escapeHtml(t.status)}</span></td>
+    <td><span class="badge ${statusBadgeClass(t.status)}">${escapeHtml(t.status)}</span></td>
     <td style="font-size:12px">${agentCell}</td>
     <td class="mono" style="font-size:11px">${t.session ? escapeHtml(t.session) : '<span style="color:#9ca3af">—</span>'}</td>
     <td class="mono" style="font-size:11px">${t.repo ? escapeHtml(t.repo) : '<span style="color:#9ca3af">—</span>'}</td>
@@ -920,21 +940,76 @@ export function renderTasksPage(
           })
           .join("\n");
 
+  // State toggle params (preserve other filters, reset page)
+  const makeStateParams = (newState: string) => {
+    const p = new URLSearchParams();
+    if (newState !== "open") p.set("state", newState);
+    if (filters.session) p.set("session", filters.session);
+    if (filters.repo) p.set("repo", filters.repo);
+    if (filters.agent) p.set("agent", filters.agent);
+    const qs = p.toString();
+    return qs ? `?${qs}` : "";
+  };
+
+  const activeState = filters.state ?? "open";
+  const stateToggle = `
+    <div style="display:flex;gap:0;border:1px solid #e5e7eb;border-radius:6px;overflow:hidden;width:fit-content">
+      <a href="/admin/tasks${makeStateParams("open")}"
+         style="padding:5px 14px;font-size:12px;text-decoration:none;${activeState === "open" ? "background:#6366f1;color:#fff;font-weight:600" : "background:#fff;color:#374151"}">Open</a>
+      <a href="/admin/tasks${makeStateParams("closed")}"
+         style="padding:5px 14px;font-size:12px;text-decoration:none;border-left:1px solid #e5e7eb;${activeState === "closed" ? "background:#6366f1;color:#fff;font-weight:600" : "background:#fff;color:#374151"}">Closed</a>
+    </div>`;
+
   const statusOptions = [
     "",
     "pending",
     "in_progress",
     "pr_open",
     "approved",
+    "merged",
     "done",
+    "deploying",
+    "deployed",
     "blocked",
     "cancelled",
   ]
     .map(
       (s) =>
-        `<option value="${escapeHtml(s)}" ${filters.status === s ? "selected" : ""}>${s === "" ? "All statuses" : escapeHtml(s)}</option>`,
+        `<option value="${escapeHtml(s)}" ${filters.status === s ? "selected" : ""}>${s === "" ? "Any status" : escapeHtml(s)}</option>`,
     )
     .join("");
+
+  // Pagination
+  const totalPages = Math.max(
+    1,
+    Math.ceil(pagination.total / pagination.limit),
+  );
+  const page = pagination.page;
+  const makePageUrl = (p: number) => {
+    const params = new URLSearchParams();
+    if (filters.status) params.set("status", filters.status);
+    else if (filters.state && filters.state !== "open")
+      params.set("state", filters.state);
+    if (filters.session) params.set("session", filters.session);
+    if (filters.repo) params.set("repo", filters.repo);
+    if (filters.agent) params.set("agent", filters.agent);
+    if (p > 1) params.set("page", String(p));
+    const qs = params.toString();
+    return `/admin/tasks${qs ? `?${qs}` : ""}`;
+  };
+
+  const from = pagination.total === 0 ? 0 : (page - 1) * pagination.limit + 1;
+  const to = Math.min(page * pagination.limit, pagination.total);
+  const paginationHtml =
+    pagination.total === 0
+      ? ""
+      : `<div style="display:flex;justify-content:space-between;align-items:center;padding:12px 0 0;font-size:12px;color:#6b7280">
+      <span>${from}–${to} of ${pagination.total}</span>
+      <div style="display:flex;gap:4px">
+        ${page > 1 ? `<a href="${makePageUrl(page - 1)}" class="btn btn-secondary" style="font-size:11px;padding:3px 10px">← Prev</a>` : ""}
+        ${page < totalPages ? `<a href="${makePageUrl(page + 1)}" class="btn btn-secondary" style="font-size:11px;padding:3px 10px">Next →</a>` : ""}
+      </div>
+    </div>`;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -944,19 +1019,23 @@ export function renderTasksPage(
   <title>Tasks — Shipwright Admin</title>
   <style>${baseStyles()}
     .badge-blue { background:#dbeafe;color:#1d4ed8;border:1px solid #bfdbfe; }
+    .badge-green { background:#dcfce7;color:#166534;border:1px solid #bbf7d0; }
+    .badge-red { background:#fee2e2;color:#991b1b;border:1px solid #fecaca; }
     .alert-warning { background:#fefce8;color:#854d0e;border:1px solid #fde047;border-radius:6px;padding:10px 14px;margin-bottom:16px;font-size:13px; }
   </style>
 </head>
 <body>
   ${renderAdminToolbar(userName, "/admin/tasks")}
   <div class="vos-page">
-    <div class="page-header">
-      <h1 class="page-title">Tasks</h1>
+    <div class="page-header" style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+      <h1 class="page-title" style="margin:0">Tasks</h1>
+      ${stateToggle}
     </div>
     ${errorHtml}
     ${degradedHtml}
     <div class="card" style="margin-bottom:16px">
       <form method="GET" action="/admin/tasks" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
+        ${filters.state && !filters.status ? `<input type="hidden" name="state" value="${escapeHtml(filters.state)}" />` : ""}
         <div class="form-group" style="margin-bottom:0">
           <label class="form-label" style="font-size:11px">Status</label>
           <select name="status" class="form-input" style="font-size:12px;padding:4px 8px">${statusOptions}</select>
@@ -993,6 +1072,7 @@ export function renderTasksPage(
           ${rows}
         </tbody>
       </table>
+      ${paginationHtml}
     </div>
   </div>
 </body>

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -2084,7 +2084,12 @@ describe("admin UI — tasks page", () => {
     ];
     const app = createAdminUIApp(
       makeMockDeps({
-        fetchTaskStoreTasks: async () => mockTasks,
+        fetchTaskStoreTasks: async () => ({
+          tasks: mockTasks,
+          total: mockTasks.length,
+          limit: 50,
+          offset: 0,
+        }),
       }),
     );
     const res = await app.request("/admin/tasks", {
@@ -2141,7 +2146,12 @@ describe("admin UI — tasks page", () => {
     ];
     const app = createAdminUIApp(
       makeMockDeps({
-        fetchTaskStoreTasks: async () => mockTasks,
+        fetchTaskStoreTasks: async () => ({
+          tasks: mockTasks,
+          total: mockTasks.length,
+          limit: 50,
+          offset: 0,
+        }),
       }),
     );
     const res = await app.request("/admin/tasks", {
@@ -2176,7 +2186,14 @@ describe("admin UI — tasks page", () => {
       },
     ];
     const app = createAdminUIApp(
-      makeMockDeps({ fetchTaskStoreTasks: async () => mockTasks }),
+      makeMockDeps({
+        fetchTaskStoreTasks: async () => ({
+          tasks: mockTasks,
+          total: mockTasks.length,
+          limit: 50,
+          offset: 0,
+        }),
+      }),
     );
     const res = await app.request("/admin/tasks?agent=test", {
       headers: { Cookie: `admin_session=${cookie}` },
@@ -2191,7 +2208,12 @@ describe("admin UI — tasks page", () => {
     const released: string[] = [];
     const app = createAdminUIApp(
       makeMockDeps({
-        fetchTaskStoreTasks: async () => [],
+        fetchTaskStoreTasks: async () => ({
+          tasks: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        }),
         fetchTaskStoreTask: async () => null,
         releaseTask: async (id: string) => {
           released.push(id);
@@ -2211,7 +2233,12 @@ describe("admin UI — tasks page", () => {
     const released: string[] = [];
     const app = createAdminUIApp(
       makeMockDeps({
-        fetchTaskStoreTasks: async () => [],
+        fetchTaskStoreTasks: async () => ({
+          tasks: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        }),
         releaseTask: async (id: string) => {
           released.push(id);
         },
@@ -2229,7 +2256,12 @@ describe("admin UI — tasks page", () => {
   it("POST /admin/tasks/:id/release redirects with ?error=release_failed when releaseTask throws", async () => {
     const app = createAdminUIApp(
       makeMockDeps({
-        fetchTaskStoreTasks: async () => [],
+        fetchTaskStoreTasks: async () => ({
+          tasks: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        }),
         releaseTask: async () => {
           throw new Error("task store unavailable");
         },

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1543,7 +1543,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         c.var.userEmail,
         agentNames,
         { total, limit, page },
-        error ? { error } : undefined,
+        { ...(error ? { error } : {}), agentFilterActive: agentFilterIds !== null },
       ),
     );
   });

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -187,7 +187,12 @@ export interface AdminUIDeps {
    * Fetch tasks from the task-store service. If absent, the tasks page renders
    * in degraded mode (empty table + yellow notice) rather than returning 500.
    */
-  fetchTaskStoreTasks?: (params: URLSearchParams) => Promise<TaskItem[]>;
+  fetchTaskStoreTasks?: (params: URLSearchParams) => Promise<{
+    tasks: TaskItem[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>;
   /**
    * Fetch a single task by ID from the task-store service. If absent, the
    * detail route redirects back to the list.
@@ -1452,10 +1457,22 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
   app.get("/admin/tasks", requireAuth, async (c) => {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
     const status = c.req.query("status") ?? undefined;
+    const stateRaw = c.req.query("state");
+    // Default to "open" when neither state nor status is provided.
+    const state: "open" | "closed" | undefined =
+      stateRaw === "open" || stateRaw === "closed"
+        ? stateRaw
+        : status
+          ? undefined
+          : "open";
     const session = c.req.query("session") ?? undefined;
     const repo = c.req.query("repo") ?? undefined;
     const agent = c.req.query("agent") ?? undefined;
     const error = c.req.query("error") ?? undefined;
+    const pageRaw = c.req.query("page");
+    const page = pageRaw ? Math.max(1, Number.parseInt(pageRaw, 10)) : 1;
+    const limit = 50;
+    const offset = (page - 1) * limit;
 
     // When filtering by agent name, resolve matching IDs upfront so we can
     // filter tasks client-side (task store only supports a single assignee ID).
@@ -1468,6 +1485,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }
 
     let tasks: TaskItem[] = [];
+    let total = 0;
     let degraded = false;
 
     if (!fetchTaskStoreTasks) {
@@ -1475,10 +1493,17 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     } else {
       const params = new URLSearchParams();
       if (status) params.set("status", status);
+      if (state) params.set("state", state);
       if (session) params.set("session", session);
       if (repo) params.set("repo", repo);
+      // Agent-name filtering is done client-side, so we fetch a larger slice
+      // when an agent filter is active to avoid under-counting across pages.
+      params.set("limit", agentFilterIds !== null ? "500" : String(limit));
+      params.set("offset", agentFilterIds !== null ? "0" : String(offset));
       try {
-        tasks = await fetchTaskStoreTasks(params);
+        const result = await fetchTaskStoreTasks(params);
+        tasks = result.tasks;
+        total = result.total;
       } catch {
         degraded = true;
       }
@@ -1491,6 +1516,8 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
           (t.assignee && ids.has(t.assignee)) ||
           (t.claimedBy && ids.has(t.claimedBy)),
       );
+      total = tasks.length;
+      tasks = tasks.slice(offset, offset + limit);
     }
 
     const agentIds = [
@@ -1511,10 +1538,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     return html(
       renderTasksPage(
         tasks,
-        { status, session, repo, agent },
+        { status, state, session, repo, agent },
         degraded,
         c.var.userEmail,
         agentNames,
+        { total, limit, page },
         error ? { error } : undefined,
       ),
     );

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1470,7 +1470,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     const agent = c.req.query("agent") ?? undefined;
     const error = c.req.query("error") ?? undefined;
     const pageRaw = c.req.query("page");
-    const page = pageRaw ? Math.max(1, Number.parseInt(pageRaw, 10)) : 1;
+    const page = pageRaw ? Math.max(1, Number.parseInt(pageRaw, 10) || 1) : 1;
     const limit = 50;
     const offset = (page - 1) * limit;
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,23 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
+## `GET /tasks` response shape change
+
+**Version**: next (feat/task-filters)
+
+`GET /tasks` previously returned a bare `Task[]`. It now returns an envelope:
+
+```json
+{ "tasks": Task[], "total": number, "limit": number, "offset": number }
+```
+
+**What to update:**
+- Any code that calls `GET /tasks` and expects an array must unwrap `.tasks` from the response.
+- `check-helpers.ts` in the plugin is updated in this PR. Custom scripts or agents calling `/tasks` directly need the same fix.
+- `GET /tasks?ready=true` is unchanged — it still returns `Task[]`.
+
+---
+
 ## `AgentProvisioner.reconcile()` interface change _(v4.29.0)_
 
 - **`reconcile(agentIds: string[])` → `reconcile(agents: Array<{ id: string; slug?: string }>)`**: The `AgentProvisioner` interface's `reconcile()` method now accepts structured agent objects instead of raw ID strings. This is a **compile-time breaking change** for any code that implements or calls `AgentProvisioner` directly.

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -343,7 +343,8 @@ export function createTaskStoreClient(): {
       const res = await fetch(`${baseUrl}/tasks?${params}`, { headers });
       if (!res.ok)
         throw new Error(`task-store GET /tasks?${params} → ${res.status}`);
-      return res.json() as Promise<Task[]>;
+      const result = (await res.json()) as { tasks: Task[] };
+      return result.tasks;
     },
     async update(id: string, fields: Record<string, unknown>): Promise<Task> {
       const res = await fetch(`${baseUrl}/tasks/${id}`, {

--- a/task-store/src/api.integration.test.ts
+++ b/task-store/src/api.integration.test.ts
@@ -230,6 +230,110 @@ describeOrSkip("task-store API (integration)", () => {
     expect(res.status).toBe(404);
   });
 
+  // ─── List response shape ───────────────────────────────────────────────────
+
+  it("GET /tasks returns { tasks, total, limit, offset }", async () => {
+    await createPendingTask("A");
+    await createPendingTask("B");
+    const res = await app.request("/tasks", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: unknown[];
+      total: number;
+      limit: number;
+      offset: number;
+    };
+    expect(Array.isArray(body.tasks)).toBe(true);
+    expect(body.total).toBe(2);
+    expect(body.limit).toBe(50);
+    expect(body.offset).toBe(0);
+  });
+
+  // ─── ?state filter ─────────────────────────────────────────────────────────
+
+  it("GET /tasks?state=open returns only active statuses", async () => {
+    await createPendingTask("open-task");
+    await prisma.task.create({ data: { title: "done-task", status: "done" } });
+    await prisma.task.create({
+      data: { title: "cancelled-task", status: "cancelled" },
+    });
+
+    const res = await app.request("/tasks?state=open", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: Array<{ title: string }>;
+      total: number;
+    };
+    expect(body.total).toBe(1);
+    expect(body.tasks.map((t) => t.title)).toContain("open-task");
+    expect(body.tasks.map((t) => t.title)).not.toContain("done-task");
+  });
+
+  it("GET /tasks?state=closed returns only terminal statuses", async () => {
+    await createPendingTask("open-task");
+    await prisma.task.create({
+      data: { title: "merged-task", status: "merged" },
+    });
+    await prisma.task.create({
+      data: { title: "deployed-task", status: "deployed" },
+    });
+
+    const res = await app.request("/tasks?state=closed", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: Array<{ title: string }>;
+      total: number;
+    };
+    expect(body.total).toBe(2);
+    const titles = body.tasks.map((t) => t.title);
+    expect(titles).toContain("merged-task");
+    expect(titles).toContain("deployed-task");
+    expect(titles).not.toContain("open-task");
+  });
+
+  // ─── Pagination ────────────────────────────────────────────────────────────
+
+  it("GET /tasks?limit=2&offset=0 returns first page", async () => {
+    await createPendingTask("T1");
+    await createPendingTask("T2");
+    await createPendingTask("T3");
+
+    const res = await app.request("/tasks?limit=2&offset=0", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: unknown[];
+      total: number;
+      limit: number;
+      offset: number;
+    };
+    expect(body.total).toBe(3);
+    expect(body.tasks.length).toBe(2);
+    expect(body.limit).toBe(2);
+    expect(body.offset).toBe(0);
+  });
+
+  it("GET /tasks?limit=2&offset=2 returns second page", async () => {
+    await createPendingTask("T1");
+    await createPendingTask("T2");
+    await createPendingTask("T3");
+
+    const res = await app.request("/tasks?limit=2&offset=2", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: unknown[];
+      total: number;
+      limit: number;
+      offset: number;
+    };
+    expect(body.total).toBe(3);
+    expect(body.tasks.length).toBe(1);
+    expect(body.offset).toBe(2);
+  });
+
   // ─── ready=true filter ─────────────────────────────────────────────────────
 
   it("GET /tasks?ready=true returns only pending tasks with satisfied deps", async () => {

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -135,8 +135,14 @@ function fakeTaskService(
   } = {},
 ): TaskServiceLike {
   return {
-    async list() {
-      return opts.listResult ?? [];
+    async list(filters?) {
+      const tasks = opts.listResult ?? [];
+      return {
+        tasks,
+        total: tasks.length,
+        limit: filters?.limit ?? 50,
+        offset: filters?.offset ?? 0,
+      };
     },
     async listReady() {
       return opts.listReadyResult ?? [];
@@ -461,7 +467,7 @@ describe("task-store API (smoke)", () => {
       ...fakeTaskService(),
       async list(opts?) {
         capturedAssignees.push(opts?.assignee);
-        return [];
+        return { tasks: [], total: 0, limit: 50, offset: 0 };
       },
     };
 

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Task } from "./index.ts";
-import type { TaskListFilters, TaskServiceLike } from "./task-service.ts";
+import type { TaskListFilters, TaskListResult, TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
 // ─── Fakes ────────────────────────────────────────────────────────────────────
@@ -407,9 +407,9 @@ describe("task-store API (smoke)", () => {
       headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as Task[];
-    expect(body).toHaveLength(1);
-    expect(body[0].assignee).toBe("agent-1");
+    const body = (await res.json()) as TaskListResult;
+    expect(body.tasks).toHaveLength(1);
+    expect(body.tasks[0].assignee).toBe("agent-1");
   });
 
   it("PATCH /tasks/:id with agent token pins assignee to the agent's ID", async () => {

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -89,9 +89,9 @@ export function createTasksRoutes(
       claimedBy: c.req.query("claimedBy"),
       pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
       branch: c.req.query("branch"),
-      limit: limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : undefined,
+      limit: limitRaw !== undefined ? (Number.parseInt(limitRaw, 10) || undefined) : undefined,
       offset:
-        offsetRaw !== undefined ? Number.parseInt(offsetRaw, 10) : undefined,
+        offsetRaw !== undefined ? (Number.parseInt(offsetRaw, 10) || undefined) : undefined,
     });
     return c.json(result, 200);
   });

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -12,7 +12,8 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /tasks               list (?status, ?session, ?assignee, ?pr, ?branch, ?ready=true)
+ *   GET    /tasks               list (?status, ?state=open|closed, ?session, ?assignee, ?pr, ?branch, ?limit, ?offset, ?ready=true)
+ *                              returns { tasks, total, limit, offset } — or Task[] when ?ready=true
  *   POST   /tasks               create one (409 if id exists)
  *   POST   /tasks/bulk          insert array, skip 409s → { inserted, updated }
  *   GET    /tasks/:id           fetch one (404 when missing)
@@ -73,8 +74,14 @@ export function createTasksRoutes(
     }
 
     const prRaw = c.req.query("pr");
-    const tasks = await taskService.list({
+    const limitRaw = c.req.query("limit");
+    const offsetRaw = c.req.query("offset");
+    const stateRaw = c.req.query("state");
+    const state =
+      stateRaw === "open" || stateRaw === "closed" ? stateRaw : undefined;
+    const result = await taskService.list({
       status: c.req.query("status"),
+      state,
       session: c.req.query("session"),
       repo: c.req.query("repo"),
       // Agent tokens always scope to their own tasks; ignore any provided ?assignee.
@@ -82,8 +89,11 @@ export function createTasksRoutes(
       claimedBy: c.req.query("claimedBy"),
       pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
       branch: c.req.query("branch"),
+      limit: limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : undefined,
+      offset:
+        offsetRaw !== undefined ? Number.parseInt(offsetRaw, 10) : undefined,
     });
-    return c.json(tasks, 200);
+    return c.json(result, 200);
   });
 
   // ─── Create ────────────────────────────────────────────────────────────────

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -86,9 +86,14 @@ export class TaskService implements TaskServiceLike {
 
   async list(filters: TaskListFilters = {}): Promise<TaskListResult> {
     const where: Prisma.TaskWhereInput = {};
-    if (filters.status) where.status = filters.status as Task["status"];
-    if (filters.state === "open") where.status = { in: [...OPEN_STATUSES] };
-    if (filters.state === "closed") where.status = { in: [...CLOSED_STATUSES] };
+    if (filters.status) {
+      // status takes precedence over state when both are provided
+      where.status = filters.status as Task["status"];
+    } else if (filters.state === "open") {
+      where.status = { in: [...OPEN_STATUSES] };
+    } else if (filters.state === "closed") {
+      where.status = { in: [...CLOSED_STATUSES] };
+    }
     if (filters.session) where.session = filters.session;
     if (filters.repo) where.repo = filters.repo;
     if (filters.assignee) where.assignee = filters.assignee;

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -17,20 +17,50 @@ import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Prisma, PrismaClient, Task } from "./index.ts";
 import { resolveReadyTasks } from "./ready.ts";
 
+/** Terminal statuses — a task in one of these is considered "closed". */
+export const CLOSED_STATUSES = [
+  "merged",
+  "done",
+  "deploying",
+  "deployed",
+  "cancelled",
+] as const;
+
+/** Open statuses — everything not closed. */
+export const OPEN_STATUSES = [
+  "pending",
+  "in_progress",
+  "pr_open",
+  "approved",
+  "blocked",
+] as const;
+
 /** Filters accepted by TaskService.list. */
 export interface TaskListFilters {
   status?: string;
+  /** High-level lifecycle filter: "open" = active, "closed" = terminal. */
+  state?: "open" | "closed";
   session?: string;
   repo?: string;
   assignee?: string;
   claimedBy?: string;
   pr?: number;
   branch?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Paginated list result from TaskService.list. */
+export interface TaskListResult {
+  tasks: Task[];
+  total: number;
+  limit: number;
+  offset: number;
 }
 
 /** The subset of TaskService the routes depend on. */
 export interface TaskServiceLike {
-  list(filters?: TaskListFilters): Promise<Task[]>;
+  list(filters?: TaskListFilters): Promise<TaskListResult>;
   listReady(agentId?: string): Promise<Task[]>;
   get(id: string): Promise<Task | null>;
   create(data: Prisma.TaskCreateInput): Promise<Task>;
@@ -54,19 +84,32 @@ export class TaskService implements TaskServiceLike {
 
   // ─── Reads ─────────────────────────────────────────────────────────────────
 
-  async list(filters: TaskListFilters = {}): Promise<Task[]> {
+  async list(filters: TaskListFilters = {}): Promise<TaskListResult> {
     const where: Prisma.TaskWhereInput = {};
     if (filters.status) where.status = filters.status as Task["status"];
+    if (filters.state === "open") where.status = { in: [...OPEN_STATUSES] };
+    if (filters.state === "closed") where.status = { in: [...CLOSED_STATUSES] };
     if (filters.session) where.session = filters.session;
     if (filters.repo) where.repo = filters.repo;
     if (filters.assignee) where.assignee = filters.assignee;
     if (filters.claimedBy) where.claimedBy = filters.claimedBy;
     if (filters.pr !== undefined) where.pr = filters.pr;
     if (filters.branch !== undefined) where.branch = filters.branch;
-    return this.prisma.task.findMany({
-      where,
-      orderBy: { createdAt: "asc" },
-    });
+
+    const limit = filters.limit ?? 50;
+    const offset = filters.offset ?? 0;
+
+    const [tasks, total] = await this.prisma.$transaction([
+      this.prisma.task.findMany({
+        where,
+        orderBy: { createdAt: "asc" },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.task.count({ where }),
+    ]);
+
+    return { tasks, total, limit, offset };
   }
 
   /**


### PR DESCRIPTION
## Summary

- **`GET /tasks` response** is now `{ tasks, total, limit, offset }` — consistent wrapper enabling pagination metadata
- **`?state=open|closed`** coarse filter maps to the terminal/active status sets already codified in `ready.ts`
- **`?limit` / `?offset`** pagination params, default limit 50
- **Admin UI** defaults to `state=open` (open tasks only on page load), adds an Open/Closed toggle in the page header, prev/next pagination controls, and fixes the missing `merged`/`deploying`/`deployed` statuses in the dropdown
- **Badge colors** extended: green for merged/done/deployed, red for blocked/cancelled

## Test plan

- [ ] `task-store`: integration tests cover new `{ tasks, total, limit, offset }` response shape, `?state=open`, `?state=closed`, `?limit=2&offset=0`, and `?limit=2&offset=2`
- [ ] `task-store`: smoke tests updated to match new `list()` return type
- [ ] `admin`: smoke tests updated to match new `fetchTaskStoreTasks` return shape
- [ ] Typecheck passes (only pre-existing Prisma client environment error)
- [ ] Biome lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)