### PR TITLE
feat: add admin proxy routes for task-store token CRUD

### DIFF
--- a/admin/src/admin-tokens.smoke.test.ts
+++ b/admin/src/admin-tokens.smoke.test.ts
@@ -269,6 +269,25 @@ describe("admin UI — /admin/tokens routes", () => {
     expect(html).toContain("sw_raw_abc123");
   });
 
+  it("POST /admin/tokens redirects with error when label is empty", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        adminCreateToken: async () => ({ ...MOCK_TS_TOKEN, rawToken: "sw_raw_abc123" }),
+      }),
+    );
+    const body = new URLSearchParams({ label: "" });
+    const res = await app.request("/admin/tokens", {
+      method: "POST",
+      headers: {
+        Cookie: `admin_session=${cookie}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body.toString(),
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/admin/tokens?error=");
+  });
+
   it("POST /admin/tokens returns 503 when adminCreateToken is absent", async () => {
     const app = createAdminUIApp(makeMockDeps());
     const body = new URLSearchParams({ label: "my-token" });

--- a/admin/src/admin-tokens.smoke.test.ts
+++ b/admin/src/admin-tokens.smoke.test.ts
@@ -1,0 +1,314 @@
+/**
+ * admin/src/admin-tokens.smoke.test.ts
+ * Smoke tests for the /admin/tokens proxy routes.
+ *
+ * Uses app.request() — no real server, no real task-store.
+ * The three task-store fetchers are injected as in-memory doubles.
+ */
+
+import { beforeAll, describe, expect, it } from "bun:test";
+import { sign } from "hono/jwt";
+import { createAdminUIApp } from "./admin-ui.ts";
+import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
+import type { GoogleAuthClient } from "./google-auth-client.ts";
+
+const SESSION_SECRET = "test-admin-session-secret-32-bytes!";
+const AGENT_ID = "agent-test-123";
+const TOKEN_ID = "ts-token-abc";
+
+const MOCK_TS_TOKEN = {
+  id: TOKEN_ID,
+  label: "ci-token",
+  agentId: AGENT_ID,
+  token: "hashed",
+  createdAt: new Date("2024-01-01"),
+  revokedAt: null,
+};
+
+async function makeSessionCookie(): Promise<string> {
+  return sign(
+    {
+      userId: "google-sub-123",
+      email: "admin@example.com",
+      isAdmin: true,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    },
+    SESSION_SECRET,
+    "HS256",
+  );
+}
+
+const BASE_SLACK_CLIENT: AdminUISlackClient = {
+  createAppManifest: async () => ({
+    appId: "A123456",
+    oauthRedirectUrl: "https://slack.com/oauth/authorize?client_id=123",
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+    signingSecret: "test-signing-secret",
+  }),
+  updateAppManifest: async () => {},
+  exchangeOAuthCode: async () => ({ botToken: "xoxb-mock" }),
+};
+
+function makeGoogleClient(): GoogleAuthClient {
+  return {
+    exchangeCode: async () => ({
+      accessToken: "test-access-token",
+      refreshToken: "test-refresh-token",
+      expiresIn: 3600,
+    }),
+    getUserInfo: async () => ({
+      sub: "google-sub-123",
+      email: "admin@example.com",
+      email_verified: true,
+      name: "Admin User",
+    }),
+  };
+}
+
+function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
+  return {
+    prisma: {
+      agent: {
+        findMany: async () => [
+          {
+            id: AGENT_ID,
+            name: "Test Agent",
+            slackId: "U123456",
+            createdAt: new Date("2024-01-01"),
+          },
+        ],
+        findUnique: async () => ({
+          id: AGENT_ID,
+          name: "Test Agent",
+          slackId: "U123456",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          repos: [],
+        }),
+        create: async () => ({
+          id: AGENT_ID,
+          name: "Test Agent",
+          slackId: null,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          repos: [],
+        }),
+        update: async () => ({
+          id: AGENT_ID,
+          name: "Test Agent",
+          slackId: null,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          repos: [],
+        }),
+        delete: async () => ({
+          id: AGENT_ID,
+          name: "Test Agent",
+          slackId: null,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          repos: [],
+        }),
+      },
+      agentPlugin: { findMany: async () => [] },
+      agentMember: {
+        findMany: async () => [],
+        findUnique: async () => null,
+        create: async () => ({ id: "m1", agentId: AGENT_ID, email: "m@example.com" }),
+        deleteMany: async () => ({ count: 0 }),
+      },
+    },
+    agentEnvService: {
+      getByAgentId: async () => ({}),
+      upsert: async () => {},
+      deleteKey: async () => {},
+      getConfigBundle: async () => null,
+    },
+    agentCronJobService: {
+      list: async () => [],
+      listWithRunSummary: async () => [],
+      get: async () => ({
+        id: "c1", agentId: AGENT_ID, schedule: "0 * * * *", prompt: "test",
+        channel: "C1", user: null, enabled: true, name: null, system: false,
+        silent: false, preCheck: null, createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01"),
+      }),
+      create: async () => ({
+        id: "c1",
+        agentId: AGENT_ID,
+        schedule: "0 * * * *",
+        prompt: "test",
+        channel: "C1",
+        user: null,
+        enabled: true,
+        name: null,
+        system: false,
+        silent: false,
+        preCheck: null,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      setEnabled: async () => ({
+        id: "c1", agentId: AGENT_ID, schedule: "0 * * * *", prompt: "test",
+        channel: "C1", user: null, enabled: true, name: null, system: false,
+        silent: false, preCheck: null, createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01"),
+      }),
+      update: async () => ({
+        id: "c1", agentId: AGENT_ID, schedule: "0 * * * *", prompt: "test",
+        channel: "C1", user: null, enabled: true, name: null, system: false,
+        silent: false, preCheck: null, createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01"),
+      }),
+      delete: async () => {},
+      reconcileSystemCrons: async () => ({ created: 0, updated: 0, deleted: 0 }),
+    },
+    agentToolService: {
+      list: async () => [],
+      add: async () => ({ id: "t1", agentId: AGENT_ID, pattern: "*", enabled: true, createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01") }),
+      toggle: async () => ({ id: "t1", agentId: AGENT_ID, pattern: "*", enabled: false, createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01") }),
+      remove: async () => {},
+    },
+    agentTokenService: {
+      listForAgent: async () => [],
+      create: async () => ({
+        token: { id: "tok1", agentId: AGENT_ID, token: "h", label: null, createdAt: new Date("2024-01-01"), revokedAt: null },
+        rawToken: "raw123",
+      }),
+      revoke: async () => null,
+    },
+    agentPluginService: { list: async () => [] },
+    provisioner: {
+      provision: async () => ({ resourceName: "r", secretName: "s", deploymentName: "d" }),
+      deprovision: async () => {},
+      reconcile: async () => ({ recreated: [], updated: [], orphans: [], failed: [] }),
+    },
+    sessionSecret: SESSION_SECRET,
+    googleClientId: "test-google-client-id",
+    googleClientSecret: "test-google-client-secret",
+    adminAllowedEmails: ["admin@example.com"],
+    googleClient: makeGoogleClient(),
+    slackClient: BASE_SLACK_CLIENT,
+    appBaseUrl: "https://example.com",
+    ...overrides,
+  };
+}
+
+describe("admin UI — /admin/tokens routes", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  // ─── GET /admin/tokens ────────────────────────────────────────────────────
+
+  it("GET /admin/tokens returns 200 with token list when adminListTokens is wired", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        adminListTokens: async () => [MOCK_TS_TOKEN],
+      }),
+    );
+    const res = await app.request("/admin/tokens", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("ci-token");
+    expect(html).toContain("Tokens");
+  });
+
+  it("GET /admin/tokens returns 200 in degraded mode when adminListTokens is absent", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/tokens", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("unavailable");
+  });
+
+  it("GET /admin/tokens unauthenticated redirects to /admin/login", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/tokens");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin/login");
+  });
+
+  it("GET /admin/tokens returns 403 for non-admin user", async () => {
+    const nonAdminCookie = await sign(
+      { userId: "u2", email: "user@example.com", isAdmin: false, iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 3600 },
+      SESSION_SECRET,
+      "HS256",
+    );
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/tokens", {
+      headers: { Cookie: `admin_session=${nonAdminCookie}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  // ─── POST /admin/tokens ───────────────────────────────────────────────────
+
+  it("POST /admin/tokens creates token and renders success page with rawToken", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        adminCreateToken: async () => ({ ...MOCK_TS_TOKEN, rawToken: "sw_raw_abc123" }),
+      }),
+    );
+    const body = new URLSearchParams({ label: "ci-token" });
+    const res = await app.request("/admin/tokens", {
+      method: "POST",
+      headers: {
+        Cookie: `admin_session=${cookie}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body.toString(),
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("sw_raw_abc123");
+  });
+
+  it("POST /admin/tokens returns 503 when adminCreateToken is absent", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const body = new URLSearchParams({ label: "my-token" });
+    const res = await app.request("/admin/tokens", {
+      method: "POST",
+      headers: {
+        Cookie: `admin_session=${cookie}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body.toString(),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  // ─── POST /admin/tokens/:id/revoke ────────────────────────────────────────
+
+  it("POST /admin/tokens/:id/revoke calls adminRevokeToken and redirects to list", async () => {
+    let revokedId: string | undefined;
+    const app = createAdminUIApp(
+      makeMockDeps({
+        adminRevokeToken: async (id: string) => {
+          revokedId = id;
+        },
+      }),
+    );
+    const res = await app.request(`/admin/tokens/${TOKEN_ID}/revoke`, {
+      method: "POST",
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin/tokens");
+    expect(revokedId).toBe(TOKEN_ID);
+  });
+
+  it("POST /admin/tokens/:id/revoke returns 503 when adminRevokeToken is absent", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(`/admin/tokens/${TOKEN_ID}/revoke`, {
+      method: "POST",
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(503);
+  });
+});

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2093,6 +2093,7 @@ export function renderTokensPage(
   activePath = "/admin/tokens",
   rawToken?: string,
   timezone?: string,
+  error?: string,
 ): string {
   const tz = timezone ?? "America/Los_Angeles";
   const fmt = (d: Date | string | null | undefined) => {
@@ -2103,6 +2104,10 @@ export function renderTokensPage(
 
   const degradedBanner = degraded
     ? `<div class="alert alert-warning">Token store unavailable — configure SHIPWRIGHT_TASK_STORE_URL and SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN.</div>`
+    : "";
+
+  const errorBanner = error
+    ? `<div class="alert alert-danger" style="margin-bottom:16px">${escapeHtml(decodeURIComponent(error))}</div>`
     : "";
 
   const rawTokenBanner = rawToken
@@ -2123,7 +2128,7 @@ export function renderTokensPage(
           (t) => `<tr>
           <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.id)}</td>
           <td>${escapeHtml(t.label ?? "—")}</td>
-          <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.agentId ?? "admin")}</td>
+          <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.agentId ?? "(admin)")}</td>
           <td>${fmt(t.createdAt)}</td>
           <td>${t.revokedAt ? `<span style="color:#dc2626">Revoked ${fmt(t.revokedAt)}</span>` : '<span style="color:#16a34a">Active</span>'}</td>
           <td>
@@ -2144,8 +2149,8 @@ export function renderTokensPage(
         <h2 style="font-size:15px;font-weight:600;margin-bottom:12px">Create token</h2>
         <form method="POST" action="/admin/tokens" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
           <div>
-            <label style="display:block;font-size:12px;color:#6b7280;margin-bottom:4px">Label (optional)</label>
-            <input type="text" name="label" placeholder="e.g. ci-pipeline" class="form-input" style="width:220px">
+            <label style="display:block;font-size:12px;color:#6b7280;margin-bottom:4px">Label <span style="color:#dc2626">*</span></label>
+            <input type="text" name="label" placeholder="e.g. ci-pipeline" class="form-input" style="width:220px" required>
           </div>
           <div>
             <label style="display:block;font-size:12px;color:#6b7280;margin-bottom:4px">Agent ID (optional — blank for admin token)</label>
@@ -2171,6 +2176,7 @@ export function renderTokensPage(
       <h1 class="page-title">Tokens</h1>
     </div>
     ${degradedBanner}
+    ${errorBanner}
     ${rawTokenBanner}
     <div class="card" style="overflow:auto">
       <table class="data-table" style="width:100%">

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2107,7 +2107,7 @@ export function renderTokensPage(
     : "";
 
   const errorBanner = error
-    ? `<div class="alert alert-danger" style="margin-bottom:16px">${escapeHtml(decodeURIComponent(error))}</div>`
+    ? `<div class="alert alert-danger" style="margin-bottom:16px">${escapeHtml(error)}</div>`
     : "";
 
   const rawTokenBanner = rawToken

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -180,6 +180,18 @@ export interface TaskItem {
   blockedBy?: BlockedByEntry[] | null;
 }
 
+// Token shape returned by the task-store /tokens endpoint (admin token only).
+// Mirrors TaskToken fields relevant to the admin UI; avoids cross-package coupling.
+export interface TaskStoreTokenItem {
+  id: string;
+  label: string | null;
+  agentId: string | null;
+  token: string;
+  createdAt: Date | string;
+  revokedAt: Date | string | null;
+  rawToken?: string;
+}
+
 // ─── Inline markdown renderer ─────────────────────────────────────────────────
 
 /**
@@ -2055,6 +2067,115 @@ export function renderProvisionCompletePage(
     <div class="card">
       ${bodyHtml}
     </div>
+  </div>
+</body>
+</html>`;
+}
+
+// ─── Task-store tokens page ────────────────────────────────────────────────────
+
+export function renderTokensPage(
+  tokens: TaskStoreTokenItem[],
+  degraded: boolean,
+  userName: string,
+  activePath = "/admin/tokens",
+  rawToken?: string,
+  timezone?: string,
+): string {
+  const tz = timezone ?? "America/Los_Angeles";
+  const fmt = (d: Date | string | null | undefined) => {
+    if (!d) return "—";
+    const date = d instanceof Date ? d : new Date(d);
+    return date.toLocaleString("en-US", { timeZone: tz, dateStyle: "medium", timeStyle: "short" });
+  };
+
+  const degradedBanner = degraded
+    ? `<div class="alert alert-warning">Token store unavailable — configure SHIPWRIGHT_TASK_STORE_URL and SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN.</div>`
+    : "";
+
+  const rawTokenBanner = rawToken
+    ? `<div class="alert alert-success" style="margin-bottom:16px">
+        <strong>Token created.</strong> Copy it now — it will not be shown again.<br>
+        <code id="raw-token" style="display:block;margin-top:8px;font-size:13px;word-break:break-all">${escapeHtml(rawToken)}</code>
+        <button type="button" class="btn btn-sm btn-secondary" style="margin-top:8px"
+          onclick="navigator.clipboard.writeText(document.getElementById('raw-token').textContent)">
+          Copy
+        </button>
+      </div>`
+    : "";
+
+  const rows = tokens.length === 0
+    ? `<tr><td colspan="6" class="empty-state">No tokens found.</td></tr>`
+    : tokens
+        .map(
+          (t) => `<tr>
+          <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.id)}</td>
+          <td>${escapeHtml(t.label ?? "—")}</td>
+          <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.agentId ?? "admin")}</td>
+          <td>${fmt(t.createdAt)}</td>
+          <td>${t.revokedAt ? `<span style="color:#dc2626">Revoked ${fmt(t.revokedAt)}</span>` : '<span style="color:#16a34a">Active</span>'}</td>
+          <td>
+            ${
+              t.revokedAt
+                ? ""
+                : `<form method="POST" action="/admin/tokens/${encodeURIComponent(t.id)}/revoke" style="margin:0" onsubmit="return confirm('Revoke this token?')">
+                    <button type="submit" class="btn btn-sm btn-danger">Revoke</button>
+                  </form>`
+            }
+          </td>
+        </tr>`,
+        )
+        .join("");
+
+  const createForm = !degraded
+    ? `<div class="card" style="margin-top:24px">
+        <h2 style="font-size:15px;font-weight:600;margin-bottom:12px">Create token</h2>
+        <form method="POST" action="/admin/tokens" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
+          <div>
+            <label style="display:block;font-size:12px;color:#6b7280;margin-bottom:4px">Label (optional)</label>
+            <input type="text" name="label" placeholder="e.g. ci-pipeline" class="form-input" style="width:220px">
+          </div>
+          <div>
+            <label style="display:block;font-size:12px;color:#6b7280;margin-bottom:4px">Agent ID (optional — blank for admin token)</label>
+            <input type="text" name="agentId" placeholder="agent-id" class="form-input" style="width:220px">
+          </div>
+          <button type="submit" class="btn btn-primary">Create</button>
+        </form>
+      </div>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Tokens — Shipwright Admin</title>
+  <style>${baseStyles()}</style>
+</head>
+<body>
+  ${renderAdminToolbar(userName, activePath)}
+  <div class="vos-page">
+    <div class="page-header">
+      <h1 class="page-title">Tokens</h1>
+    </div>
+    ${degradedBanner}
+    ${rawTokenBanner}
+    <div class="card" style="overflow:auto">
+      <table class="data-table" style="width:100%">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Label</th>
+            <th>Agent</th>
+            <th>Created</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+    ${createForm}
   </div>
 </body>
 </html>`;

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1864,6 +1864,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
 
   app.get("/admin/tokens", requireAuth, async (c) => {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    const error = c.req.query("error") ?? undefined;
     let tokens: TaskStoreTokenItem[] = [];
     let degraded = false;
     if (!adminListTokens) {
@@ -1876,7 +1877,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       }
     }
     return html(
-      renderTokensPage(tokens, degraded, c.var.userEmail, c.req.path, undefined, timezone),
+      renderTokensPage(tokens, degraded, c.var.userEmail, c.req.path, undefined, timezone, error),
     );
   });
 
@@ -1884,7 +1885,8 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
     if (!adminCreateToken) return new Response("Token store not configured", { status: 503 });
     const form = await c.req.formData();
-    const label = form.get("label")?.toString() || undefined;
+    const label = form.get("label")?.toString()?.trim() || undefined;
+    if (!label) return c.redirect("/admin/tokens?error=Label+is+required", 302);
     const agentId = form.get("agentId")?.toString() || undefined;
     let result: (TaskStoreTokenItem & { rawToken: string }) | undefined;
     try {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -38,6 +38,8 @@ import {
   renderPrsPage,
   renderTaskDetailPage,
   renderTasksPage,
+  renderTokensPage,
+  type TaskStoreTokenItem,
 } from "./admin-ui-pages.ts";
 import type { AgentCronJobService } from "./agent-cron-jobs.ts";
 import type { AgentEnvService } from "./agent-envs.ts";
@@ -257,6 +259,23 @@ export interface AdminUIDeps {
    * If absent or returns null, the PR detail route redirects to /admin/prs.
    */
   fetchTaskStorePrById?: (id: string) => Promise<PrListItem | null>;
+  /**
+   * List all tokens from the task-store service (admin token required).
+   * If absent, the tokens page renders in degraded mode.
+   */
+  adminListTokens?: () => Promise<TaskStoreTokenItem[]>;
+  /**
+   * Create a new token in the task-store service (admin token required).
+   * Returns the token record plus the rawToken — shown once, never stored.
+   */
+  adminCreateToken?: (
+    label?: string,
+    agentId?: string,
+  ) => Promise<TaskStoreTokenItem & { rawToken: string }>;
+  /**
+   * Revoke a token by ID via the task-store service (admin token required).
+   */
+  adminRevokeToken?: (id: string) => Promise<void>;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -358,6 +377,9 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     fetchTaskStorePr,
     fetchTaskStorePrs,
     fetchTaskStorePrById,
+    adminListTokens,
+    adminCreateToken,
+    adminRevokeToken,
   } = deps;
 
   const app = new Hono<AdminUIEnv>();
@@ -1839,6 +1861,64 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }
 
     return html(renderPrDetailPage(pr, c.var.userEmail, agentNames, timezone));
+  });
+
+  // ─── Task-store token proxy routes ────────────────────────────────────────
+
+  app.get("/admin/tokens", requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    let tokens: TaskStoreTokenItem[] = [];
+    let degraded = false;
+    if (!adminListTokens) {
+      degraded = true;
+    } else {
+      try {
+        tokens = await adminListTokens();
+      } catch {
+        degraded = true;
+      }
+    }
+    return html(
+      renderTokensPage(tokens, degraded, c.var.userEmail, c.req.path, undefined, timezone),
+    );
+  });
+
+  app.post("/admin/tokens", requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    if (!adminCreateToken) return new Response("Token store not configured", { status: 503 });
+    const form = await c.req.formData();
+    const label = form.get("label")?.toString() || undefined;
+    const agentId = form.get("agentId")?.toString() || undefined;
+    let result: (TaskStoreTokenItem & { rawToken: string }) | undefined;
+    try {
+      result = await adminCreateToken(label, agentId);
+    } catch (err) {
+      const msg = err instanceof Error ? encodeURIComponent(err.message) : "create_failed";
+      return c.redirect(`/admin/tokens?error=${msg}`, 302);
+    }
+    // Render inline — never redirect with the raw token in the URL.
+    let tokens: TaskStoreTokenItem[] = [];
+    try {
+      if (adminListTokens) tokens = await adminListTokens();
+    } catch {
+      // best-effort refresh; show the new token even if list fails
+    }
+    return html(
+      renderTokensPage(tokens, false, c.var.userEmail, "/admin/tokens", result.rawToken, timezone),
+    );
+  });
+
+  app.post("/admin/tokens/:id/revoke", requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    if (!adminRevokeToken) return new Response("Token store not configured", { status: 503 });
+    const tokenId = c.req.param("id");
+    try {
+      await adminRevokeToken(tokenId);
+    } catch (err) {
+      const msg = err instanceof Error ? encodeURIComponent(err.message) : "revoke_failed";
+      return c.redirect(`/admin/tokens?error=${msg}`, 302);
+    }
+    return c.redirect("/admin/tokens", 302);
   });
 
   // ─── Agent delete (danger zone) ───────────────────────────────────────────

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -335,6 +335,35 @@ async function startServer(): Promise<void> {
               throw new Error(`task-store GET /prs/${id} → ${res.status}`);
             return res.json();
           },
+          adminListTokens: async () => {
+            const res = await fetch(`${taskStoreUrl}/tokens`, {
+              headers: { Authorization: `Bearer ${taskStoreAdminToken}` },
+            });
+            if (!res.ok)
+              throw new Error(`task-store GET /tokens → ${res.status}`);
+            return res.json();
+          },
+          adminCreateToken: async (label?: string, agentId?: string) => {
+            const res = await fetch(`${taskStoreUrl}/tokens`, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${taskStoreAdminToken}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ label, agentId }),
+            });
+            if (!res.ok)
+              throw new Error(`task-store POST /tokens → ${res.status}`);
+            return res.json();
+          },
+          adminRevokeToken: async (id: string) => {
+            const res = await fetch(`${taskStoreUrl}/tokens/${id}`, {
+              method: "DELETE",
+              headers: { Authorization: `Bearer ${taskStoreAdminToken}` },
+            });
+            if (!res.ok)
+              throw new Error(`task-store DELETE /tokens/${id} → ${res.status}`);
+          },
         }
       : {};
 

