### PR TITLE
fix(ci): pin go-task to 3.51.1 to avoid unauthenticated GitHub API rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install go-task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.51.1
 
       - name: Install dependencies
         run: task setup
@@ -132,7 +132,7 @@ jobs:
       - name: Install go-task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.51.1
 
       - name: Install dependencies
         run: task setup


### PR DESCRIPTION
## Summary

- `arduino/setup-task` with `version: 3.x` calls the GitHub API to resolve the semver range — unauthenticated, which caps at 60 req/hr per runner IP
- This caused a transient CI failure on run [28571764276](https://github.com/app-vitals/shipwright/actions/runs/28571764276) — the `Install go-task` step failed mid-run when the shared runner IP was rate-limited
- Pinning to `3.51.1` (current latest stable) bypasses the resolution call entirely — no API needed, downloads directly

## Test plan

- [ ] CI passes on this PR (the pinned version downloads successfully without hitting the API)
- [ ] Both `ci` and `e2e` jobs install go-task correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)