### PR TITLE
docs: add task store API reference page (DRR-2.1)

### DIFF
--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -21,7 +21,13 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `bunx astro build && bunx pagefind --site dist && bunx astro preview --port ${PORT}`,
+    // SKIP_PAGEFIND=1 lets CI-equivalent local environments skip the pagefind
+    // indexing step (e.g. ARM systems where the pagefind binary fails due to
+    // jemalloc/page-size incompatibilities). CI always runs without this var,
+    // so pagefind runs normally in GitHub Actions.
+    command: process.env.SKIP_PAGEFIND
+      ? `bunx astro build && bunx astro preview --port ${PORT}`
+      : `bunx astro build && bunx pagefind --site dist && bunx astro preview --port ${PORT}`,
     url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/site/src/content/docs/prs-api.mdx
+++ b/site/src/content/docs/prs-api.mdx
@@ -108,8 +108,8 @@ Atomically claim a PR for review. Returns **201** when a new record is created, 
 |---|---|---|---|
 | `repo` | string | yes | `org/repo` format |
 | `prNumber` | int | yes | GitHub PR number |
-| `commitSha` | string | no | Current HEAD commit SHA of the PR branch |
-| `agentId` | string | no | Claiming agent ID |
+| `commitSha` | string | yes | Current HEAD commit SHA of the PR branch |
+| `claimedBy` | string | admin tokens only | Agent ID to claim as; agent tokens use the token's own agent ID |
 | `taskId` | string | no | Associated task ID |
 
 **Claim semantics:**

