### PR TITLE
fix: merge main into a branch only to resolve a conflict, not to stay up to date

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -124,8 +124,8 @@ favors permissive: false positives are visible and self-correcting; false negati
 | `check-review.ts` | `review` cron | Open PRs with unreviewed commits (by headRefOid dedup against task store `/prs` records); respects `allow_self_review` policy |
 | `check-deploy.ts` | `deploy` cron | Open PRs with `APPROVED` review decision and green CI; respects `allow_self_review` for self-authored PRs |
 | `check-dev-task.ts` | `dev-task` cron | Pending tasks with all dependencies satisfied (task store `ready: true` query) |
-| `check-patch.ts` | `patch` cron | Auto-updates BEHIND branches via `gh pr update-branch`; signals patch skill for unaddressed review findings, stuck-BEHIND branches (update-branch failures), merge conflicts, and failing CI; queries GitHub directly — does NOT read `state/reviews.json` |
-| `check-review-patch.ts` | `review-patch` cron | Delegates to `check-patch.ts` + `check-review.ts`; exits 0 if either exits 0, covering the full scope of the review-patch orchestrator (unaddressed findings, failing CI, BEHIND branches, merge conflicts, and unreviewed commits) |
+| `check-patch.ts` | `patch` cron | Signals patch skill for unaddressed review findings, merge conflicts (DIRTY), and failing CI; queries GitHub directly — does NOT read `state/reviews.json`. Branches merely BEHIND main (no conflict) are not patch-worthy — main is only merged into a branch to resolve a conflict. |
+| `check-review-patch.ts` | `review-patch` cron | Delegates to `check-patch.ts` + `check-review.ts`; exits 0 if either exits 0, covering the full scope of the review-patch orchestrator (unaddressed findings, failing CI, merge conflicts, and unreviewed commits) |
 
 ---
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -643,32 +643,24 @@ The execution cron will not pick it up until a human intervenes.
 
 ## Step 9b: CI Gate
 
-After PR creation, update the branch from main and monitor GitHub Actions CI checks before proceeding.
+After PR creation, check for merge conflicts with main and monitor GitHub Actions CI
+checks before proceeding. Branches are no longer required to be up to date with main
+before merging — main is merged into the branch only to resolve an actual conflict.
 
-### 9b.1. Update from Main
+### 9b.1. Check for Merge Conflicts
 
-Merge the latest main into the PR branch to satisfy branch protection rules:
+Check the PR's merge state — do not merge unless there's a real conflict:
 
+```bash
+gh pr view {pr-number} --repo {org}/{repo} --json mergeStateStatus
 ```
-git fetch origin main
-git merge origin/main
-```
 
-If the merge **succeeds** (no conflicts):
+**If `mergeStateStatus` is `"DIRTY"`** (real conflict): jump directly to 9b.4 (Fix Loop)
+with "merge conflict with origin/main" as the failure context. The fix subagent will run
+`git merge origin/main`, resolve the conflicts, commit, and push.
 
-Check whether the merge actually brought in new commits:
-```
-git diff HEAD @{1} --quiet
-```
-If no changes (exit code 0 = already up to date), skip the push — CI is already running against the current code. Proceed directly to 9b.2.
-
-If there are changes:
-```
-git push
-```
-The push triggers new CI runs against the updated code. Proceed to 9b.2.
-
-If the merge produces **conflicts**: do NOT commit the merge. Instead, abort it (`git merge --abort`) and jump directly to 9b.4 (Fix Loop) with the conflict details as the failure context. The fix subagent will run `git merge origin/main`, resolve the conflicts, commit, and push.
+**Otherwise** (including `"BEHIND"` — behind but no conflict): no merge needed. CI is
+already running against the code pushed in Step 9. Proceed directly to 9b.2.
 
 ### 9b.2. Wait for Checks
 
@@ -771,7 +763,7 @@ While `ci_attempt < ci_max_retries`:
 
 4. After the subagent completes, **append a one-line summary** of what this attempt tried to `ci_fix_history` (e.g., `"Attempt 1: updated failing snapshot in UserCard.test.tsx"`, `"Attempt 2: fixed type error in api/auth.ts — wrong return type"`).
 
-5. **Loop back to 9b.1** — update from main again (main may have moved while the fix was in progress), then re-wait for CI in 9b.2.
+5. **Loop back to 9b.1** — re-check merge state (main may have moved while the fix was in progress, potentially producing a new conflict), then re-wait for CI in 9b.2.
 
 5. **All checks pass:** Break the loop. Print:
    ```

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1,17 +1,16 @@
 ---
