### PR TITLE
fix(ci): merge auto-bump/sync PRs directly instead of queued auto-merge

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -12,7 +12,7 @@ name: Auto-Bump Chart Version
 #     → this workflow
 #       → bump patch version in Chart.yaml
 #       → open PR (chore/chart-v{new_version})
-#       → enable auto-merge (squash)
+#       → wait for required checks, then merge (squash)
 #     → PR merges to main
 #       → chart-release.yml triggers (paths: charts/shipwright/**)
 #         → packages the chart + commits .tgz + index.yaml to gh-pages
@@ -21,7 +21,7 @@ name: Auto-Bump Chart Version
 #   1. Push a dummy tag matching one of the trigger patterns:
 #        git tag agent-v9.9.9 && git push origin agent-v9.9.9
 #   2. Observe this workflow runs, creates branch chore/chart-v{N},
-#      opens a PR, and enables auto-merge.
+#      opens a PR, and merges it once checks pass.
 #   3. Verify PR description includes the triggering tag name.
 #   4. After merge, confirm chart-release.yml fires and publishes the new version.
 #   5. Delete the dummy tag to clean up:
@@ -250,45 +250,22 @@ jobs:
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
           echo "Opened PR: ${PR_URL}"
 
-      # Enable auto-merge so the PR merges as soon as required checks pass.
-      # This requires "Allow auto-merge" to be enabled in the repo Settings.
-      - name: Enable auto-merge
+      # Merge directly once required checks pass, rather than GitHub's native
+      # queued auto-merge (`gh pr merge --auto`). Native auto-merge only
+      # re-evaluates mergeability on its own schedule, which can lag well past
+      # this workflow's 10-minute wait when the merge relies on a repo
+      # ruleset bypass (self-authored PR, no external reviewer) instead of a
+      # genuine approval — `gh pr checks --watch` blocks on required checks,
+      # then an immediate `gh pr merge` (no `--auto`) applies the bypass right
+      # away, the same way a manual merge click does.
+      - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
+        timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           PR_URL="${{ steps.pr.outputs.pr_url }}"
-          gh pr merge "$PR_URL" --auto --squash
-          echo "Auto-merge enabled on ${PR_URL}"
-
-      # Hold the concurrency slot until the PR merges.
-      #
-      # Without this wait the workflow exits immediately after enabling auto-merge
-      # while the PR is still open. The next queued run then starts, checks out
-      # main (which still carries the pre-bump chart version), computes the same
-      # new-version branch name, finds the branch already exists, and silently
-      # skips — dropping that release's chart bump entirely (burst-collapse).
-      #
-      # By blocking here until the merge lands, we guarantee the next run always
-      # reads the post-merge chart version and computes a fresh increment.
-      # Timeout is 10 minutes; on expiry we exit 1 so the failure surfaces in the
-      # Actions UI — a chart bump PR that never merged within the window needs
-      # investigation (e.g. a required check stalled or auto-merge was disabled).
-      - name: Wait for PR to merge
-        if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true' && steps.pr.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-        run: |
-          PR_URL="${{ steps.pr.outputs.pr_url }}"
-          echo "Waiting for ${PR_URL} to merge (up to 10 minutes)..."
-          for i in $(seq 1 60); do
-            STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-            if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
-              echo "PR is ${STATE} — releasing concurrency slot."
-              exit 0
-            fi
-            echo "  attempt ${i}/60: state=${STATE}"
-            sleep 10
-          done
-          echo "ERROR: timed out after 10 minutes waiting for ${PR_URL} to merge."
-          exit 1
+          echo "Waiting for required checks on ${PR_URL}..."
+          gh pr checks "$PR_URL" --watch --interval 15 --required
+          echo "Checks passed — merging ${PR_URL}."
+          gh pr merge "$PR_URL" --squash

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -210,35 +210,25 @@ jobs:
       # own commit above, so the PR's required status checks still run
       # normally pre-merge. Once merged, the push-to-main event for this
       # commit carries [skip ci], so no push-triggered workflow re-fires.
-      - name: Enable auto-merge
+      #
+      # Merge directly once required checks pass, rather than GitHub's native
+      # queued auto-merge (`gh pr merge --auto`). Native auto-merge only
+      # re-evaluates mergeability on its own schedule, which can lag well past
+      # this workflow's 10-minute wait when the merge relies on a repo
+      # ruleset bypass (self-authored PR, no external reviewer) instead of a
+      # genuine approval — `gh pr checks --watch` blocks on required checks,
+      # then an immediate `gh pr merge` (no `--auto`) applies the bypass right
+      # away, the same way a manual merge click does.
+      - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.diff.outputs.changed == 'true' && steps.commit-push.outputs.push_skipped != 'true'
+        timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           PR_URL="${{ steps.pr.outputs.pr_url }}"
           VERSION="${{ steps.version.outputs.version }}"
-          gh pr merge "$PR_URL" --auto --squash \
+          echo "Waiting for required checks on ${PR_URL}..."
+          gh pr checks "$PR_URL" --watch --interval 15 --required
+          echo "Checks passed — merging ${PR_URL}."
+          gh pr merge "$PR_URL" --squash \
             --subject "chore(plugin): sync version to ${VERSION} [skip ci]"
-          echo "Auto-merge enabled on ${PR_URL}"
-
-      # Hold the concurrency slot until the PR merges, same reasoning as
-      # auto-bump-chart.yml: without this, the next queued run could read
-      # main before this sync landed and collide on the same branch name.
-      - name: Wait for PR to merge
-        if: steps.idempotency.outputs.skip != 'true' && steps.diff.outputs.changed == 'true' && steps.commit-push.outputs.push_skipped != 'true' && steps.pr.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-        run: |
-          PR_URL="${{ steps.pr.outputs.pr_url }}"
-          echo "Waiting for ${PR_URL} to merge (up to 10 minutes)..."
-          for i in $(seq 1 60); do
-            STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-            if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
-              echo "PR is ${STATE} — releasing concurrency slot."
-              exit 0
-            fi
-            echo "  attempt ${i}/60: state=${STATE}"
-            sleep 10
-          done
-          echo "ERROR: timed out after 10 minutes waiting for ${PR_URL} to merge."
-          exit 1


### PR DESCRIPTION
## Summary

Both `auto-bump-chart.yml` and `sync-plugin-version.yml` self-merge their generated PRs via `gh pr merge --auto`, relying on the new `require review from code owners` ruleset's per-user bypass (these PRs are self-authored, no external approval).

GitHub's native queued auto-merge doesn't re-evaluate bypass eligibility promptly — observed delay was ~12 minutes from enabling to actual merge, which exceeded the workflow's 10-minute wait and failed the run (see `agent-v0.123.0` run, PR #1070).

## Change

Replace `gh pr merge --auto` + a polling "wait for merge" step with a single step: `gh pr checks --watch --required` (blocks until required checks pass) then an immediate `gh pr merge` (no `--auto`) — an immediate merge call applies the bypass right away, same as a manual merge click, instead of waiting on the queued auto-merge feature's own reconciliation schedule.

## Test plan
- [ ] Push a dummy tag (e.g. `agent-v9.9.9`) and confirm the chart-bump PR merges promptly once checks pass
- [ ] Confirm `sync-plugin-version.yml` still produces the `[skip ci]` squash subject correctly