### PR TITLE
feat: add repos field to Agent model with org/repo validation

### DIFF
--- a/admin/openapi.json
+++ b/admin/openapi.json
@@ -31,6 +31,10 @@
             ],
             "example": "U0AALR8M69X"
           },
+          "selfHosted": {
+            "type": "boolean",
+            "example": false
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -45,6 +49,7 @@
         "required": [
           "id",
           "name",
+          "selfHosted",
           "createdAt",
           "updatedAt"
         ]
@@ -72,6 +77,10 @@
           "slackId": {
             "type": "string",
             "example": "U0AALR8M69X"
+          },
+          "selfHosted": {
+            "type": "boolean",
+            "example": false
           }
         },
         "required": [
@@ -82,6 +91,12 @@
         "type": "object",
         "properties": {
           "recreated": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "updated": {
             "type": "array",
             "items": {
               "type": "string"
@@ -114,9 +129,107 @@
         },
         "required": [
           "recreated",
+          "updated",
           "orphans",
           "failed"
         ]
+      },
+      "ProvisionAgentResult": {
+        "type": "object",
+        "properties": {
+          "resourceName": {
+            "type": "string"
+          },
+          "secretName": {
+            "type": "string"
+          },
+          "deploymentName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "resourceName",
+          "secretName",
+          "deploymentName"
+        ]
+      },
+      "ProvisionSkippedResult": {
+        "type": "object",
+        "properties": {
+          "skipped": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "skipped",
+          "reason"
+        ]
+      },
+      "GetAgentResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slackId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "selfHosted": {
+            "type": "boolean"
+          },
+          "repos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "selfHosted",
+          "repos",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PatchAgentBody": {
+        "type": "object",
+        "properties": {
+          "selfHosted": {
+            "type": "boolean",
+            "example": false
+          },
+          "repos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "my-org/my-repo"
+            ]
+          }
+        }
       },
       "AgentSummary": {
         "type": "object",
@@ -128,11 +241,16 @@
           "name": {
             "type": "string",
             "example": "Bodhi"
+          },
+          "selfHosted": {
+            "type": "boolean",
+            "example": false
           }
         },
         "required": [
           "id",
-          "name"
+          "name",
+          "selfHosted"
         ]
       },
       "Ok": {
@@ -812,7 +930,170 @@
         }
       }
     },