-description: Address unresolved review findings, BEHIND branches, merge conflicts, and failing CI on own open PRs — queries GitHub directly, fixes in worktree, pushes
+description: Address unresolved review findings, merge conflicts, and failing CI on own open PRs — queries GitHub directly, fixes in worktree, pushes
 ---
 
 # Patch
 
-Scan own open PRs for four conditions: unaddressed review/PR comments, branches BEHIND
-main that the precheck could not auto-update, merge conflicts with base, and failing CI.
-For each PR, apply the appropriate fix. Goes silent when nothing needs addressing.
+Scan own open PRs for three conditions: unaddressed review/PR comments, merge conflicts
+with base, and failing CI. For each PR, apply the appropriate fix. Goes silent when
+nothing needs addressing.
 
-> **Note:** The patch precheck (`check-patch.ts`) attempts to auto-update BEHIND branches
-> via `gh pr update-branch` before this skill runs. If the auto-update succeeds, the PR
-> does not appear in List B. If it fails (e.g., transient error), `check-patch.ts` exits 0
-> and this skill handles the stuck-BEHIND branch in Step 7.
+> **Note:** Branches merely BEHIND main (no conflict) are not patch-worthy. Main is only
+> merged into a branch to resolve an actual conflict — see Step 2.5 and Step 4 for the
+> conflict-only (DIRTY) path.
 
 **This command runs autonomously. Do not pause for user input.**
 
@@ -78,16 +77,15 @@ gh pr update-branch --rebase {number} --repo {org}/{repo}
 
 ---
 
-## Step 3: Classify PRs into Four Lists
+## Step 3: Classify PRs into Three Lists
 
-Check each PR against all four conditions independently. A PR may appear in multiple lists.
+Check each PR against all three conditions independently. A PR may appear in multiple lists.
 
 - **List A** — PRs with unresolved review or PR comments
-- **List B** — PRs that are BEHIND main and could not be auto-updated by the precheck
 - **List C** — PRs with merge conflicts (DIRTY)
 - **List D** — PRs with failing CI
 
-Work through all PRs before continuing. When a PR appears in multiple lists, all applicable fixes run — processed in the order the steps execute (C → A → D → B).
+Work through all PRs before continuing. When a PR appears in multiple lists, all applicable fixes run — processed in the order the steps execute (C → A → D).
 
 **This command does not read `state/reviews.json`.** All data comes from GitHub directly.
 
@@ -157,7 +155,7 @@ If a PR has unaddressed findings, add it to **List A**. Store the unresolved thr
 `id` — needed for the `resolveReviewThread` mutation in Step 5) and review bodies for use in
 Step 5.
 
-### Step 3b: Check for BEHIND or DIRTY State
+### Step 3b: Check for DIRTY State
 
 For each PR, check its merge state:
 
@@ -165,8 +163,9 @@ For each PR, check its merge state:
 gh pr view {pr} --repo {org}/{repo} --json mergeStateStatus
 ```
 
-- If `mergeStateStatus` is `"BEHIND"` → add to **List B**
 - If `mergeStateStatus` is `"DIRTY"` → add to **List C**
+- Any other state (including `"BEHIND"`) → not patch-worthy on its own; being behind
+  main without a conflict does not require action
 
 Store the fetched `mergeStateStatus` — do not re-fetch in Step 3c.
 
@@ -186,7 +185,7 @@ If failing CI is found, add the PR to **List D**.
 
 ### Step 3d: Summary
 
-If all four lists are empty:
+If all three lists are empty:
 
 ```
 No PRs need attention.
