### PR TITLE
feat(admin): tasks show-all default and Reset button

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1283,8 +1283,7 @@ export function renderTasksPage(
   const makePageUrl = (p: number) => {
     const params = new URLSearchParams();
     if (filters.status) params.set("status", filters.status);
-    else if (filters.state && filters.state !== "ready")
-      params.set("state", filters.state);
+    else if (filters.state) params.set("state", filters.state);
     if (filters.session) params.set("session", filters.session);
     if (filters.repo) params.set("repo", filters.repo);
     if (filters.agent) params.set("agent", filters.agent);
@@ -1468,8 +1467,12 @@ export function renderTaskDetailPage(
   const prSection = pullRequest
     ? (() => {
         const prUrl = `https://github.com/${pullRequest.repo}/pull/${pullRequest.prNumber}`;
-        const reviewedFmt = pullRequest.reviewedAt ? dateField("Reviewed", pullRequest.reviewedAt) : "";
-        const patchedFmt = pullRequest.patchedAt ? dateField("Patched", pullRequest.patchedAt) : "";
+        const reviewedFmt = pullRequest.reviewedAt
+          ? dateField("Reviewed", pullRequest.reviewedAt)
+          : "";
+        const patchedFmt = pullRequest.patchedAt
+          ? dateField("Patched", pullRequest.patchedAt)
+          : "";
         return `<div class="card" style="margin-bottom:16px">
       <div style="font-size:12px;font-weight:600;color:#374151;margin-bottom:8px;text-transform:uppercase;letter-spacing:.05em">Pull Request Review</div>
       <table class="detail-table"><tbody>
@@ -1680,7 +1683,12 @@ export function renderTaskDetailPage(
 
 export function renderPrsPage(
   prs: PrListItem[],
-  filters: { repo?: string; state?: string; reviewState?: string; taskId?: string },
+  filters: {
+    repo?: string;
+    state?: string;
+    reviewState?: string;
+    taskId?: string;
+  },
   degraded: boolean,
   userName: string,
   agentNames: Record<string, string> = {},
@@ -1771,7 +1779,10 @@ export function renderPrsPage(
     </div>`;
 
   // Pagination
-  const totalPages = Math.max(1, Math.ceil(pagination.total / pagination.limit));
+  const totalPages = Math.max(
+    1,
+    Math.ceil(pagination.total / pagination.limit),
+  );
   const page = pagination.page;
   const makePageUrl = (p: number) => {
     const params = new URLSearchParams();

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1238,7 +1238,7 @@ export function renderTasksPage(
     return qs ? `?${qs}` : "";
   };
 
-  const activeState = filters.state ?? "ready";
+  const activeState = filters.state;
   const tabStyle = (state: string) =>
     activeState === state
       ? "background:#6366f1;color:#fff;font-weight:600"
@@ -1351,6 +1351,7 @@ export function renderTasksPage(
           <input name="agent" type="text" class="form-input" style="font-size:12px;padding:4px 8px" value="${escapeHtml(filters.agent ?? "")}" placeholder="agent name"${suggestions?.agents?.length ? ' list="agents-list"' : ""} />
         </div>
         <button type="submit" class="btn btn-secondary" style="font-size:12px">Filter</button>
+        <a href="/admin/tasks" class="btn btn-secondary" style="font-size:12px">Reset</a>
         ${suggestions?.sessions?.length ? `<datalist id="sessions-list">${suggestions.sessions.map((s) => `<option value="${escapeHtml(s)}">`).join("")}</datalist>` : ""}
         ${suggestions?.repos?.length ? `<datalist id="repos-list">${suggestions.repos.map((r) => `<option value="${escapeHtml(r)}">`).join("")}</datalist>` : ""}
         ${suggestions?.agents?.length ? `<datalist id="agents-list">${suggestions.agents.map((a) => `<option value="${escapeHtml(a)}">`).join("")}</datalist>` : ""}

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1230,7 +1230,7 @@ export function renderTasksPage(
   // State toggle params (preserve other filters, reset page)
   const makeStateParams = (newState: string) => {
     const p = new URLSearchParams();
-    if (newState !== "ready") p.set("state", newState);
+    p.set("state", newState);
     if (filters.session) p.set("session", filters.session);
     if (filters.repo) p.set("repo", filters.repo);
     if (filters.agent) p.set("agent", filters.agent);

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1761,6 +1761,27 @@ describe("renderTasksPage — 4-state toggle", () => {
     expect(html).toMatch(/background:#fff;color:#374151[^>]*>Blocked/);
   });
 
+  test("Ready tab is active and links to ?state=ready when state=ready", () => {
+    const html = renderTasksPage(
+      [],
+      { state: "ready" },
+      false,
+      USER_NAME,
+      {},
+      EMPTY_PAGINATION,
+      undefined,
+      undefined,
+    );
+    // Ready tab has active (indigo) styling
+    expect(html).toContain("background:#6366f1;color:#fff");
+    // Ready tab href contains state=ready
+    expect(html).toMatch(/href="\/admin\/tasks\?state=ready"[^>]*>Ready</);
+    // Other tabs are not active
+    expect(html).toMatch(/background:#fff;color:#374151[^>]*>In Progress/);
+    expect(html).toMatch(/background:#fff;color:#374151[^>]*>Blocked/);
+    expect(html).toMatch(/background:#fff;color:#374151[^>]*>Closed/);
+  });
+
   test("Tab links preserve session and repo query params", () => {
     const html = renderTasksPage(
       [],

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1667,7 +1667,7 @@ describe("renderTasksPage — blocker badges", () => {
 const EMPTY_PAGINATION = { total: 0, limit: 50, page: 1 };
 
 describe("renderTasksPage — 4-state toggle", () => {
-  test("Ready tab is active by default (no state filter)", () => {
+  test("no tab highlighted when no state filter (show all)", () => {
     const html = renderTasksPage(
       [],
       {},
@@ -1678,14 +1678,28 @@ describe("renderTasksPage — 4-state toggle", () => {
       undefined,
       undefined,
     );
-    // Ready link URL should NOT contain ?state= (it's the default)
-    expect(html).toMatch(/href="\/admin\/tasks"[^>]*>Ready</);
-    // Ready tab has active styling
-    expect(html).toContain("background:#6366f1;color:#fff");
-    // Other tabs are present
+    // No tab should have active (indigo) styling
+    expect(html).not.toContain("background:#6366f1;color:#fff");
+    // All tabs are present
+    expect(html).toContain("Ready");
     expect(html).toContain("In Progress");
     expect(html).toContain("Blocked");
     expect(html).toContain("Closed");
+  });
+
+  test("Reset button links to /admin/tasks with no params", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      USER_NAME,
+      {},
+      EMPTY_PAGINATION,
+      undefined,
+      undefined,
+    );
+    expect(html).toContain('href="/admin/tasks"');
+    expect(html).toContain("Reset");
   });
 
   test("In Progress tab is active when state=in_progress", () => {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -2536,7 +2536,7 @@ describe("admin UI — tasks page", () => {
     expect(html).not.toContain("Pull Request Review");
   });
 
-  it("GET /admin/tasks with no ?state= forwards state=ready to task-store by default", async () => {
+  it("GET /admin/tasks with no ?state= forwards no state to task-store (show all)", async () => {
     let capturedParams: URLSearchParams | null = null;
     const app = createAdminUIApp(
       makeMockDeps({
@@ -2551,9 +2551,7 @@ describe("admin UI — tasks page", () => {
     });
     expect(res.status).toBe(200);
     expect(capturedParams).not.toBeNull();
-    expect((capturedParams as unknown as URLSearchParams).get("state")).toBe(
-      "ready",
-    );
+    expect((capturedParams as unknown as URLSearchParams).get("state")).toBeNull();
   });
 
   it("GET /admin/tasks?state=blocked returns 200 and forwards state=blocked to task-store", async () => {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1579,16 +1579,13 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
     const status = c.req.query("status") ?? undefined;
     const stateRaw = c.req.query("state");
-    // Default to "ready" when neither state nor status is provided.
     const state: "ready" | "in_progress" | "blocked" | "closed" | undefined =
       stateRaw === "ready" ||
       stateRaw === "in_progress" ||
       stateRaw === "blocked" ||
       stateRaw === "closed"
         ? stateRaw
-        : status
-          ? undefined
-          : "ready";
+        : undefined;
     const session = c.req.query("session") ?? undefined;
     const repo = c.req.query("repo") ?? undefined;
     const agent = c.req.query("agent") ?? undefined;


### PR DESCRIPTION
## Summary
- Remove implicit `state=ready` fallback from `GET /admin/tasks` so visiting with no params returns all tasks
- Update tab styling so no tab is highlighted when no state filter is active
- Add a Reset button next to the Filter button that clears all params back to `/admin/tasks`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | GET /admin/tasks with no params returns all tasks, no tab highlighted | ✅ MET |
| 2 | Reset button appears next to Filter, links to /admin/tasks | ✅ MET |
| 3 | State tabs still work when explicit state= param is present | ✅ MET |
| 4 | HTML rendering only — no new backend/API tests needed | ✅ MET |

## Test Plan
- [x] Unit tests updated: `renderTasksPage — 4-state toggle` now asserts no active tab on unfiltered load
- [x] New unit test: Reset button present and links correctly
- [x] Smoke test updated: `GET /admin/tasks` with no params forwards no state to task-store
- [x] All 835 admin tests pass (0 failures)
- [x] `bunx biome lint .` — clean

Generated with [Claude Code](https://claude.com/claude-code)
