### PR TITLE
fix: wait for checks to register before gh pr checks --watch

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -265,6 +265,19 @@ jobs:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           PR_URL="${{ steps.pr.outputs.pr_url }}"
+
+          # `gh pr checks --watch` fails fast with "no checks reported" if it
+          # runs before GitHub has registered any check runs on the new
+          # commit — the check-triggering workflows haven't started yet
+          # immediately after `gh pr create`. Poll until at least one check
+          # appears before handing off to --watch.
+          echo "Waiting for checks to register on ${PR_URL}..."
+          for _ in $(seq 1 30); do
+            CHECK_COUNT=$(gh pr checks "$PR_URL" --json name -q 'length' 2>/dev/null || echo 0)
+            [ "$CHECK_COUNT" -gt 0 ] && break
+            sleep 2
+          done
+
           echo "Waiting for required checks on ${PR_URL}..."
           gh pr checks "$PR_URL" --watch --interval 15 --required
           echo "Checks passed — merging ${PR_URL}."

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -227,6 +227,19 @@ jobs:
         run: |
           PR_URL="${{ steps.pr.outputs.pr_url }}"
           VERSION="${{ steps.version.outputs.version }}"
+
+          # `gh pr checks --watch` fails fast with "no checks reported" if it
+          # runs before GitHub has registered any check runs on the new
+          # commit — the check-triggering workflows haven't started yet
+          # immediately after `gh pr create`. Poll until at least one check
+          # appears before handing off to --watch.
+          echo "Waiting for checks to register on ${PR_URL}..."
+          for _ in $(seq 1 30); do
+            CHECK_COUNT=$(gh pr checks "$PR_URL" --json name -q 'length' 2>/dev/null || echo 0)
+            [ "$CHECK_COUNT" -gt 0 ] && break
+            sleep 2
+          done
+
           echo "Waiting for required checks on ${PR_URL}..."
           gh pr checks "$PR_URL" --watch --interval 15 --required
           echo "Checks passed — merging ${PR_URL}."


### PR DESCRIPTION
## Problem

`auto-bump-chart.yml` and `sync-plugin-version.yml` both create a version-bump PR and then immediately run:

```
gh pr checks "$PR_URL" --watch --interval 15 --required
```

`gh pr create` returns before GitHub has attached any check runs to the new commit (the check-triggering workflows haven't started yet), so `--watch` sees zero checks and fails fast with "no checks reported" — in practice this happens in ~11 seconds. The PR is left open with CI still green but never auto-merged, which is why version-bump PRs (e.g. #1080, #1081, #1082) pile up waiting on manual merge.

## Fix

Poll `gh pr checks --json name -q 'length'` (up to 30 attempts / 2s apart = 60s max) until at least one check has registered, before handing off to `--watch`. Applied identically to both workflows since they share the same create-then-watch pattern.

## Test plan

- [ ] Verify next tag push triggers `auto-bump-chart.yml` and the bump PR auto-merges without manual intervention
- [ ] Verify next tag push triggers `sync-plugin-version.yml` and the sync PR auto-merges without manual intervention