@@ -196,9 +195,8 @@ Append `[silent]` and stop.
 Print a summary before proceeding:
 
 ```
-Found {A} PR(s) with unaddressed review findings, {B} PR(s) BEHIND main (not auto-updated), {C} PR(s) with merge conflicts, {D} PR(s) with failing CI:
+Found {A} PR(s) with unaddressed review findings, {C} PR(s) with merge conflicts, {D} PR(s) with failing CI:
   Review findings:  {for each in List A: "#{pr} — {title} ({org}/{repo})"}
-  Behind main:      {for each in List B: "#{pr} — {title} ({org}/{repo})"}
   Merge conflicts:  {for each in List C: "#{pr} — {title} ({org}/{repo})"}
   Failing CI:       {for each in List D: "#{pr} — {title} ({org}/{repo})"}
 ```
@@ -728,126 +726,9 @@ git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WOR
 
 ---
 
-## Step 7: Update BEHIND Branches
+## Step 7: Report
 
-For each PR in List B (branches that are BEHIND base and could not be auto-updated by
-the precheck), set up a worktree, attempt a merge, validate, and push. Fully complete
-one PR before moving to the next.
-
-### Step 7a: Set Up Worktree
-
-Same pattern as Step 5a — branch slug = branch name with `/` replaced by `-`:
-
-```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} fetch origin
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/{branch}
-```
-
-If the worktree already exists (prior interrupted run):
-```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} --force
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/{branch}
-```
-
-### Step 7a.5: Detect Project Toolchain
-
-From `{worktree-path}`, detect the project toolchain:
-
-1. Scan the project root for config files:
-   - `package.json` + lockfile → Node.js (detect manager: pnpm/yarn/npm/bun)
-   - `Cargo.toml` → Rust
-   - `go.mod` → Go
-   - `pom.xml` → Java/Maven (use `./mvnw` wrapper if present, else `mvn`)
-   - `build.gradle` / `build.gradle.kts` → Java/Gradle (use `./gradlew` wrapper if present, else `gradle`)
-   - `pyproject.toml` / `setup.py` → Python
-   - `Gemfile` → Ruby
-   - `Makefile` → Generic Make
-
-2. For Node.js: read `package.json` scripts for `test` and `lint`
-
-3. Store detected commands:
-   - **{lint command}**: e.g., `bun run lint`, `cargo clippy`, `golangci-lint run`
-   - **{test command}**: e.g., `bun test`, `cargo test`, `go test ./...`, `pytest`
-
-Refer to `references/toolchain-patterns.md` for the full detection lookup table.
-
-### Step 7b: Attempt Auto-Update
-
-Try a fast-path update via the GitHub API:
-
-```bash
-gh pr update-branch {number} --repo {org}/{repo}
-```
-
-- **Succeeds (exit 0)**: Branch updated cleanly. Proceed to Step 7e (cleanup).
-- **Fails (non-zero exit)**: GitHub could not auto-merge. Proceed to Step 7c to dispatch
-  a subagent for a manual merge.
-
-### Step 7c: Dispatch Update Subagent
-
-Dispatch a `general-purpose` subagent via the Agent tool with this prompt:
-
-```
-You are updating a branch that is behind its base. Merge the base branch, validate,
-and push.
-
-PR: #{pr} — {title}
-Repo: {org}/{repo}
-Branch: {branch}
-Base branch: {base}
-Worktree: {worktree-path}
-
-TOOLCHAIN:
-  Lint command: {lint command}
-  Test command: {test command}
-
-INSTRUCTIONS — follow in order:
-
-[A] Merge the base branch
-  - From the worktree: `git merge origin/{base}`
-  - If there are unresolvable conflicts, report BLOCKED — do not force-push or
-    discard changes
-
-[B] Validate
-  - Run: {lint command}
-  - Run: {test command}
-  - Fix any failures introduced by the merge
-  - Re-run until both pass cleanly
-
-[C] Push
-  - Push: `git push origin {branch}`
-
-[D] Report back
-  At the end, output:
-
-  STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
-
-  CONCERNS: (if DONE_WITH_CONCERNS)
-  BLOCKER: (if BLOCKED — include conflict details)
-```
-
-### Step 7d: Handle Subagent Status
-
-Parse the subagent's STATUS:
-
-- **DONE**: Record the update. Proceed to Step 7e (cleanup).
-- **DONE_WITH_CONCERNS**: Log concerns. If the push already happened, continue.
-- **BLOCKED**: Log the blocker. Skip cleanup. Move to the next PR in List B.
-  Include the blocker in the final report.
-
-### Step 7e: Cleanup Worktree
-
-After a successful push (subagent status DONE or DONE_WITH_CONCERNS with push completed):
-
-```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} --force
-```
-
----
-
-## Step 8: Report
-
-After processing all four lists, print a summary:
+After processing all three lists, print a summary:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -862,13 +743,6 @@ REVIEW FINDINGS ({A} PR(s)):
    {if DONE_WITH_CONCERNS: "⚠ Concerns: {concern summary}"}
    Findings addressed:
    {bullet list from subagent FINDINGS_ADDRESSED}"}
