### PR TITLE
chore(chart): bump chart version to 1.6.118

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.118] - 2026-06-29
+
+### Changed
+
+- auto-bump to chart v1.6.118 triggered by release tag `agent-v0.95.0`
+
 ## [1.6.117] - 2026-06-28
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.117
+version: 1.6.118
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwright-harness.com
@@ -28,8 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "metrics: wire METRICS_TASK_STORE_URL + METRICS_TASK_STORE_TOKEN so the dashboard can select TASKSTORE mode instead of crash-looping on the SQLite fallback"
+    - kind: changed
+      description: "auto-bump to chart v1.6.118 triggered by release tag agent-v0.95.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer


### PR DESCRIPTION
## Chart version bump: 1.6.117 → 1.6.118

**Triggering tag:** `agent-v0.95.0`
**New chart version:** `1.6.118`

### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.118 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._