### PR TITLE
feat(docs): author remaining 5 MDX content sections (SD-4.2)

### DIFF
--- a/site/src/content/docs/deploying-to-cloud.mdx
+++ b/site/src/content/docs/deploying-to-cloud.mdx
@@ -1,35 +1,283 @@
 ---
 title: Deploying to Cloud
-description: Deploy Shipwright as an autonomous agent in your cloud infrastructure.
+description: Deploy Shipwright to Kubernetes with the official Helm chart — Minikube, GKE (Gateway API), and EKS (ALB) targets covered end to end.
 section: Operations
-order: 3
-prev: "/docs/getting-started"
+order: 0
+prev: "/docs/the-agent"
+next: "/docs/slack-integration"
 ---
 
 # Deploying to Cloud
 
-Run Shipwright as an autonomous agent in your cloud. The agent picks up ready work from your task store, builds it, runs review, and ships PRs — all without manual intervention.
+Run Shipwright as a persistent autonomous agent in your cloud. The official Helm chart packages all
+four services (admin, metrics, agent, task-store) with Minikube-friendly defaults and production
+configurations for GKE and EKS.
 
 ## Prerequisites
 
-Before you deploy, ensure you have:
+Ask Claude Code:
 
-- A Kubernetes cluster (Minikube, GKE, EKS, or similar)
-- Docker installed locally (for building the agent image)
-- Access to your git repository
+```text
+Help me deploy Shipwright to Kubernetes using Helm. I'm targeting [Minikube / GKE / EKS].
+```
 
-## Deployment options
+Claude Code will walk through the right prerequisites, values, and install commands for your target.
 
-Shipwright supports several cloud platforms:
+### What you need
 
-- **Kubernetes**: Deploy using Helm or raw manifests
-- **GKE (Google Cloud)**: Gateway API + cert-manager integration
-- **EKS (AWS)**: ALB (Application Load Balancer) integration
+- **Kubernetes cluster** — Minikube (local), GKE, or EKS
+- **Helm 3** — `brew install helm` / `apt install helm`
+- **kubectl** configured to point at your cluster
 
-## Getting started
+## Networking model
 
