### PR TITLE
feat(plugin): scrub plugins/shipwright - remove internal identifiers

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -517,7 +517,7 @@ Write the PR body to a temp file:
 Reverts {SQUASH_SHA[0..7]} after canary failure.
 
 ## Context
-PR #{pr} was merged to main and deployed to GKE. The canary suite failed
+PR #{pr} was merged to main and deployed. The canary suite failed
 after deployment. This revert restores the previous state.
 
 **Canary run:** {canary_run_url}

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -274,10 +274,10 @@ describe("check-deploy", () => {
     });
     const result = await run(
       makeDeps({
-        repos: ["acme/example-repo", "app-vitals/patrol"],
+        repos: ["acme/example-repo", "acme/other-repo"],
         prs: {
           "acme/example-repo": [pr1],
-          "app-vitals/patrol": [pr2],
+          "acme/other-repo": [pr2],
         },
         ciRuns: { sha20: [{ status: "completed", conclusion: "success" }] },
       }),
@@ -304,10 +304,10 @@ describe("check-deploy", () => {
     const deps = {
       getCurrentUser: () => "bodhi-agent",
       isSelfReviewAllowed: true,
-      repos: ["app-vitals/failing-repo", "acme/example-repo"],
+      repos: ["acme/failing-repo", "acme/example-repo"],
       fetchActiveDeployRuns: async () => [],
       listOpenPrs: async (repo: string): Promise<GhPr[]> => {
-        if (repo === "app-vitals/failing-repo") throw new Error("rate limited");
+        if (repo === "acme/failing-repo") throw new Error("rate limited");
         return [pr];
       },
       fetchCiRuns: async (
@@ -326,7 +326,7 @@ describe("check-deploy", () => {
     process.stderr.write = origStderr;
 
     expect(result.exit).toBe(0);
-    expect(stderrLines.some((l) => l.includes("app-vitals/failing-repo"))).toBe(
+    expect(stderrLines.some((l) => l.includes("acme/failing-repo"))).toBe(
       true,
     );
   });

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -126,12 +126,12 @@ describe("resolveRepos", () => {
     );
     makeGitClone(
       reposDir,
-      "patrol",
-      "https://github.com/app-vitals/patrol.git",
+      "other-repo",
+      "https://github.com/acme/other-repo.git",
     );
     const result = resolveRepos(tmpDir);
     expect(result).toContain("acme/example-repo");
-    expect(result).toContain("app-vitals/patrol");
+    expect(result).toContain("acme/other-repo");
     expect(result).toHaveLength(2);
   });
 
@@ -195,15 +195,15 @@ describe("resolveRepos", () => {
     mkdirSync(envReposDir, { recursive: true });
     makeGitClone(
       envReposDir,
-      "patrol",
-      "https://github.com/app-vitals/patrol.git",
+      "other-repo",
+      "https://github.com/acme/other-repo.git",
     );
 
     process.env.SHIPWRIGHT_REPOS_DIR = envReposDir;
     const result = resolveRepos(tmpDir);
     // repos/ is non-empty, so env var is ignored
     expect(result).toContain("acme/example-repo");
-    expect(result).not.toContain("app-vitals/patrol");
+    expect(result).not.toContain("acme/other-repo");
   });
 
   test("returns empty array when SHIPWRIGHT_REPOS_DIR points to nonexistent path", () => {
@@ -258,10 +258,10 @@ describe("resolveAllRepos", () => {
     mkdirSync(reposDir, { recursive: true });
     makeGitClone(
       reposDir,
-      "patrol",
-      "https://github.com/app-vitals/patrol.git",
+      "other-repo",
+      "https://github.com/acme/other-repo.git",
     );
-    expect(resolveAllRepos(tmpDir)).toEqual(["app-vitals/patrol"]);
+    expect(resolveAllRepos(tmpDir)).toEqual(["acme/other-repo"]);
   });
 });
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -31,10 +31,10 @@ echo "Token: ${SHIPWRIGHT_TASK_STORE_TOKEN:+(set)}"
 
 1. Open your Shipwright admin UI at `<admin-url>/admin/tokens`
 2. Click **Create token** and enter a descriptive label (e.g. `my-local-agent`)
-3. **Agent ID field** — leave blank for local or HITL use; enter your agent's ID for Vitals OS shipwright agents
+3. **Agent ID field** — leave blank for local or HITL use; enter your agent's ID for managed Shipwright agents
 4. Copy the generated token and wire it up:
    - **Local plugin / shell:** `export SHIPWRIGHT_TASK_STORE_TOKEN=<token>`
-   - **Vitals OS shipwright agent:** add `SHIPWRIGHT_TASK_STORE_TOKEN=<token>` as an agent env var in the Vitals OS admin UI — it takes effect within 60 seconds, no restart needed
+   - **Managed Shipwright agent:** add `SHIPWRIGHT_TASK_STORE_TOKEN=<token>` as an agent env var via the Shipwright admin UI — it takes effect within 60 seconds, no restart needed
 
 **HITL note:** For local HITL execution (`/shipwright:hitl`), create an admin token with **Agent ID left blank** — this keeps the token unscoped so it can read any agent's tasks. Pass the task ID explicitly when invoking the skill.
 


### PR DESCRIPTION
## Summary

- File-by-file manual review of `plugins/shipwright/**` before the repo goes public (MIT)
- Removed all internal identifiers: internal product name, internal repo names, and infra-specific references
- Confirmed `task check-strings` passes with no banned strings found

## Root-Cause Notes (Dave Submission Checklist)

| Finding | File | Category | Action |
|---------|------|----------|--------|
| `"Vitals OS shipwright agents"` / `"Vitals OS admin UI"` | `plugins/shipwright/skills/task-store/SKILL.md:34,37` | Internal product name | Replaced with `"managed Shipwright agents"` / `"Shipwright admin UI"` |
| `"deployed to GKE"` | `plugins/shipwright/commands/deploy.md:519` | Internal infra identifier (Google Kubernetes Engine hardcoded in revert PR body template) | Replaced with generic `"deployed"` — the deploy target is user-configurable and shouldn't be hardcoded |
| `"patrol"` / `"app-vitals/patrol"` (test fixture) | `plugins/shipwright/scripts/check-helpers.unit.test.ts:129-134,198-206,261-264` | Internal repo name used as test fixture for a second monitored repo | Replaced with `"other-repo"` / `"acme/other-repo"` |
| `"app-vitals/patrol"` (test fixture) | `plugins/shipwright/scripts/check-deploy.test.ts:277-281` | Internal repo name in multi-repo test fixture | Replaced with `"acme/other-repo"` |
| `"app-vitals/failing-repo"` (test fixture) | `plugins/shipwright/scripts/check-deploy.test.ts:307-310,329` | Internal org name in failure-path test fixture | Replaced with `"acme/failing-repo"` |

**Root causes:** Test fixtures were written against real internal repo names rather than neutral placeholders. The `task-store` SKILL.md was authored in the context of the internal deployment platform and retained product-specific terminology. The `deploy.md` template hardcoded the internal infra provider.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `task check-strings` passes | ✅ Passes — no banned strings found |
| 2 | Manual review of `plugins/shipwright/**` finds no secrets, client names, absolute paths, or internal IDs | ✅ Clean after fixes |
| 3 | Findings fixed in same PR | ✅ All 5 findings fixed across 4 files |
| 4 | Root-cause notes documented in PR description | ✅ See table above |

## Test Plan

- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` → `✓ No banned strings found.`
- [x] `bun test plugins/shipwright/` → 544 pass, 0 fail

Generated with [Claude Code](https://claude.com/claude-code)
