### PR TITLE
docs: rename VCR/cassette terminology to recorded fixture doubles

### DIFF
--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -12,7 +12,7 @@ boundary determines which dependencies are permitted in that test.
 | Layer | Boundary rule | Framework | When to use |
 |---|---|---|---|
 | **unit** | Pure logic — no I/O of any kind. No filesystem reads, no network calls, no process spawning. | `bun test` | Functions, parsers, validators, data-transformation utilities, any code whose only inputs/outputs are in-memory values. |
-| **integration** | Real dependency behavior via recorded fixtures or injected doubles. Exercises the integration seam without a live external service. | `bun test` + recorded-fixture clients injected via DI | Service classes, client wrappers, anything that reads/writes to an external system — tested via cassette-backed `RecordedXClient` doubles instead of the real service. |
+| **integration** | Real dependency behavior via recorded fixtures or injected doubles. Exercises the integration seam without a live external service. | `bun test` + recorded-fixture clients injected via DI | Service classes, client wrappers, anything that reads/writes to an external system — tested via recorded fixture doubles (`RecordedXClient`) instead of the real service. |
 | **smoke** | Hono endpoints exercised via in-process `app.request()`. No real socket, no port allocation. | `bun test` + Hono `app.request()` | HTTP route contracts: status codes, response shapes, auth checks, error handling. Full middleware + routing pipeline without spinning up a server. |
 | **e2e** | Full browser-driven flows against a real running server. | `@playwright/test` | Multi-step user journeys through the metrics dashboard UI: navigation, rendering, data display, interaction flows. Phase B only. |
 
@@ -45,7 +45,7 @@ The plugin is pure TypeScript — no server, no database, no external HTTP in pr
 | integration | `bun test --filter plugins/shipwright` | <500 ms | <2 s | <30 s |
 
 **Notes:**
-- Integration tests inject `RecordedGithubClient` (cassette-backed) for any GitHub API calls (issue reads/writes, label operations).
+- Integration tests inject `RecordedGithubClient` (a recorded fixture double) for any GitHub API calls (issue reads/writes, label operations).
 - No smoke or e2e layer — the plugin has no HTTP surface.
 - Plugin code must remain repo-agnostic; tests must not hardcode paths to any external repository.
 
@@ -60,7 +60,7 @@ The metrics service is a stateless Hono app backed by task-store/fixture provide
 | smoke | `bun test --filter metrics` | <2 s | <10 s | <30 s |
 
 **Notes:**
-- Integration tests inject `RecordedTaskStoreClient` (cassette-backed) for task and PR queries. Cassette data lives in `metrics/src/fixtures/task-store-fixtures.ts`.
+- Integration tests inject `RecordedTaskStoreClient` (a recorded fixture double) for task and PR queries. Fixture data lives in `metrics/src/fixtures/task-store-fixtures.ts`.
 - Smoke tests drive the Hono app via `app.request()` — no real socket, no `fetch()` to localhost. Import the app factory and call `app.request(new Request(...))` directly.
 - No e2e layer until Phase B ships a browser-rendered dashboard. E2e layer added then via Playwright.
 - Tests run offline by default with no external service URLs configured.
@@ -130,6 +130,7 @@ The agent is a thin runner with a Prisma-backed PostgreSQL database and a Hono H
 
 - **Layer order:** unit → integration → smoke → e2e. A lower-layer failure skips higher layers (fail-fast).
 - **Parallelism:** unit and integration run in parallel across packages. Smoke layers (metrics + agent) run in parallel with each other, sequentially after all integration jobs pass.
