### PR TITLE
fix(metrics): public dashboard read-only toolbar + token-render guard

### DIFF
--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -13,6 +13,15 @@ export interface ShipwrightToolbarOptions {
   metricsUrl?: string;
   /** Base URL of the admin service. Defaults to empty string (same origin). */
   adminBaseUrl?: string;
+  /**
+   * Public, unauthenticated variant. When true, render only the read-only
+   * surfaces (Metrics dashboard + public task board) and no sign-out — the
+   * authenticated /admin/* links and logout are omitted, since they 404 (and
+   * aren't reachable) on the public proof host.
+   */
+  readOnly?: boolean;
+  /** Public task board URL, used only in readOnly mode. Defaults to "/public/tasks". */
+  tasksUrl?: string;
 }
 
 export function baseStyles(): string {
@@ -133,6 +142,21 @@ export function renderShipwrightToolbar(
   const adminBase = opts.adminBaseUrl ?? "";
   const active = (prefix: string) =>
     activePath.startsWith(prefix) ? " active" : "";
+
+  // Public proof surface: only the read-only Metrics + Tasks views are routed and
+  // reachable, so omit every /admin/* link and the sign-out form (they 404 on the
+  // public host). The wordmark points at the dashboard instead of /admin/agents.
+  if (opts.readOnly) {
+    const tasksUrl = opts.tasksUrl ?? "/public/tasks";
+    return `<nav class="vos-toolbar" aria-label="Site navigation">
+    <a href="${metricsUrl}" class="vos-wordmark">Shipwright</a>
+    <div class="vos-nav">
+      <a href="${metricsUrl}" class="vos-nav-link${active(metricsUrl)}">Metrics</a>
+      <a href="${tasksUrl}" class="vos-nav-link${active(tasksUrl)}">Tasks</a>
+    </div>
+  </nav>`;
+  }
+
   return `<nav class="vos-toolbar" aria-label="Site navigation">
     <a href="${adminBase}/admin/agents" class="vos-wordmark">Shipwright</a>
     <div class="vos-nav">

--- a/metrics/src/api.public.smoke.test.ts
+++ b/metrics/src/api.public.smoke.test.ts
@@ -84,6 +84,17 @@ describe("public dashboard — read-only render", () => {
     expect(html).not.toContain("token-agent-table");
   });
 
+  // The public toolbar must not link to authenticated /admin/* pages (they 404 on
+  // the proof host) and must not offer sign-out; it surfaces only Metrics + Tasks.
+  test("GET /public/dashboard → toolbar omits admin links + logout, links to public tasks", async () => {
+    const app = buildApp();
+    const html = await (await app.request("/public/dashboard")).text();
+    expect(html).not.toContain("/admin/");
+    expect(html).not.toContain("Sign out");
+    expect(html).toContain('href="/public/tasks"');
+    expect(html).toContain('href="/public/dashboard"');
+  });
+
   // PPL-1.4: the read-only page must point its client at the /public mount so
   // app.js fetches /public/metrics/* (repo-scoped, no auth) — not the
   // authenticated /metrics/* endpoints, which would 401 and leave it dataless.

--- a/metrics/src/dashboard/app.js
+++ b/metrics/src/dashboard/app.js
@@ -307,6 +307,9 @@
 
   function updateTokens(res) {
     const $ = (id) => document.getElementById(id);
+    // Read-only/public dashboard omits the token-usage section entirely, so its
+    // elements don't exist — skip rather than crash on a null textContent set.
+    if (!$("token-input")) return;
     if (!res || res.error || !res.data) {
       $("token-input").textContent = "--";
       $("token-output").textContent = "--";

--- a/metrics/src/dashboard/dashboard-page.ts
+++ b/metrics/src/dashboard/dashboard-page.ts
@@ -101,7 +101,7 @@ export function renderDashboardPage(opts: DashboardPageOptions): string {
   <link rel="stylesheet" href="${base}/dashboard/styles.css" />
 </head>
 <body>
-  ${renderShipwrightToolbar({ userName: opts.userName, activePath: `${base}/dashboard`, logoutAction: "/admin/logout", metricsUrl: `${base}/dashboard`, adminBaseUrl: opts.adminBaseUrl })}
+  ${renderShipwrightToolbar({ userName: opts.userName, activePath: `${base}/dashboard`, logoutAction: "/admin/logout", metricsUrl: `${base}/dashboard`, adminBaseUrl: opts.adminBaseUrl, readOnly, tasksUrl: `${base}/tasks` })}
   <div class="app">
 
     <!-- Page Controls -->


### PR DESCRIPTION
## Problem
On `proof.shipwrightharness.com` the metrics dashboard showed **"Failed to load metrics: Cannot set properties of null (setting 'textContent')"** and every nav link 404'd.

Two bugs in the read-only public dashboard:
1. **JS crash:** `app.js updateTokens()` writes `textContent` on `token-*` elements unconditionally (incl. the null-data branch, hit because `/public/metrics/tokens` → 404). Read-only omits the token section, so those elements are null → throw → whole render aborts ("Failed to load metrics").
2. **404 nav:** the shared toolbar renders `/admin/agents|provision|tasks|prs|tokens` + a `/admin/logout` form + wordmark→`/admin/agents`. None of `/admin/*` is routed on the proof host → every link 404s.

## Fix
- `app.js`: `updateTokens` early-returns when the token section is absent.
- `lib/web/toolbar.ts`: new `readOnly` variant — renders only Metrics + Tasks (public task board), no `/admin/*` links, no sign-out; wordmark → dashboard.
- `dashboard-page.ts`: pass `readOnly` + `tasksUrl` (`/public/tasks`) to the toolbar.
- (The admin `/public/tasks` board already renders no toolbar in read-only.)

## Tests
Public smoke: asserts the dashboard toolbar omits `/admin/` + "Sign out" and links to `/public/tasks`; existing token-omission + base-path tests still pass. 15/15 public smoke; dashboard unit suite green; typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)