### PR TITLE
feat(task-store): add blockedBy computed field to task API responses

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,6 +37,7 @@ Each `Task` in the response now includes a `blockedBy` array describing why the 
 
 `BlockedByEntry` is one of:
 - `{ type: "hitl" }` — the task has `hitl: true` and `hitlNotifiedAt` is null (awaiting human confirmation)
+- `{ type: "hitl", notified: true }` — notification was already sent (`hitlNotifiedAt` is set); the task is still excluded from `?ready=true` but no agent-actionable block remains
 - `{ type: "dependency"; id: string; status: string }` — a dependency task is not satisfied (see dependency satisfaction rules in `docs/task-store.md`)
 
 When `blockedBy` is empty, the task is ready to execute (assuming it has `status: pending`).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,9 +4,9 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
-## `GET /tasks` response shape change
+## `GET /tasks` and `GET /tasks/:id` response shape change
 
-**Version**: next (feat/task-filters)
+**Version**: next (feat/task-filters, feat/ts-api-blocked-by)
 
 `GET /tasks` previously returned a bare `Task[]`. It now returns an envelope:
 
@@ -14,10 +14,38 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 { "tasks": Task[], "total": number, "limit": number, "offset": number }
 ```
 
+Each `Task` in the response now includes a `blockedBy` array describing why the task is not yet ready:
+
+```json
+{
+  "tasks": [
+    {
+      "id": "task-1",
+      "status": "pending",
+      ...
+      "blockedBy": [
+        { "type": "hitl" },
+        { "type": "dependency", "id": "dep-1", "status": "in_progress" }
+      ]
+    }
+  ],
+  "total": 1,
+  "limit": 50,
+  "offset": 0
+}
+```
+
+`BlockedByEntry` is one of:
+- `{ type: "hitl" }` — the task has `hitl: true` and `hitlNotifiedAt` is null (awaiting human confirmation)
+- `{ type: "dependency"; id: string; status: string }` — a dependency task is not satisfied (see dependency satisfaction rules in `docs/task-store.md`)
+
+When `blockedBy` is empty, the task is ready to execute (assuming it has `status: pending`).
+
 **What to update:**
 - Any code that calls `GET /tasks` and expects an array must unwrap `.tasks` from the response.
 - `check-helpers.ts` in the plugin is updated in this PR. Custom scripts or agents calling `/tasks` directly need the same fix.
-- `GET /tasks?ready=true` is unchanged — it still returns `Task[]`.
+- Code that checks task readiness should use the `blockedBy` array instead of duplicating dependency logic.
+- `GET /tasks?ready=true` is unchanged — it still returns `Task[]` (filtered to ready tasks only, with `blockedBy` also present).
 
 ---
 

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Task } from "./index.ts";
-import type { TaskListFilters, TaskListResult, TaskServiceLike } from "./task-service.ts";
+import type { TaskListFilters, TaskListResult, TaskServiceLike, TaskWithBlockedBy } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
 // ─── Fakes ────────────────────────────────────────────────────────────────────
@@ -125,6 +125,10 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
+function withBlockedBy(task: Task): TaskWithBlockedBy {
+  return { ...task, blockedBy: [] };
+}
+
 /** Minimal TaskService fake — only the methods exercised by smoke tests. */
 function fakeTaskService(
   opts: {
@@ -136,7 +140,7 @@ function fakeTaskService(
 ): TaskServiceLike {
   return {
     async list(filters?) {
-      const tasks = opts.listResult ?? [];
+      const tasks = (opts.listResult ?? []).map(withBlockedBy);
       return {
         tasks,
         total: tasks.length,
@@ -148,8 +152,8 @@ function fakeTaskService(
       return opts.listReadyResult ?? [];
     },
     async get(id: string) {
-      if ("getResult" in opts) return opts.getResult ?? null;
-      return makeTask({ id });
+      if ("getResult" in opts) return opts.getResult ? withBlockedBy(opts.getResult) : null;
+      return withBlockedBy(makeTask({ id }));
     },
     async create(data) {
       return makeTask({ ...(data as Partial<Task>), id: "created-1" });

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -1,0 +1,304 @@
+/**
+ * task-store/src/blocked-by.smoke.test.ts
+ *
+ * Smoke tests verifying that blockedBy is present on both
+ * GET /tasks/:id and GET /tasks (list) responses.
+ *
+ * No real socket, no real DB — services are injected as in-memory fakes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createTaskStoreApp } from "./app.ts";
+import { computeBlockedBy } from "./blocked-by.ts";
+import type { Task } from "./index.ts";
+import type { TaskListFilters, TaskListResult, TaskServiceLike, TaskWithBlockedBy } from "./task-service.ts";
+import type { TokenServiceLike } from "./token-service.ts";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────────
+
+const VALID_TOKEN = "valid-token";
+
+function fakeTokenService(): TokenServiceLike {
+  return {
+    async create(label?: string) {
+      return {
+        token: {
+          id: "tok-1",
+          token: "hash",
+          label: label ?? null,
+          agentId: null,
+          createdAt: new Date(),
+          revokedAt: null,
+        },
+        rawToken: "raw",
+      };
+    },
+    async validate(raw: string) {
+      return raw === VALID_TOKEN ? { id: "tok-1", agentId: null } : null;
+    },
+    async revoke() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "A task",
+    status: "pending",
+    source: null,
+    session: null,
+    repo: null,
+    description: null,
+    acceptanceCriteria: [],
+    layer: null,
+    branch: null,
+    dependencies: [],
+    pr: null,
+    hours: null,
+    addedAt: null,
+    startedAt: null,
+    prCreatedAt: null,
+    mergedAt: null,
+    blockedAt: null,
+    blockedReason: null,
+    note: null,
+    type: null,
+    priority: null,
+    cancelledAt: null,
+    completedAt: null,
+    deployingAt: null,
+    ciFixAttempts: null,
+    mergeCommit: null,
+    prUrl: null,
+    assignee: null,
+    issue: null,
+    model: null,
+    complexity: null,
+    hitl: null,
+    hitlNotifiedAt: null,
+    claimedBy: null,
+    agentHint: null,
+    claimedAt: null,
+    heartbeatAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Task;
+}
+
+/** Attach blockedBy to a Task using the real computeBlockedBy helper. */
+function withBlockedBy(task: Task, allTasks: Task[]): TaskWithBlockedBy {
+  return { ...task, blockedBy: computeBlockedBy(task, allTasks) };
+}
+
+/** Task service fake that returns configured tasks for get/list. */
+function fakeTaskService(
+  opts: {
+    getResult?: Task | null;
+    listResult?: Task[];
+    listReadyResult?: Task[];
+    allTasks?: Task[];
+  } = {},
+): TaskServiceLike {
+  const allTasks = opts.allTasks ?? [];
+  return {
+    async list(filters?: TaskListFilters) {
+      const tasks = opts.listResult ?? allTasks;
+      const tasksWithBlockedBy = tasks.map((t) => withBlockedBy(t, allTasks));
+      return {
+        tasks: tasksWithBlockedBy,
+        total: tasks.length,
+        limit: filters?.limit ?? 50,
+        offset: filters?.offset ?? 0,
+      };
+    },
+    async listReady() {
+      return opts.listReadyResult ?? [];
+    },
+    async get(id: string) {
+      if ("getResult" in opts) {
+        if (!opts.getResult) return null;
+        return withBlockedBy(opts.getResult, allTasks);
+      }
+      const found = allTasks.find((t) => t.id === id) ?? makeTask({ id });
+      return withBlockedBy(found, allTasks);
+    },
+    async create(data) {
+      return makeTask({ ...(data as Partial<Task>), id: "created-1" });
+    },
+    async update(id, data) {
+      return makeTask({ ...(data as Partial<Task>), id });
+    },
+    async remove() {
+      return;
+    },
+    async claim(id: string, claimedBy: string) {
+      return makeTask({ id, status: "in_progress", claimedBy });
+    },
+    async heartbeat(id: string) {
+      return makeTask({ id, status: "in_progress" });
+    },
+    async complete(id: string) {
+      return makeTask({ id, status: "done" });
+    },
+    async fail(id: string) {
+      return makeTask({ id, status: "blocked" });
+    },
+    async release(id: string) {
+      return makeTask({ id, status: "pending" });
+    },
+    async bulk(_tasks) {
+      return { inserted: 0, updated: 0 };
+    },
+  };
+}
+
+function makeApp(taskService: TaskServiceLike) {
+  return createTaskStoreApp({
+    taskService,
+    tokenService: fakeTokenService(),
+  });
+}
+
+function auth(): Record<string, string> {
+  return { Authorization: `Bearer ${VALID_TOKEN}` };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("blockedBy field on API responses (smoke)", () => {
+  // ─── GET /tasks/:id ─────────────────────────────────────────────────────────
+
+  it("GET /tasks/:id includes blockedBy array on a simple pending task", async () => {
+    const task = makeTask({ id: "t1", status: "pending" });
+    const app = makeApp(fakeTaskService({ getResult: task }));
+    const res = await app.request("/tasks/t1", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskWithBlockedBy;
+    expect(Array.isArray(body.blockedBy)).toBe(true);
+    expect(body.blockedBy).toEqual([]);
+  });
+
+  it("GET /tasks/:id includes { type: 'hitl' } when hitl=true and hitlNotifiedAt=null", async () => {
+    const task = makeTask({
+      id: "t1",
+      status: "pending",
+      hitl: true,
+      hitlNotifiedAt: null,
+    });
+    const app = makeApp(fakeTaskService({ getResult: task }));
+    const res = await app.request("/tasks/t1", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskWithBlockedBy;
+    expect(body.blockedBy).toContainEqual({ type: "hitl" });
+  });
+
+  it("GET /tasks/:id blockedBy is empty when hitl=true but hitlNotifiedAt is set", async () => {
+    const task = makeTask({
+      id: "t1",
+      status: "pending",
+      hitl: true,
+      hitlNotifiedAt: "2026-06-24T10:00:00.000Z",
+    });
+    const app = makeApp(fakeTaskService({ getResult: task }));
+    const res = await app.request("/tasks/t1", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskWithBlockedBy;
+    expect(body.blockedBy).toEqual([]);
+  });
+
+  it("GET /tasks/:id includes dep block when dep is in non-terminal status", async () => {
+    const dep = makeTask({ id: "dep-1", status: "in_progress" });
+    const task = makeTask({
+      id: "t1",
+      status: "pending",
+      dependencies: ["dep-1"],
+    });
+    // allTasks includes both so get() can look up the dep
+    const app = makeApp(fakeTaskService({ getResult: task, allTasks: [task, dep] }));
+    const res = await app.request("/tasks/t1", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskWithBlockedBy;
+    expect(body.blockedBy).toContainEqual({
+      type: "dependency",
+      id: "dep-1",
+      status: "in_progress",
+    });
+  });
+
+  it("GET /tasks/:id blockedBy is empty when all deps are satisfied (done)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "done" });
+    const task = makeTask({
+      id: "t1",
+      status: "pending",
+      dependencies: ["dep-1"],
+    });
+    const app = makeApp(fakeTaskService({ getResult: task, allTasks: [task, dep] }));
+    const res = await app.request("/tasks/t1", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskWithBlockedBy;
+    expect(body.blockedBy).toEqual([]);
+  });
+
+  // ─── GET /tasks (list) ──────────────────────────────────────────────────────
+
+  it("GET /tasks list response includes blockedBy on each task", async () => {
+    const task = makeTask({ id: "t1", status: "pending" });
+    const app = makeApp(fakeTaskService({ listResult: [task] }));
+    const res = await app.request("/tasks", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tasks: TaskWithBlockedBy[]; total: number; limit: number; offset: number };
+    expect(Array.isArray(body.tasks)).toBe(true);
+    expect(body.tasks).toHaveLength(1);
+    expect(Array.isArray(body.tasks[0].blockedBy)).toBe(true);
+  });
+
+  it("GET /tasks list response shape is { tasks, total, limit, offset }", async () => {
+    const task = makeTask({ id: "t1", status: "pending" });
+    const app = makeApp(fakeTaskService({ listResult: [task] }));
+    const res = await app.request("/tasks", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: TaskWithBlockedBy[];
+      total: number;
+      limit: number;
+      offset: number;
+    };
+    expect(typeof body.total).toBe("number");
+    expect(typeof body.limit).toBe("number");
+    expect(typeof body.offset).toBe("number");
+  });
+
+  it("GET /tasks list returns hitl block on tasks with hitl=true and hitlNotifiedAt=null", async () => {
+    const task = makeTask({
+      id: "t1",
+      status: "pending",
+      hitl: true,
+      hitlNotifiedAt: null,
+    });
+    const app = makeApp(fakeTaskService({ listResult: [task] }));
+    const res = await app.request("/tasks", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tasks: TaskWithBlockedBy[] };
+    expect(body.tasks[0].blockedBy).toContainEqual({ type: "hitl" });
+  });
+
+  it("GET /tasks list returns empty blockedBy for tasks with no blocks", async () => {
+    const task = makeTask({
+      id: "t1",
+      status: "pending",
+      hitl: false,
+      dependencies: [],
+    });
+    const app = makeApp(fakeTaskService({ listResult: [task] }));
+    const res = await app.request("/tasks", { headers: auth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tasks: TaskWithBlockedBy[] };
+    expect(body.tasks[0].blockedBy).toEqual([]);
+  });
+});

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -198,7 +198,7 @@ describe("blockedBy field on API responses (smoke)", () => {
     expect(body.blockedBy).toContainEqual({ type: "hitl" });
   });
 
-  it("GET /tasks/:id blockedBy is empty when hitl=true but hitlNotifiedAt is set", async () => {
+  it("GET /tasks/:id includes { type: 'hitl', notified: true } when hitl=true and hitlNotifiedAt is set", async () => {
     const task = makeTask({
       id: "t1",
       status: "pending",
@@ -209,7 +209,7 @@ describe("blockedBy field on API responses (smoke)", () => {
     const res = await app.request("/tasks/t1", { headers: auth() });
     expect(res.status).toBe(200);
     const body = (await res.json()) as TaskWithBlockedBy;
-    expect(body.blockedBy).toEqual([]);
+    expect(body.blockedBy).toEqual([{ type: "hitl", notified: true }]);
   });
 
   it("GET /tasks/:id includes dep block when dep is in non-terminal status", async () => {

--- a/task-store/src/blocked-by.ts
+++ b/task-store/src/blocked-by.ts
@@ -20,9 +20,20 @@ import { CLOSED_STATUSES } from "./statuses.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-/** A single reason why a task is not yet ready. */
+/**
+ * A single reason why a task is not yet ready.
+ *
+ * `{ type: "hitl" }` — notification has not yet been sent; task is awaiting
+ * the HITL gate to be opened.
+ *
+ * `{ type: "hitl"; notified: true }` — notification was already sent
+ * (`hitlNotifiedAt` is set) so the agent-actionable block is cleared, but the
+ * task is still excluded from `listReady` because `hitl=true` tasks are never
+ * considered ready. Consumers MUST NOT infer that `blockedBy: []` means
+ * "this task is ready" — it only means there are no agent-actionable blocks.
+ */
 export type BlockedByEntry =
-  | { type: "hitl" }
+  | { type: "hitl"; notified?: true }
   | { type: "dependency"; id: string; status: string };
 
 // ─── Terminal statuses ────────────────────────────────────────────────────────
@@ -44,9 +55,17 @@ export function computeBlockedBy(
 ): BlockedByEntry[] {
   const blocks: BlockedByEntry[] = [];
 
-  // HITL gate: blocked when hitl=true and the notification hasn't been sent yet.
-  if (task.hitl === true && task.hitlNotifiedAt == null) {
-    blocks.push({ type: "hitl" });
+  // HITL gate.
+  // - hitl=true, hitlNotifiedAt=null  → notification not yet sent; agent-actionable block.
+  // - hitl=true, hitlNotifiedAt set   → notification already sent; passive wait.
+  //   Emit { type: "hitl", notified: true } so consumers can distinguish the
+  //   two states. The task is still excluded from listReady in both cases.
+  if (task.hitl === true) {
+    if (task.hitlNotifiedAt == null) {
+      blocks.push({ type: "hitl" });
+    } else {
+      blocks.push({ type: "hitl", notified: true });
+    }
   }
 
   // Dependency gate.

--- a/task-store/src/blocked-by.ts
+++ b/task-store/src/blocked-by.ts
@@ -16,6 +16,7 @@
  */
 
 import type { ReadyTaskLike } from "./ready.ts";
+import { CLOSED_STATUSES } from "./statuses.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -24,15 +25,9 @@ export type BlockedByEntry =
   | { type: "hitl" }
   | { type: "dependency"; id: string; status: string };
 
-// ─── Terminal statuses (mirrors task-service.ts CLOSED_STATUSES) ──────────────
+// ─── Terminal statuses ────────────────────────────────────────────────────────
 
-const TERMINAL_STATUSES = new Set([
-  "merged",
-  "done",
-  "deploying",
-  "deployed",
-  "cancelled",
-]);
+const TERMINAL_STATUSES = new Set<string>(CLOSED_STATUSES);
 
 // ─── Core helper ─────────────────────────────────────────────────────────────
 

--- a/task-store/src/blocked-by.ts
+++ b/task-store/src/blocked-by.ts
@@ -1,0 +1,90 @@
+/**
+ * task-store/src/blocked-by.ts
+ *
+ * Pure helper: computeBlockedBy(task, allTasks) → BlockedByEntry[]
+ *
+ * A task can be blocked by:
+ *   1. An HITL gate (hitl=true AND hitlNotifiedAt is null)
+ *   2. Unsatisfied dependency tasks
+ *
+ * Dependency-satisfied rules (mirrors ready.ts):
+ *   1. dep.status ∈ { merged, done, deploying, deployed, cancelled } → satisfied
+ *   2. same-branch dep with status ∈ { pr_open, approved } → satisfied (bundled)
+ *   3. anything else → not satisfied (including cross-branch pr_open without a
+ *      verified merge — the task-store has no GitHub access, so we never treat
+ *      cross-branch pr_open as satisfied)
+ */
+
+import type { ReadyTaskLike } from "./ready.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** A single reason why a task is not yet ready. */
+export type BlockedByEntry =
+  | { type: "hitl" }
+  | { type: "dependency"; id: string; status: string };
+
+// ─── Terminal statuses (mirrors task-service.ts CLOSED_STATUSES) ──────────────
+
+const TERMINAL_STATUSES = new Set([
+  "merged",
+  "done",
+  "deploying",
+  "deployed",
+  "cancelled",
+]);
+
+// ─── Core helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Compute all reasons why `task` is currently blocked.
+ * Returns an empty array when nothing blocks the task.
+ *
+ * @param task      The task to evaluate.
+ * @param allTasks  The full task list used to resolve dependency IDs.
+ */
+export function computeBlockedBy(
+  task: ReadyTaskLike,
+  allTasks: ReadyTaskLike[],
+): BlockedByEntry[] {
+  const blocks: BlockedByEntry[] = [];
+
+  // HITL gate: blocked when hitl=true and the notification hasn't been sent yet.
+  if (task.hitl === true && task.hitlNotifiedAt == null) {
+    blocks.push({ type: "hitl" });
+  }
+
+  // Dependency gate.
+  if (task.dependencies && task.dependencies.length > 0) {
+    const byId = new Map(allTasks.map((t) => [t.id, t]));
+
+    for (const depId of task.dependencies) {
+      const dep = byId.get(depId);
+
+      if (!dep) {
+        // Dependency is not in the task list — treat as unknown/blocking.
+        blocks.push({ type: "dependency", id: depId, status: "unknown" });
+        continue;
+      }
+
+      // 1. Terminal statuses → satisfied.
+      if (TERMINAL_STATUSES.has(dep.status)) {
+        continue;
+      }
+
+      // 2. Same-branch pr_open / approved → bundled, satisfied.
+      if (
+        dep.branch &&
+        dep.branch === task.branch &&
+        (dep.status === "pr_open" || dep.status === "approved")
+      ) {
+        continue;
+      }
+
+      // 3. Everything else → not satisfied.
+      blocks.push({ type: "dependency", id: depId, status: dep.status });
+    }
+  }
+
+  return blocks;
+}

--- a/task-store/src/blocked-by.unit.test.ts
+++ b/task-store/src/blocked-by.unit.test.ts
@@ -45,14 +45,14 @@ describe("computeBlockedBy", () => {
     expect(result).toEqual([{ type: "hitl" }]);
   });
 
-  it("does NOT include hitl block when hitl=true but hitlNotifiedAt is set", () => {
+  it("includes { type: 'hitl', notified: true } when hitl=true and hitlNotifiedAt is set", () => {
     const task = makeTask({
       id: "t1",
       hitl: true,
       hitlNotifiedAt: "2026-06-24T10:00:00.000Z",
     });
     const result = computeBlockedBy(task, [task]);
-    expect(result).toEqual([]);
+    expect(result).toEqual([{ type: "hitl", notified: true }]);
   });
 
   it("includes dep block for dependency in non-terminal status (pending)", () => {

--- a/task-store/src/blocked-by.unit.test.ts
+++ b/task-store/src/blocked-by.unit.test.ts
@@ -1,0 +1,213 @@
+/**
+ * task-store/src/blocked-by.unit.test.ts
+ *
+ * Unit tests for the computeBlockedBy() pure helper.
+ * No I/O — pure logic only.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { computeBlockedBy } from "./blocked-by.ts";
+import type { ReadyTaskLike } from "./ready.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<ReadyTaskLike> = {}): ReadyTaskLike {
+  return {
+    id: "task-1",
+    status: "pending",
+    branch: null,
+    dependencies: [],
+    pr: null,
+    hitl: null,
+    hitlNotifiedAt: null,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("computeBlockedBy", () => {
+  it("returns empty array when task has no HITL and no dependencies", () => {
+    const task = makeTask({ id: "t1" });
+    const result = computeBlockedBy(task, [task]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when HITL is false and no dependencies", () => {
+    const task = makeTask({ id: "t1", hitl: false });
+    const result = computeBlockedBy(task, [task]);
+    expect(result).toEqual([]);
+  });
+
+  it("includes hitl block when hitl=true and hitlNotifiedAt is null", () => {
+    const task = makeTask({ id: "t1", hitl: true, hitlNotifiedAt: null });
+    const result = computeBlockedBy(task, [task]);
+    expect(result).toEqual([{ type: "hitl" }]);
+  });
+
+  it("does NOT include hitl block when hitl=true but hitlNotifiedAt is set", () => {
+    const task = makeTask({
+      id: "t1",
+      hitl: true,
+      hitlNotifiedAt: "2026-06-24T10:00:00.000Z",
+    });
+    const result = computeBlockedBy(task, [task]);
+    expect(result).toEqual([]);
+  });
+
+  it("includes dep block for dependency in non-terminal status (pending)", () => {
+    const dep = makeTask({ id: "dep-1", status: "pending" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([
+      { type: "dependency", id: "dep-1", status: "pending" },
+    ]);
+  });
+
+  it("includes dep block for dependency in non-terminal status (in_progress)", () => {
+    const dep = makeTask({ id: "dep-1", status: "in_progress" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([
+      { type: "dependency", id: "dep-1", status: "in_progress" },
+    ]);
+  });
+
+  it("returns empty array when dependency is in terminal status (merged)", () => {
+    const dep = makeTask({ id: "dep-1", status: "merged" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when dependency is in terminal status (done)", () => {
+    const dep = makeTask({ id: "dep-1", status: "done" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when dependency is in terminal status (deploying)", () => {
+    const dep = makeTask({ id: "dep-1", status: "deploying" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when dependency is in terminal status (deployed)", () => {
+    const dep = makeTask({ id: "dep-1", status: "deployed" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when dependency is in terminal status (cancelled)", () => {
+    const dep = makeTask({ id: "dep-1", status: "cancelled" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when same-branch dep has pr_open status (bundled)", () => {
+    const dep = makeTask({
+      id: "dep-1",
+      status: "pr_open",
+      branch: "feat/shared",
+    });
+    const task = makeTask({
+      id: "t1",
+      dependencies: ["dep-1"],
+      branch: "feat/shared",
+    });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when same-branch dep has approved status (bundled)", () => {
+    const dep = makeTask({
+      id: "dep-1",
+      status: "approved",
+      branch: "feat/shared",
+    });
+    const task = makeTask({
+      id: "t1",
+      dependencies: ["dep-1"],
+      branch: "feat/shared",
+    });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([]);
+  });
+
+  it("includes dep block when cross-branch dep has pr_open status (not satisfied)", () => {
+    const dep = makeTask({
+      id: "dep-1",
+      status: "pr_open",
+      branch: "feat/other",
+      pr: 42,
+    });
+    const task = makeTask({
+      id: "t1",
+      dependencies: ["dep-1"],
+      branch: "feat/main",
+    });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([
+      { type: "dependency", id: "dep-1", status: "pr_open" },
+    ]);
+  });
+
+  it("includes dep block for dep with approved status on different branch", () => {
+    const dep = makeTask({
+      id: "dep-1",
+      status: "approved",
+      branch: "feat/other",
+    });
+    const task = makeTask({
+      id: "t1",
+      dependencies: ["dep-1"],
+      branch: "feat/main",
+    });
+    const result = computeBlockedBy(task, [task, dep]);
+    expect(result).toEqual([
+      { type: "dependency", id: "dep-1", status: "approved" },
+    ]);
+  });
+
+  it("includes dep block when dep is missing from allTasks", () => {
+    const task = makeTask({ id: "t1", dependencies: ["missing-dep"] });
+    const result = computeBlockedBy(task, [task]);
+    expect(result).toEqual([
+      { type: "dependency", id: "missing-dep", status: "unknown" },
+    ]);
+  });
+
+  it("accumulates multiple blocks: hitl + multiple unsatisfied deps", () => {
+    const dep1 = makeTask({ id: "dep-1", status: "in_progress" });
+    const dep2 = makeTask({ id: "dep-2", status: "pending" });
+    const task = makeTask({
+      id: "t1",
+      hitl: true,
+      hitlNotifiedAt: null,
+      dependencies: ["dep-1", "dep-2"],
+    });
+    const result = computeBlockedBy(task, [task, dep1, dep2]);
+    expect(result).toEqual([
+      { type: "hitl" },
+      { type: "dependency", id: "dep-1", status: "in_progress" },
+      { type: "dependency", id: "dep-2", status: "pending" },
+    ]);
+  });
+
+  it("handles mixed deps: one satisfied, one not", () => {
+    const satisfied = makeTask({ id: "dep-done", status: "done" });
+    const blocking = makeTask({ id: "dep-pending", status: "pending" });
+    const task = makeTask({
+      id: "t1",
+      dependencies: ["dep-done", "dep-pending"],
+    });
+    const result = computeBlockedBy(task, [task, satisfied, blocking]);
+    expect(result).toEqual([
+      { type: "dependency", id: "dep-pending", status: "pending" },
+    ]);
+  });
+});

--- a/task-store/src/index.ts
+++ b/task-store/src/index.ts
@@ -8,3 +8,4 @@
 
 export { PrismaClient, Prisma, TaskStatus } from "../prisma/client/index.js";
 export type { Task, TaskToken } from "../prisma/client/index.js";
+export type { BlockedByEntry, TaskWithBlockedBy, TaskListResult } from "./task-service.ts";

--- a/task-store/src/ready.ts
+++ b/task-store/src/ready.ts
@@ -27,6 +27,9 @@ export interface ReadyTaskLike {
   dependencies?: string[];
   pr?: number | null;
   hitl?: boolean | null;
+  /** ISO timestamp set when HITL notification was sent; null while awaiting. */
+  hitlNotifiedAt?: string | null;
+  assignee?: string | null;
 }
 
 export async function resolveReadyTasks<T extends ReadyTaskLike>(

--- a/task-store/src/ready.ts
+++ b/task-store/src/ready.ts
@@ -29,7 +29,6 @@ export interface ReadyTaskLike {
   hitl?: boolean | null;
   /** ISO timestamp set when HITL notification was sent; null while awaiting. */
   hitlNotifiedAt?: string | null;
-  assignee?: string | null;
 }
 
 export async function resolveReadyTasks<T extends ReadyTaskLike>(

--- a/task-store/src/statuses.ts
+++ b/task-store/src/statuses.ts
@@ -1,0 +1,25 @@
+/**
+ * task-store/src/statuses.ts
+ *
+ * Shared task status constants. Extracted here so that both task-service.ts
+ * and blocked-by.ts can import from a single source of truth, eliminating
+ * any risk of silent drift when new statuses are added.
+ */
+
+/** Terminal statuses — a task in one of these is considered "closed". */
+export const CLOSED_STATUSES = [
+  "merged",
+  "done",
+  "deploying",
+  "deployed",
+  "cancelled",
+] as const;
+
+/** Open statuses — everything not closed. */
+export const OPEN_STATUSES = [
+  "pending",
+  "in_progress",
+  "pr_open",
+  "approved",
+  "blocked",
+] as const;

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -13,9 +13,16 @@
  */
 
 import { type Clock, SystemClock } from "./clock.ts";
+import { type BlockedByEntry, computeBlockedBy } from "./blocked-by.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Prisma, PrismaClient, Task } from "./index.ts";
 import { resolveReadyTasks } from "./ready.ts";
+
+// Re-export so callers can import from task-service without reaching into blocked-by.
+export type { BlockedByEntry };
+
+/** A Task augmented with a computed blockedBy array. */
+export type TaskWithBlockedBy = Task & { blockedBy: BlockedByEntry[] };
 
 /** Terminal statuses — a task in one of these is considered "closed". */
 export const CLOSED_STATUSES = [
@@ -52,7 +59,7 @@ export interface TaskListFilters {
 
 /** Paginated list result from TaskService.list. */
 export interface TaskListResult {
-  tasks: Task[];
+  tasks: TaskWithBlockedBy[];
   total: number;
   limit: number;
   offset: number;
@@ -62,7 +69,7 @@ export interface TaskListResult {
 export interface TaskServiceLike {
   list(filters?: TaskListFilters): Promise<TaskListResult>;
   listReady(agentId?: string): Promise<Task[]>;
-  get(id: string): Promise<Task | null>;
+  get(id: string): Promise<TaskWithBlockedBy | null>;
   create(data: Prisma.TaskCreateInput): Promise<Task>;
   bulk(
     tasks: Prisma.TaskCreateInput[],
@@ -104,7 +111,8 @@ export class TaskService implements TaskServiceLike {
     const limit = filters.limit ?? 50;
     const offset = filters.offset ?? 0;
 
-    const [tasks, total] = await this.prisma.$transaction([
+    // Load all tasks for dependency resolution (computeBlockedBy needs the full graph).
+    const [pageTasks, total, allTasks] = await this.prisma.$transaction([
       this.prisma.task.findMany({
         where,
         orderBy: { createdAt: "asc" },
@@ -112,7 +120,13 @@ export class TaskService implements TaskServiceLike {
         skip: offset,
       }),
       this.prisma.task.count({ where }),
+      this.prisma.task.findMany(),
     ]);
+
+    const tasks: TaskWithBlockedBy[] = pageTasks.map((t: Task) => ({
+      ...t,
+      blockedBy: computeBlockedBy(t, allTasks),
+    }));
 
     return { tasks, total, limit, offset };
   }
@@ -133,8 +147,12 @@ export class TaskService implements TaskServiceLike {
     return ready;
   }
 
-  async get(id: string): Promise<Task | null> {
-    return this.prisma.task.findUnique({ where: { id } });
+  async get(id: string): Promise<TaskWithBlockedBy | null> {
+    const task = await this.prisma.task.findUnique({ where: { id } });
+    if (!task) return null;
+    // Load all tasks for dependency resolution.
+    const allTasks = await this.prisma.task.findMany();
+    return { ...task, blockedBy: computeBlockedBy(task, allTasks) };
   }
 
   // ─── Writes ────────────────────────────────────────────────────────────────

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -17,30 +17,14 @@ import { type BlockedByEntry, computeBlockedBy } from "./blocked-by.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Prisma, PrismaClient, Task } from "./index.ts";
 import { resolveReadyTasks } from "./ready.ts";
+import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
 
 // Re-export so callers can import from task-service without reaching into blocked-by.
 export type { BlockedByEntry };
+export { CLOSED_STATUSES, OPEN_STATUSES };
 
 /** A Task augmented with a computed blockedBy array. */
 export type TaskWithBlockedBy = Task & { blockedBy: BlockedByEntry[] };
-
-/** Terminal statuses — a task in one of these is considered "closed". */
-export const CLOSED_STATUSES = [
-  "merged",
-  "done",
-  "deploying",
-  "deployed",
-  "cancelled",
-] as const;
-
-/** Open statuses — everything not closed. */
-export const OPEN_STATUSES = [
-  "pending",
-  "in_progress",
-  "pr_open",
-  "approved",
-  "blocked",
-] as const;
 
 /** Filters accepted by TaskService.list. */
 export interface TaskListFilters {
@@ -150,8 +134,11 @@ export class TaskService implements TaskServiceLike {
   async get(id: string): Promise<TaskWithBlockedBy | null> {
     const task = await this.prisma.task.findUnique({ where: { id } });
     if (!task) return null;
-    // Load all tasks for dependency resolution.
-    const allTasks = await this.prisma.task.findMany();
+    // Scope the dependency lookup to only the IDs this task depends on —
+    // avoids a full-table scan when GET /tasks/:id is called frequently.
+    const allTasks = task.dependencies?.length
+      ? await this.prisma.task.findMany({ where: { id: { in: task.dependencies } } })
+      : [];
     return { ...task, blockedBy: computeBlockedBy(task, allTasks) };
   }
 


### PR DESCRIPTION
## Summary

- Adds `blockedBy: BlockedByEntry[]` computed field to all task API responses, explaining exactly why a task isn't ready
- `GET /tasks` list and `GET /tasks/:id` single-task endpoints both return `blockedBy`
- Exports `TaskWithBlockedBy`, `BlockedByEntry`, and updated `TaskListResult` from `@shipwright/task-store`

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All tasks include a `blockedBy` array (empty if nothing blocks) | ✅ MET |
| 2 | HITL block as `{ type: "hitl" }` when `hitl=true` and `hitlNotifiedAt=null` | ✅ MET |
| 3 | Dep blocks as `{ type: "dependency", id, status }` per unsatisfied dep | ✅ MET |
| 4 | Tasks with all deps satisfied + no HITL have `blockedBy: []` | ✅ MET |
| 5 | `blockedBy` present on both list and single-task (`GET /tasks/:id`) responses | ✅ MET |
| 6 | List response shape is `{ tasks: TaskWithBlockedBy[], total, limit, offset }` | ✅ MET |
| 7 | Single-task response shape is `TaskWithBlockedBy` | ✅ MET |
| 8 | Existing `?state`, `?status`, `?ready`, `?limit`, `?offset` behavior unchanged | ✅ MET |
| 9 | TypeScript types `TaskWithBlockedBy`, `BlockedByEntry`, `TaskListResult` exported | ✅ MET |

## Test Plan

- [x] 18 unit tests for `computeBlockedBy()` pure helper — all pass
- [x] 9 smoke tests for API responses (`GET /tasks` and `GET /tasks/:id`) — all pass
- [x] `blocked-by.ts` line coverage: 94.59%
- [x] Typecheck passes (`tsc --noEmit`, excluding expected Prisma client errors)
- [x] Biome lint: no issues

Generated with [Claude Code](https://claude.com/claude-code)
