### PR TITLE
feat: author Getting Started and Introduction MDX content (SD-4.1)

### DIFF
--- a/site/src/content/docs/deploying-to-cloud.mdx
+++ b/site/src/content/docs/deploying-to-cloud.mdx
@@ -3,6 +3,7 @@ title: Deploying to Cloud
 description: Deploy Shipwright as an autonomous agent in your cloud infrastructure.
 section: Operations
 order: 3
+prev: "/docs/getting-started"
 ---
 
 # Deploying to Cloud

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -71,7 +71,7 @@ task dev     # start the metrics dashboard at http://localhost:3460/dashboard
 
 Once the dashboard is running, install the plugin inside your Claude Code session:
 
-```bash
+```text
 /plugin install shipwright@app-vitals/shipwright
 ```
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -1,26 +1,88 @@
 ---
 title: Getting Started
-description: Get up and running with Shipwright Harness.
+description: Go from zero to a running local metrics dashboard in a single Claude Code prompt.
 section: Getting Started
 order: 1
+prev: "/docs/introduction"
+next: "/docs/deploying-to-cloud"
 ---
 
 # Getting Started
 
-Welcome to Shipwright Harness — the open-source autonomous delivery agent for Claude Code.
+This guide takes you from zero to a running Shipwright Harness setup — including the local metrics
+dashboard — in a single Claude Code prompt. No cloud account or secrets needed.
 
 ## Prerequisites
 
-Before you begin, make sure you have Claude Code installed and configured.
+Make sure you have these tools installed before you begin:
 
-## Install the plugin
+- **Claude Code** — the AI coding assistant this plugin runs inside
+- **git** — to clone the repository
+- **Bun** — the JavaScript runtime used by all Shipwright services
+- **go-task** (`task`) — the task runner used for local dev commands
 
-Install the Shipwright plugin into your Claude Code workspace:
+## The one-prompt setup
+
+Paste this into Claude Code and it will handle the rest:
+
+```text
+Set up Shipwright Harness locally and open the metrics dashboard.
+1. In a terminal, run: git clone https://github.com/app-vitals/shipwright.git && cd shipwright && ./scripts/quickstart.sh
+2. Inside this Claude Code session, install the plugin: /plugin install shipwright@app-vitals/shipwright
+3. Open the dashboard in your browser: http://localhost:3460/dashboard
+```
+
+That's it. Claude Code will run the commands, install the plugin, and let you know when the dashboard
+is ready.
+
+## What the setup does
+
+When you run the one-prompt setup, three things happen in sequence:
+
+1. **Clone and quickstart** — `scripts/quickstart.sh` checks your prerequisites, runs `task setup`
+   (installs all workspace dependencies), then starts the dev server with `task dev`. The metrics
+   dashboard launches at `http://localhost:3460/dashboard` in offline fixtures mode — no secrets
+   required.
+
+2. **Plugin install** — `/plugin install shipwright@app-vitals/shipwright` loads the Shipwright
+   plugin into your Claude Code session. The plugin provides the full delivery-loop commands:
+   `/shipwright:plan-session`, `/shipwright:dev-task`, `/shipwright:review`, and
+   `/shipwright:deploy`.
+
+3. **Dashboard** — the metrics dashboard shows cycle time, first-time-quality, and task throughput.
+   In fixtures mode it loads sample data so you can explore the UI immediately.
+
+## Manual setup
+
+If you prefer to run the steps yourself:
+
+```bash
+git clone https://github.com/app-vitals/shipwright.git
+cd shipwright
+./scripts/quickstart.sh
+```
+
+The quickstart script runs the following commands internally:
+
+```bash
+task setup   # install all workspace dependencies
+task dev     # start the metrics dashboard at http://localhost:3460/dashboard
+```
+
+Once the dashboard is running, install the plugin inside your Claude Code session:
 
 ```bash
 /plugin install shipwright@app-vitals/shipwright
 ```
 
+The dashboard will be available at `http://localhost:3460/dashboard`. It starts in offline mode
+(fixtures), so you can explore without configuring any external services.
+
 ## Next steps
 
