### PR TITLE
feat(chart): wire chat admin token into admin + chat deployments via chat.adminToken

### DIFF
--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.206
+version: 1.6.207
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.206 triggered by release tag agent-v0.120.0"
+      description: "wire chat admin token into admin + chat deployments via chat.adminToken"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -236,6 +236,22 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
+            {{- if and .Values.chat.enabled .Values.chat.adminToken.existingSecret }}
+            # ── Chat-service wiring ───────────────────────────────────────────
+            # Enables the admin console's Chat tab (/admin/chat) and per-agent
+            # chat-token minting during provisioning. The URL is the in-cluster
+            # chat Service; the token is the same raw value the chat service
+            # seeds at boot via CHAT_SEED_ADMIN_TOKEN, so the pair works out of
+            # the box. Override the URL via admin.extraEnv if needed (extraEnv
+            # is appended last and wins).
+            - name: SHIPWRIGHT_CHAT_SERVICE_URL
+              value: {{ printf "http://%s:%v" (include "shipwright.chat.fullname" .) .Values.chat.service.port | quote }}
+            - name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.chat.adminToken.existingSecret }}
+                  key: {{ .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+            {{- end }}
             {{- with .Values.admin.extraEnv }}
             # admin.extraEnv: caller-supplied env vars appended last so they can
             # override anything above if needed.

--- a/charts/shipwright/templates/chat-deployment.yaml
+++ b/charts/shipwright/templates/chat-deployment.yaml
@@ -55,6 +55,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.chat.database.existingSecret | default "shipwright-secrets" }}
                   key: DATABASE_URL_SHIPWRIGHT_CHAT
