### PR TITLE
fix: exclude self-authored reviews from check-patch findings detection

### DIFF
--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -84,6 +84,7 @@ function makeDeps(
     pr: number,
   ) => Promise<void> = async () => {},
   listPrCommits: (_prNumber: number) => Promise<CommitInfo[]> = async () => [],
+  getCurrentUser: () => string = () => "the-agent",
 ) {
   return {
     listOwnOpenPrs: async (_repo: string) => ownPrs,
@@ -113,6 +114,7 @@ function makeDeps(
     },
     updateBranch,
     listPrCommits,
+    getCurrentUser,
   };
 }
 
@@ -660,5 +662,114 @@ describe("check-patch", () => {
       ),
     );
     expect(result.exit).toBe(1);
+  });
+
+  // ─── Self-authored review exclusion (CPF-1.1) ─────────────────────────────
+
+  test("exits 1 when only review is self-authored COMMENTED at current HEAD with non-empty body", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "APPROVE — looks good, no changes needed.",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => [],
+        () => "the-agent",
+      ),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when only review is self-authored COMMENTED at a stale commit with merge-only commits since", async () => {
+    const pr = makeOwnPr({ headRefOid: "merge-sha" });
+    const reviewData = makePrReviewData({
+      headRefOid: "merge-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "review-sha" }, // posted before the merge commit
+            body: "APPROVE — looks good, no changes needed.",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const commits: CommitInfo[] = [
+      { sha: "review-sha", parents: [{ sha: "p0" }] },
+      { sha: "merge-sha", parents: [{ sha: "a" }, { sha: "b" }] }, // merge commit
+    ];
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => commits,
+        () => "the-agent",
+      ),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when self-authored review coexists with a different reviewer's CHANGES_REQUESTED finding", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "APPROVE — looks good, no changes needed.",
+          },
+          {
+            author: { login: "reviewer1" },
+            state: "CHANGES_REQUESTED",
+            submittedAt: "2026-05-26T11:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Please address these issues before merging.",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps(
+        [pr],
+        { 10: reviewData },
+        {},
+        {},
+        async () => {},
+        async () => [],
+        () => "the-agent",
+      ),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("patch");
   });
 });

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -85,6 +85,7 @@ export interface Deps {
   ) => Promise<MergeStatusInfo>;
   updateBranch: (org: string, repo: string, pr: number) => Promise<void>;
   listPrCommits: (prNumber: number, repo?: string) => Promise<CommitInfo[]>;
