### PR TITLE
feat: cron log model + cost columns

### DIFF
--- a/admin/openapi.json
+++ b/admin/openapi.json
@@ -284,6 +284,42 @@
             "example": {
               "MY_VAR": "value"
             }
+          },
+          "secretKeys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "MY_SECRET"
+            ]
+          }
+        },
+        "required": [
+          "env",
+          "secretKeys"
+        ]
+      },
+      "AgentEnvPatchBody": {
+        "type": "object",
+        "properties": {
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": {
+              "MY_VAR": "value"
+            }
+          },
+          "secretKeys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "MY_SECRET"
+            ]
           }
         },
         "required": [
@@ -577,6 +613,43 @@
           "crons"
         ]
       },
+      "ModelBreakdownEntry": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "example": "claude-sonnet-4-5"
+          },
+          "inputTokens": {
+            "type": "integer",
+            "default": 0,
+            "example": 200
+          },
+          "outputTokens": {
+            "type": "integer",
+            "default": 0,
+            "example": 100
+          },
+          "cacheReadTokens": {
+            "type": "integer",
+            "default": 0,
+            "example": 8
+          },
+          "cacheCreationTokens": {
+            "type": "integer",
+            "default": 0,
+            "example": 4
+          },
+          "costUsd": {
+            "type": "number",
+            "default": 0,
+            "example": 0.002
+          }
+        },
+        "required": [
+          "model"
+        ]
+      },
       "AgentCronRun": {
         "type": "object",
         "properties": {
@@ -662,6 +735,14 @@
             "type": "string",
             "format": "date-time",
             "example": "2026-01-01T08:00:00.000Z"
+          },
+          "modelBreakdown": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelBreakdownEntry"
+            },
+            "default": [],
+            "description": "Per-model token/cost breakdown for this run"
           }
         },
         "required": [
@@ -776,43 +857,6 @@
         },
         "required": [
           "run"
-        ]
-      },
-      "ModelBreakdownEntry": {
-        "type": "object",
-        "properties": {
-          "model": {
-            "type": "string",
-            "example": "claude-sonnet-4-5"
-          },
-          "inputTokens": {
-            "type": "integer",
-            "default": 0,
-            "example": 200
-          },
-          "outputTokens": {
-            "type": "integer",
-            "default": 0,
-            "example": 100
-          },
-          "cacheReadTokens": {
-            "type": "integer",
-            "default": 0,
-            "example": 8
-          },
-          "cacheCreationTokens": {
-            "type": "integer",
-            "default": 0,
-            "example": 4
-          },
-          "costUsd": {
-            "type": "number",
-            "default": 0,
-            "example": 0.002
-          }
-        },
-        "required": [
-          "model"
         ]
       },
       "PatchAgentCronRunBody": {
@@ -1278,6 +1322,12 @@
             "items": {
               "$ref": "#/components/schemas/DailyTokenAggregate"
             }
+          },
+          "byCronModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DoubleKeyedTokenAggregate"
+            }
           }
         },
         "required": [
@@ -1285,7 +1335,8 @@
           "byAgent",
           "byCron",
           "byModel",
-          "daily"
+          "daily",
+          "byCronModel"
         ]
       },
       "ChatTokenStats": {
@@ -1903,7 +1954,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AgentEnvBody"
+                "$ref": "#/components/schemas/AgentEnvPatchBody"
               }
             }
           }

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -123,6 +123,15 @@ export interface CronJobItem {
   runCountToday?: number;
 }
 
