### PR TITLE
feat(admin): mobile-friendly horizontal scroll for tasks table

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1326,22 +1326,24 @@ export function renderTasksPage(
       </form>
     </div>
     <div class="card">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Title</th>
-            <th>Status</th>
-            <th>Assignee</th>
-            <th>Session</th>
-            <th>Repo</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          ${rows}
-        </tbody>
-      </table>
+      <div class="data-table-wrapper">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Title</th>
+              <th>Status</th>
+              <th>Assignee</th>
+              <th>Session</th>
+              <th>Repo</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>
+      </div>
       ${paginationHtml}
     </div>
   </div>

--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -256,6 +256,17 @@ export function baseStyles(): string {
     .data-table-wrapper {
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
+      /* Scroll-shadow: fades appear at edges when content overflows */
+      background-color: #fff;
+      background-image:
+        linear-gradient(to right, #fff, #fff),
+        linear-gradient(to right, rgba(0,0,0,0.05), transparent),
+        linear-gradient(to left, #fff, #fff),
+        linear-gradient(to left, rgba(0,0,0,0.05), transparent);
+      background-position: left, left, right, right;
+      background-size: 20px 100%, 20px 100%, 24px 100%, 24px 100%;
+      background-repeat: no-repeat;
+      background-attachment: local, scroll, local, scroll;
     }
     @media (max-width: 600px) {
       .vos-page {
@@ -270,6 +281,15 @@ export function baseStyles(): string {
       .vos-toolbar {
         padding: 0 12px;
         gap: 12px;
+      }
+      .data-table th,
+      .data-table td {
+        white-space: nowrap;
+      }
+      /* Let the table bleed to card edges on mobile so scroll shadow aligns */
+      .card .data-table-wrapper {
+        margin: 0 -12px;
+        padding: 0 12px;
       }
     }
   `;

--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -282,8 +282,8 @@ export function baseStyles(): string {
         padding: 0 12px;
         gap: 12px;
       }
-      .data-table th,
-      .data-table td {
+      .data-table-wrapper .data-table th,
+      .data-table-wrapper .data-table td {
         white-space: nowrap;
       }
       /* Let the table bleed to card edges on mobile so scroll shadow aligns */


### PR DESCRIPTION
## Summary

- Wraps the tasks table in `.data-table-wrapper` so `overflow-x: auto` actually fires on mobile (the class existed in CSS but wasn't applied to this table)
- Adds a CSS scroll-shadow using the multi-background `local`/`scroll` technique — a subtle fade appears at the right edge when there's content off-screen, disappearing once you've scrolled to the end
- On `max-width: 600px`, cells get `white-space: nowrap` so columns stay at natural width and the user swipes to reveal Session, Repo, and Actions
- Negative margin on `.card .data-table-wrapper` on mobile lets the table extend to card edges so the scroll shadow aligns with the card border

## Test plan

- [ ] On a phone or narrow browser (<600px), open `/admin/tasks` — confirm the table scrolls horizontally
- [ ] Confirm a subtle right-edge shadow appears when there are hidden columns, and disappears when scrolled to the end
- [ ] On desktop, confirm nothing changed (table still fills the card, no shadow artifacts)
- [ ] Confirm pagination appears below the scroll area, not inside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)