### PR TITLE
feat(drj-2.3): migrate review-staged to task store, remove readReviews()

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -24,14 +24,22 @@ when available, but never load-bearing.
 
 Applies to: **review**, **deploy**, **patch**, **dev-task**
 
-### 2. State Files Are Caches, Not Prerequisites
+### 2. Task Store PR Record Is the Dedup Source
 
-`state/reviews.json` is a local dedup cache that speeds up common
-paths. Skills must not fail or behave incorrectly when this file is absent, empty, or
-stale. When a cache entry conflicts with live GitHub data, GitHub wins.
+The task store `PullRequest` record (accessible via `GET /prs?repo=X`) is the source of
+truth for review deduplication. `commitSha` on the record is compared to the current
+`headRefOid` from GitHub to detect "new commits since last review" without re-fetching
+history. Skills must not fail or behave incorrectly when no PR record exists — a missing
+record means the PR has not been reviewed yet and should be treated as eligible.
 
-Applies to: **review** (dedup by headRefOid), **deploy** (falls back to `gh pr view --json
-reviewDecision` when no local APPROVE entry exists)
+Local files (`state/reviews/PR_REVIEW_{pr}.md`, `state/reviews/pr_review_{pr}.json`) hold
+the review narrative (findings, verdict, inline comments) for posting to GitHub. They are
+written by `/shipwright:review` and consumed by `/shipwright:review-staged`. They are not
+dedup state — the task store record owns that.
+
+Applies to: **review** (dedup by `commitSha`), **review-staged** (stale check via `commitSha`
+vs current `headRefOid`), **deploy** (falls back to `gh pr view --json reviewDecision`
+when no task store APPROVE record exists)
 
 ### 3. A PR Created Outside Shipwright Is Fully Serviceable
 
@@ -113,7 +121,7 @@ favors permissive: false positives are visible and self-correcting; false negati
 
 | Script | Guards | What it checks |
 |---|---|---|
-| `check-review.ts` | `review` cron | Open PRs with unreviewed commits (by headRefOid dedup against `state/reviews.json`); respects `allow_self_review` policy |
+| `check-review.ts` | `review` cron | Open PRs with unreviewed commits (by headRefOid dedup against task store `/prs` records); respects `allow_self_review` policy |
 | `check-deploy.ts` | `deploy` cron | Open PRs with `APPROVED` review decision and green CI; respects `allow_self_review` for self-authored PRs |
 | `check-dev-task.ts` | `dev-task` cron | Pending tasks with all dependencies satisfied (task store `ready: true` query) |
 | `check-patch.ts` | `patch` cron | Auto-updates BEHIND branches via `gh pr update-branch`; signals patch skill for unaddressed review findings, stuck-BEHIND branches (update-branch failures), merge conflicts, and failing CI; queries GitHub directly — does NOT read `state/reviews.json` |

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -102,7 +102,8 @@ stale metadata) to populate the display:
 gh pr view {pr} --repo {org}/{repo} --json title,additions,deletions
 ```
 `diffSize` = `additions + deletions`. Treat a record with `reviewState: "approved"` as an
-APPROVE verdict for sorting.
+APPROVE verdict for sorting. `reviewState: "in_progress"` means COMMENT (records staged
+before the verdict-persist fix — backwards-compatible).
 
 Present them in priority order:
 1. **APPROVE verdicts first** (`reviewState: "approved"`) — unblocking is highest value
@@ -572,7 +573,19 @@ should be held; the inline comments convey the specific feedback to the author.
 
 ### If `auto_post_reviews` is false (default):
 
-1. Mark the PR record staged:
+1. Mark the PR record staged, persisting the verdict so the APPROVE-first sort in
+   `/shipwright:review-staged` (and the drain display above) works correctly:
+
+   If `{verdict}` is `APPROVE`:
+   ```bash
+   curl -sf -X PATCH \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
+     -d '{"staged": true, "reviewState": "approved"}' >/dev/null
+   ```
+
+   If `{verdict}` is `COMMENT`:
    ```bash
    curl -sf -X PATCH \
      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
