### PR TITLE
feat(plugin): recognize taskStore: "shipwright" backend + reconcile task-store docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,14 +77,19 @@ This repo is **private today but destined to be a public, MIT open-source projec
 
 ## How work is tracked
 
-The task store is **GitHub Issues** in this repo, configured via `.shipwright.json` (`taskStore: "github"`, owner `app-vitals`, repo `shipwright`). Work is planned as issues under the **`shipwright-oss`** milestone, each with a machine-readable ```` ```shipwright ```` YAML block (`id`, `layer`, `branch`, `dependencies`, `hours`, `status`, `pr`) and a `status:*` label.
+Two surfaces — do not conflate them:
 
-**Find the next ready task:**
-```bash
-gh issue list --milestone shipwright-oss --state open --label status:pending
-```
+1. **Automated task store** (what `/shipwright:dev-task` and the agents read/write): the **HTTP Shipwright task-store service** (artifact D). Individual tasks like `PV-1.2` live here. Query it directly — **`gh issue list` does not see these tasks.**
+   ```bash
+   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.tasks'
+   ```
+2. **Manual human planning** (historical): GitHub Issues under the **`shipwright-oss`** milestone, each with a machine-readable ```` ```shipwright ```` YAML block and a `status:*` label. A record/planning surface for humans; the automated loop does **not** read it.
+   ```bash
+   gh issue list --milestone shipwright-oss --state open --label status:pending
+   ```
 
-**Status lifecycle** (the label is the single signal of where a task is):
+**Status lifecycle:**
 ```
 pending → in_progress → pr_open → merged → deployed → done
 ```
@@ -92,14 +97,14 @@ plus `approved`, `blocked`, `cancelled`.
 
 ### Execution loop
 
-1. Pick a `status:pending` task whose every `dependencies` entry is `status:done`.
-2. Branch from the task's YAML `branch` field (`feat/sw-x-y-slug`) — never work on `main`.
+1. Pick a `pending` task whose every `dependencies` entry is done.
+2. Branch from the task's `branch` field (`feat/sw-x-y-slug`) — never work on `main`.
 3. Build + land tests **in the same PR, at the correct layer** (no "tests later").
-4. Open a PR; move the status label through its lifecycle.
+4. Open a PR; move the status through its lifecycle.
 
 Driven by Shipwright's own commands: `/shipwright:dev-task` → `/shipwright:review` / `/shipwright:patch` → `/shipwright:deploy`. The `ship-loop` skill drains the queue autonomously (one pipeline step per call, wrapped by `/loop`).
 
-**Task-store config resolution** (`plugins/shipwright/scripts/create-task-store.ts` → `loadConfig`): (1) walk up from cwd for `.shipwright.json`; (2) fall back to `SHIPWRIGHT_CONFIG` env var; (3) fall back to local JSON (`state/`). If task operations seem to no-op, confirm which backend is active.
+**Task-store backend resolution** (`plugins/shipwright/scripts/check-helpers.ts` → `resolveTaskStoreBackend`): (1) explicit `taskStore` in `state/shipwright.config.json` (`"shipwright"` | `"github"`); (2) otherwise, when both `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` are set → `"shipwright"` (how managed GKE agents *and* local installs select it — the provisioner injects only those two env vars, never a config file); (3) otherwise → `"github"`. The HTTP store is the only backend with a runtime task-data client today; connection details always come from env, never the committed config file. If task operations seem to no-op, check `SHIPWRIGHT_TASK_STORE_URL` first.
 
 ## Test conventions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,35 +41,32 @@ Configuration for the Shipwright Claude Code plugin (`plugins/shipwright/`). The
 
 `.shipwright.json` is for use when you **install and run the Shipwright plugin in Claude Code (or a compatible system)** directly — without a managed Shipwright agent. Managed agents receive all configuration via env vars from the admin service; they do not read `.shipwright.json`.
 
