### PR TITLE
feat: pipe agent x cron x model breakdown into dashboard By Agent panel (MA-6)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -65,7 +65,7 @@ Require a bearer token (scope `"*"`) or session cookie (with `OWNER` role if req
 | GET | `/metrics/features` | Per-feature task / CI / review breakdown. |
 | GET | `/metrics/queue` | Shipwright v3 queue metrics: funnel counts, block rate, avg cycle time (days), avg review findings. |
 | GET | `/metrics/cost-efficiency` | Fleet-wide and per-cron cost efficiency: routed cost vs. all-Opus counterfactual. Run/cron-centric. |
-| GET | `/metrics/tokens` | Token usage — totals, by agent, by session type, by agent + session type, by agent + cron, by agent + model, and trends; each group includes a `cost` field (USD). |
+| GET | `/metrics/tokens` | Token usage — totals, by agent, by session type, by agent + session type, by agent + cron, by agent + model, by agent + cron + model, and trends; each group includes a `cost` field (USD). |
 | GET | `/dashboard` | Server-rendered dashboard HTML (session-gated). |
 | GET | `/dashboard/*` | Static dashboard assets (`styles.css`, `app.js`). |
 

--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -919,6 +919,7 @@ export function createMetricsApp(
         byAgentBySessionTypeResult,
         byAgentByCronResult,
         byAgentByModelResult,
+        byAgentByCronModelResult,
       ] = await Promise.all([
         provider.query({ kind: "tokensTotals", range: dateRange }),
         provider.query({ kind: "tokensBySessionType", range: dateRange }),
@@ -930,6 +931,10 @@ export function createMetricsApp(
         }),
         provider.query({ kind: "tokensByAgentByCron", range: dateRange }),
         provider.query({ kind: "tokensByAgentByModel", range: dateRange }),
+        provider.query({
+          kind: "tokensByAgentByCronModel",
+          range: dateRange,
+        }),
       ]);
 
       const totalsRow = rowToObject(totalsResult) ?? {};
@@ -1046,6 +1051,25 @@ export function createMetricsApp(
         cronName: cronDisplayNameMap.get(row.cronName) ?? row.cronName,
       }));
 