+    "/agents/{id}/provision": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx1234567890"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent provisioned (or already-provisioned — idempotent), or skipped for self-hosted agents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ProvisionAgentResult"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ProvisionSkippedResult"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/agents/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx1234567890"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Full agent record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAgentResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx1234567890"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchAgentBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAgentResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "parameters": [
           {

--- a/admin/prisma/migrations/20260624120000_add_agent_repos/migration.sql
+++ b/admin/prisma/migrations/20260624120000_add_agent_repos/migration.sql
@@ -1,0 +1,3 @@
+-- AddColumn: repos TEXT[] to Agent (additive, non-breaking)
+-- Existing agents default to repos: []
+ALTER TABLE "Agent" ADD COLUMN "repos" TEXT[] NOT NULL DEFAULT '{}';

--- a/admin/prisma/schema.prisma
+++ b/admin/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Agent {
   slackBotToken   String?  // AES-256-GCM encrypted at the service layer
   anthropicApiKey String?  // AES-256-GCM encrypted at the service layer
   selfHosted      Boolean  @default(false)
+  repos           String[] @default([])
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 

--- a/admin/src/agents-api.integration.test.ts
+++ b/admin/src/agents-api.integration.test.ts
@@ -195,4 +195,29 @@ describeOrSkip("admin CRUD API (integration)", () => {
     expect(listedToken.token).toBeUndefined();
     expect(listedToken.id).toBe(dbRecord?.id);
   });
+
+  // ─── repos field round-trip ───────────────────────────────────────────────────
+
+  it("PATCH /agents/:id with repos sets the field; GET /agents/:id returns it", async () => {
+    // PATCH to set repos
+    const patchRes = await app.request(`/agents/${agentId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ repos: ["app-vitals/vitals-os"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(patchRes.status).toBe(200);
+    const patchBody = await patchRes.json();
+    expect(patchBody.repos).toEqual(["app-vitals/vitals-os"]);
+
+    // GET to confirm persisted value
+    const getRes = await app.request(`/agents/${agentId}`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.repos).toEqual(["app-vitals/vitals-os"]);
+  });
 });

--- a/admin/src/agents-api.integration.test.ts
+++ b/admin/src/agents-api.integration.test.ts
@@ -202,7 +202,7 @@ describeOrSkip("admin CRUD API (integration)", () => {
     // PATCH to set repos
     const patchRes = await app.request(`/agents/${agentId}`, {
       method: "PATCH",
-      body: JSON.stringify({ repos: ["app-vitals/vitals-os"] }),
+      body: JSON.stringify({ repos: ["my-org/my-repo"] }),
       headers: {
         "Content-Type": "application/json",
         Cookie: `admin_session=${cookie}`,
@@ -210,7 +210,7 @@ describeOrSkip("admin CRUD API (integration)", () => {
     });
     expect(patchRes.status).toBe(200);
     const patchBody = await patchRes.json();
-    expect(patchBody.repos).toEqual(["app-vitals/vitals-os"]);
+    expect(patchBody.repos).toEqual(["my-org/my-repo"]);
 
     // GET to confirm persisted value
     const getRes = await app.request(`/agents/${agentId}`, {
@@ -218,6 +218,6 @@ describeOrSkip("admin CRUD API (integration)", () => {
     });
     expect(getRes.status).toBe(200);
     const getBody = await getRes.json();
-    expect(getBody.repos).toEqual(["app-vitals/vitals-os"]);
+    expect(getBody.repos).toEqual(["my-org/my-repo"]);
   });
 });

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -1604,3 +1604,108 @@ describe("admin API — selfHosted field", () => {
     expect(agentsPassed.map((a) => a.id)).toContain(AGENT_ID);
   });
 });
+
+// ─── repos field smoke tests ──────────────────────────────────────────────────
+
+describe("admin API — repos field", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  it("PATCH /agents/:id with repos: ['vitals-os'] returns 400 (missing org)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ repos: ["vitals-os"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/org\/repo/i);
+  });
+
+  it("PATCH /agents/:id with repos: ['app-vitals/vitals-os'] returns 200", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findUnique: async (args: { where: { id: string } }) =>
+            args.where.id === AGENT_ID
+              ? {
+                  id: AGENT_ID,
+                  name: "Existing Agent",
+                  slackId: null,
+                  selfHosted: false,
+                  repos: [],
+                  createdAt: new Date("2024-01-01"),
+                  updatedAt: new Date("2024-01-01"),
+                }
+              : null,
+          update: async (args: {
+            where: { id: string };
+            data: { selfHosted?: boolean; repos?: string[] };
+          }) => ({
+            id: args.where.id,
+            name: "Existing Agent",
+            slackId: null,
+            selfHosted: args.data.selfHosted ?? false,
+            repos: args.data.repos ?? [],
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          }),
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ repos: ["app-vitals/vitals-os"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.repos).toEqual(["app-vitals/vitals-os"]);
+  });
+
+  it("GET /agents/:id returns repos field (empty array for existing agents)", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findUnique: async (args: { where: { id: string } }) =>
+            args.where.id === AGENT_ID
+              ? {
+                  id: AGENT_ID,
+                  name: "Existing Agent",
+                  slackId: null,
+                  selfHosted: false,
+                  repos: [],
+                  createdAt: new Date("2024-01-01"),
+                  updatedAt: new Date("2024-01-01"),
+                }
+              : null,
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.repos)).toBe(true);
+    expect(body.repos).toEqual([]);
+  });
+});

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -1677,6 +1677,54 @@ describe("admin API — repos field", () => {
     expect(body.repos).toEqual(["my-org/my-repo"]);
   });
 
+  it("PATCH /agents/:id with repos: [] clears repos and returns 200 with repos: []", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      prisma: {
+        agent: {
+          ...base.prisma.agent,
+          findUnique: async (args: { where: { id: string } }) =>
+            args.where.id === AGENT_ID
+              ? {
+                  id: AGENT_ID,
+                  name: "Existing Agent",
+                  slackId: null,
+                  selfHosted: false,
+                  repos: ["my-org/my-repo"],
+                  createdAt: new Date("2024-01-01"),
+                  updatedAt: new Date("2024-01-01"),
+                }
+              : null,
+          update: async (args: {
+            where: { id: string };
+            data: { selfHosted?: boolean; repos?: string[] };
+          }) => ({
+            id: args.where.id,
+            name: "Existing Agent",
+            slackId: null,
+            selfHosted: args.data.selfHosted ?? false,
+            repos: args.data.repos ?? [],
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          }),
+        },
+      } as unknown as AdminDeps["prisma"],
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ repos: [] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.repos).toEqual([]);
+  });
+
   it("GET /agents/:id returns repos field (empty array for existing agents)", async () => {
     const base = makeMockDeps();
     const deps: AdminDeps = {

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -1614,11 +1614,11 @@ describe("admin API — repos field", () => {
     cookie = await makeSessionCookie();
   });
 
-  it("PATCH /agents/:id with repos: ['vitals-os'] returns 400 (missing org)", async () => {
+  it("PATCH /agents/:id with repos: ['my-repo'] returns 400 (missing org)", async () => {
     const app = createAdminApp(makeMockDeps());
     const res = await app.request(`/agents/${AGENT_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ repos: ["vitals-os"] }),
+      body: JSON.stringify({ repos: ["my-repo"] }),
       headers: {
         "Content-Type": "application/json",
         Cookie: `admin_session=${cookie}`,
@@ -1629,7 +1629,7 @@ describe("admin API — repos field", () => {
     expect(body.error).toMatch(/org\/repo/i);
   });
 
-  it("PATCH /agents/:id with repos: ['app-vitals/vitals-os'] returns 200", async () => {
+  it("PATCH /agents/:id with repos: ['my-org/my-repo'] returns 200", async () => {
     const base = makeMockDeps();
     const deps: AdminDeps = {
       ...base,
@@ -1666,7 +1666,7 @@ describe("admin API — repos field", () => {
     const app = createAdminApp(deps);
     const res = await app.request(`/agents/${AGENT_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ repos: ["app-vitals/vitals-os"] }),
+      body: JSON.stringify({ repos: ["my-org/my-repo"] }),
       headers: {
         "Content-Type": "application/json",
         Cookie: `admin_session=${cookie}`,
@@ -1674,7 +1674,7 @@ describe("admin API — repos field", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.repos).toEqual(["app-vitals/vitals-os"]);
+    expect(body.repos).toEqual(["my-org/my-repo"]);
   });
 
   it("GET /agents/:id returns repos field (empty array for existing agents)", async () => {

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -730,19 +730,6 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     const { id: agentId } = c.req.valid("param");
     const body = c.req.valid("json");
 
-    // Validate repos format: each entry must be "org/repo" (exactly one /, both sides non-empty)
-    if (body.repos !== undefined) {
-      const invalid = body.repos.filter((r) => {
-        const parts = r.split("/");
-        return !(parts.length === 2 && parts[0].length > 0 && parts[1].length > 0);
-      });
-      if (invalid.length > 0) {
-        throw new BadRequestError(
-          `invalid repos format (expected org/repo): ${invalid.join(", ")}`,
-        );
-      }
-    }
-
     const existing = await prisma.agent.findUnique({
       where: { id: agentId },
       select: { id: true },

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -150,6 +150,7 @@ const GetAgentResultSchema = z
     name: z.string(),
     slackId: z.string().nullable().optional(),
     selfHosted: z.boolean(),
+    repos: z.array(z.string()),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })
@@ -705,7 +706,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     return c.json({ resourceName, secretName, deploymentName }, 200);
   });
 
-  // GET /agents/:id — get full agent record including selfHosted
+  // GET /agents/:id — get full agent record including selfHosted and repos
   app.openapi(getAgentRoute, async (c) => {
     if (c.get("isAdmin") !== true) {
       throw new ForbiddenError("Admin access required to get agent");
@@ -713,7 +714,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     const { id: agentId } = c.req.valid("param");
     const agent = await prisma.agent.findUnique({
       where: { id: agentId },
-      select: { id: true, name: true, slackId: true, selfHosted: true, createdAt: true, updatedAt: true },
+      select: { id: true, name: true, slackId: true, selfHosted: true, repos: true, createdAt: true, updatedAt: true },
     });
     if (!agent) {
       throw new NotFoundError(`agent ${agentId} not found`);
@@ -721,13 +722,27 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     return c.json(serializeAgent(agent), 200);
   });
 
-  // PATCH /agents/:id — update agent fields (currently: selfHosted)
+  // PATCH /agents/:id — update agent fields (selfHosted, repos)
   app.openapi(patchAgentRoute, async (c) => {
     if (c.get("isAdmin") !== true) {
       throw new ForbiddenError("Admin access required to update agent");
     }
     const { id: agentId } = c.req.valid("param");
     const body = c.req.valid("json");
+
+    // Validate repos format: each entry must be "org/repo" (exactly one /, both sides non-empty)
+    if (body.repos !== undefined) {
+      const invalid = body.repos.filter((r) => {
+        const parts = r.split("/");
+        return !(parts.length === 2 && parts[0].length > 0 && parts[1].length > 0);
+      });
+      if (invalid.length > 0) {
+        throw new BadRequestError(
+          `invalid repos format (expected org/repo): ${invalid.join(", ")}`,
+        );
+      }
+    }
+
     const existing = await prisma.agent.findUnique({
       where: { id: agentId },
       select: { id: true },
@@ -737,8 +752,11 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     }
     const agent = await prisma.agent.update({
       where: { id: agentId },
-      data: { selfHosted: body.selfHosted },
-      select: { id: true, name: true, slackId: true, selfHosted: true, createdAt: true, updatedAt: true },
+      data: {
+        selfHosted: body.selfHosted,
+        ...(body.repos !== undefined ? { repos: body.repos } : {}),
+      },
+      select: { id: true, name: true, slackId: true, selfHosted: true, repos: true, createdAt: true, updatedAt: true },
     });
     return c.json(serializeAgent(agent), 200);
   });
@@ -1081,6 +1099,7 @@ function serializeAgent(agent: {
   name: string;
   slackId: string | null | undefined;
   selfHosted: boolean;
+  repos?: string[];
   createdAt: Date;
   updatedAt: Date;
 }): z.infer<typeof GetAgentResultSchema> {
@@ -1089,6 +1108,7 @@ function serializeAgent(agent: {
     name: agent.name,
     slackId: agent.slackId,
     selfHosted: agent.selfHosted,
+    repos: agent.repos ?? [],
     createdAt: agent.createdAt.toISOString(),
     updatedAt: agent.updatedAt.toISOString(),
   };

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -74,7 +74,15 @@ export const PatchAgentBodySchema = z
   .object({
     selfHosted: z.boolean().optional().openapi({ example: false }),
     repos: z
-      .array(z.string())
+      .array(
+        z.string().refine(
+          (r) => {
+            const p = r.split("/");
+            return p.length === 2 && p[0].length > 0 && p[1].length > 0;
+          },
+          { message: "each repo must be in org/repo format" },
+        ),
+      )
       .optional()
       .openapi({ example: ["my-org/my-repo"] }),
   })

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -73,6 +73,10 @@ export const CreateAgentBodySchema = z
 export const PatchAgentBodySchema = z
   .object({
     selfHosted: z.boolean().optional().openapi({ example: false }),
+    repos: z
+      .array(z.string())
+      .optional()
+      .openapi({ example: ["app-vitals/vitals-os"] }),
   })
   .openapi("PatchAgentBody");
 

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -76,7 +76,7 @@ export const PatchAgentBodySchema = z
     repos: z
       .array(z.string())
       .optional()
-      .openapi({ example: ["app-vitals/vitals-os"] }),
+      .openapi({ example: ["my-org/my-repo"] }),
   })
   .openapi("PatchAgentBody");
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -48,7 +48,7 @@ Mounted at `/agents/*` (unified with the runtime API surface). Auth: **admin key
 
 | Resource | Endpoints |
 |---|---|
-| Agents | `POST /agents` (admin-only: creates agent, returns `{id, name, slackId, selfHosted, createdAt, updatedAt}` with `201`), `GET /agents/:id` (admin-only: fetches agent record), `GET /agents` (admin-only: lists agents), `PATCH /agents/:id` (admin-only: updates agent fields like `selfHosted`), `POST /agents/:id/provision` (admin-only: provisions a managed agent or returns `{skipped: true, reason: "self-hosted"}` for self-hosted agents) |
+| Agents | `POST /agents` (admin-only: creates agent, returns `{id, name, slackId, selfHosted, repos, createdAt, updatedAt}` with `201`), `GET /agents/:id` (admin-only: fetches agent record), `GET /agents` (admin-only: lists agents), `PATCH /agents/:id` (admin-only: updates agent fields like `selfHosted` and `repos`; repos validation: each entry must be `org/repo` format), `POST /agents/:id/provision` (admin-only: provisions a managed agent or returns `{skipped: true, reason: "self-hosted"}` for self-hosted agents) |
 | Envs | `POST` / `GET` / `PATCH` `/agents/:id/envs`, `DELETE /agents/:id/envs/:key` |
 | Crons | `POST` `/agents/:id/crons`, `PATCH` / `DELETE` `/agents/:id/crons/:cronId`, `POST /agents/:id/crons/reconcile` |
 | Reconciliation | `POST /agents/reconcile` (admin-only: reconciles K8s Deployments against all managed (non-self-hosted) agents; returns `{recreated: string[], updated: string[], orphans: string[], failed: Array<{agentId, error}>}`) |
@@ -84,7 +84,7 @@ Each REPL session generates a single `session` UUID so successive messages resum
 
 | Model | Owns | Notable fields |
 |---|---|---|
-| `Agent` | The runner identity | `name`, `slackId` (unique), `selfHosted` (boolean; when true, agent manages its own workload and skips K8s provisioning), `slackBotToken` / `anthropicApiKey` (AES-256-GCM encrypted). |
+| `Agent` | The runner identity | `name`, `slackId` (unique), `selfHosted` (boolean; when true, agent manages its own workload and skips K8s provisioning), `repos` (array of `org/repo` strings; agent's accessible repositories), `slackBotToken` / `anthropicApiKey` (AES-256-GCM encrypted). |
 | `AgentEnv` | Key/value env store | `key`, `value` (encrypted); unique per `[agentId, key]`. |
 | `AgentCronJob` | Scheduled prompts | `schedule` (cron expr), `prompt`, `channel` **xor** `user`, `silent`, `enabled`, `preCheck`, `name`/`system` (system-cron key). |
 | `AgentTool` | Allowed tool patterns | `pattern` (e.g. `Read`, `Bash`), `enabled`; unique per `[agentId, pattern]`. |

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -133,7 +133,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{id}": {
+    "/agents/{id}/provision": {
         parameters: {
             query?: never;
             header?: never;
@@ -141,6 +141,100 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Agent provisioned (or already-provisioned — idempotent), or skipped for self-hosted agents */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ProvisionAgentResult"] | components["schemas"]["ProvisionSkippedResult"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Agent not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Full agent record */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GetAgentResult"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Agent not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
         put?: never;
         post?: never;
         delete: {
@@ -183,7 +277,59 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["PatchAgentBody"];
+                };
+            };
+            responses: {
+                /** @description Agent updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GetAgentResult"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Agent not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/agents/{id}/envs": {
@@ -978,6 +1124,8 @@ export interface components {
             name: string;
             /** @example U0AALR8M69X */
             slackId?: string | null;
+            /** @example false */
+            selfHosted: boolean;
             /**
              * Format: date-time
              * @example 2026-01-01T00:00:00.000Z
@@ -998,20 +1146,56 @@ export interface components {
             name: string;
             /** @example U0AALR8M69X */
             slackId?: string;
+            /** @example false */
+            selfHosted?: boolean;
         };
         ReconcileAgentsResult: {
             recreated: string[];
+            updated: string[];
             orphans: string[];
             failed: {
                 agentId: string;
                 error: string;
             }[];
         };
+        ProvisionAgentResult: {
+            resourceName: string;
+            secretName: string;
+            deploymentName: string;
+        };
+        ProvisionSkippedResult: {
+            /** @enum {boolean} */
+            skipped: true;
+            reason: string;
+        };
+        GetAgentResult: {
+            id: string;
+            name: string;
+            slackId?: string | null;
+            selfHosted: boolean;
+            repos: string[];
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        PatchAgentBody: {
+            /** @example false */
+            selfHosted?: boolean;
+            /**
+             * @example [
+             *       "my-org/my-repo"
+             *     ]
+             */
+            repos?: string[];
+        };
         AgentSummary: {
             /** @example clx1234567890 */
             id: string;
             /** @example Bodhi */
             name: string;
+            /** @example false */
+            selfHosted: boolean;
         };
         Ok: {
             /** @enum {boolean} */


### PR DESCRIPTION
## Summary
- Adds `repos String[] @default([])` to the `Agent` Prisma model with an additive migration (existing agents default to `[]`)
- PATCH `/agents/:id` now accepts a `repos` array and validates each entry matches `org/repo` format, returning 400 with a descriptive error on invalid entries
- GET `/agents/:id` now returns the `repos` field in all responses

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | PATCH repos: ['vitals-os'] → 400 (missing org) | MET |
| 2 | PATCH repos: ['app-vitals/vitals-os'] → 200 | MET |
| 3 | GET returns repos field ([] for existing agents) | MET |
| 4 | Migration additive — existing agents default to [] | MET |
| 5 | Smoke test (validation) + integration (round-trip) | MET |

## Test Plan
- [x] Smoke tests: PATCH invalid format → 400, PATCH valid format → 200, GET → repos field present
- [x] Integration test: PATCH repos → GET confirms round-trip persistence
- [x] All 75 admin smoke tests pass
- [x] Biome lint clean; TypeScript typecheck exit 0
- [x] Coverage: 98.27% lines on agents-api.ts (above 90% threshold)

Generated with [Claude Code](https://claude.com/claude-code)
