### PR TITLE
feat(review): migrate review.md from state/reviews.json to task store PR API

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -7,9 +7,11 @@ argument-hint: "[org/repo#number]"
 
 Evaluate open PRs and post findings. Scope: review only — no patching, merging, or deploying.
 
-`state/reviews.json` is a local dedup cache. It tracks reviewed commit SHAs to avoid
-re-posting on PRs that haven't changed. It is not shared state and is not read by other
-agents — each agent maintains its own.
+PR tracking state — claimed commit SHAs, review state, and staging status — lives in the
+task store PR API (`$SHIPWRIGHT_TASK_STORE_URL/prs`). This is shared state across agents:
+claims are atomic, so two agents won't review the same commit simultaneously. The review
+narrative itself is still written locally to `state/reviews/PR_REVIEW_{pr}.md` and
+`state/reviews/pr_review_{pr}.json` for posting.
 
 ---
 
@@ -17,7 +19,7 @@ agents — each agent maintains its own.
 
 Parse `$ARGUMENTS`:
 - `org/repo#number` (e.g. `app-vitals/shipwright#123`): target a specific PR. If a staged
-  review exists in `state/reviews.json`, post it. Otherwise, review it.
+  review exists (PR record with `staged: true`), post it. Otherwise, review it.
 - `number` or `#number`: same, using the repo from the task store API
 - No arguments: normal review flow — find the next PR to review from the queue
 
@@ -49,18 +51,30 @@ Policy: {staging|auto-posting} reviews
 
 If `cleanup_merged_worktrees` is true:
 
-1. Read `state/reviews.json` (create as `[]` if missing)
-2. For entries with `status` of `staged`, `posted`, or `reviewing`:
+1. List PR records for each configured repo:
+   ```bash
+   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}" | jq -c '.prs[]'
+   ```
+2. For each record whose `reviewState` is `in_progress`, `posted`, or `approved`:
    - Check if the PR is merged or closed: `gh pr view {pr} --repo {org}/{repo} --json state -q '.state'`
-   - If `MERGED` or `CLOSED`: remove the worktree if it exists (`git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force 2>/dev/null`), update `status: "merged"`, set `mergedAt`
-3. For entries with `status: "merged"`: set `status: "cleaned"` (terminal)
-4. Remove stale worktrees older than `cleanup_after_days`:
+   - If `MERGED` or `CLOSED`:
+     - Remove the worktree if it exists: `git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force 2>/dev/null`
+     - Mark the record terminal in one PATCH:
+       ```bash
+       curl -sf -X PATCH \
+         -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+         -H "Content-Type: application/json" \
+         "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}" \
+         -d "{\"state\": \"merged\", \"mergedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >/dev/null
+       ```
+       `state: "merged"` is the terminal state — no further status progression is needed.
+3. Remove stale worktrees older than `cleanup_after_days`:
    ```bash
    find worktrees/ -maxdepth 1 -type d -mtime +{cleanup_after_days} -exec basename {} \;
    ```
    For each, remove via `git worktree remove`.
-5. Write updated `state/reviews.json`
-6. If any cleaned: print `Cleaned {N} worktrees`
+4. If any cleaned: print `Cleaned {N} worktrees`
 
 ---
 
@@ -74,10 +88,22 @@ gh api /user -q '.login'
 
 ### Step 3a: Drain Staged Queue (interactive mode)
 
-Read `state/reviews.json` for entries with `status: "staged"`.
+Fetch staged PR records for each configured repo:
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&staged=true" | jq -c '.prs[]'
+```
 
-If any staged reviews exist, present them in priority order:
-1. **APPROVE verdicts first** — unblocking is highest value
+If any staged records exist, fetch current GitHub metadata for each (the record may hold
+stale metadata) to populate the display:
+```bash
+gh pr view {pr} --repo {org}/{repo} --json title,additions,deletions
+```
+`diffSize` = `additions + deletions`. Treat a record with `reviewState: "approved"` as an
+APPROVE verdict for sorting.
+
+Present them in priority order:
+1. **APPROVE verdicts first** (`reviewState: "approved"`) — unblocking is highest value
 2. **Then by `diffSize` ascending** — smallest diffs are fastest to confirm
 
 Display:
@@ -90,6 +116,8 @@ Display:
 
 Post staged reviews, or skip to new reviews?
 ```
+
+The "Staged" column comes from `record.updatedAt`.
 
 **If posting**: work through them one at a time using the Step 14 posting mechanics
 (show review summary → confirm → post → move to next). After all staged reviews are
@@ -110,7 +138,7 @@ REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
 
 ```bash
 gh pr list --state open --repo {org}/{repo} \
-  --json number,title,author,headRefName,baseRefName,isDraft,reviews,updatedAt,additions,deletions
+  --json number,title,author,headRefName,baseRefName,isDraft,reviews,createdAt,updatedAt,additions,deletions
 ```
 
 Exclude:
@@ -120,7 +148,7 @@ Exclude:
 
 When a PR is checked out for review, also query the task store for a task whose `pr`
 field matches the PR number — if found, record the `id` and `session` for metrics enrichment
-in Steps 12 and 13:
+in Step 13:
 
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
@@ -129,40 +157,37 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 
 ### Deduplication and Filtering
 
