### PR TITLE
fix(metrics): graceful degradation in token provider when admin stats fail

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -134,10 +134,10 @@ The `/public/*` endpoints require **no authentication**. Access is controlled by
 | `metrics/src/api.ts` | App factory `createMetricsApp()`, route + auth middleware registration, dashboard handler. |
 | `metrics/src/metrics-provider.ts` | `MetricsProvider` interface + `MetricQuery` / `MetricTable` types — the backend-agnostic read seam. |
 | `metrics/src/select-provider.ts` | Pure env-to-mode selector (`selectProviderMode()`) — maps env vars to `"fixtures" \| "taskstore"` based on `METRICS_OFFLINE` and task-store URL configuration. |
-| `metrics/src/providers/task-store-provider.ts` | `TaskStoreProvider` — implements `MetricsProvider` over a `TaskStoreClient` (tasks + PRs) and an `AdminMetricsClient` (token stats); the live read backend for taskstore mode. |
+| `metrics/src/providers/task-store-provider.ts` | `TaskStoreProvider` — implements `MetricsProvider` over a `TaskStoreClient` (tasks + PRs) and an `AdminMetricsClient` (token stats); the live read backend for taskstore mode. Includes graceful degradation: when admin stats endpoints fail, returns zero aggregates for that stream instead of erroring, allowing partial metrics to remain available. |
 | `metrics/src/lib/task-store-client.ts` | `TaskStoreClient` interface + `HttpTaskStoreClient` impl (and `TaskStoreClientError`) — reads tasks + PRs from the task-store HTTP API. |
 | `metrics/src/lib/admin-metrics-client.ts` | `AdminMetricsClient` interface + `HttpAdminMetricsClient` impl (and `AdminMetricsClientError`) — reads token-aggregation stats from the admin service. |
-| `metrics/src/providers/task-store-recorded.ts` | `RecordedTaskStoreClient` + `RecordedAdminMetricsClient` — replay cassette data offline; back the fixtures provider and integration tests. |
+| `metrics/src/providers/task-store-recorded.ts` | `RecordedTaskStoreClient` + `RecordedAdminMetricsClient` — replay cassette data offline; back the fixtures provider and integration tests. Also includes faulting doubles (`FaultingCronAdminMetricsClient`, `FaultingChatAdminMetricsClient`, `FaultingBothAdminMetricsClient`) for testing graceful degradation when admin stats endpoints fail. |
 | `metrics/src/fixtures/task-store-fixtures.ts` | `createFixtureTaskStoreProvider()` — offline `TaskStoreProvider` over recorded cassettes with a fixed clock; used in offline mode and integration tests. |
 | `metrics/src/secrets.ts` | Secrets resolution: env-first, optional GCP Secret Manager fallback. |
 | `metrics/src/dashboard/` | Server-rendered dashboard (`dashboard-page.ts`, `app.js`, `styles.css`, `index.html`). |

--- a/metrics/src/lib/admin-metrics-client.ts
+++ b/metrics/src/lib/admin-metrics-client.ts
@@ -10,13 +10,6 @@
  * counting total. The admin server returns already-grouped aggregates; this
  * client just shuttles them. Mirrors accounts-client.ts (Bearer auth, trailing-
  * slash strip, typed error).
- *
- * Prerequisite (MME-4.2): the two stats endpoints this client targets
- *   GET /agents/:id/cron-runs/stats
- *   GET /agents/chat-tokens/daily/stats
- * are NOT implemented server-side yet. The provider's behaviour is proven via
- * the RecordedAdminMetricsClient cassettes; the live Http path is exercised only
- * once those endpoints land.
  */
 
 // ─── Token aggregate shapes ───────────────────────────────────────────────────

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -426,6 +426,7 @@ describe("TaskStoreProvider (integration)", () => {
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "total_tokens",
+      "cost_usd",
     ]);
     const row = t.results[0];
     // Cron should be zero; chat should still be present
