### PR TITLE
fix: quote YAML frontmatter values that silently failed to parse in three plugin commands

### DIFF
--- a/plugins/shipwright/commands/entropy-fix.md
+++ b/plugins/shipwright/commands/entropy-fix.md
@@ -1,6 +1,6 @@
 ---
 name: entropy-fix
-description: Read entropy-report.md and open targeted refactoring PRs for pr_worthy violations. One PR per golden principle. Requires /entropy-scan to have been run first. Flags: --dry-run (preview PRs without creating them), --rule {id} (fix one specific rule only).
+description: "Read entropy-report.md and open targeted refactoring PRs for pr_worthy violations. One PR per golden principle. Requires /entropy-scan to have been run first. Flags: --dry-run (preview PRs without creating them), --rule {id} (fix one specific rule only)."
 ---
 
 Invoke the `entropy-fix` skill.

--- a/plugins/shipwright/commands/entropy-scan.md
+++ b/plugins/shipwright/commands/entropy-scan.md
@@ -1,6 +1,6 @@
 ---
 name: entropy-scan
-description: Scan codebase for golden principle violations. Report only — no code changes. Flags: --init (create starter config), --summary (print summary only, skip report file), --trend (print trend from quality log, skip scan).
+description: "Scan codebase for golden principle violations. Report only — no code changes. Flags: --init (create starter config), --summary (print summary only, skip report file), --trend (print trend from quality log, skip scan)."
 ---
 
 # /entropy-scan

--- a/plugins/shipwright/commands/test-publish.md
+++ b/plugins/shipwright/commands/test-publish.md
@@ -1,6 +1,6 @@
 ---
 description: Phase 5 — publish the approved roadmap to GitHub as a dashboard of issues. Creates one issue per task with full context inline, plus milestones, labels, and a parent tracking issue.
-argument-hint: [--dry-run] [--yes] [--repo owner/name]
+argument-hint: "[--dry-run] [--yes] [--repo owner/name]"
 allowed-tools: [Read, Glob, Grep, Bash, Write, Skill]
 ---
 


### PR DESCRIPTION
## Summary
- `claude plugin validate` (run pre-submission to the Anthropic community marketplace) flagged three commands whose YAML frontmatter fails to parse — at runtime they load with **empty metadata** (description/argument-hint/allowed-tools silently dropped)
- `test-publish.md`: `argument-hint: [--dry-run] [--yes] [...]` parses as a flow sequence then errors on the second `[` — now quoted
- `entropy-fix.md` / `entropy-scan.md`: descriptions contain `Flags: --dry-run` — a `: ` inside an unquoted scalar is invalid YAML — now quoted

## Verification
- `claude plugin validate plugins/shipwright` now passes (one pre-existing non-blocking warning about plugin-root CLAUDE.md remains)
- `bun test plugins/shipwright`: 544 pass, 0 fail; `task lint` clean
- Pre-existing on main, untouched here: `@shipwright/agent` typecheck errors + 5 k8s-related agent test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VYpmViDqFGtwyiHfDGBfB