### PR TITLE
feat: repoint entropy-scan/entropy-fix to principles.md

### DIFF
--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: entropy-fix
-description: Read entropy-report.md, fix pr_worthy violations, and open targeted PRs. One PR per concern. Requires entropy-scan to have run first.
+description: Read entropy-report.md, fix PR-worthy violations, and open targeted PRs. One PR per concern. Requires entropy-scan to have run first.
 ---
 
 # Entropy Fix
 
-Read the latest `entropy-report.md` and open focused, human-reviewable PRs for `pr_worthy` violations. Each PR fixes one rule — no bundled concerns, max 3 files changed per PR.
+Read the latest `entropy-report.md` and open focused, human-reviewable PRs for `PR-worthy` violations. Each PR fixes one rule — no bundled concerns, max 3 files changed per PR.
 
 **Prerequisites:** Run `/entropy-scan` first to produce `entropy-report.md`.
 
@@ -35,28 +35,29 @@ Before starting, check for flags:
 
 ---
 
-## Step 2: Load Golden Principles
+## Step 2: Load Principles
 
-Load the same golden principles config that the scan used:
+Load the same principles file that the scan used, filtered the same way:
 
-1. Check `.claude/entropy-patrol/golden-principles.yaml` in the project root. If it exists, load it.
-2. Otherwise, load the plugin default: `skills/entropy-scan/golden-principles.yaml`.
-3. Build a map of `rule_id → rule` for quick lookup (needed for `pr_worthy` status and PR body generation).
+1. Check `.claude/shipwright/principles.md` in the project root. If it exists, load it.
+2. Otherwise, load the plugin default: `references/principles.md` (relative to the plugin root).
+3. Filter to only entries containing a `**Detection:**` field — the same entropy-scannable set `/entropy-scan` used.
+4. Build a map of `rule_id → entry` for quick lookup (needed for `PR-worthy` status and PR body generation).
 
 ---
 
 ## Step 3: Filter and Group Findings
 
 1. Parse the report's `## Findings` section. Collect all unchecked (`- [ ]`) findings.
-2. Filter to only findings whose rule has `pr_worthy: true` in the golden principles config.
+2. Filter to only findings whose entry has `**PR-worthy:** true` in the principles file.
 3. If `--rule` flag was passed, further filter to only that rule's findings. If no findings match that rule ID, print: "No unchecked findings for rule `{rule_id}`. Nothing to fix." and stop.
 4. Group findings by `rule_id`. One PR will be opened per group.
 5. Sort groups: high-severity rules first, then medium, then low.
-6. If no `pr_worthy` unchecked findings exist, print:
+6. If no `PR-worthy` unchecked findings exist, print:
    ```
-   No pr_worthy findings to fix. All violations are either:
+   No PR-worthy findings to fix. All violations are either:
    - Already checked off (fixed)
-   - In categories marked pr_worthy: false (fix manually)
+   - In entries marked PR-worthy: false (fix manually)
    Run /entropy-scan to refresh the report.
    ```
    Then stop.
@@ -122,7 +123,7 @@ Stop after printing.
 If there are more than 10 rule groups to fix, note:
 
 ```
-Found {N} rules with pr_worthy findings. Capping at 10 PRs per run.
+Found {N} rules with PR-worthy findings. Capping at 10 PRs per run.
 Fixing highest-severity rules first. Re-run after merging to continue.
 ```
 
@@ -178,9 +179,9 @@ Findings ({count} total):
 - {file_path}:{line} — {finding_description}
 {Include ALL findings. If there are more than 20, include the first 20 and append: "(+N more — re-run /entropy-fix to see all)"}
 
-Fix guidance: {rule.detection_hint or remediation guidance from the golden principles config}
+Fix guidance: {rule.detection_hint or remediation guidance from the principles file}
 
-Rule: {rule.id} | Severity: {rule.severity} | Category: {rule.category}
+Rule: {rule.id} | Severity: {rule.severity} | Domain: {rule.domain}
 ```
 
 The `{YYYY-Www}` suffix in the task ID uses ISO week format. Compute from the current date:
@@ -279,7 +280,7 @@ PR body format:
 ```markdown
 ## Entropy Fix: {rule.description}
 