+      const byAgentCronModelRaw = resultToRows(byAgentByCronModelResult).map(
+        (row) => ({
+          agentId: String(row.agent_id ?? ""),
+          cronName: String(row.cron_name ?? ""),
+          model: String(row.model ?? ""),
+          input: toNum(row.input_tokens),
+          output: toNum(row.output_tokens),
+          cacheRead: toNum(row.cache_read_input_tokens),
+          cacheCreation: toNum(row.cache_creation_input_tokens),
+          total: toNum(row.total_tokens),
+          cost: toNum(row.cost_usd),
+        }),
+      );
+
+      const byAgentCronModel = byAgentCronModelRaw.map((row) => ({
+        ...row,
+        cronName: cronDisplayNameMap.get(row.cronName) ?? row.cronName,
+      }));
+
       const byAgentModel = resultToRows(byAgentByModelResult).map((row) => ({
         agentId: String(row.agent_id ?? ""),
         model: String(row.model ?? ""),
@@ -1067,6 +1091,7 @@ export function createMetricsApp(
             byAgentSessionType,
             byAgentCron,
             byAgentModel,
+            byAgentCronModel,
           },
           {
             dateRange: dateRangeMeta,

--- a/metrics/src/dashboard/app.js
+++ b/metrics/src/dashboard/app.js
@@ -405,7 +405,11 @@
             }
             agentTbody.appendChild(tr);
 
-            // Model sub-rows nested under this cron sub-row.
+            // Model sub-rows nested under this cron sub-row. Both
+            // byAgentCronModel and byAgentCron are mapped through
+            // cronDisplayNameMap in api.ts before reaching the client, so
+            // comparing cronName here is safe — keep both sides mapped
+            // consistently if this logic changes.
             const cronModelRows = (byAgentCronModel || []).filter(
               (r) =>
                 r.agentId === agent.agentId &&

--- a/metrics/src/dashboard/app.js
+++ b/metrics/src/dashboard/app.js
@@ -325,8 +325,13 @@
       $("token-cost").textContent = "$0.00";
       return;
     }
-    const { totals, byAgent, byAgentCron, byAgentModel, byAgentSessionType } =
-      res.data;
+    const {
+      totals,
+      byAgent,
+      byAgentCron,
+      byAgentCronModel,
+      byAgentSessionType,
+    } = res.data;
     $("token-input").textContent = fmtTokens(totals.input);
     $("token-output").textContent = fmtTokens(totals.output);
     $("token-cache").textContent = fmtTokens(
@@ -347,9 +352,6 @@
             (r) => r.agentId === agent.agentId,
           );
           const agentSessionRows = (byAgentSessionType || []).filter(
-            (r) => r.agentId === agent.agentId,
-          );
-          const agentModelRows = (byAgentModel || []).filter(
             (r) => r.agentId === agent.agentId,
           );
 
@@ -402,25 +404,30 @@
               tr.appendChild(td);
             }
             agentTbody.appendChild(tr);
-          }
 
-          // Model sub-rows
-          for (const modelRow of agentModelRows) {
-            const tr = document.createElement("tr");
-            tr.className = "agent-model-row";
-            const modelCells = [
-              `◦ ${modelRow.model}`,
-              "--",
-              "--",
-              fmtTokens(modelRow.total),
-              fmtCost(modelRow.cost),
-            ];
-            for (const text of modelCells) {
-              const td = document.createElement("td");
-              td.textContent = text;
-              tr.appendChild(td);
+            // Model sub-rows nested under this cron sub-row.
+            const cronModelRows = (byAgentCronModel || []).filter(
+              (r) =>
+                r.agentId === agent.agentId &&
+                r.cronName === cronRow.cronName,
+            );
+            for (const modelRow of cronModelRows) {
+              const modelTr = document.createElement("tr");
+              modelTr.className = "agent-cron-model-row";
+              const modelCells = [
+                `  ◦ ${modelRow.model}`,
+                "--",
+                "--",
+                fmtTokens(modelRow.total),
+                fmtCost(modelRow.cost),
+              ];
+              for (const text of modelCells) {
+                const td = document.createElement("td");
+                td.textContent = text;
+                modelTr.appendChild(td);
+              }
+              agentTbody.appendChild(modelTr);
             }
-            agentTbody.appendChild(tr);
           }
         }
       }

--- a/metrics/src/metrics-provider.ts
+++ b/metrics/src/metrics-provider.ts
@@ -40,6 +40,7 @@ export type MetricQuery =
   | { kind: "tokensByAgentBySessionType"; range: QueryDateRange }
   | { kind: "tokensByAgentByCron"; range: QueryDateRange }
   | { kind: "tokensByAgentByModel"; range: QueryDateRange }
+  | { kind: "tokensByAgentByCronModel"; range: QueryDateRange }
   | { kind: "costEfficiency"; range: QueryDateRange };
 
 export type MetricQueryKind = MetricQuery["kind"];

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -3,7 +3,7 @@
  * Integration: drive TaskStoreProvider over Recorded task-store + admin doubles
  * with a FixedClock, asserting it emits sql-provider-identical MetricTables for
  * the headline kinds, that token totals = cron + chat (no double-counting), that
- * a custom {from,to} range filters cassette rows, and that all 16 kinds return a
+ * a custom {from,to} range filters cassette rows, and that all 17 kinds return a
  * table without throwing.
  */
 
@@ -122,7 +122,18 @@ const CRON_STATS: CronRunTokenStats = {
     { key1: "agent-a", key2: "opus", ...agg(1000, 500, 200, 100, 1.5) },
   ],
   daily: [{ period: "2026-06-02", ...agg(1000, 500, 200, 100, 1.5) }],