+export interface CronRunModelBreakdownItem {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number;
+}
+
 export interface CronRunItem {
   id?: string;
   startedAt: Date;
@@ -133,6 +142,7 @@ export interface CronRunItem {
   error: string | null;
   inputTokens: number | null;
   outputTokens: number | null;
+  modelBreakdown?: CronRunModelBreakdownItem[];
 }
 
 // Inline CSS for cron-run outcome badges, keyed by outcome string.
@@ -149,6 +159,24 @@ const CRON_OUTCOME_STYLE_DEFAULT = "background:#9ca3af;color:white";
 /** Resolve the badge style for a cron outcome, falling back to a neutral gray. */
 function cronOutcomeStyle(outcome: string | null | undefined): string {
   return CRON_OUTCOME_STYLE[outcome ?? ""] ?? CRON_OUTCOME_STYLE_DEFAULT;
+}
+
+/**
+ * Render a run's per-model cost breakdown as a stack of small badges — one
+ * badge per model, showing the model name and its cost. A run can have
+ * multiple model breakdown rows (one-to-many), so badges stack vertically
+ * within a single table cell. Renders "—" when there's no breakdown data.
+ */
+function renderModelCostBadges(
+  modelBreakdown: CronRunModelBreakdownItem[] | null | undefined,
+): string {
+  if (!modelBreakdown || modelBreakdown.length === 0) return "—";
+  return modelBreakdown
+    .map(
+      (b) =>
+        `<span class="badge" style="background:#eef2ff;color:#4338ca;display:block;margin-bottom:2px;width:fit-content" title="${escapeHtml(b.model)}">${escapeHtml(b.model)}: $${b.costUsd.toFixed(3)}</span>`,
+    )
+    .join("");
 }
 
 export interface ToolItem {
@@ -2242,17 +2270,20 @@ export function renderCronRunsPage(opts: {
         ? "—"
         : `${escapeHtml(String(r.inputTokens ?? 0))} in / ${escapeHtml(String(r.outputTokens ?? 0))} out`;
 
+    const modelCostCell = renderModelCostBadges(r.modelBreakdown);
+
     return `<tr>
       <td>${outcomeCell}</td>
       <td style="font-size:12px">${startedCell}</td>
       <td class="mono" style="font-size:12px">${durationCell}</td>
       <td class="mono" style="font-size:12px">${tokensCell}</td>
+      <td style="font-size:12px">${modelCostCell}</td>
     </tr>`;
   }
 
   const bodyRows =
     runs.length === 0
-      ? `<tr><td colspan="4" class="empty-state">No runs recorded yet.</td></tr>`
+      ? `<tr><td colspan="5" class="empty-state">No runs recorded yet.</td></tr>`
       : runs.map(row).join("\n");
 
   const cronLabel = cron.name ?? cron.schedule;
@@ -2286,6 +2317,7 @@ export function renderCronRunsPage(opts: {
             <th>Started</th>
             <th>Duration</th>
             <th>Tokens</th>
+            <th>Model / Cost</th>
           </tr>
         </thead>
         <tbody>

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -554,6 +554,18 @@ describe("admin UI — authenticated pages", () => {
                 cacheReadTokens: null,
                 cacheCreationTokens: null,
                 createdAt: new Date("2026-06-01T10:00:00Z"),
+                modelBreakdown: [
+                  {
+                    id: "breakdown-1",
+                    cronRunId: "run-1",
+                    model: "claude-sonnet-4-5",
+                    inputTokens: 999,
+                    outputTokens: 111,
+                    cacheReadTokens: 0,
+                    cacheCreationTokens: 0,
+                    costUsd: 0.002,
+                  },
+                ],
               },
             ],
             total: 1,
@@ -573,6 +585,8 @@ describe("admin UI — authenticated pages", () => {
     const html = await res.text();
     expect(html).toContain("posted");
     expect(html).not.toContain("No runs recorded yet.");
+    expect(html).toContain("claude-sonnet-4-5");
+    expect(html).toContain("$0.002");
   });
 
   it("authenticated GET /admin/provision shows the session user's email in the navbar", async () => {

--- a/admin/src/agent-cron-runs.integration.test.ts
+++ b/admin/src/agent-cron-runs.integration.test.ts
@@ -200,6 +200,57 @@ describeOrSkip("AgentCronRunService (integration)", () => {
     );
   });
 
+  it("list() returns modelBreakdown rows for a run with multiple models", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-15T10:00:00Z"),
+      skipped: false,
+    });
+
+    await runService.patch(run.id, agentId, cronId, {
+      modelBreakdown: [
+        {
+          model: "claude-sonnet-4-5",
+          inputTokens: 200,
+          outputTokens: 100,
+          cacheReadTokens: 8,
+          cacheCreationTokens: 4,
+          costUsd: 0.002,
+        },
+        {
+          model: "claude-haiku-4-5",
+          inputTokens: 50,
+          outputTokens: 20,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.0001,
+        },
+      ],
+    });
+
+    const { items } = await runService.list(cronId, agentId);
+
+    expect(items).toHaveLength(1);
+    const breakdown = items[0].modelBreakdown;
+    expect(breakdown).toHaveLength(2);
+
+    const sonnet = breakdown.find((b) => b.model === "claude-sonnet-4-5");
+    expect(sonnet).toBeDefined();
+    expect(sonnet?.inputTokens).toBe(200);
+    expect(sonnet?.outputTokens).toBe(100);
+    expect(sonnet?.cacheReadTokens).toBe(8);
+    expect(sonnet?.cacheCreationTokens).toBe(4);
+    expect(sonnet?.costUsd).toBe(0.002);
+
+    const haiku = breakdown.find((b) => b.model === "claude-haiku-4-5");
+    expect(haiku).toBeDefined();
+    expect(haiku?.inputTokens).toBe(50);
+    expect(haiku?.outputTokens).toBe(20);
+    expect(haiku?.costUsd).toBe(0.0001);
+  });
+
   // ─── patch ──────────────────────────────────────────────────────────────────
 
   it("patch() updates token fields and completion fields on a run", async () => {

--- a/admin/src/agent-cron-runs.ts
+++ b/admin/src/agent-cron-runs.ts
@@ -6,10 +6,24 @@
  * returned false), the outcome, and any error.
  */
 
-import type { AgentCronRun, PrismaClient } from "../prisma/client/index.js";
+import type {
+  AgentCronRun,
+  Prisma,
+  PrismaClient,
+} from "../prisma/client/index.js";
 import { NotFoundError } from "./errors.ts";
 
 export type { AgentCronRun };
+
+/**
+ * AgentCronRun with its per-model token/cost breakdown included.
+ * Only list() attaches this relation — create()/patch() return the plain
+ * AgentCronRun shape, since a freshly created/patched run has no breakdown
+ * rows attached in the same query.
+ */
+export type AgentCronRunWithBreakdown = Prisma.AgentCronRunGetPayload<{
+  include: { modelBreakdown: true };
+}>;
 
 export interface CreateAgentCronRunInput {
   startedAt: Date;
@@ -48,7 +62,7 @@ export interface ListAgentCronRunsOptions {
 }
 
 export interface AgentCronRunList {
-  items: AgentCronRun[];
+  items: AgentCronRunWithBreakdown[];
   total: number;
   limit: number;
   offset: number;
@@ -202,6 +216,7 @@ export class AgentCronRunService {
         orderBy: { startedAt: "desc" },
         take: limit,
         skip: offset,
+        include: { modelBreakdown: true },
       }),
       this.prisma.agentCronRun.count({
         where: { cronId, agentId },

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -1963,6 +1963,27 @@ describe("admin API — cron runs", () => {
     expect(typeof body.offset).toBe("number");
   });
 
+  it("GET /agents/:id/crons/:cronId/runs includes modelBreakdown on each run", async () => {
+    const deps = makeMockDepsWithRunService();
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}/crons/${CRON_ID}/runs`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(Array.isArray(body.items[0].modelBreakdown)).toBe(true);
+    expect(body.items[0].modelBreakdown).toHaveLength(1);
+    expect(body.items[0].modelBreakdown[0]).toMatchObject({
+      model: "claude-sonnet-4-5",
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 8,
+      cacheCreationTokens: 4,
+      costUsd: 0.002,
+    });
+  });
+
   it("PATCH /agents/:id/crons/:cronId/runs/:runId returns 200 with updated run including token fields", async () => {
     const deps = makeMockDepsWithRunService();
     const app = createAdminApp(deps);
@@ -2086,6 +2107,18 @@ function makeMockDepsWithRunService(opts?: {
     cacheReadTokens: null,
     cacheCreationTokens: null,
     createdAt: new Date("2026-01-01T08:00:00.000Z"),
+    modelBreakdown: [
+      {
+        id: "breakdown-test-1",
+        cronRunId: RUN_ID,
+        model: "claude-sonnet-4-5",
+        inputTokens: 200,
+        outputTokens: 100,
+        cacheReadTokens: 8,
+        cacheCreationTokens: 4,
+        costUsd: 0.002,
+      },
+    ],
   };
 
   const base = makeMockDeps();

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -1471,6 +1471,16 @@ function serializeCronRun(run: {
   cacheReadTokens?: number | null;
   cacheCreationTokens?: number | null;
   createdAt: Date;
+  // Absent on create()/patch() results (no breakdown rows in the same call);
+  // present on list() results, which include the relation. Defaults to [].
+  modelBreakdown?: Array<{
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    costUsd: number;
+  }>;
 }): z.infer<typeof AgentCronRunSchema> {
   return {
     id: run.id,
@@ -1487,6 +1497,14 @@ function serializeCronRun(run: {
     cacheReadTokens: run.cacheReadTokens ?? null,
     cacheCreationTokens: run.cacheCreationTokens ?? null,
     createdAt: run.createdAt.toISOString(),
+    modelBreakdown: (run.modelBreakdown ?? []).map((entry) => ({
+      model: entry.model,
+      inputTokens: entry.inputTokens,
+      outputTokens: entry.outputTokens,
+      cacheReadTokens: entry.cacheReadTokens,
+      cacheCreationTokens: entry.cacheCreationTokens,
+      costUsd: entry.costUsd,
+    })),
   };
 }
 

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -161,6 +161,21 @@ export const PatchAgentCronJobBodySchema = z
   })
   .openapi("PatchAgentCronJobBody");
 
+// ─── Model breakdown entry ────────────────────────────────────────────────────
+
+export const ModelBreakdownEntrySchema = z
+  .object({
+    model: z.string().openapi({ example: "claude-sonnet-4-5" }),
+    inputTokens: z.number().int().default(0).openapi({ example: 200 }),
+    outputTokens: z.number().int().default(0).openapi({ example: 100 }),
+    cacheReadTokens: z.number().int().default(0).openapi({ example: 8 }),
+    cacheCreationTokens: z.number().int().default(0).openapi({ example: 4 }),
+    costUsd: z.number().default(0).openapi({ example: 0.002 }),
+  })
+  .openapi("ModelBreakdownEntry");
+
+export type ModelBreakdownEntry = z.infer<typeof ModelBreakdownEntrySchema>;
+
 // ─── AgentCronRun ─────────────────────────────────────────────────────────────
 
 export const AgentCronRunSchema = z
@@ -192,6 +207,10 @@ export const AgentCronRunSchema = z
       .string()
       .datetime()
       .openapi({ example: "2026-01-01T08:00:00.000Z" }),
+    modelBreakdown: z
+      .array(ModelBreakdownEntrySchema)
+      .default([])
+      .openapi({ description: "Per-model token/cost breakdown for this run" }),
   })
   .openapi("AgentCronRun");
 
@@ -230,21 +249,6 @@ export const CreateAgentCronRunBodySchema = z
     error: z.string().nullable().optional().openapi({ example: null }),
   })
   .openapi("CreateAgentCronRunBody");
-
-// ─── Model breakdown entry ────────────────────────────────────────────────────
-
-export const ModelBreakdownEntrySchema = z
-  .object({
-    model: z.string().openapi({ example: "claude-sonnet-4-5" }),
-    inputTokens: z.number().int().default(0).openapi({ example: 200 }),
-    outputTokens: z.number().int().default(0).openapi({ example: 100 }),
-    cacheReadTokens: z.number().int().default(0).openapi({ example: 8 }),
-    cacheCreationTokens: z.number().int().default(0).openapi({ example: 4 }),
-    costUsd: z.number().default(0).openapi({ example: 0.002 }),
-  })
-  .openapi("ModelBreakdownEntry");
-
-export type ModelBreakdownEntry = z.infer<typeof ModelBreakdownEntrySchema>;
 
 /**
  * PATCH /agents/:id/crons/:cronId/runs/:runId body.

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -238,7 +238,7 @@ GET /agents/:id/crons/:cronId/runs
 
 Query params: `limit` (default 20), `offset` (default 0). Returns `{ items: AgentCronRun[], total: number }`.
 
-Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`.
+Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`, and `modelBreakdown` (an array of per-model cost entries, each with `model`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`).
 
 ### Update cron run
 

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -238,7 +238,7 @@ GET /agents/:id/crons/:cronId/runs
 
 Query params: `limit` (default 20), `offset` (default 0). Returns `{ items: AgentCronRun[], total: number }`.
 
-Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`, and `modelBreakdown` (an array of per-model cost entries, each with `model`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`).
+Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `createdAt`, and `modelBreakdown` (an array of per-model cost entries, each with `model`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd` — a run can span multiple models, so this is one-to-many).
 
 ### Update cron run
 

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -411,7 +411,7 @@ export interface paths {
             };
             requestBody?: {
                 content: {
-                    "application/json": components["schemas"]["AgentEnvBody"];
+                    "application/json": components["schemas"]["AgentEnvPatchBody"];
                 };
             };
             responses: {
@@ -1585,6 +1585,28 @@ export interface components {
             env: {
                 [key: string]: string;
             };
+            /**
+             * @example [
+             *       "MY_SECRET"
+             *     ]
+             */
+            secretKeys: string[];
+        };
+        AgentEnvPatchBody: {
+            /**
+             * @example {
+             *       "MY_VAR": "value"
+             *     }
+             */
+            env: {
+                [key: string]: string;
+            };
+            /**
+             * @example [
+             *       "MY_SECRET"
+             *     ]
+             */
+            secretKeys?: string[];
         };
         AgentCronJob: {
             /** @example clx1234567890 */
@@ -1687,6 +1709,35 @@ export interface components {
         CronsWithSummaryWrapper: {
             crons: components["schemas"]["AgentCronJobWithRunSummary"][];
         };
+        ModelBreakdownEntry: {
+            /** @example claude-sonnet-4-5 */
+            model: string;
+            /**
+             * @default 0
+             * @example 200
+             */
+            inputTokens: number;
+            /**
+             * @default 0
+             * @example 100
+             */
+            outputTokens: number;
+            /**
+             * @default 0
+             * @example 8
+             */
+            cacheReadTokens: number;
+            /**
+             * @default 0
+             * @example 4
+             */
+            cacheCreationTokens: number;
+            /**
+             * @default 0
+             * @example 0.002
+             */
+            costUsd: number;
+        };
         AgentCronRun: {
             /** @example clx1234567890 */
             id: string;
@@ -1725,6 +1776,11 @@ export interface components {
              * @example 2026-01-01T08:00:00.000Z
              */
             createdAt: string;
+            /**
+             * @description Per-model token/cost breakdown for this run
+             * @default []
+             */
+            modelBreakdown: components["schemas"]["ModelBreakdownEntry"][];
         };
         CronRunWrapper: {
             run: components["schemas"]["AgentCronRun"];
@@ -1760,35 +1816,6 @@ export interface components {
         };
         PatchCronRunWrapper: {
             run: components["schemas"]["AgentCronRun"];
-        };
-        ModelBreakdownEntry: {
-            /** @example claude-sonnet-4-5 */
-            model: string;
-            /**
-             * @default 0
-             * @example 200
-             */
-            inputTokens: number;
-            /**
-             * @default 0
-             * @example 100
-             */
-            outputTokens: number;
-            /**
-             * @default 0
-             * @example 8
-             */
-            cacheReadTokens: number;
-            /**
-             * @default 0
-             * @example 4
-             */
-            cacheCreationTokens: number;
-            /**
-             * @default 0
-             * @example 0.002
-             */
-            costUsd: number;
         };
         PatchAgentCronRunBody: {
             /**
@@ -1946,6 +1973,7 @@ export interface components {
             byCron: components["schemas"]["DoubleKeyedTokenAggregate"][];
             byModel: components["schemas"]["DoubleKeyedTokenAggregate"][];
             daily: components["schemas"]["DailyTokenAggregate"][];
+            byCronModel: components["schemas"]["DoubleKeyedTokenAggregate"][];
         };
         ChatTokenStats: {
             totals: components["schemas"]["TokenAggregate"];


### PR DESCRIPTION
## Summary
- Wire the existing `AgentCronRunModelBreakdown` data (added in PR #917) into the admin cron-runs list endpoint and UI, restoring per-run model/cost visibility that PR #932 intentionally dropped pending this replacement.
- `AgentCronRunService.list()` now includes the `modelBreakdown` relation; `AgentCronRunSchema` gains a `modelBreakdown` array field (openapi.json / admin-types.ts regenerated); `serializeCronRun()` passes it through.
- The cron-runs admin UI table gains a "Model / Cost" column rendering a stacked badge per model (a run can span multiple models — this is genuinely one-to-many).
- Fixed a stale doc line in `docs/agent-api.md` that still described removed top-level `model`/`costUsd` fields on the run record.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `admin/src/agent-cron-runs.ts` list() query includes modelBreakdown rows | MET |
| 2 | `AgentCronRunSchema` gains modelBreakdown array field; openapi.json/admin-types.ts regenerated | MET |
| 3 | `serializeCronRun()` passes modelBreakdown through to the response | MET |
| 4 | admin-ui-pages.ts cron-runs table renders per-run model badges (stacked) with cost | MET |
| 5 | Integration test for list() with multi-model run; smoke test for the new response field | MET |

## Test Plan
- New integration test: `list()` returns `modelBreakdown` rows for a run with two distinct models (DB-gated, runs in CI).
- New smoke tests: `GET /agents/:id/crons/:cronId/runs` includes `modelBreakdown` in the JSON response; admin UI cron-runs page renders model name + cost badge.
- Full repo test suite: 2936 pass / 14 fail (all 14 pre-existing on `main`, unrelated to this change — confirmed via `git stash` comparison).
- `bun run --filter='*' typecheck`, `bunx biome lint .`, `check-banned-strings`, `check-config-docs`, `sync-version --check` all pass.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
