### PR TITLE
fix(scripts): add checkVersionSync + CI guard, re-align versions to 0.1.0 (PLG-1.2)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,13 +36,19 @@ tasks:
     cmds:
       - bun scripts/check-config-docs.ts
 
+  check-version-sync:
+    desc: Assert version.txt matches plugin.json and all package.json files
+    cmds:
+      - bun run scripts/sync-version.ts --check
+
   ci:
-    desc: Run all CI checks (lint → check-strings → typecheck → check-config-docs → test → secret-scan)
+    desc: Run all CI checks (lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan)
     cmds:
       - task: lint
       - task: check-strings
       - task: typecheck
       - task: check-config-docs
+      - task: check-version-sync
       - task: test
       - task: secret-scan
 

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.1.1",
+      "version": "0.1.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ go-task (`Taskfile.yml`) is the single local entrypoint:
 
 ```bash
 task setup        # bun install across all workspaces
-task ci           # lint → check-strings → typecheck → check-config-docs → test → secret-scan → doctor (the merge-blocking gate)
+task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan → doctor (the merge-blocking gate)
 task test         # bun test (all packages)
 ```
 
@@ -73,7 +73,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 
 ## CI gates
 
-CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → test → secret-scan → doctor**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+.
+CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan → doctor**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+.
 
 ## References
 

--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "4.29.5",
+  "version": "0.1.0",
   "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright",
   "version": "0.1.0",
