### PR TITLE
feat(site): clean up stale plugin env vars in config-vars.ts

### DIFF
--- a/site/src/data/config-vars.ts
+++ b/site/src/data/config-vars.ts
@@ -6,16 +6,12 @@ export interface ConfigVar {
 }
 
 export const pluginEnvVars: ConfigVar[] = [
-  { name: "JIRA_BASE_URL", type: "string", def: "—", desc: "Base URL of the Jira instance (e.g. https://example.atlassian.net). Required when using the Jira backend." },
-  { name: "JIRA_PROJECT_KEY", type: "string", def: "—", desc: "Jira project key (e.g. SHIP). Required when using the Jira backend." },
-  { name: "SHIPWRIGHT_REPOS_DIR", type: "string", def: "<AGENT_HOME>/workspace/repos", desc: "Override the workspace repos directory." },
-  { name: "SHIPWRIGHT_WORKTREE_DIR", type: "string", def: "<AGENT_HOME>/workspace/worktrees", desc: "Override the workspace worktrees directory." },
   { name: "SHIPWRIGHT_DEV_CHAT", type: "bool", def: "false", desc: "Enables the unauthenticated POST /chat endpoint. Must not be set in production." },
   { name: "GH_CMD", type: "string", def: "gh", desc: "Override the gh CLI executable. Useful in environments where gh is installed to a non-default path." },
-  { name: "AGENT_HOME", type: "string", def: "~/.shipwright-agent", desc: "Persistent storage root for workspace files, mise caches, and ~/.claude." },
+  { name: "AGENT_HOME", type: "string", def: "/data/agent-home", desc: "Persistent storage root for workspace files, mise caches, and ~/.claude." },
   { name: "WORKSPACE_PATH", type: "string", def: "—", desc: "Direct workspace path override. Takes precedence over AGENT_HOME-based discovery when set." },
-  { name: "JIRA_API_TOKEN", type: "string", def: "—", desc: "API token for Jira authentication. Required when using the Jira backend. Env-var-only (secret)." },
-  { name: "JIRA_EMAIL", type: "string", def: "—", desc: "Email address for Jira authentication. Required when using the Jira backend." },
+  { name: "SHIPWRIGHT_TASK_STORE_URL", type: "string", def: "—", desc: "Base URL of the Shipwright task-store service. Injected into the agent Deployment by the admin provisioner; agents use this to authenticate with the task-store API when claiming tasks or updating status." },
+  { name: "SHIPWRIGHT_TASK_STORE_TOKEN", type: "string", def: "—", desc: "Bearer token for task-store API access. Minted per-agent by the admin provisioner; used by agents and plugin scripts to claim tasks, update status, and query the task queue. Env-var-only (secret)." },
 ];
 
 export const agentClaudeVars: ConfigVar[] = [


### PR DESCRIPTION
## Summary
- Remove 6 stale vars from `pluginEnvVars` (JIRA_*, SHIPWRIGHT_REPOS_DIR, SHIPWRIGHT_WORKTREE_DIR)
- Fix `AGENT_HOME` default from `~/.shipwright-agent` to `/data/agent-home`
- Add `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` with accurate descriptions

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All nine removed vars gone from `pluginEnvVars` | ✅ MET |
| 2 | AGENT_HOME default reads `/data/agent-home` in plugin section | ✅ MET |
| 3 | SHIPWRIGHT_TASK_STORE_URL and _TOKEN in pluginEnvVars with matching descriptions | ✅ MET |
| 4 | `npm run build` in site/ exits 0 with no TypeScript errors | ✅ MET |
| 5 | No test changes needed (data-only, build is gate) | ✅ MET |

## Test Plan
- [x] `bun run build` in `site/` passes — 12 pages built, no errors
- [x] `bunx biome lint` on changed file — no issues
- [x] TypeScript compilation via `build:check` — all pages on-brand

Generated with [Claude Code](https://claude.com/claude-code)