@@ -580,6 +593,7 @@ should be held; the inline comments convey the specific feedback to the author.
      "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
      -d '{"staged": true}' >/dev/null
    ```
+
    (`PR_RECORD_ID` is the claim response `.id` from Step 4.)
 2. Post Slack message to the configured channel (see below)
 3. Print: `Review staged for #{pr}. Slack notification sent.`

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -7,7 +7,6 @@
  * - Workspace path resolution (WORKSPACE_PATH env var or cwd heuristic)
  * - Org/repo resolution from repos/ dir and shipwright.config.json
  * - gh CLI execution helper
- * - reviews.json reading
  */
 
 import { spawnSync } from "node:child_process";
@@ -70,18 +69,6 @@ export interface Task {
   hitlNotifiedAt?: string;
 }
 
-// ─── ReviewEntry ──────────────────────────────────────────────────────────────
-
-export interface ReviewEntry {
-  pr: number;
-  repo: string;
-  org?: string;
-  verdict?: string;
-  posted?: boolean;
-  lastReviewedCommit?: string;
-  status?: string;
-}
-
 // ─── Policy helpers ───────────────────────────────────────────────────────────
 
 export function parseAllowSelfReview(content: string): boolean {
@@ -123,14 +110,6 @@ export function resolveWorkspacePath(): string {
   if (!agentHome)
     throw new Error("AGENT_HOME is not set — cannot resolve workspace path");
   return join(agentHome, "workspace");
-}
-
-// ─── reviews.json reading ─────────────────────────────────────────────────────
-
-export function readReviews(workspacePath: string): ReviewEntry[] {
-  const reviewsPath = join(workspacePath, "state", "reviews.json");
-  if (!existsSync(reviewsPath)) return [];
-  return JSON.parse(readFileSync(reviewsPath, "utf-8")) as ReviewEntry[];
 }
 
 // ─── Shipwright config ────────────────────────────────────────────────────────

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -22,6 +22,7 @@ import {
   resolveAllRepos,
   resolveRepos,
 } from "./check-helpers.ts";
+import * as checkHelpers from "./check-helpers.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -548,5 +549,17 @@ describe("createTaskStoreClient query()", () => {
     await expect(
       client.query(new URLSearchParams({ status: "in_progress" })),
     ).rejects.toThrow("Unexpected task-store response format");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Removed exports — readReviews and ReviewEntry were removed in DRJ-2.3
+// ---------------------------------------------------------------------------
+
+describe("removed exports", () => {
+  test("readReviews is not exported from check-helpers", () => {
+    expect(
+      (checkHelpers as Record<string, unknown>).readReviews,
+    ).toBeUndefined();
   });
 });

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -553,7 +553,7 @@ describe("createTaskStoreClient query()", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Removed exports — readReviews and ReviewEntry were removed in DRJ-2.3
+// Removed exports
 // ---------------------------------------------------------------------------
 
 describe("removed exports", () => {

--- a/plugins/shipwright/skills/review-staged/SKILL.md
+++ b/plugins/shipwright/skills/review-staged/SKILL.md
@@ -182,13 +182,20 @@ After posting successfully, update the task store record:
      "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}/complete" >/dev/null
    ```
 
-3. Update agentId and reviewState (if not already set by `complete`):
+3. Re-assert agentId and reviewState. `complete()` unconditionally sets `reviewState: "posted"`,
+   so for APPROVE verdicts (where the staged record had `reviewState: "approved"`), explicitly
+   re-assert `"approved"` in this PATCH — mirroring review.md Step 11b:
    ```bash
+   if [ "{record.reviewState}" = "approved" ]; then
+     PATCH_DATA="{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"reviewState\": \"approved\"}"
+   else
+     PATCH_DATA="{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+   fi
    curl -sf -X PATCH \
      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      -H "Content-Type: application/json" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}" \
-     -d "{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >/dev/null
+     -d "$PATCH_DATA" >/dev/null
    ```
 
 Print the posted review URL.

--- a/plugins/shipwright/skills/review-staged/SKILL.md
+++ b/plugins/shipwright/skills/review-staged/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-staged
-description: Walk through staged PR reviews from `state/reviews.json` conversationally — APPROVEs first, then COMMENTs, smallest diff to largest within each. For each PR, present a concise summary and accept owner direction (post, skip, draft, discuss). Use when asked to "drain the staged reviews", "walk through staged reviews", or "what's staged".
+description: Walk through staged PR reviews from the task store conversationally — APPROVEs first, then COMMENTs, smallest diff to largest within each. For each PR, present a concise summary and accept owner direction (post, skip, draft, discuss). Use when asked to "drain the staged reviews", "walk through staged reviews", or "what's staged".
 ---
 
 # Review Staged
@@ -8,18 +8,33 @@ description: Walk through staged PR reviews from `state/reviews.json` conversati
 Conversational walkthrough of staged reviews. The owner sees one PR at a time
 and steers each with a verb. No reviews are posted without an explicit "post it".
 
-This skill assumes `/shipwright:review` has already staged the reviews into
-`state/reviews.json` + `state/reviews/PR_REVIEW_{pr}.md`. It does **not** review
-new PRs and does **not** merge anything — merging is handled exclusively by
-`/shipwright:deploy`.
+This skill assumes `/shipwright:review` has already staged the reviews into the
+task store (`staged: true`) and written review files to `state/reviews/PR_REVIEW_{pr}.md`
+and `state/reviews/pr_review_{pr}.json`. It does **not** review new PRs and does
+**not** merge anything — merging is handled exclusively by `/shipwright:deploy`.
 
 ---
 
 ## 1. Load state
 
-Read `state/reviews.json`. Filter to entries with `status: "staged"`.
+Fetch staged PR records from the task store for each configured repo:
 
-If none: print `No staged reviews. Run /shipwright:review to stage some.` and stop.
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&staged=true" | jq -c '.prs[]'
+```
+
+For each record, fetch current GitHub metadata (title, additions, deletions, headRefOid, url):
+
+```bash
+gh pr view {prNumber} --repo {org}/{repo} \
+  --json number,title,author,headRefName,baseRefName,headRefOid,isDraft,reviews,commits,additions,deletions,url
+```
+
+`diffSize` = `additions + deletions`. Treat a record with `reviewState: "approved"` as an
+APPROVE verdict; `reviewState: "posted"` as a COMMENT verdict.
+
+If no staged records exist across all repos: print `No staged reviews. Run /shipwright:review to stage some.` and stop.
 
 Resolve the current GitHub user once and remember it for the rest of the run:
 
@@ -33,7 +48,7 @@ gh api /user -q '.login'
 
 Sort the staged entries:
 
-1. **APPROVEs first**, then **COMMENTs** (use the `verdict` field)
+1. **APPROVEs first** (`reviewState: "approved"`), then **COMMENTs** (`reviewState: "posted"`)
 2. Within each group, **smallest `diffSize` to largest**
 
 Print the queue header so the owner sees what's coming:
@@ -56,7 +71,7 @@ Walk the queue in order. For each entry:
 ### 3a. Refresh PR state from GitHub
 
 ```bash
-gh pr view {pr} --repo {org}/{repo} \
+gh pr view {prNumber} --repo {org}/{repo} \
   --json number,title,author,headRefName,baseRefName,headRefOid,isDraft,reviews,commits,additions,deletions,url
 ```
 
@@ -70,11 +85,11 @@ gh pr view {pr} --repo {org}/{repo} \
   `Skipping #{pr} — @{login} requested changes on {date} and there are no commits since.`
   (Use the same teammate-comment logic from `/shipwright:review` Step 3b: not a bot,
   not `CURRENT_USER`, no commits pushed after the review.)
-- **Stale staged review** — if `lastReviewedCommit` differs from the current `headRefOid`,
+- **Stale staged review** — if `record.commitSha` differs from the current `headRefOid`,
   skip with: `Skipping #{pr} — new commits since review was staged. Re-run /shipwright:review {org}/{repo}#{pr}.`
 
-When a PR is skipped for any reason, leave its `state/reviews.json` entry untouched
-(status stays `staged`). CHANGES_REQUESTED state is re-derived from GitHub on every run.
+When a PR is skipped for any reason, leave its task store record untouched
+(`staged: true` stays set). CHANGES_REQUESTED state is re-derived from GitHub on every run.
 
 ### 3c. Dependabot cross-check
 
@@ -143,14 +158,42 @@ Match the owner's response:
 
 Use the existing posting mechanics from `/shipwright:review` Step 14 (re-fetch
 for new teammate feedback, then `gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews`
-with `state/reviews/pr_review_{pr}.json`). Update `state/reviews.json` with
-`posted: true`, `postedAt`, `status: "posted"`. Print the posted review URL.
+with `state/reviews/pr_review_{pr}.json`).
+
+After posting successfully, update the task store record:
+
+1. Clear the staged flag:
+   ```bash
+   curl -sf -X PATCH \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}" \
+     -d '{"staged": false}' >/dev/null
+   ```
+
+2. Mark the review complete:
+   ```bash
+   curl -sf -X POST \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}/complete" >/dev/null
+   ```
+
+3. Update agentId and reviewState (if not already set by `complete`):
+   ```bash
+   curl -sf -X PATCH \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}" \
+     -d "{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >/dev/null
+   ```
+
+Print the posted review URL.
 
 Move to the next PR.
 
 ### `skip`
 
-Leave the entry as `status: "staged"`. Do nothing. Move to the next PR.
+Leave the task store record as `staged: true`. Do nothing. Move to the next PR.
 
 ### `next`
 
@@ -213,6 +256,8 @@ Done. {posted}/{N} posted, {skipped}/{N} skipped.
 
 - This skill never auto-posts. Every post requires an explicit "post it" from the owner.
 - This skill never merges. Merging is handled exclusively by `/shipwright:deploy`.
-- This skill never re-reviews. If the head SHA has moved, it skips and points to
-  `/shipwright:review {org}/{repo}#{pr}`.
+- This skill never re-reviews. If the head SHA has moved (current `headRefOid` differs from
+  `record.commitSha`), it skips and points to `/shipwright:review {org}/{repo}#{pr}`.
 - Use `gh` CLI for all GitHub interactions. Respect the active `GH_TOKEN` / `gh auth` context.
+- The task store is the source of truth for staged state. No `state/reviews.json` reads or
+  writes occur in this skill.

--- a/plugins/shipwright/skills/review-staged/SKILL.md
+++ b/plugins/shipwright/skills/review-staged/SKILL.md
@@ -32,7 +32,9 @@ gh pr view {prNumber} --repo {org}/{repo} \
 ```
 
 `diffSize` = `additions + deletions`. Treat a record with `reviewState: "approved"` as an
-APPROVE verdict; `reviewState: "posted"` as a COMMENT verdict.
+APPROVE verdict; `reviewState: "posted"` as a COMMENT verdict. `reviewState: "in_progress"`
+also maps to COMMENT — backwards compatibility for records staged before the verdict-persist
+fix (those records had their verdict omitted from the staging PATCH).
 
 If no staged records exist across all repos: print `No staged reviews. Run /shipwright:review to stage some.` and stop.
 
@@ -48,7 +50,9 @@ gh api /user -q '.login'
 
 Sort the staged entries:
 
-1. **APPROVEs first** (`reviewState: "approved"`), then **COMMENTs** (`reviewState: "posted"`)
+1. **APPROVEs first** (`reviewState: "approved"`), then **COMMENTs** (`reviewState: "posted"`
+   or `reviewState: "in_progress"` — the latter for backwards-compat with records staged
+   before the verdict-persist fix)
 2. Within each group, **smallest `diffSize` to largest**
 
 Print the queue header so the owner sees what's coming:


### PR DESCRIPTION
## Summary
- Migrates `review-staged` skill to fetch staged PR records from the task store (`GET /prs?staged=true`) instead of reading `state/reviews.json`
- Removes `readReviews()` function and `ReviewEntry` interface from `check-helpers.ts` (were exported but had zero callers)
- Updates `plugins/shipwright/CLAUDE.md` Principle 2 and precheck table to reflect task store as the dedup source

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | review-staged/SKILL.md has no state/reviews.json reads or writes; uses GET /prs?staged=true and PATCH/complete lifecycle calls | MET |
| 2 | readReviews() and ReviewEntry removed from check-helpers.ts; no compile errors | MET |
| 3 | reviews-schema.md documents task store PullRequest schema accurately | MET (already updated in DRJ-2.1) |
| 4 | Plugin CLAUDE.md Principle 2 updated; precheck table updated for check-review.ts | MET |
| 5 | check-helpers unit test confirming readReviews is gone | MET |
| 6 | bun test check-helpers passes; bun typecheck passes | MET |

## Test Plan
- [x] New unit test asserts `readReviews` is not exported from `check-helpers.ts`
- [x] 30/30 check-helpers unit tests pass
- [x] Full suite: 51 pre-existing failures unchanged (confirmed same count on main)
- [x] `bunx biome lint .` clean across 328 files

Generated with [Claude Code](https://claude.com/claude-code)
