### PR TITLE
fix(plugin): replace fake /tasks/repo with admin API in review/patch/deploy

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -17,7 +17,7 @@ metrics on success.
 
 Parse `$ARGUMENTS` to extract `org`, `repo`, and `pr` number:
 - `org/repo#number` (e.g. `app-vitals/shipwright#123`): explicit
-- `number` or `#number`: infer org/repo from the task store (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks/repo" | jq -r '.repo // empty'`),
+- `number` or `#number`: infer org/repo from the agent config (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[0] // empty'`),
   defaulting to `app-vitals/shipwright`
 - _(no arguments)_: scan mode — find the next ready PR to deploy (see Step 1)
 
@@ -38,7 +38,8 @@ AGENT_LOGIN=$(gh api user --jq '.login')
 
 Resolve the configured repos:
 ```bash
-REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks/repo" | jq -r '.repo // empty')
+REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[]')
 ```
 
 For each configured repo, fetch all open PRs authored by `AGENT_LOGIN`:

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -33,11 +33,11 @@ CURRENT_USER=$(gh api /user -q '.login')
 Resolve the list of repos to scan. Use the same resolver as other shipwright commands:
 
 ```bash
-REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/repo" | jq -r '.repo // empty')
+REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[]')
 ```
 
-This returns a single repo. Iterate over the result to scan it.
+Iterate over the results to scan each repo.
 
 For each repo, fetch open PRs authored by `CURRENT_USER`:
 

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -104,8 +104,8 @@ processed or skipped, continue to Step 3b.
 If `review_external_prs` is true, resolve the configured repos and fetch open PRs for each:
 
 ```bash
-REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/repo" | jq -r '.repo // empty')
+REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[]')
 ```
 
 ```bash
@@ -700,8 +700,8 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
 1. Parse the argument: extract `org`, `repo`, and `pr` number. For bare numbers,
    infer `org/repo` via:
    ```bash
-   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-     "$SHIPWRIGHT_TASK_STORE_URL/tasks/repo" | jq -r '.repo // empty'
+   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+     "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[0] // empty'
    ```
    Fall back to the current workspace repo if the command fails.
 2. Read `state/reviews.json`, find the entry for this PR.


### PR DESCRIPTION
## Summary

- `/tasks/repo` was a fake route — it hit `/tasks/:id` with `id="repo"`, returning `{"error":"task not found"}` in production
- All three affected commands (`review.md`, `patch.md`, `deploy.md`) now call `GET $SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID` with the agent's own API key to fetch configured `repos[]`
- Step 14 and the bare-number argument inference in `deploy.md` use `.repos[0]` for single-repo inference; scan-mode paths iterate `.repos[]`

## Test plan

- [ ] Invoke `/shipwright:review` with no arguments — verify it scans the repos configured on the agent, not 404
- [ ] Invoke `/shipwright:patch` with no arguments — verify it resolves repos from the agent config
- [ ] Invoke `/shipwright:deploy` with a bare PR number — verify it infers org/repo from `.repos[0]`
- [ ] Invoke `/shipwright:deploy` with no arguments — verify it scans all configured repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)