-Read `state/reviews.json`. For each candidate PR:
+For each candidate PR, fetch its PR record from the task store:
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={number}" | jq -c '.prs[0] // empty'
+```
 
-- **No entry**: eligible (new PR). Create a `pending` entry immediately:
-  ```json
-  {
-    "pr": {number}, "repo": "{repo}", "org": "{org}",
-    "title": "{title}", "author": "{author.login}", "branch": "{headRefName}",
-    "additions": {additions}, "deletions": {deletions},
-    "diffSize": {additions + deletions},
-    "firstSeen": "{now ISO}", "status": "pending"
-  }
-  ```
-- **Entry with `status: "reviewing"`**: skip (another run is working on it)
-- **Entry with `status: "staged"` or `"posted"`**: check for new commits since last review:
+The record's `commitSha` is the SHA at which the PR was last reviewed (call it
+`lastReviewedCommit`). Apply this eligibility logic:
+
+- **No record**: eligible (new PR, Tier 2). No local entry is created — the task store
+  creates the record atomically on first claim in Step 4.
+- **`staged: true`**: exclude — Step 3a owns staged records.
+- **`reviewState: "in_progress"`**: skip (another run has claimed it).
+- **`reviewState: "posted"` or `"approved"`**: check for new commits since last review:
   ```bash
   gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid'
   ```
-  If `headRefOid` differs from `lastReviewedCommit`: check whether the update is merge-only before marking eligible:
+  If `headRefOid` differs from `record.commitSha`: check whether the update is merge-only before marking eligible:
   ```bash
   gh api repos/{org}/{repo}/pulls/{pr}/commits --paginate
   ```
-  Find `lastReviewedCommit` in the commit list. Check if every commit after it has `parents.length >= 2` (i.e., all are merge commits — merge-from-base or merge-from-main). If yes: skip and print `Skipping #{pr} — merge-only update since {lastReviewedCommit[0..7]}`. If no (real code changes exist), or if the anchor commit is not found, or if the API call fails: eligible for re-review.
-  If `headRefOid` is the same as `lastReviewedCommit`: skip.
-- **Entry with `status: "cleaned"` or `"merged"`**: skip.
-
-If a `pending` entry is missing `diffSize` (created before this field was added), populate
-it from the `gh pr list` fetch before sorting.
+  Find `record.commitSha` in the commit list. Check if every commit after it has `parents.length >= 2` (i.e., all are merge commits — merge-from-base or merge-from-main). If yes: skip and print `Skipping #{pr} — merge-only update since {record.commitSha[0..7]}`. If no (real code changes exist), or if the anchor commit is not found, or if the API call fails: eligible for re-review (Tier 1).
+  If `headRefOid` is the same as `record.commitSha`: skip.
+- **`reviewState: "pending"`**: eligible.
 
 #### Unresolved Comment Check
 
-> **If `lastReviewedCommit` is set AND `headRefOid != lastReviewedCommit`: stop — do not run this check. Mark the PR eligible and proceed. New commits from the author unconditionally override all unresolved thread skip conditions.**
+> **If a record exists AND `headRefOid != record.commitSha`: stop — do not run this check. Mark the PR eligible and proceed. New commits from the author unconditionally override all unresolved thread skip conditions.**
 
 Only run the check below when BOTH of the following are true:
-- `lastReviewedCommit` is not set (first review), OR `headRefOid == lastReviewedCommit` (head has not moved)
+- There is no record (first review), OR `headRefOid == record.commitSha` (head has not moved)
 - i.e. there is no evidence the author has pushed anything new
 
 Fetch reviews and comment timeline:
@@ -183,32 +208,29 @@ Print: `Skipping #{pr} — unresolved feedback from @{login} ({type} on {date}).
 
 ### Pick Next PR
 
-Selection is based on the **value of the review action**, not diff size. Each eligible PR
-has a `state/reviews.json` entry with `status`, `posted`, `lastReviewedCommit`, and
-`firstSeen`. Compare `lastReviewedCommit` to the PR's current head SHA to detect new
-commits since the last review.
+Selection is based on the **value of the review action**, not diff size. Eligibility is
+determined by the PR record (from the task store) plus the PR's current head SHA. Compare
+`record.commitSha` to the current head SHA to detect new commits since the last review.
 
 **Tier 1 — Re-review of posted reviews** (highest priority)
-Entry has `status: "posted"` (or `posted: true`) AND the current head SHA differs from
-`lastReviewedCommit`, AND the new commits are not merge-only (as determined by the
+Record has `reviewState: "posted"` or `"approved"` AND the current head SHA differs from
+`record.commitSha`, AND the new commits are not merge-only (as determined by the
 deduplication check above). The author pushed real code changes after seeing our feedback —
 re-reviewing closes the loop and can unblock a merge.
 
-**Tier 2 — First review of pending PRs**
-Entry has `status: "pending"`, or the PR has no entry yet. Never been reviewed — give
-it first feedback so every open PR gets coverage.
+**Tier 2 — First review of new PRs**
+The PR has no record yet, or the record has `reviewState: "pending"`. Never been reviewed —
+give it first feedback so every open PR gets coverage.
 
-**Tier 3 — Stale unposted staged reviews — DO NOT auto-process**
-Entry has `status: "staged"`, `posted: false`, and head SHA differs from
-`lastReviewedCommit`. Do NOT pick these during a cron run: nobody has seen the staged
-review yet, so refreshing it just burns the slot. Leave them stale. They are re-reviewed
-only on demand via an explicit `/shipwright:review {org}/{repo}#{pr}` invocation (the
-`/shipwright:review-staged` walkthrough already skips stale entries and directs the owner
-there).
+Staged records (`staged: true`) are NOT picked here — Step 3a owns them. During a cron run,
+nobody has seen a staged review yet, so refreshing it just burns the slot. Staged records
+are re-reviewed only on demand via an explicit `/shipwright:review {org}/{repo}#{pr}`
+invocation (the `/shipwright:review-staged` walkthrough already skips stale entries and
+directs the owner there).
 
