### PR TITLE
feat(task-store): add reviewCycles to PullRequest + extend stale reaper for PR records

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -18,7 +18,8 @@ metrics on success.
 Parse `$ARGUMENTS` to extract `org`, `repo`, and `pr` number:
 - `org/repo#number` (e.g. `app-vitals/shipwright#123`): explicit
 - `number` or `#number`: infer org/repo from the agent config (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[0] // empty'`),
-  defaulting to `app-vitals/shipwright`
+  defaulting to `app-vitals/shipwright`.
+  **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
 - _(no arguments)_: scan mode — find the next ready PR to deploy (see Step 1)
 
 ---

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -704,6 +704,7 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
      "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[0] // empty'
    ```
    Fall back to the current workspace repo if the command fails.
+   **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
 2. Read `state/reviews.json`, find the entry for this PR.
 
 **If entry exists with `status: "staged"`** — check for drift, then post:

--- a/task-store/prisma/migrations/20260626000000_add_review_cycles_to_pull_request/migration.sql
+++ b/task-store/prisma/migrations/20260626000000_add_review_cycles_to_pull_request/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add reviewCycles to PullRequest
+ALTER TABLE "PullRequest" ADD COLUMN "reviewCycles" INTEGER NOT NULL DEFAULT 0;

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -144,9 +144,10 @@ model PullRequest {
   staged      Boolean       @default(false) // true = review written but not yet posted
   state       PrState       @default(open)
   reviewState PrReviewState @default(pending) // workflow phase within the review cycle
-  commitSha   String?
-  patchCycles Int           @default(0)
-  agentId     String?
+  commitSha    String?
+  patchCycles  Int           @default(0)
+  reviewCycles Int           @default(0)
+  agentId      String?
   reviewedAt  String?
   patchedAt   String?
   mergedAt    String?

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -50,6 +50,7 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     reviewState: "pending",
     commitSha: null,
     patchCycles: 0,
+    reviewCycles: 0,
     agentId: null,
     reviewedAt: null,
     patchedAt: null,
@@ -220,6 +221,7 @@ function fakePrService(
       if (!existing) throw new NotFoundError("pr not found");
       const updated = {
         ...existing,
+        reviewCycles: (existing.reviewCycles ?? 0) + 1,
         reviewState: "posted" as const,
         reviewedAt: new Date().toISOString(),
         updatedAt: new Date(),
@@ -737,5 +739,43 @@ describe("/prs routes (smoke)", () => {
       body: JSON.stringify({ staged: true }),
     });
     expect(res.status).toBe(400);
+  });
+
+  // ─── reviewCycles ─────────────────────────────────────────────────────────
+
+  it("POST /prs/:id/complete increments reviewCycles to 1 on first call", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set(
+      "pr-1",
+      makePr({ id: "pr-1", reviewState: "in_progress", reviewCycles: 0 }),
+    );
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs/pr-1/complete", {
+      method: "POST",
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequest;
+    expect(body.reviewCycles).toBe(1);
+    expect(body.reviewState).toBe("posted");
+  });
+
+  it("POST /prs/:id/complete increments reviewCycles to 2 on second call", async () => {
+    const store = new Map<string, PullRequest>();
+    // Start with reviewCycles=1 (already reviewed once)
+    store.set(
+      "pr-1",
+      makePr({ id: "pr-1", reviewState: "in_progress", reviewCycles: 1 }),
+    );
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs/pr-1/complete", {
+      method: "POST",
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequest;
+    expect(body.reviewCycles).toBe(2);
   });
 });

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -203,13 +203,17 @@ export class PullRequestService implements PullRequestServiceLike {
     }
   }
 
-  /** Mark a PR review as posted. Sets reviewState=posted and reviewedAt. */
+  /** Mark a PR review as posted. Increments reviewCycles, sets reviewState=posted and reviewedAt. */
   async complete(id: string): Promise<PullRequest> {
     const now = this.clock.now().toISOString();
     try {
       return await this.prisma.pullRequest.update({
         where: { id },
-        data: { reviewState: "posted", reviewedAt: now },
+        data: {
+          reviewCycles: { increment: 1 },
+          reviewState: "posted",
+          reviewedAt: now,
+        },
       });
     } catch (err: unknown) {
       throw this.translateNotFound(err, "pr not found");

--- a/task-store/src/stale-claim-reaper.ts
+++ b/task-store/src/stale-claim-reaper.ts
@@ -1,9 +1,10 @@
 /**
  * task-store/src/stale-claim-reaper.ts
  *
- * StaleClaimReaper — background job that reclaims stuck in_progress tasks.
+ * StaleClaimReaper — background job that reclaims stuck in_progress tasks
+ * and stuck in_progress PullRequest review records.
  *
- * A task is considered stale when the agent holding it has stopped sending
+ * A record is considered stale when the agent holding it has stopped sending
  * heartbeats. Two cases are handled:
  *   1. heartbeatAt IS NOT NULL and heartbeatAt < cutoff (agent stopped beating)
  *   2. heartbeatAt IS NULL and claimedAt < cutoff (agent claimed but never beat)
@@ -33,15 +34,15 @@ export class StaleClaimReaper {
   }
 
   /**
-   * Bulk-reset stale in_progress tasks back to pending.
-   * Returns the number of tasks that were reaped.
+   * Bulk-reset stale in_progress Task and PullRequest records back to pending.
+   * Returns the total number of records that were reaped (tasks + PRs).
    */
   async reap(): Promise<number> {
     const cutoff = new Date(
       this.clock.now().getTime() - this.ttlMs,
     ).toISOString();
 
-    const affected = await this.prisma.$executeRaw`
+    const tasksAffected = await this.prisma.$executeRaw`
       UPDATE "Task"
       SET status = 'pending',
           "claimedBy" = NULL,
@@ -57,10 +58,32 @@ export class StaleClaimReaper {
         )
     `;
 
-    if (affected > 0) {
-      console.log(`[stale-claim-reaper] reaped ${affected} stale task(s)`);
+    const prsAffected = await this.prisma.$executeRaw`
+      UPDATE "PullRequest"
+      SET "reviewState" = 'pending',
+          "claimedBy" = NULL,
+          "claimedAt" = NULL,
+          "heartbeatAt" = NULL,
+          "updatedAt" = now()
+      WHERE "reviewState" = 'in_progress'
+        AND (
+          ("heartbeatAt" IS NOT NULL AND "heartbeatAt" < ${cutoff})
+          OR
+          ("heartbeatAt" IS NULL AND "claimedAt" IS NOT NULL AND "claimedAt" < ${cutoff})
+        )
+    `;
+
+    const total = tasksAffected + prsAffected;
+
+    if (tasksAffected > 0) {
+      console.log(`[stale-claim-reaper] reaped ${tasksAffected} stale task(s)`);
+    }
+    if (prsAffected > 0) {
+      console.log(
+        `[stale-claim-reaper] reaped ${prsAffected} stale PR review(s)`,
+      );
     }
 
-    return affected;
+    return total;
   }
 }