-**Golden Principle:** `{rule.id}` ({rule.severity})
+**Principle:** `{rule.id}` ({rule.severity})
 **Findings fixed:** {count}
 
 ### What was changed
@@ -361,5 +362,5 @@ entropy-report.md updated with fixed findings checked off.
 - **No auto-merge** — PRs always require human review before merge.
 - **No cascade** — only fix what's in the current `entropy-report.md`. Do not re-scan during a fix run.
 - **Sequential branches** — create branches one at a time. Parallel branch creation causes git conflicts.
-- **No golden-principles.yaml changes** — the fix skill enforces rules, it does not modify them.
+- **No principles.md changes** — the fix skill enforces principles, it does not modify them.
 - **Confirmation required for high-severity destructive ops** — never skip this gate.

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -179,7 +179,7 @@ Findings ({count} total):
 - {file_path}:{line} — {finding_description}
 {Include ALL findings. If there are more than 20, include the first 20 and append: "(+N more — re-run /entropy-fix to see all)"}
 
-Fix guidance: {rule.detection_hint or remediation guidance from the principles file}
+Fix guidance: {entry's **Detection:** field, or remediation guidance from the principles file}
 
 Rule: {rule.id} | Severity: {rule.severity} | Domain: {rule.domain}
 ```

--- a/plugins/shipwright/skills/entropy-scan/SKILL.md
+++ b/plugins/shipwright/skills/entropy-scan/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: entropy-scan
-description: Scan codebase for golden principle deviations. Report only — no code changes.
+description: Scan codebase for principle deviations. Report only — no code changes.
 ---
 
 # Entropy Scan
 
-Scan the codebase for golden principle violations and write a structured report. This skill makes **no code changes** — it reads and reports only. Use `/entropy-fix` to act on the findings.
+Scan the codebase for principle violations and write a structured report. This skill makes **no code changes** — it reads and reports only. Use `/entropy-fix` to act on the findings.
 
 ---
 
@@ -13,7 +13,7 @@ Scan the codebase for golden principle violations and write a structured report.
 
 Before starting, check if any flags were passed:
 
-- `--init` — copy the default golden principles config to the project and exit (no scan)
+- `--init` — copy the default principles file to the project and exit (no scan)
 - `--summary` — print category counts to stdout; skip writing `entropy-report.md` or `quality-log.jsonl`
 - `--trend` — read `.entropy-patrol/quality-log.jsonl` and print a trend summary; skip the scan entirely
 
@@ -69,24 +69,24 @@ MOST WORSENING:  {rule_id} (▲ {N} violations)   {or "none — all rules stable
 
 If the `--init` flag was passed:
 
-1. Check if `.claude/entropy-patrol/golden-principles.yaml` already exists in the project root.
-   - If it exists, print: "Config already exists at `.claude/entropy-patrol/golden-principles.yaml`. Edit it to customize rules for this project." and stop.
-2. If it does not exist, create the directory and copy the default config:
-   - Source: `skills/entropy-scan/golden-principles.yaml` (relative to this skill file — the plugin's own default config)
-   - Destination: `.claude/entropy-patrol/golden-principles.yaml` in the project root
-3. Print: "Created `.claude/entropy-patrol/golden-principles.yaml`. Edit it to customize rules for this project. Re-run `/entropy-scan` to start scanning."
+1. Check if `.claude/shipwright/principles.md` already exists in the project root.
+   - If it exists, print: "Config already exists at `.claude/shipwright/principles.md`. Edit it to customize principles for this project." and stop.
+2. If it does not exist, create the directory and copy the default principles file:
+   - Source: `references/principles.md` (relative to the plugin root — the plugin's own shared principles file)
+   - Destination: `.claude/shipwright/principles.md` in the project root
+3. Print: "Created `.claude/shipwright/principles.md`. Edit it to customize principles for this project. Re-run `/entropy-scan` to start scanning."
 4. Stop — do not run the scan.
 
 ---
 
-## Step 2: Load Golden Principles
+## Step 2: Load Principles
 
-1. Check for a project-level override: `.claude/entropy-patrol/golden-principles.yaml` in the project root.
-2. If it exists, load it. Print: "Using project config: `.claude/entropy-patrol/golden-principles.yaml`"
-3. If it does not exist, load the plugin default: `skills/entropy-scan/golden-principles.yaml` (relative to this skill file). Print: "No project config found. Using default golden principles. Run `/entropy-scan --init` to customize."
-4. If neither file exists, print: "No golden principles found. Run `/entropy-scan --init` to get started." and stop.
-5. Parse the YAML. Read the `rules` list and the `todo_max_age_days` global config (default: 90).
-6. Filter out any rules where `disabled: true`. Print the count of active rules.
+1. Check for a project-level override: `.claude/shipwright/principles.md` in the project root.
+2. If it exists, load it. Print: "Using project config: `.claude/shipwright/principles.md`"
+3. If it does not exist, load the plugin default: `references/principles.md` (relative to the plugin root). Print: "No project config found. Using default principles. Run `/entropy-scan --init` to customize."
+4. If neither file exists, print: "No principles found. Run `/entropy-scan --init` to get started." and stop.
+5. Parse the markdown. Each `###` heading starting a rule entry; read its `**Domain:**`, `**Severity:**`, prose statement, and (if present) `**Detection:**`, `**PR-worthy:**`, and `**HITL:**` fields. `todo_max_age_days` defaults to 90 (no per-project override in this format — a project's `.claude/shipwright/principles.md` override can adjust the `stale_todo` entry's own Detection text if a different threshold is needed).
+6. **Filter to only entries containing a `**Detection:**` field** — these are the entropy-scannable rules; everything else is judgment-only (read by `review`/`plan-session`/`dev-task`, never mechanically scanned). Map each scannable entry's `**Domain:**` to a report category: `security` → `security`, `dead_code` → `dead_code`, `todo_debt` → `todo_debt`, `architecture` → `inconsistent_patterns`, `docs` → `documentation_gaps`. Print the count of scannable entries.
 
 ---
 
@@ -103,11 +103,10 @@ For each active rule (in order: security first, then high → medium → low sev
 
 **Order of categories:**
 1. `security` (highest stakes — always first)
-2. `missing_tests`
-3. `dead_code`
-4. `todo_debt`
-5. `inconsistent_patterns`
-6. `documentation_gaps`
+2. `dead_code`
+3. `todo_debt`
+4. `inconsistent_patterns`
+5. `documentation_gaps`
 
 Within each category, process high-severity rules before medium before low.
 
@@ -124,14 +123,13 @@ Write `entropy-report.md` to the project root (overwrite if it exists). Format:
 
 **Generated:** {YYYY-MM-DD HH:MM} {timezone}
 **Config:** {project override path | "plugin default"}
-**Rules scanned:** {count active rules} / {count total rules}
+**Rules scanned:** {count scannable entries} / {count total entries}
 
 ## Summary
 
 | Category | High | Medium | Low | Total |
 |----------|------|--------|-----|-------|
 | security | N | N | N | N |
-| missing_tests | N | N | N | N |
 | dead_code | N | N | N | N |
 | todo_debt | N | N | N | N |
 | inconsistent_patterns | N | N | N | N |
@@ -162,7 +160,7 @@ Write `entropy-report.md` to the project root (overwrite if it exists). Format:
 {List any categories or rules with zero findings here, as a quick confirmation they were checked.}
 
 ---
-_Run `/entropy-fix` to open PRs for `pr_worthy: true` violations._
+_Run `/entropy-fix` to open PRs for `PR-worthy: true` violations._
 _Run `/entropy-scan --init` to create a project-level config for rule customization._
 ```
 
@@ -171,7 +169,7 @@ Rules:
 - Each finding is a checkbox (`- [ ]`) so `/entropy-fix` can track which ones have been addressed
 - Include line numbers when available: `- [ ] \`{file_path}:{line_number}\` — {description} _{effort}_`
 - For file-level findings (no line number): `- [ ] \`{file_path}\` — {description} _{effort}_`
-- The "No Violations" section at the bottom lists all active rules where nothing was found — this confirms the rule ran and passed. Disabled rules do not appear anywhere in the report.
+- The "No Violations" section at the bottom lists all scannable entries where nothing was found — this confirms the entry ran and passed. Entries omitted from a project's `.claude/shipwright/principles.md` override do not appear anywhere in the report.
 
 ---
 
@@ -196,7 +194,7 @@ TOP ISSUES
   {severity} · {rule_id} · {file_path} — {description}
 
 {If any high-severity findings exist:}
-  ⚠️  Run /entropy-fix to open PRs for pr_worthy violations.
+  ⚠️  Run /entropy-fix to open PRs for PR-worthy violations.
 
 {If zero findings:}
   ✓ No violations found. Codebase is clean against active rules.
@@ -247,7 +245,7 @@ Schema reference: `skills/entropy-scan/references/quality-log-schema.md`
 - **No git operations.** Do not commit, branch, or stage anything.
 - **No PR creation.** That belongs to `/entropy-fix`.
 - **No network calls.** All detection is local file inspection.
-- **Respect `disabled: true`.** Never scan a disabled rule — not even "just to check."
+- **Respect the project override.** If a project's `.claude/shipwright/principles.md` omits an entry present in the plugin default, treat it as not scanned — not even "just to check."
 - **One scan, one report.** Each run fully overwrites `entropy-report.md`. Previous results are not preserved.
 - **Quality log is append-only.** Never overwrite or truncate `.entropy-patrol/quality-log.jsonl`. Appends only.
 - **`--summary` skips log.** When `--summary` is passed, no log entry is written (no report = no log entry).

--- a/plugins/shipwright/skills/entropy-scan/references/customization.md
+++ b/plugins/shipwright/skills/entropy-scan/references/customization.md
@@ -1,6 +1,7 @@
-# Customizing Golden Principles
+# Customizing Principles
 
-entropy-patrol ships with a default ruleset (`skills/entropy-scan/golden-principles.yaml`). You can customize it per project without modifying the plugin.
+Shipwright ships a default principles file (`references/principles.md`, relative to the
+plugin root). You can customize it per project without modifying the plugin.
 
 ---
 
@@ -9,66 +10,72 @@ entropy-patrol ships with a default ruleset (`skills/entropy-scan/golden-princip
 Create a file at:
 
 ```
-.claude/entropy-patrol/golden-principles.yaml
+.claude/shipwright/principles.md
 ```
 
 **Priority order** (highest to lowest):
-1. `.claude/entropy-patrol/golden-principles.yaml` — project-local overrides
-2. `<plugin-dir>/skills/entropy-scan/golden-principles.yaml` — plugin defaults
+1. `.claude/shipwright/principles.md` — project-local overrides
+2. `<plugin-dir>/references/principles.md` — plugin defaults
 
-When a local config exists, it is used **in its entirety** — individual rules from the default config are not merged in. Start by copying the default and editing from there.
+When a local file exists, it is used **in its entirety** — individual entries from the
+default file are not merged in. Start by copying the default and editing from there.
+
+Only entries containing a `**Detection:**` field are entropy-scannable — everything else
+is judgment-only (read by `review`/`plan-session`/`dev-task`, never mechanically scanned).
+See `references/schema.md` for the full field reference.
 
 ---
 
 ## Common customizations
 
-### Disable a rule you don't need
+### Disable an entry you don't need
 
-```yaml
-rules:
-  - id: commented_out_blocks
-    disabled: true
-    # ... rest of fields recommended so the rule is ready to re-enable
-```
+Omit it entirely from your local `principles.md` — entries not present in your local
+file don't run.
 
-Or omit it entirely — rules not present in your local config don't run.
-
-> **Note:** Local config replaces the default entirely — there is no merging. Any rule you omit from your local copy will not run, even if it exists in the plugin defaults.
+> **Note:** Local config replaces the default entirely — there is no merging. Any entry
+> you omit from your local copy will not run, even if it exists in the plugin defaults.
 
 ### Change severity
 
-```yaml
-rules:
-  - id: missing_test_file
-    category: missing_tests
-    severity: medium   # downgrade from high if your team is actively adding tests
-    description: Source files in src/ that have no corresponding .test.ts file
-    detection_hint: |
-      ...
-    pr_worthy: false
+Edit the entry's `**Severity:**` field directly:
+
+```
+### `missing_test_file`
+
+**Domain:** testing
+**Severity:** medium   <!-- downgraded from high if your team is actively adding tests -->
+
+...
+
+**Detection:** ...
+**PR-worthy:** false
 ```
 
-### Add a project-specific rule
+### Add a project-specific entry
 
-```yaml
-rules:
-  - id: no_console_log_in_prod
-    category: inconsistent_patterns
-    severity: medium
-    description: console.log calls in non-test source files (use the logger module instead)
-    detection_hint: |
-      Search all .ts files under src/ (excluding *.test.ts) for console.log(), console.warn(),
-      console.error() calls. Flag any that are not inside a conditional block gated on
-      NODE_ENV === 'development' or process.env.DEBUG. Report: file, line number, call text.
-      The project uses a shared logger module at lib/logger.ts — all logging should go through it.
-    pr_worthy: true
+```
+### `no_console_log_in_prod`
+
+**Domain:** architecture
+**Severity:** medium
+
+console.log calls in non-test source files (use the logger module instead).
+
+**Detection:** Search all .ts files under src/ (excluding *.test.ts) for console.log(),
+console.warn(), console.error() calls. Flag any that are not inside a conditional block
+gated on NODE_ENV === 'development' or process.env.DEBUG. Report: file, line number, call
+text. The project uses a shared logger module at lib/logger.ts — all logging should go
+through it.
+**PR-worthy:** true
+**HITL:** never
 ```
 
 ### Adjust the TODO age threshold
 
-```yaml
-todo_max_age_days: 60   # flag TODOs older than 60 days instead of the default 90
-```
+There is no per-project config field for this — adjust the `stale_todo` entry's own
+`**Detection:**` text in your local `principles.md` to reference a different threshold
+(default 90 days) if your project needs one.
 
 ---
 
@@ -76,8 +83,8 @@ todo_max_age_days: 60   # flag TODOs older than 60 days instead of the default 9
 
 **Use local config when:**
 - Your project has language-specific patterns (Python, Go, etc.)
-- You want stricter enforcement on specific categories
-- A default rule generates too much noise for your codebase
+- You want stricter enforcement on specific domains
+- A default entry generates too much noise for your codebase
 - You have project-specific conventions (e.g., a required license header)
 
 **Use plugin defaults when:**
@@ -88,6 +95,7 @@ todo_max_age_days: 60   # flag TODOs older than 60 days instead of the default 9
 
 ## Initializing local config
 
-Run `/entropy-scan --init` to copy the default ruleset to `.claude/entropy-patrol/golden-principles.yaml`.
+Run `/entropy-scan --init` to copy the default principles file to
+`.claude/shipwright/principles.md`.
 
 Then edit the file to match your project's norms.

--- a/plugins/shipwright/skills/entropy-scan/references/schema.md
+++ b/plugins/shipwright/skills/entropy-scan/references/schema.md
@@ -1,24 +1,33 @@
-# Golden Principles Schema Reference
+# Principles Schema Reference
 
-This document describes the YAML format for entropy-patrol rule definitions.
+This document describes the markdown format for Shipwright principles entries
+(`references/principles.md`, and its project-level override at
+`.claude/shipwright/principles.md`).
 
 ## File structure
 
-```yaml
-version: "1.0"
+Each principle is one `###` entry with a fixed field order:
 
-rules:
-  - id: <rule_id>
-    category: <category>
-    severity: <severity>
-    description: <one-line description>
-    detection_hint: |
-      <multi-line instruction for the scanning agent>
-    pr_worthy: <true|false>
-    disabled: <true|false>   # optional; omit to enable
-
-todo_max_age_days: 90        # global config for stale_todo threshold
 ```
+### `<id>`
+
+**Domain:** <architecture | testing | security | dead_code | todo_debt | docs>
+**Severity:** <low | medium | high>
+
+<statement prose — what to do and why>
+
+**Detection:** <instruction for the scanning agent>
+**PR-worthy:** <true | false>
+**HITL:** <always | never | per-finding>
+```
+
+`**Detection:**`, `**PR-worthy:**`, and `**HITL:**` are only present together, on entries
+that are entropy-scannable. Entries without a `**Detection:**` field are judgment-only —
+read by `review`/`plan-session`/`dev-task` but never mechanically scanned by
+`entropy-scan`/`entropy-fix`.
+
+`##` headings group entries by domain for human readability, but the `**Domain:**` field
+on each entry is what consumers key off — not the heading it's nested under.
 
 ---
 
@@ -26,32 +35,35 @@ todo_max_age_days: 90        # global config for stale_todo threshold
 
 ### `id` (required)
 
-Unique string identifier for the rule. Use `snake_case`. Must be unique across all rules in the file.
+Unique string identifier for the entry, given as the `###` heading text in backticks.
+Use `snake_case`. Must be unique across all entries in the file.
 
-```yaml
-id: dead_exports
+```
+### `dead_exports`
 ```
 
 ---
 
-### `category` (required)
+### `**Domain:**` (required)
 
-Logical grouping for the rule. Used to organize the entropy report and filter rules by type.
+Machine-authoritative grouping for the entry. `entropy-scan` maps each scannable entry's
+domain to a report category:
 
-| Category | What it covers |
-|----------|---------------|
-| `dead_code` | Unused exports, unreferenced files, commented-out blocks |
-| `missing_tests` | Source files without test coverage |
-| `inconsistent_patterns` | Duplicated utilities, inconsistent error handling |
-| `todo_debt` | TODO/FIXME/HACK comments |
-| `documentation_gaps` | Missing JSDoc, missing README sections |
-| `security` | Ungated outbound calls, hardcoded secrets |
+| Domain | Report category |
+|--------|-----------------|
+| `security` | `security` |
+| `dead_code` | `dead_code` |
+| `todo_debt` | `todo_debt` |
+| `architecture` | `inconsistent_patterns` |
+| `docs` | `documentation_gaps` |
 
-You may define custom category strings for project-specific rules (e.g., `performance`, `accessibility`).
+`testing` entries are judgment-only (no `**Detection:**` field) and do not map to a
+report category — they're read by `plan-session`/`dev-task`/`review` for test-design
+guidance, not scanned.
 
 ---
 
-### `severity` (required)
+### `**Severity:**` (required)
 
 How urgently the issue should be addressed.
 
@@ -63,19 +75,18 @@ How urgently the issue should be addressed.
 
 ---
 
-### `description` (required)
+### Statement prose (required)
 
-One-line human-readable description of what the rule detects. Appears in the entropy report summary.
-
-```yaml
-description: Exported functions that are never imported anywhere in the codebase
-```
+Human-readable description of what the entry covers and why it matters, written as
+prose immediately after the `**Severity:**` field. Appears in the entropy report summary
+and is read directly by judgment-only consumers (`review`, `plan-session`, `dev-task`).
 
 ---
 
-### `detection_hint` (required)
+### `**Detection:**` (present only on entropy-scannable entries)
 
-Natural language instruction for the scanning Claude agent. This is the most important field — it determines scan quality. Write it like a task brief:
+Natural language instruction for the scanning Claude agent. This is the most important
+field on a scannable entry — it determines scan quality. Write it like a task brief:
 
 - Be specific enough that the agent can execute it without guessing
 - Name the exact patterns, file paths, or AST constructs to look for
@@ -84,76 +95,90 @@ Natural language instruction for the scanning Claude agent. This is the most imp
 - Don't be so prescriptive that it breaks on minor project variations
 
 **Example — good:**
-```yaml
-detection_hint: |
-  For each .ts file under src/ (excluding *.test.ts and index.ts), check if a
-  corresponding .test.ts file exists in the same directory. Flag every source
-  file with no test coverage. Report: file path and line count.
+```
+**Detection:** For each .ts file under src/ (excluding *.test.ts and index.ts), check if
+a corresponding .test.ts file exists in the same directory. Flag every source file with
+no test coverage. Report: file path and line count.
 ```
 
 **Example — too vague:**
-```yaml
-detection_hint: Check if tests exist.
+```
+**Detection:** Check if tests exist.
 ```
 
 **Example — too prescriptive:**
-```yaml
-detection_hint: Run `jest --coverage` and parse the JSON output for files with 0% coverage.
 ```
+**Detection:** Run `jest --coverage` and parse the JSON output for files with 0% coverage.
+```
+
+Omitting this field entirely marks the entry as judgment-only — it will not be scanned.
 
 ---
 
-### `pr_worthy` (required)
+### `**PR-worthy:**` (present only alongside `**Detection:**`)
 
-Whether `/entropy-fix` should open a pull request to address issues found by this rule.
+Whether `/entropy-fix` should open a pull request to address issues found by this entry.
 
-```yaml
-pr_worthy: true   # /entropy-fix will open a PR (max 3 files per PR)
-pr_worthy: false  # /entropy-scan reports it; /entropy-fix skips it
+```
+**PR-worthy:** true    <!-- /entropy-fix will open a PR (max 3 files per PR) -->
+**PR-worthy:** false   <!-- /entropy-scan reports it; /entropy-fix skips it -->
 ```
 
-Use `false` for rules where:
+Use `false` for entries where:
 - The fix requires human judgment (e.g., whether a dead file should be deleted or revived)
 - The fix is high-risk (e.g., deleting a file)
-- The rule surfaces information rather than an actionable change
+- The entry surfaces information rather than an actionable change
 
 ---
 
-### `disabled` (optional)
+### `**HITL:**` (present only alongside `**Detection:**`, on `**PR-worthy:** true` entries)
 
-Set to `true` to skip a rule without deleting it. Useful for disabling a default rule that doesn't apply to your project.
+Documents routing intent for how a PR-worthy finding should be classified:
 
-```yaml
-disabled: true
+| Value | Meaning |
+|-------|---------|
+| `always` | Every finding from this entry always routes to human-in-the-loop review |
+| `never` | Findings route to an autonomous fix without human review |
+| `per-finding` | Routing is decided per finding, at fix time |
+
+This field records classification intent only — `entropy-fix`'s actual queue/HITL routing
+logic is wired independently.
+
+---
+
+## Removing an entry
+
+There is no `disabled` flag in this format. Omit an entry entirely from your project's
+`.claude/shipwright/principles.md` override to stop it from running — it will not appear
+anywhere in the entropy report ("No Violations" included).
+
+---
+
+## Complete example entry
+
+```
+### `missing_test_file`
+
+**Domain:** testing
+**Severity:** high
+
+Source files in src/ that have no corresponding .test.ts file. Missing test coverage
+compounds silently until a regression surfaces it the hard way.
+
+**Detection:** For each .ts file under src/ (excluding *.test.ts, *.spec.ts, index.ts, and
+type-only files that export only interfaces/types), check if a corresponding .test.ts
+file exists in the same directory or a __tests__/ subdirectory. Flag every source file
+with no test coverage file. Report: file path, file size (lines), approximate complexity
+(does it export functions?).
+**PR-worthy:** false
+**HITL:** never
 ```
 
-Omit this field (or set to `false`) to enable the rule.
-
 ---
 
-## Complete example rule
+## Global config
 
-```yaml
-- id: missing_test_file
-  category: missing_tests
-  severity: high
-  description: Source files in src/ that have no corresponding .test.ts file
-  detection_hint: |
-    For each .ts file under src/ (excluding *.test.ts, *.spec.ts, index.ts, and
-    type-only files that export only interfaces/types), check if a corresponding
-    .test.ts file exists in the same directory or a __tests__/ subdirectory.
-    Flag every source file with no test coverage file.
-    Report: file path, file size (lines), approximate complexity (does it export functions?).
-  pr_worthy: false
-```
-
----
-
-## Global config fields
-
-These appear at the top level of the YAML file (not inside `rules`).
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `todo_max_age_days` | `90` | Age threshold for `stale_todo` rule (in days) |
-| `version` | `"1.0"` | Schema version — used for future migration |
+**Age threshold** for the `stale_todo` / `todo_fixme_hack` entries defaults to 90 days
+(`todo_max_age_days`). There is no per-project config field for this in the current
+format — adjust the relevant entry's own `**Detection:**` text in a project override if
+a different threshold is needed.

--- a/plugins/shipwright/test/plugin-absorption.test.ts
+++ b/plugins/shipwright/test/plugin-absorption.test.ts
@@ -107,6 +107,10 @@ describe("entropy-scan support files", () => {
       ).toBe(true);
     });
   }
+
+  it("references/principles.md exists", () => {
+    expect(existsSync(pluginPath("references", "principles.md"))).toBe(true);
+  });
 });
 
 // ── entropy-scan/entropy-fix repoint to principles.md ────────────────────────

