### PR TITLE
feat: add coverage metrics to summary API

### DIFF
--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -510,6 +510,8 @@ function makeSummaryHandler(
               c5: toNum(row.complexity_5),
             },
             avgFixCascadeDepth,
+            coverageReports: toNum(row.coverage_reports),
+            avgCoverageDelta: toNumOrNull(row.avg_coverage_delta),
           },
           {
             dateRange: dateRangeMeta,

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -40,6 +40,7 @@ const TASKS: TaskRecord[] = [
     ciFixAttempts: 0,
     simplifyTotal: 2,
     addedAt: "2026-06-01T08:00:00.000Z",
+    coverageDelta: 2.5,
   },
   {
     id: "QS-1.2",
@@ -54,6 +55,7 @@ const TASKS: TaskRecord[] = [
     ciFixAttempts: 2,
     simplifyTotal: 1,
     addedAt: "2026-06-02T08:00:00.000Z",
+    coverageDelta: null,
   },
   {
     id: "MQ-2.1",
@@ -180,6 +182,8 @@ describe("TaskStoreProvider (integration)", () => {
       "complexity_4",
       "complexity_5",
       "avg_fix_cascade_depth",
+      "coverage_reports",
+      "avg_coverage_delta",
     ]);
     const row = t.results[0];
     // QS-1.1 + QS-1.2 completed; PV-9.9 out of window.
@@ -194,6 +198,83 @@ describe("TaskStoreProvider (integration)", () => {
     // reviews from PR records
     expect(row[colIndex(t, "reviews_total")]).toBe(2);
     expect(row[colIndex(t, "reviews_ship_it")]).toBe(1);
+    // coverage: QS-1.1 has coverageDelta=2.5, QS-1.2 has null → excluded, not
+    // treated as zero.
+    expect(row[colIndex(t, "coverage_reports")]).toBe(1);
+    expect(row[colIndex(t, "avg_coverage_delta")]).toBe(2.5);
+  });
+
+  test("summary coverage aggregation excludes null coverageDelta tasks from the average", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "CV-1.1",
+        status: "merged",
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        addedAt: "2026-06-01T08:00:00.000Z",
+        coverageDelta: 4,
+      },
+      {
+        id: "CV-1.2",
+        status: "merged",
+        startedAt: "2026-06-03T08:00:00.000Z",
+        completedAt: "2026-06-03T12:00:00.000Z",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        addedAt: "2026-06-02T08:00:00.000Z",
+        coverageDelta: -2,
+      },
+      {
+        id: "CV-1.3",
+        status: "merged",
+        startedAt: "2026-06-04T08:00:00.000Z",
+        completedAt: "2026-06-04T12:00:00.000Z",
+        mergedAt: "2026-06-04T12:00:00.000Z",
+        addedAt: "2026-06-03T08:00:00.000Z",
+        coverageDelta: null,
+      },
+      {
+        id: "CV-1.4",
+        status: "merged",
+        startedAt: "2026-06-05T08:00:00.000Z",
+        completedAt: "2026-06-05T12:00:00.000Z",
+        mergedAt: "2026-06-05T12:00:00.000Z",
+        addedAt: "2026-06-04T08:00:00.000Z",
+        // coverageDelta intentionally omitted (undefined)
+      },
+    ];
+    const taskStore = new RecordedTaskStoreClient(tasks, []);
+    const admin = new RecordedAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "summary", range: RANGE });
+    const row = t.results[0];
+    expect(row[colIndex(t, "tasks_completed")]).toBe(4);
+    // Only CV-1.1 and CV-1.2 have a non-null coverageDelta.
+    expect(row[colIndex(t, "coverage_reports")]).toBe(2);
+    // Average of 4 and -2 = 1, not diluted by the two null/undefined tasks.
+    expect(row[colIndex(t, "avg_coverage_delta")]).toBe(1);
+  });
+
+  test("summary coverage aggregation returns 0/null when no tasks have coverageDelta", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "CV-2.1",
+        status: "merged",
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        addedAt: "2026-06-01T08:00:00.000Z",
+      },
+    ];
+    const taskStore = new RecordedTaskStoreClient(tasks, []);
+    const admin = new RecordedAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "summary", range: RANGE });
+    const row = t.results[0];
+    expect(row[colIndex(t, "coverage_reports")]).toBe(0);
+    expect(row[colIndex(t, "avg_coverage_delta")]).toBeNull();
   });
 
   test("queueFunnel counts started/approved/merged/blocked", async () => {

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -280,6 +280,8 @@ export class TaskStoreProvider implements MetricsProvider {
       "complexity_4",
       "complexity_5",
       "avg_fix_cascade_depth",
+      "coverage_reports",
+      "avg_coverage_delta",
     ];
 
     const row = [
@@ -307,6 +309,8 @@ export class TaskStoreProvider implements MetricsProvider {
       complexityCount(4),
       complexityCount(5),
       null, // avg_fix_cascade_depth — no task-store source
+      completed.filter((t) => num(t.coverageDelta) !== null).length, // coverage_reports
+      avg(completed.map((t) => num(t.coverageDelta))), // avg_coverage_delta
     ];
 
     return table(columns, [row]);

--- a/metrics/src/schemas.ts
+++ b/metrics/src/schemas.ts
@@ -76,6 +76,8 @@ export const SummaryResultSchema = z
       c5: z.number().int(),
     }),
     avgFixCascadeDepth: z.number().nullable(),
+    coverageReports: z.number().int(),
+    avgCoverageDelta: z.number().nullable(),
   })
   .openapi("SummaryResult");
 

