### PR TITLE
fix(metrics): include cost_usd in total and per-agent token panels

### DIFF
--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -219,6 +219,7 @@ describe("TaskStoreProvider (integration)", () => {
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "total_tokens",
+      "cost_usd",
     ]);
     const row = t.results[0];
     const c = CRON_STATS.totals;
@@ -228,6 +229,7 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[2]).toBe(c.cacheRead + h.cacheRead);
     expect(row[3]).toBe(c.cacheCreation + h.cacheCreation);
     expect(row[4]).toBe(c.total + h.total);
+    expect(row[5]).toBe((c.costUsd ?? 0) + (h.costUsd ?? 0));
   });
 
   test("tokensByAgentByCron is cron-only with cost_usd", async () => {
@@ -397,11 +399,14 @@ describe("TaskStoreProvider (integration)", () => {
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "total_tokens",
+      "cost_usd",
     ]);
     const byType = new Map(t.results.map((r) => [r[0], r]));
     expect(byType.has("cron")).toBe(true);
     expect(byType.has("chat")).toBe(true);
     expect(byType.get("cron")?.[1]).toBe(CRON_STATS.totals.input);
     expect(byType.get("chat")?.[1]).toBe(CHAT_STATS.totals.input);
+    expect(byType.get("cron")?.[6]).toBe(CRON_STATS.totals.costUsd ?? 0);
+    expect(byType.get("chat")?.[6]).toBe(CHAT_STATS.totals.costUsd ?? 0);
   });
 });

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -567,7 +567,10 @@ export class TaskStoreProvider implements MetricsProvider {
     ]);
     // Disjoint sources — summing field-wise is correct, no double count.
     const total = addAggregates(cron.totals, chat.totals);
-    return table(tokenColumns(), [tokenCells(total)]);
+    return table(
+      [...tokenColumns(), "cost_usd"],
+      [[...tokenCells(total), total.costUsd ?? 0]],
+    );
   }
 
   private async tokensBySessionType(win: {
@@ -579,10 +582,10 @@ export class TaskStoreProvider implements MetricsProvider {
       this.admin.chatTokenStats(win),
     ]);
     const rows = [
-      ["cron", ...tokenCells(cron.totals)],
-      ["chat", ...tokenCells(chat.totals)],
+      ["cron", ...tokenCells(cron.totals), cron.totals.costUsd ?? 0],
+      ["chat", ...tokenCells(chat.totals), chat.totals.costUsd ?? 0],
     ].sort((a, b) => Number(b[5]) - Number(a[5]));
-    return table(tokenColumns("session_type"), rows);
+    return table([...tokenColumns("session_type"), "cost_usd"], rows);
   }
 
   private async tokensByAgent(win: {
@@ -599,9 +602,9 @@ export class TaskStoreProvider implements MetricsProvider {
       byAgent.set(a.key, prev ? addAggregates(prev, a) : a);
     }
     const rows = [...byAgent.entries()]
-      .map(([key, a]) => [key, ...tokenCells(a)])
+      .map(([key, a]) => [key, ...tokenCells(a), a.costUsd ?? 0])
       .sort((x, y) => Number(y[5]) - Number(x[5]));
-    return table(tokenColumns("agent_id"), rows);
+    return table([...tokenColumns("agent_id"), "cost_usd"], rows);
   }
 
   private async tokensTrends(win: {
@@ -732,8 +735,7 @@ export class TaskStoreProvider implements MetricsProvider {
         cache_creation_input_tokens: cacheCreation ?? 0,
       };
 
-      const routedUsd =
-        num(task.costUsd) ?? calculateCost(usage, canonicalKey);
+      const routedUsd = num(task.costUsd) ?? calculateCost(usage, canonicalKey);
       const opusUsd = calculateCost(usage, OPUS_MODEL);
 
       const existing = buckets.get(canonicalKey);


### PR DESCRIPTION
## Summary

- `tokensTotals()`, `tokensByAgent()`, and `tokensBySessionType()` used `tokenCells()` which returns only the 5 token count fields — no `costUsd`
- `byAgentByCron` and `byAgentByModel` explicitly appended `a.costUsd ?? 0`, which is why those panels worked
- The totals and per-agent panels were always emitting `null` for `cost_usd`, causing the dashboard total cost and per-agent cost columns to appear empty
- Fix: append `costUsd` to the table in all three affected methods; update tests to assert the new column

## Test plan

- [x] `bun test metrics/src/providers/task-store-provider.integration.test.ts` — 9 pass
- [x] `bun test --filter metrics` — 287 pass
- [x] `bunx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)