### PR TITLE
docs(task-store): unwrap .tasks envelope in agent instruction files (TSF-1)

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -84,9 +84,9 @@ Look up the task via the task store:
 
 ```bash
 TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?pr={pr}" | jq .)
-TASK_ID=$(echo "$TASK_JSON" | jq -r '.[0].id // empty')
-TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.[0].title // empty')
-TASK_STATUS=$(echo "$TASK_JSON" | jq -r '.[0].status // empty')
+TASK_ID=$(echo "$TASK_JSON" | jq -r '.tasks[0].id // empty')
+TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.tasks[0].title // empty')
+TASK_STATUS=$(echo "$TASK_JSON" | jq -r '.tasks[0].status // empty')
 ```
 
 If `TASK_ID` is empty or `TASK_STATUS` is not `"pr_open"`, proceed in **deploy-only mode** — no
@@ -121,8 +121,8 @@ sibling tasks on the same branch are still being developed or are blocked.
 
 ```bash
 HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
-BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch=$HEAD_BRANCH" 2>/dev/null || echo '[]')
-INCOMPLETE_TASKS=$(echo "$BRANCH_TASKS" | jq '[.[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked") | {id, status}]')
+BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch=$HEAD_BRANCH" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
+INCOMPLETE_TASKS=$(echo "$BRANCH_TASKS" | jq '[.tasks[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked") | {id, status}]')
 INCOMPLETE=$(echo "$INCOMPLETE_TASKS" | jq 'length')
 ```
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -20,10 +20,10 @@ Auto-detect the project toolchain (run once, reuse throughout). Skip this step u
 
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq '.tasks'
 ```
 
-If the result is a non-empty array, use the first task returned. The Step 2 orphan check will clean up any stale branch/PR from the prior session before restarting. Print:
+If `result.tasks` is non-empty, use the first task (`result.tasks[0]`). The Step 2 orphan check will clean up any stale branch/PR from the prior session before restarting. Print:
 
 ```
 ↩ Resuming interrupted task: {id} — {title}

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -40,9 +40,9 @@ This is the engineering planning pass. The product spec (what and why) is alread
 2. Glob the repo structure to understand the codebase layout
 3. Check for any existing tasks in this session to avoid duplicates:
    ```bash
-   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?session=$SESSION" | jq .
+   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?session=$SESSION" | jq '.tasks'
    ```
-   The output is a JSON array. If non-empty, print the existing task IDs and skip re-adding them.
+   The response is a paginated envelope — unwrap `.tasks` to get the array. If non-empty, print the existing task IDs and skip re-adding them.
 4. Read `planning/{session}/PRODUCT-SPEC.md` if it exists — this is the primary input
 
 Present a brief orientation:

--- a/plugins/shipwright/commands/refresh-plan.md
+++ b/plugins/shipwright/commands/refresh-plan.md
@@ -22,10 +22,10 @@ Follow all steps in order.
 
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?session=$ARGUMENTS" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?session=$ARGUMENTS" | jq '.tasks'
 ```
 
-If the result is a non-empty JSON array, use these live statuses to build the status summary:
+If the result is a non-empty array (unwrapped from `.tasks`), use these live statuses to build the status summary:
 - Map task_store statuses: `pending` → "not started", `in_progress` → "in-progress", `pr_open`/`approved`/`merged`/`deployed`/`done` → "done", `blocked` → "blocked", `cancelled` → "skipped"
 
 If the result is empty (`[]`), fall back to parsing the Appendix markers in the planning doc ([ ] = not started, [🔨] = in-progress, [x] = done, [⏸] = blocked, [—] = skipped).

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -124,7 +124,7 @@ in Steps 12 and 13:
 
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?pr=$PR_NUMBER" | jq '.[0] // empty'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?pr=$PR_NUMBER" | jq '.tasks[0] // empty'
 ```
 
 ### Deduplication and Filtering

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -137,12 +137,12 @@ If `--queue` was passed, run this workflow instead of Steps 6a-6e.
 Run:
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending" | jq '.tasks'
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq '.tasks'
 ```
 
-Parse both JSON arrays. From the combined results, collect tasks where:
+Parse both `.tasks` arrays. From the combined results, collect tasks where:
 - `source == "shipwright"`, OR
 - `title` starts with `"Entropy fix:"`
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -58,7 +58,7 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq .
 ```
 
-Both return a JSON array. Use the first element.
+`?ready=true` returns a bare `Task[]`. All other list calls (`?status=`, `?session=`, `?pr=`, `?branch=`, etc.) return a paginated envelope: `{ tasks: Task[], total: number, limit: number, offset: number }` — unwrap `.tasks` before accessing elements.
 
 ### Start a task
 


### PR DESCRIPTION
## Summary
- After PR #670, non-`?ready=true` GET /tasks calls return a paginated `{ tasks, total, limit, offset }` envelope instead of a bare `Task[]`
- Six agent instruction files (`SKILL.md`, `dev-task.md`, `deploy.md`, `plan-session.md`, `refresh-plan.md`, `review.md`) were still using bare-array patterns (`.[0]`, `.[]`) that silently break against the paginated response
- All non-`?ready=true` list calls now unwrap `.tasks`; `?ready=true` patterns left untouched

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | All six files updated; every non-?ready=true list call unwraps .tasks | MET | All 6 files changed, 13 lines updated |
| 2 | ?ready=true patterns left untouched | MET | dev-task.md line 38 and refresh-plan.md line 137 unchanged |
| 3 | deploy.md bundle gate uses .tasks[] pattern; fallback uses JSON object | MET | `[.tasks[] | select(...)]` + `{"tasks":[],...}` fallback |
| 4 | SKILL.md documents ?status= envelope vs ?ready=true bare array | MET | Updated line 61 with clear description of both shapes |
| 5 | No new tests needed (confirmed none test these specific jq patterns) | MET | No test changes |

## Test Plan
- [x] Pre-commit checks passing
- [x] All six files verified — `?ready=true` patterns untouched, all other list calls unwrap `.tasks`

Generated with [Claude Code](https://claude.com/claude-code)
