### PR TITLE
fix(admin): stagger SYSTEM_CRONS pipeline schedules to prevent simultaneous firing

### DIFF
--- a/admin/src/agent-cron-jobs.ts
+++ b/admin/src/agent-cron-jobs.ts
@@ -41,9 +41,10 @@ export interface CreateAgentCronJobInput {
 /**
  * Validates a cron expression.
  * Accepts standard 5-field cron: minute hour day-of-month month day-of-week.
- * Each field may contain digits, *, /, -, and comma.
+ * Each field may contain digits, *, /, -, and comma (e.g. a minute field of
+ * "0,30" for a twice-hourly, staggered schedule is valid).
  */
-function isValidCron(schedule: string): boolean {
+export function isValidCron(schedule: string): boolean {
   const fields = schedule.trim().split(/\s+/);
   if (fields.length !== 5) return false;
   const fieldPattern = /^(\*|[0-9]+([-,][0-9]+)*)(\/[0-9]+)?$|^\*\/[0-9]+$/;

--- a/admin/src/agent-cron-jobs.unit.test.ts
+++ b/admin/src/agent-cron-jobs.unit.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for the pure cron-expression validator in agent-cron-jobs.ts.
+ * Pure logic, no I/O — see docs/testing.md for the unit-layer contract.
+ */
+import { describe, expect, test } from "bun:test";
+import { isValidCron } from "./agent-cron-jobs.ts";
+
+describe("isValidCron", () => {
+  test("accepts standard 5-field schedules", () => {
+    expect(isValidCron("0 9 * * *")).toBe(true);
+    expect(isValidCron("*/5 * * * *")).toBe(true);
+    expect(isValidCron("0 4 * * 1")).toBe(true);
+  });
+
+  // The staggered pipeline schedules (SYSTEM_CRONS) use comma-separated
+  // minute lists like "0,30" to keep a 30-minute cadence while firing at a
+  // distinct offset from sibling crons. Confirm the validator accepts them.
+  test("accepts comma-separated minute lists", () => {
+    expect(isValidCron("0,30 * * * *")).toBe(true);
+    expect(isValidCron("5,35 * * * *")).toBe(true);
+    expect(isValidCron("10,40 * * * *")).toBe(true);
+    expect(isValidCron("15,45 * * * *")).toBe(true);
+    expect(isValidCron("20,50 * * * *")).toBe(true);
+  });
+
+  test("accepts comma lists in other fields", () => {
+    expect(isValidCron("0 9 * * 1,3,5")).toBe(true);
+    expect(isValidCron("0 9,17 * * *")).toBe(true);
+  });
+
+  test("rejects schedules without exactly 5 fields", () => {
+    expect(isValidCron("0 9 * *")).toBe(false);
+    expect(isValidCron("0 9 * * * *")).toBe(false);
+    expect(isValidCron("")).toBe(false);
+  });
+
+  test("rejects non-cron garbage", () => {
+    expect(isValidCron("not-a-cron")).toBe(false);
+    expect(isValidCron("bad")).toBe(false);
+  });
+});

--- a/admin/src/system-crons.ts
+++ b/admin/src/system-crons.ts
@@ -19,7 +19,7 @@ export interface SystemCron {
 export const SYSTEM_CRONS: readonly SystemCron[] = [
   {
     name: "shipwright-dev-task",
-    schedule: "*/30 * * * *",
+    schedule: "0,30 * * * *",
     prompt: "/shipwright:dev-task",
     silent: true,
     preCheck: "shipwright:check-dev-task.ts",
@@ -27,7 +27,7 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
   },
   {
     name: "shipwright-patch",
-    schedule: "*/30 * * * *",
+    schedule: "5,35 * * * *",
     prompt: "/shipwright:patch",
     silent: true,
     preCheck: "shipwright:check-patch.ts",
@@ -35,7 +35,7 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
   },
   {
     name: "shipwright-review-patch",
-    schedule: "*/30 * * * *",
+    schedule: "10,40 * * * *",
     prompt: "/shipwright:review-patch",
     silent: true,
     preCheck: "shipwright:check-review-patch.ts",
@@ -43,7 +43,7 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
   },
   {
     name: "shipwright-review",
-    schedule: "*/30 * * * *",
+    schedule: "15,45 * * * *",
     prompt: "/shipwright:review",
     silent: true,
     preCheck: "shipwright:check-review.ts",
@@ -51,7 +51,7 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
   },
   {
     name: "shipwright-deploy",
-    schedule: "*/30 * * * *",
+    schedule: "20,50 * * * *",
     prompt: "/shipwright:deploy",
     silent: true,
     preCheck: "shipwright:check-deploy.ts",

--- a/admin/src/system-crons.unit.test.ts
+++ b/admin/src/system-crons.unit.test.ts
@@ -1,6 +1,101 @@
 import { describe, expect, test } from "bun:test";
 import { SYSTEM_CRONS } from "./system-crons.ts";
 
+/**
+ * Expands the minute field of a 5-field cron schedule into the set of
+ * minutes-past-the-hour it fires on. Supports plain numbers, comma lists
+ * (e.g. "0,30"), and step expressions (star followed by slash and a step,
+ * e.g. every-N-minutes). Sufficient for the schedules used in SYSTEM_CRONS —
+ * not a general-purpose cron parser.
+ */
+function expandMinuteField(schedule: string): number[] {
+  const minuteField = schedule.trim().split(/\s+/)[0];
+  if (minuteField === undefined) {
+    throw new Error(`schedule has no minute field: ${schedule}`);
+  }
+  const stepMatch = minuteField.match(/^\*\/(\d+)$/);
+  if (stepMatch) {
+    const step = Number(stepMatch[1]);
+    const minutes: number[] = [];
+    for (let m = 0; m < 60; m += step) minutes.push(m);
+    return minutes;
+  }
+  if (minuteField === "*") {
+    return Array.from({ length: 60 }, (_, m) => m);
+  }
+  return minuteField.split(",").map((n) => Number(n));
+}
+
+const PIPELINE_CRON_NAMES = [
+  "shipwright-dev-task",
+  "shipwright-patch",
+  "shipwright-review-patch",
+  "shipwright-review",
+  "shipwright-deploy",
+] as const;
+
+function pipelineCrons() {
+  return PIPELINE_CRON_NAMES.map((name) => {
+    const cron = SYSTEM_CRONS.find((c) => c.name === name);
+    if (!cron) throw new Error(`missing system cron: ${name}`);
+    return cron;
+  });
+}
+
+describe("SYSTEM_CRONS pipeline schedule staggering", () => {
+  test("each pipeline cron fires on exactly 2 minutes, 30 minutes apart", () => {
+    for (const cron of pipelineCrons()) {
+      const minutes = expandMinuteField(cron.schedule);
+      expect(minutes).toHaveLength(2);
+      const [first, second] = minutes;
+      expect(second === undefined || first === undefined).toBe(false);
+      expect((second ?? 0) - (first ?? 0)).toBe(30);
+    }
+  });
+
+  test("no two pipeline SYSTEM_CRONS entries fire in the same minute", () => {
+    const minuteSets = pipelineCrons().map((cron) => ({
+      name: cron.name,
+      minutes: expandMinuteField(cron.schedule),
+    }));
+    for (const [i, a] of minuteSets.entries()) {
+      for (const b of minuteSets.slice(i + 1)) {
+        const overlap = a.minutes.filter((m) => b.minutes.includes(m));
+        expect(overlap).toEqual([]);
+      }
+    }
+  });
+
+  test("pipeline crons keep the current expected staggered schedules", () => {
+    const expected: Record<(typeof PIPELINE_CRON_NAMES)[number], string> = {
+      "shipwright-dev-task": "0,30 * * * *",
+      "shipwright-patch": "5,35 * * * *",
+      "shipwright-review-patch": "10,40 * * * *",
+      "shipwright-review": "15,45 * * * *",
+      "shipwright-deploy": "20,50 * * * *",
+    };
+    for (const cron of pipelineCrons()) {
+      expect(cron.schedule).toBe(
+        expected[cron.name as (typeof PIPELINE_CRON_NAMES)[number]],
+      );
+    }
+  });
+
+  test("daily/weekly SYSTEM_CRONS schedules are unchanged", () => {
+    const expected: Record<string, string> = {
+      "shipwright-test-readiness": "0 6 * * *",
+      "shipwright-docs-freshness": "0 7 * * *",
+      "learn-dream": "0 3 * * *",
+      "dependabot-triage": "0 8 * * *",
+      "entropy-patrol-maintenance": "0 4 * * 1",
+    };
+    for (const [name, schedule] of Object.entries(expected)) {
+      const cron = SYSTEM_CRONS.find((c) => c.name === name);
+      expect(cron?.schedule).toBe(schedule);
+    }
+  });
+});
+
 describe("SYSTEM_CRONS", () => {
   test("exports exactly ten crons", () => {
     expect(SYSTEM_CRONS).toHaveLength(10);
@@ -161,7 +256,9 @@ describe("SYSTEM_CRONS", () => {
     expect(cron?.prompt).toContain("/shipwright:research-docs");
   });
 
-  test("polling crons have schedule */30 * * * *", () => {
+  test("polling crons keep a 30-minute cadence, staggered to distinct minutes", () => {
+    // See the "SYSTEM_CRONS pipeline schedule staggering" describe block above
+    // for the collision-detection assertions. This test only pins the cadence.
     const pollingCrons = SYSTEM_CRONS.filter(
       (c) =>
         c.name !== "shipwright-test-readiness" &&
@@ -171,7 +268,7 @@ describe("SYSTEM_CRONS", () => {
         c.name !== "entropy-patrol-maintenance",
     );
     for (const cron of pollingCrons) {
-      expect(cron.schedule).toBe("*/30 * * * *");
+      expect(cron.schedule).toMatch(/^\d+,\d+ \* \* \* \*$/);
     }
   });
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -135,11 +135,11 @@ Every new agent is seeded with ten system crons (the canonical definitions live 
 
 | Cron | Schedule (cron expr) | Default | What it does |
 |---|---|---|---|
-| `shipwright-dev-task` | `*/30 * * * *` (every 30 min) | **on** | Picks the next ready task, builds it with tests, opens a PR. |
-| `shipwright-review-patch` | `*/30 * * * *` (every 30 min) | **on** | Reviews open PRs and patches the ones failing CI or review. |
-| `shipwright-review` | `*/30 * * * *` (every 30 min) | off | Review-only pass over open PRs. |
-| `shipwright-patch` | `*/30 * * * *` (every 30 min) | off | Fixes failing CI and unresolved review findings. |
-| `shipwright-deploy` | `*/30 * * * *` (every 30 min) | off | Merges approved PRs and deploys them. |
+| `shipwright-dev-task` | `0,30 * * * *` (min 0, 30) | **on** | Picks the next ready task, builds it with tests, opens a PR. |
+| `shipwright-review-patch` | `10,40 * * * *` (min 10, 40) | **on** | Reviews open PRs and patches the ones failing CI or review. |
+| `shipwright-review` | `15,45 * * * *` (min 15, 45) | off | Review-only pass over open PRs. |
+| `shipwright-patch` | `5,35 * * * *` (min 5, 35) | off | Fixes failing CI and unresolved review findings. |
+| `shipwright-deploy` | `20,50 * * * *` (min 20, 50) | off | Merges approved PRs and deploys them. |
 | `shipwright-test-readiness` | `0 6 * * *` (daily, 06:00) | off | Runs the full test-readiness audit (`--full --publish`). |
 | `shipwright-docs-freshness` | `0 7 * * *` (daily, 07:00) | off | Refreshes docs that drifted from the code (`research-docs --auto`). |
 | `learn-dream` | `0 3 * * *` (daily, 03:00) | off | Mines the last day of merged PRs for durable learnings. |


### PR DESCRIPTION
## Summary
- Stagger the five pipeline SYSTEM_CRONS schedules (`0,30` / `5,35` / `10,40` / `15,45` / `20,50`) so no two fire in the same minute — each keeps its every-30-minutes cadence
- Fixes agent pod OOMKills (2Gi limit) caused by all enabled pipeline crons firing at :00/:30 simultaneously and launching concurrent Claude Code sessions in one pod
- Add unit tests: pairwise minute-disjointness (regression gate), cadence + schedule pins, and direct `isValidCron` tests (exported, no logic change — regex already accepted comma minute lists)
- `reconcileSystemCrons()` propagates the new schedules fleet-wide on the next agent boot/reconcile; daily/weekly crons unchanged

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Five pipeline crons have distinct minute pairs, 30-min cadence | MET |
| 2 | No two pipeline crons fire at the same minute | MET |
| 3 | All schedules valid per existing `isValidCron` | MET |
| 4 | Daily/weekly cron schedules unchanged | MET |
| 5 | Unit test fails CI if a collision is reintroduced | MET |
| 6 | Lint, typecheck, full test suite pass | MET |

## Test Plan
- New unit tests confirmed RED against the old shared `*/30` schedules, GREEN after
- `task ci` green locally: 2950 pass / 0 fail (lint, check-strings, typecheck, secret-scan included)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
