### PR TITLE
feat: wire principles.md into plan-session and dev-task

### DIFF
--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -342,7 +342,7 @@ curl -s -o /dev/null -X POST \
 
 ## Step 6: Simplify
 
-After implementation completes, run a simplification pass:
+After implementation completes, run a simplification pass. Ground both the implementation subagent's build (Step 5) and this pass in `plugins/shipwright/references/principles.md` — the shared architecture/testing principles file `plan-session` and `review` also read from. Respect its `architecture` domain entries (e.g. `architecture_layering`) when arranging code across layers, and its `testing` domain entries (e.g. the `t*` rules) when writing or adjusting tests during simplification.
 
 1. Review `git diff main...HEAD` to see all changes on this branch
 2. Look for and fix:

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -161,6 +161,8 @@ Iterate on feedback. Do not move to task breakdown until the design is approved.
 
 Break the approved design into tasks. Each task should be independently shippable (its own PR) unless they are explicitly bundled (see Bundles below).
 
+Before writing tasks, skim `plugins/shipwright/references/principles.md` — the shared architecture/testing principles file `dev-task` and `review` also read from. Let its `architecture` and `testing` domain entries inform each task's scope and acceptance criteria (e.g. respecting `architecture_layering` when splitting a task across layers, or citing the relevant `t*` testing entry when writing the test decision bullet below).
+
 For each task:
 - **ID**: `{PREFIX}-{N}.{M}` — prefix is 2-3 letters from the feature name
 - **Title**: short, verb-first (e.g., "Add billing schema migration")

--- a/plugins/shipwright/commands/principles-wiring.unit.test.ts
+++ b/plugins/shipwright/commands/principles-wiring.unit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * principles.md wiring tests — PRN-2.3
+ *
+ * Verifies plan-session.md and dev-task.md each reference the shared
+ * references/principles.md file — net-new wiring so generated tasks (plan-session)
+ * and execution guidance (dev-task) reflect the architecture/testing principles
+ * defined there.
+ *
+ * Content-assertion only: existsSync/readFileSync, no I/O beyond local file
+ * reads (mirrors principles-content.unit.test.ts).
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/commands/ → plugins/shipwright/
+const pluginRoot = resolve(import.meta.dir, "..");
+
+function pluginPath(...parts: string[]): string {
+  return join(pluginRoot, ...parts);
+}
+
+const planSessionPath = pluginPath("commands", "plan-session.md");
+const devTaskPath = pluginPath("commands", "dev-task.md");
+
+function readPlanSession(): string {
+  return readFileSync(planSessionPath, "utf8");
+}
+
+function readDevTask(): string {
+  return readFileSync(devTaskPath, "utf8");
+}
+
+describe("principles.md wiring — files exist", () => {
+  it("commands/plan-session.md exists", () => {
+    expect(existsSync(planSessionPath)).toBe(true);
+  });
+
+  it("commands/dev-task.md exists", () => {
+    expect(existsSync(devTaskPath)).toBe(true);
+  });
+});
+
+describe("plan-session.md — references principles.md", () => {
+  it("mentions references/principles.md", () => {
+    expect(readPlanSession()).toContain("references/principles.md");
+  });
+
+  it("references principles.md near task generation guidance (Step 5: Task Breakdown)", () => {
+    const content = readPlanSession();
+    const stepIndex = content.indexOf("## Step 5: Task Breakdown");
+    const nextStepIndex = content.indexOf("## Step 5.5: HITL Detection");
+    expect(stepIndex).toBeGreaterThan(-1);
+    expect(nextStepIndex).toBeGreaterThan(stepIndex);
+    const stepSection = content.slice(stepIndex, nextStepIndex);
+    expect(stepSection).toContain("references/principles.md");
+  });
+});
+
+describe("dev-task.md — references principles.md", () => {
+  it("mentions references/principles.md", () => {
+    expect(readDevTask()).toContain("references/principles.md");
+  });
+
+  it("references principles.md near execution guidance (PROJECT CONVENTIONS / implementation steps)", () => {
+    const content = readDevTask();
+    const briefIndex = content.indexOf("PROJECT CONVENTIONS (from CLAUDE.md):");
+    const ciGateIndex = content.indexOf("## Step 9b: CI Gate");
+    expect(briefIndex).toBeGreaterThan(-1);
+    expect(ciGateIndex).toBeGreaterThan(briefIndex);
+    const executionSection = content.slice(briefIndex, ciGateIndex);
+    expect(executionSection).toContain("references/principles.md");
+  });
+});


### PR DESCRIPTION
## Summary
- Wire `plugins/shipwright/references/principles.md` into `plan-session.md` (Step 5: Task Breakdown) so generated tasks reflect architecture/testing principles up front
- Wire the same file into `dev-task.md` (Step 6: Simplify) so execution guidance follows the same principles, matching the reference `review` already has
- Add a net-new unit test asserting both files reference `references/principles.md` at the expected sections

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | plan-session.md references principles.md when describing task generation | MET | Step 5: Task Breakdown now points to `plugins/shipwright/references/principles.md` |
| 2 | dev-task.md references principles.md when describing execution guidance | MET | Step 6: Simplify now points to `plugins/shipwright/references/principles.md` |
| 3 | Test decision: unit test asserting both files reference principles.md | MET | Added `plugins/shipwright/commands/principles-wiring.unit.test.ts` |

## Test Plan
- `bun test` — 640 pass, 0 fail (includes 6 new tests in `principles-wiring.unit.test.ts`)
- `bun run typecheck` — all packages pass
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