-Config-file resolution (`create-task-store.ts` → `loadConfig`):
-1. Check `SHIPWRIGHT_TASK_STORE` env var — if set, use env vars directly and skip file-based config.
-2. Walk up from `cwd` looking for `.shipwright.json`.
-3. Fall back to `SHIPWRIGHT_CONFIG` env var.
-4. Fall back to local JSON state (`state/`).
+The config file lives at `state/shipwright.config.json` (relative to the resolved workspace path). Backend resolution (`plugins/shipwright/scripts/check-helpers.ts` → `resolveTaskStoreBackend`):
+1. Explicit `taskStore` in `state/shipwright.config.json` (`"shipwright"` | `"github"`).
+2. Otherwise, when both `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` are set → `"shipwright"`. This is how managed agents (the admin provisioner injects only those two env vars) **and** env-configured local installs select the HTTP store.
+3. Otherwise → `"github"`.
+
+Connection details (URL/token) always come from env, never the config file — so the file is safe to commit.
 
 #### Task store keys
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `taskStore` | `"json" \| "github" \| "jira"` | required | Backend for the task store. |
-| `github.owner` | `string` | required if `taskStore="github"` | GitHub org or user that owns the issues repo. |
-| `github.repo` | `string` | required if `taskStore="github"` | GitHub repo name containing issues used as tasks. |
-| `jira.baseUrl` | `string` | required if `taskStore="jira"` | Base URL of the Jira instance (e.g. `https://yourorg.atlassian.net`). |
-| `jira.projectKey` | `string` | required if `taskStore="jira"` | Jira project key (e.g. `SHIP`). |
-| `jira.readyJql` | `string` | — | Custom JQL to filter ready tasks. Overrides the default status-based query. |
-| `jira.statusMap` | `Record<string, TaskStatus>` | — | Maps Jira status names to Shipwright task statuses. |
+| `taskStore` | `"shipwright" \| "github"` | inferred (see resolution above) | Backend for the task store. `"shipwright"` = the HTTP Shipwright task-store service (the only backend with a runtime task-data client). `"github"` = GitHub Issues; used today only for PR-repo discovery, not as a task-data source. |
+| `github.owner` | `string` | required if `taskStore="github"` | GitHub org or user for PR-repo discovery. |
+| `github.repo` | `string` | required if `taskStore="github"` | GitHub repo name for PR-repo discovery. |
+
+> **Not yet implemented:** `taskStore: "jira"` and `taskStore: "json"` (and the `jira.*` keys / `SHIPWRIGHT_TASK_STORE`, `JIRA_*` env vars) are reserved for planned pluggable backends. There is no Jira or JSON task-data client in the code today; only `"shipwright"` and `"github"` are recognized by `resolveTaskStoreBackend`.
 
 #### Minimal example
 
 ```json
 {
-  "taskStore": "github",
-  "github": {
-    "owner": "your-org",
-    "repo": "your-repo"
-  }
+  "taskStore": "shipwright"
 }
 ```
