### PR TITLE
fix: correct BOOTSTRAP.md.template cron listing to reflect enabled-by-default state

### DIFF
--- a/agent/workspace/BOOTSTRAP.md.template
+++ b/agent/workspace/BOOTSTRAP.md.template
@@ -12,13 +12,11 @@ _You're seeing this because this is a fresh workspace. Run the ritual, then dele
    - Team: add `@TEAM.md` at the bottom
 5. **Create USER.md or TEAM.md** — fill it in with context about your human(s)
 6. **Clone the repo** — `git clone <repo-url> repos/<repo>` so it's available for research
-7. **Walk through the dev loop** — explain that cron jobs are already running:
+7. **Walk through the dev loop** — explain that two cron jobs are enabled by default:
    - `shipwright-dev-task` (every 30 min) — picks up approved todos and ships them via `/shipwright:dev-task`
-   - `shipwright-patch` (every 30 min) — addresses unresolved review findings and CI failures via `/shipwright:patch`
-   - `shipwright-deploy` (every 30 min) — merges and deploys approved PRs via `/shipwright:deploy`
-   - `shipwright-review` (every 30 min) — reviews open PRs via `/shipwright:review`
    - `shipwright-review-patch` (every 30 min) — fixes findings from own PR reviews via `/shipwright:review-patch`
    Work flows in via `state/todos.json`. Once a todo is approved, it gets picked up automatically.
+   Note: `shipwright-patch`, `shipwright-review`, and `shipwright-deploy` are installed but disabled by default — enable them via the accounts API when the agent is ready for autonomous patching, reviewing, and deployment.
 8. **Delete this file** — once bootstrap is complete, remove BOOTSTRAP.md
 
 ## What You're Building


### PR DESCRIPTION
## Summary
- Reapplies the content change from commit `53c579c` (stranded on the unmerged branch `origin/feat/she-5-1-setup-plugin-registry`) to `main`
- `BOOTSTRAP.md.template` step 7 now lists only the two crons enabled by default (`shipwright-dev-task`, `shipwright-review-patch`) instead of all five, and notes that `shipwright-patch`, `shipwright-review`, and `shipwright-deploy` require explicit opt-in via the accounts API
- Verified against `admin/src/system-crons.ts`: only `shipwright-dev-task` and `shipwright-review-patch` have `enabled: true`

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | BOOTSTRAP.md.template step 7 matches actual default-enabled cron state (2 enabled, 3 opt-in) | MET | Diff matches `system-crons.ts` ground truth |
| 2 | Test: none needed — static template content, no logic | MET | Only `BOOTSTRAP.md.template` changed, no test files touched |

## Test Plan
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — no banned strings
- [x] `bunx biome lint` on changed file — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