-
-BEHIND MAIN ({B} PR(s)):
-{for each PR in List B:
-  "#{pr} — {title} ({org}/{repo})
-   {if DONE or DONE_WITH_CONCERNS with push: "✓ Updated and pushed"}
-   {if BLOCKED: "✗ Blocked: {blocker summary}"}
-   {if DONE_WITH_CONCERNS: "⚠ Concerns: {concern summary}"}"}
 
 MERGE CONFLICTS ({C} PR(s)):
 {for each PR in List C:

--- a/plugins/shipwright/commands/review-patch.md
+++ b/plugins/shipwright/commands/review-patch.md
@@ -149,6 +149,6 @@ Elapsed:              {ELAPSED}s
 
 **Backward compatibility**: The cron invocation format is unchanged — `/shipwright:review-patch` works the same as before. No cron prompt updates are needed.
 
-**Scope expansion**: The new orchestrator delegates to `/shipwright:patch` (Lists B/C/D — BEHIND branches, merge conflicts, failing CI) and `/shipwright:review`, expanding scope beyond the old List A–only behavior. A single review-patch cron now covers all PR health checks.
+**Scope expansion**: The new orchestrator delegates to `/shipwright:patch` (Lists C/D — merge conflicts, failing CI) and `/shipwright:review`, expanding scope beyond the old List A–only behavior. A single review-patch cron now covers all PR health checks.
 
 **Cron overlap**: Agents running all three crons (review, patch, review-patch) on separate schedules risk concurrent sessions working the same PRs. Recommended configuration: use review-patch as the sole cron (replacing separate review and patch crons), since it now subsumes both. If all three must run, ensure non-overlapping schedules.

--- a/plugins/shipwright/commands/spc-2.1.unit.test.ts
+++ b/plugins/shipwright/commands/spc-2.1.unit.test.ts
@@ -112,7 +112,7 @@ describe("patch.md — subagent prompt templates", () => {
   it("uses {worktree-path} placeholder in all subagent prompts", () => {
     const occurrences = (patch.match(/Worktree: \{worktree-path\}/g) ?? [])
       .length;
-    expect(occurrences).toBe(4);
+    expect(occurrences).toBe(3);
   });
 });
 

--- a/plugins/shipwright/commands/spc-3.1.unit.test.ts
+++ b/plugins/shipwright/commands/spc-3.1.unit.test.ts
@@ -33,11 +33,6 @@ describe("patch.md — toolchain detection steps present", () => {
     expect(section).toContain("### Step 6a.5: Detect Project Toolchain");
   });
 
-  it("has toolchain detection between Step 7a and Step 7b (Step 7a.5)", () => {
-    const section = extractSection(patch, "### Step 7a:", "### Step 7b:");
-    expect(section).toContain("### Step 7a.5: Detect Project Toolchain");
-  });
-
   it("references toolchain-patterns.md in the Step 5a.5 detection step", () => {
     const section = extractSection(patch, "### Step 5a.5:", "### Step 5b:");
     expect(section).toContain("toolchain-patterns.md");
@@ -45,11 +40,6 @@ describe("patch.md — toolchain detection steps present", () => {
 
   it("references toolchain-patterns.md in the Step 6a.5 detection step", () => {
     const section = extractSection(patch, "### Step 6a.5:", "### Step 6b:");
-    expect(section).toContain("toolchain-patterns.md");
-  });
-
-  it("references toolchain-patterns.md in the Step 7a.5 detection step", () => {
-    const section = extractSection(patch, "### Step 7a.5:", "### Step 7b:");
     expect(section).toContain("toolchain-patterns.md");
   });
 });
@@ -104,33 +94,6 @@ describe("patch.md — Step 6c subagent prompt: no hardcoded bun commands", () =
 
   it("uses {test command} placeholder in Step 6c [C] Validate", () => {
     const section = extractSection(patch, "### Step 6c:", "### Step 6d:");
-    expect(section).toContain("{test command}");
-  });
-});
-
-describe("patch.md — Step 7c subagent prompt: no hardcoded bun commands", () => {
-  it("does NOT contain 'Run: bun run lint' in Step 7c subagent prompt", () => {
-    const section = extractSection(patch, "### Step 7c:", "### Step 7d:");
-    expect(section).not.toContain("Run: bun run lint");
-  });
-
-  it("does NOT contain 'Run: bun test' in Step 7c subagent prompt", () => {
-    const section = extractSection(patch, "### Step 7c:", "### Step 7d:");
-    expect(section).not.toContain("Run: bun test");
-  });
-
-  it("has a TOOLCHAIN: block in Step 7c subagent prompt", () => {
-    const section = extractSection(patch, "### Step 7c:", "### Step 7d:");
-    expect(section).toContain("TOOLCHAIN:");
-  });
-
-  it("uses {lint command} placeholder in Step 7c [C] Validate", () => {
-    const section = extractSection(patch, "### Step 7c:", "### Step 7d:");
-    expect(section).toContain("{lint command}");
-  });
-
-  it("uses {test command} placeholder in Step 7c [C] Validate", () => {
-    const section = extractSection(patch, "### Step 7c:", "### Step 7d:");
     expect(section).toContain("{test command}");
   });
 });

--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -47,7 +47,6 @@ interface CiCheckStatus {
 }
 
 interface MergeStatusInfo {
-  isBehind: boolean;
   isDirty: boolean;
 }
 
@@ -78,11 +77,6 @@ function makeDeps(
   reviewDataByPr: Record<number, PrReviewData>,
   ciStatusByPr: Record<number, CiCheckStatus> = {},
   mergeStatusByPr: Record<number, MergeStatusInfo> = {},
-  updateBranch: (
-    org: string,
-    repo: string,
-    pr: number,
-  ) => Promise<void> = async () => {},
   listPrCommits: (_prNumber: number) => Promise<CommitInfo[]> = async () => [],
 ) {
   return {
@@ -109,9 +103,8 @@ function makeDeps(
       _repo: string,
       pr: number,
     ): Promise<MergeStatusInfo> => {
-      return mergeStatusByPr[pr] ?? { isBehind: false, isDirty: false };
+      return mergeStatusByPr[pr] ?? { isDirty: false };
     },
-    updateBranch,
     listPrCommits,
   };
 }
@@ -312,14 +305,14 @@ describe("check-patch", () => {
         },
       }),
     };
-    // PR 10 is clean (no findings, no failing CI, not behind) — continues to PR 11
+    // PR 10 is clean (no findings, no failing CI, no conflict) — continues to PR 11
     // PR 11 has findings — triggers patch (exit 0)
     const result = await run(makeDeps(prs, reviewDataMap));
     expect(result.exit).toBe(0);
     expect(result.output).toContain("patch");
   });
 
