### PR TITLE
fix(ci): resolve base SHA before dorny/paths-filter to fix invalid-refspec bug

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -22,11 +22,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
+      - name: Resolve base SHA
+        id: base
+        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          base: ${{ github.event.workflow_run.head_sha }}~1
+          base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             changed:

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -22,11 +22,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
+      - name: Resolve base SHA
+        id: base
+        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          base: ${{ github.event.workflow_run.head_sha }}~1
+          base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             changed:

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -22,11 +22,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
+      - name: Resolve base SHA
+        id: base
+        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          base: ${{ github.event.workflow_run.head_sha }}~1
+          base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             changed:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -22,11 +22,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
+      - name: Resolve base SHA
+        id: base
+        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          base: ${{ github.event.workflow_run.head_sha }}~1
+          base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             changed:

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -22,11 +22,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
+      - name: Resolve base SHA
+        id: base
+        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          base: ${{ github.event.workflow_run.head_sha }}~1
+          base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             changed:


### PR DESCRIPTION
## Summary
- All 5 `Build and Push *Image` workflows (admin, agent, chat, metrics, task-store) have been failing on essentially every merge to main since PR #1019: `dorny/paths-filter@v3` was given `base: ${{ head_sha }}~1`, a relative-revision expression, and the action's fallback `git fetch --depth=100 origin <sha>~1 <sha>` rejects it as an invalid refspec (exit 128) — regardless of the job's `fetch-depth: 0` checkout already having the commit locally.
- Adds a "Resolve base SHA" step that runs `git rev-parse <sha>~1` locally and passes the resulting literal SHA to `paths-filter`'s `base:` input, so the action never sees `~1` syntax.
- No changes to triggers, permissions, secrets, or per-file path filters — purely additive.

## Acceptance Criteria
- [x] All 5 build-*.yml filter jobs gain a "Resolve base SHA" step whose output feeds dorny/paths-filter's `base:` as a literal SHA, not `head_sha~1`
- [x] No other behavior changes: same `workflow_run` trigger, same `head_branch == 'main'` gate, same per-file path filters, same downstream `build-and-push` job
- [x] Test decision: no unit/integration test layer applies (CI workflow YAML only) — verification is operational, see Test Plan below
- [x] Safe to deploy standalone: yes — purely additive step, no renames/removals

## Test Plan
- No automated test layer applies to workflow YAML. Verification: after merge, re-run a previously-failed run's filter job (e.g. `gh run rerun 28668155031 --job <filter-job-id>`) — `workflow_run`-triggered workflows resolve their YAML from the default branch at run time, so a rerun should pick up this fix immediately. Falling back to watching the next real merge if that doesn't apply cleanly.
- [x] Manually diffed all 5 files — identical, minimal, mechanical change

Generated with [Claude Code](https://claude.com/claude-code)
