### PR TITLE
fix(dev): clear stale agent container on task stack + surface chat errors

### DIFF
--- a/agent/src/chat.smoke.test.ts
+++ b/agent/src/chat.smoke.test.ts
@@ -7,8 +7,16 @@
 
 import { describe, expect, it } from "bun:test";
 import { createChatApp } from "./chat.ts";
+import { ClaudeRunError, ClaudeTimeoutError } from "./claude.ts";
 import { createComposedApp } from "./run-agent.ts";
 import { makeMockDeps } from "./test-helpers/mock-deps.ts";
+
+/** A runner that always rejects with the given error — for error-path tests. */
+function makeThrowingRunner(err: unknown) {
+  return async (_message: string, _sessionKey?: string): Promise<never> => {
+    throw err;
+  };
+}
 
 /**
  * Build a fake runner mirroring createRunClaude's returned seam:
@@ -95,6 +103,80 @@ describe("createChatApp — POST /chat", () => {
       body: JSON.stringify({ message: "   " }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("surfaces a ClaudeRunError 429 as 429 with the upstream message", async () => {
+    const runner = makeThrowingRunner(
+      new ClaudeRunError(
+        "claude exited 1: api_error_status=429",
+        429,
+        "You've hit your Sonnet limit · resets 8pm (UTC)",
+        undefined,
+      ),
+    );
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("You've hit your Sonnet limit · resets 8pm (UTC)");
+  });
+
+  it("maps a non-429 ClaudeRunError to 502 with the upstream message", async () => {
+    const runner = makeThrowingRunner(
+      new ClaudeRunError(
+        "claude exited 1: api_error_status=401",
+        401,
+        "invalid api key",
+        undefined,
+      ),
+    );
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("invalid api key");
+  });
+
+  it("maps a ClaudeTimeoutError to 504", async () => {
+    const runner = makeThrowingRunner(new ClaudeTimeoutError(30_000));
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(504);
+    const body = await res.json();
+    expect(body.error).toContain("timed out");
+  });
+
+  it("maps a generic runner throw to 500 with the message in the body", async () => {
+    const runner = makeThrowingRunner(new Error("boom"));
+    const app = createChatApp({ runner });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("boom");
   });
 });
 

--- a/agent/src/chat.ts
+++ b/agent/src/chat.ts
@@ -15,6 +15,7 @@
  */
 
 import { Hono } from "hono";
