### PR TITLE
ci(agent): fail the Docker build on any unresolvable agent module import

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -100,6 +100,14 @@ COPY lib/ ./lib/
 COPY plugins/ ./plugins/
 COPY .claude-plugin/ ./.claude-plugin/
 
+# Module-resolution guard: bundle every agent source file as its own entry
+# point so an unresolvable import fails the build itself, rather than only
+# surfacing as a runtime crash after the image ships. A plain `docker build`
+# succeeding is not proof the image runs — this bundles the whole agent/src
+# tree (not just entrypoint-main.ts's reachable graph) so an import missed
+# by that one entry point, like the lib/ omission above, still gets caught.
+RUN find agent/src -name "*.ts" | xargs bun build --target=bun --outdir=/tmp/module-check
+
 # ─── Runtime stage (non-root) ─────────────────────────────────────────────────
 
 FROM base AS runtime


### PR DESCRIPTION
## Summary
- Follow-up to #901. Root cause of the vitals-os prod outage was that \`docker build\` on \`agent/Dockerfile\` succeeded even though the image would crash at runtime — a plain build isn't proof the image runs.
- Adds a build-time guard: bundle every file in \`agent/src/\` as its own entry point (not just \`entrypoint-main.ts\`'s reachable graph — that's what missed \`pricing.ts\` before, since it isn't imported from the main entry). Any workspace import that doesn't resolve now fails \`docker build\` directly, with a clear file:line error, instead of silently shipping and crash-looping in prod.
- Verified both directions locally: reintroducing the exact \`COPY lib/ ./lib/\` omission from the outage reproduces the failure at build time (\`error: Could not resolve: "@shipwright/lib/pricing"\`); the current (fixed) Dockerfile builds clean.
- This lives in \`agent/Dockerfile\` itself (not just a CI workflow step), so it protects every build path — CI's existing \`agent-docker-build\` job, downstream derived images (e.g. vitals-os's), and local builds — not just one call site.

## Test plan
- [x] \`docker build -f agent/Dockerfile .\` succeeds on current main
- [x] Removing the \`COPY lib/ ./lib/\` line reproduces the outage and fails the build at the new guard step with a clear error