### PR TITLE
fix: dedupe CI runs to prevent stale-rerun false positive in check-patch

### DIFF
--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -675,23 +675,29 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 Poll every 30 seconds for up to **10 minutes** (20 polls max). On each poll:
 ```bash
-gh api "repos/$REPO/actions/runs?branch={branch}&per_page=10" \
-  --jq '[.workflow_runs[] | select(.head_sha == "'$HEAD_SHA'") | {id, name, status, conclusion}]'
+gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
+  --jq '[.workflow_runs[] | {id, name, workflow_id, run_number, status, conclusion}]'
 ```
 
-Filter to runs where `head_sha == HEAD_SHA`. Keep polling while any matching run has `status` of `queued`, `in_progress`, or `waiting`. If the poll times out at 10 minutes, treat it as a failure.
+Filter to runs where `head_sha == HEAD_SHA`. Keep polling while any run has `status` of
+`queued`, `in_progress`, or `waiting`. If the poll times out at 10 minutes, treat it as a failure.
+
+**Deduplicate by workflow:** When a workflow run fails and is rerun, both the original and
+rerun appear with the same `workflow_id` but different `run_number` values. Evaluate only
+the **latest run per workflow** (highest `run_number` for each `workflow_id`) to match the
+behavior of `gh pr checks`.
 
 **No CI configured:** If no matching runs appear after 60 seconds (2 polls), skip the rest of Step 9b and proceed to Step 10. Print:
 ```
 ⏭ No CI checks configured — skipping CI gate
 ```
 
-**All checks pass:** If all matching runs have `conclusion == "success"`, print and proceed to Step 10:
+**All checks pass:** If all latest-per-workflow runs have `conclusion == "success"`, print and proceed to Step 10:
 ```
 ✓ CI checks passed
 ```
 
-**Any check fails:** If any run has `conclusion != "success"` (e.g., `failure`, `cancelled`, `timed_out`), continue to 9b.3.
+**Any check fails:** If any latest-per-workflow run has `conclusion != "success"` (e.g., `failure`, `cancelled`, `timed_out`), continue to 9b.3.
 
 ### 9b.3. Collect Failure Logs
 
@@ -699,8 +705,9 @@ Initialize: `ci_checks = []` (accumulates structured check data from each failed
 
 1. Get failed run IDs from the Actions API (reuse `$REPO` and `$HEAD_SHA` from 9b.2):
    ```bash
-   gh api "repos/$REPO/actions/runs?branch={branch}&per_page=10" \
-     --jq '.workflow_runs[] | select(.head_sha == "'$HEAD_SHA'" and .conclusion == "failure") | {id, name}'
+   gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
+     --jq '.workflow_runs[] | {id, name, workflow_id, run_number, conclusion}' \
+     | jq -s 'group_by(.workflow_id) | map(max_by(.run_number)) | .[] | select(.conclusion == "failure") | {id, name}'
    ```
 
 2. For each failed run, get per-job results:

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -174,12 +174,18 @@ Store the fetched `mergeStateStatus` — do not re-fetch in Step 3c.
 For each PR not in List C (DIRTY PRs have unreliable CI until conflicts are resolved), check its CI checks:
 
 ```bash
-gh api "repos/{org}/{repo}/actions/runs?branch={branch}&per_page=10" \
-  -q '.workflow_runs[] | select(.head_sha == "{headRefOid}") | "\(.name): \(.status) \(.conclusion)"'
+gh api "repos/{org}/{repo}/actions/runs?head_sha={headRefOid}&per_page=20" \
+  -q '.workflow_runs[] | {workflow_id, run_number, conclusion}'
 ```
 
-A PR has **failing CI** when at least one workflow run matching the current HEAD SHA has
-`conclusion == "failure"` or `conclusion == "timed_out"`.
+A PR has **failing CI** when any workflow's **latest run** (highest `run_number` per
+`workflow_id`) has `conclusion == "failure"` or `conclusion == "timed_out"`.
+
+**Why deduplicate by workflow:** When a workflow run fails and is rerun, the GitHub API
+returns both the original failed run and the new rerun as separate entries with the same
+`workflow_id` but different `run_number` values. Evaluating every historical run would
+produce a false positive if an older run failed but a newer rerun passed. Deduplication
+by keeping only the latest run per workflow mirrors the behavior of `gh pr checks`.
 
 If failing CI is found, add the PR to **List D**.
 

--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { CommitInfo } from "./check-helpers.ts";
-import { run } from "./check-patch.ts";
+import { hasFailingCi, run } from "./check-patch.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -650,5 +650,46 @@ describe("check-patch", () => {
     );
     expect(result.exit).toBe(0);
     expect(result.output).toContain("patch");