-  test("exits 0 when multiple PRs and one has unaddressed findings AND another is behind main", async () => {
+  test("exits 0 when multiple PRs and one has unaddressed findings AND another is merely behind main (not dirty)", async () => {
     const prs = [
       makeOwnPr({ number: 10, headRefOid: "sha-behind" }),
       makeOwnPr({ number: 11, headRefOid: "sha-findings" }),
@@ -345,15 +338,10 @@ describe("check-patch", () => {
         reviewThreads: { nodes: [] },
       }),
     };
-    // PR 10 is BEHIND main — branch silently synced, loop continues
+    // PR 10 is behind but not dirty — not patch-worthy on its own, loop continues
     // PR 11 has findings — triggers patch (exit 0)
     const result = await run(
-      makeDeps(
-        prs,
-        reviewDataMap,
-        {},
-        { 10: { isBehind: true, isDirty: false } },
-      ),
+      makeDeps(prs, reviewDataMap, {}, { 10: { isDirty: false } }),
     );
     expect(result.exit).toBe(0);
     expect(result.output).toContain("patch");
@@ -398,101 +386,23 @@ describe("check-patch", () => {
     expect(result.output).toContain("patch");
   });
 
-  test("calls updateBranch and exits 1 when PR is BEHIND with no other issues", async () => {
+  test("exits 1 when PR is merely behind main (not dirty) with no other issues", async () => {
     const pr = makeOwnPr({ number: 10 });
-    const updated: number[] = [];
     const result = await run(
-      makeDeps(
-        [pr],
-        {},
-        {},
-        { 10: { isBehind: true, isDirty: false } },
-        async (_org, _repo, prNum) => {
-          updated.push(prNum);
-        },
-      ),
+      makeDeps([pr], {}, {}, { 10: { isDirty: false } }),
     );
-    expect(updated).toContain(10);
     expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
   });
 
-  test("calls updateBranch then exits 0 when PR is BEHIND with failing CI", async () => {
-    const pr = makeOwnPr({ number: 10 });
-    const updated: number[] = [];
-    const result = await run(
-      makeDeps(
-        [pr],
-        {},
-        { 10: { hasFailing: true } },
-        { 10: { isBehind: true, isDirty: false } },
-        async (_org, _repo, prNum) => {
-          updated.push(prNum);
-        },
-      ),
-    );
-    expect(updated).toContain(10);
-    expect(result.exit).toBe(0);
-    expect(result.output).toContain("patch");
-  });
-
-  test("calls updateBranch then exits 0 when PR is BEHIND with unaddressed review findings", async () => {
-    const pr = makeOwnPr({ number: 10 });
-    const reviewData = makePrReviewData({
-      reviews: {
-        nodes: [
-          {
-            author: { login: "reviewer1" },
-            state: "COMMENTED",
-            submittedAt: "2026-05-26T10:00:00Z",
-            commit: { oid: "current-head-sha" },
-            body: "Please fix this",
-          },
-        ],
-      },
-      reviewThreads: { nodes: [] },
-    });
-    const updated: number[] = [];
-    const result = await run(
-      makeDeps(
-        [pr],
-        { 10: reviewData },
-        {},
-        { 10: { isBehind: true, isDirty: false } },
-        async (_org, _repo, prNum) => {
-          updated.push(prNum);
-        },
-      ),
-    );
-    // Branch is silently synced; findings trigger patch (exit 0)
-    expect(updated).toContain(10);
-    expect(result.exit).toBe(0);
-    expect(result.output).toContain("patch");
-  });
-
-  test("exits 0 (patch-worthy) when updateBranch fails and no other issues", async () => {
-    const pr = makeOwnPr({ number: 10 });
-    const result = await run(
-      makeDeps(
-        [pr],
-        {},
-        {},
-        { 10: { isBehind: true, isDirty: false } },
-        async () => {
-          throw new Error("update failed");
-        },
-      ),
-    );
-    expect(result.exit).toBe(0);
-  });
-
-  test("exits 1 when PR has no findings, green CI, and is up to date", async () => {
+  test("exits 1 when PR has no findings, green CI, and no merge conflict", async () => {
     const pr = makeOwnPr({ number: 10 });
     const result = await run(
       makeDeps(
         [pr],
         {},
         { 10: { hasFailing: false } },
-        { 10: { isBehind: false, isDirty: false } },
+        { 10: { isDirty: false } },
       ),
     );
     expect(result.exit).toBe(1);
@@ -505,7 +415,7 @@ describe("check-patch", () => {
         [pr],
         {},
         { 10: { hasFailing: false } },
-        { 10: { isBehind: false, isDirty: true } },
+        { 10: { isDirty: true } },
       ),
     );
     expect(result.exit).toBe(0);
@@ -536,14 +446,7 @@ describe("check-patch", () => {
       { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] }, // merge commit
     ];
     const result = await run(
-      makeDeps(
-        [pr],
-        { 10: reviewData },
-        {},
-        {},
-        async () => {},
-        async () => commits,
-      ),
+      makeDeps([pr], { 10: reviewData }, {}, {}, async () => commits),
     );
     expect(result.exit).toBe(0);
     expect(result.output).toContain("patch");
@@ -580,14 +483,7 @@ describe("check-patch", () => {
       { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] },
     ];
     const result = await run(
-      makeDeps(
-        [pr],
-        { 10: reviewData },
-        {},
-        {},
-        async () => {},
-        async () => commits,
-      ),
+      makeDeps([pr], { 10: reviewData }, {}, {}, async () => commits),
     );
     expect(result.exit).toBe(0);
     expect(result.output).toContain("patch");
@@ -615,14 +511,7 @@ describe("check-patch", () => {
       { sha: "real-work-sha", parents: [{ sha: "p1" }] }, // regular (non-merge) commit
     ];
     const result = await run(
-      makeDeps(
-        [pr],
-        { 10: reviewData },
-        {},
-        {},
-        async () => {},
-        async () => commits,
-      ),
+      makeDeps([pr], { 10: reviewData }, {}, {}, async () => commits),
     );
     expect(result.exit).toBe(1);
     expect(result.output).toBe("");
@@ -650,14 +539,7 @@ describe("check-patch", () => {
       { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] },
     ];
     const result = await run(
-      makeDeps(
-        [pr],
-        { 10: reviewData },
-        {},
-        {},
-        async () => {},
-        async () => commits,
-      ),
+      makeDeps([pr], { 10: reviewData }, {}, {}, async () => commits),
     );
     expect(result.exit).toBe(1);
   });

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -4,8 +4,9 @@
  *
  * Pre-check for the patch cron.
  *
- * Scans own open PRs for unaddressed review findings, failing CI, or branches
- * behind/dirty main.
+ * Scans own open PRs for unaddressed review findings, failing CI, or merge
+ * conflicts with main. Branches merely behind main (no conflict) are not
+ * patch-worthy — main is only merged into a branch to resolve a conflict.
  *
  * Does NOT read state/reviews.json — all data comes from GitHub directly.
  *
@@ -21,7 +22,6 @@ import {
   getCurrentUser,
   ghGraphql,
   ghJson,
-  ghRun,
   isMergeOnlyUpdate,
   resolveAllRepos,
   resolveWorkspacePath,
@@ -61,7 +61,6 @@ interface CiCheckStatus {
 }
 
 interface MergeStatusInfo {
-  isBehind: boolean;
   isDirty: boolean;
 }
 
@@ -83,7 +82,6 @@ export interface Deps {
     repo: string,
     pr: number,
   ) => Promise<MergeStatusInfo>;
-  updateBranch: (org: string, repo: string, pr: number) => Promise<void>;
   listPrCommits: (prNumber: number, repo?: string) => Promise<CommitInfo[]>;
 }
 
@@ -171,26 +169,14 @@ export async function run(deps: Deps): Promise<RunResult> {
       ? pr.repo.split("/", 2)
       : ["app-vitals", pr.repo];
 
-    // Update stale branches before checking other conditions. BEHIND-only PRs
-    // get synced here and exit 1 — no Claude session needed.
+    // Only a real merge conflict (DIRTY) needs patch attention. A branch
+    // that's merely behind main is not patch-worthy — main is only merged
+    // into a branch to resolve a conflict.
     const mergeStatus = await deps.fetchMergeStatus(org, repo, pr.number);
-    let updateFailed = false;
-    if (mergeStatus.isBehind) {
-      try {
-        await deps.updateBranch(org, repo, pr.number);
-      } catch (err) {
-        process.stderr.write(
-          `check-patch: update-branch failed for PR ${pr.number}: ${String(err)}\n`,
-        );
-        updateFailed = true;
-      }
-    }
-
-    if (mergeStatus.isDirty || updateFailed) {
+    if (mergeStatus.isDirty) {
       return {
         exit: 0,
-        output:
-          "Fix BEHIND/conflict state on own open PRs via /shipwright:patch",
+        output: "Fix merge conflicts on own open PRs via /shipwright:patch",
       };
     }
 
@@ -344,18 +330,14 @@ export async function buildProductionDeps(): Promise<Deps> {
           "mergeStateStatus",
         ]);
         return {
-          isBehind: data.mergeStateStatus === "BEHIND",
           isDirty: data.mergeStateStatus === "DIRTY",
         };
       } catch (err) {
         process.stderr.write(
           `check-patch: gh merge status query failed for PR ${pr}: ${String(err)}\n`,
         );
-        return { isBehind: false, isDirty: false };
+        return { isDirty: false };
       }
-    },
-    updateBranch: async (org: string, repo: string, pr: number) => {
-      ghRun(["pr", "update-branch", String(pr), "--repo", `${org}/${repo}`]);
     },
     listPrCommits: async (prNumber: number, repo?: string) => {
       const targetRepo = repo ?? allRepos[0];


### PR DESCRIPTION
## Summary
- `dev-task.md` Step 9b.1 no longer unconditionally merges `origin/main` into every new PR — it checks `mergeStateStatus` and only merges (via the existing CI fix loop) when GitHub reports `DIRTY`.
- `patch.md` and `check-patch.ts` drop BEHIND-branch handling entirely (List B / Step 7) — a branch that's merely behind main (no conflict) is no longer patch-worthy. `DIRTY` (real conflicts) is still handled via Step 2.5/Step 4, unchanged.
- Updated the plugin constitution's precheck contract table and `review-patch.md`'s migration notes to match.
- Rewrote `check-patch.test.ts` for the simplified `MergeStatusInfo`/`Deps` shape (dropped `isBehind` and `updateBranch`).

## Context
Per Dan: we're removing "branch must be up to date with main" as a merge requirement. Main should only get merged into a branch to resolve an actual conflict, not just to stay current. Separately, we're adding a test gate on `main` before build/deploy as a sanity check now that PRs won't be forced up to date before merging — that's tracked as follow-up work, not part of this PR.

**Depends on:** confirming GitHub branch protection ("require branches to be up to date before merging") is off for this repo — if it's still on, GitHub will keep blocking BEHIND PRs from merging regardless of this change.

## Test plan
- [x] `bun test plugins/shipwright/scripts/` — 295 pass, 0 fail
- [x] `bun run --filter='*' typecheck` — all workspaces pass
- [x] `bunx biome check` on changed files — clean (pre-existing repo-wide lint errors are unrelated to this change)

Generated with [Claude Code](https://claude.com/claude-code)