### PR TITLE
fix: add --admin to self-merge of auto-generated version-bump PRs

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -253,11 +253,11 @@ jobs:
       # Merge directly once required checks pass, rather than GitHub's native
       # queued auto-merge (`gh pr merge --auto`). Native auto-merge only
       # re-evaluates mergeability on its own schedule, which can lag well past
-      # this workflow's 10-minute wait when the merge relies on a repo
-      # ruleset bypass (self-authored PR, no external reviewer) instead of a
-      # genuine approval — `gh pr checks --watch` blocks on required checks,
-      # then an immediate `gh pr merge` (no `--auto`) applies the bypass right
-      # away, the same way a manual merge click does.
+      # this workflow's 10-minute wait. `--admin` is required because this PR
+      # is self-authored (no external reviewer can approve it) and branch
+      # protection otherwise rejects the merge outright — confirmed via
+      # PR #1084, where `gh pr merge --squash` (no `--admin`) failed with
+      # "the base branch policy prohibits the merge" even after checks passed.
       - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
@@ -281,4 +281,4 @@ jobs:
           echo "Waiting for required checks on ${PR_URL}..."
           gh pr checks "$PR_URL" --watch --interval 15 --required
           echo "Checks passed — merging ${PR_URL}."
-          gh pr merge "$PR_URL" --squash
+          gh pr merge "$PR_URL" --squash --admin

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -214,11 +214,11 @@ jobs:
       # Merge directly once required checks pass, rather than GitHub's native
       # queued auto-merge (`gh pr merge --auto`). Native auto-merge only
       # re-evaluates mergeability on its own schedule, which can lag well past
-      # this workflow's 10-minute wait when the merge relies on a repo
-      # ruleset bypass (self-authored PR, no external reviewer) instead of a
-      # genuine approval — `gh pr checks --watch` blocks on required checks,
-      # then an immediate `gh pr merge` (no `--auto`) applies the bypass right
-      # away, the same way a manual merge click does.
+      # this workflow's 10-minute wait. `--admin` is required because this PR
+      # is self-authored (no external reviewer can approve it) and branch
+      # protection otherwise rejects the merge outright — confirmed via
+      # PR #1084, where `gh pr merge --squash` (no `--admin`) failed with
+      # "the base branch policy prohibits the merge" even after checks passed.
       - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.diff.outputs.changed == 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
@@ -243,5 +243,5 @@ jobs:
           echo "Waiting for required checks on ${PR_URL}..."
           gh pr checks "$PR_URL" --watch --interval 15 --required
           echo "Checks passed — merging ${PR_URL}."
-          gh pr merge "$PR_URL" --squash \
+          gh pr merge "$PR_URL" --squash --admin \
             --subject "chore(plugin): sync version to ${VERSION} [skip ci]"


### PR DESCRIPTION
## Problem

Follow-up to #1083. That PR fixed the `gh pr checks --watch` race (waiting for checks to register before watching them), and it worked — PR #1084 shows the workflow correctly reaching "Checks passed — merging". But the plain `gh pr merge --squash` call then failed:

```
X Pull request app-vitals/shipwright#1084 is not mergeable: the base branch policy prohibits the merge.
To use administrator privileges to immediately merge the pull request, add the `--admin` flag.
```

These version-bump PRs are self-authored (opened by the same bot account the workflow runs as), so no external reviewer can approve them, and branch protection has no bypass for that without `--admin`. The previous code comment assumed a ruleset bypass already applied to self-authored PRs on plain merge — #1084 shows that assumption was wrong; it was simply never reached before because the check-registration race failed first.

## Fix

Add `--admin` to both `gh pr merge` calls (`auto-bump-chart.yml`, `sync-plugin-version.yml`), same as the manual admin-merges used to clear the backlog (#1080, #1082, #1084) while this was being diagnosed.

## Test plan

- [ ] Next tag push creates a version-bump PR that merges automatically end-to-end with zero manual intervention