### PR TITLE
docs(site): fix skills section in the-plugin.mdx — replace dev tools with plugin skills

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ The plugin drives the delivery loop: **spec → plan → execute → review → 
 Key surfaces (see `plugins/shipwright/README.md` and `plugins/shipwright/CLAUDE.md` for the full command/skill catalog):
 
 - **Commands** (`commands/`) — `prd`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, the five-phase test-readiness pipeline (`test-inventory` → `test-design` → `test-migration` → `test-roadmap` → `test-publish`), `metrics`, `research`, `research-docs`, and more.
-- **Skills** (`skills/`) — autonomous behaviors including `ship-loop` (drains the task queue one pipeline step per call) and `shipwright-brand`.
+- **Skills** (`skills/`) — autonomous behaviors including `pull-requests`, `review-staged`, `entropy-scan`, `entropy-fix`, `agent-admin`, `investigate-cron`, `learning-capture`, `task-store`, `test-readiness`, `test-debt`, `triage-dependabot-pr`, and `triage-dependabot-prs`.
 - **Scripts** (`scripts/`) — the task-store adapters, `check-dev-task.ts`, and supporting tooling.
 - **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, …).
 

--- a/site/src/content/docs/the-plugin.mdx
+++ b/site/src/content/docs/the-plugin.mdx
@@ -76,25 +76,49 @@ Claude Code will run each phase in order, wait for results, and publish the fina
 
 Skills are autonomous behaviors that run multi-step loops without manual hand-holding.
 
+### Delivery loop
+
 | Skill | What it does |
 |-------|--------------|
-| `ship-loop` | Drains the task queue autonomously — one pipeline step per call (pick → build → review → deploy) |
-| `shipwright-brand` | Validates and enforces brand consistency across site artifacts |
+| `pull-requests` | Query PR records from the task store — filter by repo, PR number, state, reviewState, or staged flag |
+| `review-staged` | Walk through staged PR reviews from the task store conversationally — APPROVEs first, then COMMENTs, smallest diff to largest |
 
-To start the ship loop:
+### Code health
 
-```text
-/shipwright:ship-loop
-```
+| Skill | What it does |
+|-------|--------------|
+| `entropy-scan` | Scan codebase for golden principle deviations — report only, no code changes |
+| `entropy-fix` | Read the entropy report, fix pr-worthy violations, and open targeted PRs — one PR per concern |
 
-The loop runs until the queue is empty or it hits a decision that requires human input.
+### Agent operations
+
+| Skill | What it does |
+|-------|--------------|
+| `agent-admin` | Query and manage Shipwright agents via the admin API — cron jobs, env vars, tool permissions, API tokens, and plugins |
+| `investigate-cron` | Diagnose why a cron run behaved unexpectedly — finds the session transcript by cron name and time |
+| `learning-capture` | Capture a durable learning by editing CLAUDE.md or LEARNINGS.md directly |
+| `task-store` | Query and update the Shipwright task store — pick the next ready task, mark status transitions, append new tasks |
+
+### Dependabot
+
+| Skill | What it does |
+|-------|--------------|
+| `triage-dependabot-pr` | Analyze a single Dependabot PR — classify risk (merge/review/hold) and stage a review comment |
+| `triage-dependabot-prs` | Scan all repos for open Dependabot PRs, triage new ones, and stage review comments in batch |
+
+### Test-readiness
+
+| Skill | What it does |
+|-------|--------------|
+| `test-readiness` | Orchestrate the full test-readiness pipeline (phases 1–5) for the active worktree |
+| `test-debt` | Compute a corrective-commit ratio per milestone to surface planning debt after a run |
 
 ## Plugin anatomy
 
 The plugin lives at `plugins/shipwright/` in the repo and is structured around four directories:
 
 - **`commands/`** — every slash command listed above, as individual TypeScript files
-- **`skills/`** — autonomous behavior scripts (`ship-loop`, `shipwright-brand`, and more)
+- **`skills/`** — autonomous behavior scripts (`agent-admin`, `entropy-scan`, `test-readiness`, and more)
 - **`scripts/`** — task-store adapters, `check-dev-task.ts`, and supporting tooling
 - **`references/`** — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`)
 


### PR DESCRIPTION
## Summary
- Replace `ship-loop` and `shipwright-brand` (repo-local dev tools) with the 12 actual plugin skills from `plugins/shipwright/skills/`
- Group skills by purpose: Delivery loop, Code health, Agent operations, Dependabot, Test-readiness
- Omit internal-contract skills (canary-execution, repo-config, speed-budgets) from user-facing table
- Fix Plugin anatomy bullet to name real plugin skills instead of dev tools

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `ship-loop` and `shipwright-brand` absent from Skills section and Plugin anatomy | ✅ MET |
| 2 | All 12 user-facing plugin skills present with accurate descriptions, grouped by category | ✅ MET |
| 3 | Internal-contract skills omitted from user-facing table | ✅ MET |
| 4 | Plugin anatomy bullet uses correct skill examples | ✅ MET |
| 5 | Content-only edit — no test changes | ✅ MET |

## Test Plan
- [x] Site builds cleanly (`npm run build` in `site/`) — `the-plugin/index.html` generated
- [x] No test file changes (content-only docs edit)

Generated with [Claude Code](https://claude.com/claude-code)
