### PR TITLE
feat: stamp plugin version into the agent image at build time (PVS-1.2)

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -33,6 +33,19 @@ jobs:
           default_bump: patch
           fetch_all_tags: true
 
+      # Bare semver off the tag (agent-v0.117.0 → 0.117.0), stamped into the
+      # image at build time below so the deployed artifact's plugin.json
+      # always matches the tag it was built for — see agent/Dockerfile's
+      # "sync plugin version" step. This does not touch git; the git-committed
+      # version (needed for the public plugin marketplace listing) is synced
+      # asynchronously by .github/workflows/sync-plugin-version.yml, which
+      # this same tag also triggers.
+      - name: Parse bare version from tag
+        id: version
+        run: |
+          TAG="${{ steps.tag.outputs.new_tag }}"
+          echo "version=${TAG#agent-v}" >> "$GITHUB_OUTPUT"
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -46,6 +59,7 @@ jobs:
         run: |
           docker build \
             -f agent/Dockerfile \
+            --build-arg AGENT_VERSION=${{ steps.version.outputs.version }} \
             -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }} \
             .
 

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -14,11 +14,17 @@ name: Sync Plugin Version
 #      from a prior container generation, and skips re-syncing file content
 #      when that string is unchanged — so a frozen version silently prevents
 #      deployed agents from ever picking up new plugin script content, even
-#      though fresh source is baked into every new image.
+#      though fresh source is baked into every new image. As of PVS-1.2,
+#      build-agent.yml stamps the correct version straight into the image at
+#      build time (agent/Dockerfile's `ARG AGENT_VERSION` + sync-version.ts
+#      RUN step) — this workflow no longer needs to solve that half of the
+#      problem, it just happens to also do so a cycle behind (see below).
 #   2. Installed externally via `claude plugin marketplace add <this-repo>` /
 #      `install shipwright@shipwright`, which reads the git-committed
 #      marketplace.json directly — a frozen version gives external installs
-#      no way to detect or pull updates at all.
+#      no way to detect or pull updates at all. This is the case this
+#      workflow actually exists for: build-time stamping (above) never
+#      touches git, so it does nothing for external installs.
 #
 # Flow:
 #   agent-v* tag push (created by build-agent.yml on every merge that could
@@ -35,15 +41,17 @@ name: Sync Plugin Version
 #         task-store/chat) — without [skip ci] the merge could kick off
 #         some or all of them again.
 #
-# Known, accepted lag: the image build-agent.yml produces in a given run is
-# built BEFORE that same run's tag triggers this workflow, so the image
-# actually deployed each cycle still has the *previous* cycle's version
-# number baked in, even though its file content (agent + plugin code) is
-# fully current. This is harmless — the baked-in version number still
-# changes on every real deploy relative to the last one (since a sync cycle
-# runs after every tag), which is the only thing `claude plugin update`'s
-# cache-diff needs to correctly detect and re-sync fresh content. Given
-# merges land many times a day, the lag self-heals within one deploy cycle.
+# Lag, and where it does/doesn't matter: the commit this workflow lands on
+# main always trails the tag that triggered it by a minute or two (PR open +
+# checks + auto-merge). This matters not at all for the deployed image —
+# PVS-1.2 stamps the correct version directly into the image at build time,
+# independent of this workflow's git commit — but it does mean the
+# git-committed version (what `marketplace.json` on `main` shows, and what
+# external `claude plugin install` reads) is briefly behind the version
+# that's already live in production. That window is self-resolving (this
+# workflow's own PR closes it within minutes) and never regresses — main
+# only ever catches up to a version that was already actually built, never
+# claims one that wasn't.
 #
 # Manual test plan (cannot be tested in CI without a real tag + secrets):
 #   1. Push a dummy tag: git tag agent-v9.9.9 && git push origin agent-v9.9.9

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -74,6 +74,15 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 
 FROM base AS build
 
+# Bare semver (no "agent-v" prefix) for the tag this image is being built
+# for — passed via --build-arg from build-agent.yml. Stamped into the
+# plugin's version files below so the deployed image always matches the tag
+# it was built for, independent of scripts/sync-version.ts's separate,
+# asynchronous git-commit path (.github/workflows/sync-plugin-version.yml).
+# Defaulted so ci.yml's PR-time `docker build` (no --build-arg passed) still
+# succeeds — sync-version.ts requires valid semver and would fail on empty.
+ARG AGENT_VERSION=0.0.0-dev
+
 WORKDIR /app
 
 # Copy workspace manifests first (layer caching for deps)
@@ -101,6 +110,12 @@ COPY lib/ ./lib/
 # Copy the plugin source so the local marketplace is available at runtime
 COPY plugins/ ./plugins/
 COPY .claude-plugin/ ./.claude-plugin/
+# Copy the version-sync script so the version stamp below can run.
+COPY scripts/ ./scripts/
+
+# Stamp AGENT_VERSION into the plugin's version files inside the image only
+# (no git commit, no git operations) — see ARG AGENT_VERSION above for why.
+RUN bun run scripts/sync-version.ts "${AGENT_VERSION}"
 
 # Module-resolution guard: bundle every agent source file as its own entry
 # point so an unresolvable import fails the build itself, rather than only


### PR DESCRIPTION
## Summary
- Stamp the correct plugin version into the agent image at Docker build time (`ARG AGENT_VERSION` + `sync-version.ts` RUN step in `agent/Dockerfile`'s build stage), fed from a bare-version parse step in `build-agent.yml`.
- Closes the "deployed image is one cycle behind" gap left by PVS-1.1 (`sync-plugin-version.yml`), which still lands the git-committed version asynchronously for external `claude plugin install` — that path is unchanged.
- `ARG AGENT_VERSION` defaults to `0.0.0-dev` so `ci.yml`'s PR-time `docker build` (no build-arg) doesn't break.

## Acceptance Criteria
- [x] `build-agent.yml` passes `--build-arg AGENT_VERSION=<bare semver>` to `docker build`, computed via shell string stripping
- [x] `agent/Dockerfile`'s build stage declares `ARG AGENT_VERSION`, copies `scripts/`, and runs `sync-version.ts` after `plugins/`/`.claude-plugin/` are copied in, before the runtime stage copies them out
- [x] `sync-plugin-version.yml` (PVS-1.1) is unmodified — still the source of truth for the git-committed version; header comment updated to describe the new split of responsibilities
- [x] Existing `test-sync-plugin-version.sh` still passes (the reused prefix-stripping logic is already covered there); no new bash test file needed since no new pure-logic branch was introduced beyond that
- [ ] Manual verification after merge: confirm the next `build-agent.yml` run's image has `version.txt` matching that run's own `agent-v*` tag

## Test Plan
- `bash .github/workflows/test-sync-plugin-version.sh` — 10/10 pass (unaffected, confirms shared logic still correct)
- Simulated `sync-version.ts` invocation locally against copied fixture files with both a real version and the `0.0.0-dev` default — both produce valid output
- YAML validated via `Bun.YAML.parse`
- `docker build` itself cannot be exercised in this sandbox (no docker) — relies on `ci.yml`'s `agent-docker-build` job for real validation

Generated with [Claude Code](https://claude.com/claude-code)