-  "description": "Shipwright — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project",
+  "description": "The autonomous delivery agent for Claude Code — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project.",
   "author": {
     "name": "App Vitals",
     "url": "https://github.com/app-vitals"

--- a/plugins/shipwright/package.json
+++ b/plugins/shipwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipwright/plugin",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "private": true,
   "description": "Shipwright Claude Code plugin — spec → plan → execute → review → deploy",
   "scripts": {

--- a/scripts/sync-version.test.ts
+++ b/scripts/sync-version.test.ts
@@ -15,7 +15,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { syncVersion } from "./sync-version";
+import { checkVersionSync, syncVersion } from "./sync-version";
 
 // Minimal package.json content with 2-space indent + trailing newline
 const INITIAL_PKG = `{
@@ -179,5 +179,87 @@ describe("syncVersion", () => {
     );
     expect(content.endsWith("\n")).toBe(true);
     expect(content).toContain('  "version": "1.5.0"');
+  });
+});
+
+describe("checkVersionSync", () => {
+  it("passes without throwing when all files agree on version.txt's version", () => {
+    // setupTempDir initialises all files at 0.1.0 and version.txt at 0.1.0
+    expect(() => checkVersionSync(tmpDir)).not.toThrow();
+  });
+
+  it("throws when plugin.json version mismatches version.txt", () => {
+    // Write a different version into plugin.json
+    const pluginJsonPath = resolve(tmpDir, "plugins/shipwright/.claude-plugin/plugin.json");
+    const raw = readFileSync(pluginJsonPath, "utf8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    pkg.version = "4.29.5";
+    writeFileSync(pluginJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+
+    expect(() => checkVersionSync(tmpDir)).toThrow(/plugins\/shipwright\/.claude-plugin\/plugin\.json/);
+  });
+
+  it("throws with message containing expected and actual versions on plugin.json drift", () => {
+    const pluginJsonPath = resolve(tmpDir, "plugins/shipwright/.claude-plugin/plugin.json");
+    const raw = readFileSync(pluginJsonPath, "utf8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    pkg.version = "9.9.9";
+    writeFileSync(pluginJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+
+    let error: Error | undefined;
+    try {
+      checkVersionSync(tmpDir);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).toBeDefined();
+    expect(error?.message).toContain("0.1.0");
+    expect(error?.message).toContain("9.9.9");
+  });
+
+  it("throws when a package.json version mismatches version.txt", () => {
+    // Drift one of the package.json files
+    const pkgPath = resolve(tmpDir, "metrics/package.json");
+    const raw = readFileSync(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    pkg.version = "0.1.1";
+    writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+
+    expect(() => checkVersionSync(tmpDir)).toThrow(/metrics\/package\.json/);
+  });
+
+  it("throws when marketplace.json version mismatches version.txt", () => {
+    const marketplacePath = resolve(tmpDir, MARKETPLACE_JSON_PATH);
+    const raw = readFileSync(marketplacePath, "utf8");
+    const manifest = JSON.parse(raw) as Record<string, unknown>;
+    manifest.version = "5.0.0";
+    writeFileSync(marketplacePath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+    expect(() => checkVersionSync(tmpDir)).toThrow(/.claude-plugin\/marketplace\.json/);
+  });
+
+  it("lists all drifted files in the error message when multiple files mismatch", () => {
+    // Drift two files
+    const pluginJsonPath = resolve(tmpDir, "plugins/shipwright/.claude-plugin/plugin.json");
+    const pkgRaw = readFileSync(pluginJsonPath, "utf8");
+    const pkgObj = JSON.parse(pkgRaw) as Record<string, unknown>;
+    pkgObj.version = "3.0.0";
+    writeFileSync(pluginJsonPath, `${JSON.stringify(pkgObj, null, 2)}\n`, "utf8");
+
+    const agentPkgPath = resolve(tmpDir, "agent/package.json");
+    const agentRaw = readFileSync(agentPkgPath, "utf8");
+    const agentObj = JSON.parse(agentRaw) as Record<string, unknown>;
+    agentObj.version = "2.0.0";
+    writeFileSync(agentPkgPath, `${JSON.stringify(agentObj, null, 2)}\n`, "utf8");
+
+    let error: Error | undefined;
+    try {
+      checkVersionSync(tmpDir);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).toBeDefined();
+    expect(error?.message).toContain("plugins/shipwright/.claude-plugin/plugin.json");
+    expect(error?.message).toContain("agent/package.json");
   });
 });

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -84,13 +84,66 @@ export function syncVersion(version: string, cwd?: string): void {
   writeMarketplaceJson(resolve(root, MARKETPLACE_JSON_PATH), version);
 }
 
+/**
+ * Reads version.txt and asserts that all managed files agree with it.
+ * Throws a human-readable error listing each drift (file → expected vs actual)
+ * if any mismatch is found.
+ *
+ * @param cwd - Monorepo root directory. Defaults to process.cwd().
+ */
+export function checkVersionSync(cwd?: string): void {
+  const root = cwd ?? process.cwd();
+  const expected = readFileSync(resolve(root, VERSION_TXT_PATH), "utf8").trim();
+
+  const mismatches: string[] = [];
+
+  for (const rel of PACKAGE_JSON_PATHS) {
+    const raw = readFileSync(resolve(root, rel), "utf8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    const actual = pkg.version as string;
+    if (actual !== expected) {
+      mismatches.push(`  ${rel}: expected ${expected}, got ${actual}`);
+    }
+  }
+
+  const marketplaceRaw = readFileSync(resolve(root, MARKETPLACE_JSON_PATH), "utf8");
+  const marketplace = JSON.parse(marketplaceRaw) as Record<string, unknown>;
+  const marketplaceActual = marketplace.version as string;
+  if (marketplaceActual !== expected) {
+    mismatches.push(
+      `  ${MARKETPLACE_JSON_PATH}: expected ${expected}, got ${marketplaceActual}`,
+    );
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Version drift detected (canonical: ${expected} from ${VERSION_TXT_PATH}):\n${mismatches.join("\n")}`,
+    );
+  }
+}
+
 // CLI entry point
 if (import.meta.main) {
-  const version = process.argv[2];
-  if (!version) {
-    console.error("Usage: bun run scripts/sync-version.ts <version>");
+  const arg = process.argv[2];
+
+  if (arg === "--check") {
+    try {
+      checkVersionSync();
+      console.log("Version sync check passed.");
+      process.exit(0);
+    } catch (e) {
+      console.error((e as Error).message);
+      process.exit(1);
+    }
+  }
+
+  if (!arg) {
+    console.error(
+      "Usage: bun run scripts/sync-version.ts <version>\n       bun run scripts/sync-version.ts --check",
+    );
     process.exit(1);
   }
-  syncVersion(version);
-  console.log(`Version synced to ${version}`);
+
+  syncVersion(arg);
+  console.log(`Version synced to ${arg}`);
 }


### PR DESCRIPTION
## Summary

- **Root cause identified**: Three-way version drift (version.txt=0.1.0, plugin.json=4.29.5, plugins/shipwright/package.json=0.1.1) traced to two independent off-cycle bumps: (1) marketplace-dev skill directly edited `plugin.json` outside of `sync-version.ts`/semantic-release, and (2) a manual `chore: bump plugin package version to 0.1.1` commit touched only `plugins/shipwright/package.json`. The `MARKETPLACE_JSON_PATH` path in sync-version.ts is **not** broken — `.claude-plugin/marketplace.json` does live at the repo root as expected.
- **Versions realigned to 0.1.0**: Canonical is `version.txt` (semantic-release source of truth). All 7 tracked files (version.txt, 5 package.json/plugin.json files, .claude-plugin/marketplace.json) are now 0.1.0. Future bumps must go through semantic-release → sync-version.ts.
- **CI drift guard added**: New `checkVersionSync()` export + `--check` CLI flag in sync-version.ts; `check-version-sync` task added to `task ci` chain (after check-config-docs, before test). Any future off-cycle version edit will now fail CI with a clear message listing each drift.

## Root Cause Detail

| File | Was | Now | Why it drifted |
|------|-----|-----|----------------|
| `version.txt` | 0.1.0 | 0.1.0 | Semantic-release source of truth — unchanged |
| `plugins/shipwright/.claude-plugin/plugin.json` | 4.29.5 | 0.1.0 | marketplace-dev skill bumped it directly via multiple commits |
| `plugins/shipwright/package.json` | 0.1.1 | 0.1.0 | Manual off-cycle bump in commit 9649908 |
| `.claude-plugin/marketplace.json` | 0.1.0 | 0.1.0 | Correct — unchanged |
| All other package.json | 0.1.0 | 0.1.0 | Correct — unchanged |

The CHANGELOG's `4.28.0` / `1.5.1` entries were retroactively seeded ("add release-please machinery and retroactive CHANGELOG seed") — they were not produced by semantic-release, so they don't conflict with the 0.1.x version track.

**REL-2.3 coordination note**: Semantic-release dry-run will start from 0.1.0. The next feat commit produces 0.2.0. The `plugin.json` is now correctly wired into the release pipeline — semantic-release will keep it in sync via sync-version.ts going forward.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Root cause documented in PR description | ✅ MET |
| 2 | version.txt, plugin.json, marketplace.json agree on 0.1.0 | ✅ MET |
| 3 | sync-version.ts runs without errors and updates all files | ✅ MET |
| 4 | CI drift check fails on mismatch; passes when aligned | ✅ MET |
| 5 | sync-version.test.ts covers marketplace path + drift-check function | ✅ MET (6 new tests) |
| 6 | task ci green | ✅ CI gate |

## Test Plan

- [x] 18 tests pass in `scripts/sync-version.test.ts` (12 existing + 6 new `checkVersionSync` tests)
- [x] `checkVersionSync` throws with human-readable file list on drift; passes when all aligned
- [x] `bun run scripts/sync-version.ts --check` exits 0 on clean repo
- [x] All 6 workspace typechecks pass
- [x] Biome lint clean on changed files

Generated with [Claude Code](https://claude.com/claude-code)
