### PR TITLE
feat(site): add GA4 analytics and SEO improvements

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://shipwrightharness.com/sitemap-index.xml

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -1,0 +1,24 @@
+---
+// Google Analytics 4 (gtag.js). Included in <head> by BaseLayout and DocsLayout
+// so every page is tracked. The Measurement ID is public by design — it ships
+// in the client-side tag — so committing it here is expected, not a secret leak.
+//
+// This is the site's ONLY first-party runtime JS; the marketing pages are
+// otherwise zero-JS. The home e2e suite asserts no <script> exists beyond this
+// analytics tag (see site/tests/home.spec.ts).
+const GA_MEASUREMENT_ID = "G-WS5TVR713J";
+---
+
+<!-- Google tag (gtag.js) — GA4 -->
+<script
+  is:inline
+  async
+  src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
+<script define:vars={{ GA_MEASUREMENT_ID }}>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+  gtag("config", GA_MEASUREMENT_ID);
+</script>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,8 +1,9 @@
 ---
 // Dark-premium base layout for Shipwright Harness.
-// Ships ZERO runtime JS: fonts load via plain <link rel="stylesheet">,
-// the glow orb is pure CSS (.sw-orb from brand.css). No <script> tags.
+// First-party runtime JS is limited to the GA4 analytics tag (<Analytics/>);
+// fonts load via plain <link rel="stylesheet"> and the glow orb is pure CSS.
 import "../styles/brand.css";
+import Analytics from "../components/Analytics.astro";
 
 interface Props {
   title?: string;
@@ -21,6 +22,47 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 // OG/social card (SWW-3.1): 1280x640 typographic card in site/public/.
 // MUST be absolute — link-preview crawlers reject relative URLs.
 const ogImage = new URL("/og-default-1280x640.png", Astro.site);
+const ogImageAlt =
+  "Shipwright Harness — the open-source autonomous delivery agent for Claude Code.";
+
+// Structured data (JSON-LD): describes the org, site, and product so search
+// engines can render richer results. Inert data block — not executable JS.
+const siteUrl = Astro.site?.toString().replace(/\/$/, "") ?? "";
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${siteUrl}/#organization`,
+      name: "Shipwright Harness",
+      url: `${siteUrl}/`,
+      logo: `${siteUrl}/shipwright-icon.png`,
+      sameAs: ["https://github.com/app-vitals/shipwright"],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${siteUrl}/#website`,
+      url: `${siteUrl}/`,
+      name: "Shipwright Harness",
+      description:
+        "The open-source autonomous delivery agent for Claude Code.",
+      publisher: { "@id": `${siteUrl}/#organization` },
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "Shipwright Harness",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Cross-platform",
+      url: `${siteUrl}/`,
+      description:
+        "The open-source autonomous delivery agent for Claude Code — plan, build, review, and ship, on your own infrastructure.",
+      license: "https://opensource.org/licenses/MIT",
+      isAccessibleForFree: true,
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+      sameAs: ["https://github.com/app-vitals/shipwright"],
+    },
+  ],
+};
 
 // Footer links (SWW-2.3): repo, license, platform, community.
 const repoUrl = "https://github.com/app-vitals/shipwright";
@@ -57,12 +99,24 @@ const year = new Date().getFullYear();
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="640" />
+    <meta property="og:image:alt" content={ogImageAlt} />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content={ogImageAlt} />
+
+    <!-- Structured data (JSON-LD) — inert data block, not runtime JS. -->
+    <script
+      type="application/ld+json"
+      is:inline
+      set:html={JSON.stringify(structuredData)}
+    />
+
+    <!-- Google Analytics 4 (the only first-party runtime JS). -->
+    <Analytics />
 
     <!--
       Fonts (no runtime JS): Space Grotesk + JetBrains Mono from Google Fonts,

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -7,6 +7,7 @@
 //   • ONE <script> tag (Pagefind UI only — never reaches BaseLayout)
 import { getCollection } from "astro:content";
 import "../styles/brand.css";
