### PR TITLE
fix: scope check-deploy's active-deploy guard per repo

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -122,7 +122,7 @@ favors permissive: false positives are visible and self-correcting; false negati
 | Script | Guards | What it checks |
 |---|---|---|
 | `check-review.ts` | `review` cron | Open PRs with unreviewed commits (by headRefOid dedup against task store `/prs` records); respects `allow_self_review` policy |
-| `check-deploy.ts` | `deploy` cron | Open PRs with `APPROVED` review decision and green CI; respects `allow_self_review` for self-authored PRs |
+| `check-deploy.ts` | `deploy` cron | Open PRs with `APPROVED` review decision and green CI; respects `allow_self_review` for self-authored PRs; skips a repo with an active Deploy workflow run, scoped per repo — a busy repo does not block ready PRs in other configured repos |
 | `check-dev-task.ts` | `dev-task` cron | Pending tasks with all dependencies satisfied (task store `ready: true` query) |
 | `check-patch.ts` | `patch` cron | Auto-updates BEHIND branches via `gh pr update-branch`; signals patch skill for unaddressed review findings, stuck-BEHIND branches (update-branch failures), merge conflicts, and failing CI; queries GitHub directly — does NOT read `state/reviews.json` |
 | `check-review-patch.ts` | `review-patch` cron | Delegates to `check-patch.ts` + `check-review.ts`; exits 0 if either exits 0, covering the full scope of the review-patch orchestrator (unaddressed findings, failing CI, BEHIND branches, merge conflicts, and unreviewed commits) |

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -9,6 +9,9 @@
  *    allow_self_review is true in agent-policy.md, and author has a review
  *    with "APPROVE" in the body.
  * 2. CI: at least one CI run with conclusion == "success" for the PR's HEAD SHA
+ * 3. Deploying guard: a repo with an active Deploy workflow run is skipped
+ *    for this pass — scoped per repo, so a busy repo does not block PRs in
+ *    other configured repos.
  *
  * Exit 0 + one-line prompt → at least one PR is ready to deploy
  * Exit 1 + no output       → nothing to do
@@ -136,9 +139,11 @@ export async function run(deps: Deps): Promise<RunResult> {
     );
   }
 
-  // Deploying guard: bail out if any configured repo has an active Deploy workflow run.
-  // Queued runs older than 1 hour are treated as stuck/ghost and skipped.
+  // Deploying guard: a repo with an active Deploy workflow run is skipped, but
+  // that must not block PRs in other, independent repos. Queued runs older
+  // than 1 hour are treated as stuck/ghost and ignored.
   const now = deps.clock ? deps.clock() : new Date().toISOString();