@@ -446,6 +447,7 @@ describe("TaskStoreProvider (integration)", () => {
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "total_tokens",
+      "cost_usd",
     ]);
     const row = t.results[0];
     // Chat should be zero; cron should still be present
@@ -466,6 +468,7 @@ describe("TaskStoreProvider (integration)", () => {
       "cache_read_input_tokens",
       "cache_creation_input_tokens",
       "total_tokens",
+      "cost_usd",
     ]);
     const row = t.results[0];
     // All zeros

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -17,6 +17,9 @@ import { FixedClock } from "../lib/test-helpers.ts";
 import type { MetricQuery } from "../metrics-provider.ts";
 import { TaskStoreProvider } from "./task-store-provider.ts";
 import {
+  FaultingBothAdminMetricsClient,
+  FaultingChatAdminMetricsClient,
+  FaultingCronAdminMetricsClient,
   RecordedAdminMetricsClient,
   RecordedTaskStoreClient,
 } from "./task-store-recorded.ts";
@@ -403,5 +406,92 @@ describe("TaskStoreProvider (integration)", () => {
     expect(byType.has("chat")).toBe(true);
     expect(byType.get("cron")?.[1]).toBe(CRON_STATS.totals.input);
     expect(byType.get("chat")?.[1]).toBe(CHAT_STATS.totals.input);
+  });
+
+  test("graceful degradation: cronRunTokenStats throws, returns 200 with zero cron + chat data", async () => {
+    const taskStore = new RecordedTaskStoreClient(TASKS, PRS);
+    const admin = new FaultingCronAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "tokensTotals", range: RANGE });
+    // Should return 200 (not throw) with only chat data
+    expect(t.columns).toEqual([
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "total_tokens",
+    ]);
+    const row = t.results[0];
+    // Cron should be zero; chat should still be present
+    expect(row[0]).toBe(CHAT_STATS.totals.input);
+    expect(row[1]).toBe(CHAT_STATS.totals.output);
+  });
+
+  test("graceful degradation: chatTokenStats throws, returns 200 with cron data + zero chat", async () => {
+    const taskStore = new RecordedTaskStoreClient(TASKS, PRS);
+    const admin = new FaultingChatAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "tokensTotals", range: RANGE });
+    // Should return 200 (not throw) with only cron data
+    expect(t.columns).toEqual([
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "total_tokens",
+    ]);
+    const row = t.results[0];
+    // Chat should be zero; cron should still be present
+    expect(row[0]).toBe(CRON_STATS.totals.input);
+    expect(row[1]).toBe(CRON_STATS.totals.output);
+  });
+
+  test("graceful degradation: both throw, returns 200 with all-zero aggregates", async () => {
+    const taskStore = new RecordedTaskStoreClient(TASKS, PRS);
+    const admin = new FaultingBothAdminMetricsClient();
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "tokensTotals", range: RANGE });
+    // Should return 200 (not throw) with zero aggregates
+    expect(t.columns).toEqual([
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "total_tokens",
+    ]);
+    const row = t.results[0];
+    // All zeros
+    expect(row[0]).toBe(0);
+    expect(row[1]).toBe(0);
+    expect(row[2]).toBe(0);
+    expect(row[3]).toBe(0);
+    expect(row[4]).toBe(0);
+  });
+
+  test("graceful degradation: all 7 token methods handle cron failure", async () => {
+    const taskStore = new RecordedTaskStoreClient(TASKS, PRS);
+    const admin = new FaultingCronAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const kinds: MetricQuery[] = [
+      { kind: "tokensTotals", range: RANGE },
+      { kind: "tokensBySessionType", range: RANGE },
+      { kind: "tokensByAgent", range: RANGE },
+      { kind: "tokensTrends", range: RANGE },
+      { kind: "tokensByAgentBySessionType", range: RANGE },
+      { kind: "tokensByAgentByCron", range: RANGE },
+      { kind: "tokensByAgentByModel", range: RANGE },
+    ];
+
+    for (const q of kinds) {
+      const t = await provider.query(q);
+      // Should not throw and should return valid table
+      expect(Array.isArray(t.columns)).toBe(true);
+      expect(t.columns.length).toBeGreaterThan(0);
+      expect(Array.isArray(t.results)).toBe(true);
+    }
   });
 });

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -23,14 +23,12 @@ import {
   normalizeModelToRateKey,
 } from "@shipwright/lib/pricing";
 import { resolveQueryRange } from "../formatters.ts";
