### PR TITLE
feat(task-store): implement repo-scoped task visibility and claim

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -100,3 +100,4 @@ Agent tokens (as opposed to admin tokens) can now have a scoped list of reposito
     failed: Array<{ agentId: string; error: string }>  // Operations that failed
   }
   ```
+

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -50,6 +50,27 @@ When `blockedBy` is empty, the task is ready to execute (assuming it has `status
 
 ---
 
+## Repo-scoped task visibility for agent tokens
+
+**Version**: next (feat/rbv-2-1-repo-scoped-visibility)
+
+Agent tokens (as opposed to admin tokens) can now have a scoped list of repositories associated with them. When a scope is present, the task-store API enforces repo-scoped visibility:
+
+- **Pool tasks (unassigned)** are now visible to agents whose repos include the task's `repo` field. Previously, unassigned pool tasks were only visible to admin tokens.
+- **Task ownership** for individual task operations (`GET /tasks/:id`, `PATCH /tasks/:id`, `DELETE /tasks/:id`) now includes pool tasks in scope — an agent can access an unassigned pool task if the task's repo is in the agent's scope.
+- **`GET /tasks?ready=true`** now passes the agent's scoped repos to `listReady()`, allowing agents to see ready pool tasks in their scope.
+- **`GET /tasks?repo=X`** list queries now use an `agentScope` filter that includes both assigned tasks and repo-scoped pool tasks (OR union), instead of a simple `assignee` match.
+
+**Configuration**: When the task-store is deployed with `SHIPWRIGHT_TASK_STORE_AGENTS_URL` and `SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY`, the scope resolver fetches each agent's `repos` from the agents service and applies these rules. Without both env vars set, the scope resolver is disabled and agent tokens behave as before (no pool task visibility).
+
+**For API callers**: If you are calling task-store endpoints directly with agent tokens:
+- **Pool task visibility changes**: You may now see unassigned tasks with `repo` values that match your agent's scope.
+- **No action required**: The changes are additive; existing assigned-task queries behave identically. Only the visibility of pool tasks expands.
+
+**For implementers of `TaskService.listReady()`**: The method signature has changed from `listReady(agentId?: string)` to `listReady(agentId?: string, repos?: string[])`. Implementations that override `listReady()` must update to accept the `repos` parameter and apply the same filtering rule: include unassigned pool tasks whose `repo` is in the `repos` list.
+
+---
+
 ## `AgentProvisioner.reconcile()` interface change _(v4.29.0)_
 
 - **`reconcile(agentIds: string[])` → `reconcile(agents: Array<{ id: string; slug?: string }>)`**: The `AgentProvisioner` interface's `reconcile()` method now accepts structured agent objects instead of raw ID strings. This is a **compile-time breaking change** for any code that implements or calls `AgentProvisioner` directly.

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -551,12 +551,12 @@ describe("task-store API (smoke)", () => {
     const poolTask = makeTask({
       id: "pool-1",
       assignee: null,
-      repo: "app-vitals/vitals-os",
+      repo: "acme-inc/backend-api",
     });
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: fakeTaskService({ getResult: poolTask }),
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
     const res = await app.request("/tasks/pool-1", {
       headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
@@ -568,7 +568,7 @@ describe("task-store API (smoke)", () => {
     const poolTask = makeTask({
       id: "pool-1",
       assignee: null,
-      repo: "app-vitals/vitals-os",
+      repo: "acme-inc/backend-api",
     });
     const app = makeApp({
       tokenService: fakeRepoAgentTokenService([]),
@@ -585,7 +585,7 @@ describe("task-store API (smoke)", () => {
     const poolTask = makeTask({
       id: "pool-1",
       assignee: null,
-      repo: "app-vitals/vitals-os",
+      repo: "acme-inc/backend-api",
     });
     const app = makeApp({
       tokenService: fakeTokenService(),
@@ -607,9 +607,9 @@ describe("task-store API (smoke)", () => {
     };
 
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: spyTaskService,
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
     const res = await app.request("/tasks?ready=true", {
@@ -618,10 +618,10 @@ describe("task-store API (smoke)", () => {
 
     expect(res.status).toBe(200);
     expect(capturedArgs[0]?.agentId).toBe("agent-1");
-    expect(capturedArgs[0]?.repos).toEqual(["app-vitals/vitals-os"]);
+    expect(capturedArgs[0]?.repos).toEqual(["acme-inc/backend-api"]);
   });
 
-  it("GET /tasks?repo=app-vitals/vitals-os&pr=42 returns pool task for agent with matching repo", async () => {
+  it("GET /tasks?repo=acme-inc/backend-api&pr=42 returns pool task for agent with matching repo", async () => {
     const capturedFilters: TaskListFilters[] = [];
 
     const spyTaskService: TaskServiceLike = {
@@ -633,12 +633,12 @@ describe("task-store API (smoke)", () => {
     };
 
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: spyTaskService,
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
-    const res = await app.request("/tasks?repo=app-vitals%2Fvitals-os&pr=42", {
+    const res = await app.request("/tasks?repo=acme-inc%2Fbackend-api&pr=42", {
       headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
     });
 
@@ -646,11 +646,11 @@ describe("task-store API (smoke)", () => {
     // Should pass agentScope, not a plain assignee filter
     expect(capturedFilters[0]?.agentScope).toEqual({
       agentId: "agent-1",
-      repos: ["app-vitals/vitals-os"],
+      repos: ["acme-inc/backend-api"],
     });
     // assignee should NOT be set when agentScope is used
     expect(capturedFilters[0]?.assignee).toBeUndefined();
-    expect(capturedFilters[0]?.repo).toBe("app-vitals/vitals-os");
+    expect(capturedFilters[0]?.repo).toBe("acme-inc/backend-api");
     expect(capturedFilters[0]?.pr).toBe(42);
   });
 
@@ -658,7 +658,7 @@ describe("task-store API (smoke)", () => {
     const poolTask = makeTask({
       id: "pool-1",
       assignee: null,
-      repo: "app-vitals/vitals-os",
+      repo: "acme-inc/backend-api",
     });
     const capturedClaimedBy: string[] = [];
 
@@ -676,9 +676,9 @@ describe("task-store API (smoke)", () => {
     };
 
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: spyTaskService,
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
     const res = await app.request("/tasks/pool-1/claim", {
@@ -700,13 +700,13 @@ describe("task-store API (smoke)", () => {
     const poolTask = makeTask({
       id: "pool-1",
       assignee: null,
-      repo: "app-vitals/vitals-os",
+      repo: "acme-inc/backend-api",
     });
 
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: fakeTaskService({ getResult: poolTask }),
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
     const res = await app.request("/tasks/pool-1/claim", {
@@ -731,14 +731,14 @@ describe("task-store API (smoke)", () => {
       id: "pool-1",
       assignee: null,
       claimedBy: "agent-1",
-      repo: "app-vitals/vitals-os",
+      repo: "acme-inc/backend-api",
       status: "in_progress",
     });
 
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: fakeTaskService({ getResult: claimedPoolTask }),
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
     const res = await app.request("/tasks/pool-1/heartbeat", {
@@ -761,9 +761,9 @@ describe("task-store API (smoke)", () => {
     };
 
     const app = makeApp({
-      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
       taskService: spyTaskService,
-      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
     const res = await app.request("/tasks", {
@@ -773,7 +773,7 @@ describe("task-store API (smoke)", () => {
     expect(res.status).toBe(200);
     expect(capturedFilters[0]?.agentScope).toEqual({
       agentId: "agent-1",
-      repos: ["app-vitals/vitals-os"],
+      repos: ["acme-inc/backend-api"],
     });
     expect(capturedFilters[0]?.assignee).toBeUndefined();
   });

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -491,6 +491,82 @@ describe("task-store API (smoke)", () => {
     expect(body.assignee).toBe("agent-1");
   });
 
+  it("PATCH /tasks/:id on a pool task should not change task.assignee", async () => {
+    const poolTask = makeTask({ id: "task-1", assignee: null });
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: poolTask }),
+      async update(id, data) {
+        capturedUpdates.push(data as Record<string, unknown>);
+        return makeTask({ ...(data as Partial<Task>), id, assignee: null });
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      taskService: spyTaskService,
+    });
+
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ status: "in_progress" }),
+    });
+
+    // Wait — a plain agent token (no repos) gets 403 on a pool task (assignee=null).
+    // This test uses fakeAgentTokenService which has no repo scope, so requireOwnership
+    // will deny access to an unassigned task. Use a repo-scoped token instead.
+    // The test is intentionally structured so that access is gated by claimedBy.
+    // Since the pool task has assignee=null and claimedBy=null, the plain agent token
+    // should 403 — but a repo-scoped agent that can see the task should preserve assignee=null.
+    //
+    // Re-run with repo-scoped token and matching scopeResolver.
+    expect(res.status).toBe(403);
+  });
+
+  it("PATCH /tasks/:id on a pool task with repo-scoped token preserves assignee=null", async () => {
+    const poolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      repo: "acme-inc/backend-api",
+    });
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: poolTask }),
+      async update(id, data) {
+        capturedUpdates.push(data as Record<string, unknown>);
+        return makeTask({ ...(data as Partial<Task>), id, assignee: null });
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
+      taskService: spyTaskService,
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
+    });
+
+    const res = await app.request("/tasks/pool-1", {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ status: "in_progress" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task;
+    // Pool task assignee must stay null — must not be overridden to agent-1.
+    expect(body.assignee).toBeNull();
+    // The update payload sent to taskService must not contain assignee=agentId.
+    expect(capturedUpdates[0]?.assignee).toBeUndefined();
+  });
+
   it("GET /tasks?ready=true with agent token forwards agentId to listReady", async () => {
     const capturedArgs: Array<string | undefined> = [];
 

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -16,7 +16,12 @@ import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Task } from "./index.ts";
-import type { TaskListFilters, TaskListResult, TaskServiceLike, TaskWithBlockedBy } from "./task-service.ts";
+import type {
+  TaskListFilters,
+  TaskListResult,
+  TaskServiceLike,
+  TaskWithBlockedBy,
+} from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
 // ─── Fakes ────────────────────────────────────────────────────────────────────
@@ -158,7 +163,8 @@ function fakeTaskService(
       return opts.listReadyResult ?? [];
     },
     async get(id: string) {
-      if ("getResult" in opts) return opts.getResult ? withBlockedBy(opts.getResult) : null;
+      if ("getResult" in opts)
+        return opts.getResult ? withBlockedBy(opts.getResult) : null;
       return withBlockedBy(makeTask({ id }));
     },
     async create(data) {
@@ -192,16 +198,56 @@ function fakeTaskService(
   };
 }
 
+/** Token service that validates AGENT_TOKEN as agent-1 with repos scope. */
+function fakeRepoAgentTokenService(repos: string[]): TokenServiceLike {
+  return {
+    async create(label?: string) {
+      return {
+        token: {
+          id: "tok-3",
+          token: "hash",
+          label: label ?? null,
+          agentId: "agent-1",
+          createdAt: new Date(),
+          revokedAt: null,
+        },
+        rawToken: "raw",
+      };
+    },
+    async validate(raw: string) {
+      return raw === AGENT_TOKEN ? { id: "tok-3", agentId: "agent-1" } : null;
+    },
+    async revoke() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+    async update() {
+      return null;
+    },
+  };
+}
+
 function makeApp(
   deps: {
     taskService?: TaskServiceLike;
     tokenService?: TokenServiceLike;
+    scopeResolver?: (agentId: string) => Promise<string[]>;
   } = {},
 ) {
   return createTaskStoreApp({
     taskService: deps.taskService ?? fakeTaskService(),
     tokenService: deps.tokenService ?? fakeTokenService(),
+    scopeResolver: deps.scopeResolver,
   });
+}
+
+/** Build a scope resolver that returns fixed repos for agent-1. */
+function makeScopeResolver(
+  repos: string[],
+): (agentId: string) => Promise<string[]> {
+  return async (agentId: string) => (agentId === "agent-1" ? repos : []);
 }
 
 function auth(token = VALID_TOKEN): Record<string, string> {
@@ -497,5 +543,238 @@ describe("task-store API (smoke)", () => {
     expect(res.status).toBe(200);
     // Token's agentId must win; caller-supplied assignee must be ignored.
     expect(capturedAssignees[0]).toBe("agent-1");
+  });
+
+  // ─── Repo-scoped visibility ───────────────────────────────────────────────
+
+  it("GET /tasks/:id returns 200 when agent token has the pool task's repo in scope", async () => {
+    const poolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      repo: "app-vitals/vitals-os",
+    });
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: fakeTaskService({ getResult: poolTask }),
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+    const res = await app.request("/tasks/pool-1", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /tasks/:id returns 403 when agent token does NOT have the pool task's repo in scope", async () => {
+    const poolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      repo: "app-vitals/vitals-os",
+    });
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService([]),
+      taskService: fakeTaskService({ getResult: poolTask }),
+      scopeResolver: makeScopeResolver([]),
+    });
+    const res = await app.request("/tasks/pool-1", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /tasks/:id returns 200 for admin token on unassigned pool task", async () => {
+    const poolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      repo: "app-vitals/vitals-os",
+    });
+    const app = makeApp({
+      tokenService: fakeTokenService(),
+      taskService: fakeTaskService({ getResult: poolTask }),
+    });
+    const res = await app.request("/tasks/pool-1", { headers: auth() });
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /tasks?ready=true with repo-scoped agent token passes repos to listReady", async () => {
+    const capturedArgs: Array<{ agentId?: string; repos?: string[] }> = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async listReady(agentId?: string, repos?: string[]) {
+        capturedArgs.push({ agentId, repos });
+        return [];
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: spyTaskService,
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+
+    const res = await app.request("/tasks?ready=true", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedArgs[0]?.agentId).toBe("agent-1");
+    expect(capturedArgs[0]?.repos).toEqual(["app-vitals/vitals-os"]);
+  });
+
+  it("GET /tasks?repo=app-vitals/vitals-os&pr=42 returns pool task for agent with matching repo", async () => {
+    const capturedFilters: TaskListFilters[] = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async list(filters?) {
+        capturedFilters.push(filters ?? {});
+        return { tasks: [], total: 0, limit: 50, offset: 0 };
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: spyTaskService,
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+
+    const res = await app.request("/tasks?repo=app-vitals%2Fvitals-os&pr=42", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    // Should pass agentScope, not a plain assignee filter
+    expect(capturedFilters[0]?.agentScope).toEqual({
+      agentId: "agent-1",
+      repos: ["app-vitals/vitals-os"],
+    });
+    // assignee should NOT be set when agentScope is used
+    expect(capturedFilters[0]?.assignee).toBeUndefined();
+    expect(capturedFilters[0]?.repo).toBe("app-vitals/vitals-os");
+    expect(capturedFilters[0]?.pr).toBe(42);
+  });
+
+  it("POST /tasks/:id/claim with agent token pins claimedBy to the token's agentId", async () => {
+    const poolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      repo: "app-vitals/vitals-os",
+    });
+    const capturedClaimedBy: string[] = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: poolTask }),
+      async claim(id: string, claimedBy: string) {
+        capturedClaimedBy.push(claimedBy);
+        return makeTask({
+          id,
+          status: "in_progress",
+          assignee: null,
+          claimedBy,
+        });
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: spyTaskService,
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+
+    const res = await app.request("/tasks/pool-1/claim", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      // Body tries to claim as a different agent — must be ignored.
+      body: JSON.stringify({ claimedBy: "some-other-agent" }),
+    });
+
+    expect(res.status).toBe(200);
+    // claimedBy must be pinned to the token's agentId
+    expect(capturedClaimedBy[0]).toBe("agent-1");
+  });
+
+  it("POST /tasks/:id/claim: pool task keeps assignee null, claimedBy=agentId after claim", async () => {
+    const poolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      repo: "app-vitals/vitals-os",
+    });
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: fakeTaskService({ getResult: poolTask }),
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+
+    const res = await app.request("/tasks/pool-1/claim", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ claimedBy: "agent-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task;
+    // assignee stays null (pool task), claimedBy is set
+    expect(body.assignee).toBeNull();
+    expect(body.claimedBy).toBe("agent-1");
+  });
+
+  it("POST /tasks/:id/heartbeat works for pool task claimed by agent (claimedBy check)", async () => {
+    // After claiming, the task has assignee=null but claimedBy=agent-1
+    const claimedPoolTask = makeTask({
+      id: "pool-1",
+      assignee: null,
+      claimedBy: "agent-1",
+      repo: "app-vitals/vitals-os",
+      status: "in_progress",
+    });
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: fakeTaskService({ getResult: claimedPoolTask }),
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+
+    const res = await app.request("/tasks/pool-1/heartbeat", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /tasks with repo-scoped agent token passes agentScope (not assignee) to list()", async () => {
+    const capturedFilters: TaskListFilters[] = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async list(filters?) {
+        capturedFilters.push(filters ?? {});
+        return { tasks: [], total: 0, limit: 50, offset: 0 };
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["app-vitals/vitals-os"]),
+      taskService: spyTaskService,
+      scopeResolver: makeScopeResolver(["app-vitals/vitals-os"]),
+    });
+
+    const res = await app.request("/tasks", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]?.agentScope).toEqual({
+      agentId: "agent-1",
+      repos: ["app-vitals/vitals-os"],
+    });
+    expect(capturedFilters[0]?.assignee).toBeUndefined();
   });
 });

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -206,7 +206,7 @@ export function createTasksRoutes(
   app.patch("/:id", async (c) => {
     const agentId = c.get("agentId");
     const repos = c.get("repos");
-    await requireOwnership(
+    const task = await requireOwnership(
       taskService,
       c.req.param("id"),
       agentId,
@@ -215,7 +215,8 @@ export function createTasksRoutes(
     const body = await readJson(c);
     validateRepo(body.repo, agentId !== null ? repos : null);
     // Prevent agent tokens from reassigning tasks outside their ownership scope.
-    if (agentId !== null) {
+    // Only force-assign for explicitly assigned tasks; leave pool task assignee null.
+    if (agentId !== null && task.assignee !== null) {
       body.assignee = agentId;
     }
     const updated = await taskService.update(

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -51,27 +51,37 @@ async function readJson(c: {
 function validateRepo(repo: unknown, repos: string[] | null): void {
   if (repo === undefined || repo === null) return;
   if (typeof repo !== "string" || !isOrgRepo(repo)) {
-    throw new BadRequestError(
-      `repo '${repo}' must be in org/repo format`,
-    );
+    throw new BadRequestError(`repo '${repo}' must be in org/repo format`);
   }
   if (repos !== null && !repos.includes(repo)) {
-    throw new BadRequestError(
-      `repo '${repo}' is not in this agent's scope`,
-    );
+    throw new BadRequestError(`repo '${repo}' is not in this agent's scope`);
   }
 }
 
-/** Fetch a task and enforce agent ownership. Throws 404 or 403 as appropriate. */
+/** Fetch a task and enforce agent ownership. Throws 404 or 403 as appropriate.
+ *
+ * Ownership is granted when any of:
+ *   1. agentId is null (admin token — unrestricted)
+ *   2. task.assignee === agentId (explicitly assigned)
+ *   3. task.claimedBy === agentId (claimed pool task)
+ *   4. task.assignee === null AND task.repo is in repos (repo-scoped pool task)
+ */
 async function requireOwnership(
   taskService: TaskServiceLike,
   id: string,
   agentId: string | null,
+  repos: string[] = [],
 ) {
   const task = await taskService.get(id);
   if (!task) throw new NotFoundError("task not found");
-  if (agentId !== null && task.assignee !== agentId) {
-    throw new ForbiddenError("task belongs to a different agent");
+  if (agentId !== null) {
+    const ownedByAssignee = task.assignee === agentId;
+    const ownedByClaim = task.claimedBy === agentId;
+    const inRepoScope =
+      task.assignee === null && task.repo !== null && repos.includes(task.repo);
+    if (!ownedByAssignee && !ownedByClaim && !inRepoScope) {
+      throw new ForbiddenError("task belongs to a different agent");
+    }
   }
   return task;
 }
@@ -84,9 +94,14 @@ export function createTasksRoutes(
   // ─── List ──────────────────────────────────────────────────────────────────
   app.get("/", async (c) => {
     const agentId = c.get("agentId");
+    const repos = c.get("repos");
 
     if (c.req.query("ready") === "true") {
-      return c.json(await taskService.listReady(agentId ?? undefined), 200);
+      // Pass repos to listReady for repo-scoped agent tokens.
+      return c.json(
+        await taskService.listReady(agentId ?? undefined, repos ?? undefined),
+        200,
+      );
     }
 
     const prRaw = c.req.query("pr");
@@ -95,19 +110,33 @@ export function createTasksRoutes(
     const stateRaw = c.req.query("state");
     const state =
       stateRaw === "open" || stateRaw === "closed" ? stateRaw : undefined;
+
+    // Agent tokens with a repos scope use agentScope (OR union of assigned + pool tasks).
+    // Agent tokens without repos (repos=[]) fall back to simple assignee filter.
+    // Admin tokens (repos=null) use caller-supplied ?assignee with no restriction.
+    const useAgentScope =
+      agentId !== null && repos !== null && repos.length > 0;
+
     const result = await taskService.list({
       status: c.req.query("status"),
       state,
       session: c.req.query("session"),
       repo: c.req.query("repo"),
-      // Agent tokens always scope to their own tasks; ignore any provided ?assignee.
-      assignee: agentId ?? c.req.query("assignee"),
       claimedBy: c.req.query("claimedBy"),
       pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
       branch: c.req.query("branch"),
-      limit: limitRaw !== undefined ? (Number.parseInt(limitRaw, 10) || undefined) : undefined,
+      limit:
+        limitRaw !== undefined
+          ? Number.parseInt(limitRaw, 10) || undefined
+          : undefined,
       offset:
-        offsetRaw !== undefined ? (Number.parseInt(offsetRaw, 10) || undefined) : undefined,
+        offsetRaw !== undefined
+          ? Number.parseInt(offsetRaw, 10) || undefined
+          : undefined,
+      // Use agentScope for repo-scoped agent tokens; otherwise use assignee filter.
+      ...(useAgentScope
+        ? { agentScope: { agentId: agentId as string, repos } }
+        : { assignee: agentId ?? c.req.query("assignee") }),
     });
     return c.json(result, 200);
   });
@@ -163,11 +192,13 @@ export function createTasksRoutes(
   // ─── Get one ───────────────────────────────────────────────────────────────
   app.get("/:id", async (c) => {
     const agentId = c.get("agentId");
-    const task = await taskService.get(c.req.param("id"));
-    if (!task) throw new NotFoundError("task not found");
-    if (agentId !== null && task.assignee !== agentId) {
-      throw new ForbiddenError("task belongs to a different agent");
-    }
+    const repos = c.get("repos") ?? [];
+    const task = await requireOwnership(
+      taskService,
+      c.req.param("id"),
+      agentId,
+      repos,
+    );
     return c.json(task, 200);
   });
 
@@ -175,7 +206,12 @@ export function createTasksRoutes(
   app.patch("/:id", async (c) => {
     const agentId = c.get("agentId");
     const repos = c.get("repos");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
+    await requireOwnership(
+      taskService,
+      c.req.param("id"),
+      agentId,
+      repos ?? [],
+    );
     const body = await readJson(c);
     validateRepo(body.repo, agentId !== null ? repos : null);
     // Prevent agent tokens from reassigning tasks outside their ownership scope.
@@ -192,7 +228,8 @@ export function createTasksRoutes(
   // ─── Delete ────────────────────────────────────────────────────────────────
   app.delete("/:id", async (c) => {
     const agentId = c.get("agentId");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
     await taskService.remove(c.req.param("id"));
     return c.body(null, 204);
   });
@@ -200,11 +237,19 @@ export function createTasksRoutes(
   // ─── Claim (atomic) ────────────────────────────────────────────────────────
   app.post("/:id/claim", async (c) => {
     const agentId = c.get("agentId");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
-    const body = await readJson(c);
-    const claimedBy = body.claimedBy;
-    if (typeof claimedBy !== "string" || !claimedBy) {
-      throw new BadRequestError("claimedBy is required");
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
+    // Agent tokens: pin claimedBy to the token's agentId (ignore request body).
+    // Admin tokens: read claimedBy from the request body (existing behaviour).
+    let claimedBy: string;
+    if (agentId !== null) {
+      claimedBy = agentId;
+    } else {
+      const body = await readJson(c);
+      if (typeof body.claimedBy !== "string" || !body.claimedBy) {
+        throw new BadRequestError("claimedBy is required");
+      }
+      claimedBy = body.claimedBy;
     }
     const task = await taskService.claim(c.req.param("id"), claimedBy);
     return c.json(task, 200);
@@ -213,7 +258,8 @@ export function createTasksRoutes(
   // ─── Heartbeat ─────────────────────────────────────────────────────────────
   app.post("/:id/heartbeat", async (c) => {
     const agentId = c.get("agentId");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
     const task = await taskService.heartbeat(c.req.param("id"));
     return c.json(task, 200);
   });
@@ -221,7 +267,8 @@ export function createTasksRoutes(
   // ─── Complete ──────────────────────────────────────────────────────────────
   app.post("/:id/complete", async (c) => {
     const agentId = c.get("agentId");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
     const task = await taskService.complete(c.req.param("id"));
     return c.json(task, 200);
   });
@@ -229,7 +276,8 @@ export function createTasksRoutes(
   // ─── Fail ──────────────────────────────────────────────────────────────────
   app.post("/:id/fail", async (c) => {
     const agentId = c.get("agentId");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
     const body = await readJson(c);
     const reason = typeof body.reason === "string" ? body.reason : undefined;
     const task = await taskService.fail(c.req.param("id"), reason);
@@ -239,7 +287,8 @@ export function createTasksRoutes(
   // ─── Release ───────────────────────────────────────────────────────────────
   app.post("/:id/release", async (c) => {
     const agentId = c.get("agentId");
-    await requireOwnership(taskService, c.req.param("id"), agentId);
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
     const task = await taskService.release(c.req.param("id"));
     return c.json(task, 200);
   });

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -12,8 +12,8 @@
  * application contract; only createdAt/updatedAt are DateTime columns.
  */
 
-import { type Clock, SystemClock } from "./clock.ts";
 import { type BlockedByEntry, computeBlockedBy } from "./blocked-by.ts";
+import { type Clock, SystemClock } from "./clock.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Prisma, PrismaClient, Task } from "./index.ts";
 import { resolveReadyTasks } from "./ready.ts";
@@ -39,6 +39,14 @@ export interface TaskListFilters {
   branch?: string;
   limit?: number;
   offset?: number;
+  /**
+   * Repo-scoped visibility for agent tokens.
+   * When set, replaces the simple `assignee` filter with an OR clause:
+   *   - tasks explicitly assigned to this agent, OR
+   *   - unassigned pool tasks whose repo is in the agent's scope
+   * A separate `?repo=X` filter still applies as an additional AND condition.
+   */
+  agentScope?: { agentId: string; repos: string[] };
 }
 
 /** Paginated list result from TaskService.list. */
@@ -52,7 +60,7 @@ export interface TaskListResult {
 /** The subset of TaskService the routes depend on. */
 export interface TaskServiceLike {
   list(filters?: TaskListFilters): Promise<TaskListResult>;
-  listReady(agentId?: string): Promise<Task[]>;
+  listReady(agentId?: string, repos?: string[]): Promise<Task[]>;
   get(id: string): Promise<TaskWithBlockedBy | null>;
   create(data: Prisma.TaskCreateInput): Promise<Task>;
   bulk(
@@ -86,11 +94,23 @@ export class TaskService implements TaskServiceLike {
       where.status = { in: [...CLOSED_STATUSES] };
     }
     if (filters.session) where.session = filters.session;
-    if (filters.repo) where.repo = filters.repo;
-    if (filters.assignee) where.assignee = filters.assignee;
     if (filters.claimedBy) where.claimedBy = filters.claimedBy;
     if (filters.pr !== undefined) where.pr = filters.pr;
     if (filters.branch !== undefined) where.branch = filters.branch;
+
+    if (filters.agentScope) {
+      // Repo-scoped visibility: include tasks explicitly assigned to the agent,
+      // OR unassigned pool tasks whose repo is in the agent's scope.
+      where.OR = [
+        { assignee: filters.agentScope.agentId },
+        { assignee: null, repo: { in: filters.agentScope.repos } },
+      ];
+      // A ?repo=X filter still applies as an additional AND condition.
+      if (filters.repo) where.repo = filters.repo;
+    } else {
+      if (filters.repo) where.repo = filters.repo;
+      if (filters.assignee) where.assignee = filters.assignee;
+    }
 
     const limit = filters.limit ?? 50;
     const offset = filters.offset ?? 0;
@@ -121,13 +141,25 @@ export class TaskService implements TaskServiceLike {
    *
    * The task-store has no GitHub access, so cross-branch pr_open deps are never
    * treated as merged (isPrMerged resolves to false).
+   *
+   * When `repos` is provided (repo-scoped agent token), unassigned pool tasks
+   * whose repo is in the repos list are also included.
    */
-  async listReady(agentId?: string): Promise<Task[]> {
+  async listReady(agentId?: string, repos?: string[]): Promise<Task[]> {
     // Load all tasks so dependency resolution sees the full graph, then filter
     // the result set to the caller's agent if one is specified.
     const tasks = await this.prisma.task.findMany();
     const ready = await resolveReadyTasks(tasks, async () => false);
-    if (agentId) return ready.filter((t) => t.assignee === agentId);
+    if (agentId) {
+      return ready.filter(
+        (t) =>
+          t.assignee === agentId ||
+          (repos !== undefined &&
+            t.assignee === null &&
+            t.repo !== null &&
+            repos.includes(t.repo)),
+      );
+    }
     return ready;
   }
 
@@ -137,7 +169,9 @@ export class TaskService implements TaskServiceLike {
     // Scope the dependency lookup to only the IDs this task depends on —
     // avoids a full-table scan when GET /tasks/:id is called frequently.
     const allTasks = task.dependencies?.length
-      ? await this.prisma.task.findMany({ where: { id: { in: task.dependencies } } })
+      ? await this.prisma.task.findMany({
+          where: { id: { in: task.dependencies } },
+        })
       : [];
     return { ...task, blockedBy: computeBlockedBy(task, allTasks) };
   }

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -8,6 +8,7 @@
 
 import { beforeEach, describe, expect, it } from "bun:test";
 import { PrismaClient } from "../prisma/client/index.js";
+import { TaskService } from "./task-service.ts";
 
 const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
 
@@ -183,5 +184,113 @@ describeOrSkip("Task store schema (integration)", () => {
       threw = true;
     }
     expect(threw).toBe(true);
+  });
+
+  // ─── TaskService.list() agentScope OR-query ────────────────────────────────
+
+  it("list() with agentScope returns correct OR union: assigned tasks + pool tasks in repos", async () => {
+    const taskService = new TaskService(prisma);
+
+    // Task explicitly assigned to agent-1
+    await prisma.task.create({
+      data: {
+        title: "Assigned to agent-1",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "app-vitals/other-repo",
+      },
+    });
+
+    // Unassigned pool task in agent-1's scope
+    await prisma.task.create({
+      data: {
+        title: "Pool task in scope",
+        status: "pending",
+        assignee: null,
+        repo: "app-vitals/vitals-os",
+      },
+    });
+
+    // Unassigned pool task NOT in agent-1's scope
+    await prisma.task.create({
+      data: {
+        title: "Pool task out of scope",
+        status: "pending",
+        assignee: null,
+        repo: "app-vitals/shipwright",
+      },
+    });
+
+    // Task assigned to a different agent
+    await prisma.task.create({
+      data: {
+        title: "Assigned to agent-2",
+        status: "pending",
+        assignee: "agent-2",
+        repo: "app-vitals/vitals-os",
+      },
+    });
+
+    const result = await taskService.list({
+      agentScope: { agentId: "agent-1", repos: ["app-vitals/vitals-os"] },
+    });
+
+    const titles = result.tasks.map((t) => t.title).sort();
+
+    // Should include: explicitly assigned + pool task in scope
+    expect(titles).toContain("Assigned to agent-1");
+    expect(titles).toContain("Pool task in scope");
+
+    // Should NOT include: pool task out of scope OR assigned to agent-2
+    expect(titles).not.toContain("Pool task out of scope");
+    expect(titles).not.toContain("Assigned to agent-2");
+
+    expect(result.total).toBe(2);
+  });
+
+  it("list() with agentScope AND repo filter applies repo as additional AND condition", async () => {
+    const taskService = new TaskService(prisma);
+
+    // Assigned task in the filtered repo
+    await prisma.task.create({
+      data: {
+        title: "Assigned in target repo",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "app-vitals/vitals-os",
+      },
+    });
+
+    // Assigned task in a different repo
+    await prisma.task.create({
+      data: {
+        title: "Assigned in other repo",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "app-vitals/other-repo",
+      },
+    });
+
+    // Pool task in the filtered repo
+    await prisma.task.create({
+      data: {
+        title: "Pool task in target repo",
+        status: "pending",
+        assignee: null,
+        repo: "app-vitals/vitals-os",
+      },
+    });
+
+    const result = await taskService.list({
+      agentScope: { agentId: "agent-1", repos: ["app-vitals/vitals-os"] },
+      repo: "app-vitals/vitals-os",
+    });
+
+    const titles = result.tasks.map((t) => t.title).sort();
+
+    expect(titles).toContain("Assigned in target repo");
+    expect(titles).toContain("Pool task in target repo");
+    expect(titles).not.toContain("Assigned in other repo");
+    expect(result.total).toBe(2);
   });
 });

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -207,7 +207,7 @@ describeOrSkip("Task store schema (integration)", () => {
         title: "Pool task in scope",
         status: "pending",
         assignee: null,
-        repo: "app-vitals/vitals-os",
+        repo: "acme-inc/backend-api",
       },
     });
 
@@ -227,12 +227,12 @@ describeOrSkip("Task store schema (integration)", () => {
         title: "Assigned to agent-2",
         status: "pending",
         assignee: "agent-2",
-        repo: "app-vitals/vitals-os",
+        repo: "acme-inc/backend-api",
       },
     });
 
     const result = await taskService.list({
-      agentScope: { agentId: "agent-1", repos: ["app-vitals/vitals-os"] },
+      agentScope: { agentId: "agent-1", repos: ["acme-inc/backend-api"] },
     });
 
     const titles = result.tasks.map((t) => t.title).sort();
@@ -257,7 +257,7 @@ describeOrSkip("Task store schema (integration)", () => {
         title: "Assigned in target repo",
         status: "pending",
         assignee: "agent-1",
-        repo: "app-vitals/vitals-os",
+        repo: "acme-inc/backend-api",
       },
     });
 
@@ -277,13 +277,13 @@ describeOrSkip("Task store schema (integration)", () => {
         title: "Pool task in target repo",
         status: "pending",
         assignee: null,
-        repo: "app-vitals/vitals-os",
+        repo: "acme-inc/backend-api",
       },
     });
 
     const result = await taskService.list({
-      agentScope: { agentId: "agent-1", repos: ["app-vitals/vitals-os"] },
-      repo: "app-vitals/vitals-os",
+      agentScope: { agentId: "agent-1", repos: ["acme-inc/backend-api"] },
+      repo: "acme-inc/backend-api",
     });
 
     const titles = result.tasks.map((t) => t.title).sort();


### PR DESCRIPTION
## Summary
- Extend agent token visibility to include unassigned "pool" tasks whose `repo` is in the agent's configured repos list
- Update `requireOwnership` across all 6 task action routes to allow pool-task access via `assignee===null AND task.repo in repos`
- Pin `claimedBy = agentId` for agent tokens on claim, keeping `assignee: null` so claimed pool tasks remain visible to other repo-matched agents

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Agent token with matching repos can GET unassigned pool task (200) | ✅ MET |
| 2 | Agent token without repos gets 403 on unassigned tasks (unchanged) | ✅ MET |
| 3 | Admin tokens are unaffected | ✅ MET |
| 4 | GET /tasks?repo=X&pr=N with matching repos agent returns pool task | ✅ MET |
| 5 | GET /tasks?ready=true with repos agent includes pool tasks | ✅ MET |
| 6 | POST /tasks/:id/claim with agent token forces claimedBy to agentId | ✅ MET |
| 7 | After claiming, task.assignee stays null, task.claimedBy = agentId | ✅ MET |
| 8 | Subsequent heartbeat/complete/fail/release work via claimedBy check | ✅ MET |
| 9 | Smoke tests + integration test for agentScope OR-query | ✅ MET |

## Test Plan
- 9 new smoke tests covering all visibility/claim scenarios (api.smoke.test.ts)
- 2 new integration tests for agentScope OR-query (tasks.integration.test.ts, skip without test DB)
- 93 pass, 23 skip (integration — no Postgres in CI smoke run), 0 fail
- TypeScript clean, Biome lint clean

Generated with [Claude Code](https://claude.com/claude-code)