-Pick the first PR from the highest non-empty tier. Within each tier, sort by `firstSeen`
-ascending (oldest first) so no PR starves. `diffSize` is no longer used for ordering;
-it may be used only as a final tie-breaker within the same `firstSeen` value.
+Pick the first PR from the highest non-empty tier. Order within tiers:
+- **Tier 1**: sort by `record.updatedAt` descending (most recently touched first).
+- **Tier 2**: sort by the GitHub PR `createdAt` ascending (oldest open PR first) so no PR starves.
 
 If nothing to review:
 ```
@@ -233,7 +255,33 @@ git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force
 git -C repos/{repo} worktree add worktrees/{repo}-{branch-slug} origin/{branch}
 ```
 
-Update `state/reviews.json`: add or update the entry with `status: "reviewing"`.
+### Save the pre-claim commit, then claim
+
+Before claiming, save the existing record's `commitSha` — this is `lastReviewedCommit`,
+the SHA the PR was last reviewed at. The claim overwrites `commitSha` with the new head, so
+capture it first:
+```bash
+LAST_REVIEWED_COMMIT=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" \
+  | jq -r '.prs[0].commitSha // empty')
+```
+`LAST_REVIEWED_COMMIT` is empty for a first review (no record yet). Use it in Steps 5 and 9.
+
+Then claim the PR atomically at the current head. Fetch the head SHA first:
+```bash
+headRefOid=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid')
+```
+```bash
+PR_CLAIM=$(curl -s -o /tmp/pr_claim.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"{headRefOid}\"$([ -n \"{taskId}\" ] && echo \", \\\"taskId\\\": \\\"{taskId}\\\"\" || true)}")
+```
+- `201` (new) or `200` (update): claimed. Capture `.id` from `/tmp/pr_claim.json` as
+  `PR_RECORD_ID`; the claim sets `reviewState: "in_progress"`.
+- `409` (conflict): another agent holds the claim at this commit. **Skip this PR** and
+  return to Step 3b to pick the next candidate.
 
 All subsequent steps run from `worktrees/{repo}-{branch-slug}/`.
 
