### PR TITLE
docs: remove repo from pr_open PATCH and update task-schema.md

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -195,7 +195,7 @@ Claim semantics:
 - Same `commitSha` and `reviewState !== pending` → returns `409` (already reviewed at this commit)
 - Different `commitSha` or `reviewState === pending` → updates and returns `200` (new review cycle)
 
-When a `taskId` is provided, the claim operation also syncs `pr` to the associated Task record. This keeps the PR reference current on the task side without requiring a separate update call. If no `taskId` is provided, the Task table is not modified.
+When a `taskId` is provided, the claim operation also syncs `pr` and `repo` to the associated Task record. This keeps the PR reference and repo scope current on the task side without requiring a separate update call. If no `taskId` is provided, the Task table is not modified.
 
 #### Claim next PR (atomic)
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -195,7 +195,7 @@ Claim semantics:
 - Same `commitSha` and `reviewState !== pending` → returns `409` (already reviewed at this commit)
 - Different `commitSha` or `reviewState === pending` → updates and returns `200` (new review cycle)
 
-When a `taskId` is provided, the claim operation also syncs `pr` and `repo` to the associated Task record. This keeps the PR reference and repo scope current on the task side without requiring a separate update call. If no `taskId` is provided, the Task table is not modified.
+When a `taskId` is provided, the claim operation also syncs `pr` to the associated Task record. This keeps the PR reference current on the task side without requiring a separate update call. If no `taskId` is provided, the Task table is not modified.
 
 #### Claim next PR (atomic)
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -568,7 +568,7 @@ gh pr list --head {branch} --state open --json number,url
 
 **If a PR already exists** (bundled task — joining an existing PR):
 - The push above added the commits to the existing branch/PR — no new PR needed
-- Set `pr: {existing-pr-number}`, `prCreatedAt: "{ISO timestamp}"`, and `repo: {repo}` in the task store for this task
+- Set `pr: {existing-pr-number}` and `prCreatedAt: "{ISO timestamp}"` in the task store for this task
 - Print the existing PR URL
 - Skip PR creation and proceed to Step 9b
 
@@ -815,7 +815,7 @@ PR_CREATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
-  -d "{\"status\": \"pr_open\", \"pr\": {pr_number}, \"prCreatedAt\": \"$PR_CREATED_AT\", \"repo\": \"{repo}\", \"ciFixAttempts\": {ci_attempt}, \"simplifyTotal\": {simplify_total}, \"simplifyDry\": {simplify_dry}, \"simplifyDeadCode\": {simplify_dead_code}, \"simplifyNaming\": {simplify_naming}, \"simplifyComplexity\": {simplify_complexity}, \"simplifyConsistency\": {simplify_consistency}, \"coverageDelta\": {coverage_delta}, \"model\": \"{EFFECTIVE_MODEL}\"}" | jq .
+  -d "{\"status\": \"pr_open\", \"pr\": {pr_number}, \"prCreatedAt\": \"$PR_CREATED_AT\", \"ciFixAttempts\": {ci_attempt}, \"simplifyTotal\": {simplify_total}, \"simplifyDry\": {simplify_dry}, \"simplifyDeadCode\": {simplify_dead_code}, \"simplifyNaming\": {simplify_naming}, \"simplifyComplexity\": {simplify_complexity}, \"simplifyConsistency\": {simplify_consistency}, \"coverageDelta\": {coverage_delta}, \"model\": \"{EFFECTIVE_MODEL}\"}" | jq .
 ```
 
 ### 10d. Print Handoff

--- a/plugins/shipwright/skills/task-store/references/task-schema.md
+++ b/plugins/shipwright/skills/task-store/references/task-schema.md
@@ -23,7 +23,7 @@ contract: the same shape whether the backend is GitHub Issues, Jira, or the loca
 | field | type | notes |
 |---|---|---|
 | `session` | string | Planning-session slug; groups tasks (a milestone / `session:` label on GitHub). |
-| `repo` | string | Source repo the task targets; routes `/dev-task` to the right tree. |
+| `repo` | string **(required)** | Source repo the task targets; routes `/dev-task` to the right tree. |
 | `layer` | string | `Shared`, `API`, `Database`, `Agent`, `CLI`, `Web`. |
 | `dependencies` | string[] | Task ids that must be satisfied before this is `--ready`. |
 | `branch` | string | Feature branch; used for same-branch dependency satisfaction. |
@@ -68,7 +68,7 @@ absent — set them in the **same `update`** that changes status:
 | transition | must set |
 |---|---|
 | → `in_progress` | `model` (soft — recommended) |
-| → `pr_open` | `pr` (or `prUrl`), `prCreatedAt`, **and** `repo` |
+| → `pr_open` | `pr` (or `prUrl`) and `prCreatedAt` |
 | `pr_open` → `approved` / `merged` | `ciFixAttempts` |
 
 The exact `PATCH` invocations for each transition are in `SKILL.md` (Standard lifecycle).


### PR DESCRIPTION
## Summary
- Undoes the `pr_open`-transition `repo` documentation added in PR #956
- Removes `repo` from the `pr_open` PATCH curl command (Step 10a) and the bundled-task instruction (Step 9) in `dev-task.md`
- Marks `repo` as `(required)` in `task-schema.md`'s Planning & routing table instead, and removes it from the `-> pr_open` transition row

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | dev-task.md Step 10a pr_open PATCH does not include repo field | MET |
| 2 | dev-task.md Step 9 bundled-task instruction does not include repo | MET |
| 3 | task-schema.md Planning & routing table marks repo as (required) | MET |
| 4 | task-schema.md -> pr_open transition row lists only pr (or prUrl) and prCreatedAt | MET |
| 5 | No test changes needed (markdown-only; CI covers via check-strings) | MET |

## Test Plan
- `task check-strings` (banned-strings scan) — passes
- `bunx biome lint` on changed files — no issues
- Markdown-only change; no test files touched, matching acceptance criterion 5
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
