### PR TITLE
feat(metrics): public metrics routes, repo-scope filter, read-only dashboard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ The plugin is pure TypeScript with **no server, no database, and no external HTT
 
 ## B — Metrics dashboard
 
-A Hono service that turns pipeline events into analytics. Five read-only JSON endpoints (`/metrics/summary|trends|features|queue|tokens`) plus a session-gated `/dashboard`, all served by a backend-agnostic `MetricsProvider` interface. The active backend is selected from env at startup: **fixtures** (offline) or **taskstore** (live task-store + admin APIs). See **[metrics.md](./metrics.md)**.
+A Hono service that turns pipeline events into analytics. Two sets of read-only JSON endpoints: authenticated `/metrics/*` (summary, trends, features, queue, tokens) and unauthenticated `/public/*` (summary, trends, features, queue), plus session-gated `/dashboard` and public `/public/dashboard`. All served by a backend-agnostic `MetricsProvider` interface. The active backend is selected from env at startup: **fixtures** (offline) or **taskstore** (live task-store + admin APIs). See **[metrics.md](./metrics.md)**.
 
 ## C — Shipwright agent
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,6 +54,10 @@ When `METRICS_OFFLINE=true`, `server.ts` injects an offline `TaskStoreProvider` 
 
 All metric endpoints are `GET`, return JSON, and accept the same date-window query params: `preset` (`today` | `7d` | `30d` | `90d`) or an explicit `from`/`to` range. `/metrics/trends` additionally accepts `groupBy`.
 
+### Authenticated routes (`/metrics/*`)
+
+Require a bearer token (scope `"*"`) or session cookie (with `OWNER` role if required).
+
 | Method | Path | Description |
 |---|---|---|
 | GET | `/metrics/summary` | Headline totals + average cycle time over the window. |
@@ -63,17 +67,45 @@ All metric endpoints are `GET`, return JSON, and accept the same date-window que
 | GET | `/metrics/tokens` | Token usage — totals, by agent, by session type, by agent + session type, by agent + cron, by agent + model, and trends; each group includes a `cost` field (USD). |
 | GET | `/dashboard` | Server-rendered dashboard HTML (session-gated). |
 | GET | `/dashboard/*` | Static dashboard assets (`styles.css`, `app.js`). |