-  byCronModel: [],
+  byCronModel: [
+    {
+      key1: "agent-a:ship-loop",
+      key2: "opus",
+      ...agg(700, 350, 140, 70, 1.0),
+    },
+    {
+      key1: "agent-a:patrol",
+      key2: "opus",
+      ...agg(300, 150, 60, 30, 0.5),
+    },
+  ],
 };
 
 const CHAT_STATS: ChatTokenStats = {
@@ -260,6 +271,33 @@ describe("TaskStoreProvider (integration)", () => {
     expect(t.results[0][7]).toBe(1.0);
   });
 
+  test("tokensByAgentByCronModel is cron-only with cost_usd, split from key1", async () => {
+    const provider = buildProvider();
+    const t = await provider.query({
+      kind: "tokensByAgentByCronModel",
+      range: RANGE,
+    });
+    expect(t.columns).toEqual([
+      "agent_id",
+      "cron_name",
+      "model",
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "total_tokens",
+      "cost_usd",
+    ]);
+    expect(t.results.length).toBe(2);
+    // sorted by total desc → ship-loop first
+    expect(t.results[0][0]).toBe("agent-a");
+    expect(t.results[0][1]).toBe("ship-loop");
+    expect(t.results[0][2]).toBe("opus");
+    expect(t.results[0][8]).toBe(1.0);
+    expect(t.results[1][1]).toBe("patrol");
+    expect(t.results[1][8]).toBe(0.5);
+  });
+
   test("custom {from,to} range filters out-of-window tasks", async () => {
     const provider = buildProvider();
     // Window covering only July → only PV-9.9 completes
@@ -272,7 +310,7 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[colIndex(t, "tasks_blocked")]).toBe(0);
   });
 