--- a/plugins/shipwright/test/plugin-absorption.test.ts
+++ b/plugins/shipwright/test/plugin-absorption.test.ts
@@ -109,6 +109,29 @@ describe("entropy-scan support files", () => {
   }
 });
 
+// ── entropy-scan/entropy-fix repoint to principles.md ────────────────────────
+
+describe("entropy-scan/entropy-fix reference principles.md, not golden-principles.yaml", () => {
+  const skillFiles = [
+    pluginPath("skills", "entropy-scan", "SKILL.md"),
+    pluginPath("skills", "entropy-fix", "SKILL.md"),
+  ];
+
+  for (const file of skillFiles) {
+    const relPath = file.replace(`${pluginRoot}/`, "");
+
+    it(`${relPath} does not reference golden-principles.yaml`, () => {
+      const content = readFileSync(file, "utf8");
+      expect(content.includes("golden-principles.yaml")).toBe(false);
+    });
+
+    it(`${relPath} references principles.md`, () => {
+      const content = readFileSync(file, "utf8");
+      expect(content.includes("principles.md")).toBe(true);
+    });
+  }
+});
+
 // ── learning-capture support files ───────────────────────────────────────────
 
 describe("learning-capture support files", () => {


### PR DESCRIPTION
## Summary
- Repoint `entropy-scan` and `entropy-fix` to load `references/principles.md` instead of `golden-principles.yaml`, filtering to entries with a `**Detection:**` field
- Drop `missing_tests` from entropy-scan's category scan order (now: security → dead_code → todo_debt → inconsistent_patterns → documentation_gaps)
- Move the `/entropy-scan --init` override path to `.claude/shipwright/principles.md`
- Rewrite `customization.md` and `schema.md` to describe the new markdown schema and override path
- Extend `plugin-absorption.test.ts` to assert the SKILL.md files no longer reference `golden-principles.yaml` and do reference `principles.md`

`golden-principles.yaml` is intentionally left in place — removed in PRN-4.1 once every consumer is repointed.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | entropy-scan/SKILL.md and entropy-fix/SKILL.md reference principles.md, not golden-principles.yaml | MET |
| 2 | Category scan order no longer includes missing_tests | MET |
| 3 | /entropy-scan --init writes .claude/shipwright/principles.md | MET |
| 4 | customization.md and schema.md describe the new markdown schema and override path | MET |
| 5 | plugin-absorption.test.ts extended to assert golden-principles.yaml no longer referenced, principles.md referenced instead | MET |

## Test Plan
- `bun test plugins/shipwright/` — 616 pass, 0 fail
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