-Once installed, configure Shipwright to point at your task store. See the configuration reference for the full details.
+Once you have the local setup running, you can:
+
+- **Point at a real repository** — open any repo in Claude Code and use `/shipwright:plan-session`
+  to generate a task queue from your product spec.
+- **Deploy to cloud** — run Shipwright as an always-on autonomous agent. See
+  [Deploying to Cloud](/docs/deploying-to-cloud) for the full container setup.

--- a/site/src/content/docs/introduction.mdx
+++ b/site/src/content/docs/introduction.mdx
@@ -1,27 +1,69 @@
 ---
 title: Introduction
-description: Understand Shipwright Harness and how it automates your delivery pipeline.
+description: What Shipwright Harness is and how the four-artifact A→B→C→D architecture fits together.
 section: Getting Started
 order: 0
+next: "/docs/getting-started"
 ---
 
 # Introduction
 
-Shipwright Harness is the open-source autonomous delivery agent for Claude Code — a system that plans, builds, reviews, and ships code automatically.
+Shipwright Harness is the open-source autonomous delivery agent for Claude Code. It drives the full
+software delivery loop — **spec → plan → execute → review → deploy** — across any repository, without
+manual hand-offs.
 
-## How it works
+## What is Shipwright Harness?
 
-Shipwright runs on Claude Code as a plugin or deploys to your cloud as an autonomous agent. Either way, it drives the full delivery loop: **spec → plan → build → review → deploy**.
+Shipwright Harness is a Claude Code plugin you install once and use everywhere. It is repo-agnostic:
+it plans, builds, reviews, and ships code against any codebase — Node.js, Go, Rust, Python, Ruby, or
+anything else — using only standard git and a task queue.
 
-## Key concepts
+The core guarantee is that you stay in the loop only where it matters. Shipwright handles the
+mechanical work (writing failing tests, implementing code, opening PRs, watching CI) and surfaces
+decisions that require human judgment.
 
-- **Repo-agnostic**: Runs against any repository (Node, Go, Rust, Python, Ruby, etc.)
-- **Test-first**: Writes failing tests before implementation
-- **Autonomous**: Builds, reviews, and ships with you in the loop only where it counts
-- **Measured**: Tracks first-time-quality, cycle time, and accuracy
+Install the plugin into your Claude Code workspace once:
+
+```bash
+/plugin install shipwright@app-vitals/shipwright
+```
+
+It ships as four artifacts — built and activated in sequence — so you can adopt as much or as little
+as you need.
+
+## How it works — A → B → C → D
+
+Each artifact is independently useful and adds capability when combined with the next:
+
+| Phase | Artifact | What it is |
+|-------|----------|------------|
+| **A** | **Plugin** (`plugins/shipwright/`) | Claude Code plugin covering the full delivery loop. Install with `/plugin install shipwright`. Repo-agnostic. |
+| **B** | **Metrics dashboard** (`metrics/`) | Hono service with backend-agnostic JSON endpoints and a server-rendered dashboard. Two modes: fixtures (offline) or live task store. |
+| **C** | **Shipwright agent** (`agent/`) | Thin autonomous runner: pick next ready task → build → ship PR → forward metrics. Deploys to any container host. |
+| **D** | **Task store service** (`task-store/`) | Postgres-backed task queue, PR tracking, and scoped access tokens. Replaces the local JSON fallback when you go to production. |
+
+You can stop at A (the plugin alone is fully functional), add B to get local metrics, add C to run
+hands-off in the cloud, and add D when you want a durable, multi-agent task queue.
+
+## Design principles
+
+**Local-first.** Every artifact runs offline by default. The metrics dashboard serves fixtures with no
+secrets needed. The plugin works against any local git repo. No cloud account required to get started.
+
+**Repo-agnostic.** The plugin carries no opinions about your stack. It reads your test command from
+context and adapts. It never hard-codes paths, frameworks, or CI providers.
+
+**No new coupling.** Each artifact draws a clean boundary. The plugin does not import the agent. The
+metrics service has no database. The task store has no UI. Boundaries are enforced by the build — not
+by convention.
+
+**Test-first.** Shipwright writes failing tests before implementation code, every time. This is
+enforced by the plugin's execution loop, not by a linter.
 
 ## Next steps
 
