### PR TITLE
feat(admin): wire SHIPWRIGHT_ADMIN_PUBLIC_REPO into task board bootstrap (PPL-2.2)

### DIFF
--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -188,6 +188,18 @@ export function resolveTaskStoreBaseUrl(
   return env.SHIPWRIGHT_TASK_STORE_PUBLIC_URL ?? env.SHIPWRIGHT_TASK_STORE_URL;
 }
 
+/**
+ * Resolve the public read-only task board repo from the environment.
+ * Reads SHIPWRIGHT_ADMIN_PUBLIC_REPO; trims whitespace so a blank/whitespace
+ * value behaves like unset (returns undefined → board stays in degraded mode)
+ * rather than producing an empty repo filter.
+ */
+export function resolvePublicRepo(
+  env: Record<string, string | undefined>,
+): string | undefined {
+  return env.SHIPWRIGHT_ADMIN_PUBLIC_REPO?.trim() || undefined;
+}
+
 async function startServer(): Promise<void> {
   const port = Number(process.env.PORT ?? DEFAULT_PORT);
 
@@ -225,6 +237,10 @@ async function startServer(): Promise<void> {
   const appBaseUrl =
     process.env.SHIPWRIGHT_ADMIN_APP_BASE_URL ?? `http://localhost:${port}`;
   const adminApiKeys = parseAdminApiKeys(process.env.SHIPWRIGHT_ADMIN_API_KEYS);
+  // Repo slug for the public read-only task board (GET /public/tasks). When set,
+  // the board renders unauthenticated, scoped to this repo; when absent the route
+  // stays in degraded mode (no tasks).
+  const publicRepo = resolvePublicRepo(process.env);
 
   const googleClient = new HttpGoogleAuthClient();
   const slackClient = new HttpSlackProvisioningClient();
@@ -416,6 +432,7 @@ async function startServer(): Promise<void> {
     googleClient,
     slackClient,
     appBaseUrl,
+    publicRepo,
     devAuthEnabled: isDevAuthAllowed(process.env),
     timezone: adminTz,
     ...taskStoreFetchers,

--- a/admin/src/main.unit.test.ts
+++ b/admin/src/main.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { resolvePublicRepo } from "./main.ts";
+
+// resolvePublicRepo is the pure env rule wired into main.ts startServer():
+// it sources SHIPWRIGHT_ADMIN_PUBLIC_REPO and feeds createAdminUIApp's
+// publicRepo option, which gates the unauthenticated GET /public/tasks board.
+// Tested without touching process.env.
+describe("resolvePublicRepo", () => {
+  it("returns the repo slug when set", () => {
+    expect(
+      resolvePublicRepo({
+        SHIPWRIGHT_ADMIN_PUBLIC_REPO: "app-vitals/shipwright",
+      }),
+    ).toBe("app-vitals/shipwright");
+  });
+
+  it("returns undefined when unset (board stays in degraded mode)", () => {
+    expect(resolvePublicRepo({})).toBeUndefined();
+  });
+
+  it("treats an empty string as unset", () => {
+    expect(
+      resolvePublicRepo({ SHIPWRIGHT_ADMIN_PUBLIC_REPO: "" }),
+    ).toBeUndefined();
+  });
+
+  it("treats whitespace-only as unset rather than an empty repo filter", () => {
+    expect(
+      resolvePublicRepo({ SHIPWRIGHT_ADMIN_PUBLIC_REPO: "   " }),
+    ).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace from a valid value", () => {
+    expect(
+      resolvePublicRepo({
+        SHIPWRIGHT_ADMIN_PUBLIC_REPO: "  app-vitals/shipwright  ",
+      }),
+    ).toBe("app-vitals/shipwright");
+  });
+});


### PR DESCRIPTION
## Summary
Closes the bootstrap wiring gap for the public read-only task board (PPL-2.1). `createAdminUIApp` accepts a `publicRepo` option, but `admin/src/main.ts` never read `SHIPWRIGHT_ADMIN_PUBLIC_REPO` or passed it through — so `GET /public/tasks` would render in degraded (no-repo) mode in any real deployment regardless of env. The feature was tested at the factory/smoke layer but dead at runtime.

## Changes
- Add exported pure helper `resolvePublicRepo(env)` (mirrors `resolveTaskStoreBaseUrl`) — reads `SHIPWRIGHT_ADMIN_PUBLIC_REPO`, trims, treats blank/whitespace as unset.
- Wire its result into `createAdminUIApp({ publicRepo })` in `startServer()`.
- Unit test for the env precedence/trim rule.

## Why now
Prerequisite for lighting up `proof.shipwrightharness.com` (public dogfooding surface). The chart-side metrics wiring lands in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)