@@ -270,13 +318,17 @@ All subsequent steps run from `worktrees/{repo}-{branch-slug}/`.
 
 7. **Test-readiness context** (optional): try to read `worktrees/{repo}-{branch-slug}/docs/test-readiness/test-system.md`. If absent, note that no repo-specific test-readiness doc exists. When the changed files include any path that looks like a test file — by common conventions across languages (e.g. files named or located in a way that signals they contain tests, such as files in `test/`, `tests/`, `spec/`, or `__tests__/` directories, or files whose names follow typical test-naming conventions for the project's language), also extract the "## Testing" section from the root CLAUDE.md (if present). Use the project's language and toolchain (visible from the diff and CLAUDE.md) to recognise test files — do not apply a fixed set of glob patterns. Combine both pieces into `testReadinessContext`. If neither produces content, `testReadinessContext` is absent — omit it entirely from the subagent prompt.
 
+`lastReviewedCommit` is the `LAST_REVIEWED_COMMIT` value saved from the pre-claim record in
+Step 4 (the record's `commitSha` before the claim overwrote it).
+
 Apply the unresolved comment check from Step 3 using the fetched `reviews` and `comments`
 (they were just fetched above — no extra API call needed). **If `lastReviewedCommit` is set AND
 `headRefOid != lastReviewedCommit`: skip this check entirely and continue — head has moved,
 re-review unconditionally.** Only run the check for first reviews (no `lastReviewedCommit`) or
 when the head has not moved (`headRefOid == lastReviewedCommit`). If any substantive unresolved
-feedback is found: update `state/reviews.json` status to `pending`, skip this PR,
-and return to Step 3b to pick the next candidate.
+feedback is found: release the claim so the record returns to `pending`
+(`POST $SHIPWRIGHT_TASK_STORE_URL/prs/{PR_RECORD_ID}/release`), skip this PR, and return to
+Step 3b to pick the next candidate.
 
 ---
 
@@ -418,9 +470,12 @@ Write `state/reviews/PR_REVIEW_{pr}.md`:
 
 ### Re-Review (Update)
 
-If this PR was reviewed before (entry in reviews.json with `reviewCount >= 1`):
+If this agent reviewed this PR before — detected by the local file `state/reviews/PR_REVIEW_{pr}.md`
+already existing (`test -f state/reviews/PR_REVIEW_{pr}.md`):
 
-Append an update section instead of creating a new file:
+Append an update section instead of creating a new file. (Do not use `reviewCycles` from the
+task store — another agent may have incremented it without this agent ever reviewing, so the
+local file is the authoritative signal that *this* agent has a prior review to append to.)
 
 ```markdown
 ---
@@ -504,14 +559,21 @@ should be held; the inline comments convey the specific feedback to the author.
      --input state/reviews/pr_review_{pr}.json
    ```
 2. Capture `html_url` from response
-3. Run Step 11b to upsert the PullRequest record.
-4. Update `state/reviews.json`: `posted: true`, `postedAt: now`, `status: "posted"`
-5. Print: `Posted review for #{pr}: {html_url}`
-6. Post Slack message (see below)
+3. Run Step 11b to mark the PR record posted.
+4. Print: `Posted review for #{pr}: {html_url}`
+5. Post Slack message (see below)
 
 ### If `auto_post_reviews` is false (default):
 
-1. Update `state/reviews.json`: `status: "staged"`
+1. Mark the PR record staged:
+   ```bash
+   curl -sf -X PATCH \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
+     -d '{"staged": true}' >/dev/null
+   ```
+   (`PR_RECORD_ID` is the claim response `.id` from Step 4.)
 2. Post Slack message to the configured channel (see below)
 3. Print: `Review staged for #{pr}. Slack notification sent.`
 
@@ -543,37 +605,23 @@ Use the Slack MCP tool if available. If no Slack integration is configured, prin
 
 ---
 
-## Step 11b: Upsert PullRequest Record
+## Step 11b: Mark PullRequest Record Posted
 
-Run this step immediately after posting a review (applies to both the `auto_post_reviews` path in Step 11 and the targeted PR posting path in Step 14). Skip this step when the review is staged (not posted). The `reviews.json` write in Step 12 is unchanged — this is a side effect only.
+Run this step immediately after posting a review (applies to both the `auto_post_reviews` path in Step 11 and the targeted PR posting path in Step 14). Skip this step when the review is staged (not posted).
 
-Use `{org}`, `{repo}`, `{pr}`, `{headRefOid}` (from Step 5), `{verdict}` (from Step 10), and `{taskId}` (from Step 3b if a matching task was found).
+Use `{verdict}` (from Step 10) and `PR_RECORD_ID` — the record ID captured from the claim in Step 4 (targeted flow: from the staged record fetched in Step 14).
 
-### 1. Claim the PR record
-
-```bash
-PR_CLAIM=$(curl -sf -X POST \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "${SHIPWRIGHT_TASK_STORE_URL}/prs/claim" \
-  -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"{headRefOid}\"$([ -n \"{taskId}\" ] && echo \", \\\"taskId\\\": \\\"{taskId}\\\"\" || true)}" \
-  2>/dev/null)
-```
-
-If the claim call fails, `PR_CLAIM` will be empty; step 2 handles this case.
-
-### 2. Extract record ID
+### 1. Confirm the record ID
 
 ```bash
-PR_RECORD_ID=$(echo "$PR_CLAIM" | jq -r '.id // empty')
 if [ -z "$PR_RECORD_ID" ]; then
-  echo "Warning: could not extract PR record ID from claim response — skipping"
+  echo "Warning: no PR record ID available — skipping"
 else
 ```
 
-Wrap steps 3–4 in the `else` branch and close with `fi` after step 4.
+Wrap steps 2–3 in the `else` branch and close with `fi` after step 3.
 
-### 3. Mark review as posted
+### 2. Mark review as posted
 
 ```bash
 curl -sf -X POST \
@@ -581,7 +629,7 @@ curl -sf -X POST \
   "${SHIPWRIGHT_TASK_STORE_URL}/prs/${PR_RECORD_ID}/complete" >/dev/null 2>&1
 ```
 
-### 4. Set agentId (and reviewState for APPROVE)
+### 3. Set agentId (and reviewState for APPROVE)
 
 Set `agentId` from `$SHIPWRIGHT_AGENT_ID`. For APPROVE verdicts, also set `reviewState=approved`; for COMMENT/CHANGES_REQUESTED, set agentId only:
 
@@ -599,29 +647,7 @@ curl -sf -X PATCH \
 fi
 ```
 
----
-
-## Step 12: Update reviews.json
-
-Update the entry for this PR:
-
-```json
-{
-  "lastReviewedAt": "{now}",
-  "lastReviewedCommit": "{head_sha}",
-  "reviewCount": "{increment}",
-  "reviewFile": "state/reviews/PR_REVIEW_{pr}.md",
-  "verdict": "{APPROVE|COMMENT}",
-  "findingsCount": "{count}",
-  "posted": "{true|false}",
-  "postedAt": "{timestamp|null}",
-  "status": "{staged|posted}"
-}
-```
-
-Write `state/reviews.json`.
-
-**Never update task status when posting a review.** The deploy skill looks up tasks by PR number (expecting `status: 'pr_open'`) to perform post-deployment tracking — changing status here breaks that linkage. Task status transitions are owned by the deploy skill (`pr_open` → `deployed`).
+**Never update task status when posting a review.** The deploy skill looks up tasks by PR number (expecting `status: 'pr_open'`) to perform post-deployment tracking — changing task status here breaks that linkage. Task status transitions are owned by the deploy skill (`pr_open` → `deployed`). This applies to the task store *task* record only; the PR *record* updates above (`complete`, `agentId`, `reviewState`) are expected.
 
 ---
 
@@ -705,9 +731,14 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
    ```
    Fall back to the current workspace repo if the command fails.
    **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
-2. Read `state/reviews.json`, find the entry for this PR.
+2. Fetch the PR record from the task store:
+   ```bash
+   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" | jq -c '.prs[0] // empty'
+   ```
+   Capture the record's `id` as `PR_RECORD_ID` and `commitSha` as `lastReviewedCommit`.
 
-**If entry exists with `status: "staged"`** — check for drift, then post:
+**If a record exists with `staged: true`** — check for drift, then post:
 
 > **Design note**: When `auto_post_reviews` is false, the cron stages reviews and
 > notifies the owner. Explicitly targeting a staged PR (`/shipwright:review {pr}`) IS
@@ -718,19 +749,26 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
 ```bash
 gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
 ```
-Compare to `lastReviewedCommit` in the reviews.json entry.
+Compare to `record.commitSha` (`lastReviewedCommit`).
 
-If `headRefOid != lastReviewedCommit` (author pushed new commits since the review was staged):
+If `headRefOid != record.commitSha` (author pushed new commits since the review was staged):
 - Do **not** post the stale review body.
-- Update `state/reviews.json`: `status: "reviewing"`
+- Re-claim the record at the new head to flip it to `in_progress` and clear staged:
+  ```bash
+  curl -sf -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+    -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"{headRefOid}\"}" >/dev/null
+  ```
 - Print:
   ```
-  Staged review is stale — {pr} has new commits since the review was written ({lastReviewedCommit[0..7]} → {headRefOid[0..7]}).
+  Staged review is stale — {pr} has new commits since the review was written ({record.commitSha[0..7]} → {headRefOid[0..7]}).
   Re-reviewing now.
   ```
 - Continue from **Step 4** (checkout into worktree) with this PR as the target.
   The Step 9 "Re-Review (Update)" mechanics will append an update section to the
-  existing `state/reviews/PR_REVIEW_{pr}.md` and re-stage the entry.
+  existing `state/reviews/PR_REVIEW_{pr}.md` and re-stage the record.
 - Stop the post flow here.
 
 **2b. Re-fetch for new unresolved feedback** before posting (only reached when head SHA matches):
@@ -738,11 +776,11 @@ If `headRefOid != lastReviewedCommit` (author pushed new commits since the revie
 gh pr view {pr} --repo {org}/{repo} --json reviews,comments,commits
 ```
 Apply the unresolved comment check from Step 3, but restricted to feedback that arrived
-**after `lastReviewedAt`** in the reviews.json entry.
+**after the record's `reviewedAt`** timestamp.
 
 If any substantive unresolved comments or `CHANGES_REQUESTED` reviews arrived since the
 review was staged:
-- Update `state/reviews.json`: `status: "staged"`, `needsRereviewReason: "{summary}"`
+- No state change is needed — the record stays staged.
 - Print:
   ```
   Not posting — new unresolved feedback arrived since the review was staged:
@@ -767,12 +805,19 @@ review was staged:
      --input state/reviews/pr_review_{pr}.json
    ```
 7. Capture `html_url`
-8. Run Step 11b to upsert the PullRequest record.
-9. Update `state/reviews.json`: `posted: true`, `postedAt: now`, `status: "posted"`
-10. Print: `Posted review for #{pr}: {html_url}`
-11. Post Slack message using the format from Step 11
+8. Clear the staged flag, then run Step 11b to mark the record posted:
+   ```bash
+   curl -sf -X PATCH \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
+     -d '{"staged": false}' >/dev/null
+   ```
+   Then run Step 11b (using `PR_RECORD_ID`) to `complete()` and set `agentId`/`reviewState`.
+9. Print: `Posted review for #{pr}: {html_url}`
+10. Post Slack message using the format from Step 11
 
-**If no entry or entry is not staged** — review it:
+**If no record or record is not staged** — review it:
 3. Skip Step 3 (queue building) and go directly to Step 4 (checkout) with this
    specific PR as the target.
 

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -166,10 +166,19 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 ```
 
 The record's `commitSha` is the SHA at which the PR was last reviewed (call it
-`lastReviewedCommit`). Apply this eligibility logic:
+`lastReviewedCommit`). When a record is fetched, capture it immediately:
 
-- **No record**: eligible (new PR, Tier 2). No local entry is created — the task store
-  creates the record atomically on first claim in Step 4.
+```bash
+LAST_REVIEWED_COMMIT=$(echo "$record" | jq -r '.commitSha // empty')
+```
+
+`LAST_REVIEWED_COMMIT` is empty when there is no record (first review). This value is
+used in Steps 4, 5, and 9 — do not fetch it again.
+
+Apply this eligibility logic:
+
+- **No record**: eligible (new PR, Tier 2). `LAST_REVIEWED_COMMIT` is empty. No local
+  entry is created — the task store creates the record atomically on first claim in Step 4.
 - **`staged: true`**: exclude — Step 3a owns staged records.
 - **`reviewState: "in_progress"`**: skip (another run has claimed it).
 - **`reviewState: "posted"` or `"approved"`**: check for new commits since last review:
@@ -257,17 +266,12 @@ git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force
 git -C repos/{repo} worktree add worktrees/{repo}-{branch-slug} origin/{branch}
 ```
 
-### Save the pre-claim commit, then claim
+### Claim using pre-captured commit SHA
 
-Before claiming, save the existing record's `commitSha` — this is `lastReviewedCommit`,
-the SHA the PR was last reviewed at. The claim overwrites `commitSha` with the new head, so
-capture it first:
-```bash
-LAST_REVIEWED_COMMIT=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" \
-  | jq -r '.prs[0].commitSha // empty')
-```
-`LAST_REVIEWED_COMMIT` is empty for a first review (no record yet). Use it in Steps 5 and 9.
+`LAST_REVIEWED_COMMIT` was already captured in Step 3b from the PR record fetched during
+deduplication (empty if no record existed). The claim will overwrite `commitSha` with the
+new head — `LAST_REVIEWED_COMMIT` preserves the pre-claim value without an extra fetch.
+Use it in Steps 5 and 9.
 
 Then claim the PR atomically at the current head. Fetch the head SHA first:
 ```bash
@@ -282,8 +286,9 @@ PR_CLAIM=$(curl -s -o /tmp/pr_claim.json -w '%{http_code}' -X POST \
 ```
 - `201` (new) or `200` (update): claimed. Capture `.id` from `/tmp/pr_claim.json` as
   `PR_RECORD_ID`; the claim sets `reviewState: "in_progress"`.
-- `409` (conflict): another agent holds the claim at this commit. **Skip this PR** and
-  return to Step 3b to pick the next candidate.
+- `409` (conflict): another agent holds the claim at this commit. Remove the worktree
+  (`git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force 2>/dev/null`),
+  **skip this PR**, and return to Step 3b to pick the next candidate.
 
 All subsequent steps run from `worktrees/{repo}-{branch-slug}/`.
 

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -326,7 +326,7 @@ All subsequent steps run from `worktrees/{repo}-{branch-slug}/`.
 7. **Test-readiness context** (optional): try to read `worktrees/{repo}-{branch-slug}/docs/test-readiness/test-system.md`. If absent, note that no repo-specific test-readiness doc exists. When the changed files include any path that looks like a test file — by common conventions across languages (e.g. files named or located in a way that signals they contain tests, such as files in `test/`, `tests/`, `spec/`, or `__tests__/` directories, or files whose names follow typical test-naming conventions for the project's language), also extract the "## Testing" section from the root CLAUDE.md (if present). Use the project's language and toolchain (visible from the diff and CLAUDE.md) to recognise test files — do not apply a fixed set of glob patterns. Combine both pieces into `testReadinessContext`. If neither produces content, `testReadinessContext` is absent — omit it entirely from the subagent prompt.
 
 `lastReviewedCommit` is the `LAST_REVIEWED_COMMIT` value saved from the pre-claim record in
-Step 4 (the record's `commitSha` before the claim overwrote it).
+Step 3b (the record's `commitSha` before the claim overwrote it).
 
 Apply the unresolved comment check from Step 3 using the fetched `reviews` and `comments`
 (they were just fetched above — no extra API call needed). **If `lastReviewedCommit` is set AND

--- a/plugins/shipwright/references/reviews-schema.md
+++ b/plugins/shipwright/references/reviews-schema.md
@@ -1,95 +1,132 @@
 # Reviews Schema -- Shipwright Review Tracking
 
-Review state is tracked in `state/reviews.json`. Each entry represents an agent's
-relationship with a PR -- whether it's been reviewed, posted, merged, or cleaned up.
+PR tracking state lives in the task store's `PullRequest` model. Each record tracks
+an agent's relationship with a PR — claimed commit SHAs, review state, staging status,
+and workflow phases. The task store is the source of truth; atomic claims prevent
+concurrent review of the same commit.
 
-## Schema
+The review narrative itself (findings, verdict, inline comments) is still written locally
+to `state/reviews/PR_REVIEW_{pr}.md` and `state/reviews/pr_review_{pr}.json` for posting
+to GitHub.
+
+## API Endpoint
+
+Access PR records via the task store API:
+
+```bash
+# List all PR records for a repo
+curl -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}"
+
+# List staged records only
+curl -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&staged=true"
+
+# Fetch one PR record
+curl -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/{id}"
+
+# Claim a PR at its current head
+curl -X POST -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d '{"repo": "{org}/{repo}", "prNumber": {number}, "commitSha": "{sha}"}'
+```
+
+## Record Schema
 
 ```json
 {
-  "pr": 123,
-  "repo": "app-vitals",
-  "org": "app-vitals",
-  "title": "Add billing webhook handler",
-  "author": "agent-bot",
-  "branch": "feat/ts-1.1-billing-webhook",
+  "id": "clp1234abcd",
+  "repo": "app-vitals/shipwright",
+  "prNumber": 123,
   "taskId": "TS-1.1",
-  "session": "may-billing-refactor",
-  "additions": 45,
-  "deletions": 12,
-  "diffSize": 57,
-  "firstSeen": "2026-04-15T08:00:00Z",
-  "lastReviewedAt": "2026-04-15T10:45:00Z",
-  "lastReviewedCommit": "abc1234def5678",
-  "reviewCount": 1,
-  "reviewFile": "state/reviews/PR_REVIEW_123.md",
-  "verdict": "COMMENT",
-  "findingsCount": 3,
-  "posted": false,
-  "postedAt": null,
-  "status": "staged"
+  "staged": true,
+  "state": "open",
+  "reviewState": "posted",
+  "commitSha": "abc1234def5678",
+  "patchCycles": 0,
+  "reviewCycles": 1,
+  "agentId": "agent-123",
+  "reviewedAt": "2026-04-15T10:45:00Z",
+  "patchedAt": null,
+  "mergedAt": null,
+  "claimedBy": "agent-123",
+  "claimedAt": "2026-04-15T10:30:00Z",
+  "heartbeatAt": "2026-04-15T10:45:00Z",
+  "createdAt": "2026-04-15T08:00:00Z",
+  "updatedAt": "2026-04-15T10:45:00Z"
 }
 ```
 
-## Status Flow
+## State and ReviewState Enums
 
-```
-pending -> reviewing -> staged -> posted
-```
+### `state` — Terminal PR state
 
-| Status | Set by | Meaning |
-|---|---|---|
-| `pending` | review Step 3 | PR discovered, not yet reviewed |
-| `reviewing` | review Step 4 | Review in progress (prevents double-review) |
-| `staged` | review Step 10 | Review file written, awaiting owner confirmation |
-| `posted` | review Step 10/13 | Review posted to GitHub |
+| Value | Meaning |
+|-------|---------|
+| `open` | PR is open on GitHub (default) |
+| `merged` | PR was merged; terminal |
+| `closed` | PR was closed without merge; terminal |
 
-**Principle:** Don't track state locally that can be derived from GitHub. PR merge/close
-state lives in GH; CHANGES_REQUESTED state lives in GH — re-derive on every run rather
-than caching in a local terminal status. Worktree cleanup (`review.md` Step 2) queries GH
-directly to find merged/closed PRs instead of relying on a local `merged` status.
+### `reviewState` — Review workflow phase
 
-**Multi-task PRs:** When multiple tasks share one PR, `taskId` holds only one ID. Task
-completion state for the others must be derived from the PR's GH state (open/merged), not
-from a local status field.
+| Value | Set by | Meaning |
+|-------|--------|---------|
+| `pending` | review.md Step 3 | PR discovered, not yet reviewed |
+| `in_progress` | review.md Step 4 (claim) | Review in progress — claim acquired |
+| `posted` | review.md Step 11b | Review posted to GitHub |
+| `approved` | review.md Step 11b (APPROVE verdict) | Review posted with APPROVE verdict |
 
 ## Field Reference
 
 | Field | Type | Description |
 |---|---|---|
-| `pr` | number | PR number |
-| `repo` | string | Repository name (e.g., `app-vitals`) |
-| `org` | string | GitHub org (e.g., `app-vitals`) |
-| `title` | string | PR title |
-| `author` | string | PR author login |
-| `branch` | string | Head branch name |
-| `taskId` | string \| null | Shipwright task ID (from the task store) |
-| `session` | string \| null | Shipwright session slug |
-| `additions` | number | Lines added at time of discovery |
-| `deletions` | number | Lines deleted at time of discovery |
-| `diffSize` | number | `additions + deletions` — used for queue prioritization |
-| `firstSeen` | ISO string | When the PR was first discovered in the queue |
-| `lastReviewedAt` | ISO string | When the last review was performed |
-| `lastReviewedCommit` | string | HEAD SHA at time of last review |
-| `reviewCount` | number | How many times this PR has been reviewed |
-| `reviewFile` | string | Path to PR_REVIEW markdown file |
-| `verdict` | string | APPROVE or COMMENT |
-| `findingsCount` | number | Number of findings in last review |
-| `posted` | boolean | Whether the review has been posted to GitHub |
-| `postedAt` | ISO string \| null | When the review was posted |
-| `status` | string | See Status Flow above |
+| `id` | string | Unique record ID (CUID) |
+| `repo` | string | Repository in `org/repo` format |
+| `prNumber` | number | GitHub PR number |
+| `taskId` | string \| null | Shipwright task ID (if from a task store task) |
+| `staged` | boolean | `true` = review written, not yet posted; `false` = not staged or already posted |
+| `state` | enum | Terminal PR state: `open`, `merged`, or `closed` |
+| `reviewState` | enum | Workflow phase: `pending`, `in_progress`, `posted`, or `approved` |
+| `commitSha` | string \| null | HEAD SHA when the PR was claimed (most recent review point) |
+| `patchCycles` | number | Count of patch attempts on this PR |
+| `reviewCycles` | number | Count of review passes on this PR |
+| `agentId` | string \| null | ID of the agent that posted the review |
+| `reviewedAt` | ISO string \| null | When the review was posted to GitHub |
+| `patchedAt` | ISO string \| null | When the PR was last patched |
+| `mergedAt` | ISO string \| null | When the PR was merged (set during cleanup) |
+| `claimedBy` | string \| null | User or agent ID that acquired the claim |
+| `claimedAt` | ISO string \| null | When the claim was acquired |
+| `heartbeatAt` | ISO string \| null | Last activity timestamp (keep-alive signal) |
+| `createdAt` | ISO string | Record creation time |
+| `updatedAt` | ISO string | Last update time |
 
 ## Key Behaviors
 
-- `lastReviewedCommit` enables "new commits since last review" detection without
-  re-fetching GitHub history. Compare against `gh pr view --json headRefOid`.
-- `diffSize` drives queue prioritization — smallest diffs are reviewed first, keeping
-  small PRs from being starved behind large ones. Set at `pending` time from the
-  `gh pr list` fetch (`additions + deletions`). Missing on entries created before
-  v4.1.0 — populated lazily on next review pass.
-- `firstSeen` is the tiebreaker when `diffSize` is equal or missing — oldest first.
-- `taskId` is nullable -- PRs not from shipwright todos still get reviewed when
+- **Atomic claiming**: the `/prs/claim` endpoint is atomic — two concurrent requests at the same
+  commit return 201 (created) for the first, 409 (conflict) for the second. Prevents concurrent
+  review of the same commit.
+
+- **`commitSha` tracking**: `commitSha` is the HEAD SHA at which the PR was last reviewed (captured
+  during claim in Step 4). Comparing it to the current GitHub head detects "new commits since
+  last review" without re-fetching history. Compare against `gh pr view --json headRefOid`.
+
+- **`staged` flag**: when `auto_post_reviews` is false (default), reviews are staged. Set `staged: true`
+  on Step 11 (before posting). Explicit `/shipwright:review {org}/{repo}#{pr}` invocation
+  posts a staged review (owner confirmation).
+
+- **Workflow phases**: `reviewState` drives the queue prioritization (review.md Step 3):
+  - `in_progress` = another agent is working; skip
+  - `posted` / `approved` + new commits = Tier 1 (re-review, highest priority)
+  - `pending` or no record = Tier 2 (first review)
+
+- **Terminal states**: when a PR is merged or closed, mark `state: merged` or `closed` (Step 2
+  cleanup). `state` is independent of `reviewState` — a record can have `state: merged` while
+  `reviewState: posted` (the review was posted before merge).
+
+- `taskId` is nullable — PRs not from shipwright tasks still get reviewed when
   `review_external_prs` is enabled in agent-policy.md.
-- The `reviewing` status prevents concurrent cron runs from double-reviewing the
-  same PR. If a review was interrupted (agent restart), the status stays `reviewing`
-  and must be manually reset to `pending`.
+
+- **Multi-agent coordination**: the atomic claim + heartbeat mechanism allows multiple agents
+  to review different PRs in parallel without coordination overhead.

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -211,6 +211,19 @@ Branch statuses: `blocked`, `cancelled`, `deploying`, `deployed`
 | `POST` | `/tasks/:id/complete` | Mark `done` |
 | `POST` | `/tasks/:id/fail` | Mark `blocked` |
 
+**PR tracking (`/prs`)**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/prs` | List PR records (`?repo`, `?prNumber`, `?taskId`, `?state`, `?reviewState`, `?staged`, `?limit`, `?offset`) |
+| `POST` | `/prs/claim` | Upsert + claim a PR record → `in_progress` (body: `repo`, `prNumber`, `commitSha`; optional: `claimedBy`, `taskId`) |
+| `GET` | `/prs/:id` | Fetch one PR record (404 if missing) |
+| `PATCH` | `/prs/:id` | Update PR fields (partial update) |
+| `POST` | `/prs/:id/heartbeat` | Extend review TTL (prevents StaleClaimReaper from auto-releasing) |
+| `POST` | `/prs/:id/complete` | Mark review complete |
+| `POST` | `/prs/:id/patch` | Record a patch cycle on this PR |
+| `POST` | `/prs/:id/release` | Release claim → `pending` |
+
 > **Scoping:** All endpoints automatically scope to the calling agent's tasks via the bearer token. Admin tokens see all agents' tasks.
 
 ---

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -153,6 +153,8 @@ function fakePrService(
       if (filters?.reviewState)
         prs = prs.filter((p) => p.reviewState === filters.reviewState);
       if (filters?.repo) prs = prs.filter((p) => p.repo === filters.repo);
+      if (filters?.staged !== undefined)
+        prs = prs.filter((p) => p.staged === filters.staged);
       return {
         prs,
         total: prs.length,
@@ -594,6 +596,38 @@ describe("/prs routes (smoke)", () => {
     expect(body.prs.every((p: PullRequest) => p.reviewState === "posted")).toBe(
       true,
     );
+  });
+
+  it("GET /prs?staged=true returns only staged records", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", staged: true }));
+    store.set("pr-2", makePr({ id: "pr-2", staged: false }));
+    store.set("pr-3", makePr({ id: "pr-3", staged: true }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs?staged=true", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs).toHaveLength(2);
+    expect(body.prs.every((p: PullRequest) => p.staged === true)).toBe(true);
+  });
+
+  it("GET /prs?staged=false returns only non-staged records", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", staged: true }));
+    store.set("pr-2", makePr({ id: "pr-2", staged: false }));
+    store.set("pr-3", makePr({ id: "pr-3", staged: false }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs?staged=false", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs).toHaveLength(2);
+    expect(body.prs.every((p: PullRequest) => p.staged === false)).toBe(true);
   });
 
   // ─── GET /prs/:id ─────────────────────────────────────────────────────────

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -10,7 +10,7 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState)
+ *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState, ?staged)
  *   POST   /prs/claim         atomic claim (201 new, 200 update, 409 conflict)
  *   GET    /prs/:id           fetch one (404 when missing)
  *   PATCH  /prs/:id           update fields
@@ -72,6 +72,10 @@ export function createPrsRoutes(
       taskId: c.req.query("taskId"),
       state: c.req.query("state"),
       reviewState: c.req.query("reviewState"),
+      staged:
+        c.req.query("staged") !== undefined
+          ? c.req.query("staged") === "true"
+          : undefined,
       limit:
         limitRaw !== undefined
           ? Number.parseInt(limitRaw, 10) || undefined


### PR DESCRIPTION
## Summary
- Migrate `plugins/shipwright/commands/review.md` from local `state/reviews.json` to the task store `/prs` API for all PR tracking state
- Add `?staged` query param support to `GET /prs` list route (service already supported it; route was missing the wire-up)
- Refresh `references/reviews-schema.md` to reflect the new PR API tracking model

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | No reads or writes to state/reviews.json remain in review.md | MET |
| 2 | Step 2 cleanup uses GET /prs?repo and GitHub state check; removes worktree on merged/closed | MET |
| 3 | Step 3a staged queue uses GET /prs?repo&staged=true with GitHub metadata fetch for display | MET |
| 4 | Step 3b dedup uses GET /prs?repo&prNumber; eligibility logic matches documented trigger logic | MET |
| 5 | Step 4 claim uses POST /prs/claim; 409 handling documented; lastReviewedCommit saved before claim | MET |
| 6 | Step 9 re-review detection uses local file existence (state/reviews/PR_REVIEW_{pr}.md) | MET |
| 7 | Step 12 removed; Step 11b updated to remove stale reference | MET |
| 8 | No automated tests needed - markdown skill file | MET |

## Test Plan
- [x] biome lint passes (327 files, no fixes)
- [x] No remaining reviews.json references in review.md
- [x] PR API endpoints verified present for all migrated steps
- [x] staged query param wired from route to service

Generated with [Claude Code](https://claude.com/claude-code)