+  });
+});
+
+// ─── hasFailingCi (CPC-1.1) ────────────────────────────────────────────────────
+
+describe("hasFailingCi", () => {
+  test("returns false when a workflow's earlier run failed but a later rerun (same workflow_id, higher run_number) succeeded", () => {
+    // Mirrors app-vitals/shipwright#1045: pr-title-lint run #2131 (workflow_id
+    // 290585892) failed, was rerun as run #2132 (same workflow_id, same SHA)
+    // and passed. Only the latest run per workflow should count.
+    const runs = [
+      { workflow_id: 290585892, run_number: 2131, conclusion: "failure" },
+      { workflow_id: 290585892, run_number: 2132, conclusion: "success" },
+    ];
+    expect(hasFailingCi(runs)).toBe(false);
+  });
+
+  test("returns true when the latest run for a workflow_id has conclusion 'failure'", () => {
+    const runs = [
+      { workflow_id: 1, run_number: 1, conclusion: "success" },
+      { workflow_id: 2, run_number: 1, conclusion: "failure" },
+      { workflow_id: 2, run_number: 2, conclusion: "failure" },
+    ];
+    expect(hasFailingCi(runs)).toBe(true);
+  });
+
+  test("returns true when the latest run for a workflow_id has conclusion 'timed_out'", () => {
+    const runs = [
+      { workflow_id: 1, run_number: 1, conclusion: "success" },
+      { workflow_id: 3, run_number: 5, conclusion: "timed_out" },
+    ];
+    expect(hasFailingCi(runs)).toBe(true);
+  });
+
+  test("returns false for an empty runs array", () => {
+    expect(hasFailingCi([])).toBe(false);
+  });
+
+  test("returns false for a single passing run", () => {
+    const runs = [{ workflow_id: 1, run_number: 1, conclusion: "success" }];
+    expect(hasFailingCi(runs)).toBe(false);
   });
 });

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -86,6 +86,40 @@ export interface Deps {
   getCurrentUser: () => string;
 }
 
+// ─── CI status (dedup stale reruns — CPC-1.1) ─────────────────────────────────
+
+/**
+ * Returns true if any workflow's latest run (highest run_number per
+ * workflow_id) failed or timed out.
+ *
+ * The GitHub Actions API returns one entry per *run*, not per workflow — a
+ * rerun of a failed workflow appears as an additional entry with the same
+ * workflow_id and a higher run_number, alongside the original failed entry.
+ * Evaluating every historical run at a SHA (rather than just the latest per
+ * workflow) produces a false positive when a failure was later rerun and
+ * passed. This mirrors how `gh pr checks` already reports only the latest
+ * run per check.
+ */
+export function hasFailingCi(
+  runs: {
+    workflow_id: number;
+    run_number: number;
+    conclusion: string | null;
+  }[],
+): boolean {
+  const latestByWorkflow = new Map<number, (typeof runs)[number]>();
+  for (const run of runs) {
+    const current = latestByWorkflow.get(run.workflow_id);
+    if (!current || run.run_number > current.run_number) {
+      latestByWorkflow.set(run.workflow_id, run);
+    }
+  }
+
+  return [...latestByWorkflow.values()].some(
+    (r) => r.conclusion === "failure" || r.conclusion === "timed_out",
+  );
+}
+
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
 
 /**
@@ -325,16 +359,19 @@ export async function buildProductionDeps(): Promise<Deps> {
       sha: string,
     ) => {
       type ApiResponse = {
-        workflow_runs: { status: string; conclusion: string | null }[];
+        workflow_runs: {
+          status: string;
+          conclusion: string | null;
+          workflow_id: number;
+          run_number: number;
+        }[];
       };
       try {
         const data = ghJson<ApiResponse>([
           "api",
           `repos/${org}/${repo}/actions/runs?head_sha=${sha}`,
         ]);
-        const hasFailing = data.workflow_runs.some(
-          (r) => r.conclusion === "failure" || r.conclusion === "timed_out",
-        );
+        const hasFailing = hasFailingCi(data.workflow_runs);
         return { hasFailing };
       } catch (err) {
         process.stderr.write(


### PR DESCRIPTION
## Summary
- Extract the CI-failure check out of `fetchCiStatus`'s inline `.some()` into an exported pure function `hasFailingCi(runs)` in `plugins/shipwright/scripts/check-patch.ts`
- Dedupe `workflow_runs` by `workflow_id`, keeping only the run with the highest `run_number` per workflow, and evaluate `hasFailing` from those latest runs only
- Fixes a confirmed live false positive: app-vitals/shipwright#1045 — `pr-title-lint` run #2131 failed and was rerun as run #2132 (same workflow_id, same SHA) which passed, but `fetchCiStatus` kept reporting `hasFailing: true` from the stale run #2131, causing check-patch's precheck to loop indefinitely on "Fix failing CI..." with zero actionable work
- Refreshed `patch.md` and `dev-task.md` command docs to document the same dedup-by-workflow behavior for their own CI-check API calls

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `hasFailingCi` returns false for stale-fail-then-rerun-success (shipwright#1045 case) | MET |
| 2 | `hasFailingCi` returns true for genuine failure/timed_out on latest run | MET |
| 3 | `hasFailingCi` returns false for empty array and single passing run | MET |
| 4 | Unit test only, new `describe("hasFailingCi")` block, no existing tests modified/removed | MET |

## Test Plan
- `bun test plugins/shipwright/scripts/check-patch.test.ts` — 27 pass, 0 fail (5 new `hasFailingCi` cases + all 22 pre-existing `run()` tests unaffected)
- `bunx biome lint` — clean
- `tsc --noEmit` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