+- **Test-DB service container:** CI provisions a real `postgres:16` service container (see `.github/workflows/ci.yml`) for any DB-backed integration/smoke test (e.g., the agent's DB integration suite) — never a mocked or in-memory Postgres substitute.
 
 ## Speed budgets (consolidated)
 
@@ -150,7 +151,7 @@ The agent is a thin runner with a Prisma-backed PostgreSQL database and a Hono H
 
 **Time:** Any production code path that calls `new Date()` or `Date.now()` non-trivially must accept a `Clock` interface. Tests inject `FixedClock(t)`. Raw `Date.now()` in a code path under test is a bug — it makes time-sensitive assertions flaky.
 
-**External HTTP:** External service clients (`SlackClient`, `GithubClient`, etc.) are defined as interfaces with an `Http*Client` production implementation. Tests inject `Recorded*Client` doubles that replay cassettes from `tests/fixtures/<service>/*.json`. Cassette files are versioned JSON committed to the repository.
+**External HTTP:** External service clients (`SlackClient`, `GithubClient`, etc.) are defined as interfaces with an `Http*Client` production implementation. Tests inject `Recorded*Client` recorded fixture doubles that replay fixture data from `tests/fixtures/<service>/*.json`. Fixture files are versioned JSON committed to the repository.
 
 **No global state:** Tests must not mutate module-level globals, override built-in globals, or rely on test-execution order. Each test is independently runnable.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,7 +67,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 ## Test isolation contract (hard rules)
 
 - **Time:** any production code path that calls `new Date()` / `Date.now()` non-trivially must accept a `Clock` interface; tests inject `FixedClock(t)`. Raw `Date.now()` in code under test is a bug.
-- **External HTTP:** service clients (`TaskStoreClient`, `GithubClient`, …) are interfaces with an `Http*Client` production impl; tests inject `Recorded*Client` doubles replaying cassettes from `tests/fixtures/<service>/*.json` (versioned JSON committed to the repo).
+- **External HTTP:** service clients (`TaskStoreClient`, `GithubClient`, …) are interfaces with an `Http*Client` production impl; tests inject `Recorded*Client` recorded fixture doubles replaying fixture data from `tests/fixtures/<service>/*.json` (versioned JSON committed to the repo).
 - **No global state:** **no `mock.module()`**, **no `global.fetch` / `global.*` overrides.** Bun runs test files in the same process, so module-level mocks and global mutation leak across sibling suites. Each test must be independently runnable, order-independent.
 - **Offline by default:** no live external calls. Live external service credentials must be absent for metrics unit/integration/smoke tests; `DATABASE_URL_ADMIN_TEST` must be set to a Postgres connection string for agent DB integration tests (suites skip automatically when the var is absent).
 

--- a/plugins/shipwright/skills/repo-config/SKILL.md
+++ b/plugins/shipwright/skills/repo-config/SKILL.md
@@ -39,7 +39,7 @@ For each external integration named in the inventory, list the GitHub secret nee
 Minimum set for the test pipeline:
 - `TEST_CANARY_API_KEY` — scoped canary auth token
 - `TEST_TARGET_URL` per environment (often set in the workflow, not as a secret)
-- Per-external: `<SERVICE>_API_KEY` (used only if recording new cassettes)
+- Per-external: `<SERVICE>_API_KEY` (used only if recording new fixtures)
 - Per-environment GitHub Environments (`staging`, `production`) with required reviewers if promotion is gated
 
 ### 3. Deploy hooks
@@ -58,11 +58,13 @@ See [`references/deploy-canary-promote.md`](./references/deploy-canary-promote.m
 
 A PR template (`.github/pull_request_template.md`) can enforce the verification-output convention via a checklist.
 
-### 5. Cassette maintenance loop
+### 5. Recorded-fixture maintenance loop (deferred)
 
-Recorded fixtures (VCR cassettes, msw handlers, nock recordings) capture the shape of third-party API responses at a point in time. Without scheduled re-recording, cassettes go stale silently — the test suite stays green while the live integration is broken. A maintenance loop catches this before production does.
+Recorded fixture doubles (msw handlers, nock recordings, hand-authored JSON) capture the shape of third-party API responses at a point in time. Without scheduled re-recording, recorded fixtures go stale silently — the test suite stays green while the live integration is broken. A maintenance loop catches this before production does.
 
-See the [full cassette maintenance loop pattern](#cassette-maintenance-loop) below for implementation details.
+**Status: deferred — not implemented.** The auto-recording GitHub Actions pattern below is a target design, not built tooling. Do not wire it up until the manual, hand-authored-fixture workflow is running and tuned.
+
+See the [full recorded-fixture maintenance loop pattern](#recorded-fixture-maintenance-loop-deferred) below for implementation details (deferred).
 
 ## The pairing rule (Phase 4 — test-roadmap)
 
@@ -113,18 +115,20 @@ A `## Repo configuration tasks` block listed alongside the test tasks. By defaul
 
 A `## Closing checklist` section at the bottom.
 
-## Cassette maintenance loop
+## Recorded-fixture maintenance loop (deferred)
 
-Recorded fixtures (VCR cassettes, msw handlers, nock recordings) capture the shape of third-party API responses at a point in time. Without scheduled re-recording, cassettes go stale silently — the test suite passes while the integration is broken in production. A cassette maintenance loop catches drift weekly before it becomes a production incident.
+> **Deferred — not implemented.** This section documents the target auto-recording design (a scheduled GitHub Actions workflow). None of this tooling — the workflow, the environment, the re-record scripting — has been built yet. Defer implementation until the manual, hand-authored-fixture workflow is running and tuned.
+
+Recorded fixture doubles (msw handlers, nock recordings, hand-authored JSON) capture the shape of third-party API responses at a point in time. Without scheduled re-recording, recorded fixtures go stale silently — the test suite passes while the integration is broken in production. A recorded-fixture maintenance loop catches drift weekly before it becomes a production incident.
 
 ### Where the cron lives
 
-A dedicated GitHub Actions workflow `.github/workflows/cassette-refresh.yml` on a weekly schedule (e.g., `cron: '0 9 * * 1'` — Mondays at 09:00 UTC). The job:
+A dedicated GitHub Actions workflow `.github/workflows/recorded-fixture-refresh.yml` (not yet created) on a weekly schedule (e.g., `cron: '0 9 * * 1'` — Mondays at 09:00 UTC). The job:
 
 1. Checks out the repo
-2. Runs re-record mode for each service that has cassettes (typically `RECORD_MODE=all bun test` or the VCR/msw equivalent)
+2. Runs re-record mode for each service that has recorded fixtures (typically `RECORD_MODE=all bun test` or the msw/nock equivalent)
 3. Checks `git diff` for any changed fixture files
-4. If diff is non-empty: opens a PR titled `chore: refresh cassettes (auto)` via `gh pr create`, with a `git diff --stat` summary and one expanded hunk in the body
+4. If diff is non-empty: opens a PR titled `chore: refresh recorded fixtures (auto)` via `gh pr create`, with a `git diff --stat` summary and one expanded hunk in the body
 5. If diff is empty: exits 0 silently
 
 ### What triggers re-recording
@@ -133,16 +137,16 @@ A dedicated GitHub Actions workflow `.github/workflows/cassette-refresh.yml` on 
 |---|---|
 | Scheduled cron | Weekly (always) |
 | Manual `workflow_dispatch` | When a third-party publishes a breaking-change notice |
-| Feature-branch CI | Never — cassettes are not re-recorded on PRs (avoids network flake) |
+| Feature-branch CI | Never — recorded fixtures are not re-recorded on PRs (avoids network flake) |
 
-The re-record job authenticates against the real third-party APIs using credentials stored in a dedicated `cassette-refresh` GitHub Environment. This environment has narrower permissions than `production` and is not shared with integration test runs.
+The re-record job authenticates against the real third-party APIs using credentials stored in a dedicated `recorded-fixture-refresh` GitHub Environment. This environment has narrower permissions than `production` and is not shared with integration test runs.
 
 ### How diff alerts are surfaced
 
 | Scenario | Outcome |
 |---|---|
 | No diff | Silent pass — no PR, no noise |
-| Diff detected | PR opened, tagged `cassette-refresh`, body includes diff stat + one expanded hunk |
+| Diff detected | PR opened, tagged `recorded-fixture-refresh`, body includes diff stat + one expanded hunk |
 | API call fails during re-record | Workflow fails; GitHub sends default failure notification to repo watchers |
 | Open refresh PR already exists | Skip creation — check for existing open PR with same title before calling `gh pr create` |
 
@@ -152,14 +156,14 @@ The re-record job authenticates against the real third-party APIs using credenti
 
 Include in the **Required secrets and environments** section of the `test-system.md` artifact:
 
-- **GitHub Environment:** `cassette-refresh` — no required reviewers (cron runs unattended), restricted to the `cassette-refresh.yml` workflow
+- **GitHub Environment:** `recorded-fixture-refresh` — no required reviewers (cron runs unattended), restricted to the `recorded-fixture-refresh.yml` workflow
 - **Secrets in this environment:** one per external integration (`STRIPE_TEST_API_KEY`, `SENDGRID_API_KEY`, etc.)
-- The `cassette-refresh` workflow runs on `main` and submits PRs — it is safe to enable before branch protection is configured
+- The `recorded-fixture-refresh` workflow runs on `main` and submits PRs — it is safe to enable before branch protection is configured
 
 Include in the **test-readiness-plan.md** task list (M1):
 
-- One task per external HTTP dependency that has cassettes: "Wire cassette-refresh cron for `<service>`"
-- One task: "Add `cassette-refresh` GitHub Environment + secrets"
+- One task per external HTTP dependency that has recorded fixtures: "Wire recorded-fixture-refresh cron for `<service>`"
+- One task: "Add `recorded-fixture-refresh` GitHub Environment + secrets"
 
 These tasks depend on the same-layer "record fixtures for `<service>`" task, not on branch protection.
 
@@ -170,6 +174,6 @@ These tasks depend on the same-layer "record fixtures for `<service>`" task, not
 - **Admin exemption without a break-glass policy.** Exempting admins is fine if there's a documented "in case of fire" procedure; otherwise it's an unmonitored backdoor.
 - **Secrets baked into workflows.** Use GitHub Secrets + Environments. Workflow YAML references `${{ secrets.X }}`, never literal values.
 - **No PR template.** Closing checklists in issue bodies help, but PRs without a template forget the verification-output convention within weeks.
-- **Committing cassette diffs directly to main.** The refresh job must always open a PR, never push directly — the diff must be reviewed.
+- **Committing recorded-fixture diffs directly to main.** The refresh job must always open a PR, never push directly — the diff must be reviewed.
 - **Re-recording on every CI run.** Network calls in CI create flake, inflate build times, and burn third-party rate limits. Re-record on schedule only.
-- **Sharing cassette-refresh credentials with CI integration tests.** Integration tests should use read-only scoped tokens. Re-record credentials are broader — keep them scoped to the `cassette-refresh` environment.
+- **Sharing recorded-fixture-refresh credentials with CI integration tests.** Integration tests should use read-only scoped tokens. Re-record credentials are broader — keep them scoped to the `recorded-fixture-refresh` environment.

--- a/plugins/shipwright/skills/test-design/SKILL.md
+++ b/plugins/shipwright/skills/test-design/SKILL.md
@@ -45,8 +45,8 @@ For every external dependency named in the inventory, prescribe a **local substi
 | Postgres / MySQL | Real DB per test run (testcontainers or a dedicated test DB). **Pattern:** wrap ORM calls in a typed service layer (interface + implementation); integration tests hit a real DB through that interface; unit tests mock the interface. Never mock the DB itself at the SQL or ORM level — that mocks the wrong thing. |
 | Redis | testcontainers / in-memory shim |
 | S3 / blob storage | localstack / minio |
-| Internal HTTP service | Cassettes (VCR / msw / nock) by default — they're faster and require no service infra. If the service ships a Go/TS client interface, prefer mocking that interface over mocking the wire protocol. Inline service or docker-compose only when cassettes are impractical (e.g., bidirectional streaming). |
-| Third-party HTTP API | Cassettes (VCR / msw / nock) — never live. Requires a cassette maintenance loop (see `repo-config/SKILL.md`) — without weekly re-recording, cassettes go stale silently. |
+| Internal HTTP service | Recorded fixture doubles (msw / nock / hand-authored JSON) by default — they're faster and require no service infra. If the service ships a Go/TS client interface, prefer mocking that interface over mocking the wire protocol. Inline service or docker-compose only when recorded fixture doubles are impractical (e.g., bidirectional streaming). |
+| Third-party HTTP API | Recorded fixture doubles (msw / nock / hand-authored JSON) — never live. Requires a recorded-fixture maintenance loop (see `repo-config/SKILL.md` — deferred, not yet implemented) — without periodic re-recording, recorded fixtures go stale silently. |
 | SMTP / email | mailhog / capture-only |
 | Webhook receiver | local HTTP listener (e.g., smee / ngrok-recorded) |
 
@@ -130,7 +130,7 @@ List the test-support code the implementation will need:
 Reference `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md` and include a **Repo configuration** section in the artifact covering:
 
 - **Branch protection** rule definition for `main` — required status checks (every layer-relevant CI job from the pipeline shape above), required reviews, conversation resolution, admin enforcement decision
-- **Required secrets** — `TEST_CANARY_API_KEY`, per-external service auth tokens (for cassette recording), staging/prod deploy credentials
+- **Required secrets** — `TEST_CANARY_API_KEY`, per-external service auth tokens (for recorded-fixture recording), staging/prod deploy credentials
 - **Required GitHub Environments** — `staging`, `production` with reviewer gates
 - **PR template recommendation** — `.github/pull_request_template.md` with a Closing Checklist that requires the verification-command output
 

--- a/plugins/shipwright/test/fixture-terminology-content.unit.test.ts
+++ b/plugins/shipwright/test/fixture-terminology-content.unit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Cassette/VCR terminology rename regression guard — PRN-1.2
+ *
+ * Verifies docs/testing.md, docs/test-readiness/test-system.md,
+ * skills/test-design/SKILL.md, and skills/repo-config/SKILL.md use
+ * "recorded fixture doubles" terminology instead of "VCR"/"cassette"
+ * (mirrors plugins/shipwright/test/principles-content.unit.test.ts, PRN-1.1).
+ *
+ * Content-assertion only: readFileSync, no I/O beyond local file reads.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/test/ → repo root
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+function repoPath(...parts: string[]): string {
+  return join(repoRoot, ...parts);
+}
+
+const TARGET_FILES = [
+  "docs/testing.md",
+  "docs/test-readiness/test-system.md",
+  "plugins/shipwright/skills/test-design/SKILL.md",
+  "plugins/shipwright/skills/repo-config/SKILL.md",
+] as const;
+
+function readTarget(path: string): string {
+  return readFileSync(repoPath(path), "utf8");
+}
+
+describe("fixture terminology rename — no cassette/VCR", () => {
+  for (const path of TARGET_FILES) {
+    it(`${path} does not contain 'cassette' (case-insensitive)`, () => {
+      expect(readTarget(path).toLowerCase()).not.toContain("cassette");
+    });
+
+    it(`${path} does not contain 'VCR' (case-insensitive)`, () => {
+      expect(readTarget(path).toLowerCase()).not.toContain("vcr");
+    });
+
+    it(`${path} uses 'recorded fixture double' terminology`, () => {
+      expect(readTarget(path).toLowerCase()).toContain("recorded fixture double");
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Renames VCR/cassette terminology to "recorded fixture doubles" across docs/testing.md, docs/test-readiness/test-system.md, skills/test-design/SKILL.md, and skills/repo-config/SKILL.md
- Marks the cassette-refresh auto-recording GitHub Actions pattern in repo-config/SKILL.md as deferred/not-implemented (the tooling — msw/nock, a refresh workflow — was never actually built)
- Documents the existing `postgres:16` test-DB service container as an explicit required CI ingredient in test-system.md's CI pipeline shape section (no CI change — ci.yml already provisions it)
- Adds a regression test asserting none of the four files contain "cassette" or "VCR"

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Zero occurrences of 'VCR' or 'cassette' in the four target files | MET | Verified via case-insensitive grep across all four files — zero matches |
| 2 | Cassette-refresh auto-recording pattern removed or marked deferred | MET | repo-config/SKILL.md section explicitly marked "(deferred)" with a "Status: deferred — not implemented" blockquote |
| 3 | test-system.md CI pipeline shape section names test-DB service container | MET | New bullet: "CI provisions a real `postgres:16` service container... never a mocked or in-memory Postgres substitute" |
| 4 | Unit test asserting no cassette/VCR remains, no existing tests retired | MET | `plugins/shipwright/test/fixture-terminology-content.unit.test.ts` — 12 assertions across the 4 files, no existing tests removed |

## Test Plan
- `bun test plugins/shipwright/test/fixture-terminology-content.unit.test.ts` — 12/12 pass
- `bun run --filter='./plugins/shipwright' typecheck` — passes
- `bunx biome lint docs/ plugins/shipwright/` — passes
- Full `bun test` run has pre-existing unrelated failures (confirmed present on origin/main as well — installPlugins/k8s-client env issues, not caused by this change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