-  test("all 16 kinds return a non-throwing MetricTable", async () => {
+  test("all 17 kinds return a non-throwing MetricTable", async () => {
     const provider = buildProvider();
     const kinds: MetricQuery[] = [
       { kind: "summary", range: RANGE },
@@ -291,6 +329,7 @@ describe("TaskStoreProvider (integration)", () => {
       { kind: "tokensByAgentBySessionType", range: RANGE },
       { kind: "tokensByAgentByCron", range: RANGE },
       { kind: "tokensByAgentByModel", range: RANGE },
+      { kind: "tokensByAgentByCronModel", range: RANGE },
     ];
     for (const q of kinds) {
       const t = await provider.query(q);
@@ -481,7 +520,7 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[4]).toBe(0);
   });
 
-  test("graceful degradation: all 7 token methods handle cron failure", async () => {
+  test("graceful degradation: all 8 token methods handle cron failure", async () => {
     const taskStore = new RecordedTaskStoreClient(TASKS, PRS);
     const admin = new FaultingCronAdminMetricsClient(CRON_STATS, CHAT_STATS);
     const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
@@ -494,6 +533,7 @@ describe("TaskStoreProvider (integration)", () => {
       { kind: "tokensByAgentBySessionType", range: RANGE },
       { kind: "tokensByAgentByCron", range: RANGE },
       { kind: "tokensByAgentByModel", range: RANGE },
+      { kind: "tokensByAgentByCronModel", range: RANGE },
     ];
 
     for (const q of kinds) {

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -2,7 +2,7 @@
  * metrics/src/providers/task-store-provider.ts
  *
  * MetricsProvider backed by the Shipwright task store (tasks + PRs) and the
- * admin token-aggregation endpoints. Answers all 16 MetricQuery kinds by
+ * admin token-aggregation endpoints. Answers all 17 MetricQuery kinds by
  * aggregating client-side in TypeScript, emitting MetricTables. api.ts parses
  * the result positionally, so column shapes must remain stable across providers.
  *
@@ -217,6 +217,8 @@ export class TaskStoreProvider implements MetricsProvider {
         return this.tokensByAgentByCron(win);
       case "tokensByAgentByModel":
         return this.tokensByAgentByModel(win);
+      case "tokensByAgentByCronModel":
+        return this.tokensByAgentByCronModel(win);
       case "costEfficiency":
         return this.costEfficiency(win);
     }
@@ -748,6 +750,26 @@ export class TaskStoreProvider implements MetricsProvider {
       .sort((a, b) => Number(b[7]) - Number(a[7]));
 
     return table(["agent_id", "model", ...tokenColumns(), "cost_usd"], rows);
+  }
+
+  private async tokensByAgentByCronModel(win: {
+    from: string;
+    to: string;
+  }): Promise<MetricTable> {
+    // Cron-only: chat has no cron dimension (same reasoning as tokensByAgentByCron).
+    const cron = await this.safeCronStats(win);
+    const rows = cron.byCronModel
+      .map((a) => {
+        const sepIdx = a.key1.indexOf(":");
+        const agentId = sepIdx === -1 ? a.key1 : a.key1.slice(0, sepIdx);
+        const cronName = sepIdx === -1 ? "" : a.key1.slice(sepIdx + 1);
+        return [agentId, cronName, a.key2, ...tokenCells(a), a.costUsd ?? 0];
+      })
+      .sort((a, b) => Number(b[7]) - Number(a[7]));
+    return table(
+      ["agent_id", "cron_name", "model", ...tokenColumns(), "cost_usd"],
+      rows,
+    );
   }
 
   // ─── Graceful degradation helpers ─────────────────────────────────────────

--- a/metrics/src/schemas.ts
+++ b/metrics/src/schemas.ts
@@ -233,6 +233,20 @@ const TokensByAgentByModelSchema = z
   })
   .openapi("TokensByAgentByModel");
 
+const TokensByAgentByCronModelSchema = z
+  .object({
+    agentId: z.string(),
+    cronName: z.string(),
+    model: z.string(),
+    input: z.number(),
+    output: z.number(),
+    cacheRead: z.number(),
+    cacheCreation: z.number(),
+    total: z.number(),
+    cost: z.number(),
+  })
+  .openapi("TokensByAgentByCronModel");
+
 export const TokensResultSchema = z
   .object({
     totals: TokenTotalsSchema,
@@ -242,6 +256,7 @@ export const TokensResultSchema = z
     byAgentSessionType: z.array(TokensByAgentBySessionTypeSchema),
     byAgentCron: z.array(TokensByAgentByCronSchema),
     byAgentModel: z.array(TokensByAgentByModelSchema),
+    byAgentCronModel: z.array(TokensByAgentByCronModelSchema),
   })
   .openapi("TokensResult");
 


### PR DESCRIPTION
## Summary
- Forward the admin service's already-computed `byCronModel` (agentId, cronName, model) breakdown through the metrics service's token provider and `/metrics/tokens` API response as a new `byAgentCronModel` field.
- Render it in the dashboard's By Agent table as per-cron model sub-rows nested under each cron sub-row, replacing the previous flat agent-level model list.
- Docs refresh: note the new `byAgentCronModel` grouping in `docs/metrics.md`'s `/metrics/tokens` endpoint description.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | task-store-provider.ts forwards byCronModel from admin cronRunTokenStats() unmodified | MET | new `tokensByAgentByCronModel()` method maps `cron.byCronModel` entries (values untouched, only `key1` split into `agent_id`/`cron_name` for table columns) |
| 2 | api.ts includes new field in /metrics/tokens response; schemas.ts documents shape | MET | api.ts adds `byAgentByCronModelResult` query + `byAgentCronModel` in response object; schemas.ts adds `TokensByAgentByCronModelSchema` + `byAgentCronModel` array field on `TokensResultSchema` |
| 3 | app.js updateTokens() renders per-cron model sub-rows nested under cron sub-row, replacing flat agent-level model list | MET | old flat `agent-model-row` block deleted; new `agent-cron-model-row` block renders inside the per-cronRow loop, filtered on `(agentId, cronName)` |
| 4 | Unit test for byCronModel pass-through; dashboard snapshot updated if applicable; no tests retired | MET | new integration test `tokensByAgentByCronModel` asserts columns/sort/split-key1/cost_usd unmodified; all-kinds and graceful-degradation kind lists updated (16→17, 7→8); dashboard-page.unit.test.ts confirmed unaffected (static shell only) — no tests removed |

## Test Plan
- `cd metrics && bun test` — 269 pass, 0 fail (RED confirmed first: new/updated tests failed before implementation, all pass after)
- `cd metrics && bun run typecheck` — clean
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
