### PR TITLE
fix(agent): copy lib/ source into the agent Docker image

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -92,6 +92,10 @@ RUN bun install --frozen-lockfile
 
 # Copy the rest of the agent source
 COPY agent/ ./agent/
+# Copy the shared lib source — @shipwright/lib is a workspace symlink; only its
+# package.json was copied above (for install caching), so without this the
+# symlink resolves but re-exports like @shipwright/lib/pricing are missing.
+COPY lib/ ./lib/
 # Copy the plugin source so the local marketplace is available at runtime
 COPY plugins/ ./plugins/
 COPY .claude-plugin/ ./.claude-plugin/
@@ -130,6 +134,9 @@ ENV PATH="/home/bun/.local/share/mise/shims:/app/agent/scripts/bin:${PATH}"
 # the root node_modules holds bun's content-addressed store they point into.)
 COPY --from=build --chown=1000:1000 /app/node_modules ./node_modules
 COPY --from=build --chown=1000:1000 /app/agent ./agent
+# agent/node_modules/@shipwright/lib is a relative symlink to /app/lib — the
+# workspace source itself, not just its package.json, must exist here too.
+COPY --from=build --chown=1000:1000 /app/lib ./lib
 # Plugin source + marketplace manifest — needed for local `claude plugin marketplace add`
 COPY --from=build --chown=1000:1000 /app/plugins ./plugins
 COPY --from=build --chown=1000:1000 /app/.claude-plugin ./.claude-plugin


### PR DESCRIPTION
## Summary
- Every agent pod in vitals-os prod is crash-looping with \`Cannot find module '@shipwright/lib/pricing'\` — root cause is a Dockerfile bug, not app code.
- \`agent/Dockerfile\`'s build stage only copied \`lib/package.json\` (for install caching) but never the \`lib/\` source directory, and the runtime stage never copied \`/app/lib\` from the build stage either. \`@shipwright/lib\` resolves via a workspace symlink, so the image builds fine but the module is missing at runtime.
- Broke silently since PCE-1.1 (#897) added the first runtime import of \`@shipwright/lib/pricing\` from agent code; shipped in released tag \`agent-v0.100.0\`, which vitals-os's automated BASE_TAG bump (#1988) picked up minutes later.
- Verified locally: rebuilt the image with this fix and confirmed \`agent/src/pricing.ts\` resolves and exports correctly (it failed with the exact production error before the fix).

## Test plan
- [x] \`docker build -f agent/Dockerfile .\` succeeds
- [x] \`bun run\` inside the built image successfully imports \`agent/src/pricing.ts\` (previously failed with \`Cannot find module '@shipwright/lib/pricing'\`)
- [ ] After merge: cut a new \`shipwright-agent\` release, bump vitals-os \`BASE_TAG\`, rebuild \`vitals-os-agent\`, and roll the crash-looping pods