### PR TITLE
feat(chart): add taskStore.extraEnv passthrough (v1.6.35)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.35] - 2026-06-24
+
+### Added
+
+- `taskStore.extraEnv` passthrough for additional env vars on the task-store pod (enables scope resolver wiring via `SHIPWRIGHT_TASK_STORE_AGENTS_URL` + `SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY`)
+
 ## [1.6.34] - 2026-06-25
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.34
+version: 1.6.35
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.6.34 triggered by release tag task-store-v0.10.0"
+    - kind: added
+      description: "taskStore.extraEnv passthrough for additional env vars on the task-store pod"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/task-store-deployment.yaml
+++ b/charts/shipwright/templates/task-store-deployment.yaml
@@ -55,6 +55,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.taskStore.database.existingSecret | default "shipwright-secrets" }}
                   key: DATABASE_URL_SHIPWRIGHT_TASK_STORE
+            {{- with .Values.taskStore.extraEnv }}
+            # taskStore.extraEnv: caller-supplied env vars appended last so they can
+            # override anything above if needed.
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.taskStore.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -487,6 +487,10 @@ taskStore:
     # Defaults to "shipwright-secrets" (the canonical cluster secret name).
     # The chart does NOT manage this Secret — create it before deploying.
     existingSecret: "shipwright-secrets"
+  # -- Extra env vars to inject into the task-store container. Use for service
+  # wiring (e.g. SHIPWRIGHT_TASK_STORE_AGENTS_URL + AGENTS_API_KEY for the
+  # scope resolver) without baking those into the chart template.
+  extraEnv: []
   # -- ServiceAccount for the task-store pod. Set create: false and name: <sa>
   # to reuse an existing SA (e.g. the umbrella chart'''s Workload Identity SA).
   serviceAccount:


### PR DESCRIPTION
## Summary

- Adds `taskStore.extraEnv` to the task-store Deployment template, mirroring the existing `admin.extraEnv` pattern
- Defaults to `[]` in `values.yaml` — zero behaviour change for existing installs
- Bumps chart version 1.6.34 → 1.6.35

## Motivation

The task-store scope resolver (`createScopeResolver` in `auth.ts`) needs two env vars to call the agents service:
- `SHIPWRIGHT_TASK_STORE_AGENTS_URL` — base URL of the admin service
- `SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY` — bearer token with scope `*`

Without a `taskStore.extraEnv` passthrough, these can't be set via Helm values. The vitals-os umbrella chart will follow with a separate PR wiring these in `values-prod.yaml`.

## Test plan

- [ ] `helm template` with `taskStore.extraEnv` set renders the env vars in the Deployment
- [ ] `helm template` with `taskStore.extraEnv: []` renders identically to pre-change (no extra env block)
- [ ] CI chart lint passes (ct lint --check-version-increment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)