-For detailed deployment instructions, refer to the Shipwright documentation on Kubernetes deployment.
+`networking.type` controls how services are exposed. Admin UI/API serves at `/` and the metrics
+dashboard at `/dashboard` on a single host:
+
+| `networking.type` | What renders | Typical target |
+|-------------------|--------------|----------------|
+| `ClusterIP` | Services only; reach via `kubectl port-forward` | Default; any cluster |
+| `NodePort` | NodePort Services | Bare-metal / kind |
+| `LoadBalancer` | LoadBalancer Services | Cloud L4 LB |
+| `ingress` | An `Ingress` routing `/dashboard` → metrics, `/` → admin | Minikube (nginx), EKS (ALB) |
+| `gateway` | A Gateway API `Gateway` + `HTTPRoute`s | GKE (managed L7) |
+
+`ingress` and `gateway` are mutually exclusive — only one is ever rendered.
+
+## Minikube (local)
+
+A quick local deployment over plain HTTP using the Minikube nginx ingress addon. PostgreSQL is
+bundled, so no external database is required.
+
+### Setup
+
+```bash
+minikube start
+minikube addons enable ingress      # installs the nginx ingress controller
+```
+
+### Install
+
+```bash
+helm dependency build charts/shipwright    # resolve the pinned PostgreSQL subchart
+helm install shipwright charts/shipwright \
+  --namespace shipwright --create-namespace \
+  --set networking.type=ingress \
+  --set networking.ingress.className=nginx \
+  --set networking.ingress.host=shipwright.local
+```
+
+Or from the published Helm repo:
+
+```bash
+helm repo add shipwright https://app-vitals.github.io/shipwright
+helm install shipwright shipwright/shipwright \
+  --namespace shipwright --create-namespace \
+  --set networking.type=ingress \
+  --set networking.ingress.className=nginx \
+  --set networking.ingress.host=shipwright.local
+```
+
+### Reach the services
+
+Point the Minikube IP at the local hostname:
+
+```bash
+echo "$(minikube ip) shipwright.local" | sudo tee -a /etc/hosts
+```
+
+Then:
+
+- Admin UI/API: `http://shipwright.local/`
+- Metrics dashboard: `http://shipwright.local/dashboard`
+
+Or skip the ingress and port-forward directly:
+
+```bash
+kubectl port-forward svc/shipwright-admin   3001:3001 -n shipwright
+kubectl port-forward svc/shipwright-metrics 3460:3460 -n shipwright
+```
+
+### Key values
+
+```yaml
+networking:
+  type: ingress
+  ingress:
+    className: nginx
+    host: shipwright.local
+tls:
+  certManager:
+    enabled: false        # Minikube = plain HTTP
+auth:
+  mode: open              # dev auth — no real authentication; local use only
+postgresql:
+  enabled: true           # bundled PostgreSQL (default)
+```
+
+> **Security:** `auth.mode=open` performs no authentication — anyone who can reach the admin
+> service is treated as a logged-in user. Use it only on a local cluster or behind a private
+> network you fully control.
+
+## GKE (Gateway API + cert-manager)
+
+Production deployment on GKE using the managed external L7 load balancer via the Gateway API,
+with TLS issued by cert-manager.
+
+### Prerequisites
+
+- **Gateway API CRDs** (`gateway.networking.k8s.io/v1`) installed — provided by the GKE Gateway
+  API add-on with the `gke-l7-global-external-managed` GatewayClass
+- **cert-manager** installed with a `ClusterIssuer` already created (e.g. `letsencrypt-prod`)
+
+### Install
+
+```bash
+helm install shipwright charts/shipwright \
+  --namespace shipwright --create-namespace \
+  -f charts/shipwright/examples/values-gke-gateway.yaml
+```
+
+### Key values
+
+```yaml
+networking:
+  type: gateway
+  gateway:
+    gatewayClassName: gke-l7-global-external-managed
+    host: shipwright.example.com
+tls:
+  certManager:
+    enabled: true
+    issuerRef:
+      name: letsencrypt-prod
+      kind: ClusterIssuer
+auth:
+  mode: google
+  google:
+    clientId: <your-oauth-client-id>
+    clientSecret: <your-oauth-client-secret>
+    allowedEmails: you@your-domain.example
+```
+
+The chart renders a `Gateway` plus `HTTPRoute`s: an HTTP listener on `:80`, an HTTPS listener on
+`:443` (when TLS is enabled), and an HTTP→HTTPS redirect route. Point your DNS `A`/`AAAA` record
+at the Gateway's external address once provisioned.
+
+- Admin UI/API: `https://shipwright.example.com/`
+- Metrics dashboard: `https://shipwright.example.com/dashboard`
+
+## EKS (ALB ingress + cert-manager)
+
+Production deployment on EKS using the AWS Load Balancer Controller to provision an ALB from the
+chart's `Ingress`, with cert-manager for certificate management.
+
+### Prerequisites
+
+- **AWS Load Balancer Controller** installed — watches `Ingress` objects with
+  `ingressClassName: alb` and provisions an ALB
+- **cert-manager** or AWS Certificate Manager for TLS
+
+### Install
+
+Prefer a values file for the ALB annotations:
+
+```yaml
+networking:
+  type: ingress
+  ingress:
+    className: alb
+    host: shipwright.example.com
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+      alb.ingress.kubernetes.io/certificate-arn: <your-acm-certificate-arn>
+tls:
+  certManager:
+    enabled: false      # TLS is via ALB/ACM annotations on the ingress path
+auth:
+  mode: google
+  google:
+    clientId: <your-oauth-client-id>
+    clientSecret: <your-oauth-client-secret>
+    allowedEmails: you@your-domain.example
+```
+
+```bash
+helm install shipwright charts/shipwright \
+  --namespace shipwright --create-namespace \
+  -f my-values.yaml
+```
+
+Point your DNS record at the ALB's DNS name once provisioned.
+
+- Admin UI/API: `https://shipwright.example.com/`
+- Metrics dashboard: `https://shipwright.example.com/dashboard`
+
+## Agent runtime provisioning
+
+By default the admin service runs in **Noop** mode — creating an agent only writes a database row.
+Set `agent.provisioning.enabled=true` to switch to the **Kubernetes** provisioner:
+
+```yaml
+agent:
+  provisioning:
+    enabled: true
+    namespace: ""          # target namespace for provisioned agent resources
+    image:
+      repository: shipwright-agent
+      tag: ""              # defaults to chart appVersion
+    replicas: 1
+```
+
+When provisioning is enabled, `POST /agents/:id/provision` creates:
+1. A **PersistentVolumeClaim** (persistent agent home storage)
+2. A **Secret** (scoped agent token)
+3. A **Deployment** (agent container)
+
+The chart also renders a `ClusterRole` and `ClusterRoleBinding` granting the admin ServiceAccount
+`create`, `get`, and `delete` on PVCs, Deployments, and Secrets. The PVC is intentionally retained
+on agent deletion for data safety.
+
+Self-hosted agents (`selfHosted: true`) are skipped by the provisioner — they manage their own
+workload.
+
+## Authentication modes
+
+### `auth.mode=open` (default, dev only)
+
+Sets `ADMIN_DEV_AUTH=true`. No real authentication — local use only.
+
+### `auth.mode=google` (production)
+
+Sets `NODE_ENV=production` and enables Google OAuth. Required for any internet-reachable deployment.
+Only emails on `allowedEmails` may sign in.
+
+## Bringing your own PostgreSQL
+
+The bundled PostgreSQL is the Bitnami `postgresql` subchart. To use an external database:
+
+```yaml
+postgresql:
+  enabled: false
+externalDatabase:
+  existingSecret: my-db-secret
+  adminUrlKey: DATABASE_URL_SHIPWRIGHT_ADMIN
+```
+
+For task-store, also supply a separate secret:
+
+```yaml
+taskStore:
+  enabled: true
+  database:
+    existingSecret: my-task-store-db-secret
+```
+
+The task-store database **must be separate** from the admin database.
 
 ## Next steps
 
-Once deployed, configure your task store and set up cron jobs to automate your delivery pipeline.
+With the agent deployed and running in the cloud, connect it to Slack so it can receive tasks via
+DM and mentions. See [Slack Integration](/docs/slack-integration).

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -4,7 +4,7 @@ description: Go from zero to a running local metrics dashboard in a single Claud
 section: Getting Started
 order: 1
 prev: "/docs/introduction"
-next: "/docs/deploying-to-cloud"
+next: "/docs/the-plugin"
 ---
 
 # Getting Started
@@ -84,5 +84,7 @@ Once you have the local setup running, you can:
 
 - **Point at a real repository** — open any repo in Claude Code and use `/shipwright:plan-session`
   to generate a task queue from your product spec.
+- **Explore the plugin** — learn about all the commands, skills, and agents the plugin provides.
+  See [The Plugin](/docs/the-plugin) for the full reference.
 - **Deploy to cloud** — run Shipwright as an always-on autonomous agent. See
   [Deploying to Cloud](/docs/deploying-to-cloud) for the full container setup.

