### PR TITLE
feat(site): rewrite hero with own-it framing and two-path CTA (PPL-3.1)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Shipwright Harness — Documentation
 
-Shipwright Harness is the open-source autonomous delivery agent for [Claude Code](https://www.anthropic.com/claude-code): a deployable cloud agent and the autonomous coding system that powers it, built on the `shipwright` plugin.
+Shipwright Harness is the open-source autonomous delivery system in your own environment: a deployable cloud agent and the autonomous coding system that powers it, built on the `shipwright` plugin.
 
 > 🚧 **Early development.** These docs grow as the toolchain becomes runnable. Start with the [README](../README.md) for the overview and install command.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Shipwright Harness is the open-source autonomous delivery agent for [Claude Code](https://www.anthropic.com/claude-code). It ships as four artifacts, built and sequenced **A → B → C → D**, each independently runnable and depending on **no external platform service**:
+Shipwright Harness is the open-source autonomous delivery system in your own environment. It ships as four artifacts, built and sequenced **A → B → C → D**, each independently runnable and depending on **no external platform service**:
 
 | Phase | Artifact | Directory | What it is |
 |---|---|---|---|

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -266,16 +266,13 @@ $ /shipwright:deploy
       {taglinePrefix}<span class="sw-gradient-text">{taglineGradient}</span>.
     </h1>
 
-    <!-- Two-path CTA: install or discovery call, equally prominent -->
     <div class="mt-10 grid gap-6 sm:grid-cols-2 max-w-2xl">
-      <!-- Path 1: Install the plugin -->
       <div class="sw-card flex flex-col gap-3">
         <span class="sw-label">Try it now</span>
         <p class="text-sm">Drop it into Claude Code and run it on any repository.</p>
         <pre class="sw-code text-sm"><code>{install}</code></pre>
       </div>
 
-      <!-- Path 2: Design Partner / Discovery call -->
       <div class="sw-card flex flex-col gap-3">
         <span class="sw-label">Work with us</span>
         <p class="text-sm">Get a walkthrough on your own codebase and deploy to your cloud.</p>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,8 +4,8 @@
 // No runtime JS, no hardcoded hex colors, no competitor names.
 import BaseLayout from "../layouts/BaseLayout.astro";
 
-const taglinePrefix = "The open-source autonomous delivery agent for ";
-const taglineGradient = "Claude Code";
+const taglinePrefix = "The open-source autonomous delivery system ";
+const taglineGradient = "in your own environment";
 const tagline = `${taglinePrefix}${taglineGradient}.`;
 const install = "/plugin install shipwright@app-vitals/shipwright";
 const githubUrl = "https://github.com/app-vitals/shipwright";
@@ -259,12 +259,31 @@ $ /shipwright:deploy
 ---
 
 <BaseLayout title="Shipwright Harness" description={tagline}>
-  <!-- ── Hero ── (minimal: eyebrow + tagline; flows straight into two-ways) -->
-  <section class="relative z-10 pt-12 pb-8">
+  <!-- ── Hero ── (tagline + two-path CTA) -->
+  <section class="relative z-10 pt-12 pb-12">
     <p class="sw-label">Built on Claude Code</p>
     <h1 class="sw-display mt-4 max-w-3xl">
       {taglinePrefix}<span class="sw-gradient-text">{taglineGradient}</span>.
     </h1>
+
+    <!-- Two-path CTA: install or discovery call, equally prominent -->
+    <div class="mt-10 grid gap-6 sm:grid-cols-2 max-w-2xl">
+      <!-- Path 1: Install the plugin -->
+      <div class="sw-card flex flex-col gap-3">
+        <span class="sw-label">Try it now</span>
+        <p class="text-sm">Drop it into Claude Code and run it on any repository.</p>
+        <pre class="sw-code text-sm"><code>{install}</code></pre>
+      </div>
+
+      <!-- Path 2: Design Partner / Discovery call -->
+      <div class="sw-card flex flex-col gap-3">
+        <span class="sw-label">Work with us</span>
+        <p class="text-sm">Get a walkthrough on your own codebase and deploy to your cloud.</p>
+        <a class="sw-btn sw-btn-secondary w-fit" href={discoveryUrl}>
+          Book a discovery call
+        </a>
+      </div>
+    </div>
   </section>
 
   <!-- Showcase: four tabbed panels (Two ways · Crons · Metrics · Demo).

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -62,15 +62,16 @@ test("hero CTA section includes both paths: install snippet and discovery call l
   page,
 }) => {
   await page.goto("/");
+  const hero = page.locator("section").first();
   // Install path: the plugin install command should be visible in the hero area.
   await expect(
-    page.getByText("/plugin install shipwright@app-vitals/shipwright", {
+    hero.getByText("/plugin install shipwright@app-vitals/shipwright", {
       exact: false,
-    }).first(),
+    }),
   ).toBeVisible();
   // Discovery call path: link to cal.com/app-vitals/discovery should be visible in hero.
   await expect(
-    page.getByRole("link", { name: /discovery call/i }).first(),
+    hero.getByRole("link", { name: /discovery call/i }),
   ).toBeVisible();
 });
 

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -49,9 +49,9 @@ test("home document ships NO runtime JS (zero <script> tags)", async ({
   expect(scriptCount).toBe(0);
 });
 
-// SWW-2.1: Hero. The hero is intentionally minimal — eyebrow + tagline only.
-// (The install command + repo link live in the two-ways/social-proof/footer
-// sections; those are covered by their own tests below.)
+// SWW-2.1: Hero. The hero contains the eyebrow, brand tagline, and a two-path CTA
+// (install snippet + discovery call link). Tests below scope to page.locator("section").first()
+// to guard the hero specifically; lower sections (social-proof, footer) are covered separately.
 
 test("eyebrow features 'Built on Claude Code'", async ({ page }) => {
   await page.goto("/");

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -22,7 +22,7 @@ test("hero heading renders the brand tagline", async ({ page }) => {
   await page.goto("/");
   const heading = page.locator("h1");
   await expect(heading).toBeVisible();
-  await expect(heading).toContainText(/autonomous delivery agent/i);
+  await expect(heading).toContainText(/own environment/i);
 });
 
 test("dark-premium navy base background is applied", async ({ page }) => {
@@ -56,6 +56,30 @@ test("home document ships NO runtime JS (zero <script> tags)", async ({
 test("eyebrow features 'Built on Claude Code'", async ({ page }) => {
   await page.goto("/");
   await expect(page.getByText(/Built on Claude Code/i).first()).toBeVisible();
+});
+
+test("hero CTA section includes both paths: install snippet and discovery call link", async ({
+  page,
+}) => {
+  await page.goto("/");
+  // Install path: the plugin install command should be visible in the hero area.
+  await expect(
+    page.getByText("/plugin install shipwright@app-vitals/shipwright", {
+      exact: false,
+    }).first(),
+  ).toBeVisible();
+  // Discovery call path: link to cal.com/app-vitals/discovery should be visible in hero.
+  await expect(
+    page.getByRole("link", { name: /discovery call/i }).first(),
+  ).toBeVisible();
+});
+
+test("page does NOT contain the string 'Autonomous programming, installed'", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const text = (await page.locator("body").textContent()) ?? "";
+  expect(text).not.toContain("Autonomous programming, installed");
 });
 
 test("'Inside a task' tab details the dev-task steps in order", async ({


### PR DESCRIPTION
## Summary
- Replaces the hero tagline with "own-it alternative" framing: "The open-source autonomous delivery system in your own environment"
- Adds two-path CTA in the hero — install snippet (self-serve) and discovery call link (Design Partner) — equally prominent side-by-side
- Updates `home.spec.ts`: fixes the tagline assertion, adds hero CTA test and regression guard for "Autonomous programming, installed"

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Hero/title excludes "Autonomous programming, installed" | ✅ MET |
| 2 | Both CTA paths present and link correctly | ✅ MET |
| 3 | Site build succeeds with no errors | ✅ MET |
| 4 | All Playwright tests pass; no assertions removed | ✅ MET |
| 5 | No runtime JS, no hardcoded hex colors, no competitor names | ✅ MET |

## Test Plan
- [x] `npm run build` in `site/` — passes (3 pages, no errors)
- [x] `npm test` in `site/` — 47/47 Playwright tests passing
- [x] Zero `<script>` tags confirmed by existing test
- [x] New: hero CTA test verifies install snippet + discovery call link visible
- [x] New: regression guard — "Autonomous programming, installed" absent from page

Generated with [Claude Code](https://claude.com/claude-code)
