### PR TITLE
feat: restore self-healing @BOOTSTRAP.md include for first-run ritual

### DIFF
--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -323,6 +323,29 @@ describe("ensureAgentHome", () => {
     expect(content).toContain("@IDENTITY.md");
   });
 
+  it("CLAUDE.md loads @BOOTSTRAP.md immediately after @IDENTITY.md for a freshly-seeded workspace", () => {
+    ensureAgentHome(testHome);
+    const content = readFileSync(
+      join(testHome, "workspace", "CLAUDE.md"),
+      "utf8",
+    );
+    expect(content).toContain("@BOOTSTRAP.md");
+    // @file includes are loaded literally by Claude Code, unconditionally — the
+    // ordering matters (right after @IDENTITY.md) so the First-Run Ritual is
+    // the next thing loaded after identity, not a prose note the model has to
+    // notice and act on.
+    const identityIdx = content.indexOf("@IDENTITY.md");
+    const bootstrapIdx = content.indexOf("@BOOTSTRAP.md");
+    expect(identityIdx).toBeGreaterThanOrEqual(0);
+    expect(bootstrapIdx).toBeGreaterThan(identityIdx);
+    const between = content.slice(
+      identityIdx + "@IDENTITY.md".length,
+      bootstrapIdx,
+    );
+    // Nothing but whitespace/newlines between the two includes.
+    expect(between.trim()).toBe("");
+  });
+
   it("seeds state/todos.json as empty array", () => {
     ensureAgentHome(testHome);
     const todosPath = join(testHome, "workspace", "state", "todos.json");
@@ -411,6 +434,59 @@ describe("ensureAgentHome", () => {
     const state = loadState(testHome);
     expect(state.setupCompletedAt).toBeDefined();
     expect(typeof state.setupCompletedAt).toBe("string");
+  });
+
+  it("strips the @BOOTSTRAP.md include line from CLAUDE.md the moment setupCompletedAt first fires", () => {
+    ensureAgentHome(testHome);
+    const claudeMdPath = join(testHome, "workspace", "CLAUDE.md");
+    const beforeContent = readFileSync(claudeMdPath, "utf8");
+    expect(beforeContent).toContain("@BOOTSTRAP.md");
+
+    // Simulate the ritual completing: BOOTSTRAP.md deleted, IDENTITY.md filled in.
+    rmSync(join(testHome, "workspace", "BOOTSTRAP.md"));
+    writeFileSync(
+      join(testHome, "workspace", "IDENTITY.md"),
+      "# Identity (filled)",
+      "utf8",
+    );
+
+    ensureAgentHome(testHome);
+
+    const state = loadState(testHome);
+    expect(state.setupCompletedAt).toBeDefined();
+
+    const afterContent = readFileSync(claudeMdPath, "utf8");
+    expect(afterContent).not.toContain("@BOOTSTRAP.md");
+
+    // Rest of the file is untouched — compare byte-for-byte minus the
+    // stripped line (and its trailing newline).
+    const expected = beforeContent
+      .split("\n")
+      .filter((line) => !line.includes("@BOOTSTRAP.md"))
+      .join("\n");
+    expect(afterContent).toBe(expected);
+  });
+
+  it("does not re-strip or error when ensureAgentHome runs again after setupCompletedAt is already set", () => {
+    ensureAgentHome(testHome);
+    rmSync(join(testHome, "workspace", "BOOTSTRAP.md"));
+    writeFileSync(
+      join(testHome, "workspace", "IDENTITY.md"),
+      "# Identity (filled)",
+      "utf8",
+    );
+    ensureAgentHome(testHome); // fires the strip
+    const claudeMdPath = join(testHome, "workspace", "CLAUDE.md");
+    const strippedContent = readFileSync(claudeMdPath, "utf8");
+    expect(strippedContent).not.toContain("@BOOTSTRAP.md");
+
+    // Custom edit after ritual completion — must survive further startups.
+    const customContent = `${strippedContent}\n<!-- custom note -->\n`;
+    writeFileSync(claudeMdPath, customContent, "utf8");
+
+    ensureAgentHome(testHome); // must be a no-op w.r.t. CLAUDE.md content
+
+    expect(readFileSync(claudeMdPath, "utf8")).toBe(customContent);
   });
 
   it("does not re-seed BOOTSTRAP.md when bootstrapSeededAt already set", () => {

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -512,6 +512,20 @@ export function ensureDotClaudeSymlink(
   log(`[entrypoint] symlinked ${jsonLink} → ${jsonTarget}`);
 }
 
+/**
+ * Strips the `@BOOTSTRAP.md` include line from workspace/CLAUDE.md so it
+ * doesn't dangle once the First-Run Ritual deletes BOOTSTRAP.md itself.
+ * No-op if the path or the include line doesn't exist.
+ */
+export function stripBootstrapInclude(claudeMdPath: string): void {
+  if (!existsSync(claudeMdPath)) return;
+  const content = readFileSync(claudeMdPath, "utf8");
+  const lines = content.split("\n");
+  const filtered = lines.filter((line) => !line.includes("@BOOTSTRAP.md"));
+  if (filtered.length === lines.length) return; // nothing to strip
+  writeFileSync(claudeMdPath, filtered.join("\n"), "utf8");
+}
+
 export function ensureAgentHome(home: string): void {
   const workspaceDir = join(home, "workspace");
   const stateDir = join(workspaceDir, "state");
@@ -592,8 +606,12 @@ export function ensureAgentHome(home: string): void {
     saveState(home, state);
   } else if (
     state.bootstrapSeededAt &&
-    !existsSync(join(workspaceDir, "BOOTSTRAP.md"))
+    !existsSync(join(workspaceDir, "BOOTSTRAP.md")) &&
+    !state.setupCompletedAt
   ) {
+    // First startup after the ritual deletes BOOTSTRAP.md — clean up the
+    // now-dangling include before setupCompletedAt gates this branch off.
+    stripBootstrapInclude(join(workspaceDir, "CLAUDE.md"));
     state.setupCompletedAt = new Date().toISOString();
     saveState(home, state);
   }

--- a/agent/workspace/CLAUDE.md.template
+++ b/agent/workspace/CLAUDE.md.template
@@ -2,6 +2,7 @@
 
 @SOUL.md
 @IDENTITY.md
+@BOOTSTRAP.md
 
 ## How You Work
 


### PR DESCRIPTION
## Summary
- Restores a literal `@BOOTSTRAP.md` include in `CLAUDE.md.template` right after `@IDENTITY.md` — Claude Code loads `@file` includes unconditionally, which is the mechanism that was live-tested and confirmed to reliably trigger the First-Run Ritual (prose-based "if BOOTSTRAP.md exists, run its ritual" instructions were tested and silently ignored).
- Fixes the dangling-include problem that caused this mechanism to be reverted previously: `ensureAgentHome` in `agent/src/setup.ts` now detects ritual completion (`bootstrapSeededAt` set, `BOOTSTRAP.md` deleted, `setupCompletedAt` not yet set) and calls a new `stripBootstrapInclude()` helper to remove the `@BOOTSTRAP.md` line from `CLAUDE.md` on the very next startup — no reliance on the agent remembering to edit its own CLAUDE.md.
- Extends `setup.integration.test.ts` with tests asserting: the include is present and correctly ordered in a freshly-seeded workspace, the strip happens end-to-end on ritual completion (byte-for-byte preservation of the rest of the file), and re-running `ensureAgentHome` after completion is a no-op.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Fresh agents seeded with BOOTSTRAP.md have `@BOOTSTRAP.md` present in CLAUDE.md immediately after `@IDENTITY.md` | MET |
| 2 | Next agent startup after ritual completion auto-strips the include via `ensureAgentHome`, verified by integration test | MET |
| 3 | Existing initial-seeding test coverage extended to assert include presence/ordering | MET |
| 4 | New integration test asserting strip-on-completion end-to-end | MET |

## Test Plan
- `bun test agent/src/setup.integration.test.ts` — 64 pass (73 total; 9 pre-existing failures unrelated to this change, confirmed identical on `main`)
- `bun run typecheck` (agent workspace) — clean
- `bunx biome lint` on changed files — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