--- a/site/src/content/docs/running-locally.mdx
+++ b/site/src/content/docs/running-locally.mdx
@@ -1,0 +1,133 @@
+---
+title: Running Locally
+description: Spin up the full Shipwright dev stack — metrics dashboard, admin service, task store, and agent — with a single command.
+section: Plugin
+order: 1
+prev: "/docs/the-plugin"
+next: "/docs/the-agent"
+---
+
+# Running Locally
+
+Shipwright has two local run modes: a lightweight metrics-only mode (`task dev`) that requires no
+secrets, and a full six-pane dev stack (`task stack`) that brings up every service together. Both
+are driven by the `task` command runner.
+
+## Option A — Quickstart (recommended for first run)
+
+Ask Claude Code:
+
+```text
+Clone Shipwright, run the quickstart script, install the plugin, and open the dashboard.
+```
+
+Claude Code will run these steps in order:
+
+```bash
+git clone https://github.com/app-vitals/shipwright.git
+cd shipwright
+./scripts/quickstart.sh
+```
+
+Then inside the Claude Code session:
+
+```text
+/plugin install shipwright@app-vitals/shipwright
+```
+
+The dashboard opens at `http://localhost:3460/dashboard` in offline fixtures mode — no secrets
+required.
+
+## Option B — `task dev` (metrics only)
+
+`task dev` is the no-secrets fallback. It starts the metrics dashboard with fixture data and
+supervises child processes so Ctrl-C kills everything cleanly.
+
+Ask Claude Code:
+
+```text
+Start the Shipwright metrics dashboard in offline mode.
+```
+
+Manually:
+
+```bash
+task dev
+```
+
+The dashboard is available at `http://localhost:3460/dashboard`. The dev supervisor starts the
+metrics service with `METRICS_OFFLINE=true` — fixture data is injected automatically; no external
+credentials are required.
+
+## Option C — `task stack` (full dev environment)
+
+`task stack` launches all four Shipwright services in a six-pane tmux session. This is the
+recommended setup when you want to run the agent locally alongside the admin UI and task store.
+
+Ask Claude Code:
+
+```text
+Start the full Shipwright dev stack using task stack.
+```
+
+Manually:
+
+```bash
+task stack
+```
+
+### What `task stack` launches
+
+| Pane | Service | Port | Notes |
+|------|---------|------|-------|
+| metrics | Metrics dashboard | `:3460` | SQLite-backed; `http://localhost:3460/dashboard` |
+| admin | Admin CRUD API + UI | `:3001` | `http://localhost:3001` |
+| task-store | Task store service | `:3002` | Postgres-backed task queue |
+| agent | Shipwright agent (Docker) | `:3000` | Dev `/chat` endpoint enabled |
+| chat | TUI REPL | — | Connects to the agent's `/chat` endpoint |
+| logs | Scratch shell | — | Free pane for manual commands |
+
+Before launching, `task stack` runs `prisma migrate deploy` to ensure the admin service's Postgres
+schema is current.
+
+### Prerequisites for `task stack`
+
+- **tmux** installed (`brew install tmux` / `apt install tmux`)
+- **Docker** running locally
+- **`state/dev-agent.env`** — copy from the example and fill in credentials:
+
+```bash
+cp state/dev-agent.env.example state/dev-agent.env
+# Edit state/dev-agent.env and set one of:
+#   CLAUDE_CODE_OAUTH_TOKEN=<your token>
+#   ANTHROPIC_API_KEY=<your key>
+```
+
+The agent pane reads secrets from `state/dev-agent.env` at runtime — they are never baked into
+the Docker image or printed in the command line.
+
+> If tmux is not installed, `task stack` fails fast and points you at `task dev` as the fallback.
+
+### Stopping the stack
+
+```bash
+tmux kill-session -t shipwright
+```
+
+This stops every pane. `task stack` is additive — it does not affect `task dev` processes.
+
+## Offline mode
+
+To run the metrics service in full offline mode without the full stack:
+
+```bash
+METRICS_OFFLINE=true bun metrics/src/server.ts
+```
+
+When `METRICS_OFFLINE=true`, the service injects an offline `TaskStoreProvider` built from
+recorded fixture cassettes and bypasses session auth on `/dashboard` (serves as "Offline User").
+
+## Next steps
+
+Once the local stack is running, you can explore the agent runtime — how it picks tasks, runs
+cron jobs, and connects to Slack. See [The Agent](/docs/the-agent) for the full runtime reference.