-import type {
-  AdminMetricsClient,
-  ChatTokenStats,
-  CronRunTokenStats,
-  TokenAggregate,
-} from "../lib/admin-metrics-client.ts";
 import {
   AdminMetricsClientError,
+  type AdminMetricsClient,
+  type ChatTokenStats,
+  type CronRunTokenStats,
+  type TokenAggregate,
 } from "../lib/admin-metrics-client.ts";
 import { type Clock, SystemClock } from "../lib/clock.ts";
 import type {

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -25,7 +25,12 @@ import {
 import { resolveQueryRange } from "../formatters.ts";
 import type {
   AdminMetricsClient,
+  ChatTokenStats,
+  CronRunTokenStats,
   TokenAggregate,
+} from "../lib/admin-metrics-client.ts";
+import {
+  AdminMetricsClientError,
 } from "../lib/admin-metrics-client.ts";
 import { type Clock, SystemClock } from "../lib/clock.ts";
 import type {
@@ -48,6 +53,29 @@ const BLOCKED_STATUS = "blocked";
 // Task-store PR review-state that denotes an approved ("ship it") review. The
 // live task store records `reviewState` as one of `approved | posted | pending`.
 const SHIP_IT_REVIEW_STATE = "approved";
+
+// Zero aggregates for graceful degradation when admin stats endpoints fail.
+const ZERO_AGG: TokenAggregate = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  total: 0,
+};
+
+const ZERO_CRON_STATS: CronRunTokenStats = {
+  totals: ZERO_AGG,
+  byAgent: [],
+  byCron: [],
+  byModel: [],
+  daily: [],
+};
+
+const ZERO_CHAT_STATS: ChatTokenStats = {
+  totals: ZERO_AGG,
+  byAgent: [],
+  daily: [],
+};
 
 // ─── Value helpers ────────────────────────────────────────────────────────────
 
@@ -562,8 +590,8 @@ export class TaskStoreProvider implements MetricsProvider {
     to: string;
   }): Promise<MetricTable> {
     const [cron, chat] = await Promise.all([
-      this.admin.cronRunTokenStats(win),
-      this.admin.chatTokenStats(win),
+      this.safeCronStats(win),
+      this.safeChatStats(win),
     ]);
     // Disjoint sources — summing field-wise is correct, no double count.
     const total = addAggregates(cron.totals, chat.totals);
@@ -575,8 +603,8 @@ export class TaskStoreProvider implements MetricsProvider {
     to: string;
   }): Promise<MetricTable> {
     const [cron, chat] = await Promise.all([
-      this.admin.cronRunTokenStats(win),
-      this.admin.chatTokenStats(win),
+      this.safeCronStats(win),
+      this.safeChatStats(win),
     ]);
     const rows = [
       ["cron", ...tokenCells(cron.totals)],
@@ -590,8 +618,8 @@ export class TaskStoreProvider implements MetricsProvider {
     to: string;
   }): Promise<MetricTable> {
     const [cron, chat] = await Promise.all([
-      this.admin.cronRunTokenStats(win),
-      this.admin.chatTokenStats(win),
+      this.safeCronStats(win),
+      this.safeChatStats(win),
     ]);
     const byAgent = new Map<string, TokenAggregate>();
     for (const a of [...cron.byAgent, ...chat.byAgent]) {
@@ -609,8 +637,8 @@ export class TaskStoreProvider implements MetricsProvider {
     to: string;
   }): Promise<MetricTable> {
     const [cron, chat] = await Promise.all([
-      this.admin.cronRunTokenStats(win),
-      this.admin.chatTokenStats(win),
+      this.safeCronStats(win),
+      this.safeChatStats(win),
     ]);
     const byDay = new Map<string, TokenAggregate>();
     for (const d of [...cron.daily, ...chat.daily]) {
@@ -628,8 +656,8 @@ export class TaskStoreProvider implements MetricsProvider {
     to: string;
   }): Promise<MetricTable> {
     const [cron, chat] = await Promise.all([
-      this.admin.cronRunTokenStats(win),
-      this.admin.chatTokenStats(win),
+      this.safeCronStats(win),
+      this.safeChatStats(win),
     ]);
     const rows: unknown[][] = [];
     for (const a of cron.byAgent) {
@@ -650,7 +678,7 @@ export class TaskStoreProvider implements MetricsProvider {
     to: string;
   }): Promise<MetricTable> {
     // Cron-only: chat has no cron name.
-    const cron = await this.admin.cronRunTokenStats(win);
+    const cron = await this.safeCronStats(win);
     const rows = cron.byCron
       .map((a) => [a.key1, a.key2, ...tokenCells(a), a.costUsd ?? 0])
       .sort((a, b) => Number(b[6]) - Number(a[6]));
@@ -664,11 +692,43 @@ export class TaskStoreProvider implements MetricsProvider {
     from: string;
     to: string;
   }): Promise<MetricTable> {
-    const cron = await this.admin.cronRunTokenStats(win);
+    const cron = await this.safeCronStats(win);
     const rows = cron.byModel
       .map((a) => [a.key1, a.key2, ...tokenCells(a), a.costUsd ?? 0])
       .sort((a, b) => Number(b[6]) - Number(a[6]));
     return table(["agent_id", "model", ...tokenColumns(), "cost_usd"], rows);
+  }
+
+  // ─── Graceful degradation helpers ─────────────────────────────────────────
+
+  private async safeCronStats(win: {
+    from: string;
+    to: string;
+  }): Promise<CronRunTokenStats> {
+    return this.admin.cronRunTokenStats(win).catch((e) => {
+      if (e instanceof AdminMetricsClientError) {
+        console.error(
+          `[metrics] cronRunTokenStats failed: ${e.message}; falling back to zero aggregates`,
+        );
+        return ZERO_CRON_STATS;
+      }
+      throw e;
+    });
+  }
+
+  private async safeChatStats(win: {
+    from: string;
+    to: string;
+  }): Promise<ChatTokenStats> {
+    return this.admin.chatTokenStats(win).catch((e) => {
+      if (e instanceof AdminMetricsClientError) {
+        console.error(
+          `[metrics] chatTokenStats failed: ${e.message}; falling back to zero aggregates`,
+        );
+        return ZERO_CHAT_STATS;
+      }
+      throw e;
+    });
   }
 
   // ─ Cost efficiency ─

--- a/metrics/src/providers/task-store-recorded.ts
+++ b/metrics/src/providers/task-store-recorded.ts
@@ -9,10 +9,11 @@
  * cassette rows.
  */
 
-import type {
-  AdminMetricsClient,
-  ChatTokenStats,
-  CronRunTokenStats,
+import {
+  AdminMetricsClientError,
+  type AdminMetricsClient,
+  type ChatTokenStats,
+  type CronRunTokenStats,
 } from "../lib/admin-metrics-client.ts";
 import {
   type PrRecord,
@@ -83,8 +84,6 @@ export class RecordedAdminMetricsClient implements AdminMetricsClient {
 }
 
 // ─── Faulting doubles for graceful degradation tests ────────────────────────
-
-import { AdminMetricsClientError } from "../lib/admin-metrics-client.ts";
 
 export class FaultingCronAdminMetricsClient implements AdminMetricsClient {
   constructor(

--- a/metrics/src/providers/task-store-recorded.ts
+++ b/metrics/src/providers/task-store-recorded.ts
@@ -87,7 +87,7 @@ export class RecordedAdminMetricsClient implements AdminMetricsClient {
 
 export class FaultingCronAdminMetricsClient implements AdminMetricsClient {
   constructor(
-    private readonly cron: CronRunTokenStats,
+    private readonly _cron: CronRunTokenStats,
     private readonly chat: ChatTokenStats,
   ) {}
 
@@ -103,7 +103,7 @@ export class FaultingCronAdminMetricsClient implements AdminMetricsClient {
 export class FaultingChatAdminMetricsClient implements AdminMetricsClient {
   constructor(
     private readonly cron: CronRunTokenStats,
-    private readonly chat: ChatTokenStats,
+    private readonly _chat: ChatTokenStats,
   ) {}
 
   async cronRunTokenStats(): Promise<CronRunTokenStats> {

--- a/metrics/src/providers/task-store-recorded.ts
+++ b/metrics/src/providers/task-store-recorded.ts
@@ -81,3 +81,47 @@ export class RecordedAdminMetricsClient implements AdminMetricsClient {
     return this.chat;
   }
 }
+
+// ─── Faulting doubles for graceful degradation tests ────────────────────────
+
+import { AdminMetricsClientError } from "../lib/admin-metrics-client.ts";
+
+export class FaultingCronAdminMetricsClient implements AdminMetricsClient {
+  constructor(
+    private readonly cron: CronRunTokenStats,
+    private readonly chat: ChatTokenStats,
+  ) {}
+
+  async cronRunTokenStats(): Promise<CronRunTokenStats> {
+    throw new AdminMetricsClientError(500, "cron stats endpoint failed");
+  }
+
+  async chatTokenStats(): Promise<ChatTokenStats> {
+    return this.chat;
+  }
+}
+
+export class FaultingChatAdminMetricsClient implements AdminMetricsClient {
+  constructor(
+    private readonly cron: CronRunTokenStats,
+    private readonly chat: ChatTokenStats,
+  ) {}
+
+  async cronRunTokenStats(): Promise<CronRunTokenStats> {
+    return this.cron;
+  }
+
+  async chatTokenStats(): Promise<ChatTokenStats> {
+    throw new AdminMetricsClientError(500, "chat stats endpoint failed");
+  }
+}
+
+export class FaultingBothAdminMetricsClient implements AdminMetricsClient {
+  async cronRunTokenStats(): Promise<CronRunTokenStats> {
+    throw new AdminMetricsClientError(500, "cron stats endpoint failed");
+  }
+
+  async chatTokenStats(): Promise<ChatTokenStats> {
+    throw new AdminMetricsClientError(500, "chat stats endpoint failed");
+  }
+}


### PR DESCRIPTION
## Summary
- Add graceful degradation to all 7 `/metrics/tokens` endpoint methods: when either `cronRunTokenStats` or `chatTokenStats` throws `AdminMetricsClientError`, the method falls back to zero/empty aggregates and logs to stderr instead of propagating a 500
- Remove stale comment in `admin-metrics-client.ts` asserting the stats endpoints are not yet implemented (they are)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | cronRunTokenStats throws → zero cron + chat data preserved | MET |
| 2 | chatTokenStats throws → zero chat + cron data preserved | MET |
| 3 | Both throw → all-zero aggregates returned | MET |
| 4 | Errors logged to stderr | MET |
| 5 | Stale comment removed from admin-metrics-client.ts | MET |

## Test Plan
- Added `FaultingCronAdminMetricsClient`, `FaultingChatAdminMetricsClient`, `FaultingBothAdminMetricsClient` test doubles to `task-store-recorded.ts`
- 4 new integration tests covering all degradation scenarios (cron only, chat only, both, all 7 kinds)
- [x] 257 tests passing, 0 failures
- [x] Biome lint clean
- [x] All 5 workspaces typecheck clean

Generated with [Claude Code](https://claude.com/claude-code)