--- a/metrics/src/server-offline-mode.smoke.test.ts
+++ b/metrics/src/server-offline-mode.smoke.test.ts
@@ -73,6 +73,20 @@ describe("server.ts fixture-branch — METRICS_OFFLINE=true + METRICS_DASHBOARD_
     expect(typeof body.data.tasksCompleted).toBe("number");
   });
 
+  test("/metrics/summary?preset=7d returns coverageReports and avgCoverageDelta end to end", async () => {
+    const deps = buildFixtureDeps();
+    const app = createMetricsApp(new Map(), noopAccountsClient, deps);
+    const res = await app.request("/metrics/summary?preset=7d");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Fixture cassette: QS-1.1 (coverageDelta=5), QS-1.2 (coverageDelta=3),
+    // MQ-2.1 (coverageDelta=8) are all completed within the 7d window.
+    expect(typeof body.data.coverageReports).toBe("number");
+    expect(body.data.coverageReports).toBe(3);
+    expect(typeof body.data.avgCoverageDelta).toBe("number");
+    expect(body.data.avgCoverageDelta).toBeCloseTo((5 + 3 + 8) / 3, 5);
+  });
+
   test("/dashboard returns 200 server-rendered HTML without credentials", async () => {
     const deps = buildFixtureDeps();
     const app = createMetricsApp(new Map(), noopAccountsClient, deps);


### PR DESCRIPTION
## Summary
- Add `coverageReports` (count) and `avgCoverageDelta` (nullable number) fields to the metrics `/metrics/summary` endpoint, sourced from the already-captured `Task.coverageDelta` field.
- `task-store-provider.ts`'s `summary()` handler computes both across completed tasks in range, excluding tasks with a null `coverageDelta` from the average (not treating null as zero).
- Read-side only — no changes to how `coverageDelta` is captured (that's already wired up in `dev-task.md` step 10a).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `SummaryResultSchema` gains `coverageReports` (count) and `avgCoverageDelta` (nullable number) fields | MET | `metrics/src/schemas.ts` |
| 2 | `task-store-provider.ts` computes both from `Task.coverageDelta`, excluding null from the average | MET | `metrics/src/providers/task-store-provider.ts`, verified by mixed null/non-null + all-null edge case tests |
| 3 | `metrics/src/api.ts` returns both fields from the summary route | MET | `makeSummaryHandler` |
| 4 | Aggregation test (mixed null/non-null) + integration test for route end-to-end; no existing tests retired | MET | `task-store-provider.integration.test.ts`, `server-offline-mode.smoke.test.ts` |

## Test Plan
- `task-store-provider.integration.test.ts`: extended existing summary columns assertion; added a mixed null/non-null/undefined `coverageDelta` aggregation test; added an all-null edge case test (coverageReports=0, avgCoverageDelta=null).
- `server-offline-mode.smoke.test.ts`: added an end-to-end test hitting `/metrics/summary?preset=7d` asserting `coverageReports`/`avgCoverageDelta` in the response body against the fixture cassette.
- [x] `bunx biome lint .` — clean
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- [x] `bun run --filter='*' typecheck` — clean across all workspaces
- [x] `bun test metrics` — 305/305 pass (metrics workspace)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