--- a/site/src/content/docs/slack-integration.mdx
+++ b/site/src/content/docs/slack-integration.mdx
@@ -1,0 +1,154 @@
+---
+title: Slack Integration
+description: Connect the Shipwright agent to Slack — Socket Mode setup, DMs, mentions, cron notifications, and voice notes.
+section: Operations
+order: 1
+prev: "/docs/deploying-to-cloud"
+---
+
+# Slack Integration
+
+The Shipwright agent communicates via Slack using the Bolt SDK in Socket Mode — no public HTTP
+endpoint needed. The agent handles DMs, `@mentions`, reactions, file attachments, and voice
+transcription. Cron jobs post their results to a configured Slack channel.
+
+## How it works
+
+The agent connects to Slack via a persistent WebSocket (Socket Mode). Every incoming message
+arrives as a prompt; the agent runs Claude and posts the response back to the same thread.
+
+Messages are prefixed with `[Name]: ` where `Name` is the sender's Slack display name, so the
+agent knows who it's talking to. Cron job results are posted to a configured channel automatically.
+
+## Connecting a Slack app
+
+Ask Claude Code:
+
+```text
+Help me create a Slack app and connect it to the Shipwright agent.
+```
+
+Claude Code will walk through creating the app manifest, provisioning credentials, and setting
+the required environment variables.
+
+{/* TODO: needs human review — The Slack app creation flow (manifest builder, OAuth provisioning
+UI, and the exact steps through api.slack.com) requires hands-on Slack workspace access to verify.
+The steps below reflect the documented buildAgentManifest flow from docs/agent.md; confirm the
+exact UI steps before publishing. */}
+
+### Manual setup
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app **from an app
+   manifest**. The Shipwright admin UI's provisioning flow (`/admin/agents/:id/provision`) can
+   generate a manifest for you automatically.
+
+2. Enable **Socket Mode** in the app settings and generate an app-level token with
+   `connections:write` scope. This becomes `SLACK_APP_TOKEN`.
+
+3. Install the app to your workspace and copy the **Bot User OAuth Token**. This becomes
+   `SLACK_BOT_TOKEN`.
+
+4. Copy the **Signing Secret** from the app's Basic Information page. This becomes
+   `SLACK_SIGNING_SECRET`.
+
+5. Set the three required environment variables on the agent (via the admin UI or the
+   `/agents/:id/envs` API):
+
+```bash
+SLACK_BOT_TOKEN=xoxb-...        # Bot User OAuth Token
+SLACK_APP_TOKEN=xapp-...        # App-level token (Socket Mode)
+SLACK_SIGNING_SECRET=...        # Signing secret from Basic Information
+```
+
+6. Restart the agent. It connects to Slack via Socket Mode on startup.
+
+## Required Slack environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SLACK_BOT_TOKEN` | yes | Slack bot user OAuth token (`xoxb-...`) |
+| `SLACK_APP_TOKEN` | yes | Slack app-level token for Socket Mode (`xapp-...`) |
+| `SLACK_SIGNING_SECRET` | yes | Verifies incoming Slack request signatures |
+| `SLACK_ADMIN_TOKEN` | no | Optional admin-level token for privileged Slack operations |
+| `SLACK_ALERT_CHANNEL` | no | Channel ID to post system alerts (e.g. startup errors) |
+| `SLACK_OWNER_USER` | no | Slack user ID of the agent owner, used for DM fallback |
+
+## Interacting with the agent
+
+### Direct messages
+
+Send the agent a DM to start a private conversation. The agent replies in the same thread. Each
+session maintains conversation continuity — successive messages in a thread resume the same Claude
+conversation.
+
+```
+@Shipwright What's the status of the current task queue?
+```
+
+### Mentions
+
+Mention the agent in any channel where it has been invited:
+
+```
+@Shipwright run /shipwright:dev-task
+```
+
+The agent picks up the mention and responds in a thread on the same message.
+
+### Reactions
+
+The agent can also respond to `reaction_added` events. This is useful for triggering workflows
+from a thumbs-up or a custom emoji without sending a message.
+
+### Voice notes
+
+Voice notes arrive pre-transcribed by Whisper STT as `[voice transcript: <text>]` in the prompt.
+The agent replies with a `[speak:text]` marker to deliver a spoken response — conversational,
+no bullet points, one to three sentences.
+
+Voice support requires `agent.voice.enabled=true` in the Helm chart (see
+[Deploying to Cloud](/docs/deploying-to-cloud)) or a `WHISPER_SERVICE_URL` / `GROQ_API_KEY` in
+the agent environment.
+
+## Response markers
+
+The agent embeds markers in its responses to trigger side effects. Markers are stripped from the
+visible message before posting:
+
+| Marker | Effect |
+|--------|--------|
+| `[silent]` | Skip posting entirely (useful for cron jobs with nothing to report) |
+| `[upload:/path/to/file]` | Attach a file to the message |
+| `[react:emoji1,emoji2]` | Add emoji reactions to the agent's reply |
+| `[speak:text]` | Synthesize speech and upload as audio |
+| `[plan:url]` | Post a plan link to the rendered planning artifact |
+
+## Cron job notifications
+
+Cron jobs are scheduled prompts that run on a recurring schedule and post results to Slack. Most
+crons are `silent` by default — they only post when there is something worth surfacing (a completed
+PR, a failing check, or an error).
+
+The `channel` field on a cron job controls where results are posted. When `user` is set instead of
+`channel`, results are posted as a DM to that user.
+
+To configure which channel receives cron results, set the `channel` on each cron job via the admin
+UI or the `/agents/:id/crons/:cronId` API, or set `SLACK_ALERT_CHANNEL` as the global fallback for
+system alerts.
+
+## Message format
+
+Incoming Slack messages always arrive with the sender's Slack display name prepended:
+
+```
+[Alice]: Please review the latest PR on the metrics service.
+```
+
+The agent uses this prefix to know who is making the request, which is especially useful in
+channels where multiple people may be interacting with the same agent.
+
+## Next steps
+
+With Slack connected, the agent is fully operational as a 24/7 autonomous delivery system.
+Enable the opt-in cron jobs from the admin UI to automate review, patching, deployment, and
+maintenance — see [The Agent](/docs/the-agent) for the full cron reference.

