### PR TITLE
fix(chart): wire metrics task-store env so dashboard avoids SQLite crash-loop

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,18 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.117] - 2026-06-28
+
+### Added
+
+- metrics: wire `METRICS_TASK_STORE_URL` + `METRICS_TASK_STORE_TOKEN` into the
+  metrics Deployment via `metrics.provider.taskStoreUrl` and
+  `metrics.provider.taskStoreToken`. Set `taskStoreUrl` alongside `adminUrl` to
+  run the dashboard in TASKSTORE mode. Without this the provider selector falls
+  through to the bundled SQLite store, which has no writable path in the
+  published image and crash-loops on boot (`SQLITE_CANTOPEN`) — the regression
+  introduced when metrics v0.91.0 replaced PostHog mode with task-store mode.
+
 ## [1.6.116] - 2026-06-29
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.116
+version: 1.6.117
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.6.116 triggered by release tag admin-v0.112.0"
+    - kind: added
+      description: "metrics: wire METRICS_TASK_STORE_URL + METRICS_TASK_STORE_TOKEN so the dashboard can select TASKSTORE mode instead of crash-looping on the SQLite fallback"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/metrics-deployment.yaml
+++ b/charts/shipwright/templates/metrics-deployment.yaml
@@ -103,6 +103,23 @@ spec:
             - name: METRICS_ADMIN_URL
               value: {{ .Values.metrics.provider.adminUrl | quote }}
             {{- end }}
+            # Task-store mode: when taskStoreUrl is set alongside adminUrl, the
+            # metrics service selects TASKSTORE mode (TaskStoreProvider over the
+            # task-store + admin APIs). Without it the selector falls through to
+            # the local SQLite store, which has no writable path in this image and
+            # crashes on boot (SQLITE_CANTOPEN). The token authenticates the
+            # task-store HTTP client (METRICS_TASK_STORE_TOKEN).
+            {{- if .Values.metrics.provider.taskStoreUrl }}
+            - name: METRICS_TASK_STORE_URL
+              value: {{ .Values.metrics.provider.taskStoreUrl | quote }}
+            {{- end }}
+            {{- if .Values.metrics.provider.taskStoreToken.existingSecret }}
+            - name: METRICS_TASK_STORE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.metrics.provider.taskStoreToken.existingSecret }}
+                  key: {{ .Values.metrics.provider.taskStoreToken.key }}
+            {{- end }}
             {{- if .Values.metrics.provider.basePath }}
             - name: METRICS_BASE_PATH
               value: {{ .Values.metrics.provider.basePath | quote }}

--- a/charts/shipwright/tests/metrics_workload_test.yaml
+++ b/charts/shipwright/tests/metrics_workload_test.yaml
@@ -292,6 +292,48 @@ tests:
           content:
             name: METRICS_ADMIN_URL
 
+  - it: injects METRICS_TASK_STORE_URL as a literal env when taskStoreUrl is set (selects TASKSTORE mode)
+    template: templates/metrics-deployment.yaml
+    set:
+      metrics.provider.taskStoreUrl: "http://shipwright-task-store:3000"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_URL
+            value: "http://shipwright-task-store:3000"
+
+  - it: omits METRICS_TASK_STORE_URL when taskStoreUrl is empty (default)
+    template: templates/metrics-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_URL
+
+  - it: injects METRICS_TASK_STORE_TOKEN via secretKeyRef when taskStoreToken.existingSecret is set
+    template: templates/metrics-deployment.yaml
+    set:
+      metrics.provider.taskStoreToken.existingSecret: my-task-store-secret
+      metrics.provider.taskStoreToken.key: METRICS_TASK_STORE_TOKEN
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-task-store-secret
+                key: METRICS_TASK_STORE_TOKEN
+
+  - it: omits METRICS_TASK_STORE_TOKEN when taskStoreToken.existingSecret is empty (default)
+    template: templates/metrics-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_TOKEN
+
   - it: injects METRICS_BASE_PATH as a literal env when basePath is set
     template: templates/metrics-deployment.yaml
     set:

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -216,6 +216,27 @@
                   }
                 },
                 "adminUrl": { "type": "string" },
