### PR TITLE
feat: add review-iterations proxy metric (MA-9)

### DIFF
--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -501,6 +501,7 @@ function makeSummaryHandler(
             reviewsTotal,
             reviewsShipIt,
             reviewShipItRate,
+            avgReviewIterations: toNumOrNull(row.avg_review_iterations),
             estimationAccuracy,
             complexityDist: {
               c1: toNum(row.complexity_1),

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -337,6 +337,10 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
               <span class="stat-label">SHIP IT<span class="info-icon" data-tooltip="Reviews where no blocking issues were found" tabindex="0" aria-label="Reviews where no blocking issues were found">i</span></span>
               <span class="stat-value good" id="review-ship-it">--</span>
             </div>
+            <div class="stat-row" data-metric="review-iterations">
+              <span class="stat-label">Review Iterations<span class="info-icon" data-tooltip="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count" tabindex="0" aria-label="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count">i</span></span>
+              <span class="stat-value" id="review-iterations">--</span>
+            </div>
           </div>
 
           <!-- Coverage -->
@@ -825,6 +829,10 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
             <div class="stat-row" data-metric="reviews-ship-it">
               <span class="stat-label">SHIP IT<span class="info-icon" data-tooltip="Reviews where no blocking issues were found" tabindex="0" aria-label="Reviews where no blocking issues were found">i</span></span>
               <span class="stat-value good" id="review-ship-it">--</span>
+            </div>
+            <div class="stat-row" data-metric="review-iterations">
+              <span class="stat-label">Review Iterations<span class="info-icon" data-tooltip="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count" tabindex="0" aria-label="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count">i</span></span>
+              <span class="stat-value" id="review-iterations">--</span>
             </div>
           </div>
 
@@ -1315,6 +1323,10 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
               <span class="stat-label">SHIP IT<span class="info-icon" data-tooltip="Reviews where no blocking issues were found" tabindex="0" aria-label="Reviews where no blocking issues were found">i</span></span>
               <span class="stat-value good" id="review-ship-it">--</span>
             </div>
+            <div class="stat-row" data-metric="review-iterations">
+              <span class="stat-label">Review Iterations<span class="info-icon" data-tooltip="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count" tabindex="0" aria-label="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count">i</span></span>
+              <span class="stat-value" id="review-iterations">--</span>
+            </div>
           </div>
 
           <!-- Coverage -->
@@ -1804,6 +1816,10 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
               <span class="stat-label">SHIP IT<span class="info-icon" data-tooltip="Reviews where no blocking issues were found" tabindex="0" aria-label="Reviews where no blocking issues were found">i</span></span>
               <span class="stat-value good" id="review-ship-it">--</span>
             </div>
+            <div class="stat-row" data-metric="review-iterations">
+              <span class="stat-label">Review Iterations<span class="info-icon" data-tooltip="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count" tabindex="0" aria-label="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count">i</span></span>
+              <span class="stat-value" id="review-iterations">--</span>
+            </div>
           </div>
 
           <!-- Coverage -->
@@ -2281,6 +2297,10 @@ exports[`renderDashboardPage — PCE-1.4 Cost Efficiency card readOnly page snap
             <div class="stat-row" data-metric="reviews-ship-it">
               <span class="stat-label">SHIP IT<span class="info-icon" data-tooltip="Reviews where no blocking issues were found" tabindex="0" aria-label="Reviews where no blocking issues were found">i</span></span>
               <span class="stat-value good" id="review-ship-it">--</span>
+            </div>
+            <div class="stat-row" data-metric="review-iterations">
+              <span class="stat-label">Review Iterations<span class="info-icon" data-tooltip="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count" tabindex="0" aria-label="Avg review + patch cycles per PR — an iteration-count proxy, not a findings count">i</span></span>
+              <span class="stat-value" id="review-iterations">--</span>
             </div>
           </div>
 

--- a/metrics/src/dashboard/app.js
+++ b/metrics/src/dashboard/app.js
@@ -213,6 +213,7 @@
     // Reviews
     $("review-total").textContent = fmtInt(data.reviewsTotal);
     $("review-ship-it").textContent = fmtInt(data.reviewsShipIt);
+    $("review-iterations").textContent = fmtNum(data.avgReviewIterations);
 
     // Coverage
     $("coverage-reports").textContent = fmtInt(data.coverageReports);

--- a/metrics/src/dashboard/dashboard-page.ts
+++ b/metrics/src/dashboard/dashboard-page.ts
@@ -301,6 +301,10 @@ export function renderDashboardPage(opts: DashboardPageOptions): string {
               <span class="stat-label">SHIP IT${infoIcon("Reviews where no blocking issues were found")}</span>
               <span class="stat-value good" id="review-ship-it">--</span>
             </div>
+            <div class="stat-row" data-metric="review-iterations">
+              <span class="stat-label">Review Iterations${infoIcon("Avg review + patch cycles per PR — an iteration-count proxy, not a findings count")}</span>
+              <span class="stat-value" id="review-iterations">--</span>
+            </div>
           </div>
 
           <!-- Coverage -->

--- a/metrics/src/dashboard/dashboard-page.unit.test.ts
+++ b/metrics/src/dashboard/dashboard-page.unit.test.ts
@@ -204,6 +204,16 @@ describe("renderDashboardPage — MG-1.2 clickable metrics: data-metric attribut
     expect(html).toContain('data-metric="reviews-ship-it"');
   });
 
+  test("review-iterations stat-row is labeled honestly as an iteration proxy", () => {
+    const html = renderDashboardPage(BASE_OPTS);
+    expect(html).toContain('data-metric="review-iterations"');
+    expect(html).toContain("Review Iterations");
+    const iterationsRow = html
+      .split('data-metric="review-iterations"')[1]
+      ?.split("</div>")[0];
+    expect(iterationsRow).not.toContain("Findings");
+  });
+
   test("efficiency stat-blocks have data-metric attributes", () => {
     const html = renderDashboardPage(BASE_OPTS);
     expect(html).toContain('data-metric="avg-estimated-hours"');

--- a/metrics/src/lib/task-store-client.ts
+++ b/metrics/src/lib/task-store-client.ts
@@ -69,6 +69,8 @@ export interface PrRecord {
   mergedAt?: string | null;
   /** Owning repository in `org/repo` form. Used for public-mode repo scoping. */
   repo?: string | null;
+  reviewCycles?: number | null;
+  patchCycles?: number | null;
 }
 
 // ─── Error type ───────────────────────────────────────────────────────────────

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -86,6 +86,8 @@ const PRS: PrRecord[] = [
     reviewState: "approved",
     createdAt: "2026-06-02T11:00:00.000Z",
     mergedAt: "2026-06-02T12:00:00.000Z",
+    reviewCycles: 1,
+    patchCycles: 1,
   },
   {
     id: "pr-2",
@@ -93,6 +95,8 @@ const PRS: PrRecord[] = [
     reviewState: "posted",
     createdAt: "2026-06-03T14:00:00.000Z",
     mergedAt: "2026-06-03T15:00:00.000Z",
+    reviewCycles: 2,
+    patchCycles: 1,
   },
 ];
 
@@ -174,6 +178,7 @@ describe("TaskStoreProvider (integration)", () => {
       "simplify_avg_consistency",
       "reviews_total",
       "reviews_ship_it",
+      "avg_review_iterations",
       "complexity_1",
       "complexity_2",
       "complexity_3",
@@ -194,6 +199,8 @@ describe("TaskStoreProvider (integration)", () => {
     // reviews from PR records
     expect(row[colIndex(t, "reviews_total")]).toBe(2);
     expect(row[colIndex(t, "reviews_ship_it")]).toBe(1);
+    // avg_review_iterations = avg(reviewCycles + patchCycles) = avg(2, 3) = 2.5
+    expect(row[colIndex(t, "avg_review_iterations")]).toBe(2.5);
   });
 
   test("queueFunnel counts started/approved/merged/blocked", async () => {

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -255,6 +255,13 @@ export class TaskStoreProvider implements MetricsProvider {
       (p) => p.reviewState === SHIP_IT_REVIEW_STATE,
     ).length;
 
+    // Interim proxy for true review-findings tracking (deferred — needs a
+    // schema decision): reviewCycles + patchCycles per PR, averaged. This is
+    // an iteration count, not a findings count.
+    const avgReviewIterations = avg(
+      prs.map((p) => (num(p.reviewCycles) ?? 0) + (num(p.patchCycles) ?? 0)),
+    );
+
     const columns = [
       "tasks_completed",
       "tasks_blocked",
@@ -274,6 +281,7 @@ export class TaskStoreProvider implements MetricsProvider {
       "simplify_avg_consistency",
       "reviews_total",
       "reviews_ship_it",
+      "avg_review_iterations",
       "complexity_1",
       "complexity_2",
       "complexity_3",
@@ -301,6 +309,7 @@ export class TaskStoreProvider implements MetricsProvider {
       null, // simplify_avg_consistency — no task-store source
       prs.length,
       shipIt,
+      avgReviewIterations,
       complexityCount(1),
       complexityCount(2),
       complexityCount(3),

--- a/metrics/src/schemas.ts
+++ b/metrics/src/schemas.ts
@@ -67,6 +67,7 @@ export const SummaryResultSchema = z
     reviewsTotal: z.number().int(),
     reviewsShipIt: z.number().int(),
     reviewShipItRate: z.number().nullable(),
+    avgReviewIterations: z.number().nullable(),
     estimationAccuracy: z.number().nullable(),
     complexityDist: z.object({
       c1: z.number().int(),


### PR DESCRIPTION
## Summary
- Add `avgReviewIterations` (nullable) to `SummaryResultSchema` as an interim, honestly-labeled proxy for true review-findings tracking (which is deferred pending a schema decision)
- `TaskStoreProvider.summary()` computes it as `avg(reviewCycles + patchCycles)` across PRs in range — zero schema change, reuses existing `PullRequest` fields
- Dashboard adds a "Review Iterations" stat-row (with an explicit iteration-proxy tooltip) — deliberately does not say "Findings"

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `schemas.ts` gains `avgReviewIterations` nullable field, placed with other review fields | MET |
| 2 | `task-store-provider.ts` computes it from `reviewCycles + patchCycles`, averaged across PRs | MET |
| 3 | Dashboard label reads "Review Iterations", not "Review Findings" | MET |
| 4 | Unit test for the aggregation; dashboard snapshot updated; no existing tests retired | MET |

## Test Plan
- `bun test` in `metrics/` — 269 pass, 0 fail
- New integration test asserts `avg_review_iterations = 2.5` for a 2-PR fixture (reviewCycles/patchCycles = 1+1, 2+1)
- New dashboard unit test asserts the new stat-row is labeled "Review Iterations" and its markup excludes "Findings"
- `bun run --filter='*' typecheck` — clean across all workspaces
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
