### PR TITLE
fix(metrics): serve public dashboard at trailing-slash path (proof root entry)

### DIFF
--- a/metrics/src/api.public.smoke.test.ts
+++ b/metrics/src/api.public.smoke.test.ts
@@ -103,6 +103,18 @@ describe("public dashboard — read-only render", () => {
     const html = await res.text();
     expect(html).toContain('window.__METRICS_BASE__ = "/m/public";');
   });
+
+  // The proof-host root redirect lands on "/public/dashboard/" (GKE appends a
+  // slash), which Hono treats as a distinct route — serve it too so the apex
+  // entry doesn't 404.
+  test("GET /public/dashboard/ (trailing slash) → 200, same page", async () => {
+    const app = buildApp();
+    const res = await app.request("/public/dashboard/");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Pipeline Queue");
+    expect(html).toContain('window.__METRICS_BASE__ = "/public";');
+  });
 });
 
 describe("public dashboard — static assets", () => {

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -1237,7 +1237,11 @@ export function createPublicMetricsApp(
 
   // Read-only dashboard variant — pipeline panels only, no token usage.
   // Rendered with basePath=publicBase so the client fetches /public/metrics/*.
-  app.get("/public/dashboard", (c) => {
+  // Registered for both the bare and trailing-slash paths: a proof-host root
+  // redirect lands on "/public/dashboard/" (GKE's ReplacePrefixMatch on "/"
+  // appends a slash), and Hono treats the trailing slash as a distinct,
+  // otherwise-unmatched route — so without the alias the apex entry 404s.
+  const dashboardHandler = () => {
     const body = renderDashboardPage({
       userName: "Public",
       isOwner: false,
@@ -1247,7 +1251,9 @@ export function createPublicMetricsApp(
     return new Response(body, {
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
-  });
+  };
+  app.get("/public/dashboard", dashboardHandler);
+  app.get("/public/dashboard/", dashboardHandler);
 
   // Dashboard static assets under the public mount, so the read-only page can
   // load its own CSS/JS without reaching the authenticated /dashboard/* routes.


### PR DESCRIPTION
## Problem
`https://proof.shipwrightharness.com/` (the bare apex) ends up 404ing. The proof-host root is a GKE `RequestRedirect` → `/public/dashboard`, but GKE's `ReplacePrefixMatch` on a root `/` appends a slash, so the redirect Location is `/public/dashboard/`. Hono treats the trailing slash as a distinct, unmatched route → 404 (confirmed in-cluster: `/public/dashboard` 200, `/public/dashboard/` 404). GKE rejects `ReplaceFullPath` and can't emit the exact path, so this is fixed app-side.

## Fix
Register the read-only dashboard handler for both `/public/dashboard` and `/public/dashboard/`. Durable regardless of how the apex is linked.

## Tests
Added a smoke test for the trailing-slash path (200, same page, base `/public`). Full public smoke suite 14/14; typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)