### PR TITLE
fix(site): hide header nav on mobile, fix iOS sidebar toggle

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -172,7 +172,7 @@ const year = new Date().getFullYear();
           >
         </span>
       </a>
-      <nav class="flex items-center gap-6" aria-label="Primary">
+      <nav class="hidden md:flex items-center gap-6" aria-label="Primary">
         <a href={configUrl} class="sw-label">Configuration</a>
         <a href={compareUrl} class="sw-label">Compare</a>
         <a href={repoUrl} class="sw-label">GitHub ↗</a>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -116,19 +116,20 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
         .docs-sidebar {
           position: fixed;
           top: 0;
-          left: -100%;
+          left: 0;
+          transform: translateX(-100%);
           width: 280px;
           height: 100vh;
           z-index: 50;
           background: var(--sw-color-bg-raised);
           border-right: 1px solid var(--sw-color-border-muted);
-          transition: left 0.25s ease;
+          transition: transform 0.25s ease;
           overflow-y: auto;
           padding: 1.5rem;
         }
 
         #docs-sidebar-toggle:checked ~ .sw-container .docs-layout .docs-sidebar {
-          left: 0;
+          transform: translateX(0);
         }
 
         #docs-sidebar-toggle:checked ~ .docs-sidebar-overlay {
@@ -255,7 +256,7 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
       }
     </style>
   </head>
-  <body class="min-h-screen overflow-x-hidden">
+  <body class="min-h-screen">
     <!-- Mobile sidebar toggle (CSS-only, hidden checkbox) -->
     <input type="checkbox" id="docs-sidebar-toggle" aria-hidden="true" />
 
@@ -299,7 +300,7 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
           >
         </span>
       </a>
-      <nav class="flex items-center gap-6" aria-label="Primary">
+      <nav class="hidden md:flex items-center gap-6" aria-label="Primary">
         <a href="/docs/getting-started" class="sw-label">Docs</a>
         <a href="/compare" class="sw-label">Compare</a>
         <a href={repoUrl} class="sw-label">GitHub ↗</a>


### PR DESCRIPTION
## Summary

- **Header nav not responsive** — both `BaseLayout` and `DocsLayout` had `<nav class="flex">` with no mobile hiding, causing the three links to collide with the logo on small screens. Fixed with `hidden md:flex`.
- **Docs sidebar broken on iOS Safari** — the sidebar used `left: -100%` for its off-screen state, and the body had `overflow-x-hidden`. iOS Safari is known to change how `position: fixed` elements behave when the body has `overflow: hidden` — fixed elements become relative to the body scroll container instead of the viewport, which breaks the slide-in. Switched to `transform: translateX(-100%)` (off-flow, GPU-accelerated, no overflow interaction) and removed the `overflow-x-hidden` from the docs body.

## Test plan

- [ ] Resize browser to <768px on the marketing site — nav links should be hidden, logo fills the header cleanly
- [ ] Resize browser to <768px on a docs page — nav links hidden, ☰ Menu button visible, tapping it opens the sidebar
- [ ] Test on iOS Safari (real device or simulator) — sidebar should slide in/out correctly
- [ ] Verify ≥768px desktop is unaffected — nav links visible, sidebar sticky

🤖 Generated with [Claude Code](https://claude.com/claude-code)