### PR TITLE
fix(release): commit marketplace.json version sync in release commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -79,6 +79,7 @@
           "package.json",
           "plugins/shipwright/package.json",
           "plugins/shipwright/.claude-plugin/plugin.json",
+          ".claude-plugin/marketplace.json",
           "metrics/package.json",
           "agent/package.json"
         ],


### PR DESCRIPTION
sync-version.ts writes the release version into `.claude-plugin/marketplace.json`, but the file was missing from `@semantic-release/git`'s assets list — every release would leave marketplace.json stranded at the old version. Adds it to the assets so the release commit carries it.

Unblocks the v5.0.0 release (baseline tag `v4.29.5` pushed; dry run confirms semantic-release computes 5.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vub7BYybM5YT8MzwXqQjTK