### PR TITLE
docs: fix agent-admin skill doc gap

### DIFF
--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -337,6 +337,13 @@ curl -sf -X DELETE \
 
 ## Creating a New Agent (Admin Only)
 
+Two paths, depending on whether the agent is self-hosted.
+
+**Non-self-hosted (preferred):** use the inline provisioning wizard at `/admin/provision`.
+Select the "Create new agent" toggle (instead of "Use existing agent") to walk through
+Slack app creation, GitHub auth, and AI credentials in one flow.
+
+**Self-hosted:** the wizard doesn't apply — register the agent directly via the admin API.
 Requires an admin-level API key configured in `SHIPWRIGHT_ADMIN_API_KEYS` on the server.
 
 ```bash
@@ -348,8 +355,8 @@ curl -sf -X POST \
 # Returns: { id, name, slackId, createdAt }
 ```
 
-After creating an agent, set env vars, add tool patterns, install plugins, and seed crons.
-See `docs/agent-onboarding.md` for the full provisioning runbook.
+After creating a self-hosted agent via the raw API, set env vars, add tool patterns, install
+plugins, and seed crons using the endpoints documented elsewhere in this skill.
 
 ---
 


### PR DESCRIPTION
## Summary
- Removed the dead `docs/agent-onboarding.md` pointer from the agent-admin skill's "Creating a New Agent" section — that file doesn't exist in this repo.
- Documented the two real provisioning paths: the `/admin/provision` inline wizard's "Create new agent" toggle (preferred, non-self-hosted) and the raw `POST /agents` admin API (self-hosted, where the wizard doesn't apply).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | No dead doc link remains in the agent-admin skill | MET |
| 2 | Skill accurately reflects current provisioning options (wizard vs. raw API) | MET |
| 3 | Test: none — markdown-only skill doc change, no logic to test | MET |

## Test Plan
- Repo-wide grep confirms no remaining references to `docs/agent-onboarding.md`.
- Verified the `/admin/provision` "Create new agent" toggle and the self-hosted `/admin/agents` flow against `admin/src/admin-ui-pages.ts` to keep the doc accurate to actual code.
- [x] `task check-strings` passing
- [x] `biome lint` passing (no-op on markdown)

Generated with [Claude Code](https://claude.com/claude-code)
