### PR TITLE
chore(chart): bump chart version to 1.6.36

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.36] - 2026-06-25
+
+### Changed
+
+- auto-bump to chart v1.6.36 triggered by release tag `agent-v0.70.0`
+
 ## [1.6.35] - 2026-06-24
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.35
+version: 1.6.36
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "taskStore.extraEnv passthrough for additional env vars on the task-store pod"
+    - kind: changed
+      description: "auto-bump to chart v1.6.36 triggered by release tag agent-v0.70.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer


### PR DESCRIPTION
## Chart version bump: 1.6.35 → 1.6.36

**Triggering tag:** `agent-v0.70.0`
**New chart version:** `1.6.36`

### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.36 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._