### PR TITLE
feat: show blocker badges on task list view

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -15,6 +15,11 @@ import {
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+// Inline type — mirrors task-store/src/blocked-by.ts without cross-package coupling.
+export type BlockedByEntry =
+  | { type: "hitl"; notified?: true }
+  | { type: "dependency"; id: string; status: string };
+
 export interface AgentListItem {
   id: string;
   name: string;
@@ -104,6 +109,7 @@ export interface TaskItem {
   mergeCommit?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
+  blockedBy?: BlockedByEntry[];
 }
 
 // ─── Login page ───────────────────────────────────────────────────────────────
@@ -917,6 +923,18 @@ export function renderTasksPage(
     return "badge-gray";
   };
 
+  const renderBlockerBadges = (blockedBy: BlockedByEntry[] | undefined): string => {
+    if (!blockedBy || blockedBy.length === 0) return "";
+    return blockedBy
+      .map((b) => {
+        if (b.type === "hitl") {
+          return `<span class="badge badge-hitl" style="font-size:10px;margin-left:6px">Waiting: HITL</span>`;
+        }
+        return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${escapeHtml(b.id)}</span>`;
+      })
+      .join("");
+  };
+
   const rows =
     tasks.length === 0
       ? `<tr><td colspan="7" class="empty-state">No tasks found.</td></tr>`
@@ -926,9 +944,10 @@ export function renderTasksPage(
             const agentCell = agentId
               ? escapeHtml(agentNames[agentId] ?? agentId)
               : '<span style="color:#9ca3af">—</span>';
+            const blockerBadges = renderBlockerBadges(t.blockedBy);
             return `<tr data-href="/admin/tasks/${escapeHtml(t.id)}" style="cursor:pointer">
     <td class="mono" style="font-size:11px"><a href="/admin/tasks/${escapeHtml(t.id)}" style="color:#6366f1;text-decoration:none" title="View details">${escapeHtml(t.id)}</a></td>
-    <td><a href="/admin/tasks/${escapeHtml(t.id)}" style="color:inherit;text-decoration:none">${escapeHtml(t.title)}</a></td>
+    <td><a href="/admin/tasks/${escapeHtml(t.id)}" style="color:inherit;text-decoration:none">${escapeHtml(t.title)}</a>${blockerBadges}</td>
     <td><span class="badge ${statusBadgeClass(t.status)}">${escapeHtml(t.status)}</span></td>
     <td style="font-size:12px">${agentCell}</td>
     <td class="mono" style="font-size:11px">${t.session ? escapeHtml(t.session) : '<span style="color:#9ca3af">—</span>'}</td>
@@ -1025,6 +1044,8 @@ export function renderTasksPage(
     .badge-blue { background:#dbeafe;color:#1d4ed8;border:1px solid #bfdbfe; }
     .badge-green { background:#dcfce7;color:#166534;border:1px solid #bbf7d0; }
     .badge-red { background:#fee2e2;color:#991b1b;border:1px solid #fecaca; }
+    .badge-hitl { background:#fff7ed;color:#c2410c;border:1px solid #fed7aa; }
+    .badge-dep { background:#fefce8;color:#a16207;border:1px solid #fde047; }
     .alert-warning { background:#fefce8;color:#854d0e;border:1px solid #fde047;border-radius:6px;padding:10px 14px;margin-bottom:16px;font-size:13px; }
   </style>
 </head>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1112,6 +1112,139 @@ describe("renderTasksPage — row click navigation", () => {
   });
 });
 
+// ─── renderTasksPage — blocker badges ────────────────────────────────────────
+
+describe("renderTasksPage — blocker badges", () => {
+  function render(tasks: TaskItem[]): string {
+    return renderTasksPage(tasks, {}, false, USER_NAME, {}, { total: tasks.length, limit: 50, page: 1 });
+  }
+
+  const PENDING_TASK_NO_BLOCKERS: TaskItem = {
+    id: "TASK-3",
+    title: "Pending nothing",
+    status: "pending",
+    session: null,
+    repo: null,
+    assignee: null,
+    claimedBy: null,
+    blockedBy: [],
+  };
+
+  const PENDING_TASK_HITL: TaskItem = {
+    id: "TASK-4",
+    title: "Waiting on human",
+    status: "pending",
+    session: null,
+    repo: null,
+    assignee: null,
+    claimedBy: null,
+    blockedBy: [{ type: "hitl" }],
+  };
+
+  const PENDING_TASK_DEP: TaskItem = {
+    id: "TASK-5",
+    title: "Blocked by dep",
+    status: "pending",
+    session: null,
+    repo: null,
+    assignee: null,
+    claimedBy: null,
+    blockedBy: [{ type: "dependency", id: "REL-2.2", status: "pending" }],
+  };
+
+  const PENDING_TASK_MULTI: TaskItem = {
+    id: "TASK-6",
+    title: "Multiple blockers",
+    status: "pending",
+    session: null,
+    repo: null,
+    assignee: null,
+    claimedBy: null,
+    blockedBy: [
+      { type: "hitl" },
+      { type: "dependency", id: "REL-3.1", status: "in_progress" },
+    ],
+  };
+
+  // AC1: pending task with blockedBy entries shows badge(s) in the list view
+  test("pending task with HITL block shows a blocker badge", () => {
+    const html = render([PENDING_TASK_HITL]);
+    expect(html).toContain("Waiting: HITL");
+  });
+
+  // AC2: HITL block renders as a distinct badge "Waiting: HITL"
+  test("HITL badge renders as 'Waiting: HITL'", () => {
+    const html = render([PENDING_TASK_HITL]);
+    expect(html).toContain("Waiting: HITL");
+    expect(html).toContain("badge-hitl");
+  });
+
+  // AC3: dep block renders with the dep ID "Blocked: REL-2.2"
+  test("dep block renders as 'Blocked: <dep-id>'", () => {
+    const html = render([PENDING_TASK_DEP]);
+    expect(html).toContain("Blocked: REL-2.2");
+    expect(html).toContain("badge-dep");
+  });
+
+  // AC4: tasks with blockedBy: [] show no blocker badges
+  test("empty blockedBy shows no blocker badges", () => {
+    const html = render([PENDING_TASK_NO_BLOCKERS]);
+    expect(html).not.toContain("Waiting: HITL");
+    expect(html).not.toContain("Blocked:");
+  });
+
+  // AC5: multiple blockers all render
+  test("task with multiple blockers renders all badges", () => {
+    const html = render([PENDING_TASK_MULTI]);
+    expect(html).toContain("Waiting: HITL");
+    expect(html).toContain("Blocked: REL-3.1");
+  });
+
+  // AC5: badges are visually distinct from status badges (different CSS class)
+  test("blocker badges use different CSS classes than status badges", () => {
+    const html = render([PENDING_TASK_HITL]);
+    // Status badge uses badge-blue/badge-green/badge-red/badge-gray
+    // Blocker badges must use badge-hitl or badge-dep — not the status classes
+    expect(html).toContain("badge-hitl");
+    expect(html).not.toContain('<span class="badge badge-blue">pending</span>');
+    // The status badge for pending should use badge-gray
+    expect(html).toContain('<span class="badge badge-gray">pending</span>');
+  });
+
+  // Task with undefined blockedBy shows no badges (backward compat)
+  test("task without blockedBy field shows no blocker badges", () => {
+    const taskNoBLockedBy: TaskItem = {
+      id: "TASK-7",
+      title: "Old task no blockedBy",
+      status: "pending",
+      session: null,
+      repo: null,
+      assignee: null,
+      claimedBy: null,
+    };
+    const html = render([taskNoBLockedBy]);
+    expect(html).not.toContain("Waiting: HITL");
+    expect(html).not.toContain("Blocked:");
+  });
+
+  // XSS: dep id is escaped
+  test("dep id is HTML-escaped in the badge", () => {
+    const xssTask: TaskItem = {
+      id: "TASK-8",
+      title: "XSS task",
+      status: "pending",
+      session: null,
+      repo: null,
+      assignee: null,
+      claimedBy: null,
+      blockedBy: [{ type: "dependency", id: "<script>alert(1)</script>", status: "pending" }],
+    };
+    const html = render([xssTask]);
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
 // ─── renderAdminToolbar — active nav highlight ────────────────────────────────
 
 describe("renderAdminToolbar — active nav highlight", () => {


### PR DESCRIPTION
## Summary
- Add `blockedBy` field to `TaskItem` interface in admin UI pages
- Render blocker badges (HITL and dependency) in the task list view title cell
- Add distinct CSS classes (`badge-hitl`, `badge-dep`) with amber/yellow color tokens

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Pending tasks with blockedBy entries show badge(s) in the list view | MET |
| 2 | HITL block renders as a distinct badge (`Waiting: HITL`) | MET |
| 3 | Dep blocks render with the dep ID (`Blocked: REL-2.2`) | MET |
| 4 | Tasks with `blockedBy: []` show no blocker badges | MET |
| 5 | Badges are visually distinct from status badges | MET |

## Test Plan
- [x] 8 new unit tests in `admin-ui-pages.unit.test.ts` covering all ACs + XSS escaping + backward compat (undefined blockedBy)
- [x] Full unit suite passes (145 tests in file)
- [x] Lint clean (`bunx biome lint`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
