### PR TITLE
docs(task-store): document ready=true exclusion rules and troubleshooting

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -315,7 +315,7 @@ When determining whether a task is ready (via `--ready`), each dependency is eva
 
 1. **Terminal status** — dependency has `status ∈ { merged, done, deploying, deployed, cancelled }` → **satisfied**
 2. **Same-branch PR** — dependency is on the same branch as the dependent task with `status ∈ { pr_open, approved }` → **satisfied** (bundled PR)
-3. **Cross-branch merged PR** — dependency is on a different branch with `status === pr_open` AND the PR is already merged in GitHub → **satisfied**
+3. **`pr_open` with a PR number** — dependency has `status === pr_open` and a PR number; check whether the PR is merged in GitHub → **satisfied** if merged
 4. **Anything else** → **not satisfied** (task is excluded from `--ready` results)
 
 **`--branch` example** — find all tasks sharing a bundle branch:

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -338,7 +338,7 @@ If `task_store.ts query --ready` returns an empty array even though tasks exist:
 
 2. **HITL flag set** — Query `task_store.ts query --status pending` to check if tasks have `"hitl": true`. Clear the flag once the human action is complete (remove the `hitl` label on GitHub, or set `hitl: false` in Jira metadata).
 
-3. **Dependencies not satisfied** — Query `task_store.ts query --status pending` to find pending tasks. They may be waiting on a dependency that is not yet in a terminal status (`merged`, `done`, `deploying`, `deployed`, `cancelled`). Check the `dependencies` array and verify each referenced task ID exists and has reached a terminal status.
+3. **Dependencies not satisfied** — Query `task_store.ts query --status pending` to find pending tasks. See the dependency satisfaction rules above — terminal status, same-branch PR open/approved, or a merged cross-branch PR all count. Check the `dependencies` array and verify each referenced task ID exists and meets at least one rule.
 
 4. **Queue empty** — No pending tasks exist at all. Check with `task_store.ts query --status pending` to confirm.
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -307,7 +307,16 @@ All filters are AND-combined. `--ready` takes precedence and ignores `--status`,
 | `--branch` | string | Match tasks whose `branch` field equals this branch name — useful for querying all tasks in a bundle |
 | `--session` | string | Match tasks belonging to this planning session slug |
 | `--hitl` | boolean | `true` returns only HITL tasks; `false` returns only non-HITL tasks |
-| `--ready` | flag | Return only tasks that are `pending` with all dependencies satisfied |
+| `--ready` | flag | Return only tasks with `status === pending`, no `hitl` flag set, and all dependencies satisfied (see Dependency satisfaction rules below) |
+
+#### Dependency satisfaction rules
+
+When determining whether a task is ready (via `--ready`), each dependency is evaluated in order. The first matching rule wins:
+
+1. **Terminal status** — dependency has `status ∈ { merged, done, deploying, deployed, cancelled }` → **satisfied**
+2. **Same-branch PR** — dependency is on the same branch as the dependent task with `status ∈ { pr_open, approved }` → **satisfied** (bundled PR)
+3. **Cross-branch merged PR** — dependency is on a different branch with `status === pr_open` AND the PR is already merged in GitHub → **satisfied**
+4. **Anything else** → **not satisfied** (task is excluded from `--ready` results)
 
 **`--branch` example** — find all tasks sharing a bundle branch:
 
@@ -320,6 +329,18 @@ The deploy cron uses this internally to check bundle completeness before merging
 ---
 
 ## Troubleshooting
+
+### `--ready` returns empty
+
+If `task_store.ts query --ready` returns an empty array even though tasks exist:
+
+1. **No tasks assigned to this agent** — The CLI command returns only tasks assigned to the authenticated user. Use an admin token or check the task store directly to see all ready tasks.
+
+2. **HITL flag set** — Query `task_store.ts query --status pending` to check if tasks have `"hitl": true`. Clear the flag once the human action is complete (remove the `hitl` label on GitHub, or set `hitl: false` in Jira metadata).
+
+3. **Dependencies not satisfied** — Query `task_store.ts query --status pending` to find pending tasks. They may be waiting on a dependency that is not yet in a terminal status (`merged`, `done`, `deploying`, `deployed`, `cancelled`). Check the `dependencies` array and verify each referenced task ID exists and has reached a terminal status.
+
+4. **Queue empty** — No pending tasks exist at all. Check with `task_store.ts query --status pending` to confirm.
 
 ### Jira: 401 Unauthorized
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -139,9 +139,16 @@ When `?ready=true` is set, `?status` and `?id` filters are ignored. Only
 - Admin tokens: results include all agents' tasks.
 - `?session` — filter by planning session slug. Omit to return ready tasks across all sessions.
 