+
+with `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` set in the environment.
 
 ---
 

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -120,33 +120,86 @@ export interface ShipwrightGitHubConfig {
 }
 
 /**
+ * The task-store backends a Shipwright install can select.
+ *
+ * - `"shipwright"` — the HTTP Shipwright task-store service (artifact D). This is
+ *   the only backend with a runtime implementation today; connection details
+ *   come from `SHIPWRIGHT_TASK_STORE_URL` + `SHIPWRIGHT_TASK_STORE_TOKEN`.
+ * - `"github"` — GitHub Issues. Used only for PR-repo discovery
+ *   (`readShipwrightConfig`); there is no GitHub-Issues task-data client.
+ */
+export type TaskStoreBackend = "shipwright" | "github";
+
+/**
+ * Parse state/shipwright.config.json into a raw object, or null when the file is
+ * absent, unreadable, or not a JSON object. Shared by readShipwrightConfig and
+ * resolveTaskStoreBackend so both read the config the same way.
+ */
+function parseShipwrightConfigFile(
+  workspacePath: string,
+): Record<string, unknown> | null {
+  const configPath = join(workspacePath, "state", "shipwright.config.json");
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
+    if (typeof raw !== "object" || raw === null) return null;
+    return raw as Record<string, unknown>;
+  } catch {
+    return null; // unreadable or invalid JSON
+  }
+}
+
+/**
+ * Resolve the effective task-store backend for plugin commands and prechecks.
+ *
+ * Precedence:
+ *  1. Explicit `taskStore` in state/shipwright.config.json — `"shipwright"` or
+ *     `"github"`.
+ *  2. No explicit config but both `SHIPWRIGHT_TASK_STORE_URL` and
+ *     `SHIPWRIGHT_TASK_STORE_TOKEN` are set → `"shipwright"`. This is how managed
+ *     (GKE) agents and env-configured local installs select the HTTP store —
+ *     the provisioner injects only those two env vars, never a config file.
+ *  3. Otherwise → `"github"`.
+ *
+ * Connection details (URL/token) ALWAYS come from env — never the config file —
+ * so the file is safe to commit in a public repo.
+ */
+export function resolveTaskStoreBackend(
+  workspacePath: string,
+  env: Record<string, string | undefined> = process.env,
+): TaskStoreBackend {
+  const declared = parseShipwrightConfigFile(workspacePath)?.taskStore;
+  if (declared === "shipwright") return "shipwright";
+  if (declared === "github") return "github";
+
+  const url = (env.SHIPWRIGHT_TASK_STORE_URL ?? "").trim();
+  const token = (env.SHIPWRIGHT_TASK_STORE_TOKEN ?? "").trim();
+  if (url && token) return "shipwright";
+
+  return "github";
+}
+
+/**
  * Read state/shipwright.config.json and return the github task store config,
  * or null if the file is absent, unreadable, or not using the github task store.
  */
 export function readShipwrightConfig(
   workspacePath: string,
 ): ShipwrightGitHubConfig | null {
-  const configPath = join(workspacePath, "state", "shipwright.config.json");
-  if (!existsSync(configPath)) return null;
-  try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
-    if (typeof raw !== "object" || raw === null) return null;
-    const cfg = raw as Record<string, unknown>;
-    if (cfg.taskStore !== "github") return null;
-    const gh = cfg.github;
-    if (
-      typeof gh === "object" &&
-      gh !== null &&
-      typeof (gh as Record<string, unknown>).owner === "string" &&
-      typeof (gh as Record<string, unknown>).repo === "string"
-    ) {
-      return {
-        owner: (gh as Record<string, unknown>).owner as string,
-        repo: (gh as Record<string, unknown>).repo as string,
-      };
-    }
-  } catch {
-    // unreadable or invalid JSON
+  const cfg = parseShipwrightConfigFile(workspacePath);
+  if (!cfg) return null;
+  if (cfg.taskStore !== "github") return null;
+  const gh = cfg.github;
+  if (
+    typeof gh === "object" &&
+    gh !== null &&
+    typeof (gh as Record<string, unknown>).owner === "string" &&
+    typeof (gh as Record<string, unknown>).repo === "string"
+  ) {
+    return {
+      owner: (gh as Record<string, unknown>).owner as string,
+      repo: (gh as Record<string, unknown>).repo as string,
+    };
   }
   return null;
 }

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -21,6 +21,7 @@ import {
   readShipwrightConfig,
   resolveAllRepos,
   resolveRepos,
+  resolveTaskStoreBackend,
 } from "./check-helpers.ts";
 import * as checkHelpers from "./check-helpers.ts";
 