--- a/site/src/content/docs/the-agent.mdx
+++ b/site/src/content/docs/the-agent.mdx
@@ -1,0 +1,148 @@
+---
+title: The Agent
+description: The Shipwright agent runtime — autonomous task runner, admin CRUD API, cron jobs, and the eight-model Prisma data store.
+section: Agent
+order: 0
+prev: "/docs/running-locally"
+next: "/docs/deploying-to-cloud"
+---
+
+# The Agent
+
+The Shipwright agent (artifact **C**) is a thin autonomous runner: it picks the next ready task
+from the queue, builds it, ships a PR, and forwards metrics — all without manual intervention.
+It has a Prisma-backed PostgreSQL store and four HTTP surfaces: a machine-polled runtime API,
+a human-facing admin CRUD API, a server-rendered admin UI, and a public read-only task board.
+
+## Run modes
+
+There are three ways to run the agent depending on your context:
+
+| Mode | Entry point | Transport | When to use |
+|------|-------------|-----------|-------------|
+| Pi / bare-metal | `agent/src/index.ts` | Slack Socket Mode | Running directly on a host with a local `.env` file |
+| K8s container | `agent/src/entrypoint-main.ts` | Slack Socket Mode | Deployed via the Dockerfile (validates vars, fetches config, installs plugins, spawns runner) |
+| Local dev | `agent/scripts/run-agent.ts --agent-id <id>` | HTTP `POST /chat` | Testing Claude locally without a Slack workspace; requires `SHIPWRIGHT_DEV_CHAT=true` |
+
+The Dockerfile `ENTRYPOINT` is `bun run admin/src/main.ts`, which runs migrations, constructs all
+services, and mounts all admin and runtime routes. The agent process
+(`agent/src/entrypoint-main.ts`) starts the health server in-process on `SHIPWRIGHT_HEALTH_PORT`
+(default `3459`) before the startup sequence so Kubernetes liveness probes are reachable during init.
+
+## Running the agent locally
+
+Ask Claude Code:
+
+```text
+Start the Shipwright agent locally in dev mode so I can test it via the chat REPL.
+```
+
+Manually:
+
+```bash
+export DATABASE_URL_SHIPWRIGHT_ADMIN="postgresql://user:password@localhost:5432/shipwright_admin"
+task db:provision          # prisma migrate deploy (idempotent)
+SHIPWRIGHT_DEV_CHAT=true bun agent/src/entrypoint-main.ts
+```
+
+Then in a second terminal:
+
+```bash
+bun scripts/chat.ts        # TUI REPL connects to the dev /chat endpoint
+```
+
+## Admin CRUD API
+
+The admin CRUD API is the human-facing control plane for agents. It is mounted at `/agents/*`.
+
+Auth is checked in this order: env API keys (`SHIPWRIGHT_ADMIN_API_KEYS`), then per-agent DB
+bearer tokens, then session cookies. Admin keys bypass all per-agent checks; scoped bearer tokens
+are restricted to their own agent ID.
+
+| Resource | Endpoints |
+|----------|-----------|
+| Agents | `POST /agents`, `GET /agents`, `GET /agents/:id`, `PATCH /agents/:id`, `POST /agents/:id/provision` |
+| Envs | `POST` / `GET` / `PATCH` `/agents/:id/envs`, `DELETE /agents/:id/envs/:key` |
+| Crons | `POST` `/agents/:id/crons`, `PATCH` / `DELETE` `/agents/:id/crons/:cronId`, `POST /agents/:id/crons/reconcile` |
+| Tools | `POST` / `GET` `/agents/:id/tools`, `PATCH` / `DELETE` `/agents/:id/tools/:toolId` |
+| Tokens | `POST` / `GET` `/agents/:id/tokens`, `DELETE /agents/:id/tokens/:tokenId` |
+| Plugins | `POST` / `GET` / `PATCH` `/agents/:id/plugins`, `DELETE /agents/:id/plugins` |
+
+Token creation returns the raw token once at creation. Only its SHA-256 hash is persisted — token
+validation is an O(1) hash-index lookup with no plaintext at rest.
+
+## Data model
+
+The agent store uses eight Prisma models on a dedicated database (`DATABASE_URL_SHIPWRIGHT_ADMIN`):
+
+| Model | What it owns |
+|-------|-------------|
+| `Agent` | Runner identity — `name`, `slackId`, `selfHosted`, `repos`, encrypted `slackBotToken` / `anthropicApiKey` |
+| `AgentEnv` | Key/value env store — `key`, `value` (AES-256-GCM encrypted); unique per `[agentId, key]` |
+| `AgentCronJob` | Scheduled prompts — `schedule`, `prompt`, `channel` or `user`, `silent`, `enabled`, `preCheck` |
+| `AgentCronRun` | Cron execution history — `startedAt`, `completedAt`, `outcome`, `inputTokens`, `outputTokens`, `costUsd`, `model` |
+| `AgentTool` | Allowed tool patterns — `pattern` (e.g. `Read`, `Bash`), `enabled` |
+| `AgentToken` | Scoped API tokens — `token` (SHA-256 hash), `label`, `revokedAt` |
+| `AgentPlugin` | Installed Claude Code plugins — `name`, `version`, `enabled` |
+| `AgentMember` | Authorized human members — `email`; unique per `[agentId, email]` |
+
+All child models cascade-delete with their parent `Agent`.
+
+Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer.
+Set `SHIPWRIGHT_ENCRYPTION_KEY` to a 64-char hex string (32 bytes) in any real deployment — if
+unset, secrets are stored in plain text with a logged warning.
+
+## Default system crons
+
+Every new agent is seeded with ten system crons. Two are enabled by default; the rest are opt-in
+and can be toggled in the admin UI or via `PATCH /agents/:id/crons/:cronId`.
+
+| Cron | Schedule | Default | What it does |
+|------|----------|---------|--------------|
+| `shipwright-dev-task` | every 30 min | **on** | Pick next ready task, build with tests, open PR |
+| `shipwright-review-patch` | every 30 min | **on** | Review open PRs and patch those failing CI or review |
+| `shipwright-review` | every 30 min | off | Review-only pass over open PRs |
+| `shipwright-patch` | every 30 min | off | Fix failing CI and unresolved review findings |
+| `shipwright-deploy` | every 30 min | off | Merge approved PRs and deploy |
+| `shipwright-test-readiness` | daily 06:00 | off | Full test-readiness audit |
+| `shipwright-docs-freshness` | daily 07:00 | off | Refresh docs that drifted from the code |
+| `learn-dream` | daily 03:00 | off | Mine merged PRs for durable learnings |
+| `dependabot-triage` | daily 08:00 | off | Review and triage open Dependabot PRs |
+| `entropy-patrol-maintenance` | weekly Mon 04:00 | off | Scan for code entropy and fix what's PR-worthy |
+
+Crons run `silent` by default — they post to Slack only when there is a result worth surfacing or
+on error. Most carry a `preCheck` script whose stdout becomes the actual prompt, so a cron only
+spends a Claude turn when there is real work ready.
+
+## Required environment variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `DATABASE_URL_SHIPWRIGHT_ADMIN` | always | Postgres connection string for the admin service |
+| `SHIPWRIGHT_AGENT_ID` | entrypoint | The agent's ID in the platform |
+| `SHIPWRIGHT_API_URL` | entrypoint | Base URL of the admin API for config fetch at startup |
+| `SHIPWRIGHT_AGENT_API_KEY` | entrypoint | Bearer token for the config fetch |
+| `SHIPWRIGHT_ENCRYPTION_KEY` | production | 64-char hex for AES-256-GCM secrets at rest |
+| `SLACK_BOT_TOKEN` | Slack mode | Slack bot user OAuth token (`xoxb-...`) |
+| `SLACK_APP_TOKEN` | Slack mode | Slack app-level token for Socket Mode (`xapp-...`) |
+| `SLACK_SIGNING_SECRET` | Slack mode | Verifies incoming Slack request signatures |
+
+See [configuration.md](https://github.com/app-vitals/shipwright/blob/main/docs/configuration.md)
+for the full environment variable reference.
+
+## Kubernetes provisioning
+
+When `SHIPWRIGHT_K8S_PROVISIONING=enabled`, the admin service acts as a Kubernetes provisioner.
+`POST /agents/:id/provision` creates:
+
+1. A **PersistentVolumeClaim** for the agent's home directory (`AGENT_HOME`)
+2. A **Secret** carrying the scoped per-agent API token (and optional task-store token)
+3. A **Deployment** running the agent container, referencing both
+
+The PVC is retained on deletion (data safety policy) — cluster admins clean it up manually.
+Self-hosted agents (`selfHosted: true`) skip provisioning; they manage their own workload.
+
+## Next steps
+
+Ready to deploy the agent as a persistent cloud service? See
+[Deploying to Cloud](/docs/deploying-to-cloud) for the Helm chart, Minikube, GKE, and EKS guides.

--- a/site/src/content/docs/the-agent.mdx
+++ b/site/src/content/docs/the-agent.mdx
@@ -24,10 +24,11 @@ There are three ways to run the agent depending on your context:
 | K8s container | `agent/src/entrypoint-main.ts` | Slack Socket Mode | Deployed via the Dockerfile (validates vars, fetches config, installs plugins, spawns runner) |
 | Local dev | `agent/scripts/run-agent.ts --agent-id <id>` | HTTP `POST /chat` | Testing Claude locally without a Slack workspace; requires `SHIPWRIGHT_DEV_CHAT=true` |
 
-The Dockerfile `ENTRYPOINT` is `bun run admin/src/main.ts`, which runs migrations, constructs all
-services, and mounts all admin and runtime routes. The agent process
-(`agent/src/entrypoint-main.ts`) starts the health server in-process on `SHIPWRIGHT_HEALTH_PORT`
-(default `3459`) before the startup sequence so Kubernetes liveness probes are reachable during init.
+The admin service Dockerfile (`admin/Dockerfile`) `ENTRYPOINT` is `bun run admin/src/main.ts`,
+which runs migrations, constructs all services, and mounts all admin and runtime routes. The agent
+container Dockerfile (`agent/Dockerfile`) `ENTRYPOINT` is `bun run agent/src/entrypoint-main.ts`,
+which starts the health server in-process on `SHIPWRIGHT_HEALTH_PORT` (default `3459`) before the
+startup sequence so Kubernetes liveness probes are reachable during init.
 
 ## Running the agent locally
 

--- a/site/src/content/docs/the-agent.mdx
+++ b/site/src/content/docs/the-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Agent
-description: The Shipwright agent runtime — autonomous task runner, admin CRUD API, cron jobs, and the eight-model Prisma data store.
+description: The Shipwright agent runtime — autonomous task runner, admin CRUD API, cron jobs, and the nine-model Prisma data store.
 section: Agent
 order: 0
 prev: "/docs/running-locally"
@@ -74,7 +74,7 @@ validation is an O(1) hash-index lookup with no plaintext at rest.
 
 ## Data model
 
-The agent store uses eight Prisma models on a dedicated database (`DATABASE_URL_SHIPWRIGHT_ADMIN`):
+The agent store uses nine Prisma models on a dedicated database (`DATABASE_URL_SHIPWRIGHT_ADMIN`):
 
 | Model | What it owns |
 |-------|-------------|
@@ -86,6 +86,7 @@ The agent store uses eight Prisma models on a dedicated database (`DATABASE_URL_
 | `AgentToken` | Scoped API tokens — `token` (SHA-256 hash), `label`, `revokedAt` |
 | `AgentPlugin` | Installed Claude Code plugins — `name`, `version`, `enabled` |
 | `AgentMember` | Authorized human members — `email`; unique per `[agentId, email]` |
+| `AgentChatTokenUsageDaily` | Daily chat token usage aggregates — `date`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`; unique per `[agentId, date]` |
 
 All child models cascade-delete with their parent `Agent`.
 

--- a/site/src/content/docs/the-plugin.mdx
+++ b/site/src/content/docs/the-plugin.mdx
@@ -1,0 +1,114 @@
+---
+title: The Plugin
+description: The Shipwright Claude Code plugin — commands, skills, and agents that drive the full delivery loop across any repository.
+section: Plugin
+order: 0
+prev: "/docs/getting-started"
+next: "/docs/running-locally"
+---
+
+# The Plugin
+
+The Shipwright plugin (artifact **A**) is the core of the system. Install it once into any Claude Code
+session and it drives the full **spec → plan → execute → review → deploy** loop against any repository.
+It is pure TypeScript with no server, no database, and no external HTTP — everything runs locally
+inside Claude Code.
+
+## Installing the plugin
+
+Ask Claude Code:
+
+```text
+Install the Shipwright plugin so I can use it in this session.
+```
+
+Claude Code will run the install command and confirm when the plugin is active.
+
+### Manual install
+
+Inside a Claude Code session:
+
+```text
+/plugin install shipwright@app-vitals/shipwright
+```
+
+The plugin is available immediately — no restart required. It registers all commands, skills, and
+agent behaviors for the current session.
+
+## Commands
+
+Commands are the hands-on tools for driving individual stages of the delivery loop. Each command is
+a slash command prefixed with `/shipwright:`.
+
+| Command | What it does |
+|---------|--------------|
+| `/shipwright:prd` | Author or update a product requirements document |
+| `/shipwright:plan-session` | Read the PRD and task queue, then produce a ready-to-execute task list |
+| `/shipwright:dev-task` | Pick the next ready task and build it — tests first, then implementation, then open a PR |
+| `/shipwright:review` | Deep single-pass code review of an open PR with inline comments |
+| `/shipwright:patch` | Fix failing CI and unresolved review findings on open PRs |
+| `/shipwright:deploy` | Merge an approved PR and watch post-merge CI |
+| `/shipwright:metrics` | Pull pipeline metrics (cycle time, throughput, first-time quality) |
+| `/shipwright:research` | Load relevant project docs and web research for the current task |
+| `/shipwright:research-docs` | Refresh docs that have drifted from the code |
+
+### Test-readiness pipeline
+
+The five-phase test-readiness pipeline audits and improves your test coverage end to end:
+
+| Phase | Command | What it does |
+|-------|---------|--------------|
+| 1 | `/shipwright:test-inventory` | Catalogue existing tests and coverage gaps |
+| 2 | `/shipwright:test-design` | Draft a test plan for uncovered areas |
+| 3 | `/shipwright:test-migration` | Move tests to the right layer (unit / integration / e2e) |
+| 4 | `/shipwright:test-roadmap` | Produce a prioritized remediation roadmap |
+| 5 | `/shipwright:test-publish` | Publish the results to the task store |
+
+Run the full pipeline in one shot:
+
+```text
+Run the full Shipwright test-readiness audit and publish results.
+```
+
+Claude Code will run each phase in order, wait for results, and publish the final report.
+
+## Skills
+
+Skills are autonomous behaviors that run multi-step loops without manual hand-holding.
+
+| Skill | What it does |
+|-------|--------------|
+| `ship-loop` | Drains the task queue autonomously — one pipeline step per call (pick → build → review → deploy) |
+| `shipwright-brand` | Validates and enforces brand consistency across site artifacts |
+
+To start the ship loop:
+
+```text
+/shipwright:ship-loop
+```
+
+The loop runs until the queue is empty or it hits a decision that requires human input.
+
+## Plugin anatomy
+
+The plugin lives at `plugins/shipwright/` in the repo and is structured around four directories:
+
+- **`commands/`** — every slash command listed above, as individual TypeScript files
+- **`skills/`** — autonomous behavior scripts (`ship-loop`, `shipwright-brand`, and more)
+- **`scripts/`** — task-store adapters, `check-dev-task.ts`, and supporting tooling
+- **`references/`** — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`)
+
+The plugin is **repo-agnostic**: it carries no opinions about your stack, reads your test command
+from context, and adapts. It never hard-codes paths, frameworks, or CI providers.
+
+## Design constraints
+
+- **No new coupling** — the plugin does not import the agent, the metrics service, or the task
+  store at runtime.
+- **No server, no database** — all plugin execution happens inside the Claude Code process.
+- **Local-first** — works offline against any local git repository. No cloud account required.
+
+## Next steps
+
+With the plugin installed, you can run the full local stack — including the metrics dashboard and
+dev agent — using `task stack`. See [Running Locally](/docs/running-locally) for the full setup.

--- a/site/tests/docs-platform.spec.ts
+++ b/site/tests/docs-platform.spec.ts
@@ -132,3 +132,116 @@ test("prev/next navigation links are present on introduction page", async ({
   const href = await nextLink.getAttribute("href");
   expect(href).toBe("/docs/getting-started");
 });
+
+// SD-4.2 — Remaining 5 MDX content sections
+
+test("GET /docs/the-plugin returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/the-plugin");
+  expect(response?.status()).toBe(200);
+});
+
+test("key headings visible in the-plugin page", async ({ page }) => {
+  await page.goto("/docs/the-plugin");
+  // Must have an h2 heading
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+  // Commands heading must be present
+  const commandsHeading = page.locator("h2", { hasText: /commands/i });
+  await expect(commandsHeading).toBeVisible();
+});
+
+test("prev/next navigation links on the-plugin page", async ({ page }) => {
+  await page.goto("/docs/the-plugin");
+  // prev → getting-started
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  expect(await prevLink.getAttribute("href")).toBe("/docs/getting-started");
+  // next → running-locally
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toBeVisible();
+  expect(await nextLink.getAttribute("href")).toBe("/docs/running-locally");
+});
+
+test("GET /docs/running-locally returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/running-locally");
+  expect(response?.status()).toBe(200);
+});
+
+test("key headings visible in running-locally page", async ({ page }) => {
+  await page.goto("/docs/running-locally");
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+  // task stack section heading must be present
+  const stackHeading = page.locator("h2", { hasText: /task stack/i });
+  await expect(stackHeading).toBeVisible();
+});
+
+test("GET /docs/the-agent returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/the-agent");
+  expect(response?.status()).toBe(200);
+});
+
+test("key headings visible in the-agent page", async ({ page }) => {
+  await page.goto("/docs/the-agent");
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+  // Run modes heading must be present
+  const runModesHeading = page.locator("h2", { hasText: /run modes/i });
+  await expect(runModesHeading).toBeVisible();
+  // Data model heading must be present
+  const dataModelHeading = page.locator("h2", { hasText: /data model/i });
+  await expect(dataModelHeading).toBeVisible();
+});
+
+test("prev/next navigation links on the-agent page", async ({ page }) => {
+  await page.goto("/docs/the-agent");
+  // prev → running-locally
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  expect(await prevLink.getAttribute("href")).toBe("/docs/running-locally");
+  // next → deploying-to-cloud
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toBeVisible();
+  expect(await nextLink.getAttribute("href")).toBe("/docs/deploying-to-cloud");
+});
+
+test("deploying-to-cloud has updated prev/next links", async ({ page }) => {
+  await page.goto("/docs/deploying-to-cloud");
+  // prev → the-agent (updated from getting-started)
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  expect(await prevLink.getAttribute("href")).toBe("/docs/the-agent");
+  // next → slack-integration (new)
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toBeVisible();
+  expect(await nextLink.getAttribute("href")).toBe("/docs/slack-integration");
+});
+
+test("key headings visible in deploying-to-cloud page", async ({ page }) => {
+  await page.goto("/docs/deploying-to-cloud");
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+  // Networking model heading must be present
+  const networkingHeading = page.locator("h2", { hasText: /networking model/i });
+  await expect(networkingHeading).toBeVisible();
+  // Minikube heading must be present
+  const minikubeHeading = page.locator("h2", { hasText: /minikube/i });
+  await expect(minikubeHeading).toBeVisible();
+});
+
+test("GET /docs/slack-integration returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/slack-integration");
+  expect(response?.status()).toBe(200);
+});
+
+test("key headings visible in slack-integration page", async ({ page }) => {
+  await page.goto("/docs/slack-integration");
+  const h2 = page.locator("h2");
+  await expect(h2.first()).toBeVisible();
+  // Connecting a Slack app heading must be present
+  const connectHeading = page.locator("h2", { hasText: /connecting a slack app/i });
+  await expect(connectHeading).toBeVisible();
+  // Response markers heading must be present
+  const markersHeading = page.locator("h2", { hasText: /response markers/i });
+  await expect(markersHeading).toBeVisible();
+});

--- a/site/tests/docs-platform.spec.ts
+++ b/site/tests/docs-platform.spec.ts
@@ -176,6 +176,18 @@ test("key headings visible in running-locally page", async ({ page }) => {
   await expect(stackHeading).toBeVisible();
 });
 
+test("prev/next navigation links on running-locally page", async ({ page }) => {
+  await page.goto("/docs/running-locally");
+  // prev → the-plugin
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  expect(await prevLink.getAttribute("href")).toBe("/docs/the-plugin");
+  // next → the-agent
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toBeVisible();
+  expect(await nextLink.getAttribute("href")).toBe("/docs/the-agent");
+});
+
 test("GET /docs/the-agent returns 200", async ({ page }) => {
   const response = await page.goto("/docs/the-agent");
   expect(response?.status()).toBe(200);
@@ -244,4 +256,15 @@ test("key headings visible in slack-integration page", async ({ page }) => {
   // Response markers heading must be present
   const markersHeading = page.locator("h2", { hasText: /response markers/i });
   await expect(markersHeading).toBeVisible();
+});
+
+test("prev/next navigation on slack-integration page (terminal page)", async ({ page }) => {
+  await page.goto("/docs/slack-integration");
+  // prev → deploying-to-cloud
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  expect(await prevLink.getAttribute("href")).toBe("/docs/deploying-to-cloud");
+  // no next link — slack-integration is the terminal page; no broken/empty href allowed
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

- Authors five new MDX doc pages: The Plugin, Running Locally, The Agent, Deploying to Cloud (full rewrite from stub), and Slack Integration
- Wires the complete 7-section prev/next nav chain: intro → getting-started → the-plugin → running-locally → the-agent → deploying-to-cloud → slack-integration
- Extends the e2e spec with 14 new tests covering 200 status, key headings, and nav links for all 5 new pages

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 5 MDX sections resolve under /docs/* and render in DocsLayout | ✅ MET |
| 2 | Each 'how to' presents a Claude Code prompt before manual shell commands | ✅ MET |
| 3 | Slack Integration covers DM/mention/cron/voice with no internal IDs | ✅ MET |
| 4 | Unsourced Slack sections flagged with TODO for human review | ✅ MET |
| 5 | All pages pass `npm run build:check` and `task check-strings` | ✅ MET |
| 6 | prev/next chain across all 7 sections has no dead ends | ✅ MET |
| 7 | e2e: key headings visible on each of the 5 new pages | ✅ MET |

## Test Plan

- [x] `npm run build` — astro build: 11 pages built, 0 errors
- [x] `task check-strings` — no banned strings found
- [x] 14 new Playwright e2e tests added (status 200, h2 headings, prev/next href checks)
- [x] Nav chain verified: each page's prev/next frontmatter links checked end-to-end

Generated with [Claude Code](https://claude.com/claude-code)
