### PR TITLE
feat: add /plan-sesh alias for /plan-session

### DIFF
--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -32,7 +32,7 @@ Every feature moves through the same stages. One `planning/{folder}/` directory 
 | Command | Description |
 |---------|-------------|
 | `/prd {folder}` | Interactive PRD session — qualifying questions, codebase research, and PRODUCT-SPEC.md output ready for /plan-session |
-| `/plan-session {repo} {session}` | Structured planning — reads input docs, analyzes codebase, produces a stateful task breakdown. Accepts 1 arg (session) with auto-detected repo as a fallback. |
+| `/plan-session {repo} {session}` (alias: `/plan-sesh`) | Structured planning — reads input docs, analyzes codebase, produces a stateful task breakdown. Accepts 1 arg (session) with auto-detected repo as a fallback. |
 | `/dev-task {task-id}` | Single task execution — branch, implement, test, simplify, review, PR |
 | `/dev-task {task-id} --merge` | Same as above, but auto-merges after review (used by dev-loop) |
 | `/dev-loop {folder?}` | Autonomous continuous dev — picks next task, runs dev-task --merge in a loop |

--- a/plugins/shipwright/commands/plan-sesh.md
+++ b/plugins/shipwright/commands/plan-sesh.md
@@ -1,0 +1,14 @@
+---
+description: Alias for /plan-session — engineer planning pass that reads the product spec, explores the codebase, and produces a task queue
+arguments:
+  - name: repo
+    description: The repo to plan work for (e.g., shipwright)
+    required: true
+  - name: session
+    description: A short slug for this planning session (e.g., may-billing-refactor). Used to group tasks and PRs.
+    required: true
+---
+
+Alias for `/plan-session`. Forwarding to `/plan-session $ARGUMENTS` now.
+
+/plan-session $ARGUMENTS


### PR DESCRIPTION
## Summary
- Adds `/plan-sesh` as a permanent short-form alias for `/shipwright:plan-session`.
- Implemented as a forwarding stub (mirrors the existing `brainstorm.md → /prd` pattern) that passes `$ARGUMENTS` straight through — no deprecation wording, since `plan-session` stays canonical.
- Documents the alias in the plugin README command table.

## Notes
- Commands are auto-discovered from `commands/`, so no manifest/registry edits are needed.
- No manual version bump — semantic-release derives the minor bump from the `feat:` commit.

## Test Plan
- [x] `task lint` passes (Biome)
- [x] Banned-string scan of the changed files is clean (the local `task check-strings` failure is pre-existing, confined to git-ignored `state/reviews/*.md` cache, and absent from CI's clean checkout)
- [ ] Invoke `/shipwright:plan-sesh <repo> <session>` and confirm it forwards identically to `/shipwright:plan-session`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
