### PR TITLE
fix(agent): raise startup watchdog to 180s + gate probes with a startupProbe

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -310,6 +310,17 @@ export function buildAgentDeploymentManifest(
               volumeMounts: [
                 { name: volumeName, mountPath: AGENT_HOME_MOUNT_PATH },
               ],
+              // Gate liveness/readiness until the agent's health server binds.
+              // Startup runs `mise install` + plugin install, which can exceed a
+              // minute on a cold/contended node; without this, liveness would
+              // restart the container (~75s in) before startup ever finished.
+              // 18 × 10s = 180s grace, aligned with the entrypoint startup
+              // watchdog (DEFAULT_STARTUP_TIMEOUT_MS in agent/src/entrypoint.ts).
+              startupProbe: {
+                httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
+                periodSeconds: 10,
+                failureThreshold: 18,
+              },
               livenessProbe: {
                 httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
                 initialDelaySeconds: 15,

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -144,6 +144,18 @@ describe("buildAgentDeploymentManifest", () => {
     expect(c.readinessProbe?.failureThreshold).toBe(3);
   });
 
+  it("gates liveness/readiness with a startupProbe granting ~180s for a slow mise startup", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const c = d.spec.template.spec.containers[0];
+    expect(c.startupProbe?.httpGet?.port).toBe(AGENT_HEALTH_PORT);
+    expect(c.startupProbe?.httpGet?.path).toBe("/health");
+    // periodSeconds × failureThreshold = total grace before liveness engages.
+    const grace =
+      (c.startupProbe?.periodSeconds as number) *
+      (c.startupProbe?.failureThreshold as number);
+    expect(grace).toBe(180);
+  });
+
   it("applies a hardened security context (fsGroup, fsGroupChangePolicy, runAsNonRoot, runAsUser)", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
     const podSpec = d.spec.template.spec;

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -77,6 +77,10 @@ export interface KubernetesContainer {
     mountPath: string;
     [key: string]: unknown;
   }>;
+  startupProbe?: {
+    httpGet?: { path?: string; port: number | string; [key: string]: unknown };
+    [key: string]: unknown;
+  };
   livenessProbe?: {
     httpGet?: { path?: string; port: number | string; [key: string]: unknown };
     [key: string]: unknown;

--- a/agent/src/entrypoint.ts
+++ b/agent/src/entrypoint.ts
@@ -51,7 +51,12 @@ export interface EntrypointDeps {
 
 // ─── Main entrypoint ──────────────────────────────────────────────────────────
 
-const DEFAULT_STARTUP_TIMEOUT_MS = 60_000;
+// 180s, not 60s: `mise install` during startup can take well over a minute on a
+// cold or contended node (e.g. during a GKE node rotation), and the original 60s
+// budget crash-looped agents that were otherwise healthy. Overridable per-agent
+// via SHIPWRIGHT_STARTUP_TIMEOUT_MS. Keep this aligned with the manifest
+// startupProbe grace window in admin/src/agent-manifest.ts.
+const DEFAULT_STARTUP_TIMEOUT_MS = 180_000;
 
 export async function runEntrypoint(deps: EntrypointDeps): Promise<void> {
   const {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,7 @@ Controls how the admin service provisions the Kubernetes workload backing each a
 | `MISE_CACHE_DIR` | `string` | `<AGENT_HOME>/mise/cache` | Override the mise cache directory. Auto-derived from `AGENT_HOME`. |
 | `XDG_CACHE_HOME` | `string` | `<AGENT_HOME>/cache` | Override the XDG cache directory. Auto-derived from `AGENT_HOME`. |
 | `XDG_DATA_HOME` | `string` | `$HOME/.local/share` | Override the XDG data directory. Used to locate the mise data dir (`$XDG_DATA_HOME/mise`) when seeding a fresh PVC. |
-| `SHIPWRIGHT_STARTUP_TIMEOUT_MS` | `number` | `60000` | Maximum milliseconds the entrypoint startup sequence may take before the agent exits. Override to a lower value (e.g. `10000`) in dev for faster fail-fast feedback. |
+| `SHIPWRIGHT_STARTUP_TIMEOUT_MS` | `number` | `180000` | Maximum milliseconds the entrypoint startup sequence may take before the agent exits. Override to a lower value (e.g. `10000`) in dev for faster fail-fast feedback. |
 | `AGENT_ALLOWED_TOOLS` | `string` (JSON array) | — | JSON array of allowed Claude tool patterns. Set by the admin service config sync; do not set manually in production. |
 
 ### Analytics


### PR DESCRIPTION
## Problem

Agent `cmqgfe7ov00425f01n8gugall` crash-looped in prod (`vitals-os` ns) during a GKE Autopilot node rotation. Root cause: the entrypoint startup watchdog (`DEFAULT_STARTUP_TIMEOUT_MS = 60_000`) fired before `mise install` completed on a cold/contended node — `[entrypoint] FATAL: startup sequence did not complete within 60000ms`. The agent was otherwise healthy.

A second, subtler trap: simply raising the watchdog isn't enough. The health server only binds *after* startup finishes, so the liveness probe (`initialDelaySeconds: 15`, `periodSeconds: 30`, `failureThreshold: 3`) would restart the container ~75s in — before a legitimately slow startup could complete.

## Fix (fleet-wide)

- **`agent/src/entrypoint.ts`** — `DEFAULT_STARTUP_TIMEOUT_MS` 60s → 180s. Still overridable per-agent via `SHIPWRIGHT_STARTUP_TIMEOUT_MS`.
- **`admin/src/agent-manifest.ts`** — add a `startupProbe` (18 × 10s = 180s grace). Kubernetes runs only the startupProbe until `/health` binds; liveness/readiness don't engage until then. Aligned with the watchdog budget.
- **`admin/src/kubernetes-client.ts`** — add `startupProbe` to the `KubernetesContainer` type.

## Context

This was already applied as a live hotfix to the one crash-looping agent's Deployment (`SHIPWRIGHT_STARTUP_TIMEOUT_MS=180000` + relaxed probe delays), which recovered it cleanly. This PR makes it the default for the whole fleet so the next node rotation doesn't take out other agents. New agents get it on provision; existing agent Deployments pick up the `startupProbe` on their next re-provision (reconcile only patches the image, so live Deployments keep the hotfix until then).

## Tests

- New `agent-manifest.unit.test.ts` assertion verifies the startupProbe grants 180s of grace on the health port.
- Existing entrypoint / provisioner / kubernetes-client suites pass.
- Pre-existing `agents-api.ts` `selfHosted` typecheck errors are unrelated (stale local Prisma client; reproduce identically on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)