### PR TITLE
feat: add cron-run token stats aggregation to admin service

### DIFF
--- a/admin/src/admin-spec.smoke.test.ts
+++ b/admin/src/admin-spec.smoke.test.ts
@@ -248,6 +248,11 @@ function buildSpecApp() {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
+      queryStats: async () => ({
+        totals: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 },
+        byAgent: [],
+        daily: [],
+      }),
     },
     agentCronRunStatsService: {
       query: async () => ({

--- a/admin/src/admin-spec.smoke.test.ts
+++ b/admin/src/admin-spec.smoke.test.ts
@@ -249,6 +249,21 @@ function buildSpecApp() {
         updatedAt: new Date(),
       }),
     },
+    agentCronRunStatsService: {
+      query: async () => ({
+        totals: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheCreation: 0,
+          total: 0,
+        },
+        byAgent: [],
+        byCron: [],
+        byModel: [],
+        daily: [],
+      }),
+    },
     prisma: {
       agent: {
         create: async () => ({

--- a/admin/src/agent-chat-tokens.integration.test.ts
+++ b/admin/src/agent-chat-tokens.integration.test.ts
@@ -193,4 +193,163 @@ describeOrSkip("AgentChatTokenService (integration)", () => {
     expect(records[1].date).toBe("2026-01-16");
     expect(records[1].inputTokens).toBe(200);
   });
+
+  // ─── queryStats ───────────────────────────────────────────────────────────────
+
+  describe("queryStats()", () => {
+    // Seed: 2 agents × 3 dates
+    // agent1: dates 2026-01-10, 2026-01-11, 2026-01-12
+    // agent2: dates 2026-01-10, 2026-01-11, 2026-01-12
+    const DATE_A = "2026-01-10";
+    const DATE_B = "2026-01-11";
+    const DATE_C = "2026-01-12";
+
+    let agent1Id: string;
+    let agent2Id: string;
+
+    beforeEach(async () => {
+      agent1Id = await createAgent(prisma, "Agent One");
+      agent2Id = await createAgent(prisma, "Agent Two");
+
+      // agent1 rows
+      await service.upsertDaily(agent1Id, DATE_A, {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 10,
+        cacheCreationTokens: 5,
+        costUsd: 0.001,
+      });
+      await service.upsertDaily(agent1Id, DATE_B, {
+        inputTokens: 200,
+        outputTokens: 100,
+        cacheReadTokens: 20,
+        cacheCreationTokens: 10,
+        costUsd: 0.002,
+      });
+      await service.upsertDaily(agent1Id, DATE_C, {
+        inputTokens: 300,
+        outputTokens: 150,
+        cacheReadTokens: 30,
+        cacheCreationTokens: 15,
+        costUsd: 0.003,
+      });
+
+      // agent2 rows
+      await service.upsertDaily(agent2Id, DATE_A, {
+        inputTokens: 400,
+        outputTokens: 200,
+        cacheReadTokens: 40,
+        cacheCreationTokens: 20,
+        costUsd: 0.004,
+      });
+      await service.upsertDaily(agent2Id, DATE_B, {
+        inputTokens: 500,
+        outputTokens: 250,
+        cacheReadTokens: 50,
+        cacheCreationTokens: 25,
+        costUsd: 0.005,
+      });
+      await service.upsertDaily(agent2Id, DATE_C, {
+        inputTokens: 600,
+        outputTokens: 300,
+        cacheReadTokens: 60,
+        cacheCreationTokens: 30,
+        costUsd: 0.006,
+      });
+    });
+
+    it("totals sums across all 6 rows (2 agents × 3 dates)", async () => {
+      const stats = await service.queryStats();
+
+      // Total input: 100+200+300 (agent1) + 400+500+600 (agent2) = 2100
+      expect(stats.totals.input).toBe(2100);
+      // Total output: 50+100+150 + 200+250+300 = 1050
+      expect(stats.totals.output).toBe(1050);
+      // Total cacheRead: 10+20+30 + 40+50+60 = 210
+      expect(stats.totals.cacheRead).toBe(210);
+      // Total cacheCreation: 5+10+15 + 20+25+30 = 105
+      expect(stats.totals.cacheCreation).toBe(105);
+      // total = 2100+1050+210+105 = 3465
+      expect(stats.totals.total).toBe(3465);
+      // costUsd should be present and close to 0.021
+      expect(stats.totals.costUsd).toBeCloseTo(0.021);
+    });
+
+    it("byAgent groups per agent with correct sums", async () => {
+      const stats = await service.queryStats();
+
+      expect(stats.byAgent).toHaveLength(2);
+
+      const sorted = [...stats.byAgent].sort((a, b) =>
+        a.key.localeCompare(b.key),
+      );
+
+      // Find each agent by key
+      const byId: Record<string, (typeof sorted)[0]> = {};
+      for (const entry of stats.byAgent) {
+        byId[entry.key] = entry;
+      }
+
+      expect(byId[agent1Id]).toBeDefined();
+      expect(byId[agent2Id]).toBeDefined();
+
+      // agent1: 100+200+300=600 input
+      expect(byId[agent1Id].input).toBe(600);
+      expect(byId[agent1Id].output).toBe(300);
+
+      // agent2: 400+500+600=1500 input
+      expect(byId[agent2Id].input).toBe(1500);
+      expect(byId[agent2Id].output).toBe(750);
+    });
+
+    it("daily buckets per date with correct sums", async () => {
+      const stats = await service.queryStats();
+
+      expect(stats.daily).toHaveLength(3);
+
+      // Sort by period ascending
+      const sorted = [...stats.daily].sort((a, b) =>
+        a.period.localeCompare(b.period),
+      );
+
+      expect(sorted[0].period).toBe(DATE_A);
+      // DATE_A: agent1(100+50+10+5) + agent2(400+200+40+20) = 825 total
+      expect(sorted[0].input).toBe(500); // 100+400
+      expect(sorted[0].output).toBe(250); // 50+200
+
+      expect(sorted[1].period).toBe(DATE_B);
+      expect(sorted[1].input).toBe(700); // 200+500
+
+      expect(sorted[2].period).toBe(DATE_C);
+      expect(sorted[2].input).toBe(900); // 300+600
+    });
+
+    it("from/to filter restricts to date range (inclusive start, inclusive end)", async () => {
+      // Only DATE_B and DATE_C
+      const stats = await service.queryStats(DATE_B, DATE_C);
+
+      // Should include only DATE_B and DATE_C rows
+      expect(stats.daily).toHaveLength(2);
+
+      const periods = stats.daily.map((d) => d.period).sort();
+      expect(periods).toEqual([DATE_B, DATE_C]);
+
+      // Totals should only include DATE_B and DATE_C
+      // agent1 DATE_B: 200 input, agent1 DATE_C: 300, agent2 DATE_B: 500, agent2 DATE_C: 600 → 1600
+      expect(stats.totals.input).toBe(1600);
+    });
+
+    it("returns zero totals and empty arrays when no rows exist", async () => {
+      // Clear all rows
+      await prisma.agentChatTokenUsageDaily.deleteMany();
+
+      const stats = await service.queryStats();
+
+      expect(stats.totals.input).toBe(0);
+      expect(stats.totals.output).toBe(0);
+      expect(stats.totals.total).toBe(0);
+      expect(stats.byAgent).toHaveLength(0);
+      expect(stats.daily).toHaveLength(0);
+    });
+  });
 });

--- a/admin/src/agent-chat-tokens.smoke.test.ts
+++ b/admin/src/agent-chat-tokens.smoke.test.ts
@@ -8,9 +8,9 @@
 
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
+import type { AgentProvisioner, ProvisionResult } from "./agent-provisioner.ts";
 import { createAdminApp } from "./agents-api.ts";
 import type { AdminDeps } from "./agents-api.ts";
-import type { AgentProvisioner, ProvisionResult } from "./agent-provisioner.ts";
 import { NotFoundError } from "./errors.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -68,7 +68,9 @@ const MOCK_DAILY_ROW = {
 
 // ─── Mock deps factory ────────────────────────────────────────────────────────
 
-function makeMockDeps(opts?: { agentChatTokenServiceThrows?: boolean }): AdminDeps {
+function makeMockDeps(opts?: {
+  agentChatTokenServiceThrows?: boolean;
+}): AdminDeps {
   return {
     agentEnvService: {
       upsert: async () => {},
@@ -95,7 +97,11 @@ function makeMockDeps(opts?: { agentChatTokenServiceThrows?: boolean }): AdminDe
       updatePreCheck: async () => {
         throw new Error("not implemented");
       },
-      reconcileSystemCrons: async () => ({ created: 0, updated: 0, deleted: 0 }),
+      reconcileSystemCrons: async () => ({
+        created: 0,
+        updated: 0,
+        deleted: 0,
+      }),
     },
     agentCronRunService: {
       create: async () => {
@@ -138,6 +144,21 @@ function makeMockDeps(opts?: { agentChatTokenServiceThrows?: boolean }): AdminDe
             throw new NotFoundError(`agent ${_agentId} not found`);
           }
         : async () => MOCK_DAILY_ROW,
+    },
+    agentCronRunStatsService: {
+      query: async () => ({
+        totals: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheCreation: 0,
+          total: 0,
+        },
+        byAgent: [],
+        byCron: [],
+        byModel: [],
+        daily: [],
+      }),
     },
     prisma: {
       agent: {

--- a/admin/src/agent-chat-tokens.smoke.test.ts
+++ b/admin/src/agent-chat-tokens.smoke.test.ts
@@ -66,6 +66,41 @@ const MOCK_DAILY_ROW = {
   updatedAt: new Date("2026-01-15T12:00:00.000Z"),
 };
 
+// ─── Mock stats result ────────────────────────────────────────────────────────
+
+const MOCK_STATS_RESULT = {
+  totals: {
+    input: 600,
+    output: 300,
+    cacheRead: 60,
+    cacheCreation: 30,
+    total: 990,
+    costUsd: 0.006,
+  },
+  byAgent: [
+    {
+      key: AGENT_ID,
+      input: 600,
+      output: 300,
+      cacheRead: 60,
+      cacheCreation: 30,
+      total: 990,
+      costUsd: 0.006,
+    },
+  ],
+  daily: [
+    {
+      period: "2026-01-15",
+      input: 600,
+      output: 300,
+      cacheRead: 60,
+      cacheCreation: 30,
+      total: 990,
+      costUsd: 0.006,
+    },
+  ],
+};
+
 // ─── Mock deps factory ────────────────────────────────────────────────────────
 
 function makeMockDeps(opts?: {
@@ -144,6 +179,7 @@ function makeMockDeps(opts?: {
             throw new NotFoundError(`agent ${_agentId} not found`);
           }
         : async () => MOCK_DAILY_ROW,
+      queryStats: async () => MOCK_STATS_RESULT,
     },
     agentCronRunStatsService: {
       query: async () => ({
@@ -298,5 +334,116 @@ describe("admin API — POST /agents/:agentId/chat-tokens/daily", () => {
     });
 
     expect(res.status).toBe(401);
+  });
+});
+
+// ─── GET /agents/chat-tokens/daily/stats smoke tests ─────────────────────────
+
+// Agent-scoped API key for smoke tests (scope tied to a specific agentId)
+const SCOPED_API_KEY = "sk_scoped_test_key";
+const SCOPED_AGENT_ID = "agent-some-other-agent";
+
+describe("admin API — GET /agents/chat-tokens/daily/stats", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  function makeDepsWithScopedKey(opts?: {
+    agentChatTokenServiceThrows?: boolean;
+  }): AdminDeps {
+    const deps = makeMockDeps(opts);
+    // Add a scoped admin API key (not admin scope)
+    deps.adminApiKeys = new Map([
+      [
+        SCOPED_API_KEY,
+        { name: "scoped-agent", scope: SCOPED_AGENT_ID },
+      ],
+    ]);
+    return deps;
+  }
+
+  it("returns 200 with correct ChatTokenStats shape for authenticated admin", async () => {
+    const deps = makeMockDeps();
+    const app = createAdminApp(deps);
+
+    const res = await app.request("/agents/chat-tokens/daily/stats", {
+      method: "GET",
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // totals shape
+    expect(typeof body.totals.input).toBe("number");
+    expect(typeof body.totals.output).toBe("number");
+    expect(typeof body.totals.cacheRead).toBe("number");
+    expect(typeof body.totals.cacheCreation).toBe("number");
+    expect(typeof body.totals.total).toBe("number");
+
+    // byAgent is an array with at least one entry having a key
+    expect(Array.isArray(body.byAgent)).toBe(true);
+    if (body.byAgent.length > 0) {
+      expect(typeof body.byAgent[0].key).toBe("string");
+    }
+
+    // daily is an array with at least one entry having a period
+    expect(Array.isArray(body.daily)).toBe(true);
+    if (body.daily.length > 0) {
+      expect(typeof body.daily[0].period).toBe("string");
+    }
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const deps = makeMockDeps();
+    const app = createAdminApp(deps);
+
+    const res = await app.request("/agents/chat-tokens/daily/stats", {
+      method: "GET",
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when using an agent-scoped API key (not admin scope)", async () => {
+    // Agent-scoped keys (scope = agentId, not "*") are not admin — stats route requires admin.
+    // The scoped key matches the route path segment "chat-tokens" against its scope, which
+    // differs → 403 from auth middleware before reaching the handler.
+    const deps = makeDepsWithScopedKey();
+    const app = createAdminApp(deps);
+
+    const res = await app.request("/agents/chat-tokens/daily/stats", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${SCOPED_API_KEY}` },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes from/to query params through to the service", async () => {
+    let capturedFrom: string | undefined;
+    let capturedTo: string | undefined;
+
+    const deps = makeMockDeps();
+    deps.agentChatTokenService.queryStats = async (from, to) => {
+      capturedFrom = from;
+      capturedTo = to;
+      return MOCK_STATS_RESULT;
+    };
+    const app = createAdminApp(deps);
+
+    const res = await app.request(
+      "/agents/chat-tokens/daily/stats?from=2026-01-01&to=2026-02-01",
+      {
+        method: "GET",
+        headers: { Cookie: `admin_session=${cookie}` },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedFrom).toBe("2026-01-01");
+    expect(capturedTo).toBe("2026-02-01");
   });
 });

--- a/admin/src/agent-chat-tokens.ts
+++ b/admin/src/agent-chat-tokens.ts
@@ -4,6 +4,9 @@
  *
  * upsertDaily() uses a single atomic SQL INSERT ... ON CONFLICT ... DO UPDATE
  * so concurrent callers accumulate tokens without any read-modify-write race.
+ *
+ * queryStats() aggregates AgentChatTokenUsageDaily into three dimensions using
+ * Prisma groupBy (no JOIN needed): totals, byAgent, and daily.
  */
 
 import { randomBytes } from "node:crypto";
@@ -11,6 +14,33 @@ import type { AgentChatTokenUsageDaily, PrismaClient } from "../prisma/client/in
 import { NotFoundError } from "./errors.ts";
 
 export type { AgentChatTokenUsageDaily };
+
+// ─── Stats types (mirrored from metrics/src/lib/admin-metrics-client.ts) ─────
+// These types are defined here to keep admin self-contained (rootDir constraint).
+// The shapes must stay in sync with ChatTokenStats in admin-metrics-client.ts.
+
+export interface TokenAggregate {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  total: number;
+  costUsd?: number;
+}
+
+export interface KeyedTokenAggregate extends TokenAggregate {
+  key: string;
+}
+
+export interface DailyTokenAggregate extends TokenAggregate {
+  period: string;
+}
+
+export interface ChatTokenStats {
+  totals: TokenAggregate;
+  byAgent: KeyedTokenAggregate[];
+  daily: DailyTokenAggregate[];
+}
 
 export interface DailyTokenInput {
   inputTokens: number;
@@ -68,5 +98,103 @@ export class AgentChatTokenService {
     `;
 
     return rows[0];
+  }
+
+  /**
+   * Aggregate daily chat token usage into three dimensions.
+   *
+   * @param from  YYYY-MM-DD — if provided, only rows with date >= from
+   * @param to    YYYY-MM-DD — if provided, only rows with date <= to
+   */
+  async queryStats(from?: string, to?: string): Promise<ChatTokenStats> {
+    const dateFilter = this.buildDateFilter(from, to);
+
+    const [aggregateResult, byAgentRows, dailyRows] = await Promise.all([
+      this.prisma.agentChatTokenUsageDaily.aggregate({
+        _sum: {
+          inputTokens: true,
+          outputTokens: true,
+          cacheReadTokens: true,
+          cacheCreationTokens: true,
+          costUsd: true,
+        },
+        where: dateFilter,
+      }),
+      this.prisma.agentChatTokenUsageDaily.groupBy({
+        by: ["agentId"],
+        _sum: {
+          inputTokens: true,
+          outputTokens: true,
+          cacheReadTokens: true,
+          cacheCreationTokens: true,
+          costUsd: true,
+        },
+        where: dateFilter,
+        orderBy: { agentId: "asc" },
+      }),
+      this.prisma.agentChatTokenUsageDaily.groupBy({
+        by: ["date"],
+        _sum: {
+          inputTokens: true,
+          outputTokens: true,
+          cacheReadTokens: true,
+          cacheCreationTokens: true,
+          costUsd: true,
+        },
+        where: dateFilter,
+        orderBy: { date: "asc" },
+      }),
+    ]);
+
+    const totals = this.toAggregate(aggregateResult._sum);
+
+    const byAgent: KeyedTokenAggregate[] = byAgentRows.map((row) => ({
+      ...this.toAggregate(row._sum),
+      key: row.agentId,
+    }));
+
+    const daily: DailyTokenAggregate[] = dailyRows.map((row) => ({
+      ...this.toAggregate(row._sum),
+      period: row.date,
+    }));
+
+    return { totals, byAgent, daily };
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────────
+
+  private buildDateFilter(
+    from?: string,
+    to?: string,
+  ): { date?: { gte?: string; lte?: string } } {
+    if (!from && !to) return {};
+    const dateClause: { gte?: string; lte?: string } = {};
+    if (from) dateClause.gte = from;
+    if (to) dateClause.lte = to;
+    return { date: dateClause };
+  }
+
+  private toAggregate(sum: {
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+    cacheReadTokens?: number | null;
+    cacheCreationTokens?: number | null;
+    costUsd?: number | null;
+  }): TokenAggregate {
+    const input = sum.inputTokens ?? 0;
+    const output = sum.outputTokens ?? 0;
+    const cacheRead = sum.cacheReadTokens ?? 0;
+    const cacheCreation = sum.cacheCreationTokens ?? 0;
+    const result: TokenAggregate = {
+      input,
+      output,
+      cacheRead,
+      cacheCreation,
+      total: input + output + cacheRead + cacheCreation,
+    };
+    if (sum.costUsd !== null && sum.costUsd !== undefined) {
+      result.costUsd = sum.costUsd;
+    }
+    return result;
   }
 }

--- a/admin/src/agent-cron-run-stats.integration.test.ts
+++ b/admin/src/agent-cron-run-stats.integration.test.ts
@@ -1,0 +1,649 @@
+/**
+ * admin/src/agent-cron-run-stats.integration.test.ts
+ * Integration tests for AgentCronRunStatsService — cron-run token aggregation.
+ *
+ * Requires DATABASE_URL_ADMIN_TEST to be set; skips otherwise.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { AgentCronJobService } from "./agent-cron-jobs.ts";
+import { AgentCronRunStatsService } from "./agent-cron-run-stats.ts";
+import { AgentCronRunService } from "./agent-cron-runs.ts";
+import { FixedClock } from "./clock.ts";
+
+const TEST_DB = process.env.DATABASE_URL_ADMIN_TEST;
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+const FIXED_NOW = new Date("2026-01-15T12:00:00Z");
+
+async function createAgent(
+  prisma: PrismaClient,
+  name = "Test Agent",
+): Promise<string> {
+  const agent = await prisma.agent.create({ data: { name } });
+  return agent.id;
+}
+
+async function createCron(
+  cronJobService: AgentCronJobService,
+  agentId: string,
+  name?: string,
+): Promise<string> {
+  const job = await cronJobService.create(agentId, {
+    schedule: "0 9 * * *",
+    prompt: "Test prompt",
+    silent: true,
+    name,
+  });
+  return job.id;
+}
+
+describeOrSkip("AgentCronRunStatsService (integration)", () => {
+  let prisma: PrismaClient;
+  let cronJobService: AgentCronJobService;
+  let runService: AgentCronRunService;
+  let statsService: AgentCronRunStatsService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    await prisma.agentCronRun.deleteMany();
+    await prisma.agentToken.deleteMany();
+    await prisma.agentCronJob.deleteMany();
+    await prisma.agentTool.deleteMany();
+    await prisma.agentEnv.deleteMany();
+    await prisma.agent.deleteMany();
+    cronJobService = new AgentCronJobService(prisma, FixedClock(FIXED_NOW));
+    runService = new AgentCronRunService(prisma);
+    statsService = new AgentCronRunStatsService(prisma);
+  });
+
+  // ─── totals ──────────────────────────────────────────────────────────────────
+
+  it("query() aggregates totals correctly across multiple runs", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    const run2 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 5,
+      costUsd: 0.001,
+      model: "claude-sonnet-4-5",
+    });
+    await runService.patch(run2.id, agentId, cronId, {
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 20,
+      cacheCreationTokens: 10,
+      costUsd: 0.002,
+      model: "claude-sonnet-4-5",
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.totals.input).toBe(300);
+    expect(stats.totals.output).toBe(150);
+    expect(stats.totals.cacheRead).toBe(30);
+    expect(stats.totals.cacheCreation).toBe(15);
+    expect(stats.totals.total).toBe(300 + 150 + 30 + 15);
+    expect(stats.totals.costUsd).toBeCloseTo(0.003, 6);
+  });
+
+  it("query() excludes skipped runs from totals", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0.001,
+      model: "claude-sonnet-4-5",
+    });
+
+    // Skipped run with tokens — must be excluded
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: true,
+      skipReason: "pre-check returned false",
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.totals.input).toBe(100);
+    expect(stats.totals.output).toBe(50);
+    expect(stats.totals.total).toBe(150);
+  });
+
+  it("query() returns zero totals when no runs exist", async () => {
+    const stats = await statsService.query();
+
+    expect(stats.totals.input).toBe(0);
+    expect(stats.totals.output).toBe(0);
+    expect(stats.totals.cacheRead).toBe(0);
+    expect(stats.totals.cacheCreation).toBe(0);
+    expect(stats.totals.total).toBe(0);
+  });
+
+  // ─── byAgent ─────────────────────────────────────────────────────────────────
+
+  it("query() groups byAgent correctly across 2 agents", async () => {
+    const agentId1 = await createAgent(prisma, "Agent Alpha");
+    const agentId2 = await createAgent(prisma, "Agent Beta");
+    const cronId1 = await createCron(cronJobService, agentId1);
+    const cronId2 = await createCron(cronJobService, agentId2);
+
+    const run1 = await runService.create(cronId1, agentId1, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    const run2 = await runService.create(cronId2, agentId2, {
+      startedAt: new Date("2026-01-10T10:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run1.id, agentId1, cronId1, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0.001,
+      model: "claude-sonnet-4-5",
+    });
+    await runService.patch(run2.id, agentId2, cronId2, {
+      inputTokens: 300,
+      outputTokens: 150,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0.003,
+      model: "claude-sonnet-4-5",
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.byAgent).toHaveLength(2);
+
+    const a1 = stats.byAgent.find((a) => a.key === agentId1);
+    const a2 = stats.byAgent.find((a) => a.key === agentId2);
+
+    expect(a1).toBeDefined();
+    expect(a1?.input).toBe(100);
+    expect(a1?.output).toBe(50);
+
+    expect(a2).toBeDefined();
+    expect(a2?.input).toBe(300);
+    expect(a2?.output).toBe(150);
+  });
+
+  it("query() byAgent excludes skipped runs", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 50,
+      outputTokens: 25,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    // Skipped run — excluded
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: true,
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.byAgent).toHaveLength(1);
+    expect(stats.byAgent[0].key).toBe(agentId);
+    expect(stats.byAgent[0].input).toBe(50);
+  });
+
+  // ─── byCron ──────────────────────────────────────────────────────────────────
+
+  it("byCron uses cron name (key2) when AgentCronJob.name is set", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId, "morning-brief");
+
+    const run = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.byCron).toHaveLength(1);
+    expect(stats.byCron[0].key1).toBe(agentId);
+    expect(stats.byCron[0].key2).toBe("morning-brief");
+    expect(stats.byCron[0].input).toBe(100);
+  });
+
+  it("byCron falls back to cronId when AgentCronJob.name is null", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId); // no name
+
+    const run = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run.id, agentId, cronId, {
+      inputTokens: 80,
+      outputTokens: 40,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.byCron).toHaveLength(1);
+    expect(stats.byCron[0].key2).toBe(cronId);
+  });
+
+  it("byCron excludes skipped runs", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId, "review-cron");
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 60,
+      outputTokens: 30,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    // Skipped run — excluded
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: true,
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.byCron).toHaveLength(1);
+    expect(stats.byCron[0].input).toBe(60);
+  });
+
+  // ─── byModel ─────────────────────────────────────────────────────────────────
+
+  it("query() groups byModel correctly across 2 models", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    const run2 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+    await runService.patch(run2.id, agentId, cronId, {
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      model: "claude-opus-4-5",
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.byModel).toHaveLength(2);
+
+    const sonnet = stats.byModel.find((m) => m.key2 === "claude-sonnet-4-5");
+    const opus = stats.byModel.find((m) => m.key2 === "claude-opus-4-5");
+
+    expect(sonnet).toBeDefined();
+    expect(sonnet?.key1).toBe(agentId);
+    expect(sonnet?.input).toBe(100);
+
+    expect(opus).toBeDefined();
+    expect(opus?.key1).toBe(agentId);
+    expect(opus?.input).toBe(200);
+  });
+
+  it("query() byModel excludes runs with null model", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    // Run with no model — should not appear in byModel
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      // no model
+    });
+
+    // Run with model — appears in byModel
+    const run2 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run2.id, agentId, cronId, {
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+
+    const stats = await statsService.query();
+
+    // Totals include both runs
+    expect(stats.totals.input).toBe(300);
+    // byModel only includes the run with a model
+    expect(stats.byModel).toHaveLength(1);
+    expect(stats.byModel[0].key2).toBe("claude-sonnet-4-5");
+    expect(stats.byModel[0].input).toBe(200);
+  });
+
+  // ─── daily ───────────────────────────────────────────────────────────────────
+
+  it("query() groups runs into daily buckets by startedAt date", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    const run2 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T15:00:00Z"),
+      skipped: false,
+    });
+    const run3 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    await runService.patch(run2.id, agentId, cronId, {
+      inputTokens: 150,
+      outputTokens: 75,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    await runService.patch(run3.id, agentId, cronId, {
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.daily).toHaveLength(2);
+
+    const day1 = stats.daily.find((d) => d.period === "2026-01-10");
+    const day2 = stats.daily.find((d) => d.period === "2026-01-11");
+
+    expect(day1).toBeDefined();
+    expect(day1?.input).toBe(250); // 100 + 150
+    expect(day1?.output).toBe(125); // 50 + 75
+
+    expect(day2).toBeDefined();
+    expect(day2?.input).toBe(200);
+    expect(day2?.output).toBe(100);
+  });
+
+  it("query() daily excludes skipped runs", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    // Skipped run on same day — excluded
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T10:00:00Z"),
+      skipped: true,
+    });
+
+    const stats = await statsService.query();
+
+    expect(stats.daily).toHaveLength(1);
+    expect(stats.daily[0].period).toBe("2026-01-10");
+    expect(stats.daily[0].input).toBe(100);
+  });
+
+  // ─── from/to filtering ───────────────────────────────────────────────────────
+
+  it("query(from, to) filters runs by startedAt", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-05T09:00:00Z"),
+      skipped: false,
+    });
+    const run2 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    const run3 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-20T09:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    await runService.patch(run2.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    await runService.patch(run3.id, agentId, cronId, {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    // Only include run2
+    const stats = await statsService.query(
+      "2026-01-08T00:00:00Z",
+      "2026-01-15T00:00:00Z",
+    );
+
+    expect(stats.totals.input).toBe(100);
+    expect(stats.totals.output).toBe(50);
+    expect(stats.daily).toHaveLength(1);
+    expect(stats.daily[0].period).toBe("2026-01-10");
+  });
+
+  it("query(from) without to includes all runs from that date", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run1 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-05T09:00:00Z"),
+      skipped: false,
+    });
+    const run2 = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run1.id, agentId, cronId, {
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    await runService.patch(run2.id, agentId, cronId, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+
+    const stats = await statsService.query("2026-01-08T00:00:00Z");
+
+    // Only run2 is in range
+    expect(stats.totals.input).toBe(100);
+  });
+
+  // ─── 3+ runs across 2 agents and 2 crons (acceptance test) ──────────────────
+
+  it("seed 3+ runs across 2 agents and 2 crons; each dimension aggregates correctly; skipped excluded", async () => {
+    const agentId1 = await createAgent(prisma, "Agent One");
+    const agentId2 = await createAgent(prisma, "Agent Two");
+    const cronId1 = await createCron(cronJobService, agentId1, "cron-alpha");
+    const cronId2 = await createCron(cronJobService, agentId2, "cron-beta");
+
+    // Run A: agent1, cron1, sonnet model
+    const runA = await runService.create(cronId1, agentId1, {
+      startedAt: new Date("2026-01-10T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(runA.id, agentId1, cronId1, {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 5,
+      costUsd: 0.001,
+      model: "claude-sonnet-4-5",
+    });
+
+    // Run B: agent2, cron2, opus model
+    const runB = await runService.create(cronId2, agentId2, {
+      startedAt: new Date("2026-01-11T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(runB.id, agentId2, cronId2, {
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 20,
+      cacheCreationTokens: 10,
+      costUsd: 0.002,
+      model: "claude-opus-4-5",
+    });
+
+    // Run C: agent1, cron1, sonnet model (second run same cron)
+    const runC = await runService.create(cronId1, agentId1, {
+      startedAt: new Date("2026-01-12T09:00:00Z"),
+      skipped: false,
+    });
+    await runService.patch(runC.id, agentId1, cronId1, {
+      inputTokens: 300,
+      outputTokens: 150,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 15,
+      costUsd: 0.003,
+      model: "claude-sonnet-4-5",
+    });
+
+    // Skipped run (should be excluded from everything)
+    await runService.create(cronId1, agentId1, {
+      startedAt: new Date("2026-01-12T10:00:00Z"),
+      skipped: true,
+      skipReason: "pre-check false",
+    });
+
+    const stats = await statsService.query();
+
+    // totals: runs A+B+C only (skipped excluded)
+    expect(stats.totals.input).toBe(600);
+    expect(stats.totals.output).toBe(300);
+    expect(stats.totals.cacheRead).toBe(60);
+    expect(stats.totals.cacheCreation).toBe(30);
+    expect(stats.totals.total).toBe(600 + 300 + 60 + 30);
+    expect(stats.totals.costUsd).toBeCloseTo(0.006, 6);
+
+    // byAgent: 2 entries
+    expect(stats.byAgent).toHaveLength(2);
+    expect(stats.byAgent.find((a) => a.key === agentId1)?.input).toBe(400); // runA + runC
+    expect(stats.byAgent.find((a) => a.key === agentId2)?.input).toBe(200); // runB
+
+    // byCron: 2 entries with names
+    expect(stats.byCron).toHaveLength(2);
+    const cAlpha = stats.byCron.find((c) => c.key2 === "cron-alpha");
+    const cBeta = stats.byCron.find((c) => c.key2 === "cron-beta");
+    expect(cAlpha).toBeDefined();
+    expect(cAlpha?.key1).toBe(agentId1);
+    expect(cAlpha?.input).toBe(400); // runA + runC
+    expect(cBeta).toBeDefined();
+    expect(cBeta?.key1).toBe(agentId2);
+    expect(cBeta?.input).toBe(200);
+
+    // byModel: 2 entries
+    expect(stats.byModel).toHaveLength(2);
+    expect(
+      stats.byModel.find((m) => m.key2 === "claude-sonnet-4-5")?.input,
+    ).toBe(400); // runA + runC
+    expect(stats.byModel.find((m) => m.key2 === "claude-opus-4-5")?.input).toBe(
+      200,
+    );
+
+    // daily: 3 days
+    expect(stats.daily).toHaveLength(3);
+    expect(stats.daily.find((d) => d.period === "2026-01-10")?.input).toBe(100);
+    expect(stats.daily.find((d) => d.period === "2026-01-11")?.input).toBe(200);
+    expect(stats.daily.find((d) => d.period === "2026-01-12")?.input).toBe(300); // only runC; skipped run excluded
+  });
+});

--- a/admin/src/agent-cron-run-stats.smoke.test.ts
+++ b/admin/src/agent-cron-run-stats.smoke.test.ts
@@ -1,0 +1,523 @@
+/**
+ * admin/src/agent-cron-run-stats.smoke.test.ts
+ * Smoke tests for GET /agents/all/cron-runs/stats.
+ *
+ * Uses app.request() — no real server, no real DB.
+ * AgentCronRunStatsService is injected as an in-memory mock.
+ */
+
+import { beforeAll, describe, expect, it } from "bun:test";
+import { sign } from "hono/jwt";
+import type { AgentCronRunStatsService } from "./agent-cron-run-stats.ts";
+import { createAdminApp, parseAdminApiKeys } from "./agents-api.ts";
+import type { AdminDeps } from "./agents-api.ts";
+
+const SESSION_SECRET = "test-admin-session-secret-32-bytes!";
+const AGENT_ID = "agent-test-123";
+const ADMIN_API_KEY = "admin-stats-key-for-tests";
+const VALID_BEARER_TOKEN = "valid-bearer-token-value";
+
+async function makeSessionCookie(secret = SESSION_SECRET): Promise<string> {
+  return sign(
+    {
+      userId: "user-123",
+      email: "admin@example.com",
+      name: "Admin User",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    },
+    secret,
+    "HS256",
+  );
+}
+
+// Minimal mock stats response matching CronRunTokenStats shape
+const MOCK_STATS = {
+  totals: {
+    input: 600,
+    output: 300,
+    cacheRead: 60,
+    cacheCreation: 30,
+    total: 990,
+    costUsd: 0.006,
+  },
+  byAgent: [
+    {
+      key: "agent-1",
+      input: 400,
+      output: 200,
+      cacheRead: 40,
+      cacheCreation: 20,
+      total: 660,
+      costUsd: 0.004,
+    },
+    {
+      key: "agent-2",
+      input: 200,
+      output: 100,
+      cacheRead: 20,
+      cacheCreation: 10,
+      total: 330,
+      costUsd: 0.002,
+    },
+  ],
+  byCron: [
+    {
+      key1: "agent-1",
+      key2: "cron-alpha",
+      input: 400,
+      output: 200,
+      cacheRead: 40,
+      cacheCreation: 20,
+      total: 660,
+      costUsd: 0.004,
+    },
+    {
+      key1: "agent-2",
+      key2: "cron-beta",
+      input: 200,
+      output: 100,
+      cacheRead: 20,
+      cacheCreation: 10,
+      total: 330,
+      costUsd: 0.002,
+    },
+  ],
+  byModel: [
+    {
+      key1: "agent-1",
+      key2: "claude-sonnet-4-5",
+      input: 400,
+      output: 200,
+      cacheRead: 40,
+      cacheCreation: 20,
+      total: 660,
+      costUsd: 0.004,
+    },
+    {
+      key1: "agent-2",
+      key2: "claude-opus-4-5",
+      input: 200,
+      output: 100,
+      cacheRead: 20,
+      cacheCreation: 10,
+      total: 330,
+      costUsd: 0.002,
+    },
+  ],
+  daily: [
+    {
+      period: "2026-01-10",
+      input: 100,
+      output: 50,
+      cacheRead: 10,
+      cacheCreation: 5,
+      total: 165,
+      costUsd: 0.001,
+    },
+    {
+      period: "2026-01-11",
+      input: 200,
+      output: 100,
+      cacheRead: 20,
+      cacheCreation: 10,
+      total: 330,
+      costUsd: 0.002,
+    },
+    {
+      period: "2026-01-12",
+      input: 300,
+      output: 150,
+      cacheRead: 30,
+      cacheCreation: 15,
+      total: 495,
+      costUsd: 0.003,
+    },
+  ],
+};
+
+function makeMockStatsService(): Pick<AgentCronRunStatsService, "query"> {
+  return {
+    query: async (_from?: string, _to?: string) => MOCK_STATS,
+  };
+}
+
+function makeMockDeps(): AdminDeps {
+  return {
+    agentEnvService: {
+      upsert: async () => {},
+      patch: async () => {},
+      getByAgentId: async () => ({}),
+      deleteKey: async () => {},
+    },
+    agentCronJobService: {
+      list: async () => [],
+      listWithRunSummary: async () => [],
+      create: async () => ({
+        id: "cron-id",
+        agentId: AGENT_ID,
+        schedule: "0 9 * * *",
+        prompt: "test",
+        channel: null,
+        user: null,
+        silent: false,
+        enabled: true,
+        preCheck: null,
+        name: null,
+        system: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      update: async () => ({
+        id: "cron-id",
+        agentId: AGENT_ID,
+        schedule: "0 9 * * *",
+        prompt: "test",
+        channel: null,
+        user: null,
+        silent: false,
+        enabled: true,
+        preCheck: null,
+        name: null,
+        system: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      delete: async () => {},
+      get: async () => ({
+        id: "cron-id",
+        agentId: AGENT_ID,
+        schedule: "0 9 * * *",
+        prompt: "test",
+        channel: null,
+        user: null,
+        silent: false,
+        enabled: true,
+        preCheck: null,
+        name: null,
+        system: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      setEnabled: async (_agentId, _cronId, enabled) => ({
+        id: "cron-id",
+        agentId: AGENT_ID,
+        schedule: "0 9 * * *",
+        prompt: "test",
+        channel: null,
+        user: null,
+        silent: false,
+        enabled,
+        preCheck: null,
+        name: null,
+        system: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      updatePreCheck: async (_agentId, _cronId, preCheck) => ({
+        id: "cron-id",
+        agentId: AGENT_ID,
+        schedule: "0 9 * * *",
+        prompt: "test",
+        channel: null,
+        user: null,
+        silent: false,
+        enabled: true,
+        preCheck,
+        name: null,
+        system: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      reconcileSystemCrons: async () => ({
+        created: 0,
+        updated: 0,
+        deleted: 0,
+      }),
+    },
+    agentToolService: {
+      list: async () => [],
+      add: async () => ({
+        id: "tool-id",
+        agentId: AGENT_ID,
+        pattern: "Read",
+        enabled: true,
+        createdAt: new Date(),
+      }),
+      toggle: async () => ({
+        id: "tool-id",
+        agentId: AGENT_ID,
+        pattern: "Read",
+        enabled: false,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
+    agentTokenService: {
+      create: async () => ({
+        token: {
+          id: "token-id",
+          agentId: AGENT_ID,
+          token: "sha256hash",
+          label: null,
+          createdAt: new Date(),
+          revokedAt: null,
+        },
+        rawToken:
+          "raw-hex-token-64chars-placeholder-pad-pad-pad-pad-pad-pad-pad",
+      }),
+      listForAgent: async () => [],
+      revoke: async () => ({
+        id: "token-id",
+        agentId: AGENT_ID,
+        token: "sha256hash",
+        label: null,
+        createdAt: new Date(),
+        revokedAt: new Date(),
+      }),
+      validate: async () => null,
+    },
+    agentPluginService: {
+      list: async () => [],
+      add: async () => ({
+        id: "plugin-id",
+        agentId: AGENT_ID,
+        name: "test",
+        version: "1.0.0",
+        enabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      remove: async () => {},
+      removeByName: async () => {},
+    },
+    agentChatTokenService: {
+      upsertDaily: async (agentId, date) => ({
+        id: "daily-id",
+        agentId,
+        date,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    },
+    agentCronRunService: {
+      create: async () => ({
+        id: "run-id",
+        cronId: "cron-id",
+        agentId: AGENT_ID,
+        startedAt: new Date(),
+        completedAt: null,
+        skipped: false,
+        skipReason: null,
+        outcome: null,
+        error: null,
+        inputTokens: null,
+        outputTokens: null,
+        cacheReadTokens: null,
+        cacheCreationTokens: null,
+        costUsd: null,
+        model: null,
+        createdAt: new Date(),
+      }),
+      list: async () => ({ items: [], total: 0, limit: 20, offset: 0 }),
+      patch: async () => ({
+        id: "run-id",
+        cronId: "cron-id",
+        agentId: AGENT_ID,
+        startedAt: new Date(),
+        completedAt: null,
+        skipped: false,
+        skipReason: null,
+        outcome: null,
+        error: null,
+        inputTokens: null,
+        outputTokens: null,
+        cacheReadTokens: null,
+        cacheCreationTokens: null,
+        costUsd: null,
+        model: null,
+        createdAt: new Date(),
+      }),
+    },
+    agentCronRunStatsService: makeMockStatsService(),
+    prisma: {
+      agent: {
+        create: async (args: {
+          data: { name: string; slackId: string | null; selfHosted?: boolean };
+        }) => ({
+          id: "agent-new-id",
+          name: args.data.name,
+          slackId: args.data.slackId,
+          selfHosted: args.data.selfHosted ?? false,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        }),
+        findUnique: async (args: { where: { id: string } }) =>
+          args.where.id === AGENT_ID
+            ? {
+                id: AGENT_ID,
+                name: "Test Agent",
+                slackId: null,
+                selfHosted: false,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              }
+            : null,
+        findMany: async () => [],
+        delete: async (args: { where: { id: string } }) => ({
+          id: args.where.id,
+          name: "Test Agent",
+          slackId: null,
+          selfHosted: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+        update: async (args: { where: { id: string }; data: unknown }) => ({
+          id: args.where.id,
+          name: "Test Agent",
+          slackId: null,
+          selfHosted: false,
+          repos: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      },
+    } as unknown as AdminDeps["prisma"],
+    provisioner: {
+      provision: async (agentId) => ({
+        resourceName: agentId,
+        secretName: `${agentId}-token`,
+        deploymentName: agentId,
+      }),
+      deprovision: async () => {},
+      reconcile: async () => ({
+        recreated: [],
+        updated: [],
+        orphans: [],
+        failed: [],
+      }),
+    },
+    sessionSecret: SESSION_SECRET,
+  };
+}
+
+// ─── Stats route smoke tests ─────────────────────────────────────────────────
+
+describe("admin API — GET /agents/all/cron-runs/stats", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  it("returns 200 with correct CronRunTokenStats shape (session auth)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request("/agents/all/cron-runs/stats", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Check all five dimensions are present
+    expect(body.totals).toBeDefined();
+    expect(body.byAgent).toBeDefined();
+    expect(body.byCron).toBeDefined();
+    expect(body.byModel).toBeDefined();
+    expect(body.daily).toBeDefined();
+
+    // Verify totals shape
+    expect(typeof body.totals.input).toBe("number");
+    expect(typeof body.totals.output).toBe("number");
+    expect(typeof body.totals.cacheRead).toBe("number");
+    expect(typeof body.totals.cacheCreation).toBe("number");
+    expect(typeof body.totals.total).toBe("number");
+
+    // Verify arrays
+    expect(Array.isArray(body.byAgent)).toBe(true);
+    expect(Array.isArray(body.byCron)).toBe(true);
+    expect(Array.isArray(body.byModel)).toBe(true);
+    expect(Array.isArray(body.daily)).toBe(true);
+
+    // Verify keyed shapes
+    if (body.byAgent.length > 0) {
+      expect(body.byAgent[0].key).toBeDefined();
+      expect(typeof body.byAgent[0].input).toBe("number");
+    }
+    if (body.byCron.length > 0) {
+      expect(body.byCron[0].key1).toBeDefined();
+      expect(body.byCron[0].key2).toBeDefined();
+    }
+    if (body.byModel.length > 0) {
+      expect(body.byModel[0].key1).toBeDefined();
+      expect(body.byModel[0].key2).toBeDefined();
+    }
+    if (body.daily.length > 0) {
+      expect(body.daily[0].period).toBeDefined();
+      expect(typeof body.daily[0].input).toBe("number");
+    }
+  });
+
+  it("returns correct mock data values", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request("/agents/all/cron-runs/stats", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.totals.input).toBe(600);
+    expect(body.totals.total).toBe(990);
+    expect(body.byAgent).toHaveLength(2);
+    expect(body.byCron).toHaveLength(2);
+    expect(body.byModel).toHaveLength(2);
+    expect(body.daily).toHaveLength(3);
+  });
+
+  it("accepts from/to query params without error", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request(
+      "/agents/all/cron-runs/stats?from=2026-01-01T00:00:00Z&to=2026-01-31T00:00:00Z",
+      { headers: { Cookie: `admin_session=${cookie}` } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 with admin bearer token", async () => {
+    const deps: AdminDeps = {
+      ...makeMockDeps(),
+      adminApiKeys: parseAdminApiKeys(`admin:${ADMIN_API_KEY}:*`),
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents/all/cron-runs/stats", {
+      headers: { Authorization: `Bearer ${ADMIN_API_KEY}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("unauthenticated request returns 401", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request("/agents/all/cron-runs/stats");
+    expect(res.status).toBe(401);
+  });
+
+  it("agent-scoped bearer token returns 403", async () => {
+    const deps: AdminDeps = {
+      ...makeMockDeps(),
+      agentTokenService: {
+        ...makeMockDeps().agentTokenService,
+        // Returns a per-agent token (not admin)
+        validate: async () => ({ agentId: AGENT_ID }),
+      },
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents/all/cron-runs/stats", {
+      headers: { Authorization: `Bearer ${VALID_BEARER_TOKEN}` },
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/admin/src/agent-cron-run-stats.smoke.test.ts
+++ b/admin/src/agent-cron-run-stats.smoke.test.ts
@@ -304,6 +304,11 @@ function makeMockDeps(): AdminDeps {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
+      queryStats: async () => ({
+        totals: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 },
+        byAgent: [],
+        daily: [],
+      }),
     },
     agentCronRunService: {
       create: async () => ({

--- a/admin/src/agent-cron-run-stats.ts
+++ b/admin/src/agent-cron-run-stats.ts
@@ -1,0 +1,532 @@
+/**
+ * admin/src/agent-cron-run-stats.ts
+ * AgentCronRunStatsService — aggregates AgentCronRun token columns into five
+ * dimensions: totals, byAgent, byCron (with AgentCronJob name JOIN), byModel,
+ * and daily (DATE(startedAt)).
+ *
+ * Skipped runs (skipped=true) are always excluded from all aggregations.
+ * Uses $queryRaw for all five dimensions — Prisma groupBy doesn't support the
+ * LEFT JOIN needed for byCron.
+ */
+
+import type { PrismaClient } from "../prisma/client/index.js";
+
+// ─── Types (mirrored from metrics/src/lib/admin-metrics-client.ts) ───────────
+// These types are defined here to keep admin self-contained (rootDir constraint).
+// The shapes must stay in sync with the interfaces in admin-metrics-client.ts.
+
+export interface TokenAggregate {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  total: number;
+  costUsd?: number;
+}
+
+export interface KeyedTokenAggregate extends TokenAggregate {
+  key: string;
+}
+
+export interface DoubleKeyedTokenAggregate extends TokenAggregate {
+  key1: string;
+  key2: string;
+}
+
+export interface DailyTokenAggregate extends TokenAggregate {
+  period: string;
+}
+
+export interface CronRunTokenStats {
+  totals: TokenAggregate;
+  byAgent: KeyedTokenAggregate[];
+  byCron: DoubleKeyedTokenAggregate[];
+  byModel: DoubleKeyedTokenAggregate[];
+  daily: DailyTokenAggregate[];
+}
+
+// ─── Raw row types from $queryRaw ────────────────────────────────────────────
+
+interface TotalsRow {
+  input: bigint | null;
+  output: bigint | null;
+  cache_read: bigint | null;
+  cache_creation: bigint | null;
+  cost_usd: number | null;
+}
+
+interface ByAgentRow {
+  agent_id: string;
+  input: bigint | null;
+  output: bigint | null;
+  cache_read: bigint | null;
+  cache_creation: bigint | null;
+  cost_usd: number | null;
+}
+
+interface ByCronRow {
+  agent_id: string;
+  cron_id: string;
+  cron_name: string | null;
+  input: bigint | null;
+  output: bigint | null;
+  cache_read: bigint | null;
+  cache_creation: bigint | null;
+  cost_usd: number | null;
+}
+
+interface ByModelRow {
+  agent_id: string;
+  model: string;
+  input: bigint | null;
+  output: bigint | null;
+  cache_read: bigint | null;
+  cache_creation: bigint | null;
+  cost_usd: number | null;
+}
+
+interface DailyRow {
+  period: string;
+  input: bigint | null;
+  output: bigint | null;
+  cache_read: bigint | null;
+  cache_creation: bigint | null;
+  cost_usd: number | null;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function num(v: bigint | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  return Number(v);
+}
+
+function toAggregate(row: {
+  input: bigint | null;
+  output: bigint | null;
+  cache_read: bigint | null;
+  cache_creation: bigint | null;
+  cost_usd: number | null;
+}): TokenAggregate {
+  const input = num(row.input);
+  const output = num(row.output);
+  const cacheRead = num(row.cache_read);
+  const cacheCreation = num(row.cache_creation);
+  const result: TokenAggregate = {
+    input,
+    output,
+    cacheRead,
+    cacheCreation,
+    total: input + output + cacheRead + cacheCreation,
+  };
+  if (row.cost_usd !== null) {
+    result.costUsd = row.cost_usd;
+  }
+  return result;
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+export class AgentCronRunStatsService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Aggregate cron-run token stats into five dimensions.
+   *
+   * @param from  ISO string — if provided, only runs with startedAt >= from
+   * @param to    ISO string — if provided, only runs with startedAt <  to
+   */
+  async query(from?: string, to?: string): Promise<CronRunTokenStats> {
+    const fromDate = from ? new Date(from) : null;
+    const toDate = to ? new Date(to) : null;
+
+    const [totalsRows, byAgentRows, byCronRows, byModelRows, dailyRows] =
+      await Promise.all([
+        this.queryTotals(fromDate, toDate),
+        this.queryByAgent(fromDate, toDate),
+        this.queryByCron(fromDate, toDate),
+        this.queryByModel(fromDate, toDate),
+        this.queryDaily(fromDate, toDate),
+      ]);
+
+    // totals: single row (or null if no runs)
+    const totalsRow = totalsRows[0];
+    const totals: TokenAggregate = totalsRow
+      ? toAggregate(totalsRow)
+      : { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 };
+
+    const byAgent: KeyedTokenAggregate[] = byAgentRows.map((row) => ({
+      ...toAggregate(row),
+      key: row.agent_id,
+    }));
+
+    const byCron: DoubleKeyedTokenAggregate[] = byCronRows.map((row) => ({
+      ...toAggregate(row),
+      key1: row.agent_id,
+      key2: row.cron_name ?? row.cron_id,
+    }));
+
+    const byModel: DoubleKeyedTokenAggregate[] = byModelRows.map((row) => ({
+      ...toAggregate(row),
+      key1: row.agent_id,
+      key2: row.model,
+    }));
+
+    const daily: DailyTokenAggregate[] = dailyRows.map((row) => ({
+      ...toAggregate(row),
+      period: row.period,
+    }));
+
+    return { totals, byAgent, byCron, byModel, daily };
+  }
+
+  // ─── Private query methods ──────────────────────────────────────────────────
+
+  private async queryTotals(
+    from: Date | null,
+    to: Date | null,
+  ): Promise<TotalsRow[]> {
+    if (from !== null && to !== null) {
+      return this.prisma.$queryRaw<TotalsRow[]>`
+        SELECT
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" >= ${from}
+          AND "startedAt" < ${to}
+      `;
+    }
+    if (from !== null) {
+      return this.prisma.$queryRaw<TotalsRow[]>`
+        SELECT
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" >= ${from}
+      `;
+    }
+    if (to !== null) {
+      return this.prisma.$queryRaw<TotalsRow[]>`
+        SELECT
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" < ${to}
+      `;
+    }
+    return this.prisma.$queryRaw<TotalsRow[]>`
+      SELECT
+        SUM("inputTokens")         AS input,
+        SUM("outputTokens")        AS output,
+        SUM("cacheReadTokens")     AS cache_read,
+        SUM("cacheCreationTokens") AS cache_creation,
+        SUM("costUsd")             AS cost_usd
+      FROM "AgentCronRun"
+      WHERE skipped = false
+    `;
+  }
+
+  private async queryByAgent(
+    from: Date | null,
+    to: Date | null,
+  ): Promise<ByAgentRow[]> {
+    if (from !== null && to !== null) {
+      return this.prisma.$queryRaw<ByAgentRow[]>`
+        SELECT
+          "agentId"                  AS agent_id,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" >= ${from}
+          AND "startedAt" < ${to}
+        GROUP BY "agentId"
+        ORDER BY "agentId"
+      `;
+    }
+    if (from !== null) {
+      return this.prisma.$queryRaw<ByAgentRow[]>`
+        SELECT
+          "agentId"                  AS agent_id,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" >= ${from}
+        GROUP BY "agentId"
+        ORDER BY "agentId"
+      `;
+    }
+    if (to !== null) {
+      return this.prisma.$queryRaw<ByAgentRow[]>`
+        SELECT
+          "agentId"                  AS agent_id,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" < ${to}
+        GROUP BY "agentId"
+        ORDER BY "agentId"
+      `;
+    }
+    return this.prisma.$queryRaw<ByAgentRow[]>`
+      SELECT
+        "agentId"                  AS agent_id,
+        SUM("inputTokens")         AS input,
+        SUM("outputTokens")        AS output,
+        SUM("cacheReadTokens")     AS cache_read,
+        SUM("cacheCreationTokens") AS cache_creation,
+        SUM("costUsd")             AS cost_usd
+      FROM "AgentCronRun"
+      WHERE skipped = false
+      GROUP BY "agentId"
+      ORDER BY "agentId"
+    `;
+  }
+
+  private async queryByCron(
+    from: Date | null,
+    to: Date | null,
+  ): Promise<ByCronRow[]> {
+    if (from !== null && to !== null) {
+      return this.prisma.$queryRaw<ByCronRow[]>`
+        SELECT
+          r."agentId"                  AS agent_id,
+          r."cronId"                   AS cron_id,
+          j.name                       AS cron_name,
+          SUM(r."inputTokens")         AS input,
+          SUM(r."outputTokens")        AS output,
+          SUM(r."cacheReadTokens")     AS cache_read,
+          SUM(r."cacheCreationTokens") AS cache_creation,
+          SUM(r."costUsd")             AS cost_usd
+        FROM "AgentCronRun" r
+        LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
+        WHERE r.skipped = false
+          AND r."startedAt" >= ${from}
+          AND r."startedAt" < ${to}
+        GROUP BY r."agentId", r."cronId", j.name
+        ORDER BY r."agentId", r."cronId"
+      `;
+    }
+    if (from !== null) {
+      return this.prisma.$queryRaw<ByCronRow[]>`
+        SELECT
+          r."agentId"                  AS agent_id,
+          r."cronId"                   AS cron_id,
+          j.name                       AS cron_name,
+          SUM(r."inputTokens")         AS input,
+          SUM(r."outputTokens")        AS output,
+          SUM(r."cacheReadTokens")     AS cache_read,
+          SUM(r."cacheCreationTokens") AS cache_creation,
+          SUM(r."costUsd")             AS cost_usd
+        FROM "AgentCronRun" r
+        LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
+        WHERE r.skipped = false
+          AND r."startedAt" >= ${from}
+        GROUP BY r."agentId", r."cronId", j.name
+        ORDER BY r."agentId", r."cronId"
+      `;
+    }
+    if (to !== null) {
+      return this.prisma.$queryRaw<ByCronRow[]>`
+        SELECT
+          r."agentId"                  AS agent_id,
+          r."cronId"                   AS cron_id,
+          j.name                       AS cron_name,
+          SUM(r."inputTokens")         AS input,
+          SUM(r."outputTokens")        AS output,
+          SUM(r."cacheReadTokens")     AS cache_read,
+          SUM(r."cacheCreationTokens") AS cache_creation,
+          SUM(r."costUsd")             AS cost_usd
+        FROM "AgentCronRun" r
+        LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
+        WHERE r.skipped = false
+          AND r."startedAt" < ${to}
+        GROUP BY r."agentId", r."cronId", j.name
+        ORDER BY r."agentId", r."cronId"
+      `;
+    }
+    return this.prisma.$queryRaw<ByCronRow[]>`
+      SELECT
+        r."agentId"                  AS agent_id,
+        r."cronId"                   AS cron_id,
+        j.name                       AS cron_name,
+        SUM(r."inputTokens")         AS input,
+        SUM(r."outputTokens")        AS output,
+        SUM(r."cacheReadTokens")     AS cache_read,
+        SUM(r."cacheCreationTokens") AS cache_creation,
+        SUM(r."costUsd")             AS cost_usd
+      FROM "AgentCronRun" r
+      LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
+      WHERE r.skipped = false
+      GROUP BY r."agentId", r."cronId", j.name
+      ORDER BY r."agentId", r."cronId"
+    `;
+  }
+
+  private async queryByModel(
+    from: Date | null,
+    to: Date | null,
+  ): Promise<ByModelRow[]> {
+    if (from !== null && to !== null) {
+      return this.prisma.$queryRaw<ByModelRow[]>`
+        SELECT
+          "agentId"                  AS agent_id,
+          model,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND model IS NOT NULL
+          AND "startedAt" >= ${from}
+          AND "startedAt" < ${to}
+        GROUP BY "agentId", model
+        ORDER BY "agentId", model
+      `;
+    }
+    if (from !== null) {
+      return this.prisma.$queryRaw<ByModelRow[]>`
+        SELECT
+          "agentId"                  AS agent_id,
+          model,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND model IS NOT NULL
+          AND "startedAt" >= ${from}
+        GROUP BY "agentId", model
+        ORDER BY "agentId", model
+      `;
+    }
+    if (to !== null) {
+      return this.prisma.$queryRaw<ByModelRow[]>`
+        SELECT
+          "agentId"                  AS agent_id,
+          model,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND model IS NOT NULL
+          AND "startedAt" < ${to}
+        GROUP BY "agentId", model
+        ORDER BY "agentId", model
+      `;
+    }
+    return this.prisma.$queryRaw<ByModelRow[]>`
+      SELECT
+        "agentId"                  AS agent_id,
+        model,
+        SUM("inputTokens")         AS input,
+        SUM("outputTokens")        AS output,
+        SUM("cacheReadTokens")     AS cache_read,
+        SUM("cacheCreationTokens") AS cache_creation,
+        SUM("costUsd")             AS cost_usd
+      FROM "AgentCronRun"
+      WHERE skipped = false
+        AND model IS NOT NULL
+      GROUP BY "agentId", model
+      ORDER BY "agentId", model
+    `;
+  }
+
+  private async queryDaily(
+    from: Date | null,
+    to: Date | null,
+  ): Promise<DailyRow[]> {
+    if (from !== null && to !== null) {
+      return this.prisma.$queryRaw<DailyRow[]>`
+        SELECT
+          TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" >= ${from}
+          AND "startedAt" < ${to}
+        GROUP BY DATE("startedAt")
+        ORDER BY DATE("startedAt")
+      `;
+    }
+    if (from !== null) {
+      return this.prisma.$queryRaw<DailyRow[]>`
+        SELECT
+          TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" >= ${from}
+        GROUP BY DATE("startedAt")
+        ORDER BY DATE("startedAt")
+      `;
+    }
+    if (to !== null) {
+      return this.prisma.$queryRaw<DailyRow[]>`
+        SELECT
+          TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
+          SUM("inputTokens")         AS input,
+          SUM("outputTokens")        AS output,
+          SUM("cacheReadTokens")     AS cache_read,
+          SUM("cacheCreationTokens") AS cache_creation,
+          SUM("costUsd")             AS cost_usd
+        FROM "AgentCronRun"
+        WHERE skipped = false
+          AND "startedAt" < ${to}
+        GROUP BY DATE("startedAt")
+        ORDER BY DATE("startedAt")
+      `;
+    }
+    return this.prisma.$queryRaw<DailyRow[]>`
+      SELECT
+        TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
+        SUM("inputTokens")         AS input,
+        SUM("outputTokens")        AS output,
+        SUM("cacheReadTokens")     AS cache_read,
+        SUM("cacheCreationTokens") AS cache_creation,
+        SUM("costUsd")             AS cost_usd
+      FROM "AgentCronRun"
+      WHERE skipped = false
+      GROUP BY DATE("startedAt")
+      ORDER BY DATE("startedAt")
+    `;
+  }
+}

--- a/admin/src/agent-cron-run-stats.ts
+++ b/admin/src/agent-cron-run-stats.ts
@@ -9,6 +9,7 @@
  * LEFT JOIN needed for byCron.
  */
 
+import { Prisma } from "../prisma/client/index.js";
 import type { PrismaClient } from "../prisma/client/index.js";
 
 // ─── Types (mirrored from metrics/src/lib/admin-metrics-client.ts) ───────────
@@ -125,6 +126,20 @@ function toAggregate(row: {
   return result;
 }
 
+/** Build a composable date-range filter fragment for $queryRaw. */
+function dateFilter(from: Date | null, to: Date | null): Prisma.Sql {
+  if (from !== null && to !== null) {
+    return Prisma.sql`AND "startedAt" >= ${from} AND "startedAt" < ${to}`;
+  }
+  if (from !== null) {
+    return Prisma.sql`AND "startedAt" >= ${from}`;
+  }
+  if (to !== null) {
+    return Prisma.sql`AND "startedAt" < ${to}`;
+  }
+  return Prisma.empty;
+}
+
 // ─── Service ─────────────────────────────────────────────────────────────────
 
 export class AgentCronRunStatsService {
@@ -139,17 +154,17 @@ export class AgentCronRunStatsService {
   async query(from?: string, to?: string): Promise<CronRunTokenStats> {
     const fromDate = from ? new Date(from) : null;
     const toDate = to ? new Date(to) : null;
+    const filter = dateFilter(fromDate, toDate);
 
     const [totalsRows, byAgentRows, byCronRows, byModelRows, dailyRows] =
       await Promise.all([
-        this.queryTotals(fromDate, toDate),
-        this.queryByAgent(fromDate, toDate),
-        this.queryByCron(fromDate, toDate),
-        this.queryByModel(fromDate, toDate),
-        this.queryDaily(fromDate, toDate),
+        this.queryTotals(filter),
+        this.queryByAgent(filter),
+        this.queryByCron(filter),
+        this.queryByModel(filter),
+        this.queryDaily(filter),
       ]);
 
-    // totals: single row (or null if no runs)
     const totalsRow = totalsRows[0];
     const totals: TokenAggregate = totalsRow
       ? toAggregate(totalsRow)
@@ -182,50 +197,7 @@ export class AgentCronRunStatsService {
 
   // ─── Private query methods ──────────────────────────────────────────────────
 
-  private async queryTotals(
-    from: Date | null,
-    to: Date | null,
-  ): Promise<TotalsRow[]> {
-    if (from !== null && to !== null) {
-      return this.prisma.$queryRaw<TotalsRow[]>`
-        SELECT
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" >= ${from}
-          AND "startedAt" < ${to}
-      `;
-    }
-    if (from !== null) {
-      return this.prisma.$queryRaw<TotalsRow[]>`
-        SELECT
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" >= ${from}
-      `;
-    }
-    if (to !== null) {
-      return this.prisma.$queryRaw<TotalsRow[]>`
-        SELECT
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" < ${to}
-      `;
-    }
+  private queryTotals(filter: Prisma.Sql): Promise<TotalsRow[]> {
     return this.prisma.$queryRaw<TotalsRow[]>`
       SELECT
         SUM("inputTokens")         AS input,
@@ -235,62 +207,11 @@ export class AgentCronRunStatsService {
         SUM("costUsd")             AS cost_usd
       FROM "AgentCronRun"
       WHERE skipped = false
+      ${filter}
     `;
   }
 
-  private async queryByAgent(
-    from: Date | null,
-    to: Date | null,
-  ): Promise<ByAgentRow[]> {
-    if (from !== null && to !== null) {
-      return this.prisma.$queryRaw<ByAgentRow[]>`
-        SELECT
-          "agentId"                  AS agent_id,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" >= ${from}
-          AND "startedAt" < ${to}
-        GROUP BY "agentId"
-        ORDER BY "agentId"
-      `;
-    }
-    if (from !== null) {
-      return this.prisma.$queryRaw<ByAgentRow[]>`
-        SELECT
-          "agentId"                  AS agent_id,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" >= ${from}
-        GROUP BY "agentId"
-        ORDER BY "agentId"
-      `;
-    }
-    if (to !== null) {
-      return this.prisma.$queryRaw<ByAgentRow[]>`
-        SELECT
-          "agentId"                  AS agent_id,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" < ${to}
-        GROUP BY "agentId"
-        ORDER BY "agentId"
-      `;
-    }
+  private queryByAgent(filter: Prisma.Sql): Promise<ByAgentRow[]> {
     return this.prisma.$queryRaw<ByAgentRow[]>`
       SELECT
         "agentId"                  AS agent_id,
@@ -301,73 +222,13 @@ export class AgentCronRunStatsService {
         SUM("costUsd")             AS cost_usd
       FROM "AgentCronRun"
       WHERE skipped = false
+      ${filter}
       GROUP BY "agentId"
       ORDER BY "agentId"
     `;
   }
 
-  private async queryByCron(
-    from: Date | null,
-    to: Date | null,
-  ): Promise<ByCronRow[]> {
-    if (from !== null && to !== null) {
-      return this.prisma.$queryRaw<ByCronRow[]>`
-        SELECT
-          r."agentId"                  AS agent_id,
-          r."cronId"                   AS cron_id,
-          j.name                       AS cron_name,
-          SUM(r."inputTokens")         AS input,
-          SUM(r."outputTokens")        AS output,
-          SUM(r."cacheReadTokens")     AS cache_read,
-          SUM(r."cacheCreationTokens") AS cache_creation,
-          SUM(r."costUsd")             AS cost_usd
-        FROM "AgentCronRun" r
-        LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
-        WHERE r.skipped = false
-          AND r."startedAt" >= ${from}
-          AND r."startedAt" < ${to}
-        GROUP BY r."agentId", r."cronId", j.name
-        ORDER BY r."agentId", r."cronId"
-      `;
-    }
-    if (from !== null) {
-      return this.prisma.$queryRaw<ByCronRow[]>`
-        SELECT
-          r."agentId"                  AS agent_id,
-          r."cronId"                   AS cron_id,
-          j.name                       AS cron_name,
-          SUM(r."inputTokens")         AS input,
-          SUM(r."outputTokens")        AS output,
-          SUM(r."cacheReadTokens")     AS cache_read,
-          SUM(r."cacheCreationTokens") AS cache_creation,
-          SUM(r."costUsd")             AS cost_usd
-        FROM "AgentCronRun" r
-        LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
-        WHERE r.skipped = false
-          AND r."startedAt" >= ${from}
-        GROUP BY r."agentId", r."cronId", j.name
-        ORDER BY r."agentId", r."cronId"
-      `;
-    }
-    if (to !== null) {
-      return this.prisma.$queryRaw<ByCronRow[]>`
-        SELECT
-          r."agentId"                  AS agent_id,
-          r."cronId"                   AS cron_id,
-          j.name                       AS cron_name,
-          SUM(r."inputTokens")         AS input,
-          SUM(r."outputTokens")        AS output,
-          SUM(r."cacheReadTokens")     AS cache_read,
-          SUM(r."cacheCreationTokens") AS cache_creation,
-          SUM(r."costUsd")             AS cost_usd
-        FROM "AgentCronRun" r
-        LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
-        WHERE r.skipped = false
-          AND r."startedAt" < ${to}
-        GROUP BY r."agentId", r."cronId", j.name
-        ORDER BY r."agentId", r."cronId"
-      `;
-    }
+  private queryByCron(filter: Prisma.Sql): Promise<ByCronRow[]> {
     return this.prisma.$queryRaw<ByCronRow[]>`
       SELECT
         r."agentId"                  AS agent_id,
@@ -381,70 +242,13 @@ export class AgentCronRunStatsService {
       FROM "AgentCronRun" r
       LEFT JOIN "AgentCronJob" j ON j.id = r."cronId"
       WHERE r.skipped = false
+      ${filter}
       GROUP BY r."agentId", r."cronId", j.name
       ORDER BY r."agentId", r."cronId"
     `;
   }
 
-  private async queryByModel(
-    from: Date | null,
-    to: Date | null,
-  ): Promise<ByModelRow[]> {
-    if (from !== null && to !== null) {
-      return this.prisma.$queryRaw<ByModelRow[]>`
-        SELECT
-          "agentId"                  AS agent_id,
-          model,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND model IS NOT NULL
-          AND "startedAt" >= ${from}
-          AND "startedAt" < ${to}
-        GROUP BY "agentId", model
-        ORDER BY "agentId", model
-      `;
-    }
-    if (from !== null) {
-      return this.prisma.$queryRaw<ByModelRow[]>`
-        SELECT
-          "agentId"                  AS agent_id,
-          model,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND model IS NOT NULL
-          AND "startedAt" >= ${from}
-        GROUP BY "agentId", model
-        ORDER BY "agentId", model
-      `;
-    }
-    if (to !== null) {
-      return this.prisma.$queryRaw<ByModelRow[]>`
-        SELECT
-          "agentId"                  AS agent_id,
-          model,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND model IS NOT NULL
-          AND "startedAt" < ${to}
-        GROUP BY "agentId", model
-        ORDER BY "agentId", model
-      `;
-    }
+  private queryByModel(filter: Prisma.Sql): Promise<ByModelRow[]> {
     return this.prisma.$queryRaw<ByModelRow[]>`
       SELECT
         "agentId"                  AS agent_id,
@@ -457,64 +261,13 @@ export class AgentCronRunStatsService {
       FROM "AgentCronRun"
       WHERE skipped = false
         AND model IS NOT NULL
+      ${filter}
       GROUP BY "agentId", model
       ORDER BY "agentId", model
     `;
   }
 
-  private async queryDaily(
-    from: Date | null,
-    to: Date | null,
-  ): Promise<DailyRow[]> {
-    if (from !== null && to !== null) {
-      return this.prisma.$queryRaw<DailyRow[]>`
-        SELECT
-          TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" >= ${from}
-          AND "startedAt" < ${to}
-        GROUP BY DATE("startedAt")
-        ORDER BY DATE("startedAt")
-      `;
-    }
-    if (from !== null) {
-      return this.prisma.$queryRaw<DailyRow[]>`
-        SELECT
-          TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" >= ${from}
-        GROUP BY DATE("startedAt")
-        ORDER BY DATE("startedAt")
-      `;
-    }
-    if (to !== null) {
-      return this.prisma.$queryRaw<DailyRow[]>`
-        SELECT
-          TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
-          SUM("inputTokens")         AS input,
-          SUM("outputTokens")        AS output,
-          SUM("cacheReadTokens")     AS cache_read,
-          SUM("cacheCreationTokens") AS cache_creation,
-          SUM("costUsd")             AS cost_usd
-        FROM "AgentCronRun"
-        WHERE skipped = false
-          AND "startedAt" < ${to}
-        GROUP BY DATE("startedAt")
-        ORDER BY DATE("startedAt")
-      `;
-    }
+  private queryDaily(filter: Prisma.Sql): Promise<DailyRow[]> {
     return this.prisma.$queryRaw<DailyRow[]>`
       SELECT
         TO_CHAR(DATE("startedAt"), 'YYYY-MM-DD') AS period,
@@ -525,6 +278,7 @@ export class AgentCronRunStatsService {
         SUM("costUsd")             AS cost_usd
       FROM "AgentCronRun"
       WHERE skipped = false
+      ${filter}
       GROUP BY DATE("startedAt")
       ORDER BY DATE("startedAt")
     `;

--- a/admin/src/agents-api.integration.test.ts
+++ b/admin/src/agents-api.integration.test.ts
@@ -15,6 +15,7 @@ import { sign } from "hono/jwt";
 import { PrismaClient } from "../prisma/client/index.js";
 import { AgentChatTokenService } from "./agent-chat-tokens.ts";
 import { AgentCronJobService } from "./agent-cron-jobs.ts";
+import { AgentCronRunStatsService } from "./agent-cron-run-stats.ts";
 import { AgentCronRunService } from "./agent-cron-runs.ts";
 import { AgentEnvService } from "./agent-envs.ts";
 import { AgentPluginService } from "./agent-plugins.ts";
@@ -90,6 +91,7 @@ describeOrSkip("admin CRUD API (integration)", () => {
       agentEnvService: new AgentEnvService(prisma, crypto),
       agentCronJobService: new AgentCronJobService(prisma),
       agentCronRunService: new AgentCronRunService(prisma),
+      agentCronRunStatsService: new AgentCronRunStatsService(prisma),
       agentToolService: new AgentToolService(prisma),
       agentTokenService: new AgentTokenService(prisma),
       agentPluginService: new AgentPluginService(prisma),

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -396,6 +396,15 @@ function makeMockDeps(): AdminDeps {
         createdAt: new Date("2024-01-01T09:00:00.000Z"),
       }),
     },
+    agentCronRunStatsService: {
+      query: async () => ({
+        totals: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 },
+        byAgent: [],
+        byCron: [],
+        byModel: [],
+        daily: [],
+      }),
+    },
     provisioner: new RecordingProvisioner(),
     sessionSecret: SESSION_SECRET,
   };

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -302,6 +302,11 @@ function makeMockDeps(): AdminDeps {
         createdAt: new Date("2024-01-01"),
         updatedAt: new Date("2024-01-01"),
       }),
+      queryStats: async () => ({
+        totals: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 },
+        byAgent: [],
+        daily: [],
+      }),
     },
     prisma: {
       agent: {

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -728,17 +728,8 @@ const cronRunTokenStatsRoute = createRoute({
 
 const chatTokenDailyStatsQuerySchema = z
   .object({
-    // date-only params (YYYY-MM-DD); no z.string().date() pattern in this codebase
-    from: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .optional()
-      .openapi({ example: "2026-01-01" }),
-    to: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .optional()
-      .openapi({ example: "2026-02-01" }),
+    from: z.string().date().optional().openapi({ example: "2026-01-01" }),
+    to: z.string().date().optional().openapi({ example: "2026-02-01" }),
   })
   .openapi("ChatTokenDailyStatsQuery");
 

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -728,8 +728,8 @@ const cronRunTokenStatsRoute = createRoute({
 
 const chatTokenDailyStatsQuerySchema = z
   .object({
-    from: z.string().datetime().optional().openapi({ example: "2026-01-01T00:00:00Z" }),
-    to: z.string().datetime().optional().openapi({ example: "2026-02-01T00:00:00Z" }),
+    from: z.string().date().optional().openapi({ example: "2026-01-01" }),
+    to: z.string().date().optional().openapi({ example: "2026-02-01" }),
   })
   .openapi("ChatTokenDailyStatsQuery");
 

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -705,8 +705,8 @@ const upsertChatTokenDailyRoute = createRoute({
 
 const cronRunStatsQuerySchema = z
   .object({
-    from: z.string().optional().openapi({ example: "2026-01-01T00:00:00Z" }),
-    to: z.string().optional().openapi({ example: "2026-02-01T00:00:00Z" }),
+    from: z.string().datetime().optional().openapi({ example: "2026-01-01T00:00:00Z" }),
+    to: z.string().datetime().optional().openapi({ example: "2026-02-01T00:00:00Z" }),
   })
   .openapi("CronRunStatsQuery");
 
@@ -728,8 +728,17 @@ const cronRunTokenStatsRoute = createRoute({
 
 const chatTokenDailyStatsQuerySchema = z
   .object({
-    from: z.string().optional().openapi({ example: "2026-01-01" }),
-    to: z.string().optional().openapi({ example: "2026-02-01" }),
+    // date-only params (YYYY-MM-DD); no z.string().date() pattern in this codebase
+    from: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional()
+      .openapi({ example: "2026-01-01" }),
+    to: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional()
+      .openapi({ example: "2026-02-01" }),
   })
   .openapi("ChatTokenDailyStatsQuery");
 

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -26,6 +26,7 @@ import type {
   AgentCronJobService,
   AgentCronJobWithRunSummary,
 } from "./agent-cron-jobs.ts";
+import type { AgentCronRunStatsService } from "./agent-cron-run-stats.ts";
 import type { AgentCronRunService } from "./agent-cron-runs.ts";
 import type { AgentEnvService } from "./agent-envs.ts";
 import type { AgentPluginService } from "./agent-plugins.ts";
@@ -61,6 +62,7 @@ import {
   CreateAgentToolBodySchema,
   CronIdParamSchema,
   CronRunIdParamSchema,
+  CronRunTokenStatsSchema,
   CronRunsListSchema,
   CronsWithSummaryWrapperSchema,
   EnvKeyParamSchema,
@@ -98,6 +100,7 @@ export interface AdminDeps {
     | "updatePreCheck"
   >;
   agentCronRunService: Pick<AgentCronRunService, "create" | "list" | "patch">;
+  agentCronRunStatsService: Pick<AgentCronRunStatsService, "query">;
   agentToolService: Pick<
     AgentToolService,
     "list" | "add" | "remove" | "toggle"
@@ -690,10 +693,35 @@ const upsertChatTokenDailyRoute = createRoute({
   responses: {
     200: {
       description: "Updated daily chat token usage row",
-      content: { "application/json": { schema: AgentChatTokenUsageDailySchema } },
+      content: {
+        "application/json": { schema: AgentChatTokenUsageDailySchema },
+      },
     },
     400: { description: "Bad request", ...jsonError },
     404: { description: "Agent not found", ...jsonError },
+  },
+});
+
+const cronRunStatsQuerySchema = z
+  .object({
+    from: z.string().optional().openapi({ example: "2026-01-01T00:00:00Z" }),
+    to: z.string().optional().openapi({ example: "2026-02-01T00:00:00Z" }),
+  })
+  .openapi("CronRunStatsQuery");
+
+const cronRunTokenStatsRoute = createRoute({
+  method: "get",
+  path: "/agents/all/cron-runs/stats",
+  request: {
+    query: cronRunStatsQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Aggregated cron-run token stats across all agents",
+      content: { "application/json": { schema: CronRunTokenStatsSchema } },
+    },
+    401: { description: "Unauthorized", ...jsonError },
+    403: { description: "Forbidden — requires admin scope", ...jsonError },
   },
 });
 
@@ -704,6 +732,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     agentEnvService,
     agentCronJobService,
     agentCronRunService,
+    agentCronRunStatsService,
     agentToolService,
     agentTokenService,
     agentPluginService,
@@ -1264,6 +1293,22 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     const { name } = c.req.valid("query");
     await agentPluginService.removeByName(agentId, name);
     return c.body(null, 204);
+  });
+
+  // ─── Cron-run token stats ──────────────────────────────────────────────────
+
+  // GET /agents/all/cron-runs/stats — aggregated token stats across all agents
+  // Static path "all" must be registered before any /:id routes to prevent
+  // the literal "all" being matched as an agentId.
+  app.openapi(cronRunTokenStatsRoute, async (c) => {
+    if (c.get("isAdmin") !== true) {
+      throw new ForbiddenError(
+        "Only admin bearers and session users can access cross-agent stats",
+      );
+    }
+    const { from, to } = c.req.valid("query");
+    const stats = await agentCronRunStatsService.query(from, to);
+    return c.json(stats, 200);
   });
 
   // ─── Chat token usage ──────────────────────────────────────────────────────

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -728,8 +728,8 @@ const cronRunTokenStatsRoute = createRoute({
 
 const chatTokenDailyStatsQuerySchema = z
   .object({
-    from: z.string().date().optional().openapi({ example: "2026-01-01" }),
-    to: z.string().date().optional().openapi({ example: "2026-02-01" }),
+    from: z.string().datetime().optional().openapi({ example: "2026-01-01T00:00:00Z" }),
+    to: z.string().datetime().optional().openapi({ example: "2026-02-01T00:00:00Z" }),
   })
   .openapi("ChatTokenDailyStatsQuery");
 

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -53,6 +53,7 @@ import {
   AgentSummarySchema,
   AgentTokenSchema,
   AgentToolSchema,
+  ChatTokenStatsSchema,
   CreateAgentBodySchema,
   CreateAgentCronJobBodySchema,
   CreateAgentCronRunBodySchema,
@@ -113,7 +114,7 @@ export interface AdminDeps {
     AgentPluginService,
     "list" | "add" | "remove" | "removeByName"
   >;
-  agentChatTokenService: Pick<AgentChatTokenService, "upsertDaily">;
+  agentChatTokenService: Pick<AgentChatTokenService, "upsertDaily" | "queryStats">;
   prisma: Pick<PrismaClient, "agent">;
   /**
    * Provisions (and tears down) the workload backing an agent. Defaults to a
@@ -725,6 +726,30 @@ const cronRunTokenStatsRoute = createRoute({
   },
 });
 
+const chatTokenDailyStatsQuerySchema = z
+  .object({
+    from: z.string().optional().openapi({ example: "2026-01-01" }),
+    to: z.string().optional().openapi({ example: "2026-02-01" }),
+  })
+  .openapi("ChatTokenDailyStatsQuery");
+
+const chatTokenDailyStatsRoute = createRoute({
+  method: "get",
+  path: "/agents/chat-tokens/daily/stats",
+  request: {
+    query: chatTokenDailyStatsQuerySchema,
+  },
+  responses: {
+    200: {
+      description:
+        "Aggregated chat token daily stats across all agents",
+      content: { "application/json": { schema: ChatTokenStatsSchema } },
+    },
+    401: { description: "Unauthorized", ...jsonError },
+    403: { description: "Forbidden — requires admin scope", ...jsonError },
+  },
+});
+
 // ─── App factory ──────────────────────────────────────────────────────────────
 
 export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
@@ -1308,6 +1333,20 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     }
     const { from, to } = c.req.valid("query");
     const stats = await agentCronRunStatsService.query(from, to);
+    return c.json(stats, 200);
+  });
+
+  // GET /agents/chat-tokens/daily/stats — aggregated daily chat token stats
+  // Static path "chat-tokens" must be registered before any /:id routes to
+  // prevent "chat-tokens" from being matched as an agentId.
+  app.openapi(chatTokenDailyStatsRoute, async (c) => {
+    if (c.get("isAdmin") !== true) {
+      throw new ForbiddenError(
+        "Only admin bearers and session users can access cross-agent stats",
+      );
+    }
+    const { from, to } = c.req.valid("query");
+    const stats = await agentChatTokenService.queryStats(from, to);
     return c.json(stats, 200);
   });
 

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -581,6 +581,11 @@ function buildCombinedApp() {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
+      queryStats: async () => ({
+        totals: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 },
+        byAgent: [],
+        daily: [],
+      }),
     },
     agentCronRunStatsService: {
       query: async () => ({

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -582,6 +582,21 @@ function buildCombinedApp() {
         updatedAt: new Date(),
       }),
     },
+    agentCronRunStatsService: {
+      query: async () => ({
+        totals: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheCreation: 0,
+          total: 0,
+        },
+        byAgent: [],
+        byCron: [],
+        byModel: [],
+        daily: [],
+      }),
+    },
     prisma: {
       agent: {
         create: async () => ({

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -24,6 +24,7 @@ import type { PullRequestItem } from "./admin-ui-pages.ts";
 import { createAdminUIApp } from "./admin-ui.ts";
 import { AgentChatTokenService } from "./agent-chat-tokens.ts";
 import { AgentCronJobService } from "./agent-cron-jobs.ts";
+import { AgentCronRunStatsService } from "./agent-cron-run-stats.ts";
 import { AgentCronRunService } from "./agent-cron-runs.ts";
 import { AgentEnvService } from "./agent-envs.ts";
 import { AgentPluginService } from "./agent-plugins.ts";
@@ -222,6 +223,7 @@ async function startServer(): Promise<void> {
   const agentTokenService = new AgentTokenService(prisma);
   const agentPluginService = new AgentPluginService(prisma);
   const agentChatTokenService = new AgentChatTokenService(prisma);
+  const agentCronRunStatsService = new AgentCronRunStatsService(prisma);
 
   // Real K8s provisioner when SHIPWRIGHT_K8S_PROVISIONING=enabled, else Noop.
   const provisioner = buildProvisioner(process.env, agentTokenService);
@@ -276,6 +278,7 @@ async function startServer(): Promise<void> {
     agentEnvService,
     agentCronJobService,
     agentCronRunService,
+    agentCronRunStatsService,
     agentToolService,
     agentTokenService,
     agentPluginService,

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -253,10 +253,30 @@ export const PatchAgentCronRunBodySchema = z
       .nullable()
       .optional()
       .openapi({ example: "pre-check returned false" }),
-    inputTokens: z.number().int().nullable().optional().openapi({ example: 1234 }),
-    outputTokens: z.number().int().nullable().optional().openapi({ example: 567 }),
-    cacheReadTokens: z.number().int().nullable().optional().openapi({ example: 89 }),
-    cacheCreationTokens: z.number().int().nullable().optional().openapi({ example: 10 }),
+    inputTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 1234 }),
+    outputTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 567 }),
+    cacheReadTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 89 }),
+    cacheCreationTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 10 }),
     costUsd: z.number().nullable().optional().openapi({ example: 0.0042 }),
     model: z
       .string()
@@ -518,6 +538,54 @@ export const AgentChatTokenUsageDailySchema = z
 export type AgentChatTokenUsageDailyType = z.infer<
   typeof AgentChatTokenUsageDailySchema
 >;
+
+// ─── CronRunTokenStats ────────────────────────────────────────────────────────
+
+/**
+ * A single rolled-up token aggregate (totals row or per-dimension bucket).
+ */
+const TokenAggregateSchema = z
+  .object({
+    input: z.number().int().openapi({ example: 600 }),
+    output: z.number().int().openapi({ example: 300 }),
+    cacheRead: z.number().int().openapi({ example: 60 }),
+    cacheCreation: z.number().int().openapi({ example: 30 }),
+    total: z.number().int().openapi({ example: 990 }),
+    costUsd: z.number().optional().openapi({ example: 0.006 }),
+  })
+  .openapi("TokenAggregate");
+
+/** A token aggregate keyed by a single grouping value (e.g. agentId). */
+const KeyedTokenAggregateSchema = TokenAggregateSchema.extend({
+  key: z.string().openapi({ example: "agent-id-123" }),
+}).openapi("KeyedTokenAggregate");
+
+/** A token aggregate keyed by two grouping values (e.g. agentId + cronName). */
+const DoubleKeyedTokenAggregateSchema = TokenAggregateSchema.extend({
+  key1: z.string().openapi({ example: "agent-id-123" }),
+  key2: z.string().openapi({ example: "morning-brief" }),
+}).openapi("DoubleKeyedTokenAggregate");
+
+/** A token aggregate bucketed by day (YYYY-MM-DD). */
+const DailyTokenAggregateSchema = TokenAggregateSchema.extend({
+  period: z.string().openapi({ example: "2026-01-10" }),
+}).openapi("DailyTokenAggregate");
+
+/**
+ * Response shape for GET /agents/all/cron-runs/stats.
+ * Matches the CronRunTokenStats interface in admin-metrics-client.ts exactly.
+ */
+export const CronRunTokenStatsSchema = z
+  .object({
+    totals: TokenAggregateSchema,
+    byAgent: z.array(KeyedTokenAggregateSchema),
+    byCron: z.array(DoubleKeyedTokenAggregateSchema),
+    byModel: z.array(DoubleKeyedTokenAggregateSchema),
+    daily: z.array(DailyTokenAggregateSchema),
+  })
+  .openapi("CronRunTokenStats");
+
+export type CronRunTokenStatsType = z.infer<typeof CronRunTokenStatsSchema>;
 
 // ─── AgentConfig (runtime GET /agents/:id/config response) ───────────────────
 

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -587,6 +587,21 @@ export const CronRunTokenStatsSchema = z
 
 export type CronRunTokenStatsType = z.infer<typeof CronRunTokenStatsSchema>;
 
+/**
+ * Response shape for GET /agents/chat-tokens/daily/stats.
+ * Matches the ChatTokenStats interface in admin-metrics-client.ts exactly.
+ * No byCron or byModel — chat tokens are not cron-scoped.
+ */
+export const ChatTokenStatsSchema = z
+  .object({
+    totals: TokenAggregateSchema,
+    byAgent: z.array(KeyedTokenAggregateSchema),
+    daily: z.array(DailyTokenAggregateSchema),
+  })
+  .openapi("ChatTokenStats");
+
+export type ChatTokenStatsType = z.infer<typeof ChatTokenStatsSchema>;
+
 // ─── AgentConfig (runtime GET /agents/:id/config response) ───────────────────
 
 export const AgentConfigPluginSchema = z

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -51,6 +51,7 @@ Mounted at `/agents/*` (unified with the runtime API surface). Auth: **admin key
 | Agents | `POST /agents` (admin-only: creates agent, returns `{id, name, slackId, selfHosted, repos, createdAt, updatedAt}` with `201`), `GET /agents/:id` (admin-only: fetches agent record), `GET /agents` (admin-only: lists agents), `PATCH /agents/:id` (admin-only: updates agent fields like `selfHosted` and `repos`; repos validation: each entry must be `org/repo` format), `POST /agents/:id/provision` (admin-only: provisions a managed agent or returns `{skipped: true, reason: "self-hosted"}` for self-hosted agents) |
 | Envs | `POST` / `GET` / `PATCH` `/agents/:id/envs`, `DELETE /agents/:id/envs/:key` |
 | Crons | `POST` `/agents/:id/crons`, `PATCH` / `DELETE` `/agents/:id/crons/:cronId`, `POST /agents/:id/crons/reconcile`, `POST` / `GET` / `PATCH` `/agents/:id/crons/:cronId/runs/{runId}` |
+| Cron Run Stats | `GET /agents/all/cron-runs/stats` (admin-only: returns aggregated token stats across all agents; query params: `from` / `to` (optional ISO datetime); returns `{totals, byAgent, byCron, byModel, daily}`) |
 | Reconciliation | `POST /agents/reconcile` (admin-only: reconciles K8s Deployments against all managed (non-self-hosted) agents; returns `{recreated: string[], updated: string[], orphans: string[], failed: Array<{agentId, error}>}`) |
 | Tools | `POST` / `GET` `/agents/:id/tools`, `PATCH` / `DELETE` `/agents/:id/tools/:toolId` |
 | Tokens | `POST` / `GET` `/agents/:id/tokens`, `DELETE /agents/:id/tokens/:tokenId` |

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -55,7 +55,7 @@ Mounted at `/agents/*` (unified with the runtime API surface). Auth: **admin key
 | Reconciliation | `POST /agents/reconcile` (admin-only: reconciles K8s Deployments against all managed (non-self-hosted) agents; returns `{recreated: string[], updated: string[], orphans: string[], failed: Array<{agentId, error}>}`) |
 | Tools | `POST` / `GET` `/agents/:id/tools`, `PATCH` / `DELETE` `/agents/:id/tools/:toolId` |
 | Tokens | `POST` / `GET` `/agents/:id/tokens`, `DELETE /agents/:id/tokens/:tokenId` |
-| Chat Tokens | `POST /agents/:id/chat-tokens/daily` (daily upsert: atomically accumulates Slack chat session token usage by `(agentId, date)`; body: `{date: YYYY-MM-DD, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd}`; returns the updated daily row `{id, agentId, date, ...}`) |
+| Chat Tokens | `POST /agents/:id/chat-tokens/daily` (daily upsert: atomically accumulates Slack chat session token usage by `(agentId, date)`; body: `{date: YYYY-MM-DD, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd}`; returns the updated daily row `{id, agentId, date, ...}`), `GET /agents/chat-tokens/daily/stats` (admin-only: aggregated chat-token daily stats across all agents; query params: `from` / `to` (optional YYYY-MM-DD date strings); returns `{totals, byAgent, daily}`) |
 | Plugins | `POST` / `GET` / `PATCH` `/agents/:id/plugins`, `DELETE /agents/:id/plugins` |
 
 Token creation returns the **raw token once** at creation; only its SHA-256 hash is persisted, so validation is an O(1) hash-index lookup.

--- a/metrics/src/lib/admin-metrics-client.ts
+++ b/metrics/src/lib/admin-metrics-client.ts
@@ -142,8 +142,15 @@ export class HttpAdminMetricsClient implements AdminMetricsClient {
     from?: string;
     to?: string;
   }): Promise<ChatTokenStats> {
+    // The chat-tokens endpoint uses z.string().date() (YYYY-MM-DD) — the
+    // underlying table is date-only. Slice any ISO datetime strings to the
+    // date portion before forwarding so the schema accepts them.
+    const dateParams = {
+      from: params.from ? params.from.slice(0, 10) : undefined,
+      to: params.to ? params.to.slice(0, 10) : undefined,
+    };
     return this.fetch<ChatTokenStats>(
-      `/agents/chat-tokens/daily/stats${HttpAdminMetricsClient.query(params)}`,
+      `/agents/chat-tokens/daily/stats${HttpAdminMetricsClient.query(dateParams)}`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- Adds `GET /agents/all/cron-runs/stats?from=&to=` endpoint (scope `*` required) to the admin service
- New `AgentCronRunStatsService` aggregates `AgentCronRun` token columns into five dimensions: totals, byAgent, byCron (LEFT JOIN `AgentCronJob` for name), byModel, and daily
- Skipped runs (`skipped=true`) excluded from all aggregations; `byCron[].key2` uses `AgentCronJob.name` when set, falls back to `cronId`
- `CronRunTokenStatsSchema` added to `openapi-schemas.ts`; all types defined locally in admin to respect `rootDir` TypeScript constraint

## Test plan

- [x] 6 smoke tests (Hono in-process, no DB): 200 session auth, correct mock values, from/to params, 200 admin bearer, 401 unauthenticated, 403 agent-scoped token
- [x] 15 integration tests (DB-backed, skip when `DATABASE_URL_ADMIN_TEST` unset): totals, byAgent grouping, byCron name/fallback, byModel, daily, skipped exclusion, from/to date filtering, comprehensive acceptance
- [x] Typecheck: `bun run --filter='*' typecheck` passes clean
- [x] Biome lint+format: all 10 changed files pass `biome check`
- [x] Regression: `agents-api.smoke.test.ts` 84/84 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)