### PR TITLE
docs(task-store): document HTTP service API

### DIFF
--- a/.claude/commands/docs-sync.md
+++ b/.claude/commands/docs-sync.md
@@ -29,6 +29,7 @@ Map each section to its source docs and the target MDX file:
 | `deploy` | `docs/deploy-kubernetes.md`, `docs/helm-repo.md` | `site/src/content/docs/deploying-to-cloud.mdx` | `Operations` | Kubernetes deployment: Minikube, GKE (Gateway API + cert-manager), EKS (ALB), agent provisioning RBAC, and auth modes |
 | `metrics` | `docs/metrics.md` | `site/src/content/docs/metrics.mdx` | `Metrics` | Metrics service (provider-agnostic JSON endpoints, dashboard, dual auth, environment) |
 | `agent` | `docs/agent.md` | `site/src/content/docs/agent.mdx` | `Agent` | Shipwright agent runtime: admin CRUD API, admin UI, Prisma store, encryption, and environment configuration |
+| `agent-api` | `docs/agent-api.md` | `site/src/content/docs/agent-api.mdx` | `Reference` | Agent admin API: agents, envs, crons, cron runs, tools, tokens, plugins, chat token stats, and runtime config |
 | `migration` | `docs/migration.md` | `site/src/content/docs/migration.mdx` | `Migration` | Breaking changes and migration steps across versions |
 
 ## Procedure

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -1,0 +1,428 @@
+# Agent Admin API
+
+The Shipwright admin service exposes a CRUD API for managing agents and their resources. It is the control plane used by the admin UI, the `agent-admin` skill, and the provisioning pipeline.
+
+Base path: `/agents`
+
+---
+
+## Authentication
+
+Three auth paths are checked in order:
+
+1. **Admin key** — `Authorization: Bearer <key>` where the key matches an entry in `SHIPWRIGHT_ADMIN_API_KEYS`. Sets `isAdmin=true`, bypasses all per-agent checks.
+2. **Per-agent bearer token** — `Authorization: Bearer <token>` where the token is a per-agent DB token scoped to a specific agent ID. Sets `isAdmin=false`, restricts access to that agent's own routes (`403` on cross-agent access).
+3. **Session cookie** — `admin_session` httpOnly JWT verified with `SHIPWRIGHT_SESSION_SECRET`. Sets `isAdmin=true`.
+
+If an `Authorization` header is present but the token is invalid in both token paths, the request is rejected with `401` (no fallthrough to cookie). Missing auth returns `401`. Cross-agent access with a per-agent token returns `403`.
+
+Routes marked **admin-only** require `isAdmin=true`. Per-agent bearer tokens cannot call these routes.
+
+---
+
+## Agents
+
+### Create agent
+
+```
+POST /agents
+```
+
+Admin-only. Creates an agent record and, for managed (non-self-hosted) agents, provisions the Kubernetes workload.
+
+Body:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Agent slug — used as the K8s Deployment name |
+| `slackId` | no | Slack user ID for the agent's bot account |
+| `selfHosted` | no | `true` if the agent runs outside Kubernetes (default `false`) |
+| `repos` | no | Array of `org/repo` strings scoped to this agent |
+
+Returns `201` with `{ id, name, slackId, selfHosted, repos, createdAt, updatedAt }`.
+
+### List agents
+
+```
+GET /agents
+```
+
+Admin-only. Returns all agents with `id`, `name`, and `selfHosted` fields. Used for metrics name resolution.
+
+### Get agent
+
+```
+GET /agents/:id
+```
+
+Admin-only. Returns the full agent record including `selfHosted` and `repos`.
+
+### Update agent
+
+```
+PATCH /agents/:id
+```
+
+Admin-only. Updatable fields: `selfHosted` (boolean), `repos` (array of `org/repo` strings — each entry is validated for format). Returns the updated agent.
+
+### Delete agent
+
+```
+DELETE /agents/:id
+```
+
+Admin-only. Deprovisions the agent's K8s workload (Deployment + Secret; PVC is retained for data safety), then deletes the DB record. All child records (envs, crons, tools, tokens, plugins) are cascade-deleted.
+
+### Provision agent
+
+```
+POST /agents/:id/provision
+```
+
+Admin-only. Provisions or re-provisions the K8s workload for a single managed agent. For self-hosted agents, returns `{ skipped: true, reason: "self-hosted" }` with no K8s changes. On success returns `204`.
+
+### Reconcile all agents
+
+```
+POST /agents/reconcile
+```
+
+Admin-only. Reconciles K8s Deployment state against all managed (non-self-hosted) agents in the DB. Returns:
+
+```json
+{
+  "recreated": ["<agentId>"],
+  "updated": ["<agentId>"],
+  "orphans": ["<deploymentName>"],
+  "failed": [{ "agentId": "<id>", "error": "<message>" }]
+}
+```
+
+---
+
+## Environment variables
+
+Env vars are stored encrypted (AES-256-GCM) and decrypted on read.
+
+### Set env vars (bulk replace)
+
+```
+POST /agents/:id/envs
+```
+
+Body: `{ [key: string]: string }`. Replaces all env vars for the agent atomically. Returns `204`.
+
+### Get env vars
+
+```
+GET /agents/:id/envs
+```
+
+Returns `{ [key: string]: string }` with decrypted values.
+
+### Patch env vars (partial update)
+
+```
+PATCH /agents/:id/envs
+```
+
+Body: `{ [key: string]: string }`. Updates specific keys without touching others. Returns `204`.
+
+### Delete env var
+
+```
+DELETE /agents/:id/envs/:key
+```
+
+Deletes a single env var by key. Returns `204`.
+
+---
+
+## Cron jobs
+
+### Create cron job
+
+```
+POST /agents/:id/crons
+```
+
+Body:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `schedule` | yes | Cron expression, e.g. `"0 9 * * 1-5"` |
+| `prompt` | yes | The prompt text sent to the agent when the cron fires |
+| `channel` | no | Slack channel ID to post in (mutually exclusive with `user`) |
+| `user` | no | Slack user ID to DM (mutually exclusive with `channel`) |
+| `silent` | no | If `true`, suppress the Slack reply after execution |
+| `enabled` | no | Whether the cron is active (default `true`) |
+| `preCheck` | no | Pre-check script path. Three formats: `"plugin:script.ts"` (relative to plugin's `scripts/` dir), `"./relative.ts"` (relative to workspace root), `"/absolute.ts"`. Pass `null` to clear. |
+| `name` | no | Human-readable identifier, e.g. `"morning-brief"` |
+
+Returns `201` with the created cron job.
+
+### List cron jobs
+
+```
+GET /agents/:id/crons
+```
+
+Returns `{ crons: AgentCronJob[] }` where each cron includes a run summary (last run timestamp, outcome, today's run count).
+
+### Update cron job
+
+```
+PATCH /agents/:id/crons/:cronId
+```
+
+Body fields are the same as create, all optional. Two constraints:
+
+- `schedule` and `prompt` must be provided together when doing a content update
+- `enabled` and `preCheck` are orthogonal — each can be sent alone or combined with any other field
+- At least one field must be present (empty body returns `400`)
+
+Returns the updated cron job.
+
+### Delete cron job
+
+```
+DELETE /agents/:id/crons/:cronId
+```
+
+Returns `204`. System crons (flagged `isSystem=true`) cannot be deleted — returns `403`.
+
+### Reconcile system crons
+
+```
+POST /agents/:id/crons/reconcile
+```
+
+Reconciles the agent's system crons against the `DEFAULT_CRONS` list in the harness. Called automatically on agent startup. Returns `204`.
+
+### Cron summary
+
+```
+GET /agents/:id/crons/summary
+```
+
+Returns a lightweight summary of all cron jobs — name, schedule, enabled state, and last run info — without full prompt text. Useful for dashboards.
+
+---
+
+## Cron runs
+
+Cron runs record each execution of a cron job, including token usage and cost.
+
+### Create cron run
+
+```
+POST /agents/:id/crons/:cronId/runs
+```
+
+Body:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `startedAt` | yes | ISO timestamp when the run started |
+| `skipped` | no | `true` if the pre-check returned false |
+| `skipReason` | no | Reason the run was skipped |
+| `outcome` | no | `"success"` or `"error"` |
+
+Returns `201` with the created run record.
+
+### List cron runs
+
+```
+GET /agents/:id/crons/:cronId/runs
+```
+
+Query params: `limit` (default 20), `offset` (default 0). Returns `{ items: AgentCronRun[], total: number }`.
+
+Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`.
+
+### Update cron run
+
+```
+PATCH /agents/:id/crons/:cronId/runs/:runId
+```
+
+Used to record completion data after a run finishes. Updatable fields: `completedAt`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`. Returns the updated run.
+
+### Cron run stats
+
+```
+GET /agents/all/cron-runs/stats
+```
+
+Admin-only. Aggregated token stats across all agents. Query params: `from` and `to` (optional ISO datetimes).
+
+Returns:
+
+```json
+{
+  "totals": { "inputTokens": 0, "outputTokens": 0, "cacheReadTokens": 0, "cacheCreationTokens": 0, "costUsd": 0 },
+  "byAgent": { "<agentId>": { ... } },
+  "byCron": { "<cronId>": { ... } },
+  "byModel": { "<modelId>": { ... } },
+  "daily": [{ "date": "YYYY-MM-DD", ... }]
+}
+```
+
+---
+
+## Tools (allowed-tools list)
+
+The allowed-tools list controls which Claude Code tools the agent can call.
+
+### Add tool
+
+```
+POST /agents/:id/tools
+```
+
+Body: `{ pattern: string, enabled?: boolean }`. Pattern is a glob or exact tool name (e.g. `"Read"`, `"Bash"`, `"mcp__*"`). Returns `201`.
+
+### List tools
+
+```
+GET /agents/:id/tools
+```
+
+Returns `{ tools: AgentTool[] }` where each entry has `id`, `pattern`, and `enabled`.
+
+### Update tool
+
+```
+PATCH /agents/:id/tools/:toolId
+```
+
+Body: `{ pattern?: string, enabled?: boolean }`. Returns the updated tool.
+
+### Delete tool
+
+```
+DELETE /agents/:id/tools/:toolId
+```
+
+Returns `204`.
+
+---
+
+## API tokens
+
+Per-agent bearer tokens for scoped API access. The raw token is returned once at creation; only its SHA-256 hash is stored.
+
+### Create token
+
+```
+POST /agents/:id/tokens
+```
+
+Body (optional): `{ label?: string }`. Returns `201` with `{ id, label, createdAt, revokedAt, token }` where `token` is the raw value — save it immediately.
+
+### List tokens
+
+```
+GET /agents/:id/tokens
+```
+
+Returns `{ tokens: AgentToken[] }` with hash and metadata. Raw token values are never returned after creation.
+
+### Revoke token
+
+```
+DELETE /agents/:id/tokens/:tokenId
+```
+
+Soft-deletes the token (sets `revokedAt`). Returns `204`.
+
+---
+
+## Plugins
+
+Plugins are Claude Code marketplace plugins installed for the agent.
+
+### Install plugin
+
+```
+POST /agents/:id/plugins
+```
+
+Body: `{ name: string, version?: string, enabled?: boolean }`. Returns `201`.
+
+### List plugins
+
+```
+GET /agents/:id/plugins
+```
+
+Returns `{ plugins: AgentPlugin[] }`.
+
+### Update plugin
+
+```
+PATCH /agents/:id/plugins
+```
+
+Query param: `name` (required). Body: `{ version?: string, enabled?: boolean }`. Returns the updated plugin.
+
+### Remove plugin
+
+```
+DELETE /agents/:id/plugins
+```
+
+Query param: `name` (required). Returns `204`.
+
+---
+
+## Chat token usage
+
+Daily aggregate of Slack chat session token usage.
+
+### Record daily usage
+
+```
+POST /agents/:id/chat-tokens/daily
+```
+
+Atomic upsert — accumulates usage into the existing row for `(agentId, date)` if one exists.
+
+Body:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `date` | yes | `YYYY-MM-DD` |
+| `inputTokens` | yes | Input tokens for the session |
+| `outputTokens` | yes | Output tokens for the session |
+| `cacheReadTokens` | yes | Cache read tokens |
+| `cacheCreationTokens` | yes | Cache creation tokens |
+| `costUsd` | yes | Cost in USD |
+
+Returns the updated daily row.
+
+### Chat token stats
+
+```
+GET /agents/chat-tokens/daily/stats
+```
+
+Admin-only. Aggregated chat-token daily stats across all agents. Query params: `from` and `to` (optional `YYYY-MM-DD` date strings).
+
+Returns `{ totals, byAgent, daily }`.
+
+---
+
+## Runtime config
+
+```
+GET /agents/:id/config
+```
+
+Used by the agent harness on startup and during the config sync loop. Returns the agent's full config bundle:
+
+- `env` — decrypted key/value env vars
+- `allowedTools` — array of tool patterns
+- `plugins` — installed plugins with derived marketplace URLs
+
+Returns `404` if the agent doesn't exist.

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -1,13 +1,313 @@
 # Task Store
 
-The Shipwright task store is the backing database for the plan-execute-review loop. It holds all tasks, their statuses, dependencies, and metadata. Two backends are available:
+The Shipwright task store is the backing database for the plan-execute-review loop. It holds all tasks, their statuses, dependencies, and PR tracking records.
+
+Two deployment modes are available:
+
+| Mode | Transport | Best for |
+|------|-----------|---------|
+| **HTTP service** | `SHIPWRIGHT_TASK_STORE_URL` | Production — shared queue across multiple agents |
+| **Plugin backends** | env vars (`JIRA_*`) or local file | Single-agent or offline use |
+
+The HTTP service (artifact **D**) is the recommended production setup. Plugin backends (JSON file and Jira) are available for local development and single-agent workflows. See [configuration.md](configuration.md) for env vars.
+
+---
+
+## HTTP service
+
+The task store ships as a standalone Hono service backed by PostgreSQL. Agents connect to it via `SHIPWRIGHT_TASK_STORE_URL` + `SHIPWRIGHT_TASK_STORE_TOKEN`. The admin service provisions per-agent tokens automatically during agent setup.
+
+### Authentication
+
+All endpoints except `GET /health` and `GET /docs/:id` require a `Bearer` token:
+
+```
+Authorization: Bearer <token>
+```
+
+Two token types:
+
+| Type | `agentId` | Access |
+|------|-----------|--------|
+| **Admin** | `null` | Unrestricted — all endpoints, all agents |
+| **Agent** | set | Scoped — own tasks and repos only |
+
+Tokens are created via `POST /tokens` (admin only). The raw token is returned once at creation; only its SHA-256 hash is stored. Agent tokens are automatically repo-scoped when the admin service is configured — writes to tasks outside the agent's repo scope return `400`.
+
+### Tasks
+
+#### List tasks
+
+```
+GET /tasks
+```
+
+Query params:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
+| `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied |
+| `session` | string | Filter by planning session slug |
+| `repo` | string | Filter by repo (`org/repo` format) |
+| `assignee` | string | Filter by assignee (admin tokens only; agent tokens see only their own tasks) |
+| `claimedBy` | string | Filter by claiming agent |
+| `pr` | number | Filter by PR number |
+| `branch` | string | Filter by branch name |
+| `limit` | number | Page size |
+| `offset` | number | Page offset |
+
+Returns `{ tasks: Task[], total: number }`.
+
+Agent tokens with a repo scope return tasks where `assignee === agentId` OR `repo` is in the agent's scope (pool tasks). Agent tokens without a repo scope see only tasks where `assignee === agentId`.
+
+#### Create task
+
+```
+POST /tasks
+```
+
+Body (JSON): task fields. `title` and `status` are required. Agent tokens force `assignee` to their own ID. Returns `201` with the created task.
+
+#### Bulk insert
+
+```
+POST /tasks/bulk
+```
+
+Body: JSON array of task objects. Skips conflicts (existing ID) rather than failing. Returns `{ inserted: number, updated: number }`.
+
+#### Distinct values
+
+```
+GET /tasks/distinct
+```
+
+Returns distinct values of key fields across the visible task set. Useful for populating filter dropdowns.
+
+#### Get task
+
+```
+GET /tasks/:id
+```
+
+Returns `404` if the task doesn't exist or is outside the agent's scope.
+
+#### Update task
+
+```
+PATCH /tasks/:id
+```
+
+Body: partial task fields. Agent tokens can only update their own tasks (by `assignee` or `claimedBy`). Returns the updated task.
+
+#### Delete task
+
+```
+DELETE /tasks/:id
+```
+
+Returns `204`. Agent tokens can only delete their own tasks.
+
+#### Claim task (atomic)
+
+```
+POST /tasks/:id/claim
+```
+
+Atomically sets `claimedBy` and `claimedAt` if the task is currently unclaimed. Returns `409` if already claimed. Agent tokens pin `claimedBy` to their own ID. Admin tokens must supply `{ claimedBy: string }` in the body.
+
+#### Heartbeat
+
+```
+POST /tasks/:id/heartbeat
+```
+
+Updates `heartbeatAt` to now. Used by agents to signal they are still working.
+
+#### Complete task
+
+```
+POST /tasks/:id/complete
+```
+
+Sets `status=done` and `completedAt`.
+
+#### Fail task
+
+```
+POST /tasks/:id/fail
+```
+
+Sets `status=blocked`. Optional body: `{ reason: string }`.
+
+#### Release task
+
+```
+POST /tasks/:id/release
+```
+
+Clears `claimedBy` and `claimedAt`, resets `status=pending`. Use when the agent stops work without completing or failing.
+
+### Task status lifecycle
+
+```
+pending → in_progress → pr_open → approved → merged → deploying → deployed
+                                                    ↘ done
+```
+
+Terminal statuses (closed): `merged`, `done`, `deploying`, `deployed`, `cancelled`.
+Paused status: `blocked` (returned to `pending` on retry).
+
+### PR tracking
+
+The `/prs` surface tracks GitHub PRs through the review → patch → deploy pipeline. One record per `(repo, prNumber)`.
+
+#### List PRs
+
+```
+GET /prs
+```
+
+Query params: `repo`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`.
+
+Returns `{ prs: PullRequest[], total: number, limit: number, offset: number }`.
+
+#### Claim PR (atomic)
+
+```
+POST /prs/claim
+```
+
+Body:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `repo` | yes | `org/repo` format |
+| `prNumber` | yes | GitHub PR number (integer) |
+| `commitSha` | yes | Current head commit SHA |
+| `claimedBy` | admin only | Agent ID (agent tokens pin to their own ID) |
+| `taskId` | no | Associated task ID |
+
+Claim semantics:
+- No existing record → creates and returns `201`
+- Same `commitSha` and `reviewState !== pending` → returns `409` (already reviewed at this commit)
+- Different `commitSha` or `reviewState === pending` → updates and returns `200` (new review cycle)
+
+#### Get PR
+
+```
+GET /prs/:id
+```
+
+Returns `404` if not found.
+
+#### Update PR
+
+```
+PATCH /prs/:id
+```
+
+Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`, `reviewState`. All other fields are managed by lifecycle endpoints. Returns `400` if no writable fields are provided.
+
+#### PR lifecycle endpoints
+
+| Endpoint | Effect |
+|----------|--------|
+| `POST /prs/:id/heartbeat` | Touch `heartbeatAt` |
+| `POST /prs/:id/complete` | `reviewState=posted`, increment `reviewCycles`, set `reviewedAt` |
+| `POST /prs/:id/patch` | `reviewState=pending`, increment `patchCycles`, set `patchedAt` |
+| `POST /prs/:id/release` | Clear `claimedBy`/`claimedAt`, `reviewState=pending` |
+
+#### PR state enums
+
+`state`: `open` | `merged` | `closed`
+
+`reviewState`: `pending` → `in_progress` → `posted` | `approved`
+
+### Token management (admin only)
+
+All `/tokens` endpoints require an admin token.
+
+#### List tokens
+
+```
+GET /tokens
+```
+
+Returns token metadata (hash + label + agentId). Never returns raw token values.
+
+#### Create token
+
+```
+POST /tokens
+```
+
+Body (optional): `{ label?: string, agentId?: string }`. Admin tokens have `agentId=null`. Agent tokens are scoped to the provided `agentId`. Returns the token record plus `rawToken` — the raw value is returned **once** and not stored.
+
+#### Update token
+
+```
+PATCH /tokens/:id
+```
+
+Body: `{ label?: string, agentId?: string }`. Returns the updated token record.
+
+#### Revoke token
+
+```
+DELETE /tokens/:id
+```
+
+Soft-deletes the token (sets `revokedAt`). Returns the revoked token record.
+
+### Ephemeral document store
+
+The task store can host short-lived HTML documents — used by the plan skill to publish planning docs for agent reference.
+
+#### Store document
+
+```
+POST /docs
+```
+
+Body: raw HTML string (not JSON). Requires bearer auth. Returns:
+
+```json
+{ "id": "<uuid>", "url": "https://…/docs/<uuid>", "expiresIn": 3600 }
+```
+
+The `url` uses `SHIPWRIGHT_TASK_STORE_DOC_TTL_SECONDS` for TTL (default 3600 seconds). Storage is in-memory — a single replica or sticky routing is required.
+
+#### Fetch document
+
+```
+GET /docs/:id
+```
+
+**No authentication required** — the unguessable `id` is the credential. Returns the HTML with `Content-Type: text/html`. Returns `404` on miss or after expiry.
+
+### Health
+
+```
+GET /health
+```
+
+No authentication required. Returns `{ "status": "ok", "service": "task-store" }`.
+
+---
+
+## Plugin backends
+
+Plugin backends are used by the `task_store.ts` CLI script — they run in-process with the agent rather than as a separate service. Two backends are available:
 
 | Backend | Where tasks live | Best for |
 |---------|-----------------|---------|
 | `json` | `state/todos.json` (local file) | Local development, offline use |
 | `jira` | Jira project issues | Teams already using Jira for project tracking |
 
-Config is resolved at startup using env vars (see [docs/configuration.md](configuration.md)). When no backend env vars are set, Shipwright defaults to the JSON backend.
+Config is resolved at startup using env vars (see [configuration.md](configuration.md)). When no backend env vars are set, Shipwright defaults to the JSON backend.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a complete HTTP API reference for the task-store service to `docs/task-store.md` — the source of truth consumed by `/docs-sync`
- Covers tasks (CRUD + lifecycle), PR tracking, token management, ephemeral doc store, health endpoint, auth model (admin vs. agent tokens, repo scoping), and task status lifecycle
- Preserves existing plugin backend content (JSON + Jira + CLI reference) under a new "Plugin backends" heading

## Why

`/docs-sync` reads `docs/task-store.md` to generate `site/src/content/docs/task-store.mdx`. Without this, a sync run would push a page describing only the local JSON/Jira CLI adapters — omitting the HTTP service that agents actually connect to in production.

## Test plan

- [ ] `/docs-sync --section task-store` generates a coherent MDX with the HTTP API content
- [ ] Site build passes (`npm run build:check` in `site/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)