--- a/task-store/src/stale-claim-reaper.unit.test.ts
+++ b/task-store/src/stale-claim-reaper.unit.test.ts
@@ -16,8 +16,18 @@ interface ExecuteRawCall {
   values: unknown[];
 }
 
-function makePrismaDouble(affectedRows = 0) {
+/**
+ * makePrismaDouble — accepts per-call return values.
+ * `affectedRowsByCall` can be a single number (applied to the first call only;
+ * subsequent calls return 0) or an array of per-call values.
+ * This lets tests isolate Task vs PullRequest reap behaviour without coupling
+ * to the order of $executeRaw calls.
+ */
+function makePrismaDouble(affectedRowsByCall: number | number[] = 0) {
   const calls: ExecuteRawCall[] = [];
+  const rowsByCall = Array.isArray(affectedRowsByCall)
+    ? affectedRowsByCall
+    : [affectedRowsByCall];
 
   const prisma = {
     $executeRaw(
@@ -25,7 +35,8 @@ function makePrismaDouble(affectedRows = 0) {
       ...values: unknown[]
     ): Promise<number> {
       calls.push({ strings, values });
-      return Promise.resolve(affectedRows);
+      const idx = calls.length - 1;
+      return Promise.resolve(rowsByCall[idx] ?? 0);
     },
     _calls: calls,
   };
@@ -71,7 +82,8 @@ describe("StaleClaimReaper", () => {
     const count = await reaper.reap();
 
     expect(count).toBe(1);
-    expect(prisma._calls).toHaveLength(1);
+    // Two $executeRaw calls: one for Task, one for PullRequest
+    expect(prisma._calls).toHaveLength(2);
 
     // The cutoff should be now - DEFAULT_TTL_MS
     const expectedCutoff = msAgo(NOW, DEFAULT_TTL_MS).toISOString();
@@ -106,9 +118,8 @@ describe("StaleClaimReaper", () => {
     const count = await reaper.reap();
 
     expect(count).toBe(1);
-    // The same $executeRaw call covers both branches (heartbeatAt IS NOT NULL stale
-    // AND heartbeatAt IS NULL with stale claimedAt). Both are in the WHERE clause.
-    expect(prisma._calls).toHaveLength(1);
+    // Two $executeRaw calls: one for Task, one for PullRequest
+    expect(prisma._calls).toHaveLength(2);
     const sql = prisma._calls[0].strings.join("?");
     expect(sql).toContain('"heartbeatAt" IS NULL');
     expect(sql).toContain('"claimedAt"');
@@ -161,5 +172,65 @@ describe("StaleClaimReaper", () => {
 
     const sql = prisma._calls[0].strings.join("?");
     expect(sql).toContain('"startedAt" = NULL');
+  });
+
+  // ─── PullRequest reaping ────────────────────────────────────────────────────
+
+  test("reaps 0 stale PRs when none are in_progress", async () => {
+    // Both calls return 0: 0 tasks, 0 PRs
+    const prisma = makePrismaDouble([0, 0]);
+    const reaper = new StaleClaimReaper(prisma as never, clock);
+
+    const count = await reaper.reap();
+
+    expect(count).toBe(0);
+    expect(prisma._calls).toHaveLength(2);
+    // Second call targets PullRequest table
+    const prSql = prisma._calls[1].strings.join("?");
+    expect(prSql).toContain('"PullRequest"');
+    expect(prSql).toContain('"reviewState"');
+  });
+
+  test("reaps N stale PRs with expired heartbeat", async () => {
+    // 0 tasks, 2 stale PRs
+    const prisma = makePrismaDouble([0, 2]);
+    const reaper = new StaleClaimReaper(prisma as never, clock);
+
+    const count = await reaper.reap();
+
+    expect(count).toBe(2);
+    expect(prisma._calls).toHaveLength(2);
+    const prSql = prisma._calls[1].strings.join("?");
+    // Resets to pending, clears claim fields
+    expect(prSql).toContain("'pending'");
+    expect(prSql).toContain('"claimedBy" = NULL');
+    expect(prSql).toContain('"claimedAt" = NULL');
+    expect(prSql).toContain('"heartbeatAt" = NULL');
+    // Same cutoff as Task reap
+    const expectedCutoff = new Date(
+      NOW.getTime() - DEFAULT_TTL_MS,
+    ).toISOString();
+    expect(prisma._calls[1].values[0]).toBe(expectedCutoff);
+  });
+
+  test("combined count: tasks + PRs both reaped", async () => {
+    // 3 tasks + 2 PRs = 5 total
+    const prisma = makePrismaDouble([3, 2]);
+    const reaper = new StaleClaimReaper(prisma as never, clock);
+
+    const count = await reaper.reap();
+
+    expect(count).toBe(5);
+  });
+
+  test("PR reap WHERE clause covers in_progress with heartbeatAt IS NULL", async () => {
+    const prisma = makePrismaDouble([0, 1]);
+    const reaper = new StaleClaimReaper(prisma as never, clock);
+
+    await reaper.reap();
+
+    const prSql = prisma._calls[1].strings.join("?");
+    expect(prSql).toContain('"heartbeatAt" IS NULL');
+    expect(prSql).toContain('"claimedAt"');
   });
 });

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -43,7 +43,7 @@ export interface TaskListFilters {
    * Repo-scoped visibility for agent tokens.
    * When set, replaces the simple `assignee` filter with an OR clause:
    *   - tasks explicitly assigned to this agent, OR
-   *   - unassigned pool tasks whose repo is in the agent's scope
+   *   - any pool task whose repo is in the agent's scope (regardless of assignee)
    * A separate `?repo=X` filter still applies as an additional AND condition.
    */
   agentScope?: { agentId: string; repos: string[] };


### PR DESCRIPTION
## Summary

- Adds `reviewCycles Int @default(0)` to the `PullRequest` Prisma schema with a migration
- `complete()` now increments `reviewCycles` alongside `reviewedAt` — same pattern as `patchCycles` in `patch()`
- `StaleClaimReaper.reap()` now also resets stale `in_progress` PullRequest records (same TTL + heartbeat logic as `Task`), returning the combined task + PR count

## agentScope visibility change

The `assignee: null` guard was removed from the pool-task branch of the `agentScope` OR query in `task-service.ts`. Semantic impact:

- **Before**: repo-scoped tokens see own tasks + **unassigned** pool tasks in scope
- **After**: repo-scoped tokens see own tasks + **all** tasks in scope (including those assigned to other agents)

This affects multi-agent setups sharing a repo (e.g. two agents both scoped to `app-vitals/shipwright`) — either agent can now see the other's assigned tasks in list results. Write access is still enforced separately via `requireOwnership`. The JSDoc comment on `agentScope` has been updated to reflect this.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `reviewCycles Int @default(0)` with valid migration | ✅ MET |
| 2 | `complete()` increments reviewCycles: 1 on first call, 2 on second | ✅ MET |
| 3 | StaleClaimReaper reaps stale PR records → `reviewState=pending`, cleared claim fields | ✅ MET |
| 4 | Existing `prs.smoke.test.ts` suite stays green | ✅ MET |
| 5 | Unit test: reaps 0 non-stale PRs and N stale PRs correctly | ✅ MET |

## Test Plan

- [x] `bun test task-store/src/stale-claim-reaper.unit.test.ts task-store/src/prs.smoke.test.ts` — 37/37 pass
- [x] Full unit + smoke suite — 170/170 pass
- [x] `bunx biome check` — clean on all changed files

Generated with [Claude Code](https://claude.com/claude-code)