### PR TITLE
docs: remote setup guide for running plan-session from a laptop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,4 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/deploy-kubernetes.md** — Kubernetes deployment guide: Minikube / GKE (Gateway API + cert-manager) / EKS (ALB), the agent runtime-provisioning RBAC model, and auth modes
 - **docs/test-readiness/test-system.md** — the authoritative test blueprint: layer matrix, boundary rules, per-component budgets, CI pipeline shape, and the full isolation contract
 - **docs/migration.md** — breaking changes and migration steps across versions (e.g. `AgentProvisioner.reconcile()` interface change)
+- **docs/remote-setup.md** — how to run Shipwright skills (e.g. `/plan-session`) from a laptop and push tasks to the shared task store

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -1,0 +1,181 @@
+# Remote Setup
+
+Run Shipwright skills (e.g. `/shipwright:plan-session`) from any Claude Code session — your laptop, a CI job, a separate agent — and push tasks to a shared task store that a cloud agent then executes.
+
+## How it works
+
+```
+Your laptop (Claude Code)          Cloud agent (e.g. Warchild)
+        │                                       │
+        │  /shipwright:plan-session             │
+        │  → POST /tasks (token: agent-scoped)  │
+        │─────────────────────────────────────► task store
+        │                                       │  ◄── picks up ready tasks
+        │                                       │  ◄── executes dev-task / review / deploy
+```
+
+When you use a token scoped to a specific agent's ID, the task store automatically assigns every task you create to that agent. The cloud agent's execution crons then pick them up without any extra configuration.
+
+---
+
+## Prerequisites
+
+| Requirement | Why |
+|---|---|
+| Claude Code installed | Runs the plugin |
+| Shipwright plugin installed | Provides `/plan-session` and all related skills |
+| GitHub CLI (`gh`) authenticated | Required by dev-task, review, and deploy skills when the cloud agent runs them |
+| Task store URL | HTTP endpoint — see [Getting the URL](#getting-the-url) below |
+| Task store token | Scoped to the agent that will execute your tasks — see [Getting a token](#getting-a-token) below |
+
+### Install the plugin
+
+```bash
+/plugin install shipwright@app-vitals/shipwright
+```
+
+---
+
+## Getting the URL
+
+The task store is an HTTP service. You need a URL that your laptop can reach.
+
+### Option A: kubectl port-forward (development)
+
+The fastest option — no chart changes required. Works as long as you have kubectl access to the cluster.
+
+```bash
+kubectl port-forward -n shipwright service/shipwright-task-store 3002:3000
+```
+
+Leave this running in a separate terminal. Use `http://localhost:3002` as your URL.
+
+### Option B: External URL (production / persistent)
+
+The Shipwright Helm chart can expose the task store through the cluster ingress. Ask your Shipwright operator to enable it:
+
+```yaml
+# values override
+taskStore:
+  enabled: true
+  ingress:
+    enabled: true
+    host: task-store.your-domain.com
+```
+
+Once deployed, use `https://task-store.your-domain.com` as your URL.
+
+---
+
+## Getting a token
+
+Tokens are agent-scoped: every task you create with a scoped token is automatically assigned to the target agent. You need an admin token to create one.
+
+Get the agent ID of the cloud agent you want to target (ask your Shipwright operator, or check the agent's env: `echo $SHIPWRIGHT_AGENT_ID`).
+
+Then create a scoped token:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tokens" \
+  -d "{\"label\": \"$(whoami)-laptop\", \"agentId\": \"<AGENT_ID>\"}" \
+  | jq '{id: .id, rawToken: .rawToken}'
+```
+
+**Save the `rawToken` value** — it is shown exactly once and cannot be retrieved again.
+
+> If you do not have an admin token, ask your Shipwright operator to create one or to mint the scoped token for you.
+
+---
+
+## Set the environment variables
+
+```bash
+export SHIPWRIGHT_TASK_STORE_URL="http://localhost:3002"   # or your external URL
+export SHIPWRIGHT_TASK_STORE_TOKEN="<rawToken from above>"
+```
+
+Add these to your shell profile (`.zshrc` / `.bashrc`) to avoid re-setting them each session:
+
+```bash
+echo 'export SHIPWRIGHT_TASK_STORE_URL="http://localhost:3002"' >> ~/.zshrc
+echo 'export SHIPWRIGHT_TASK_STORE_TOKEN="<rawToken>"' >> ~/.zshrc
+```
+
+Verify the connection:
+
+```bash
+curl -sf \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.total'
+```
+
+A `0` (or any number) is success. A `401` means the token is wrong. A connection error means the URL is unreachable.
+
+---
+
+## Run plan-session
+
+```bash
+cd /path/to/your/repo
+claude
+```
+
+Then inside Claude Code:
+
+```
+/shipwright:plan-session <repo> <session>
+```
+
+For example:
+
+```
+/shipwright:plan-session shipwright may-billing-refactor
+```
+
+Plan-session auto-detects the repo from `git remote get-url origin` if you omit it:
+
+```
+/shipwright:plan-session may-billing-refactor
+```
+
+Tasks are written to `planning/<session>/PLAN.md` in your local repo and posted to the task store. The cloud agent's execution cron picks up ready tasks automatically.
+
+---
+
+## Troubleshooting
+
+### `curl: (7) Failed to connect` or `Connection refused`
+
+The task store URL is not reachable. If using port-forward, confirm it is still running (`kubectl port-forward ...`). If using an external URL, verify the Helm chart has `taskStore.ingress.enabled: true`.
+
+### `401 Unauthorized`
+
+The token is wrong or revoked. Verify `SHIPWRIGHT_TASK_STORE_TOKEN` is set and matches the `rawToken` returned at creation time. Tokens cannot be retrieved after creation — if lost, create a new one.
+
+### Tasks not picked up by the cloud agent
+
+Check that the token used to create tasks is scoped to the right agent ID:
+
+```bash
+curl -sf \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tokens" | jq '.[] | {id, label, agentId}'
+```
+
+Compare `agentId` against the cloud agent's `SHIPWRIGHT_AGENT_ID`. If they do not match, create a new scoped token with the correct agent ID.
+
+### Tasks created but `ready=true` returns empty
+
+Check for HITL tasks or unmet dependencies:
+
+```bash
+# See all pending tasks (includes blocked ones)
+curl -sf \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending" | jq '.tasks[] | {id, hitl, dependencies}'
+```
+
+Tasks with `hitl: true` are excluded from the ready queue until a human clears the flag. Tasks with unmet `dependencies` are also excluded — check that the referenced task IDs exist and have a terminal status.

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -24,12 +24,14 @@ All requests require a Bearer token:
 Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN
 ```
 
-Both env vars are provisioned automatically by the agent harness:
+Set these env vars before calling the API:
 
 | Env var | Description |
 |---|---|
 | `SHIPWRIGHT_TASK_STORE_URL` | Base URL of the task store service |
 | `SHIPWRIGHT_TASK_STORE_TOKEN` | Bearer token for this agent |
+
+Managed agents have these injected automatically. For remote use (e.g. running `/plan-session` from a laptop), set them manually — see [docs/remote-setup.md](../../../../docs/remote-setup.md).
 
 The bearer token scopes all API operations to the calling agent's own tasks automatically — the same token that authenticates you also filters results. No `?assignee=` parameter is needed on any endpoint.
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -16,6 +16,43 @@ The task store is a REST service — call it with curl, no script discovery need
 
 ---
 
+## Setup
+
+### Install the Shipwright plugin
+
+```bash
+/plugin install shipwright@app-vitals/shipwright
+```
+
+### Set the required env vars
+
+| Env var | Description |
+|---|---|
+| `SHIPWRIGHT_TASK_STORE_URL` | Base URL of the task store service |
+| `SHIPWRIGHT_TASK_STORE_TOKEN` | Bearer token scoped to this agent |
+
+**Managed agents** (deployed via the Shipwright admin service) have these injected automatically — no action needed.
+
+**Remote sessions** (e.g. running `/plan-session` from a laptop): set them manually. Get your URL and token from the Shipwright admin app under the target agent's **Task Store Tokens** section, then:
+
+```bash
+export SHIPWRIGHT_TASK_STORE_URL="https://task-store.your-domain.com"
+export SHIPWRIGHT_TASK_STORE_TOKEN="<token from admin app>"
+```
+
+Full remote setup walkthrough: [docs/remote-setup.md](../../../../docs/remote-setup.md).
+
+### Verify the connection
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.total'
+```
+
+A number (including `0`) confirms the connection works. A `401` means the token is wrong. A connection error means the URL is unreachable.
+
+---
+
 ## Authentication
 
 All requests require a Bearer token:
@@ -24,23 +61,7 @@ All requests require a Bearer token:
 Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN
 ```
 
-Set these env vars before calling the API:
-
-| Env var | Description |
-|---|---|
-| `SHIPWRIGHT_TASK_STORE_URL` | Base URL of the task store service |
-| `SHIPWRIGHT_TASK_STORE_TOKEN` | Bearer token for this agent |
-
-Managed agents have these injected automatically. For remote use (e.g. running `/plan-session` from a laptop), set them manually — see [docs/remote-setup.md](../../../../docs/remote-setup.md).
-
 The bearer token scopes all API operations to the calling agent's own tasks automatically — the same token that authenticates you also filters results. No `?assignee=` parameter is needed on any endpoint.
-
-Verify the service is reachable before doing anything:
-
-```bash
-curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.total'
-```
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds **`docs/remote-setup.md`** — step-by-step guide for running `/shipwright:plan-session` (or any HTTP-API-backed Shipwright skill) from a local Claude Code session and pushing tasks to the shared task store for a cloud agent to execute
- Fixes a misleading note in `task-store/SKILL.md` that said env vars are "provisioned automatically by the agent harness" (they are, for managed agents — but for remote sessions the user sets them manually)
- Adds the new doc to the `@docs` reference block in `CLAUDE.md`

## How it works

When a remote user uses a token scoped to a specific agent's ID, the task store server auto-assigns every task they create to that agent (enforced server-side in `routes/tasks.ts`). No `assignee` field needed in the task JSON — the token does the work.

## Test plan

- [ ] Set `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` locally and run the verify curl from the guide — should return `{ total: 0 }` or higher
- [ ] Run `/shipwright:plan-session` from a local Claude Code session against a test repo — tasks should appear in the task store scoped to the target agent
- [ ] Confirm task-store SKILL.md note no longer misleads remote users

🤖 Generated with [Claude Code](https://claude.com/claude-code)