### PR TITLE
fix(metrics): serve public dashboard assets + data under /public mount (PPL-1.4)

### DIFF
--- a/metrics/src/api.public.smoke.test.ts
+++ b/metrics/src/api.public.smoke.test.ts
@@ -83,4 +83,39 @@ describe("public dashboard — read-only render", () => {
     expect(html).not.toContain("Token Usage");
     expect(html).not.toContain("token-agent-table");
   });
+
+  // PPL-1.4: the read-only page must point its client at the /public mount so
+  // app.js fetches /public/metrics/* (repo-scoped, no auth) — not the
+  // authenticated /metrics/* endpoints, which would 401 and leave it dataless.
+  test("GET /public/dashboard → client base + assets resolve to the /public mount", async () => {
+    const app = buildApp();
+    const res = await app.request("/public/dashboard");
+    const html = await res.text();
+    expect(html).toContain('window.__METRICS_BASE__ = "/public";');
+    expect(html).toContain('href="/public/dashboard/styles.css"');
+    expect(html).toContain('src="/public/dashboard/app.js"');
+  });
+
+  test("GET /public/dashboard prefixes the rendered base with a non-empty basePath", async () => {
+    const app = createPublicMetricsApp(makeEmptyProvider(), "/m");
+    const res = await app.request("/public/dashboard");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('window.__METRICS_BASE__ = "/m/public";');
+  });
+});
+
+describe("public dashboard — static assets", () => {
+  for (const [path, type] of [
+    ["/public/dashboard/styles.css", "text/css"],
+    ["/public/dashboard/app.js", "application/javascript"],
+  ]) {
+    test(`GET ${path} → 200 ${type}`, async () => {
+      const app = buildApp();
+      const res = await app.request(path);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain(type);
+      expect((await res.text()).length).toBeGreaterThan(0);
+    });
+  }
 });

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -1153,14 +1153,28 @@ const PUBLIC_POLICY = { kind: "public" as const };
 /**
  * Build the public, unauthenticated, repo-scoped metrics sub-app.
  *
+ * The public surface lives under a `/public` mount: JSON at /public/metrics/*,
+ * the read-only dashboard at /public/dashboard, and its client assets at
+ * /public/dashboard/{styles.css,app.js}. The dashboard is rendered with its base
+ * set to that `/public` mount so the shared client (`app.js`) fetches
+ * /public/metrics/* (repo-scoped, no auth) instead of the authenticated
+ * /metrics/* endpoints — otherwise the page renders but loads no data.
+ *
  * @param provider - a repo-scoped MetricsProvider (built in server.ts with the
  *   configured public repo). All reads are already narrowed to that repo.
- * @param basePath - optional path prefix for dashboard asset/API URLs.
+ * @param basePath - optional path prefix the whole public mount sits under.
+ * @param dashboardDir - directory holding the dashboard static assets
+ *   (styles.css, app.js); defaults to the bundled ./dashboard dir.
  */
 export function createPublicMetricsApp(
   provider: MetricsProvider,
   basePath = "",
+  dashboardDir: string = join(import.meta.dir, "dashboard"),
 ): OpenAPIHono<AuthEnv> {
+  // Base for the public dashboard's assets + client API calls. The public routes
+  // are registered literally under "/public/*", so the rendered base must resolve
+  // there (e.g. app.js → `${publicBase}/metrics/summary` = /public/metrics/summary).
+  const publicBase = `${basePath}/public`;
   const app = new OpenAPIHono<AuthEnv>({
     defaultHook: (result, c) => {
       if (!result.success) {
@@ -1222,17 +1236,55 @@ export function createPublicMetricsApp(
   app.get("/public/metrics/tokens", (c) => c.json({ error: "Not found" }, 404));
 
   // Read-only dashboard variant — pipeline panels only, no token usage.
+  // Rendered with basePath=publicBase so the client fetches /public/metrics/*.
   app.get("/public/dashboard", (c) => {
     const body = renderDashboardPage({
       userName: "Public",
       isOwner: false,
       readOnly: true,
-      basePath,
+      basePath: publicBase,
     });
     return new Response(body, {
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   });
+
+  // Dashboard static assets under the public mount, so the read-only page can
+  // load its own CSS/JS without reaching the authenticated /dashboard/* routes.
+  // Registered at the literal /public/* paths (basePath is the external,
+  // proxy-stripped prefix — present only in the rendered URLs, not the routes).
+  const PUBLIC_STATIC_FILES: Record<
+    string,
+    { contentType: string; file: string; cache?: string }
+  > = {
+    "/public/dashboard/styles.css": {
+      contentType: "text/css; charset=utf-8",
+      file: "styles.css",
+      cache: "public, max-age=3600",
+    },
+    "/public/dashboard/app.js": {
+      contentType: "application/javascript; charset=utf-8",
+      file: "app.js",
+    },
+  };
+  for (const [path, { contentType, file, cache }] of Object.entries(
+    PUBLIC_STATIC_FILES,
+  )) {
+    app.get(path, async (c) => {
+      try {
+        const body = await Bun.file(join(dashboardDir, file)).text();
+        const headers: Record<string, string> = { "Content-Type": contentType };
+        if (cache) headers["Cache-Control"] = cache;
+        return new Response(body, { headers });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          return c.json({ error: "Not found" }, 404);
+        }
+        console.error(`Static file error [${file}]:`, err);
+        return c.json({ error: "Internal server error" }, 500);
+      }
+    });
+  }
 
   return app;
 }

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -1265,6 +1265,7 @@ export function createPublicMetricsApp(
     "/public/dashboard/app.js": {
       contentType: "application/javascript; charset=utf-8",
       file: "app.js",
+      cache: "public, max-age=3600",
     },
   };
   for (const [path, { contentType, file, cache }] of Object.entries(


### PR DESCRIPTION
## Summary
The merged public metrics dashboard (PPL-1.2) renders its shell but **loads no live data**. `/public/dashboard` was rendered with the global `basePath` (empty in prod), so the shared client (`dashboard/app.js`) set `window.__METRICS_BASE__=""` and fetched the **authenticated** `/metrics/*` endpoints (401) instead of the public `/public/metrics/*` ones. Its CSS/JS also resolved to the authenticated `/dashboard/*` paths. The existing smoke test only asserts the HTML shell, so it never caught this.

## Changes (`metrics/src/api.ts`)
- Render `/public/dashboard` with base `${basePath}/public` → `__METRICS_BASE__` resolves so `app.js` fetches `/public/metrics/*` (repo-scoped, no auth).
- Serve the dashboard assets under the public mount: `GET /public/dashboard/{styles.css,app.js}` (literal routes, mirroring the authenticated static-file serving; `basePath` stays the external proxy-stripped prefix, present only in rendered URLs).
- `createPublicMetricsApp` takes an optional `dashboardDir` (defaults to the bundled dir) for asset serving + testability.

## Tests (`api.public.smoke.test.ts`)
- Asserts `__METRICS_BASE__` + asset hrefs resolve to `/public`; non-empty `basePath` prefixes correctly; both static assets serve 200 with correct content types.

## Verification
Full metrics suite: 236 pass / 0 fail. Typecheck + Biome clean.

## Context
Third and final prerequisite for the public proof surface, alongside #856 (admin bootstrap, merged) and #857 (chart wiring). Without this the metrics proof page would be blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)