+
+### Public routes (`/public/*`)
+
+**No authentication required.** Read-only; narrowed to a configured repository scope. Omits token usage.
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/public/metrics/summary` | Headline totals + average cycle time over the window. |
+| GET | `/public/metrics/trends` | Time-series trends; supports `groupBy`. |
+| GET | `/public/metrics/features` | Per-feature task / CI / review breakdown. |
+| GET | `/public/metrics/queue` | Shipwright v3 queue metrics: funnel counts, block rate, avg cycle time (days), avg review findings. |
+| GET | `/public/dashboard` | Server-rendered dashboard HTML (no session required). |
+| GET | `/public/metrics/tokens` | Not available on public routes — returns `404`. |
+
+### Utility routes
+
+| Method | Path | Description |
+|---|---|---|
 | GET | `/health` | Liveness check — `{ status: "ok" }`, **no auth**. |
 | GET | `/openapi.json` | OpenAPI 3.1 document for the service. |
 
 ## Auth
+
+### Authenticated routes (`/metrics/*`)
 
 The `/metrics/*` endpoints accept **either** credential:
 
 - **Bearer API key** — tokens parsed from `METRICS_API_KEYS`. Scoped tokens (scope `!== "*"`) are rejected with `403` on metrics routes.
 - **Session cookie** (`admin_session`) — when `METRICS_REQUIRE_OWNER_ROLE=true` and an accounts client is configured, the caller's role is checked and non-`OWNER` users get `403`.
 
-The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/admin/login`. In offline mode (`METRICS_OFFLINE=true`), session auth is skipped entirely and `/dashboard` is served as "Offline User". `/health` is always open.
+The **dashboard** is protected by the session cookie middleware; an invalid/absent session redirects to `/admin/login`. In offline mode (`METRICS_OFFLINE=true`), session auth is skipped entirely and `/dashboard` is served as "Offline User".
+
+### Public routes (`/public/*`)
+
+The `/public/*` endpoints require **no authentication**. Access is controlled by mounting the public app at a separate HTTP listener or reverse-proxy path. All public endpoints return data scoped to a pre-configured repository (set at app creation time). The `/public/metrics/tokens` endpoint is omitted entirely and returns `404`.
+
+### Utility routes
+
+`/health` and `/openapi.json` are always open (no auth required).
 
 ## Environment
 

--- a/metrics/src/api.public.smoke.test.ts
+++ b/metrics/src/api.public.smoke.test.ts
@@ -1,0 +1,86 @@
+/**
+ * metrics/src/api.public.smoke.test.ts
+ * Smoke tests (PPL-1.2): the public, unauthenticated metrics surface.
+ *
+ * Drives the public sub-app via app.request() — no real server, no network.
+ * Covers:
+ *   - 200 unauth on /public/metrics/summary (+ trends/features/queue)
+ *   - 404 on /public/metrics/tokens (token usage is not public)
+ *   - 404/405 on any mutation (POST/PUT/DELETE) under /public/*
+ *   - read-only dashboard render omits the token-usage section
+ *
+ * No mock.module(), no global overrides — the provider is injected.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createPublicMetricsApp } from "./api.ts";
+import type { MetricsProvider } from "./metrics-provider.ts";
+import type { HogQLResult } from "./types.ts";
+
+const emptyResult: HogQLResult = {
+  columns: [],
+  results: [],
+  types: [],
+  hasMore: false,
+  limit: 100,
+  offset: 0,
+};
+
+/** Provider that returns an empty table for every kind — enough to render 200s. */
+function makeEmptyProvider(): MetricsProvider {
+  return { query: async () => emptyResult };
+}
+
+function buildApp() {
+  return createPublicMetricsApp(makeEmptyProvider());
+}
+
+describe("public metrics surface — unauthenticated reads", () => {
+  for (const path of [
+    "/public/metrics/summary",
+    "/public/metrics/trends",
+    "/public/metrics/features",
+    "/public/metrics/queue",
+  ]) {
+    test(`GET ${path} → 200 with no auth header`, async () => {
+      const app = buildApp();
+      const res = await app.request(path);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toBeTruthy();
+    });
+  }
+});
+
+describe("public metrics surface — token usage hidden", () => {
+  test("GET /public/metrics/tokens → 404", async () => {
+    const app = buildApp();
+    const res = await app.request("/public/metrics/tokens");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("public metrics surface — no mutations", () => {
+  for (const method of ["POST", "PUT", "DELETE"]) {
+    test(`${method} /public/metrics/summary → 404 or 405`, async () => {
+      const app = buildApp();
+      const res = await app.request("/public/metrics/summary", { method });
+      expect([404, 405]).toContain(res.status);
+    });
+  }
+});
+
+describe("public dashboard — read-only render", () => {
+  test("GET /public/dashboard → 200 and omits token-usage section", async () => {
+    const app = buildApp();
+    const res = await app.request("/public/dashboard");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Pipeline panels remain.
+    expect(html).toContain("Pipeline Queue");
+    expect(html).toContain("Tasks Completed");
+    // Token-usage section is hidden in read-only mode.
+    expect(html).not.toContain("Token Usage");
+    expect(html).not.toContain("token-agent-table");
+  });
+});

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -24,7 +24,11 @@ import {
   SESSION_COOKIE,
   createSessionMiddleware,
 } from "./lib/session-middleware.ts";
-import type { MetricsProvider, QueryDateRange, TrendsGroupBy } from "./metrics-provider.ts";
+import type {
+  MetricsProvider,
+  QueryDateRange,
+  TrendsGroupBy,
+} from "./metrics-provider.ts";
 import {
   DateRangeQuerySchema,
   FeaturesResultSchema,
@@ -261,86 +265,18 @@ function handleQueryError(
   return c.json({ error: msg }, 500);
 }
 
-// ─── Handler factory ─────────────────────────────────────────────────────────
+// ─── Provider-bound handler factories ────────────────────────────────────────
+//
+// The summary/trends/features/queue handlers depend only on a MetricsProvider,
+// so they are extracted into factories that close over the provider. Both the
+// authenticated app (createMetricsApp) and the public app
+// (createPublicMetricsApp) register the same handler logic against their own
+// route definitions — no duplicated aggregation code.
 
-export function createMetricsApp(
-  apiKeys: Map<string, Caller>,
-  accountsClient: AccountsClient,
-  deps?: MetricsDeps,
-): OpenAPIHono<AuthEnv> {
-  const provider = deps?.provider;
-  if (!provider) {
-    throw new Error(
-      "[metrics-api] MetricsDeps.provider is required — no fallback provider is configured",
-    );
-  }
-
-  const sessionSecret =
-    deps?.sessionSecret ?? process.env.SHIPWRIGHT_SESSION_SECRET ?? "";
-  const requireOwnerRole = deps?.requireOwnerRole ?? false;
-  if (requireOwnerRole) {
-    console.warn(
-      "[metrics] METRICS_REQUIRE_OWNER_ROLE is enabled — ensure your accountsClient URL serves /accounts/users/{id}. The Shipwright admin service does not expose this endpoint.",
-    );
-  }
-  const dashboardToken = deps?.dashboardToken;
-  const offlineMode = deps?.offlineMode ?? false;
-  const dashboardDevAuth = deps?.dashboardDevAuth ?? false;
-  const basePath = deps?.basePath ?? process.env.METRICS_BASE_PATH ?? "";
-  const adminBaseUrl =
-    deps?.adminBaseUrl ?? process.env.METRICS_ADMIN_APP_URL ?? "";
-
-  const app = new OpenAPIHono<AuthEnv>({
-    defaultHook: (result, c) => {
-      if (!result.success) {
-        const issues = result.error.issues;
-        const message = issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join(", ");
-        return c.json({ error: message }, 400);
-      }
-    },
-  });
-
-  app.onError((err, c) => {
-    console.error("unhandled error:", err);
-    return c.json({ error: err.message }, 500);
-  });
-
-  // Health check — no auth required
-  app.get("/health", (c) => c.json({ status: "ok" }, 200));
-
-  // /metrics/* — accepts bearer token OR session cookie; returns 401 JSON on failure.
-  app.use(
-    "/metrics/*",
-    dashboardDevAuth
-      ? createMiddleware<AuthEnv>(async (c, next) => {
-          c.set("caller", { name: "dev-auth", scope: "*" });
-          return next();
-        })
-      : createCombinedAuthMiddleware(
-          apiKeys,
-          sessionSecret,
-          accountsClient,
-          requireOwnerRole,
-          dashboardToken,
-        ),
-  );
-
-  // Metrics combined-auth middleware accepts either an admin bearer token
-  // (scope === "*", scoped tokens already 403'd above) or an OWNER session
-  // cookie. The kind="custom" policy documents that this dual gate is
-  // applied at middleware-time, not in the route handler.
-  const metricsPolicy = {
-    kind: "custom" as const,
-    check: () => {},
-    justification:
-      "Mixed auth: admin bearer token OR OWNER session cookie (enforced by createCombinedAuthMiddleware on /metrics/*)",
-  };
-
-  // ─── /metrics/summary ─────────────────────────────────────────────────────
-
-  const handleSummary: AppHandler<typeof summaryRoute> = async (c) => {
+function makeSummaryHandler(
+  provider: MetricsProvider,
+): AppHandler<typeof summaryRoute> {
+  return async (c) => {
     const { preset, from, to } = c.req.valid("query");
 
     if ((from && !to) || (!from && to)) {
@@ -443,10 +379,12 @@ export function createMetricsApp(
       return handleQueryError(c, err);
     }
   };
+}
 
-  // ─── /metrics/trends ──────────────────────────────────────────────────────
-
-  const handleTrends: AppHandler<typeof trendsRoute> = async (c) => {
+function makeTrendsHandler(
+  provider: MetricsProvider,
+): AppHandler<typeof trendsRoute> {
+  return async (c) => {
     const { preset, from, to, groupBy } = c.req.valid("query");
 
     if ((from && !to) || (!from && to)) {
@@ -516,10 +454,12 @@ export function createMetricsApp(
       return handleQueryError(c, err);
     }
   };
+}
 
-  // ─── /metrics/features ────────────────────────────────────────────────────
-
-  const handleFeatures: AppHandler<typeof featuresRoute> = async (c) => {
+function makeFeaturesHandler(
+  provider: MetricsProvider,
+): AppHandler<typeof featuresRoute> {
+  return async (c) => {
     const { preset, from, to } = c.req.valid("query");
 
     if ((from && !to) || (!from && to)) {
@@ -620,10 +560,12 @@ export function createMetricsApp(
       return handleQueryError(c, err);
     }
   };
+}
 
-  // ─── /metrics/queue ───────────────────────────────────────────────────────
-
-  const handleQueue: AppHandler<typeof queueRoute> = async (c) => {
+function makeQueueHandler(
+  provider: MetricsProvider,
+): AppHandler<typeof queueRoute> {
+  return async (c) => {
     const { preset, from, to } = c.req.valid("query");
 
     if ((from && !to) || (!from && to)) {
@@ -720,6 +662,92 @@ export function createMetricsApp(
       return handleQueryError(c, err);
     }
   };
+}
+
+// ─── Handler factory ─────────────────────────────────────────────────────────
+
+export function createMetricsApp(
+  apiKeys: Map<string, Caller>,
+  accountsClient: AccountsClient,
+  deps?: MetricsDeps,
+): OpenAPIHono<AuthEnv> {
+  const provider = deps?.provider;
+  if (!provider) {
+    throw new Error(
+      "[metrics-api] MetricsDeps.provider is required — no fallback provider is configured",
+    );
+  }
+
+  const sessionSecret =
+    deps?.sessionSecret ?? process.env.SHIPWRIGHT_SESSION_SECRET ?? "";
+  const requireOwnerRole = deps?.requireOwnerRole ?? false;
+  if (requireOwnerRole) {
+    console.warn(
+      "[metrics] METRICS_REQUIRE_OWNER_ROLE is enabled — ensure your accountsClient URL serves /accounts/users/{id}. The Shipwright admin service does not expose this endpoint.",
+    );
+  }
+  const dashboardToken = deps?.dashboardToken;
+  const offlineMode = deps?.offlineMode ?? false;
+  const dashboardDevAuth = deps?.dashboardDevAuth ?? false;
+  const basePath = deps?.basePath ?? process.env.METRICS_BASE_PATH ?? "";
+  const adminBaseUrl =
+    deps?.adminBaseUrl ?? process.env.METRICS_ADMIN_APP_URL ?? "";
+
+  const app = new OpenAPIHono<AuthEnv>({
+    defaultHook: (result, c) => {
+      if (!result.success) {
+        const issues = result.error.issues;
+        const message = issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join(", ");
+        return c.json({ error: message }, 400);
+      }
+    },
+  });
+
+  app.onError((err, c) => {
+    console.error("unhandled error:", err);
+    return c.json({ error: err.message }, 500);
+  });
+
+  // Health check — no auth required
+  app.get("/health", (c) => c.json({ status: "ok" }, 200));
+
+  // /metrics/* — accepts bearer token OR session cookie; returns 401 JSON on failure.
+  app.use(
+    "/metrics/*",
+    dashboardDevAuth
+      ? createMiddleware<AuthEnv>(async (c, next) => {
+          c.set("caller", { name: "dev-auth", scope: "*" });
+          return next();
+        })
+      : createCombinedAuthMiddleware(
+          apiKeys,
+          sessionSecret,
+          accountsClient,
+          requireOwnerRole,
+          dashboardToken,
+        ),
+  );
+
+  // Metrics combined-auth middleware accepts either an admin bearer token
+  // (scope === "*", scoped tokens already 403'd above) or an OWNER session
+  // cookie. The kind="custom" policy documents that this dual gate is
+  // applied at middleware-time, not in the route handler.
+  const metricsPolicy = {
+    kind: "custom" as const,
+    check: () => {},
+    justification:
+      "Mixed auth: admin bearer token OR OWNER session cookie (enforced by createCombinedAuthMiddleware on /metrics/*)",
+  };
+
+  // ─── /metrics/summary, /trends, /features, /queue ─────────────────────────
+  // Provider-bound handlers (shared with the public app via the make* factories).
+
+  const handleSummary = makeSummaryHandler(provider);
+  const handleTrends = makeTrendsHandler(provider);
+  const handleFeatures = makeFeaturesHandler(provider);
+  const handleQueue = makeQueueHandler(provider);
 
   // ─── /metrics/tokens ──────────────────────────────────────────────────────
 
@@ -1090,4 +1118,121 @@ function createCombinedAuthMiddleware(
 
     return c.json({ error: "Unauthorized" }, 401);
   });
+}
+
+// ─── Public (unauthenticated, repo-scoped) metrics surface ───────────────────
+//
+// PPL-1.2: a parallel read-only surface mounted under /public/*. It reuses the
+// same provider-bound handler logic as the authenticated app but:
+//   - requires NO auth (every route uses the {kind:"public"} AuthzPolicy)
+//   - serves data scoped to a single repo (the injected provider is repo-scoped
+//     at construction time — see TaskStoreProvider's `repo` param)
+//   - omits token-usage entirely: GET /public/metrics/tokens → 404
+//   - is read-only: no POST/PUT/DELETE routes exist (mutations → 404/405)
+//   - serves a read-only dashboard at /public/dashboard
+
+const publicSummaryRoute = createRoute({
+  ...summaryRoute,
+  path: "/public/metrics/summary",
+});
+const publicTrendsRoute = createRoute({
+  ...trendsRoute,
+  path: "/public/metrics/trends",
+});
+const publicFeaturesRoute = createRoute({
+  ...featuresRoute,
+  path: "/public/metrics/features",
+});
+const publicQueueRoute = createRoute({
+  ...queueRoute,
+  path: "/public/metrics/queue",
+});
+
+const PUBLIC_POLICY = { kind: "public" as const };
+
+/**
+ * Build the public, unauthenticated, repo-scoped metrics sub-app.
+ *
+ * @param provider - a repo-scoped MetricsProvider (built in server.ts with the
+ *   configured public repo). All reads are already narrowed to that repo.
+ * @param basePath - optional path prefix for dashboard asset/API URLs.
+ */
+export function createPublicMetricsApp(
+  provider: MetricsProvider,
+  basePath = "",
+): OpenAPIHono<AuthEnv> {
+  const app = new OpenAPIHono<AuthEnv>({
+    defaultHook: (result, c) => {
+      if (!result.success) {
+        const message = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join(", ");
+        return c.json({ error: message }, 400);
+      }
+    },
+  });
+
+  app.onError((err, c) => {
+    console.error("unhandled error:", err);
+    return c.json({ error: err.message }, 500);
+  });
+
+  // Read-only metric endpoints — no auth, repo-scoped via the injected provider.
+  //
+  // The handler factories are typed against the authenticated route configs
+  // (path "/metrics/*"). The public routes share byte-identical request/response
+  // schemas — only the `path` literal differs — so the handler logic is fully
+  // compatible. `AppHandler<R>` carries the path only as a phantom type, so each
+  // handler is cast to its public route's type. This is the single place the two
+  // route families are bridged; the schemas guarantee runtime correctness.
+  registerWithAuthz(
+    app,
+    publicSummaryRoute,
+    PUBLIC_POLICY,
+    makeSummaryHandler(provider) as unknown as AppHandler<
+      typeof publicSummaryRoute
+    >,
+  );
+  registerWithAuthz(
+    app,
+    publicTrendsRoute,
+    PUBLIC_POLICY,
+    makeTrendsHandler(provider) as unknown as AppHandler<
+      typeof publicTrendsRoute
+    >,
+  );
+  registerWithAuthz(
+    app,
+    publicFeaturesRoute,
+    PUBLIC_POLICY,
+    makeFeaturesHandler(provider) as unknown as AppHandler<
+      typeof publicFeaturesRoute
+    >,
+  );
+  registerWithAuthz(
+    app,
+    publicQueueRoute,
+    PUBLIC_POLICY,
+    makeQueueHandler(provider) as unknown as AppHandler<
+      typeof publicQueueRoute
+    >,
+  );
+
+  // Token usage is owner-only telemetry — not exposed publicly.
+  app.get("/public/metrics/tokens", (c) => c.json({ error: "Not found" }, 404));
+
+  // Read-only dashboard variant — pipeline panels only, no token usage.
+  app.get("/public/dashboard", (c) => {
+    const body = renderDashboardPage({
+      userName: "Public",
+      isOwner: false,
+      readOnly: true,
+      basePath,
+    });
+    return new Response(body, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  });
+
+  return app;
 }

--- a/metrics/src/dashboard/dashboard-page.ts
+++ b/metrics/src/dashboard/dashboard-page.ts
@@ -21,6 +21,12 @@ export interface DashboardPageOptions {
    * or undefined = same-origin relative links (the default for single-host ingress).
    */
   adminBaseUrl?: string;
+  /**
+   * Read-only public variant. When true, the dashboard hides the token-usage
+   * section (KPI cards + by-agent table + trends) and any auth-gated admin
+   * controls. All pipeline metric panels remain visible. Default false.
+   */
+  readOnly?: boolean;
 }
 
 function infoIcon(tip: string): string {
@@ -29,6 +35,62 @@ function infoIcon(tip: string): string {
 
 export function renderDashboardPage(opts: DashboardPageOptions): string {
   const base = opts.basePath ?? "";
+  const readOnly = opts.readOnly ?? false;
+
+  // Token usage is owner-only telemetry — omitted entirely in the read-only
+  // public variant. Pipeline panels above/below are unaffected.
+  const tokenSection = readOnly
+    ? ""
+    : `      <!-- Token Usage -->
+      <section class="section" aria-label="Token usage">
+        <div class="section-header">
+          <h2 class="section-title">Token Usage</h2>
+        </div>
+        <div class="token-kpi-row">
+          <div class="kpi-card" data-metric="token-input">
+            <div class="kpi-label">Input Tokens</div>
+            <div class="kpi-value" id="token-input"><span class="skeleton">&nbsp;</span></div>
+            <div class="kpi-meta">total input tokens</div>
+          </div>
+          <div class="kpi-card" data-metric="token-output">
+            <div class="kpi-label">Output Tokens</div>
+            <div class="kpi-value" id="token-output"><span class="skeleton">&nbsp;</span></div>
+            <div class="kpi-meta">total output tokens</div>
+          </div>
+          <div class="kpi-card" data-metric="token-cache">
+            <div class="kpi-label">Cache Tokens</div>
+            <div class="kpi-value" id="token-cache"><span class="skeleton">&nbsp;</span></div>
+            <div class="kpi-meta">cache read + creation</div>
+          </div>
+          <div class="kpi-card" data-metric="token-cost">
+            <div class="kpi-label">Total Cost</div>
+            <div class="kpi-value" id="token-cost"><span class="skeleton">&nbsp;</span></div>
+            <div class="kpi-meta">total cost (USD)</div>
+          </div>
+        </div>
+        <div class="quality-panel">
+          <h3 class="panel-title">By Agent</h3>
+          <table class="token-table" id="token-agent-table">
+            <thead>
+              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
+            </thead>
+            <tbody id="token-agent-tbody"></tbody>
+          </table>
+          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
+        </div>
+        <div class="token-trends-section">
+          <div class="token-trends-toggles" role="group" aria-label="Token series">
+            <button class="token-series-btn active" data-token-series="input" type="button">Input</button>
+            <button class="token-series-btn" data-token-series="output" type="button">Output</button>
+            <button class="token-series-btn" data-token-series="total" type="button">Total</button>
+            <button class="token-series-btn" data-token-series="all" type="button">All</button>
+          </div>
+          <div class="chart-container token-trends-chart-container">
+            <canvas id="token-trends-chart" aria-label="Token usage trends chart"></canvas>
+          </div>
+        </div>
+      </section>`;
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -216,55 +278,7 @@ export function renderDashboardPage(opts: DashboardPageOptions): string {
         </div>
       </section>
 
-      <!-- Token Usage -->
-      <section class="section" aria-label="Token usage">
-        <div class="section-header">
-          <h2 class="section-title">Token Usage</h2>
-        </div>
-        <div class="token-kpi-row">
-          <div class="kpi-card" data-metric="token-input">
-            <div class="kpi-label">Input Tokens</div>
-            <div class="kpi-value" id="token-input"><span class="skeleton">&nbsp;</span></div>
-            <div class="kpi-meta">total input tokens</div>
-          </div>
-          <div class="kpi-card" data-metric="token-output">
-            <div class="kpi-label">Output Tokens</div>
-            <div class="kpi-value" id="token-output"><span class="skeleton">&nbsp;</span></div>
-            <div class="kpi-meta">total output tokens</div>
-          </div>
-          <div class="kpi-card" data-metric="token-cache">
-            <div class="kpi-label">Cache Tokens</div>
-            <div class="kpi-value" id="token-cache"><span class="skeleton">&nbsp;</span></div>
-            <div class="kpi-meta">cache read + creation</div>
-          </div>
-          <div class="kpi-card" data-metric="token-cost">
-            <div class="kpi-label">Total Cost</div>
-            <div class="kpi-value" id="token-cost"><span class="skeleton">&nbsp;</span></div>
-            <div class="kpi-meta">total cost (USD)</div>
-          </div>
-        </div>
-        <div class="quality-panel">
-          <h3 class="panel-title">By Agent</h3>
-          <table class="token-table" id="token-agent-table">
-            <thead>
-              <tr><th>Agent</th><th>Cron</th><th>DM/Mention</th><th>Total</th><th>Cost ($)</th></tr>
-            </thead>
-            <tbody id="token-agent-tbody"></tbody>
-          </table>
-          <p id="token-agent-empty" class="empty-state" style="display:none">No data</p>
-        </div>
-        <div class="token-trends-section">
-          <div class="token-trends-toggles" role="group" aria-label="Token series">
-            <button class="token-series-btn active" data-token-series="input" type="button">Input</button>
-            <button class="token-series-btn" data-token-series="output" type="button">Output</button>
-            <button class="token-series-btn" data-token-series="total" type="button">Total</button>
-            <button class="token-series-btn" data-token-series="all" type="button">All</button>
-          </div>
-          <div class="chart-container token-trends-chart-container">
-            <canvas id="token-trends-chart" aria-label="Token usage trends chart"></canvas>
-          </div>
-        </div>
-      </section>
+${tokenSection}
 
       <!-- Feature Breakdown -->
       <section class="section features-section" aria-label="Feature breakdown">

--- a/metrics/src/dashboard/dashboard-page.unit.test.ts
+++ b/metrics/src/dashboard/dashboard-page.unit.test.ts
@@ -531,3 +531,37 @@ describe("renderDashboardPage — TK-1.2 token trends chart", () => {
     expect(html).toMatchSnapshot();
   });
 });
+
+describe("renderDashboardPage — PPL-1.2 readOnly variant", () => {
+  const html = renderDashboardPage({
+    userName: "Public",
+    isOwner: false,
+    readOnly: true,
+  });
+
+  test("omits the Token Usage section and by-agent table", () => {
+    expect(html).not.toContain("Token Usage");
+    expect(html).not.toContain('id="token-agent-table"');
+    expect(html).not.toContain('id="token-input"');
+  });
+
+  test("keeps the pipeline KPI cards", () => {
+    expect(html).toContain("Tasks Completed");
+    expect(html).toContain("CI First-Pass Rate");
+    expect(html).toContain("Estimation Accuracy");
+    expect(html).toContain("Review SHIP IT Rate");
+  });
+
+  test("keeps the pipeline metric panels", () => {
+    expect(html).toContain("Pipeline Queue");
+    expect(html).toContain("Pipeline Quality");
+    expect(html).toContain("Feature Breakdown");
+    expect(html).toContain("Trends");
+  });
+
+  test("default (readOnly unset) still renders the Token Usage section", () => {
+    const full = renderDashboardPage(BASE_OPTS);
+    expect(full).toContain("Token Usage");
+    expect(full).toContain('id="token-agent-table"');
+  });
+});

--- a/metrics/src/lib/task-store-client.ts
+++ b/metrics/src/lib/task-store-client.ts
@@ -25,6 +25,8 @@ export interface TaskRecord {
   status: string;
   session?: string | null;
   layer?: string | null;
+  /** Owning repository in `org/repo` form. Used for public-mode repo scoping. */
+  repo?: string | null;
   /** Estimated hours for the task. */
   hours?: number | null;
   complexity?: number | null;
@@ -49,6 +51,8 @@ export interface PrRecord {
   reviewState?: string | null;
   createdAt?: string | null;
   mergedAt?: string | null;
+  /** Owning repository in `org/repo` form. Used for public-mode repo scoping. */
+  repo?: string | null;
 }
 
 // ─── Error type ───────────────────────────────────────────────────────────────
@@ -70,11 +74,13 @@ export interface TaskStoreClient {
     from?: string;
     to?: string;
     status?: string;
+    repo?: string;
   }): Promise<TaskRecord[]>;
   listPrs(params: {
     from?: string;
     to?: string;
     reviewState?: string;
+    repo?: string;
   }): Promise<PrRecord[]>;
 }
 
@@ -94,6 +100,21 @@ export function taskAnchor(t: TaskRecord): string | null {
 /** Pick the timestamp a PR is "anchored" to for window filtering. */
 export function prAnchor(p: PrRecord): string | null {
   return p.mergedAt ?? p.createdAt ?? null;
+}
+
+/**
+ * True when a record belongs to `repo`. When `repo` is undefined the filter is
+ * a no-op (every record matches). Records whose own `repo` is null/absent never
+ * match a non-empty `repo` filter — public scoping must not leak un-attributed
+ * rows. Shared by the live HTTP client and the recorded test double so both
+ * paths scope identically.
+ */
+export function matchesRepo(
+  recordRepo: string | null | undefined,
+  repo: string | undefined,
+): boolean {
+  if (repo === undefined || repo === "") return true;
+  return recordRepo === repo;
 }
 
 /**
@@ -230,23 +251,30 @@ export class HttpTaskStoreClient implements TaskStoreClient {
     from?: string;
     to?: string;
     status?: string;
+    repo?: string;
   }): Promise<TaskRecord[]> {
-    // `from`/`to` are ignored by the live route — only `status` narrows server
-    // side; the date window is applied client-side below.
+    // `from`/`to`/`repo` are ignored by the live route — only `status` narrows
+    // server side; the date window and repo scope are applied client-side below.
     const tasks = await this.fetchAllPages<TaskRecord>("/tasks", "tasks", {
       status: params.status,
     });
-    return tasks.filter((t) => inWindow(taskAnchor(t), params));
+    return tasks.filter(
+      (t) =>
+        matchesRepo(t.repo, params.repo) && inWindow(taskAnchor(t), params),
+    );
   }
 
   async listPrs(params: {
     from?: string;
     to?: string;
     reviewState?: string;
+    repo?: string;
   }): Promise<PrRecord[]> {
     const prs = await this.fetchAllPages<PrRecord>("/prs", "prs", {
       reviewState: params.reviewState,
     });
-    return prs.filter((p) => inWindow(prAnchor(p), params));
+    return prs.filter(
+      (p) => matchesRepo(p.repo, params.repo) && inWindow(prAnchor(p), params),
+    );
   }
 }

--- a/metrics/src/lib/task-store-client.unit.test.ts
+++ b/metrics/src/lib/task-store-client.unit.test.ts
@@ -77,8 +77,16 @@ describe("HttpTaskStoreClient client-side window filtering", () => {
   test("listTasks drops tasks whose anchor is outside [from,to]", async () => {
     const tasks: TaskRecord[] = [
       { id: "IN-1", status: "merged", completedAt: "2026-06-05T00:00:00.000Z" },
-      { id: "OUT-EARLY", status: "merged", completedAt: "2026-05-01T00:00:00.000Z" },
-      { id: "OUT-LATE", status: "merged", completedAt: "2026-08-01T00:00:00.000Z" },
+      {
+        id: "OUT-EARLY",
+        status: "merged",
+        completedAt: "2026-05-01T00:00:00.000Z",
+      },
+      {
+        id: "OUT-LATE",
+        status: "merged",
+        completedAt: "2026-08-01T00:00:00.000Z",
+      },
     ];
     const { fetch } = pagingFetch("tasks", tasks);
     const client = new HttpTaskStoreClient("http://store", "tok", fetch);
@@ -92,9 +100,21 @@ describe("HttpTaskStoreClient client-side window filtering", () => {
 
   test("listPrs filters on mergedAt anchor, falling back to createdAt", async () => {
     const prs: PrRecord[] = [
-      { id: "merged-in", reviewState: "approved", mergedAt: "2026-06-10T00:00:00.000Z" },
-      { id: "created-in", reviewState: "posted", createdAt: "2026-06-12T00:00:00.000Z" },
-      { id: "out", reviewState: "approved", mergedAt: "2026-05-01T00:00:00.000Z" },
+      {
+        id: "merged-in",
+        reviewState: "approved",
+        mergedAt: "2026-06-10T00:00:00.000Z",
+      },
+      {
+        id: "created-in",
+        reviewState: "posted",
+        createdAt: "2026-06-12T00:00:00.000Z",
+      },
+      {
+        id: "out",
+        reviewState: "approved",
+        mergedAt: "2026-05-01T00:00:00.000Z",
+      },
     ];
     const { fetch } = pagingFetch("prs", prs);
     const client = new HttpTaskStoreClient("http://store", "tok", fetch);
@@ -105,7 +125,11 @@ describe("HttpTaskStoreClient client-side window filtering", () => {
 
   test("an open window (no from/to) keeps all rows", async () => {
     const tasks: TaskRecord[] = [
-      { id: "anchored", status: "merged", completedAt: "2020-01-01T00:00:00.000Z" },
+      {
+        id: "anchored",
+        status: "merged",
+        completedAt: "2020-01-01T00:00:00.000Z",
+      },
       { id: "no-anchor", status: "pending" },
     ];
     const { fetch } = pagingFetch("tasks", tasks);
@@ -113,5 +137,58 @@ describe("HttpTaskStoreClient client-side window filtering", () => {
 
     const got = await client.listTasks({});
     expect(got.length).toBe(2);
+  });
+});
+
+describe("HttpTaskStoreClient repo filtering", () => {
+  test("listTasks returns only tasks matching params.repo", async () => {
+    const tasks: TaskRecord[] = [
+      { id: "A-1", status: "merged", repo: "org/alpha" },
+      { id: "B-1", status: "merged", repo: "org/beta" },
+      { id: "A-2", status: "done", repo: "org/alpha" },
+    ];
+    const { fetch } = pagingFetch("tasks", tasks);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    const got = await client.listTasks({ repo: "org/alpha" });
+    expect(got.map((t) => t.id).sort()).toEqual(["A-1", "A-2"]);
+  });
+
+  test("listPrs returns only PRs matching params.repo", async () => {
+    const prs: PrRecord[] = [
+      { id: "pr-a", reviewState: "approved", repo: "org/alpha" },
+      { id: "pr-b", reviewState: "posted", repo: "org/beta" },
+    ];
+    const { fetch } = pagingFetch("prs", prs);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    const got = await client.listPrs({ repo: "org/beta" });
+    expect(got.map((p) => p.id)).toEqual(["pr-b"]);
+  });
+
+  test("no repo param keeps records from every repo", async () => {
+    const tasks: TaskRecord[] = [
+      { id: "A-1", status: "merged", repo: "org/alpha" },
+      { id: "B-1", status: "merged", repo: "org/beta" },
+      { id: "C-1", status: "merged", repo: null },
+    ];
+    const { fetch } = pagingFetch("tasks", tasks);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    const got = await client.listTasks({});
+    expect(got.length).toBe(3);
+  });
+
+  test("repo filter excludes records with a null/absent repo", async () => {
+    const tasks: TaskRecord[] = [
+      { id: "A-1", status: "merged", repo: "org/alpha" },
+      { id: "N-1", status: "merged", repo: null },
+      { id: "N-2", status: "merged" },
+    ];
+    const { fetch } = pagingFetch("tasks", tasks);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    const got = await client.listTasks({ repo: "org/alpha" });
+    expect(got.map((t) => t.id)).toEqual(["A-1"]);
   });
 });

--- a/metrics/src/metrics-provider.ts
+++ b/metrics/src/metrics-provider.ts
@@ -43,7 +43,15 @@ export type MetricQuery =
 
 export type MetricQueryKind = MetricQuery["kind"];
 
-/** Read seam: every backend serves every query kind. */
+/**
+ * Read seam: every backend serves every query kind.
+ *
+ * Repo scoping (public mode, PPL-1.2) is a constructor-level concern, not a
+ * query parameter — a repo-scoped provider is built once (see
+ * TaskStoreProvider's `repo` ctor param) and narrows every read it answers. The
+ * MetricQuery shape is therefore unchanged: handlers stay repo-agnostic and the
+ * same code serves authenticated (all repos) and public (one repo) surfaces.
+ */
 export interface MetricsProvider {
   query(q: MetricQuery): Promise<MetricTable>;
 }

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -297,6 +297,93 @@ describe("TaskStoreProvider (integration)", () => {
     }
   });
 
+  test("repo-scoped provider counts only the target repo's tasks", async () => {
+    // Two repos in the store, both inside the window. A repo-scoped provider
+    // must see only its repo's tasks.
+    const repoTasks: TaskRecord[] = [
+      {
+        id: "RA-1.1",
+        status: "merged",
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        addedAt: "2026-06-01T08:00:00.000Z",
+        ciFixAttempts: 0,
+        repo: "org/alpha",
+      },
+      {
+        id: "RB-1.1",
+        status: "merged",
+        startedAt: "2026-06-03T08:00:00.000Z",
+        completedAt: "2026-06-03T12:00:00.000Z",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        addedAt: "2026-06-02T08:00:00.000Z",
+        ciFixAttempts: 0,
+        repo: "org/beta",
+      },
+    ];
+    const repoPrs: PrRecord[] = [
+      {
+        id: "pr-a",
+        taskId: "RA-1.1",
+        reviewState: "approved",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        repo: "org/alpha",
+      },
+      {
+        id: "pr-b",
+        taskId: "RB-1.1",
+        reviewState: "approved",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        repo: "org/beta",
+      },
+    ];
+    const taskStore = new RecordedTaskStoreClient(repoTasks, repoPrs);
+    const admin = new RecordedAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(
+      taskStore,
+      admin,
+      CLOCK,
+      "org/alpha",
+    );
+
+    const t = await provider.query({ kind: "summary", range: RANGE });
+    const row = t.results[0];
+    expect(row[colIndex(t, "tasks_completed")]).toBe(1);
+    // Only org/alpha's approved PR counts.
+    expect(row[colIndex(t, "reviews_total")]).toBe(1);
+    expect(row[colIndex(t, "reviews_ship_it")]).toBe(1);
+  });
+
+  test("unscoped provider counts both repos' tasks", async () => {
+    const repoTasks: TaskRecord[] = [
+      {
+        id: "RA-1.1",
+        status: "merged",
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        addedAt: "2026-06-01T08:00:00.000Z",
+        repo: "org/alpha",
+      },
+      {
+        id: "RB-1.1",
+        status: "merged",
+        startedAt: "2026-06-03T08:00:00.000Z",
+        completedAt: "2026-06-03T12:00:00.000Z",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        addedAt: "2026-06-02T08:00:00.000Z",
+        repo: "org/beta",
+      },
+    ];
+    const taskStore = new RecordedTaskStoreClient(repoTasks, []);
+    const admin = new RecordedAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "summary", range: RANGE });
+    expect(t.results[0][colIndex(t, "tasks_completed")]).toBe(2);
+  });
+
   test("tokensBySessionType yields a cron row and a chat row", async () => {
     const provider = buildProvider();
     const t = await provider.query({

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -137,10 +137,16 @@ function addAggregates(a: TokenAggregate, b: TokenAggregate): TokenAggregate {
 // ─── Provider ─────────────────────────────────────────────────────────────────
 
 export class TaskStoreProvider implements MetricsProvider {
+  /**
+   * @param repo - optional `org/repo` scope. When set (public mode), every
+   *   task/PR read is filtered to this repo. When omitted, all repos are
+   *   included (the authenticated default).
+   */
   constructor(
     private readonly taskStore: TaskStoreClient,
     private readonly admin: AdminMetricsClient,
     private readonly clock: Clock = SystemClock(),
+    private readonly repo?: string,
   ) {}
 
   async query(q: MetricQuery): Promise<MetricTable> {
@@ -184,11 +190,13 @@ export class TaskStoreProvider implements MetricsProvider {
   // ─ Task reads ─
 
   private tasks(win: { from: string; to: string }): Promise<TaskRecord[]> {
-    return Promise.resolve(this.taskStore.listTasks(win));
+    return Promise.resolve(
+      this.taskStore.listTasks({ ...win, repo: this.repo }),
+    );
   }
 
   private prs(win: { from: string; to: string }): Promise<PrRecord[]> {
-    return Promise.resolve(this.taskStore.listPrs(win));
+    return Promise.resolve(this.taskStore.listPrs({ ...win, repo: this.repo }));
   }
 
   // ─ Summary ─

--- a/metrics/src/providers/task-store-recorded.ts
+++ b/metrics/src/providers/task-store-recorded.ts
@@ -15,12 +15,13 @@ import type {
   CronRunTokenStats,
 } from "../lib/admin-metrics-client.ts";
 import {
-  inWindow,
   type PrRecord,
-  prAnchor,
   type TaskRecord,
-  taskAnchor,
   type TaskStoreClient,
+  inWindow,
+  matchesRepo,
+  prAnchor,
+  taskAnchor,
 } from "../lib/task-store-client.ts";
 
 // ─── Task store double ────────────────────────────────────────────────────────
@@ -40,9 +41,11 @@ export class RecordedTaskStoreClient implements TaskStoreClient {
     from?: string;
     to?: string;
     status?: string;
+    repo?: string;
   }): Promise<TaskRecord[]> {
     return this.tasks.filter((t) => {
       if (params.status && t.status !== params.status) return false;
+      if (!matchesRepo(t.repo, params.repo)) return false;
       return inWindow(taskAnchor(t), params);
     });
   }
@@ -51,10 +54,12 @@ export class RecordedTaskStoreClient implements TaskStoreClient {
     from?: string;
     to?: string;
     reviewState?: string;
+    repo?: string;
   }): Promise<PrRecord[]> {
     return this.prs.filter((p) => {
       if (params.reviewState && p.reviewState !== params.reviewState)
         return false;
+      if (!matchesRepo(p.repo, params.repo)) return false;
       return inWindow(prAnchor(p), params);
     });
   }

--- a/metrics/src/server.ts
+++ b/metrics/src/server.ts
@@ -22,14 +22,23 @@
  */
 
 import { Hono } from "hono";
-import { createMetricsApp } from "./api.ts";
+import { createMetricsApp, createPublicMetricsApp } from "./api.ts";
 import type { MetricsDeps } from "./api.ts";
 import { HttpAccountsClient } from "./lib/accounts-client.ts";
 import { parseApiKeys } from "./lib/api-auth.ts";
-import { loadEnv } from "./lib/env.ts";
+import {
+  getPublicMode,
+  getPublicRepo,
+  loadEnv,
+  validatePublicModeEnv,
+} from "./lib/env.ts";
+import type { MetricsProvider } from "./metrics-provider.ts";
 import { selectProviderMode } from "./select-provider.ts";
 
 loadEnv();
+
+// Fail fast if PUBLIC_MODE=true but PUBLIC_REPO is unset.
+validatePublicModeEnv();
 
 const mode = selectProviderMode(process.env);
 
@@ -57,6 +66,11 @@ const accountsClient = new HttpAccountsClient(
 
 let deps: MetricsDeps;
 
+// In public mode this holds a repo-scoped provider that backs the unauthenticated
+// /public/* surface. Built alongside the authenticated provider so it reuses the
+// same upstream clients (task-store + admin) with the configured repo injected.
+let publicProvider: MetricsProvider | undefined;
+
 if (mode === "fixtures") {
   const { createFixtureTaskStoreProvider } = await import(
     "./fixtures/task-store-fixtures.ts"
@@ -68,6 +82,11 @@ if (mode === "fixtures") {
     offlineMode: true,
     basePath,
   };
+  // Fixtures carry no repo attribution, so a repo filter would empty the table.
+  // Offline public mode reuses the unscoped fixture provider for a live preview.
+  if (getPublicMode()) {
+    publicProvider = createFixtureTaskStoreProvider();
+  }
   console.log("[metrics-api] Running in OFFLINE mode — fixture data injected");
 } else {
   // mode === "taskstore"
@@ -103,6 +122,15 @@ if (mode === "fixtures") {
     dashboardDevAuth,
     basePath,
   };
+  // Repo-scoped provider for the public surface (same clients, repo injected).
+  if (getPublicMode()) {
+    publicProvider = new TaskStoreProvider(
+      taskStoreClient,
+      adminMetricsClient,
+      undefined,
+      getPublicRepo(),
+    );
+  }
   console.log(
     "[metrics-api] Running in TASKSTORE mode — TaskStoreProvider over task-store + admin APIs",
   );
@@ -113,6 +141,17 @@ const metricsApp = createMetricsApp(
   accountsClient,
   deps,
 );
+
+// Public mode: mount the unauthenticated, repo-scoped /public/* surface at the
+// same root. Routes are pathed under /public/* so they never collide with the
+// authenticated /metrics/* + /dashboard routes.
+if (getPublicMode() && publicProvider) {
+  const publicApp = createPublicMetricsApp(publicProvider, basePath);
+  metricsApp.route("/", publicApp);
+  console.log(
+    `[metrics-api] PUBLIC mode enabled — /public/* scoped to repo "${getPublicRepo()}"`,
+  );
+}
 
 // OpenAPI doc for standalone mode
 metricsApp.openAPIRegistry.registerComponent("securitySchemes", "bearerAuth", {


### PR DESCRIPTION
## Summary
- Adds `repo` scoping to `TaskStoreClient` and `TaskStoreProvider` so a provider instance can be locked to a single repo (public mode)
- Introduces `createPublicMetricsApp()` — an unauthenticated, repo-scoped sub-app serving `GET /public/metrics/{summary,trends,features,queue}` with `{kind:"public"}` policy; `/public/metrics/tokens` returns 404; no mutation routes
- Adds `readOnly` mode to `DashboardPageOptions` (hides token-usage section); wires public sub-app in `server.ts` when `SHIPWRIGHT_METRICS_PUBLIC_MODE=true`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Unauth GET /public/metrics/{summary,trends,features,queue} → 200, repo-scoped | ✅ MET |
| 2 | Unauth GET /public/metrics/tokens → 404 | ✅ MET |
| 3 | POST/PUT/DELETE /public/* → 404 or 405 | ✅ MET |
| 4 | Two-repo fixture — only target repo's data returned | ✅ MET |
| 5 | Read-only dashboard omits token-usage section | ✅ MET |
| 6 | Smoke + unit + integration tests; no mock.module()/global.* | ✅ MET |

## Test Plan
- [x] `api.public.smoke.test.ts` (new): 200-unauth on all 4 read routes, 404-tokens, 404/405-mutations, read-only dashboard render
- [x] `task-store-client.unit.test.ts`: repo filter — match, exclude, null/absent exclusion, no-filter passthrough
- [x] `task-store-provider.integration.test.ts`: two-repo recorded fixture — scoped provider returns only target repo; unscoped returns both
- [x] `dashboard-page.unit.test.ts` (new): read-only variant omits token section, retains pipeline KPIs + panels
- [x] 232 tests pass, 0 fail; biome lint clean; all workspace typechecks pass

Generated with [Claude Code](https://claude.com/claude-code)