--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -140,6 +140,7 @@ export function renderShipwrightToolbar(
       <a href="${adminBase}/admin/provision" class="vos-nav-link${active("/admin/provision")}">Provision</a>
       <a href="${adminBase}/admin/tasks" class="vos-nav-link${active("/admin/tasks")}">Tasks</a>
       <a href="${adminBase}/admin/prs" class="vos-nav-link${active("/admin/prs")}">PRs</a>
+      <a href="${adminBase}/admin/tokens" class="vos-nav-link${active("/admin/tokens")}">Tokens</a>
       <a href="${metricsUrl}" class="vos-nav-link${active(metricsUrl)}">Metrics</a>
     </div>
     <div class="vos-user">

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -115,6 +115,7 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
       <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
+      <a href="/admin/tokens" class="vos-nav-link">Tokens</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">
@@ -547,6 +548,7 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
       <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
+      <a href="/admin/tokens" class="vos-nav-link">Tokens</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">
@@ -979,6 +981,7 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
       <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
+      <a href="/admin/tokens" class="vos-nav-link">Tokens</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">
@@ -1411,6 +1414,7 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
       <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
+      <a href="/admin/tokens" class="vos-nav-link">Tokens</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">


### PR DESCRIPTION
## Summary
- Add `adminListTokens`, `adminCreateToken`, `adminRevokeToken` fetcher functions to `admin/src/main.ts` wired to the task-store admin token
- Add GET /admin/tokens, POST /admin/tokens, POST /admin/tokens/:id/revoke proxy routes in `admin/src/admin-ui.ts` with graceful degradation when task-store is unconfigured
- Add Tokens nav link in the admin sidebar toolbar

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | GET /admin/tokens fetches token list from task store and passes to view | ✅ MET |
| 2 | POST /admin/tokens proxies create request, passes rawToken to success view | ✅ MET |
| 3 | POST /admin/tokens/:id/revoke proxies DELETE to task store, redirects to list | ✅ MET |
| 4 | Smoke tests for all three proxy routes via Hono in-process driver with mocked task-store responses; no existing tests retired | ✅ MET |

## Test Plan
- 8 smoke tests in `admin/src/admin-tokens.smoke.test.ts` using `app.request()` with mocked dep injection — no real server or task-store needed
- Tests cover list, create, revoke; degraded mode (dep absent); 503 responses; 302 redirects; non-admin 403; unauthenticated 302
- All 8 tests passing; lint clean

Generated with [Claude Code](https://claude.com/claude-code)
