### PR TITLE
docs: skip re-review in review.md Step 14 when commit unchanged

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -771,7 +771,26 @@ review was staged:
 10. Post Slack message using the format from Step 11
 
 **If no record or record is not staged** — review it:
-3. Skip Step 3 (queue building) and go directly to Step 4 (checkout) with this
+
+3. **Check if the PR was already reviewed at the current commit** (defense-in-depth dedup):
+
+   If a record exists (from Step 14.2, `lastReviewedCommit` is non-empty), fetch the current
+   head commit:
+   ```bash
+   gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
+   ```
+   Compare to `record.commitSha` (`lastReviewedCommit`). If `headRefOid == record.commitSha`
+   (the commit has already been reviewed and there are no new commits):
+   - Print:
+     ```
+     Skipping #{pr} — already reviewed at this commit ({headRefOid[0..7]}), nothing to do.
+     ```
+   - Stop.
+
+   If no record exists (first review), or if `headRefOid` differs from `record.commitSha`
+   (new commits exist), proceed to Step 4 below.
+
+4. Skip Step 3 (queue building) and go directly to Step 4 (checkout) with this
    specific PR as the target.
 
 ---

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -774,8 +774,10 @@ review was staged:
 
 3. **Check if the PR was already reviewed at the current commit** (defense-in-depth dedup):
 
-   If a record exists (from Step 14.2, `lastReviewedCommit` is non-empty), fetch the current
-   head commit:
+   If a record exists (from Step 14.2, `lastReviewedCommit` is non-empty) AND
+   `record.reviewState` is `posted` or `approved` (a review was actually posted, not just
+   claimed and abandoned — see `release()`, which sets `reviewState: "pending"` on an
+   incomplete claim), fetch the current head commit:
    ```bash
    gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
    ```
@@ -787,8 +789,9 @@ review was staged:
      ```
    - Stop.
 
-   If no record exists (first review), or if `headRefOid` differs from `record.commitSha`
-   (new commits exist), proceed to Step 4 below.
+   If no record exists (first review), or `record.reviewState` is `pending` (claimed but
+   never completed — never actually reviewed), or `headRefOid` differs from
+   `record.commitSha` (new commits exist), proceed to Step 4 below.
 
 4. Skip Step 3 (queue building) and go directly to Step 4 (checkout) with this
    specific PR as the target.


### PR DESCRIPTION
## Summary
- Adds a same-commit dedup short-circuit to `review.md` Step 14's targeted-PR path, matching Step 3's cron-sweep behavior.
- When a task-store PR record exists and its `commitSha` matches the current `headRefOid`, the command now prints a skip message and stops instead of re-reviewing.
- Closes a defense-in-depth gap noted separately from the #1016 incident (which was already prevented by `claim()`'s 409 same-commit rejection).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 14's "no record or not staged" branch checks headRefOid against record.commitSha before proceeding to Step 4 | MET |
| 2 | If unchanged: print a clear "already reviewed at this commit, nothing to do" message (matching Step 3's messaging style) and stop | MET |
| 3 | Test decision: review.md is a procedural doc with no automated test harness for command-file bodies; verified by manual walkthrough. No test changes apply. | MET |

## Test Plan
- Manual walkthrough of all three branches: no record → proceeds to Step 4; record + unchanged headRefOid → skip message + stop; record + new commits → proceeds to Step 4.
- `bun test`, `bun run --filter='*' typecheck`, `check-config-docs`, `check-version-sync`, `check-banned-strings` all pass. Biome lint doesn't scope markdown (no-op, expected).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
