### PR TITLE
fix(ci): add build-agent.yml to its own path filter

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -39,6 +39,7 @@ jobs:
               - ".claude-plugin/**"
               - "package.json"
               - "bun.lock"
+              - ".github/workflows/build-agent.yml"
 
   build-and-push:
     name: build / tag / push


### PR DESCRIPTION
## Summary
- `build-agent.yml` was the only one of the 5 Build-and-Push workflows whose path filter didn't include its own workflow file — `build-admin.yml`, `build-chat.yml`, `build-metrics.yml`, and `build-task-store.yml` all self-reference.
- This asymmetry meant PFR-1.1's fix commit (which edited all 5 workflow files) triggered real rebuilds for admin/chat/metrics/task-store but correctly skipped agent, since agent's filter saw no relevant diff in that commit.
- As a result, no agent image has built successfully since before the paths-filter incident (~09:52 today), leaving already-merged `plugins/**` changes (CPF-1.2, PRN-1.1) sitting on main but never packaged into a pushed image.
- Adds `.github/workflows/build-agent.yml` to its own filter list, matching the other 4 files. Real consistency fix, not just a trigger hack — and it will cause the next merge (including this one) to correctly rebuild the agent image, capturing everything currently pending.

## Acceptance Criteria
- [x] build-agent.yml's filter list includes `.github/workflows/build-agent.yml`, matching the other 4 workflows
- [x] No other changes: same trigger, same other filter paths, same build-and-push job
- [x] Test decision: no unit/integration test layer applies (CI workflow YAML only) — verification is operational, see Test Plan
- [x] Safe to deploy standalone: yes — purely additive filter entry

## Test Plan
- After merge, confirm this PR's own merge commit causes the Build and Push Agent Image workflow's `build-and-push` job to actually execute (not skipped) and push a new `agent-vX.Y.Z` tag — since this file is now in its own filter, that should happen immediately.

Generated with [Claude Code](https://claude.com/claude-code)