-Ready to try it? Head to [Getting Started](/docs/getting-started) to install the plugin.
+Ready to try it? [Get started with the local setup](/docs/getting-started) — you can go from zero to
+a running metrics dashboard in a single Claude Code prompt.
 
-Want to run it in your cloud? See [Deploying to Cloud](/docs/deploying-to-cloud) for the full setup.
+Want to run it as a 24/7 autonomous agent? See [Deploying to Cloud](/docs/deploying-to-cloud) for the
+full container deployment guide.

--- a/site/tests/docs-platform.spec.ts
+++ b/site/tests/docs-platform.spec.ts
@@ -80,3 +80,55 @@ test("fenced code block is present in getting-started page", async ({
   const codeBlock = page.locator("pre code");
   await expect(codeBlock.first()).toBeVisible();
 });
+
+// Introduction page tests (SD-4.1)
+
+test("GET /docs/introduction returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/introduction");
+  expect(response?.status()).toBe(200);
+});
+
+test("fenced code block is present in introduction page", async ({ page }) => {
+  await page.goto("/docs/introduction");
+  const codeBlock = page.locator("pre code");
+  await expect(codeBlock.first()).toBeVisible();
+});
+
+test("key headings visible in introduction page", async ({ page }) => {
+  await page.goto("/docs/introduction");
+  // At least one h2 heading must be present
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+});
+
+test("key headings visible in getting-started page", async ({ page }) => {
+  await page.goto("/docs/getting-started");
+  // Prerequisites or Getting Started h2 must be present
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+  // Specifically check for Prerequisites heading
+  const prerequisites = page.locator("h2", { hasText: /prerequisites/i });
+  await expect(prerequisites).toBeVisible();
+});
+
+test("prev/next navigation links are present on getting-started page", async ({
+  page,
+}) => {
+  await page.goto("/docs/getting-started");
+  // Should have a prev link back to introduction
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  const href = await prevLink.getAttribute("href");
+  expect(href).toBe("/docs/introduction");
+});
+
+test("prev/next navigation links are present on introduction page", async ({
+  page,
+}) => {
+  await page.goto("/docs/introduction");
+  // Should have a next link to getting-started
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toBeVisible();
+  const href = await nextLink.getAttribute("href");
+  expect(href).toBe("/docs/getting-started");
+});


### PR DESCRIPTION
## Summary

- Replaces stub `getting-started.mdx` with full first-time-user content: one-prompt Claude Code setup, manual fallback, prerequisites, and next-steps
- Replaces stub `introduction.mdx` with full evaluator-facing content: what Shipwright Harness is, A→B→C→D architecture table, and design principles
- Closes the nav chain: adds `prev`/`next` frontmatter on all three Getting Started section pages

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Getting Started: clone → dashboard with copy-paste Claude Code prompt as primary flow | ✅ MET |
| 2 | Introduction: what Shipwright Harness is + four-artifact A→B→C→D architecture | ✅ MET |
| 3 | Both pages pass `npm run build:check` and `task check-strings` | ✅ MET |
| 4 | `prev`/`next` frontmatter set correctly; no dead-end navigation | ✅ MET |
| 5 | e2e: key headings visible + fenced code block on each page | ✅ MET |

## Test Plan

- `cd site && npm run build:check` — all 7 pages built cleanly, brand-lint passed
- `task check-strings` — no banned strings found
- 6 new Playwright assertions added to `site/tests/docs-platform.spec.ts`: 200 response for `/docs/introduction`, code block on introduction page, h2 headings on both pages, `prev`/`next` nav links with correct hrefs
- `data-nav="prev"/"next"` attributes on DocsLayout links confirmed — selector tests are correct

Generated with [Claude Code](https://claude.com/claude-code)
