### PR TITLE
feat: fix metrics pane to use offline fixture mode

### DIFF
--- a/scripts/dev-tmux.ts
+++ b/scripts/dev-tmux.ts
@@ -3,7 +3,7 @@
  * `task stack` launcher — ties the full local dev stack together in a single
  * tmux session ("shipwright") with one window and 6 panes:
  *
- *   0. metrics    — metrics dashboard, offline SQLite mode             (:3460)
+ *   0. metrics    — metrics dashboard, offline fixture mode             (:3460)
  *   1. admin      — standalone admin service (CRUD API + UI)           (:3001)
  *   2. task-store — task-store service (Postgres-backed task queue)    (:3002)
  *   3. agent      — thin Shipwright agent with the dev /chat endpoint  (:3000)
@@ -170,13 +170,12 @@ export const STACK_PANES: Pane[] = [
   {
     label: "metrics",
     cmd: ["bun", "metrics/src/server.ts"],
-    // SQLite persistence mode: no METRICS_OFFLINE, no POSTHOG_PROJECT_API_KEY,
-    // no METRICS_DATABASE_URL → service defaults to sqlite mode.
-    // METRICS_DASHBOARD_DEV_AUTH bypasses dashboard/login auth (there is no login
-    // flow in the stack) while KEEPING the real sqlite provider — so the dashboard
-    // shows the metrics the agent actually forwards, not fixtures.
+    // Offline fixture mode: METRICS_OFFLINE=true tells the server to serve
+    // fixture data instead of live PostHog/SQLite queries. No database needed.
+    // METRICS_DASHBOARD_DEV_AUTH bypasses dashboard/login auth (there is no
+    // login flow in the stack) so the dashboard is accessible without credentials.
     env: {
-      METRICS_DB_PATH: "state/metrics.db",
+      METRICS_OFFLINE: "true",
       METRICS_DASHBOARD_DEV_AUTH: "true",
       // The admin console runs on a different origin (:3001) than the metrics
       // dashboard in the local stack, so the dashboard toolbar's Agents/Tasks/PRs

--- a/scripts/dev-tmux.unit.test.ts
+++ b/scripts/dev-tmux.unit.test.ts
@@ -250,13 +250,12 @@ describe("buildStackCommands", () => {
 });
 
 describe("runStack — per-pane commands via injected exec", () => {
-  test("metrics pane runs the metrics server in sqlite mode with METRICS_DB_PATH", () => {
+  test("metrics pane runs the metrics server in offline fixture mode", () => {
     const { calls, exec } = makeRecorder();
     runStack(STACK_PANES, exec);
     const sk = sendKeysForPane(calls, 0);
     expect(sk?.join(" ")).toContain("metrics/src/server.ts");
-    expect(sk?.join(" ")).toContain("METRICS_DB_PATH=state/metrics.db");
-    expect(sk?.join(" ")).not.toContain("METRICS_OFFLINE=true");
+    expect(sk?.join(" ")).toContain("METRICS_OFFLINE=true");
   });
 
   test("metrics pane sets METRICS_ADMIN_APP_URL so dashboard nav cross-links to the admin console", () => {
@@ -528,16 +527,14 @@ describe("planPostgresSetup — auto vs guide ladder", () => {
 // Docker agent stack — new tests (additive)
 // ---------------------------------------------------------------------------
 
-describe("metrics pane — sqlite mode", () => {
-  test("metrics pane runs in sqlite mode with METRICS_DB_PATH (no METRICS_OFFLINE)", () => {
+describe("offline fixture mode", () => {
+  test("metrics pane uses offline fixture mode (no METRICS_DB_PATH)", () => {
     const metrics = STACK_PANES.find((p) => p.label === "metrics") as Pane;
-    expect(metrics.env?.METRICS_OFFLINE).toBeUndefined();
-    expect(metrics.env?.METRICS_DB_PATH).toBe("state/metrics.db");
+    expect(metrics.env?.METRICS_OFFLINE).toBe("true");
+    expect(metrics.env?.METRICS_DB_PATH).toBeUndefined();
   });
 
-  test("metrics pane enables the dashboard dev-auth bypass (real data, no login)", () => {
-    // task stack has no login flow; this lets the dashboard + /metrics/* be
-    // viewed in the browser while keeping the real sqlite provider (not fixtures).
+  test("metrics pane enables the dashboard dev-auth bypass (no login flow in the stack)", () => {
     const metrics = STACK_PANES.find((p) => p.label === "metrics") as Pane;
     expect(metrics.env?.METRICS_DASHBOARD_DEV_AUTH).toBe("true");
   });


### PR DESCRIPTION
## Summary
- Switch metrics pane in `scripts/dev-tmux.ts` from SQLite mode to offline fixture mode by replacing `METRICS_DB_PATH=state/metrics.db` with `METRICS_OFFLINE=true`
- Update module-level JSDoc and inline comment to accurately describe offline fixture mode
- Update `scripts/dev-tmux.unit.test.ts`: rename describe block, flip METRICS_OFFLINE assertions, remove METRICS_DB_PATH assertions

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `task stack:up` metrics pane starts without FATAL — offline mode active | MET |
| 2 | `METRICS_OFFLINE=true` + `METRICS_DASHBOARD_DEV_AUTH=true`; `METRICS_DB_PATH` absent | MET |
| 3 | Module JSDoc and inline comment describe offline fixture mode | MET |
| 4 | Unit tests updated: describe renamed, assertions flipped, all 80 pass | MET |
| 5 | No other test changes required | MET |

## Test Plan
- [x] `bun test scripts/dev-tmux.unit.test.ts` — 80 pass, 0 fail
- [x] `task lint` — clean
- [x] `task typecheck` — clean

Generated with [Claude Code](https://claude.com/claude-code)
