### PR TITLE
fix(task-store): drop assignee=null guard from inRepoScope check

### DIFF
--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -889,6 +889,34 @@ describe("task-store API (smoke)", () => {
     expect(res.status).toBe(200);
   });
 
+  it("PATCH /tasks/:id on assigned task with repo-scoped token returns 200 when task repo is in scope", async () => {
+    // Task is assigned to agent-2, not agent-1
+    const assignedTask = makeTask({
+      id: "assigned-1",
+      assignee: "agent-2",
+      repo: "acme-inc/backend-api",
+    });
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
+      taskService: fakeTaskService({ getResult: assignedTask }),
+      scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
+    });
+
+    const res = await app.request("/tasks/assigned-1", {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ status: "in_progress" }),
+    });
+
+    // Should return 200 because the task's repo is in the token's scope,
+    // even though the task is assigned to a different agent.
+    expect(res.status).toBe(200);
+  });
+
   it("GET /tasks with repo-scoped agent token passes agentScope (not assignee) to list()", async () => {
     const capturedFilters: TaskListFilters[] = [];
 

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -897,9 +897,18 @@ describe("task-store API (smoke)", () => {
       repo: "acme-inc/backend-api",
     });
 
+    // Use a spy that merges the patch body onto the original task so the response
+    // accurately reflects what a real DB update would return.
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: assignedTask }),
+      async update(id, data) {
+        return makeTask({ ...assignedTask, ...(data as Partial<Task>), id });
+      },
+    };
+
     const app = makeApp({
       tokenService: fakeRepoAgentTokenService(["acme-inc/backend-api"]),
-      taskService: fakeTaskService({ getResult: assignedTask }),
+      taskService: spyTaskService,
       scopeResolver: makeScopeResolver(["acme-inc/backend-api"]),
     });
 
@@ -915,6 +924,35 @@ describe("task-store API (smoke)", () => {
     // Should return 200 because the task's repo is in the token's scope,
     // even though the task is assigned to a different agent.
     expect(res.status).toBe(200);
+    // Acting agent (agent-1) must NOT steal the task — assignee stays agent-2.
+    expect((await res.json() as Task).assignee).toBe("agent-2");
+  });
+
+  it("PATCH /tasks/:id with repo-scoped token for wrong repo returns 403", async () => {
+    // Task belongs to acme-inc/backend-api but token only scopes other-org/other-repo
+    const assignedTask = makeTask({
+      id: "assigned-2",
+      assignee: "agent-2",
+      repo: "acme-inc/backend-api",
+    });
+
+    const app = makeApp({
+      tokenService: fakeRepoAgentTokenService(["other-org/other-repo"]),
+      taskService: fakeTaskService({ getResult: assignedTask }),
+      scopeResolver: makeScopeResolver(["other-org/other-repo"]),
+    });
+
+    const res = await app.request("/tasks/assigned-2", {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ status: "in_progress" }),
+    });
+
+    // Repo-scoped token for a different repo must not grant write access.
+    expect(res.status).toBe(403);
   });
 
   it("GET /tasks with repo-scoped agent token passes agentScope (not assignee) to list()", async () => {

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -241,8 +241,12 @@ export function createTasksRoutes(
     const body = await readJson(c);
     validateRepo(body.repo, agentId !== null ? repos : null);
     // Prevent agent tokens from reassigning tasks outside their ownership scope.
-    // Only force-assign for explicitly assigned tasks; leave pool task assignee null.
-    if (agentId !== null && task.assignee !== null) {
+    // Only force-assign when the acting agent is the explicit assignee or claimedBy.
+    // Skip force-assign when access is purely via repo scope — the task may belong
+    // to a different agent and we should not silently steal it.
+    const ownedByAssignee = task.assignee === agentId;
+    const ownedByClaim = task.claimedBy === agentId;
+    if (agentId !== null && task.assignee !== null && (ownedByAssignee || ownedByClaim)) {
       body.assignee = agentId;
     }
     const updated = await taskService.update(

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -64,7 +64,7 @@ function validateRepo(repo: unknown, repos: string[] | null): void {
  *   1. agentId is null (admin token — unrestricted)
  *   2. task.assignee === agentId (explicitly assigned)
  *   3. task.claimedBy === agentId (claimed pool task)
- *   4. task.assignee === null AND task.repo is in repos (repo-scoped pool task)
+ *   4. task.repo is in repos (repo-scoped token with matching repo)
  */
 async function requireOwnership(
   taskService: TaskServiceLike,
@@ -77,8 +77,7 @@ async function requireOwnership(
   if (agentId !== null) {
     const ownedByAssignee = task.assignee === agentId;
     const ownedByClaim = task.claimedBy === agentId;
-    const inRepoScope =
-      task.assignee === null && task.repo !== null && repos.includes(task.repo);
+    const inRepoScope = task.repo !== null && repos.includes(task.repo);
     if (!ownedByAssignee && !ownedByClaim && !inRepoScope) {
       throw new ForbiddenError("task belongs to a different agent");
     }


### PR DESCRIPTION
## Summary
- Remove the `task.assignee === null` guard from `inRepoScope` in `requireOwnership()` so repo-scoped tokens can PATCH tasks regardless of whether the task has an assignee
- Update JSDoc on `requireOwnership()` to reflect the corrected condition 4

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | PATCH /tasks/:id returns 200 when repo in scope, even if assignee is different | MET |
| 2 | PATCH still 403s when no assignee/claimedBy/repo match | MET |
| 3 | Existing pool-task test (assignee=null, repo in scope) continues to pass | MET |
| 4 | New smoke test: assigned task + repo-scoped token → 200 | MET |
| 5 | JSDoc updated to reflect corrected condition 4 | MET |

## Test Plan
- [x] New smoke test: PATCH on task with `assignee="other-agent"` using repo-scoped token whose repos include the task's repo → 200
- [x] Existing pool-task smoke test (assignee=null) continues to pass
- [x] Full task-store test suite: 191 pass, 0 fail
- [x] Biome lint: clean

Generated with [Claude Code](https://claude.com/claude-code)