+                "taskStoreUrl": { "type": "string" },
+                "taskStoreToken": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "existingSecret": { "type": "string" },
+                    "key": { "type": "string" }
+                  },
+                  "if": {
+                    "properties": {
+                      "existingSecret": { "type": "string", "minLength": 1 }
+                    },
+                    "required": ["existingSecret"]
+                  },
+                  "then": {
+                    "properties": {
+                      "key": { "type": "string", "minLength": 1 }
+                    },
+                    "required": ["key"]
+                  }
+                },
                 "basePath": { "type": "string" },
                 "requireOwnerRole": { "type": "boolean" },
                 "internalKey": {

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -231,6 +231,21 @@ metrics:
     # Required when not using the bundled admin service (e.g., external admin).
     # Leave empty to omit the METRICS_ADMIN_URL env var.
     adminUrl: ""
+    # -- URL of the Shipwright task-store service as seen by the metrics dashboard.
+    # When set ALONGSIDE adminUrl, the metrics service runs in TASKSTORE mode
+    # (TaskStoreProvider over the task-store + admin APIs). Leave empty and the
+    # provider selector falls through to the bundled SQLite store — which has no
+    # writable path in the published image and crashes on boot (SQLITE_CANTOPEN),
+    # so set this whenever the service should read live task/PR data.
+    taskStoreUrl: ""
+    # -- Bearer token for the task-store service (METRICS_TASK_STORE_TOKEN).
+    # Set existingSecret to inject it via secretKeyRef.
+    taskStoreToken:
+      # -- Name of an existing Secret holding the task-store bearer token.
+      # Leave empty to omit the METRICS_TASK_STORE_TOKEN env var.
+      existingSecret: ""
+      # -- Key in the secret for METRICS_TASK_STORE_TOKEN.
+      key: METRICS_TASK_STORE_TOKEN
     # -- Base path for the metrics dashboard (e.g., /dashboard). Leave empty
     # to omit the METRICS_BASE_PATH env var (defaults to root inside the app).
     basePath: ""


### PR DESCRIPTION
## Problem

`shipwright-metrics` crash-loops on boot with `SQLiteError: unable to open database file` (`SQLITE_CANTOPEN`) at `local-store.ts:94`.

Root cause is chart/code drift. Metrics **v0.91.0** (#822) **removed PostHog backend mode** and replaced it with `taskstore` mode, but the Helm chart was never updated:
- The metrics Deployment still injects the now-dead `POSTHOG_*` env and has **no** `METRICS_TASK_STORE_URL` plumbing.
- With no PostHog mode, no Postgres URL, and no task-store URL, `selectProviderMode` falls through to **`sqlite`** → opens `state/metrics.db`, whose parent dir doesn't exist in the published image (not a writable volume) → crash.

## Fix

Add the task-store wiring the new mode needs:
- `metrics.provider.taskStoreUrl` → `METRICS_TASK_STORE_URL` (plain value, like `adminUrl`)
- `metrics.provider.taskStoreToken.existingSecret/key` → `METRICS_TASK_STORE_TOKEN` (secretKeyRef, like `internalKey`)

Set `taskStoreUrl` alongside `adminUrl` to select `taskstore` mode. Includes `values.schema.json` entries, 4 helm-unittest cases (set/omit for both env vars), CHANGELOG + artifacthub annotation, and chart bump to **1.6.117**.

## Verification

- `helm unittest` — 221 passed (4 new)
- `helm lint` — clean
- `ct lint --check-version-increment` — ok (1.6.116 → 1.6.117)
- `helm template` renders both env vars when values are set, omits them by default

## Follow-up (separate, vitals-os repo)

This adds the chart *plumbing* only. The prod release also needs `infra/helm/shipwright-deploy/values-prod.yaml` to set `metrics.provider.taskStoreUrl` (+ token secret), drop the dead PostHog block, and bump the `shipwright` chart dependency to 1.6.117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)