### PR TITLE
feat: wire docs/*.md into learning-dreamer mining scope

### DIFF
--- a/plugins/shipwright/agents/learning-dreamer.md
+++ b/plugins/shipwright/agents/learning-dreamer.md
@@ -27,6 +27,8 @@ interactive `learning-capture` skill gets for free.
   Managed Agents: their run logs. Read every transcript in the requested window.
 - **Current context.** The repo's `CLAUDE.md` files and skills — you propose edits to
   these, so you must know what they already say.
+- **Docs.** `docs/*.md` files in the repo — you propose fixes to lines sessions kept
+  overriding, or docs that have drifted from the code they document.
 - **The Harness TODO queue.** A `# Harness TODO` section in `CLAUDE.local.md`, where the
   interactive track logs learnings about tools that live in other repos. You flush it.
 
@@ -38,6 +40,7 @@ interactive `learning-capture` skill gets for free.
 | A workflow multiple runs independently converged on  | An emergent best practice — write it down.       |
 | A tool call, command, or path that failed repeatedly | A landmine — document the working approach.      |
 | A `CLAUDE.md` line or skill sessions kept overriding | Stale or wrong guidance — propose its removal.   |
+| A `docs/*.md` line sessions kept overriding, or a doc drifted from the code it documents | Propose a fix in review mode (`LEARNINGS-REVIEW.md`); a full rewrite hands off to `docs-refresher` instead of hand-edited prose. |
 | Duplicated / contradictory lines already in context  | Memory bloat — propose a merge or a resolution.  |
 | Recurring friction with a plugin / skill / command   | A harness defect — route it to that tool's repo. |
 

--- a/plugins/shipwright/agents/learning-dreamer.unit.test.ts
+++ b/plugins/shipwright/agents/learning-dreamer.unit.test.ts
@@ -1,0 +1,44 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const LEARNING_DREAMER_MD_PATH = join(import.meta.dir, "learning-dreamer.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(LEARNING_DREAMER_MD_PATH, "utf-8");
+});
+
+describe("learning-dreamer.md — Inputs section", () => {
+  it("lists docs/*.md as a mining input within the ## Inputs section", () => {
+    const inputsStart = content.indexOf("## Inputs");
+    expect(inputsStart).toBeGreaterThan(-1);
+    const nextHeadingIdx = content.indexOf("## ", inputsStart + "## Inputs".length);
+    expect(nextHeadingIdx).toBeGreaterThan(inputsStart);
+    const inputsSection = content.slice(inputsStart, nextHeadingIdx);
+    expect(inputsSection).toContain("docs/*.md");
+  });
+});
+
+describe("learning-dreamer.md — mining table", () => {
+  it("has a mining table row for stale/overridden docs/*.md lines with a docs-refresher hand-off", () => {
+    const tableStart = content.indexOf("## What to mine for");
+    expect(tableStart).toBeGreaterThan(-1);
+    const nextHeadingIdx = content.indexOf(
+      "## ",
+      tableStart + "## What to mine for".length,
+    );
+    expect(nextHeadingIdx).toBeGreaterThan(tableStart);
+    const tableSection = content.slice(tableStart, nextHeadingIdx);
+
+    expect(tableSection).toContain("docs/*.md");
+    expect(tableSection).toContain("docs-refresher");
+
+    const docsRowLine = tableSection
+      .split("\n")
+      .find((line) => line.includes("docs/*.md") && line.includes("|"));
+    expect(docsRowLine).toBeDefined();
+    expect(docsRowLine).toContain("docs-refresher");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `docs/*.md` as a mining input to `learning-dreamer.md`'s `## Inputs` section, alongside `CLAUDE.md`/skills
- Adds a new row to the mining table for a `docs/*.md` line sessions kept overriding, or a doc drifted from the code it documents — proposes a fix in review mode (`LEARNINGS-REVIEW.md`), with full rewrites explicitly handed off to the `docs-refresher` agent instead of the dreamer hand-editing prose
- Adds `learning-dreamer.unit.test.ts` (new file — this agent spec had no prior tests) asserting `docs/*.md` appears in the Inputs section and `docs-refresher` appears on the new mining table row

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Inputs section lists docs/*.md | MET | New 'Docs.' bullet in `## Inputs` |
| 2 | Mining table row for stale/overridden doc lines w/ docs-refresher hand-off | MET | New table row explicitly names `docs-refresher` for full rewrites |
| 3 | Unit test asserting docs/*.md + docs-refresher present | MET | `learning-dreamer.unit.test.ts` added, scoped assertions on both sections |

## Test Plan
- `bun test plugins/shipwright/agents/learning-dreamer.unit.test.ts` — new tests pass
- `bun test plugins/shipwright` — 556 pass, 0 fail, no regressions
- `bunx biome lint .` — clean
- `bun run typecheck` (plugins/shipwright) — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