+            {{- if .Values.chat.adminToken.existingSecret }}
+            # Seed the admin token (stored hashed) at boot so the admin console
+            # can authenticate without manual token minting. Idempotent upsert —
+            # the same raw value is injected into the admin Deployment as
+            # SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN.
+            - name: CHAT_SEED_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.chat.adminToken.existingSecret }}
+                  key: {{ .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+            {{- end }}
             {{- with .Values.chat.extraEnv }}
             # chat.extraEnv: caller-supplied env vars appended last so they can
             # override anything above if needed.

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -359,3 +359,69 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # ── Chat-service wiring (chat.enabled + chat.adminToken) ─────────────────
+
+  - it: does not inject chat-service env by default
+    template: templates/admin-deployment.yaml
+    release:
+      name: r
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_URL
+            value: http://r-shipwright-chat:3000
+
+  - it: does not inject chat-service env when chat.enabled but adminToken unset
+    template: templates/admin-deployment.yaml
+    set:
+      chat.enabled: true
+    release:
+      name: r
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_URL
+            value: http://r-shipwright-chat:3000
+
+  - it: injects the in-cluster chat URL + admin token when chat.enabled and adminToken set
+    template: templates/admin-deployment.yaml
+    set:
+      chat.enabled: true
+      chat.adminToken.existingSecret: shipwright-secrets
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_URL
+            value: http://r-shipwright-chat:3000
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: chat admin token honors a custom secret name and key
+    template: templates/admin-deployment.yaml
+    set:
+      chat.enabled: true
+      chat.adminToken.existingSecret: my-chat-tokens
+      chat.adminToken.key: CHAT_ADMIN_RAW
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-chat-tokens
+                key: CHAT_ADMIN_RAW

--- a/charts/shipwright/tests/chat_workload_test.yaml
+++ b/charts/shipwright/tests/chat_workload_test.yaml
@@ -120,3 +120,56 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # ── Admin-token seeding (chat.adminToken) ────────────────────────────────
+
+  - it: does not inject CHAT_SEED_ADMIN_TOKEN by default (adminToken unset)
+    template: templates/chat-deployment.yaml
+    set:
+      chat.enabled: true
+    release:
+      name: r
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: seeds CHAT_SEED_ADMIN_TOKEN from chat.adminToken.existingSecret (default key)
+    template: templates/chat-deployment.yaml
+    set:
+      chat.enabled: true
+      chat.adminToken.existingSecret: shipwright-secrets
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: seeds CHAT_SEED_ADMIN_TOKEN honoring a custom secret name and key
+    template: templates/chat-deployment.yaml
+    set:
+      chat.enabled: true
+      chat.adminToken.existingSecret: my-chat-tokens
+      chat.adminToken.key: CHAT_ADMIN_RAW
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-chat-tokens
+                key: CHAT_ADMIN_RAW

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -570,9 +570,25 @@ chat:
     # Defaults to "shipwright-secrets" (the canonical cluster secret name).
     # The chart does NOT manage this Secret — create it before deploying.
     existingSecret: "shipwright-secrets"
+  # -- Admin-token wiring for the admin console's Chat tab (/admin/chat).
+  # When existingSecret is set (and chat.enabled), the chart injects the SAME
+  # raw token into both sides so the pair works out of the box:
+  #   - chat container: CHAT_SEED_ADMIN_TOKEN — the service upserts the hashed
+  #     token into its DB at every boot (idempotent)
+  #   - admin container: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN, plus
+  #     SHIPWRIGHT_CHAT_SERVICE_URL pointing at the in-cluster chat Service —
+  #     enables the Chat tab and per-agent chat-token minting on provision
+  # Empty (default) leaves both sides unwired; the Chat tab renders its
+  # "not configured" notice. The chart does NOT manage this Secret — add the
+  # key before deploying.
+  adminToken:
+    # -- Name of a pre-existing Secret holding the raw chat admin token.
+    existingSecret: ""
+    # -- Key within that Secret holding the raw token value.
+    key: "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN"
   # -- Extra env vars to inject into the chat container. Use for optional service
-  # wiring (e.g. CHAT_SEED_ADMIN_TOKEN, SHIPWRIGHT_CHAT_AGENTS_URL,
-  # SHIPWRIGHT_CHAT_AGENTS_API_KEY) without baking those into the chart template.
+  # wiring (e.g. SHIPWRIGHT_CHAT_AGENTS_URL, SHIPWRIGHT_CHAT_AGENTS_API_KEY)
+  # without baking those into the chart template.
   extraEnv: []
   # -- ServiceAccount for the chat pod. Set create: false and name: <sa>
   # to reuse an existing SA (e.g. the umbrella chart's Workload Identity SA).

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -101,9 +101,14 @@ The chat service requires:
 ```bash
 kubectl -n shipwright patch secret shipwright-secrets --type merge \
   -p "{\"stringData\":{\"SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN\":\"$(openssl rand -hex 32)\"}}"
+```
 
---set chat.enabled=true \
---set chat.adminToken.existingSecret=shipwright-secrets
+Then upgrade the chart:
+
+```bash
+helm upgrade shipwright charts/shipwright \
+  --set chat.enabled=true \
+  --set chat.adminToken.existingSecret=shipwright-secrets
 ```
 
   The chart injects the **same raw token** into both sides: the chat container

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -93,6 +93,28 @@ The chat service requires:
   `chat.database.existingSecret` (default: `shipwright-secrets`). **Must be
   separate** from the admin and task-store databases — the schema forbids sharing
   a database connection.
+- **Admin-token wiring** (`chat.adminToken`) to light up the admin console's
+  Chat tab (`/admin/chat`). Without it the tab renders "Chat service not
+  configured". Add a raw token to a Secret (key
+  `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` by default), then:
+
+```bash
+kubectl -n shipwright patch secret shipwright-secrets --type merge \
+  -p "{\"stringData\":{\"SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN\":\"$(openssl rand -hex 32)\"}}"
+
+--set chat.enabled=true \
+--set chat.adminToken.existingSecret=shipwright-secrets
+```
+
+  The chart injects the **same raw token** into both sides: the chat container
+  gets it as `CHAT_SEED_ADMIN_TOKEN` (the service upserts the SHA-256 hash into
+  its DB at every boot — idempotent), and the admin container gets it as
+  `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` plus `SHIPWRIGHT_CHAT_SERVICE_URL`
+  pointing at the in-cluster chat Service. This also enables per-agent
+  chat-token minting during agent provisioning, which injects
+  `SHIPWRIGHT_CHAT_SERVICE_URL`/`SHIPWRIGHT_CHAT_SERVICE_TOKEN` into each
+  provisioned agent pod so its chat poll loop starts. Agents provisioned
+  **before** this wiring existed need a re-provision to pick up the chat env.
 - **Optional agent scope resolution:** when agents create chat tokens, the chat
   service can query which repos a token may access. Pass these via `chat.extraEnv`
   so they land in the chat container (not admin):


### PR DESCRIPTION
## Summary

Fixes the "Chat service not configured" notice on deployed `/admin/chat` pages. The chart shipped a chat Deployment/Service but never handed the admin pod `SHIPWRIGHT_CHAT_SERVICE_URL`/`SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN`.

- New `chat.adminToken.{existingSecret,key}` values (default key `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN`, opt-in — empty by default so existing installs are untouched)
- When set (with `chat.enabled`), the **same raw token** is injected into both sides:
  - chat container: `CHAT_SEED_ADMIN_TOKEN` — service upserts the SHA-256 hash at boot (idempotent)
  - admin container: `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` + `SHIPWRIGHT_CHAT_SERVICE_URL` (in-cluster chat Service DNS)
- Side effect: admin provisioning now also mints per-agent chat tokens, so newly provisioned agents get their chat poll loop env automatically
- 7 new helm-unittest cases (default-off, wiring on, custom secret/key); deploy-kubernetes.md documents the flow

`task helm:check` green — lint clean, 231 unit tests pass, kubeconform valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SZnsPWJGCAraXStJx4nMj