+  const busyRepos = new Set<string>();
   for (const repo of deps.repos) {
     const [org, repoName] = repo.includes("/")
       ? (repo.split("/", 2) as [string, string])
@@ -146,7 +151,7 @@ export async function run(deps: Deps): Promise<RunResult> {
     try {
       const activeRuns = await deps.fetchActiveDeployRuns(org, repoName);
       if (activeRuns.some((r) => isActiveRun(r, now))) {
-        return { exit: 1, output: "", candidate: null };
+        busyRepos.add(repo);
       }
     } catch (err) {
       process.stderr.write(
@@ -159,6 +164,8 @@ export async function run(deps: Deps): Promise<RunResult> {
   const currentUser = await deps.getCurrentUser();
 
   for (const repo of deps.repos) {
+    if (busyRepos.has(repo)) continue;
+
     const [org, repoName] = repo.includes("/")
       ? (repo.split("/", 2) as [string, string])
       : (["app-vitals", repo] as [string, string]);

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -58,6 +58,10 @@ interface MakeDepsOptions {
   reviews?: Record<number, GhReview[]>;
   ciRuns?: Record<string, CiRun[]>;
   activeDeployRuns?: WorkflowRun[];
+  // Per-repo override, keyed by "org/repo" — takes precedence over
+  // activeDeployRuns when set, so multi-repo scenarios can give each repo
+  // its own active-run state.
+  activeDeployRunsByRepo?: Record<string, WorkflowRun[]>;
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
   clock?: () => string;
@@ -70,6 +74,7 @@ function makeDeps({
   reviews = {},
   ciRuns = {},
   activeDeployRuns = [],
+  activeDeployRunsByRepo,
   currentUser = "bodhi-agent",
   isSelfReviewAllowed = true,
   clock,
@@ -92,9 +97,14 @@ function makeDeps({
       pr: number,
     ): Promise<GhReview[]> => reviews[pr] ?? [],
     fetchActiveDeployRuns: async (
-      _org: string,
-      _repo: string,
-    ): Promise<WorkflowRun[]> => activeDeployRuns,
+      org: string,
+      repo: string,
+    ): Promise<WorkflowRun[]> => {
+      if (activeDeployRunsByRepo) {
+        return activeDeployRunsByRepo[`${org}/${repo}`] ?? [];
+      }
+      return activeDeployRuns;
+    },
     ...(isBundleComplete !== undefined ? { isBundleComplete } : {}),
   };
 }
@@ -185,6 +195,58 @@ describe("check-deploy (new behaviors)", () => {
       }),
     );
     expect(result.exit).toBe(0);
+  });
+
+  test("deploying guard: scoped per repo — an active Deploy in one repo does not block a ready PR in another", async () => {
+    const busyRepoPr = makeGhPr({
+      number: 10,
+      headRefOid: "sha-busy",
+      reviewDecision: "APPROVED",
+    });
+    const readyRepoPr = makeGhPr({
+      number: 20,
+      headRefOid: "sha-ready",
+      reviewDecision: "APPROVED",
+    });
+    const result = await run(
+      makeDeps({
+        repos: ["acme/busy-repo", "acme/ready-repo"],
+        prs: {
+          "acme/busy-repo": [busyRepoPr],
+          "acme/ready-repo": [readyRepoPr],
+        },
+        ciRuns: {
+          "sha-busy": [{ status: "completed", conclusion: "success" }],
+          "sha-ready": [{ status: "completed", conclusion: "success" }],
+        },
+        activeDeployRunsByRepo: {
+          "acme/busy-repo": [{ name: "Deploy", status: "in_progress" }],
+          "acme/ready-repo": [],
+        },
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.candidate).toEqual({
+      pr: 20,
+      org: "acme",
+      repo: "ready-repo",
+    });
+  });
+
+  test("deploying guard: scoped per repo — exits 1 when the only configured repo is busy, even though the guard no longer short-circuits globally", async () => {
+    const pr = makeGhPr({ reviewDecision: "APPROVED" });
+    const result = await run(
+      makeDeps({
+        repos: ["acme/busy-repo"],
+        prs: { "acme/busy-repo": [pr] },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+        activeDeployRunsByRepo: {
+          "acme/busy-repo": [{ name: "Deploy", status: "in_progress" }],
+        },
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.candidate).toBeNull();
   });
 
   // ── Authorship filter ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `check-deploy.ts`'s "deploying guard" looped over every configured repo and returned `exit 1` (nothing to do) the moment **any** repo had an active Deploy workflow run — blocking ready-to-deploy PRs in every other, independent repo too.
- Now it collects a `busyRepos` set per repo instead of short-circuiting globally, and the main PR-scanning loop skips only the busy repo(s). A ready PR in a repo with no active deploy still surfaces as a candidate even while a different repo is mid-deploy.
- Updated the plugin constitution's precheck table to describe the per-repo scoping.

## Context
Per Dan: the deploy skill/precheck was too conservative — "we should be able to merge unless there is an active deploy on the repo. It doesn't need to be across all repos." Confirmed `deploy.md` itself has no equivalent pre-flight gate (it only monitors its own PR's post-merge Deploy run), so this precheck was the only place enforcing (over-broad) concurrency.

## Test plan
- [x] `bun test plugins/shipwright/scripts/check-deploy.ts plugins/shipwright/scripts/check-deploy.unit.test.ts` — 40 pass, 0 fail
- [x] Added two tests: a busy repo no longer blocks a ready PR in a different repo, and a single busy repo still correctly exits 1 (no regression to single-repo behavior)
- [x] `bun run --filter='*' typecheck` — all workspaces pass
- [x] `bunx biome check` on changed files — clean

Generated with [Claude Code](https://claude.com/claude-code)