@@ -288,6 +289,103 @@ describe("readShipwrightConfig", () => {
       owner: "app-vitals",
       repo: "shipwright",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTaskStoreBackend
+// ---------------------------------------------------------------------------
+
+describe("resolveTaskStoreBackend", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shipwright-backend-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(obj: unknown): void {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "shipwright.config.json"),
+      typeof obj === "string" ? obj : JSON.stringify(obj),
+    );
+  }
+
+  test("explicit taskStore 'shipwright' wins even without env vars", () => {
+    writeConfig({ taskStore: "shipwright" });
+    expect(resolveTaskStoreBackend(tmpDir, {})).toBe("shipwright");
+  });
+
+  test("explicit taskStore 'github' wins even when env vars are set", () => {
+    writeConfig({ taskStore: "github", github: { owner: "o", repo: "r" } });
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_URL: "https://ts.example.com",
+        SHIPWRIGHT_TASK_STORE_TOKEN: "tok",
+      }),
+    ).toBe("github");
+  });
+
+  test("infers 'shipwright' from env when no config file exists", () => {
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_URL: "https://ts.example.com",
+        SHIPWRIGHT_TASK_STORE_TOKEN: "tok",
+      }),
+    ).toBe("shipwright");
+  });
+
+  test("requires BOTH env vars to infer 'shipwright' (url only → github)", () => {
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_URL: "https://ts.example.com",
+      }),
+    ).toBe("github");
+  });
+
+  test("requires BOTH env vars to infer 'shipwright' (token only → github)", () => {
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_TOKEN: "tok",
+      }),
+    ).toBe("github");
+  });
+
+  test("treats whitespace-only env vars as unset", () => {
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_URL: "   ",
+        SHIPWRIGHT_TASK_STORE_TOKEN: "   ",
+      }),
+    ).toBe("github");
+  });
+
+  test("defaults to 'github' with no config and no env", () => {
+    expect(resolveTaskStoreBackend(tmpDir, {})).toBe("github");
+  });
+
+  test("falls back to env inference when config is invalid JSON", () => {
+    writeConfig("not valid json");
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_URL: "https://ts.example.com",
+        SHIPWRIGHT_TASK_STORE_TOKEN: "tok",
+      }),
+    ).toBe("shipwright");
+  });
+
+  test("ignores an unrecognized taskStore value and infers from env", () => {
+    writeConfig({ taskStore: "jira" });
+    expect(
+      resolveTaskStoreBackend(tmpDir, {
+        SHIPWRIGHT_TASK_STORE_URL: "https://ts.example.com",
+        SHIPWRIGHT_TASK_STORE_TOKEN: "tok",
+      }),
+    ).toBe("shipwright");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `taskStore: "shipwright"` as a recognized, honored task-store backend so installs can **declaratively** select the HTTP Shipwright task-store service in `state/shipwright.config.json` — alongside the existing env-var auto-detection.
- New `resolveTaskStoreBackend()` in `check-helpers.ts`: explicit config `taskStore` → env-inferred `"shipwright"` (both `SHIPWRIGHT_TASK_STORE_URL` + `_TOKEN` set) → `"github"` default. Connection secrets stay in env, never the committed config.
- Reconciles documentation drift that was actively misleading: `CLAUDE.md` and `docs/configuration.md` described a GitHub-Issues task store and a `create-task-store.ts → loadConfig` resolver that **don't exist in code**. Docs now match runtime.

## Why
A new session (or a reader) following the docs would reach for `gh issue list` and conclude a task like `PV-1.2` "doesn't exist" — it lives in the HTTP store, which is what `/dev-task` and the GKE agents actually use (provisioner injects `SHIPWRIGHT_TASK_STORE_URL` + `_TOKEN`). The docs claimed a different, unimplemented model.

## Changes
- `check-helpers.ts` — `TaskStoreBackend` type, shared `parseShipwrightConfigFile()` parser (DRY with `readShipwrightConfig`), `resolveTaskStoreBackend()`.
- `CLAUDE.md` — "How work is tracked" now distinguishes the automated HTTP store (what dev-task reads) from the historical GitHub-Issues planning surface; fixes the fictional loader reference.
- `docs/configuration.md` — `taskStore` enum is `"shipwright" | "github"`; jira/json marked not-yet-implemented; config path corrected to `state/shipwright.config.json`.

## Test Plan
- 9 new unit tests for `resolveTaskStoreBackend` (explicit config wins, env inference, both-vars-required, whitespace handling, invalid JSON, unknown values).
- Existing `readShipwrightConfig` tests stay green (shared-parser refactor is behavior-preserving).
- [x] `task ci` passes locally (lint, check-strings, typecheck, test, secret-scan, doctor)

Generated with [Claude Code](https://claude.com/claude-code)
