### PR TITLE
feat: render plan viz after /prd and /plan-session markdown write

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -55,6 +55,8 @@ Manual test scenarios for each command across different project types.
 | 38 | `/metrics` | Any (multi-task session) | Auto-docs aggregation across session | New "Auto-docs maintenance" section appears with update rate, mean lines/task, and skip breakdown; recommendation #12 fires when rate is low |
 | 39 | `/dev-task` Step 8.5 | Any (with docs/, failing pre-commit hook) | Commit failure does not produce false success | No `✓ Docs refreshed`; `skipped_reason:"commit_failed"`, `commit_sha:null`, `updated:false`; no fabricated metrics; pipeline still continues to Step 9 |
 | 40 | `/dev-task` Step 8.5 | Any | Unparseable agent result is recorded, not silent | Agent returns no/garbled `AUTO_DOCS_METRICS` block; `⚠ ... agent_error` printed; metrics record has `skipped_reason:"agent_error"`, `updated:false`; pipeline continues |
+| 41 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (hosted store configured) | Plan viz render after markdown write | `PLAN.md`/`PRODUCT-SPEC.md` written unchanged, then `render-plan.ts` runs and a `Plan viz: {url}` line is surfaced in the confirmation block |
+| 42 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (hosted store unset) | Plan viz graceful skip | `⏭ Plan viz skipped — SHIPWRIGHT_TASK_STORE_URL/TOKEN unset.` printed; markdown still written; no `Plan viz:` line; command never blocks |
 
 ---
 
@@ -1081,6 +1083,56 @@ Run these across ALL scenarios to verify genericization:
 - [ ] metrics.jsonl record has `"auto_docs":{"updated":false,"files_changed":0,"lines_changed":0,"skipped_reason":"agent_error"}`
 - [ ] `/metrics` later buckets this as `agent_error` (a failure), NOT `legacy_record`
 - [ ] Pipeline continues to Step 9 without stalling
