### PR TITLE
fix(check-helpers): handle both Task[] and paginated envelope in query()

### DIFF
--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.29.2",
+  "version": "4.29.3",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -343,8 +343,18 @@ export function createTaskStoreClient(): {
       const res = await fetch(`${baseUrl}/tasks?${params}`, { headers });
       if (!res.ok)
         throw new Error(`task-store GET /tasks?${params} → ${res.status}`);
-      const result = (await res.json()) as { tasks: Task[] };
-      return result.tasks;
+      const data = (await res.json()) as unknown;
+      // ?ready=true returns Task[]; all other queries return { tasks, total, limit, offset }
+      if (Array.isArray(data)) return data as Task[];
+      if (
+        data !== null &&
+        typeof data === "object" &&
+        Array.isArray((data as Record<string, unknown>).tasks)
+      )
+        return (data as Record<string, unknown>).tasks as Task[];
+      throw new Error(
+        `Unexpected task-store response format: ${JSON.stringify(data)}`,
+      );
     },
     async update(id: string, fields: Record<string, unknown>): Promise<Task> {
       const res = await fetch(`${baseUrl}/tasks/${id}`, {

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -506,7 +506,12 @@ describe("createTaskStoreClient query()", () => {
     globalThis.fetch = async () =>
       ({
         ok: true,
-        json: async () => ({ tasks: [FAKE_TASK], total: 1, limit: 50, offset: 0 }),
+        json: async () => ({
+          tasks: [FAKE_TASK],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        }),
       }) as Response;
 
     const client = createTaskStoreClient();

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -463,6 +463,7 @@ describe("createTaskStoreClient query()", () => {
   };
 
   let savedEnv: { url?: string; token?: string };
+  let savedFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     savedEnv = {
@@ -471,9 +472,11 @@ describe("createTaskStoreClient query()", () => {
     };
     process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.com";
     process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "test-token";
+    savedFetch = globalThis.fetch;
   });
 
   afterEach(() => {
+    globalThis.fetch = savedFetch;
     if (savedEnv.url !== undefined) {
       process.env.SHIPWRIGHT_TASK_STORE_URL = savedEnv.url;
     } else {

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -459,7 +459,7 @@ describe("createTaskStoreClient query()", () => {
   const FAKE_TASK = {
     id: "T-1",
     title: "Do the thing",
-    status: "pending",
+    status: "pending" as const,
   };
 
   let savedEnv: { url?: string; token?: string };
@@ -491,11 +491,11 @@ describe("createTaskStoreClient query()", () => {
 
   test("handles bare Task[] response (returned by ?ready=true)", async () => {
     mock.module("node:fetch", () => ({}));
-    globalThis.fetch = async () =>
+    globalThis.fetch = (async () =>
       ({
         ok: true,
         json: async () => [FAKE_TASK],
-      }) as Response;
+      }) as Response) as unknown as typeof fetch;
 
     const client = createTaskStoreClient();
     const result = await client.query(new URLSearchParams({ ready: "true" }));
@@ -503,7 +503,7 @@ describe("createTaskStoreClient query()", () => {
   });
 
   test("unwraps paginated { tasks } envelope (returned by ?status=...)", async () => {
-    globalThis.fetch = async () =>
+    globalThis.fetch = (async () =>
       ({
         ok: true,
         json: async () => ({
@@ -512,7 +512,7 @@ describe("createTaskStoreClient query()", () => {
           limit: 50,
           offset: 0,
         }),
-      }) as Response;
+      }) as Response) as unknown as typeof fetch;
 
     const client = createTaskStoreClient();
     const result = await client.query(
@@ -522,11 +522,11 @@ describe("createTaskStoreClient query()", () => {
   });
 
   test("returns empty array when paginated envelope has empty tasks list", async () => {
-    globalThis.fetch = async () =>
+    globalThis.fetch = (async () =>
       ({
         ok: true,
         json: async () => ({ tasks: [], total: 0, limit: 50, offset: 0 }),
-      }) as Response;
+      }) as Response) as unknown as typeof fetch;
 
     const client = createTaskStoreClient();
     const result = await client.query(
@@ -536,11 +536,11 @@ describe("createTaskStoreClient query()", () => {
   });
 
   test("throws on unrecognised response shape", async () => {
-    globalThis.fetch = async () =>
+    globalThis.fetch = (async () =>
       ({
         ok: true,
         json: async () => ({ unexpected: true }),
-      }) as Response;
+      }) as Response) as unknown as typeof fetch;
 
     const client = createTaskStoreClient();
     await expect(

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -1,10 +1,11 @@
 /**
  * plugins/shipwright/scripts/check-helpers.unit.test.ts
  *
- * Unit tests for resolveRepos() and getCurrentUser() in check-helpers.ts
+ * Unit tests for resolveRepos(), getCurrentUser(), and createTaskStoreClient()
+ * in check-helpers.ts
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   chmodSync,
   mkdirSync,
@@ -15,6 +16,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  createTaskStoreClient,
   getCurrentUser,
   readShipwrightConfig,
   resolveAllRepos,
@@ -446,5 +448,98 @@ describe("getCurrentUser", () => {
     process.env.PATH = `${tmpDir}:${savedPath}`;
     const result = await getCurrentUser();
     expect(result).toBe("app/example-repo-agent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTaskStoreClient — query() response shape handling
+// ---------------------------------------------------------------------------
+
+describe("createTaskStoreClient query()", () => {
+  const FAKE_TASK = {
+    id: "T-1",
+    title: "Do the thing",
+    status: "pending",
+  };
+
+  let savedEnv: { url?: string; token?: string };
+
+  beforeEach(() => {
+    savedEnv = {
+      url: process.env.SHIPWRIGHT_TASK_STORE_URL,
+      token: process.env.SHIPWRIGHT_TASK_STORE_TOKEN,
+    };
+    process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.com";
+    process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    if (savedEnv.url !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_URL = savedEnv.url;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_URL;
+    }
+    if (savedEnv.token !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_TOKEN = savedEnv.token;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    }
+    mock.restore();
+  });
+
+  test("handles bare Task[] response (returned by ?ready=true)", async () => {
+    mock.module("node:fetch", () => ({}));
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => [FAKE_TASK],
+      }) as Response;
+
+    const client = createTaskStoreClient();
+    const result = await client.query(new URLSearchParams({ ready: "true" }));
+    expect(result).toEqual([FAKE_TASK]);
+  });
+
+  test("unwraps paginated { tasks } envelope (returned by ?status=...)", async () => {
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({ tasks: [FAKE_TASK], total: 1, limit: 50, offset: 0 }),
+      }) as Response;
+
+    const client = createTaskStoreClient();
+    const result = await client.query(
+      new URLSearchParams({ status: "in_progress" }),
+    );
+    expect(result).toEqual([FAKE_TASK]);
+  });
+
+  test("returns empty array when paginated envelope has empty tasks list", async () => {
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({ tasks: [], total: 0, limit: 50, offset: 0 }),
+      }) as Response;
+
+    const client = createTaskStoreClient();
+    const result = await client.query(
+      new URLSearchParams({ status: "in_progress" }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("throws on unrecognised response shape", async () => {
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({ unexpected: true }),
+      }) as Response;
+
+    const client = createTaskStoreClient();
+    await expect(
+      client.query(new URLSearchParams({ status: "in_progress" })),
+    ).rejects.toThrow("Unexpected task-store response format");
   });
 });


### PR DESCRIPTION
## Summary

- `createTaskStoreClient().query()` crashed with `TypeError: {} is not iterable` when iterating the result of `getInProgressTasks()` — the task-store API returns `{ tasks, total, limit, offset }` for `?status=...` queries but a bare `Task[]` for `?ready=true`
- Fix detects both shapes: unwraps `.tasks` from the envelope, falls through for bare arrays, throws on anything else
- Bumps plugin to 4.29.2
- Adds 4 unit tests to `check-helpers.unit.test.ts` covering both response shapes and the error path

## Root cause

The API comment in `routes/tasks.ts` line 16 already documented the split:
> `returns { tasks, total, limit, offset } — or Task[] when ?ready=true`

But `query()` in `check-helpers.ts` only handled one shape at a time (first assumed bare array in 4.29.1, then assumed envelope in main). Neither version handled both.

## Test plan

- [ ] `bun test plugins/shipwright/scripts/check-helpers.unit.test.ts` — 29 pass
- [ ] Install 4.29.2 on Bodhi, confirm `check-dev-task.ts` preCheck exits 1 (no work) or 0 (work) without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)