+  getCurrentUser: () => string;
 }
 
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
@@ -93,15 +94,25 @@ export interface Deps {
  * Returns true if the PR has unaddressed findings:
  * - At least one COMMENTED or CHANGES_REQUESTED review posted at the current HEAD
  * - AND (has a non-empty review body OR has at least one unresolved inline thread)
+ *
+ * Self-authored reviews (author.login === currentUser) are excluded: GitHub
+ * blocks self-APPROVE via the API, so the agent's own reviews are always
+ * posted as COMMENTED even when the body is a clean approval — treating them
+ * as findings would create a permanent false positive.
  */
-function hasUnaddressedFindings(data: PrReviewData): boolean {
+function hasUnaddressedFindings(
+  data: PrReviewData,
+  currentUser: string,
+): boolean {
   const { headRefOid, reviews, reviewThreads } = data;
 
-  // Find qualifying reviews: state COMMENTED or CHANGES_REQUESTED at current HEAD
+  // Find qualifying reviews: state COMMENTED or CHANGES_REQUESTED at current HEAD,
+  // excluding self-authored reviews.
   const qualifyingReviews = reviews.nodes.filter(
     (r) =>
       (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
-      r.commit.oid === headRefOid,
+      r.commit.oid === headRefOid &&
+      r.author.login !== currentUser,
   );
 
   if (qualifyingReviews.length === 0) return false;
@@ -122,19 +133,23 @@ function hasUnaddressedFindings(data: PrReviewData): boolean {
  * all commits since that review are merge commits. Mirrors check-review's
  * merge-only skip: a branch updated only via merge-from-main hasn't had real
  * author activity, so findings from the pre-merge review are still valid.
+ *
+ * Self-authored reviews are excluded — see hasUnaddressedFindings for why.
  */
 async function hasMergeOnlyStaleFindings(
   prNumber: number,
   data: PrReviewData,
   deps: Pick<Deps, "listPrCommits">,
-  repo?: string,
+  repo: string | undefined,
+  currentUser: string,
 ): Promise<boolean> {
   const { headRefOid, reviews, reviewThreads } = data;
 
   const staleReviews = reviews.nodes.filter(
     (r) =>
       (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
-      r.commit.oid !== headRefOid,
+      r.commit.oid !== headRefOid &&
+      r.author.login !== currentUser,
   );
 
   if (staleReviews.length === 0) return false;
@@ -163,6 +178,8 @@ interface RunResult {
 }
 
 export async function run(deps: Deps): Promise<RunResult> {
+  const currentUser = await deps.getCurrentUser();
+
   const prs = await deps.listOwnOpenPrs("default");
   if (prs.length === 0) return { exit: 1, output: "" };
 
@@ -195,7 +212,7 @@ export async function run(deps: Deps): Promise<RunResult> {
     }
 
     const reviewData = await deps.fetchPrReviews(org, repo, pr.number);
-    if (hasUnaddressedFindings(reviewData)) {
+    if (hasUnaddressedFindings(reviewData, currentUser)) {
       return {
         exit: 0,
         output:
@@ -205,7 +222,15 @@ export async function run(deps: Deps): Promise<RunResult> {
 
     // If findings exist at a stale commit but all new commits are merges, the
     // findings are still valid — only a merge-from-main landed, not real author work.
-    if (await hasMergeOnlyStaleFindings(pr.number, reviewData, deps, pr.repo)) {
+    if (
+      await hasMergeOnlyStaleFindings(
+        pr.number,
+        reviewData,
+        deps,
+        pr.repo,
+        currentUser,
+      )
+    ) {
       return {
         exit: 0,
         output:
@@ -365,6 +390,7 @@ export async function buildProductionDeps(): Promise<Deps> {
         "--paginate",
       ]);
     },
+    getCurrentUser,
   };
 }
 

--- a/plugins/shipwright/scripts/check-review-patch.test.ts
+++ b/plugins/shipwright/scripts/check-review-patch.test.ts
@@ -110,6 +110,7 @@ function makePatchDepsTriggering() {
       _pr: number,
     ): Promise<void> => {},
     listPrCommits: async (): Promise<CommitInfo[]> => [],
+    getCurrentUser: () => "the-agent",
   };
 }
 
@@ -142,6 +143,7 @@ function makePatchDepsIdle() {
       _pr: number,
     ): Promise<void> => {},
     listPrCommits: async (): Promise<CommitInfo[]> => [],
+    getCurrentUser: () => "the-agent",
   };
 }
 


### PR DESCRIPTION
## Summary
- `check-patch.ts`'s `hasUnaddressedFindings` and `hasMergeOnlyStaleFindings` treated any COMMENTED/CHANGES_REQUESTED review with a non-empty body as an actionable finding, including the agent's own self-reviews (always posted as COMMENTED since GitHub blocks self-APPROVE via the API). Self-reviews could never be resolved by further agent action, so `/shipwright:review-patch` re-spawned `/shipwright:patch` every loop iteration as a permanent no-op.
- Added `getCurrentUser: () => string` to `Deps` (mirroring `check-review.ts`'s existing pattern), resolved `currentUser` once in `run()`, and excluded reviews where `r.author.login === currentUser` from both `qualifyingReviews` (`hasUnaddressedFindings`) and `staleReviews` (`hasMergeOnlyStaleFindings`).
- Scope is review-level filtering only — inline review-thread resolution logic is unaffected.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `hasUnaddressedFindings` excludes self-authored reviews regardless of `commit.oid` | MET |
| 2 | `hasMergeOnlyStaleFindings` excludes self-authored reviews | MET |
| 3 | A genuine reviewer's finding still triggers exit 0 | MET |
| 4 | 3 unit tests added to `check-patch.test.ts`, no existing tests retired, non-colliding `makeDeps()` default | MET |
| 5 | `task ci` passes | MET |

## Test Plan
- New unit tests in `check-patch.test.ts`: self-authored same-commit review (exit 1), self-authored stale-commit merge-only review (exit 1), self-authored review coexisting with a real reviewer's finding (exit 0)
- Full `bun test` suite: 2912 pass (14 pre-existing unrelated failures, confirmed via `git stash`)
- [x] `bunx biome lint .` clean
- [x] `bun run --filter='*' typecheck` all workspaces pass
- [x] `check-banned-strings`, `check-config-docs`, `sync-version --check` all pass

Generated with [Claude Code](https://claude.com/claude-code)