+
+---
+
+## Scenario 41: Plan Viz Render — Hosted Store Configured
+
+Covers the additive render step in `/plan-session` Step 6a and `/prd` Phase 4.
+The underlying parse/render/upload logic is already unit- and integration-tested
+(`render-plan*.test.ts`); this scenario verifies the command-body wiring only.
+
+### Setup
+1. Install the plugin so `render-plan.ts` resolves under `~/.claude/plugins/cache/*/shipwright/`
+2. Export a reachable hosted task store: `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN`
+3. Have a session ready to plan (any repo)
+
+### Run
+```
+/plan-session {repo} {session}
+```
+(and/or `/prd {session}` to exercise the spec path)
+
+### Verify
+- [ ] `planning/{session}/PLAN.md` (or `PRODUCT-SPEC.md`) is written exactly as before — the markdown step is unchanged
+- [ ] After the write, the render block runs `render-plan.ts` resolved via the `find … | sort -V | tail -1` idiom
+- [ ] `--type plan` is used for `PLAN.md`, `--type spec` for `PRODUCT-SPEC.md`
+- [ ] The shareable URL printed to stdout is surfaced as a `Plan viz: {url}` line in the `QUEUED` / `PRD COMPLETE` confirmation block
+- [ ] No error from the render step changes the command's exit behavior — the plan/spec is committed regardless
+
+---
+
+## Scenario 42: Plan Viz Render — Hosted Store Unset (Graceful Skip)
+
+The required negative path: the viz must degrade to a one-line notice and never
+block the plan when the hosted env is absent.
+
+### Setup
+1. `unset SHIPWRIGHT_TASK_STORE_URL SHIPWRIGHT_TASK_STORE_TOKEN` (or run where they were never set)
+2. Have a session ready to plan (any repo)
+
+### Run
+```
+/plan-session {repo} {session}
+```
+(and/or `/prd {session}`)
+
+### Verify
+- [ ] `planning/{session}/PLAN.md` (or `PRODUCT-SPEC.md`) is still written normally
+- [ ] The render block prints `⏭ Plan viz skipped — SHIPWRIGHT_TASK_STORE_URL/TOKEN unset.` and runs nothing else
+- [ ] No `Plan viz:` line appears in the confirmation block
+- [ ] The command completes successfully — the plan is never blocked on visualization
+- [ ] (Optional, same skip notice) If the env is set but `render-plan.ts` is not found in the plugin cache, the block prints `⏭ Plan viz skipped — render-plan.ts not found in plugin cache.` and proceeds
 
 ---
 

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -333,6 +333,30 @@ Write the full plan markdown (session name, technical design, and task table fro
 
 This mirrors the PRD pattern (`planning/{session}/PRODUCT-SPEC.md`) and keeps the plan co-located with the spec that produced it.
 
+**Render the plan visualization (additive — never blocks the plan).** The
+`PLAN.md` write above is complete and unchanged; this step only surfaces a
+shareable visual of what was just written. Skip cleanly when the hosted task
+store is not configured.
+
+```bash
+if [ -z "$SHIPWRIGHT_TASK_STORE_URL" ] || [ -z "$SHIPWRIGHT_TASK_STORE_TOKEN" ]; then
+  echo "⏭ Plan viz skipped — SHIPWRIGHT_TASK_STORE_URL/TOKEN unset."
+else
+  RENDER=$(find ~/.claude/plugins/cache -maxdepth 5 -name "render-plan.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2-)
+  if [ -z "$RENDER" ]; then
+    echo "⏭ Plan viz skipped — render-plan.ts not found in plugin cache."
+  else
+    bun "$RENDER" --file "planning/{session}/PLAN.md" --type plan --session "{session}"
+  fi
+fi
+```
+
+`render-plan.ts` prints the shareable hosted URL (or a local file path when it
+falls back) to stdout; human-facing notices go to stderr. Capture the stdout URL
+and surface it in the Step 6 `QUEUED` confirmation as `Plan viz: {url}`. If the
+step printed a skip notice instead, omit that line and proceed — the plan and
+its tasks are already written and the command must never block on visualization.
+
 **Step 6b — Write tasks to the store:**
 
 Write the tasks to `/tmp/new-tasks-{session}.json`. Set `source` to `"planning/{session}/PLAN.md"` on every task — this links each task back to the plan on disk:
@@ -383,6 +407,7 @@ QUEUED
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Session: {session}
 Plan: planning/{session}/PLAN.md
+Plan viz: {url}   ← omit this line if the render step was skipped
 Tasks queued: {count}
 
 READY TO START (no dependencies):

--- a/plugins/shipwright/commands/prd.md
+++ b/plugins/shipwright/commands/prd.md
@@ -212,6 +212,29 @@ Present the complete draft to the user section by section. After presenting each
    ```
 3. Iterate on feedback until the user approves
 4. Write the approved spec to `planning/$ARGUMENTS/PRODUCT-SPEC.md`
+5. **Render the plan visualization (additive — never blocks the spec).** The
+   `PRODUCT-SPEC.md` write above is complete and unchanged; this step only
+   surfaces a shareable visual of what was just written. Skip cleanly when the
+   hosted task store is not configured.
+
+   ```bash
+   if [ -z "$SHIPWRIGHT_TASK_STORE_URL" ] || [ -z "$SHIPWRIGHT_TASK_STORE_TOKEN" ]; then
+     echo "⏭ Plan viz skipped — SHIPWRIGHT_TASK_STORE_URL/TOKEN unset."
+   else
+     RENDER=$(find ~/.claude/plugins/cache -maxdepth 5 -name "render-plan.ts" -path "*/shipwright/*" 2>/dev/null | awk -F/ '{print $(NF-2), $0}' | sort -V | tail -1 | cut -d' ' -f2-)
+     if [ -z "$RENDER" ]; then
+       echo "⏭ Plan viz skipped — render-plan.ts not found in plugin cache."
+     else
+       bun "$RENDER" --file "planning/$ARGUMENTS/PRODUCT-SPEC.md" --type spec --session "$ARGUMENTS"
+     fi
+   fi
+   ```
+
+   `render-plan.ts` prints the shareable hosted URL (or a local file path when
+   it falls back) to stdout; human-facing notices go to stderr. Capture the
+   stdout URL and surface it in the Phase 5 summary as `Plan viz: {url}`. If the
+   step printed a skip notice instead, omit that line and proceed — the spec is
+   already written and the command must never block on visualization.
 
 ## Phase 5: Summary and Next Steps
 
@@ -223,6 +246,7 @@ PRD COMPLETE
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 PRD: planning/$ARGUMENTS/PRODUCT-SPEC.md
+Plan viz: {url}   ← omit this line if the render step was skipped
 
 Features: {N}
 {  Feature name} — {N} requirements, {N} acceptance criteria


### PR DESCRIPTION
## Summary
- Hook `render-plan.ts` into `/prd` (Phase 4, after the `PRODUCT-SPEC.md` write) and `/plan-session` (Step 6a, after the `PLAN.md` write) so a shareable visualization is rendered and its URL surfaced in the confirmation block. **Strictly additive — the markdown write is unchanged.**
- The render step degrades gracefully: when `SHIPWRIGHT_TASK_STORE_URL`/`TOKEN` are unset (or `render-plan.ts` is absent from the plugin cache), it prints a one-line skip notice and proceeds. The plan is **never** blocked on visualization.
- Uses the `find … | sort -V | tail -1` + `bun` plugin-cache resolution idiom (mirrors `review-patch.md`).
- `TESTING.md` documents the new render step (matrix rows 41/42) plus a manual smoke (Scenarios 41/42) asserting the graceful skip when env is unset.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `/prd` + `/plan-session` render & surface the viz after the MD write; MD output unchanged | ✅ MET |
| 2 | Hosted env unset → both commands print a skip notice and proceed (never blocked) | ✅ MET |
| 3 | Version-bump files kept in sync + `TESTING.md` documents render step + manual smoke | ✅ MET |
| 4 | No new automated test layer; verification is a documented manual smoke (graceful skip) | ✅ MET |

## Notes for the reviewer
- **No manual version bumps.** This repo's versions are owned by **semantic-release** (`scripts/sync-version.ts` invoked via `.releaserc.json` `prepareCmd`, writing all five `package.json`/`plugin.json` files + `version.txt` + `marketplace.json`). The `marketplace-dev` design constitution explicitly states: *"Never manually edit the version field… The automation owns these."* This `feat:` commit derives the minor bump on merge, which is how AC #3's "kept in sync" is satisfied. CI has no version-consistency validator that would require a manual edit.
- Pre-existing, out-of-scope: `TESTING.md`'s tail "Versioning Checklist" still describes the old manual-bump flow and now contradicts the `marketplace-dev` constitution. Left untouched to respect this task's scope; worth a follow-up to reconcile.
- The render block is intentionally duplicated across the two command prompts — they are independent markdown bodies, not shared code, so there is no DRY extraction available.

## Test Plan
- `check-banned-strings.ts` → ✓ No banned strings found
- `biome lint` on changed files → no findings (markdown is not biome-linted)
- `bash -n` on both render blocks → OK (valid shell syntax)
- Manual smoke documented in `TESTING.md` Scenarios 41 (render) and 42 (graceful skip when env unset)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