--- a/site/src/content/docs/prs-api.mdx
+++ b/site/src/content/docs/prs-api.mdx
@@ -1,0 +1,347 @@
+---
+title: PRs API
+description: "HTTP API reference for PR review tracking: endpoints, PR schema, reviewState lifecycle, staged flag, heartbeat TTL, and curl examples."
+section: Reference
+order: 10
+---
+
+# PRs API
+
+The PRs API tracks review cycles for open pull requests. Where a task record drives the **build cycle** (pending → in_progress → pr_open → deployed), a PR record drives the **review cycle** — claim, review, patch, re-review, approve.
+
+> **See also:** [Task Store API](/docs/task-store-api) — the companion surface for task queuing and execution tracking.
+
+## How PR Records Relate to Tasks
+
+| Concept | Answers | Lifecycle |
+|---|---|---|
+| **Task** | "What code work is being done?" | `pending → in_progress → pr_open → approved → deployed` |
+| **PR record** | "Is this PR reviewed and ready?" | `pending → in_progress → posted → approved` |
+
+A task typically has one associated PR record once it reaches `pr_open`. The link is optional — either resource can exist without the other — but the `taskId` field on the PR record makes the association explicit.
+
+Multiple review rounds on the same PR are represented by `reviewCycles` (how many times a review was posted) and `patchCycles` (how many times the PR was patched and re-queued).
+
+## Authentication
+
+All requests require a Bearer token in the `Authorization` header:
+
+```bash
+Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN
+```
+
+The PRs API shares its auth layer with the task store — the same token and env vars apply:
+
+| Env var | Description |
+|---|---|
+| `SHIPWRIGHT_TASK_STORE_URL` | Base URL of the task store service |
+| `SHIPWRIGHT_TASK_STORE_TOKEN` | Bearer token for this agent or admin |
+
+## reviewState Lifecycle
+
+PR records move through a defined set of review states:
+
+```
+pending → in_progress → posted → approved
+```
+
+| State | Meaning |
+|---|---|
+| `pending` | Not yet claimed for review; eligible for pickup |
+| `in_progress` | Claimed by a review agent; review is being written |
+| `posted` | Review has been posted to GitHub; counter incremented |
+| `approved` | PR passed review and is approved for merge |
+
+### State transitions
+
+| Action | From | To | Side effects |
+|---|---|---|---|
+| `POST /prs/claim` | `pending` | `in_progress` | Sets `claimedBy`, `claimedAt`, `heartbeatAt` |
+| `POST /prs/:id/complete` | `in_progress` | `posted` | `reviewCycles++`, sets `reviewedAt` |
+| `POST /prs/:id/patch` | any | `pending` | `patchCycles++`, sets `patchedAt`, clears claim fields |
+| `POST /prs/:id/release` | any | `pending` | Clears claim fields (`claimedBy`, `claimedAt`, `heartbeatAt`) |
+| `PATCH /prs/:id` | any | any | Direct field update — set `reviewState: "approved"` explicitly |
+
+## staged Flag
+
+The `staged` boolean marks a review that has been written but not yet posted to GitHub:
+
+- **`staged: false`** (default) — normal state; no review is written or the review has been posted.
+- **`staged: true`** — review text is ready locally but posting is deferred (e.g. awaiting human approval, rate-limit backoff, or policy check). The record stays in `in_progress` while staged.
+
+Set `staged` via `PATCH /prs/:id`. Once the review is posted, call `POST /prs/:id/complete` (which implicitly clears staged) or set `staged: false` in the same PATCH.
+
+## Endpoints
+
+### GET /prs
+
+List PR records. Returns `{ prs, total, limit, offset }`.
+
+| Query param | Type | Description |
+|---|---|---|
+| `repo` | string | Filter by `org/repo` format |
+| `prNumber` | int | Filter by PR number (use with `repo` to get a specific record) |
+| `taskId` | string | Filter by linked task ID |
+| `state` | string | Filter by PR state: `open`, `merged`, `closed` |
+| `reviewState` | string | Filter by review state: `pending`, `in_progress`, `posted`, `approved` |
+| `staged` | boolean | `true` to return only staged reviews |
+| `limit` | int | Max results (pagination) |
+| `offset` | int | Start offset (pagination) |
+
+```bash
+# All pending PR records in a repo
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo=org/repo&reviewState=pending" | jq '.prs'
+
+# Specific PR by repo + number
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo=org/repo&prNumber=42" | jq '.prs[0]'
+```
+
+### POST /prs/claim
+
+Atomically claim a PR for review. Returns **201** when a new record is created, **200** when an existing record is updated (re-claimed), and **409** when the PR is already claimed at the same commit by another agent.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `repo` | string | yes | `org/repo` format |
+| `prNumber` | int | yes | GitHub PR number |
+| `commitSha` | string | no | Current HEAD commit SHA of the PR branch |
+| `agentId` | string | no | Claiming agent ID |
+| `taskId` | string | no | Associated task ID |
+
+**Claim semantics:**
+
+- Same `commitSha` + `reviewState !== pending` → **409 Conflict** (PR already under review at this commit)
+- Different `commitSha` OR `reviewState === pending` → update existing record, return **200**
+- No existing record → create new record, return **201**
+
+On success the record's `reviewState` is set to `in_progress`, and `claimedBy`, `claimedAt`, and `heartbeatAt` are populated.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d '{
+    "repo": "org/repo",
+    "prNumber": 42,
+    "commitSha": "abc1234",
+    "agentId": "<agent-id>"
+  }' | jq .
+```
+
+### GET /prs/:id
+
+Fetch a single PR record by its CUID. Returns **404** when not found.
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc" | jq .
+```
+
+### PATCH /prs/:id
+
+Partial update — only the provided fields are changed. Returns the updated record.
+
+**Updatable fields:** `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`, `reviewState`
+
+```bash
+# Mark review as staged (written but not yet posted)
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc" \
+  -d '{"staged": true}' | jq .
+
+# Set reviewState to approved directly
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc" \
+  -d '{"reviewState": "approved"}' | jq .
+
+# Record that the PR merged
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc" \
+  -d '{"state": "merged", "mergedAt": "2024-01-15T12:00:00Z"}' | jq .
+```
+
+### POST /prs/:id/heartbeat
+
+Touch `heartbeatAt` to signal that the review agent is still alive. Call this periodically during long-running review work to prevent the [StaleClaimReaper](#heartbeat-and-stale-claim-reaper) from releasing the claim.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc/heartbeat" | jq .
+```
+
+### POST /prs/:id/complete
+
+Mark the review as posted. Increments `reviewCycles`, sets `reviewState` to `posted`, and records `reviewedAt`. Call this after the GitHub review comment or approval has been successfully posted.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc/complete" | jq .
+```
+
+### POST /prs/:id/patch
+
+Record that the PR author pushed a patch in response to review feedback. Increments `patchCycles`, resets `reviewState` to `pending`, and records `patchedAt`. The claim fields (`claimedBy`, `claimedAt`, `heartbeatAt`) are cleared so the PR becomes eligible for re-review.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc/patch" | jq .
+```
+
+### POST /prs/:id/release
+
+Release a claim without completing or patching. Resets `reviewState` to `pending` and clears `claimedBy`, `claimedAt`, and `heartbeatAt`. Use when a review agent is shutting down or voluntarily relinquishing the PR.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/clx1234abc/release" | jq .
+```
+
+## Heartbeat and Stale Claim Reaper
+
+The **StaleClaimReaper** runs every 60 seconds and releases stale claims automatically. A claim is considered stale when:
+
+- `heartbeatAt` is set and older than the TTL, **or**
+- `heartbeatAt` is null and `claimedAt` is older than the TTL
+
+**Default TTL:** 300,000 ms (5 minutes). Override with the `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` env var.
+
+When a claim is reaped, the reaper:
+1. Sets `reviewState` back to `pending`
+2. Clears `claimedBy`, `claimedAt`, and `heartbeatAt`
+
+The PR becomes immediately eligible for re-claim by another agent (or the same agent on restart).
+
+### Heartbeat recommendations
+
+- Call `POST /prs/:id/heartbeat` at least once every 2–3 minutes during active review work.
+- Call it after any significant step (e.g. after reading the diff, after generating review text).
+- If your agent crashes and restarts, check for `in_progress` records matching your `agentId` before claiming new work — the reaper may not have fired yet.
+
+## PR Schema
+
+All fields from the `PullRequest` model:
+
+### Identity and linking
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | CUID assigned at creation; use for all subsequent API calls |
+| `repo` | string | `org/repo` format; required on claim |
+| `prNumber` | int | GitHub PR number; unique together with `repo` |
+| `taskId` | string? | Optional link to a task store task |
+| `agentId` | string? | ID of the agent that owns this record |
+
+### Review tracking
+
+| Field | Type | Notes |
+|---|---|---|
+| `reviewState` | PrReviewState | `pending` \| `in_progress` \| `posted` \| `approved` |
+| `staged` | boolean | `true` when a review is written but not yet posted to GitHub |
+| `reviewCycles` | int | Number of times a review has been posted (starts at 0) |
+| `patchCycles` | int | Number of times the PR was patched after a review (starts at 0) |
+| `commitSha` | string? | HEAD commit SHA at the time of the last claim |
+| `reviewedAt` | string? | ISO timestamp of the last completed review |
+| `patchedAt` | string? | ISO timestamp of the last recorded patch |
+
+### PR state
+
+| Field | Type | Notes |
+|---|---|---|
+| `state` | PrState | `open` \| `merged` \| `closed` |
+| `mergedAt` | string? | ISO timestamp when the PR was merged |
+
+### Claim and liveness
+
+| Field | Type | Notes |
+|---|---|---|
+| `claimedBy` | string? | Agent ID that currently holds the claim |
+| `claimedAt` | string? | ISO timestamp when the claim was taken |
+| `heartbeatAt` | string? | ISO timestamp of the last heartbeat; used by the StaleClaimReaper |
+
+### System fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `createdAt` | DateTime | Set by the database on creation |
+| `updatedAt` | DateTime | Updated by the database on every write |
+
+## HTTP Status Codes
+
+| Code | Meaning |
+|---|---|
+| 200 | Success — existing record updated (claim, PATCH, action endpoints) |
+| 201 | Created — new PR record created by claim |
+| 400 | Bad request — missing required field or invalid format |
+| 404 | Not found — no PR record with the given ID |
+| 409 | Conflict — PR already claimed at the same commit SHA with a non-pending reviewState |
+
+## Curl Examples: Full Happy-Path Lifecycle
+
+The following sequence demonstrates the complete review cycle: claim → heartbeat → complete, and then a patch round that resets for re-review.
+
+```bash
+BASE="$SHIPWRIGHT_TASK_STORE_URL"
+TOKEN="$SHIPWRIGHT_TASK_STORE_TOKEN"
+AUTH="Authorization: Bearer $TOKEN"
+
+# 1. Claim the PR for review (201 = new record, 200 = re-claim, 409 = already active)
+CLAIM=$(curl -sf -X POST \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/prs/claim" \
+  -d '{"repo": "org/repo", "prNumber": 42, "commitSha": "abc1234"}')
+echo "$CLAIM" | jq .
+
+PR_ID=$(echo "$CLAIM" | jq -r '.id')
+
+# 2. Send heartbeats while performing the review (every 2-3 minutes)
+curl -sf -X POST -H "$AUTH" "$BASE/prs/$PR_ID/heartbeat" | jq .
+
+# 3. (Optional) Mark as staged while awaiting human approval to post
+curl -sf -X PATCH \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/prs/$PR_ID" \
+  -d '{"staged": true}' | jq .
+
+# 4. After posting review to GitHub, mark complete
+#    (reviewCycles incremented, reviewState → posted, reviewedAt set)
+curl -sf -X POST -H "$AUTH" "$BASE/prs/$PR_ID/complete" | jq .
+
+# --- If the author pushes a patch in response to the review ---
+
+# 5. Record the patch cycle (patchCycles incremented, reviewState → pending)
+curl -sf -X POST -H "$AUTH" "$BASE/prs/$PR_ID/patch" | jq .
+
+# 6. The PR is now pending again — claim it for the next review round
+curl -sf -X POST \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/prs/claim" \
+  -d '{"repo": "org/repo", "prNumber": 42, "commitSha": "def5678"}' | jq .
+
+# --- When the PR is approved ---
+
+# 7. Set reviewState to approved directly
+curl -sf -X PATCH \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/prs/$PR_ID" \
+  -d '{"reviewState": "approved"}' | jq .
+```
+
+## See also
+
+- [Task Store API](/docs/task-store-api) — task queuing, execution tracking, and the build lifecycle
+- [Configuration Reference](/docs/reference) — `SHIPWRIGHT_TASK_STORE_URL`, `SHIPWRIGHT_TASK_STORE_TOKEN`, and all other env vars

--- a/site/src/content/docs/prs-api.mdx
+++ b/site/src/content/docs/prs-api.mdx
@@ -129,7 +129,7 @@ curl -sf -X POST \
     "repo": "org/repo",
     "prNumber": 42,
     "commitSha": "abc1234",
-    "agentId": "<agent-id>"
+    "claimedBy": "<agent-id>"
   }' | jq .
 ```
 

--- a/site/src/content/docs/reference.mdx
+++ b/site/src/content/docs/reference.mdx
@@ -138,6 +138,8 @@ cleanup_after_days: 14
 
 ## See also
 
+- [Task Store API](/docs/task-store-api) — complete HTTP API reference for `/tasks`: endpoints, task schema, status lifecycle, and curl examples.
+- [PRs API](/docs/prs-api) — HTTP API reference for `/prs`: PR review tracking, `reviewState` lifecycle, heartbeat TTL, and curl examples.
 - [architecture.md](https://github.com/app-vitals/shipwright/blob/main/docs/architecture.md) — the four-artifact A→B→C→D design.
 - [agent.md](https://github.com/app-vitals/shipwright/blob/main/docs/agent.md) — Shipwright agent runtime, admin CRUD APIs, and data model.
 - [quickstart.md](https://github.com/app-vitals/shipwright/blob/main/docs/quickstart.md) — how to get the full dev stack running locally.

--- a/site/src/content/docs/task-store-api.mdx
+++ b/site/src/content/docs/task-store-api.mdx
@@ -1,0 +1,469 @@
+---
+title: Task Store API
+description: "Complete HTTP API reference for the Shipwright task store: endpoints, task schema, status lifecycle, and curl examples."
+section: Reference
+order: 9
+---
+
+# Task Store API
+
+The task store is the central queue that drives autonomous task execution. Agents query it to pick
+up work, track progress, and record outcomes. This page is the primary reference for operators and
+agents interacting with `/tasks` directly.
+
+> **See also:** [PRs API](/docs/prs-api) — the companion surface for PR review and patch tracking.
+
+## Authentication
+
+All requests require a Bearer token in the `Authorization` header:
+
+```bash
+Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN
+```
+
+| Env var | Description |
+|---|---|
+| `SHIPWRIGHT_TASK_STORE_URL` | Base URL of the task store service (provisioned at deploy time) |
+| `SHIPWRIGHT_TASK_STORE_TOKEN` | Bearer token for this agent or admin |
+
+### Token scoping
+
+Tokens come in two varieties:
+
+- **Agent tokens** (`agentId` set) — all reads are automatically scoped to tasks assigned to that
+  agent. Writes are blocked on tasks belonging to other agents (403). Task creation forces
+  `assignee` to the token's agent ID.
+- **Admin tokens** (`agentId` null) — no restrictions. Can read and write any task. Required for
+  HITL execution and cross-agent inspection.
+
+Repo-scoped agent tokens additionally include unassigned pool tasks whose `repo` is in the token's
+repos list — allowing agents to pick up shared work without requiring an explicit `assignee`.
+
+Verify connectivity before starting work:
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.total'
+```
+
+## Task Status Lifecycle
+
+Tasks move through a defined set of statuses from creation to completion:
+
+```
+pending → in_progress → pr_open → approved → merged → deploying → deployed
+```
+
+Branch statuses that can occur at any point:
+
+```
+blocked    — dependency not met, or manually paused (HITL)
+cancelled  — permanently abandoned
+done       — completed without a PR (direct task, no deploy path)
+```
+
+Terminal statuses (dependency resolution treats these as satisfied):
+`merged`, `done`, `deploying`, `deployed`, `cancelled`
+
+| Status | Meaning |
+|---|---|
+| `pending` | Not yet started; eligible for `?ready=true` pickup if dependencies are met |
+| `in_progress` | Claimed by an agent; work is underway |
+| `pr_open` | PR has been opened on GitHub; `pr` and `prCreatedAt` must be set |
+| `approved` | PR passed review; `ciFixAttempts` must be set |
+| `merged` | PR merged to main; `mergedAt` should be set |
+| `deploying` | Deploy pipeline is running; `deployingAt` should be set |
+| `deployed` | Successfully deployed to production; `deployedAt` should be set |
+| `blocked` | Explicitly paused — waiting on human action or unresolvable dependency |
+| `done` | Task complete without a PR (e.g. research or HITL tasks) |
+| `cancelled` | Permanently abandoned |
+
+## Endpoints
+
+### GET /tasks
+
+List tasks. Returns `{ tasks, total }` for ready/blocked queries; `{ tasks, total, limit, offset }`
+for all other queries.
+
+| Query param | Description |
+|---|---|
+| `ready=true` | Return only tasks that are ready to pick up (see [?ready=true semantics](#readytrue-semantics)) |
+| `state=ready` | Alias for `?ready=true` |
+| `state=blocked` | Return pending tasks with unmet dependencies, HITL-gated tasks, and explicitly blocked tasks |
+| `state=open` | Filter to open tasks (pending, in_progress, pr_open, approved) |
+| `state=closed` | Filter to closed tasks (merged, done, deploying, deployed, cancelled) |
+| `state=in_progress` | Filter to actively running tasks |
+| `status` | Filter by exact status value (e.g. `?status=pr_open`) |
+| `session` | Filter by planning session slug |
+| `assignee` | Filter by assignee (admin tokens only — agent tokens are auto-scoped) |
+| `repo` | Filter by repo in `org/repo` format |
+| `branch` | Filter by branch name |
+| `pr` | Filter by PR number |
+| `claimedBy` | Filter by the agent that claimed the task |
+| `limit` | Max results (pagination) |
+| `offset` | Start offset (pagination) |
+
+```bash
+# All pending tasks assigned to this agent
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending" | jq '.tasks'
+
+# All ready tasks (dependencies met, pending, not HITL-gated)
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.tasks'
+```
+
+### POST /tasks
+
+Create a task. Returns 201 on success, 409 if a task with the same `id` already exists.
+
+**Required fields:** `title`, `status`
+
+**Recommended fields for agent pickup:** `id`, `repo` (org/repo format), `branch`, `assignee`
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks" \
+  -d '{
+    "id": "SHE-1.1",
+    "title": "Add feature X",
+    "status": "pending",
+    "repo": "org/repo",
+    "branch": "feat/she-1-1-add-feature-x",
+    "assignee": "<agent-id>"
+  }' | jq .
+```
+
+### POST /tasks/bulk
+
+Insert an array of tasks. Skips 409 conflicts silently. Returns `{ inserted, updated }`.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/bulk" \
+  -d '[{"id": "SHE-2.1", "title": "...", "status": "pending", "repo": "org/repo", "branch": "feat/she-2-1-..."}]' \
+  | jq .
+```
+
+### GET /tasks/distinct
+
+Return the distinct `sessions` and `repos` visible to the caller. Useful for filtering UI dropdowns.
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/distinct" | jq .
+```
+
+### GET /tasks/:id
+
+Fetch a single task by ID. Returns 404 if not found. Agent tokens get 403 if the task belongs to
+another agent.
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1" | jq .
+```
+
+### PATCH /tasks/:id
+
+Partial update — only provided fields are changed. Returns the updated task.
+
+Agent tokens are restricted to their own tasks. The `repo` field must remain in `org/repo` format.
+
+```bash
+# Transition to in_progress
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1" \
+  -d '{"status": "in_progress", "startedAt": "2024-01-15T10:00:00Z"}' | jq .
+
+# Transition to pr_open (requires pr + prCreatedAt)
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1" \
+  -d '{"status": "pr_open", "pr": 42, "prCreatedAt": "2024-01-15T11:00:00Z"}' | jq .
+
+# Transition to approved (requires ciFixAttempts)
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1" \
+  -d '{"status": "approved", "ciFixAttempts": 0}' | jq .
+```
+
+### DELETE /tasks/:id
+
+Delete a task permanently. Returns 204 on success.
+
+```bash
+curl -sf -X DELETE \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1"
+```
+
+### POST /tasks/:id/claim
+
+Atomically claim a task. Returns 409 if already claimed by another agent.
+
+Agent tokens: `claimedBy` is set to the token's agent ID automatically.
+Admin tokens: `claimedBy` must be provided in the request body.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1/claim" | jq .
+```
+
+### POST /tasks/:id/heartbeat
+
+Touch the `heartbeatAt` timestamp to signal liveness. Call this periodically during long-running
+tasks to prevent the stale-claim reaper from releasing the task.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1/heartbeat" | jq .
+```
+
+### POST /tasks/:id/complete
+
+Mark a task `done`. Use for tasks that complete without opening a PR.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1/complete" | jq .
+```
+
+### POST /tasks/:id/fail
+
+Mark a task `blocked`. Optionally include a `reason` in the request body.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1/fail" \
+  -d '{"reason": "CI environment unavailable"}' | jq .
+```
+
+### POST /tasks/:id/release
+
+Unclaim a task — resets `claimedBy` and `claimedAt`, returns status to `pending`.
+Use when an agent is shutting down or voluntarily giving up a task.
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/SHE-1.1/release" | jq .
+```
+
+## ?ready=true Semantics
+
+When `?ready=true` (or `?state=ready`) is set, `?status` and `?id` filters are ignored. Only
+`?session` applies as a post-filter.
+
+A task is **ready** when **all** of the following are true:
+
+1. `status === "pending"`
+2. `hitl` is not `true` (HITL tasks are excluded until manually cleared)
+3. Every dependency in `dependencies[]` is satisfied
+
+**Dependency-satisfied rules** (first match wins):
+
+| Rule | Condition | Result |
+|---|---|---|
+| 1 | Dependency status is `merged`, `done`, `deploying`, `deployed`, or `cancelled` | Satisfied |
+| 2 | Dependency is on the same branch and has status `pr_open` or `approved` | Satisfied (bundled PR) |
+| 3 | Dependency has status `pr_open` with a PR number, and GitHub reports the PR as merged | Satisfied |
+| 4 | None of the above match | **Not satisfied** — task excluded |
+
+<div class="sw-callout mt-6 max-w-3xl">
+  <p><strong>Note:</strong> The task store has no direct GitHub access. Rule 3 (GitHub-merged check)
+  resolves to <code>false</code> in the task store itself — this rule is applied by the agent harness
+  when it calls <code>?ready=true</code>.</p>
+</div>
+
+### Diagnosing empty ?ready=true results
+
+When `{ tasks: [], total: 0 }` is returned:
+
+| Likely cause | How to check |
+|---|---|
+| No tasks assigned to this agent | Use an admin token to see all ready tasks |
+| HITL flag set | Query `?status=pending` — check for `"hitl": true`. Clear the flag once the human action is complete |
+| Dependencies not satisfied | Query `?status=pending` — check each task's `dependencies[]` and verify each dep's status against the four rules |
+| Queue is empty | No pending tasks exist at all |
+
+## Task Schema
+
+All fields from the `Task` model. Fields marked as required are enforced on creation or the
+relevant status transition.
+
+### Core fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | on create | Stable key — used by dependency resolution and all updates. Convention: `SHE-X.Y` |
+| `title` | string | always | Short description of the task |
+| `status` | TaskStatus | always | See [Status Lifecycle](#task-status-lifecycle) |
+| `repo` | string? | recommended | `org/repo` format; required for `dev-task` worktree creation |
+| `branch` | string? | recommended | Branch name; absent → task is skipped by `dev-task` |
+| `assignee` | string? | recommended | Agent ID; unset = pool task (any agent with repo scope can pick it up) |
+| `dependencies` | string[] | — | Array of task IDs that must be satisfied before this task is ready |
+| `description` | string? | — | Full task description (Markdown) |
+| `acceptanceCriteria` | string[] | — | Checklist items for task completion |
+| `layer` | string? | — | Architectural layer (e.g. `Shared`, `API`, `UI`) |
+| `session` | string? | — | Planning session slug for grouping related tasks |
+| `source` | string? | — | Origin label (e.g. plan session name) |
+| `type` | string? | — | Task category (e.g. `feature`, `fix`, `test`) |
+| `priority` | string? | — | Priority hint for ordering |
+| `hours` | float? | — | Estimated effort in hours |
+| `issue` | string? | — | Linked GitHub issue URL or ID |
+| `model` | string? | — | Preferred Claude model: `haiku`, `sonnet`, or `opus` |
+| `complexity` | int? | — | Complexity score (1–5) |
+| `hitl` | boolean? | — | When `true`, excluded from `?ready=true` until manually cleared |
+| `note` | string? | — | Free-form notes |
+| `metadata` | JSON? | — | Escape hatch for structured data without dedicated columns |
+
+### Status transition fields
+
+| Field | Type | Set when |
+|---|---|---|
+| `startedAt` | string? | → `in_progress` |
+| `pr` | int? | → `pr_open` (required) |
+| `prUrl` | string? | → `pr_open` (the GitHub PR URL) |
+| `prCreatedAt` | string? | → `pr_open` (required) |
+| `ciFixAttempts` | int? | → `approved` or `merged` (required) |
+| `mergeCommit` | string? | → `merged` |
+| `mergedAt` | string? | → `merged` |
+| `deployingAt` | string? | → `deploying` |
+| `deployedAt` | string? | → `deployed` |
+| `completedAt` | string? | → `done` |
+| `cancelledAt` | string? | → `cancelled` |
+| `blockedAt` | string? | → `blocked` |
+| `blockedReason` | string? | → `blocked` (human-readable reason) |
+
+### Claim and liveness fields
+
+| Field | Type | Set when |
+|---|---|---|
+| `claimedBy` | string? | → claimed (agent ID) |
+| `claimedAt` | string? | → claimed (ISO timestamp) |
+| `agentHint` | string? | Creation — suggested agent to pick up this task |
+| `heartbeatAt` | string? | → heartbeat (ISO timestamp of last liveness ping) |
+
+### HITL fields
+
+| Field | Type | Set when |
+|---|---|---|
+| `hitl` | boolean? | Set to `true` when human action is required before proceeding |
+| `hitlNotifiedAt` | string? | ISO timestamp when the HITL notification was sent |
+
+### Execution metrics (set by agent on completion)
+
+| Field | Type | Notes |
+|---|---|---|
+| `inputTokens` | int? | Total Claude input tokens used |
+| `outputTokens` | int? | Total Claude output tokens used |
+| `cacheReadTokens` | int? | Prompt cache read tokens |
+| `cacheCreationTokens` | int? | Prompt cache creation tokens |
+| `costUsd` | float? | Estimated USD cost |
+| `effortLevel` | string? | `low`, `medium`, or `high` |
+| `coverageDelta` | float? | Test coverage change (positive = improved) |
+| `simplifyTotal` | int? | Total simplification findings |
+| `simplifyDry` | int? | DRY violations found |
+| `simplifyDeadCode` | int? | Dead code findings |
+| `simplifyNaming` | int? | Naming issue findings |
+| `simplifyComplexity` | int? | Complexity findings |
+| `simplifyConsistency` | int? | Consistency findings |
+
+### System fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `createdAt` | DateTime | Set by the database on creation |
+| `updatedAt` | DateTime | Updated by the database on every write |
+
+## HTTP Status Codes
+
+| Code | Meaning |
+|---|---|
+| 200 | Success (GET, PATCH, POST action endpoints) |
+| 201 | Created (POST /tasks) |
+| 204 | No content (DELETE) |
+| 400 | Bad request — missing required field, invalid format, or repo not in agent scope |
+| 403 | Forbidden — agent token tried to access another agent's task |
+| 404 | Not found |
+| 409 | Conflict — task ID already exists (POST) or task already claimed (claim endpoint) |
+
+## Curl Examples: Full Happy-Path Lifecycle
+
+The following sequence demonstrates the complete lifecycle from picking a ready task to heartbeat:
+
+```bash
+BASE="$SHIPWRIGHT_TASK_STORE_URL"
+TOKEN="$SHIPWRIGHT_TASK_STORE_TOKEN"
+AUTH="Authorization: Bearer $TOKEN"
+
+# 1. Check for an interrupted task first (resume if found)
+INTERRUPTED=$(curl -sf -H "$AUTH" "$BASE/tasks?status=in_progress" | jq -r '.tasks[0].id // empty')
+
+# 2. If nothing in progress, pick the next ready task
+if [ -z "$INTERRUPTED" ]; then
+  TASK=$(curl -sf -H "$AUTH" "$BASE/tasks?ready=true" | jq '.tasks[0]')
+  TASK_ID=$(echo "$TASK" | jq -r '.id')
+else
+  TASK_ID="$INTERRUPTED"
+fi
+
+echo "Working on task: $TASK_ID"
+
+# 3. Claim the task (atomic — 409 if another agent beats you to it)
+curl -sf -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/tasks/$TASK_ID/claim" | jq .
+
+# 4. Mark in_progress
+curl -sf -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/tasks/$TASK_ID" \
+  -d "{\"status\": \"in_progress\", \"startedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | jq .
+
+# 5. Heartbeat (call periodically during long work)
+curl -sf -X POST -H "$AUTH" "$BASE/tasks/$TASK_ID/heartbeat" | jq .
+
+# 6. Open a PR (requires pr number and timestamp)
+PR_NUMBER=42
+curl -sf -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
+  "$BASE/tasks/$TASK_ID" \
+  -d "{\"status\": \"pr_open\", \"pr\": $PR_NUMBER, \"prCreatedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | jq .
+```
+
+## Required Fields Per Status Transition
+
+| Transition | Fields that must be set |
+|---|---|
+| → `in_progress` | `startedAt` (strongly recommended) |
+| → `pr_open` | `pr` (PR number), `prCreatedAt` (ISO timestamp) |
+| → `approved` | `ciFixAttempts` (set to 0 if no CI fixes were needed) |
+| → `merged` | `ciFixAttempts`, `mergedAt` (strongly recommended) |
+| → `blocked` | `blockedReason` (strongly recommended), `blockedAt` |
+
+<div class="sw-callout mt-6 max-w-3xl">
+  <p><strong>Enforcement:</strong> The task store does not hard-validate these fields on every
+  PATCH — missing fields silently result in incomplete records that may break downstream tooling
+  (e.g. the deploy scanner checks for <code>pr</code> when picking up <code>pr_open</code> tasks).
+  Always set the required fields on the relevant transition.</p>
+</div>
+
+## See also
+
+- [PRs API](/docs/prs-api) — PR review state tracking: `GET`/`POST`/`PATCH` `/prs`, claim, heartbeat, patch cycles, and release
+- [Configuration Reference](/docs/reference) — `SHIPWRIGHT_TASK_STORE_URL`, `SHIPWRIGHT_TASK_STORE_TOKEN`, and all other env vars
+- [The Agent](/docs/the-agent) — how the agent runtime consumes this API to run the dev-task loop

--- a/site/tests/docs-prs-api.spec.ts
+++ b/site/tests/docs-prs-api.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+
+// Fulfill external font CDN requests immediately so the page's 'load' event
+// fires even when CI can't reach external networks.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
+    (route) =>
+      route.fulfill({ status: 200, contentType: "text/css", body: "" }),
+  );
+});
+
+// PRs API reference page tests (DRR-2.2)
+
+test("GET /docs/prs-api returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/prs-api");
+  expect(response?.status()).toBe(200);
+});
+
+test("prs-api page has h1 heading", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  const h1 = page.locator("h1");
+  await expect(h1).toBeVisible();
+});
+
+test("prs-api page contains '/prs' text", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  const body = await page.textContent("body");
+  expect(body).toContain("/prs");
+});
+
+test("prs-api page has reviewState lifecycle section", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  // Must have a heading referencing reviewState or lifecycle
+  const lifecycleHeading = page.locator("h2, h3", {
+    hasText: /lifecycle|reviewState/i,
+  });
+  await expect(lifecycleHeading.first()).toBeVisible();
+  // The lifecycle diagram must reference the four states
+  const body = await page.textContent("body");
+  expect(body).toContain("pending");
+  expect(body).toContain("in_progress");
+  expect(body).toContain("posted");
+  expect(body).toContain("approved");
+});
+
+test("prs-api page has curl examples", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  // Must have at least one code block with curl
+  const codeBlocks = page.locator("pre code");
+  const count = await codeBlocks.count();
+  expect(count).toBeGreaterThan(0);
+  // At least one code block should contain curl
+  let hasCurl = false;
+  for (let i = 0; i < count; i++) {
+    const text = await codeBlocks.nth(i).textContent();
+    if (text?.includes("curl")) {
+      hasCurl = true;
+      break;
+    }
+  }
+  expect(hasCurl).toBe(true);
+});
+
+test("prs-api page has PR schema section", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  // Must have a heading referencing schema or fields
+  const schemaHeading = page.locator("h2, h3", {
+    hasText: /schema|fields/i,
+  });
+  await expect(schemaHeading.first()).toBeVisible();
+  // Schema must cover key fields
+  const body = await page.textContent("body");
+  expect(body).toContain("patchCycles");
+  expect(body).toContain("reviewCycles");
+  expect(body).toContain("claimedBy");
+  expect(body).toContain("heartbeatAt");
+});
+
+test("prs-api page cross-links to task-store-api", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  // The page should contain a link to /docs/task-store-api
+  const taskStoreLink = page.locator('a[href="/docs/task-store-api"]');
+  await expect(taskStoreLink.first()).toBeAttached();
+});
+
+test("prs-api page has StaleClaimReaper / heartbeat TTL section", async ({
+  page,
+}) => {
+  await page.goto("/docs/prs-api");
+  const body = await page.textContent("body");
+  // Must explain the reaper / TTL behavior
+  expect(body?.toLowerCase()).toContain("reaper");
+  expect(body).toContain("heartbeat");
+});
+
+test("prs-api sidebar is present", async ({ page }) => {
+  await page.goto("/docs/prs-api");
+  const sidebar = page.locator("nav[aria-label='Docs navigation']");
+  await expect(sidebar).toBeVisible();
+});

--- a/site/tests/docs-task-store-api.spec.ts
+++ b/site/tests/docs-task-store-api.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+// Fulfill external font CDN requests immediately so the page's 'load' event
+// fires even when CI can't reach external networks.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
+    (route) =>
+      route.fulfill({ status: 200, contentType: "text/css", body: "" }),
+  );
+});
+
+// Task Store API reference page tests (DRR-2.1)
+
+test("GET /docs/task-store-api returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/task-store-api");
+  expect(response?.status()).toBe(200);
+});
+
+test("task-store-api page has /tasks heading", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  // The page must contain a heading or prominent text referencing /tasks
+  const body = await page.textContent("body");
+  expect(body).toContain("/tasks");
+});
+
+test("task-store-api page has h1 heading", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  const h1 = page.locator("h1");
+  await expect(h1).toBeVisible();
+});
+
+test("task-store-api page has key sections", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  // Authentication section
+  const authHeading = page.locator("h2", { hasText: /auth/i });
+  await expect(authHeading.first()).toBeVisible();
+  // Status lifecycle section
+  const lifecycleHeading = page.locator("h2, h3", { hasText: /lifecycle|status/i });
+  await expect(lifecycleHeading.first()).toBeVisible();
+});
+
+test("task-store-api page has curl examples", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  // Must have at least one code block with curl
+  const codeBlocks = page.locator("pre code");
+  const count = await codeBlocks.count();
+  expect(count).toBeGreaterThan(0);
+  // At least one code block should contain curl
+  let hasCurl = false;
+  for (let i = 0; i < count; i++) {
+    const text = await codeBlocks.nth(i).textContent();
+    if (text?.includes("curl")) {
+      hasCurl = true;
+      break;
+    }
+  }
+  expect(hasCurl).toBe(true);
+});
+
+test("task-store-api page cross-links to prs-api", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  // The page should contain a link to /docs/prs-api
+  const prsLink = page.locator('a[href="/docs/prs-api"]');
+  await expect(prsLink.first()).toBeAttached();
+});
+
+test("task-store-api page has ready=true semantics section", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  const readyHeading = page.locator("h2, h3", { hasText: /ready/i });
+  await expect(readyHeading.first()).toBeVisible();
+});
+
+test("task-store-api sidebar is present", async ({ page }) => {
+  await page.goto("/docs/task-store-api");
+  const sidebar = page.locator("nav[aria-label='Docs navigation']");
+  await expect(sidebar).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Adds `site/src/content/docs/task-store-api.mdx`: comprehensive HTTP API reference for the `/tasks` endpoint covering auth, status lifecycle, all 12 endpoints, `?ready=true` semantics, full task schema, curl lifecycle examples, and HTTP status codes
- Adds `site/tests/docs-task-store-api.spec.ts`: 8 Playwright tests asserting the page loads, has key sections, contains `/tasks` heading, curl examples, and prs-api cross-links
- Adds `SKIP_PAGEFIND=1` env support in `playwright.config.ts` for ARM environments where the pagefind binary fails

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Page exists at task-store-api.mdx and renders without build errors | ✅ MET |
| 2 | All 11+ /tasks endpoints documented with method, path, description, query params | ✅ MET (12 endpoints) |
| 3 | Task schema covers all Prisma fields with types and when-set notes | ✅ MET |
| 4 | ?ready=true semantics with all 4 dependency-satisfaction rules | ✅ MET |
| 5 | Curl examples: pick ready → claim → in_progress → pr_open → heartbeat | ✅ MET |
| 6 | Page cross-links to prs-api.mdx | ✅ MET |
| 7 | npm run build in site/ exits 0 | ✅ MET |
| 8 | Playwright spec with /docs/task-store-api load + /tasks heading assertion | ✅ MET |

## Test Plan
- [x] `cd site && npm run build` exits 0 — `/docs/task-store-api/index.html` built
- [x] 8 Playwright tests written covering page load, key sections, curl presence, prs-api cross-link
- [x] `bunx biome lint .` passes (341 files, no errors)
- [x] Existing docs pages unaffected

Generated with [Claude Code](https://claude.com/claude-code)