-A task is ready when:
+A task is ready when **all** of the following are true:
 - `status === "pending"`, AND
-- all `dependencies` are satisfied (merged, or same branch with `pr_open`/`approved`)
+- `hitl` is not `true` (HITL tasks are excluded until manually cleared), AND
+- every dependency ID resolves to a task in a terminal status
+
+**Dependency-satisfied rules** (first match wins):
+1. `dep.status ∈ { merged, done, deploying, deployed, cancelled }` → satisfied
+2. Same-branch dep with `status ∈ { pr_open, approved }` → satisfied (bundled PR)
+3. Cross-branch dep with `status === pr_open` and a PR number that GitHub reports as merged → satisfied
+4. Anything else → **not satisfied** (task is excluded from `?ready=true`)
 
 ---
 
@@ -152,7 +159,8 @@ When `?ready=true` returns `[]`:
 | Likely cause | How to check |
 |---|---|
 | No tasks assigned to this agent | Use an admin token to see all ready tasks |
-| Deps not satisfied | Query `?status=pending` — tasks present but blocked on deps |
+| HITL flag set | Query `?status=pending` — check if tasks have `"hitl": true`. Clear the flag once the human action is complete. |
+| Deps not satisfied | Query `?status=pending` — tasks present but waiting on a dependency not yet in a terminal status (`merged`, `done`, `deploying`, `deployed`, `cancelled`) |
 | Queue empty | No pending tasks exist at all |
 
 ---

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -142,7 +142,7 @@ When `?ready=true` is set, `?status` and `?id` filters are ignored. Only
 A task is ready when **all** of the following are true:
 - `status === "pending"`, AND
 - `hitl` is not `true` (HITL tasks are excluded until manually cleared), AND
-- every dependency ID resolves to a task in a terminal status
+- every dependency is satisfied per the dependency rules below (terminal status, same-branch PR, or merged cross-branch PR)
 
 **Dependency-satisfied rules** (first match wins):
 1. `dep.status ∈ { merged, done, deploying, deployed, cancelled }` → satisfied

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -147,7 +147,7 @@ A task is ready when **all** of the following are true:
 **Dependency-satisfied rules** (first match wins):
 1. `dep.status ∈ { merged, done, deploying, deployed, cancelled }` → satisfied
 2. Same-branch dep with `status ∈ { pr_open, approved }` → satisfied (bundled PR)
-3. Cross-branch dep with `status === pr_open` and a PR number that GitHub reports as merged → satisfied
+3. `pr_open` dep with a PR number, GitHub reports the PR as merged → satisfied
 4. Anything else → **not satisfied** (task is excluded from `?ready=true`)
 
 ---

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -160,7 +160,7 @@ When `?ready=true` returns `[]`:
 |---|---|
 | No tasks assigned to this agent | Use an admin token to see all ready tasks |
 | HITL flag set | Query `?status=pending` — check if tasks have `"hitl": true`. Clear the flag once the human action is complete. |
-| Deps not satisfied | Query `?status=pending` — tasks present but waiting on a dependency not yet in a terminal status (`merged`, `done`, `deploying`, `deployed`, `cancelled`) |
+| Deps not satisfied | Query `?status=pending` — tasks present but blocked on a dependency. Check each dependency against the satisfaction rules above: terminal status, same-branch `pr_open`/`approved`, or a `pr_open` dep whose GitHub PR is merged all satisfy. Any dep failing all three rules blocks the task. |
 | Queue empty | No pending tasks exist at all |
 
 ---


### PR DESCRIPTION
## Summary
- Document all conditions that gate a task from `?ready=true`: `hitl === true` and unsatisfied dependencies
- List all five terminal dependency statuses that count as satisfied (`merged`, `done`, `deploying`, `deployed`, `cancelled`)
- Expand the empty-results troubleshooting table with distinct HITL and dep-blocking causes, each with how-to-check guidance

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `?ready=true` semantics section lists all exclusion conditions (hitl, unsatisfied deps) | ✅ MET |
| 2 | Terminal dep statuses listed (merged, done, deploying, deployed, cancelled) | ✅ MET |
| 3 | Troubleshooting table has hitl and dep-blocking as distinct causes with how-to-check | ✅ MET |
| 4 | No other behavior changed | ✅ MET |

## Test Plan
- [x] Docs-only change — no code behavior modified
- [x] Diff reviewed against actual `ready.ts` logic for accuracy
- [x] Spec compliance review confirmed all criteria MET

Generated with [Claude Code](https://claude.com/claude-code)