+import Analytics from "../components/Analytics.astro";
 
 interface Heading {
   depth: number;
@@ -77,6 +78,9 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="640" />
+
+    <!-- Google Analytics 4 -->
+    <Analytics />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -325,7 +325,11 @@ const differentiators = [
 
 ---
 
-<BaseLayout title="Shipwright Harness" description={tagline} pagefindIgnore={true}>
+<BaseLayout
+  title="Shipwright Harness — autonomous delivery agent for Claude Code"
+  description={tagline}
+  pagefindIgnore={true}
+>
   <!-- ── Hero ── (tagline + intro video) -->
   <section class="relative z-10 pt-12 pb-12 text-center">
     <p class="sw-label">Built on Claude Code</p>

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
 
 // Fulfill external font CDN requests immediately so the page's 'load' event
 // fires even when CI can't reach external networks.
 test.beforeEach(async ({ page }) => {
   await page.route(
-    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com/,
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
     (route) =>
       route.fulfill({ status: 200, contentType: "text/css", body: "" }),
   );
@@ -25,11 +26,11 @@ test("compare page leads with the comparison heading", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("compare page ships NO runtime JS (zero <script> tags)", async ({
+test("compare page ships no runtime JS beyond the analytics tag", async ({
   page,
 }) => {
   await page.goto("/compare");
-  expect(await page.locator("script").count()).toBe(0);
+  await expectNoRuntimeJsBeyondAnalytics(page);
 });
 
 test("landscape table names the open-source field", async ({ page }) => {

--- a/site/tests/config.spec.ts
+++ b/site/tests/config.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 // fires even when CI can't reach external networks.
 test.beforeEach(async ({ page }) => {
   await page.route(
-    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com/,
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
     (route) =>
       route.fulfill({ status: 200, contentType: "text/css", body: "" }),
   );

--- a/site/tests/docs-landing.spec.ts
+++ b/site/tests/docs-landing.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
 
 // Fulfill external font CDN requests immediately so the page's 'load' event
 // fires even when CI can't reach external networks.
 test.beforeEach(async ({ page }) => {
   await page.route(
-    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com/,
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
     (route) =>
       route.fulfill({ status: 200, contentType: "text/css", body: "" }),
   );
@@ -53,8 +54,9 @@ test("each persona card has a link with href starting with /docs/", async ({
   }
 });
 
-test("/docs landing page ships zero <script> tags", async ({ page }) => {
+test("/docs landing page ships no runtime JS beyond the analytics tag", async ({
+  page,
+}) => {
   await page.goto("/docs");
-  const scriptCount = await page.locator("script").count();
-  expect(scriptCount).toBe(0);
+  await expectNoRuntimeJsBeyondAnalytics(page);
 });

--- a/site/tests/docs-platform.spec.ts
+++ b/site/tests/docs-platform.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
 
 // Fulfill external font CDN requests immediately so the page's 'load' event
 // fires even when CI can't reach external networks.
 test.beforeEach(async ({ page }) => {
   await page.route(
-    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com/,
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
     (route) =>
       route.fulfill({ status: 200, contentType: "text/css", body: "" }),
   );
@@ -34,10 +35,11 @@ test("TOC (table of contents) is present on docs page", async ({ page }) => {
 // frontmatter field (configuration.mdx does not exist yet). Re-add once a second
 // docs page exists so the nav link can actually render.
 
-test("docs page ships exactly ONE <script> tag (Pagefind UI)", async ({ page }) => {
+test("docs page ships no runtime JS beyond Pagefind + the analytics tag", async ({
+  page,
+}) => {
   await page.goto("/docs/getting-started");
-  const scriptCount = await page.locator("script").count();
-  expect(scriptCount).toBe(1);
+  await expectNoRuntimeJsBeyondAnalytics(page, { allowPagefind: true });
 });
 
 test("sidebar lists at least one docs section", async ({ page }) => {

--- a/site/tests/docs-search.spec.ts
+++ b/site/tests/docs-search.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 // fires even when CI can't reach external networks.
 test.beforeEach(async ({ page }) => {
   await page.route(
-    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com/,
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
     (route) =>
       route.fulfill({ status: 200, contentType: "text/css", body: "" }),
   );

--- a/site/tests/helpers.ts
+++ b/site/tests/helpers.ts
@@ -1,0 +1,29 @@
+import { expect, type Page } from "@playwright/test";
+
+// Assert a page ships no first-party runtime JS beyond the explicitly allowed
+// tags. The marketing pages run zero JS of their own; the only <script> tags
+// permitted are:
+//   • the GA4 analytics tag — the async gtag.js loader + its inline config
+//   • the inert JSON-LD structured-data block (data, not executable)
+//   • (docs pages only, when allowPagefind) the Pagefind UI search loader
+// Anything else — framework hydration, bundled app JS — fails the check.
+export async function expectNoRuntimeJsBeyondAnalytics(
+  page: Page,
+  opts: { allowPagefind?: boolean } = {},
+): Promise<void> {
+  const { allowPagefind = false } = opts;
+  const scripts = await page.locator("script").all();
+  for (const s of scripts) {
+    const src = await s.getAttribute("src");
+    const type = await s.getAttribute("type");
+    const body = (await s.textContent()) ?? "";
+    const isGtagLoader = !!src && src.includes("googletagmanager.com/gtag/js");
+    const isGtagConfig = !src && body.includes("gtag(");
+    const isJsonLd = type === "application/ld+json";
+    const isPagefind = allowPagefind && /pagefind/i.test(`${src ?? ""} ${body}`);
+    expect(
+      isGtagLoader || isGtagConfig || isJsonLd || isPagefind,
+      `unexpected runtime <script> (src=${src ?? "inline"}, type=${type ?? "none"})`,
+    ).toBe(true);
+  }
+}

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
 
 // Fulfill external font CDN requests immediately so the page's 'load' event
 // fires even when CI can't reach external networks (fonts.googleapis.com, fontshare.com).
 test.beforeEach(async ({ page }) => {
   await page.route(
-    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com/,
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
     (route) =>
       route.fulfill({ status: 200, contentType: "text/css", body: "" }),
   );
@@ -41,12 +42,63 @@ test("dark-premium navy base background is applied", async ({ page }) => {
   expect(baseVar.toUpperCase()).toBe("#080E1E");
 });
 
-test("home document ships NO runtime JS (zero <script> tags)", async ({
+test("home ships no runtime JS beyond the GA4 analytics tag", async ({
   page,
 }) => {
   await page.goto("/");
-  const scriptCount = await page.locator("script").count();
-  expect(scriptCount).toBe(0);
+  await expectNoRuntimeJsBeyondAnalytics(page);
+});
+
+test("GA4 analytics tag is wired with the measurement ID", async ({ page }) => {
+  await page.goto("/");
+  // The async gtag.js loader for our GA4 stream.
+  await expect(
+    page.locator(
+      'head script[src*="googletagmanager.com/gtag/js?id=G-WS5TVR713J"]',
+    ),
+  ).toHaveCount(1);
+  // The inline config references the same measurement ID.
+  const inline = (
+    await page.locator("head script:not([src])").allTextContents()
+  ).join("\n");
+  expect(inline).toContain("G-WS5TVR713J");
+  expect(inline).toContain("gtag(");
+});
+
+test("robots.txt allows crawling and points at the sitemap", async ({
+  page,
+}) => {
+  const res = await page.request.get("/robots.txt");
+  expect(res.status()).toBe(200);
+  const body = await res.text();
+  expect(body).toMatch(/User-agent:\s*\*/i);
+  expect(body).toMatch(
+    /Sitemap:\s*https:\/\/shipwrightharness\.com\/sitemap-index\.xml/i,
+  );
+});
+
+test("home embeds JSON-LD structured data (SoftwareApplication + Organization)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const ld = await page
+    .locator('head script[type="application/ld+json"]')
+    .textContent();
+  expect(ld).toBeTruthy();
+  const data = JSON.parse(ld ?? "{}");
+  const types = (data["@graph"] ?? []).map((n) => n["@type"]);
+  expect(types).toContain("SoftwareApplication");
+  expect(types).toContain("Organization");
+});
+
+test("head wires og:image:alt and twitter:image:alt", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.locator('head meta[property="og:image:alt"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('head meta[name="twitter:image:alt"]'),
+  ).toHaveCount(1);
 });
 
 // SWW-2.1: Hero. The hero contains the eyebrow, brand tagline, and a two-path CTA
@@ -125,8 +177,8 @@ test("showcase tabs switch panels with zero runtime JS", async ({ page }) => {
   await page.locator('label[for="sw-tab-metrics"]').click();
   await expect(page.locator("#metrics")).toBeVisible();
   await expect(page.locator("#two-ways")).toBeHidden();
-  // Tabs switch via CSS :checked — no script tags anywhere.
-  expect(await page.locator("script").count()).toBe(0);
+  // Tabs switch via CSS :checked — no app JS beyond the analytics tag.
+  await expectNoRuntimeJsBeyondAnalytics(page);
 });
 
 // Brand lockup: header mark + wordmark, and the favicon wiring.
@@ -291,8 +343,8 @@ test("'Run the full stack' tab shows the task stack:up walkthrough video", async
     demo.locator('video[src="/task-stack-up-walkthrough.mp4"]'),
   ).toBeVisible();
   await expect(demo.getByText(/task stack:up/i).first()).toBeVisible();
-  // Reconfirm zero runtime JS (native <video>, no injected player).
-  expect(await page.locator("script").count()).toBe(0);
+  // Native <video>, no injected player — no app JS beyond the analytics tag.
+  await expectNoRuntimeJsBeyondAnalytics(page);
 });
 
 test("'Proof' tab makes the dogfooding case and links to the public dashboard", async ({


### PR DESCRIPTION
## Summary
- Adds **Google Analytics 4** (`G-WS5TVR713J`) across the marketing site, plus four no-tradeoff **SEO** improvements.

## Analytics (GA4)
- New `site/src/components/Analytics.astro` — the standard `gtag.js` tag (async loader + inline config). Included in **both** `BaseLayout` and `DocsLayout` so every page is tracked.
- The Measurement ID is public-by-design (it ships in the client tag), so committing it is expected.
- This is the site's only first-party runtime JS; the zero-JS guarantee otherwise holds.

## SEO
- **`public/robots.txt`** — allows crawling and points at `sitemap-index.xml` (the `@astrojs/sitemap` output).
- **JSON-LD structured data** in `BaseLayout` — `Organization` + `WebSite` + `SoftwareApplication` graph (inert data block).
- **Richer home `<title>`** — "Shipwright Harness — autonomous delivery agent for Claude Code".
- **`og:image:alt` + `twitter:image:alt`** for link-preview accessibility.

## Tests
- Replaced the "zero `<script>`" assertions across all specs with a shared `tests/helpers.ts` → `expectNoRuntimeJsBeyondAnalytics()` that allows only the GA4 tag, JSON-LD, and (on docs) Pagefind.
- Added the GA4 host to each spec's offline route mock so the page `load` event fires in network-isolated runs.
- New coverage: GA4 wiring, robots.txt + sitemap, JSON-LD types, image-alt meta.
- **87 e2e pass**; `biome lint` and `brand-lint` clean.

## Follow-up (your call)
- GA4 sets cookies — an EU **cookie-consent banner** is a separate decision, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
