### PR TITLE
feat: add setup instructions to all task-store-touching skills

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -11,6 +11,8 @@ metrics on success.
 
 **This command runs autonomously. Do not pause for user input unless pre-flight fails.**
 
+> **Task store setup:** This command updates task status in the Shipwright task store on deploy completion. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 ---
 
 ## Arguments

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -8,6 +8,8 @@ Pick the next ready task from the task store, build the feature, simplify, verif
 
 **This command runs autonomously. Do not pause for user input unless a build or test failure cannot be auto-resolved.**
 
+> **Task store setup:** This command reads from and writes to the Shipwright task store. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 ---
 
 ## Step 0: Detect Project Toolchain

--- a/plugins/shipwright/commands/hitl.md
+++ b/plugins/shipwright/commands/hitl.md
@@ -12,6 +12,8 @@ mark the task `done` when the human confirms completion.
 
 **This skill runs interactively. Pause and assist the human through each step.**
 
+> **Task store setup:** This command reads and updates tasks in the Shipwright task store. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions. For local HITL use, create an admin token with the Agent ID field left blank.
+
 ---
 
 ## Step 1: Parse Arguments

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -15,6 +15,8 @@ For each PR, apply the appropriate fix. Goes silent when nothing needs addressin
 
 **This command runs autonomously. Do not pause for user input.**
 
+> **Task store setup:** This command reads task state from the Shipwright task store when correlating CI failures with open tasks. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 ---
 
 ## Step 1: Get Own GH Login

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -11,6 +11,8 @@ arguments:
 
 # Plan Session: $ARGUMENTS
 
+> **Task store setup:** This command appends planned tasks to the Shipwright task store. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 Parse `$ARGUMENTS` to extract:
 - **repo**: first argument
 - **session**: second argument

--- a/plugins/shipwright/commands/refresh-plan.md
+++ b/plugins/shipwright/commands/refresh-plan.md
@@ -8,6 +8,8 @@ arguments:
 
 # Refresh Plan: $ARGUMENTS
 
+> **Task store setup:** This command updates task metadata in the Shipwright task store after refreshing a planning doc. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 Refresh a planning doc's stale tasks against the current codebase state. Preserves stable sections (descriptions, acceptance criteria) and updates sections that reference code (file paths, technical details, dependency statuses).
 
 Follow all steps in order.

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -11,6 +11,8 @@ Evaluate open PRs and post findings. Scope: review only — no patching, merging
 re-posting on PRs that haven't changed. It is not shared state and is not read by other
 agents — each agent maintains its own.
 
+> **Task store setup:** This command updates task status in the Shipwright task store after review. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 ---
 
 ## Arguments

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -9,6 +9,8 @@ Read the latest `entropy-report.md` and open focused, human-reviewable PRs for `
 
 **Prerequisites:** Run `/entropy-scan` first to produce `entropy-report.md`.
 
+> **Task store setup:** When using the `--queue` flag, this skill pushes findings to the Shipwright task store. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
 ---
 
 ## Setup: Parse Arguments

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -16,6 +16,30 @@ The task store is a REST service — call it with curl, no script discovery need
 
 ---
 
+## Setup
+
+Before using this skill, verify the required environment variables are set:
+
+```bash
+echo "URL:   ${SHIPWRIGHT_TASK_STORE_URL:-(missing)}"
+echo "Token: ${SHIPWRIGHT_TASK_STORE_TOKEN:+(set)}"
+```
+
+**`SHIPWRIGHT_TASK_STORE_URL` missing?** Contact your administrator — this URL is provisioned at deployment time and is not something you generate yourself.
+
+**`SHIPWRIGHT_TASK_STORE_TOKEN` missing?** Create a scoped token:
+
+1. Open your Shipwright admin UI at `<admin-url>/admin/tokens`
+2. Click **Create token** and enter a descriptive label (e.g. `my-local-agent`)
+3. **Agent ID field** — leave blank for local or HITL use; enter your agent's ID for Vitals OS shipwright agents
+4. Copy the generated token and wire it up:
+   - **Local plugin / shell:** `export SHIPWRIGHT_TASK_STORE_TOKEN=<token>`
+   - **Vitals OS shipwright agent:** add `SHIPWRIGHT_TASK_STORE_TOKEN=<token>` as an agent env var in the Vitals OS admin UI — it takes effect within 60 seconds, no restart needed
+
+**HITL note:** For local HITL execution (`/shipwright:hitl`), create an admin token with **Agent ID left blank** — this keeps the token unscoped so it can read any agent's tasks. Pass the task ID explicitly when invoking the skill.
+
+---
+
 ## Authentication
 
 All requests require a Bearer token:


### PR DESCRIPTION
## Summary
- Add a full Setup section to `skills/task-store/SKILL.md` covering missing-URL and missing-token scenarios with context-specific instructions (local plugin, Vitals OS agent env vars, and admin token for HITL use)
- Add a one-paragraph task store setup preamble to the 8 other task-store-touching files (dev-task, plan-session, deploy, hitl, review, patch, refresh-plan, entropy-fix), each pointing to `/shipwright:task-store` for setup instructions

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | task-store/SKILL.md covers missing-URL and missing-token with context-specific instructions | ✅ MET |
| 2 | HITL-specific note: admin token, Agent ID blank, pass task ID explicitly | ✅ MET |
| 3 | All 8 other files have preamble referencing task-store skill | ✅ MET |
| 4 | No automated tests — markdown prose changes, verified by review | ✅ MET |

## Test Plan
- [x] All 9 files updated with appropriate preambles
- [x] task-store/SKILL.md Setup section covers both env var cases
- [x] HITL note includes "pass the task ID explicitly" guidance
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