+import { ClaudeRunError, ClaudeTimeoutError } from "./claude.ts";
 import type { TokenUsage } from "./claude.ts";
 
 /**
@@ -78,7 +79,31 @@ export function createChatApp(deps: ChatAppDeps): Hono {
       sessions.set(session, sessionKey);
     }
 
-    const output = await runner(message, sessionKey);
+    // The runner spawns the Claude CLI, which can fail for reasons the caller
+    // needs to see (usage limit, auth, timeout). Without this catch any throw
+    // becomes a bare Hono 500 with an empty body — the REPL then shows only
+    // "non-2xx response: 500" and the real cause is buried in container logs.
+    let output: Awaited<ReturnType<typeof runner>>;
+    try {
+      output = await runner(message, sessionKey);
+    } catch (err) {
+      if (err instanceof ClaudeRunError) {
+        // Surface the upstream message (e.g. "You've hit your Sonnet limit").
+        // Pass a 429 through verbatim; map other CLI failures to 502 (the
+        // agent's upstream dependency failed, not the request itself).
+        return c.json(
+          { error: err.resultMessage },
+          err.apiErrorStatus === 429 ? 429 : 502,
+        );
+      }
+      if (err instanceof ClaudeTimeoutError) {
+        return c.json({ error: err.message }, 504);
+      }
+      return c.json(
+        { error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
 
     return c.json({ result: output.result, sessionId: output.sessionId });
   });

--- a/scripts/chat.ts
+++ b/scripts/chat.ts
@@ -7,7 +7,7 @@
  *   AGENT_URL=http://localhost:3000 bun scripts/chat.ts
  *
  * Architecture:
- *   Pure functions (buildChatRequest, formatAgentResponse, fetchChatResponse,
+ *   Pure functions (buildChatRequest, formatAgentResponse, formatHttpError,
  *   formatFetchError) are exported for unit testing — no I/O, no network.
  *   The I/O loop (runRepl) reads stdin line by line, drives the HTTP calls,
  *   and prints results. It is not unit-testable but exercises the same seam
@@ -77,12 +77,49 @@ export async function fetchChatResponse(
   });
 
   if (!response.ok) {
+    const detail = await response.text().catch(() => "");
     throw new Error(
-      `non-2xx response: ${response.status} ${response.statusText}`,
+      formatHttpError(response.status, response.statusText, detail),
     );
   }
 
   return response.json() as Promise<ChatResponseBody>;
+}
+
+/**
+ * Build a human-readable error string from a non-2xx /chat response. Prefers
+ * the server's structured `{ error }` body (e.g. the real Claude failure such
+ * as "You've hit your Sonnet limit") over the bare HTTP status line, falling
+ * back to the raw body and finally the statusText. Pure — no I/O.
+ */
+export function formatHttpError(
+  status: number,
+  statusText: string,
+  body: string,
+): string {
+  const detail = extractErrorDetail(body) || statusText;
+  return `agent error (${status})${detail ? `: ${detail}` : ""}`;
+}
+
+/**
+ * Pull the most useful message out of a response body: the `error` field of a
+ * JSON envelope when present, otherwise the trimmed raw text. Returns "" when
+ * there is nothing meaningful to show.
+ */
+function extractErrorDetail(body: string): string {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim() !== "") {
+      return parsed.error;
+    }
+  } catch {
+    // Not JSON — fall through to the raw text.
+  }
+  return trimmed;
 }
 
 /**

--- a/scripts/chat.unit.test.ts
+++ b/scripts/chat.unit.test.ts
@@ -12,6 +12,7 @@ import {
   buildChatRequest,
   formatAgentResponse,
   formatFetchError,
+  formatHttpError,
 } from "./chat.ts";
 
 // ---------------------------------------------------------------------------
@@ -110,5 +111,52 @@ describe("formatFetchError", () => {
     const err = new TypeError("fetch failed");
     const msg = formatFetchError(err, "http://example.com:9000");
     expect(msg).toContain("http://example.com:9000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatHttpError
+// ---------------------------------------------------------------------------
+
+describe("formatHttpError", () => {
+  test("prefers the JSON body's `error` field over the status line", () => {
+    const msg = formatHttpError(
+      429,
+      "Too Many Requests",
+      JSON.stringify({
+        error: "You've hit your Sonnet limit · resets 8pm (UTC)",
+      }),
+    );
+    expect(msg).toBe(
+      "agent error (429): You've hit your Sonnet limit · resets 8pm (UTC)",
+    );
+  });
+
+  test("falls back to raw body text when the body is not JSON", () => {
+    const msg = formatHttpError(
+      500,
+      "Internal Server Error",
+      "plain text boom",
+    );
+    expect(msg).toBe("agent error (500): plain text boom");
+  });
+
+  test("falls back to statusText when the body is empty", () => {
+    const msg = formatHttpError(502, "Bad Gateway", "");
+    expect(msg).toBe("agent error (502): Bad Gateway");
+  });
+
+  test("falls back to raw body when JSON lacks a usable `error` field", () => {
+    const msg = formatHttpError(
+      500,
+      "Internal Server Error",
+      JSON.stringify({}),
+    );
+    expect(msg).toBe("agent error (500): {}");
+  });
+
+  test("includes the numeric status code", () => {
+    const msg = formatHttpError(504, "Gateway Timeout", "");
+    expect(msg).toContain("504");
   });
 });

--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -448,6 +448,16 @@ export function buildStackCommands(
           `bun run scripts/seed-dev-agent.ts --db-url ${DEV_DATABASE_URL}`,
         ],
       });
+      // Preflight: remove any leftover agent container from a prior session so
+      // the `docker run --name` below cannot collide. A stack torn down with
+      // `tmux kill-session` (instead of `task stack:down`) leaves the container
+      // running; without this, the next `task stack` fails its `docker run` with
+      // "name already in use" and silently keeps talking to the stale container.
+      // `-f` is a no-op when nothing is there, so this is safe on a clean machine.
+      cmds.push({
+        kind: "preflight",
+        argv: ["sh", "-c", `docker rm -f ${DEV_DOCKER_IMAGE} 2>/dev/null || true`],
+      });
       // Preflight: build the Docker image that the agent pane will run.
       cmds.push({
         kind: "preflight",

--- a/scripts/dev-tmux.unit.test.ts
+++ b/scripts/dev-tmux.unit.test.ts
@@ -670,6 +670,39 @@ describe("buildStackCommands — docker build + seed preflights", () => {
     expect(cmdStr).toContain("agent/Dockerfile");
   });
 
+  test("removes any leftover agent container BEFORE the docker build preflight", () => {
+    const cmds = buildStackCommands(STACK_PANES, {
+      repoPath: "/fake/repo",
+    });
+    const rmIdx = cmds.findIndex((c) =>
+      c.argv.join(" ").includes("docker rm -f shipwright-agent-dev"),
+    );
+    const dockerBuildIdx = cmds.findIndex((c) =>
+      c.argv.join(" ").includes("docker build"),
+    );
+    const agentSendKeysIdx = cmds.findIndex(
+      (c) =>
+        c.kind === "send-keys" &&
+        c.argv.some((a) => a.includes(`${SESSION_NAME}:0.3`)),
+    );
+    expect(rmIdx).toBeGreaterThanOrEqual(0);
+    expect(cmds[rmIdx]?.kind).toBe("preflight");
+    // The cleanup must run before both the image build and the run.
+    expect(rmIdx).toBeLessThan(dockerBuildIdx);
+    expect(rmIdx).toBeLessThan(agentSendKeysIdx);
+  });
+
+  test("the container cleanup preflight is a no-op when nothing is there", () => {
+    const cmds = buildStackCommands(STACK_PANES, {
+      repoPath: "/fake/repo",
+    });
+    const rm = cmds.find((c) =>
+      c.argv.join(" ").includes("docker rm -f shipwright-agent-dev"),
+    );
+    // `|| true` keeps a missing container from aborting the stack launch.
+    expect(rm?.argv.join(" ")).toContain("|| true");
+  });
+
   test("buildStackCommands includes seed preflight after migrate and before agent pane", () => {
     const cmds = buildStackCommands(STACK_PANES, {
       repoPath: "/fake/repo",


### PR DESCRIPTION
## Summary

Debugged a `task stack` failure where the chat REPL returned an opaque `non-2xx response: 500 Internal Server Error`. Two independent root causes:

- **Stale Docker container shadowed the fresh stack.** `docker run --name shipwright-agent-dev` collides with a leftover container from a prior session (e.g. one torn down with `tmux kill-session` instead of `task stack:down`). The agent pane fails with "name already in use" and the stack silently keeps talking to the **old** container. Confirmed live: the running container was "Up 45 hours" while the rest of the stack was fresh.
- **The 500 itself was a Claude usage limit (429), surfaced opaquely.** `/chat` called the runner with no try/catch, so any throw became a bare Hono 500 with an empty body — the real cause (`You've hit your Sonnet limit`) was only visible in container logs.

## Changes

- `scripts/dev-tmux.ts` — add a `docker rm -f shipwright-agent-dev` preflight before the agent build/run so each `task stack` starts a fresh container.
- `agent/src/chat.ts` — wrap the runner call; map `ClaudeRunError` 429 → 429, other CLI failures → 502, `ClaudeTimeoutError` → 504, generic → 500, all with the real message in the body.
- `scripts/chat.ts` — read the error body and surface it via a new pure `formatHttpError` helper, so the REPL shows e.g. `agent error (429): You've hit your Sonnet limit`.
- Tests added at each layer (dev-tmux unit, agent chat smoke, chat script unit).

## Verification

- `bun test` full suite: 3131 pass, 0 fail. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)