### PR TITLE
fix(check-helpers): handle bare Task[] from ?ready=true in query()

### DIFF
--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -343,8 +343,10 @@ export function createTaskStoreClient(): {
       const res = await fetch(`${baseUrl}/tasks?${params}`, { headers });
       if (!res.ok)
         throw new Error(`task-store GET /tasks?${params} → ${res.status}`);
-      const result = (await res.json()) as { tasks: Task[] };
-      return result.tasks;
+      const json = await res.json();
+      // ?ready=true returns bare Task[]; all other list calls return { tasks, total, limit, offset }
+      if (Array.isArray(json)) return json as Task[];
+      return (json as { tasks: Task[] }).tasks;
     },
     async update(id: string, fields: Record<string, unknown>): Promise<Task> {
       const res = await fetch(`${baseUrl}/tasks/${id}`, {


### PR DESCRIPTION
## Summary

- PR #670 changed GET /tasks to return `{ tasks, total, limit, offset }` for all calls **except** `?ready=true`, which still returns a bare `Task[]`
- PR #670 also updated `createTaskStoreClient().query()` in `check-helpers.ts` to unwrap `.tasks` — but this breaks for bare-array responses: `[].tasks` returns `undefined`, which crashes precheck scripts (e.g. `check-dev-task`) with a `TypeError` when they iterate the result
- Fix: detect the response shape with `Array.isArray()` and return bare arrays directly; fall through to `.tasks` unwrap for paginated responses

## Test plan

- [x] All 3312 existing tests pass (`bun test` — 3.88s)
- [x] `check-dev-task.test.ts`, `check-deploy.test.ts`, and `check-helpers.unit.test.ts` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)