### PR TITLE
feat: repoint test-inventory rubrics to principles.md, document CLAUDE.md layer-declaration convention (PRN-2.4)

### DIFF
--- a/plugins/shipwright/assets/rubrics/code-classifier.md
+++ b/plugins/shipwright/assets/rubrics/code-classifier.md
@@ -2,6 +2,8 @@
 
 Used by the `test-inventory` skill to classify every meaningful unit of code into one of six categories. The category drives the layer prescription (see `layer-criteria.md`).
 
+**Layer definitions live elsewhere.** This rubric classifies code into categories only — it does not define the four test layers (unit / integration / smoke / E2E). The canonical source for layer definitions and testing-domain principles is `references/principles.md` (see its `## Testing` domain and the `data_layer_*` entries in `## Architecture`); `layer-criteria.md` maps these six categories onto those layers.
+
 ## The six categories
 
 ### 1. Pure business logic

--- a/plugins/shipwright/assets/rubrics/layer-criteria.md
+++ b/plugins/shipwright/assets/rubrics/layer-criteria.md
@@ -2,6 +2,8 @@
 
 Maps the six code categories from `code-classifier.md` to the four test layers. Enforces the canonical-layer rule — each functional unit is tested at exactly one layer, the lowest layer that can prove the property.
 
+**Source of truth:** the layer definitions below are this rubric's own content, but the testing-domain principles that justify them — no-duplicate-coverage, layer/speed alignment, and the real-boundary rule for the data sub-layer — live in `references/principles.md` (`## Testing` domain: `t5_no_duplicate_coverage`, `t6_layer_speed_mismatch`; `## Architecture` domain: `data_layer_own_database`, `data_layer_external_client`). Where this rubric's content overlaps with those entries, treat `references/principles.md` as canonical and this file as the layer-specific application of it.
+
 ## The four layers
 
 ### Unit
@@ -16,7 +18,7 @@ Maps the six code categories from `code-classifier.md` to the four test layers. 
 
 **Proves:** A real boundary works — the DB returns what we expect, the file write actually persists, the internal RPC actually completes. Schema compatibility. Transaction semantics. Idempotency at the boundary.
 
-**Boundaries:** One or more real boundaries. Tests boot the dependency locally (testcontainers, docker-compose, in-memory adapter — never a hosted service). The test asserts behavior *only at the boundary itself* — never re-asserts business rules that are already proved at unit.
+**Boundaries:** One or more real boundaries. Tests boot the dependency locally (testcontainers, docker-compose, in-memory adapter — never a hosted service). The test asserts behavior *only at the boundary itself* — never re-asserts business rules that are already proved at unit. The specific boundary discipline differs by data sub-layer — never mocked against a real test DB for a service's own database (`data_layer_own_database`), recorded fixture doubles for an external client/API (`data_layer_external_client`) — see `references/principles.md` for the full rationale.
 
 **Default for:** Categories 2 (service-boundary code), 4 (error paths involving real failures), 5 (external integrations via recorded fixtures).
 
@@ -55,7 +57,7 @@ unit > integration > smoke > E2E
 | Real third-party API response shape | Integration (recorded fixture) |
 | Auth/session middleware actually attaches user | Smoke |
 
-**Illegitimate higher-layer assertions (= trim in Phase 3):**
+**Illegitimate higher-layer assertions (= trim in Phase 3):** this is the worked application of the no-duplicate-coverage principle (`t5_no_duplicate_coverage` in `references/principles.md`) to this rubric's four layers — see that entry for the general rule; the table below is layer-criteria-specific examples.
 
 | If a unit test already proves | Then this assertion in the higher test is redundant |
 |---|---|
@@ -88,7 +90,7 @@ Canary is not a layer — it's a tag on smoke/E2E tests that also run against a 
 
 ## Speed budget alignment
 
-The canonical layer for a piece of code is also chosen with speed in mind. Per the `speed-budgets` skill:
+The canonical layer for a piece of code is also chosen with speed in mind — this is the layer-criteria application of `t6_layer_speed_mismatch` in `references/principles.md` (tests must sit in the correct speed tier). Per the `speed-budgets` skill, the concrete budgets are:
 
 - A test that requires <50ms execution → must be unit
 - A test that requires <2s and a real boundary → must be integration

--- a/plugins/shipwright/assets/rubrics/test-inventory-rubrics-wiring.unit.test.ts
+++ b/plugins/shipwright/assets/rubrics/test-inventory-rubrics-wiring.unit.test.ts
@@ -1,0 +1,93 @@
+/**
+ * test-inventory rubrics wiring tests — PRN-2.4
+ *
+ * Verifies code-classifier.md and layer-criteria.md each reference the shared
+ * references/principles.md file as the source of truth for test-layer
+ * definitions (testing-domain entries) and the two data_layer_* architecture
+ * entries — net-new wiring so the test-inventory rubrics stop duplicating
+ * layer definitions inline and instead point at principles.md.
+ *
+ * Also verifies test-inventory/SKILL.md documents the convention that a
+ * target repo's CLAUDE.md should declare its own concrete layer structure,
+ * mirroring the existing "## Testing" section pattern that feeds
+ * testReadinessContext into code-reviewer.md, kept accurate via the existing
+ * docs-refresher/research-docs mechanism.
+ *
+ * Content-assertion only: existsSync/readFileSync, no I/O beyond local file
+ * reads (mirrors principles-content.unit.test.ts / principles-wiring.unit.test.ts).
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/assets/rubrics/ → plugins/shipwright/
+const pluginRoot = resolve(import.meta.dir, "..", "..");
+
+function pluginPath(...parts: string[]): string {
+  return join(pluginRoot, ...parts);
+}
+
+const codeClassifierPath = pluginPath("assets", "rubrics", "code-classifier.md");
+const layerCriteriaPath = pluginPath("assets", "rubrics", "layer-criteria.md");
+const testInventorySkillPath = pluginPath("skills", "test-inventory", "SKILL.md");
+
+function readCodeClassifier(): string {
+  return readFileSync(codeClassifierPath, "utf8");
+}
+
+function readLayerCriteria(): string {
+  return readFileSync(layerCriteriaPath, "utf8");
+}
+
+function readTestInventorySkill(): string {
+  return readFileSync(testInventorySkillPath, "utf8");
+}
+
+describe("test-inventory rubrics wiring — files exist", () => {
+  it("assets/rubrics/code-classifier.md exists", () => {
+    expect(existsSync(codeClassifierPath)).toBe(true);
+  });
+
+  it("assets/rubrics/layer-criteria.md exists", () => {
+    expect(existsSync(layerCriteriaPath)).toBe(true);
+  });
+
+  it("skills/test-inventory/SKILL.md exists", () => {
+    expect(existsSync(testInventorySkillPath)).toBe(true);
+  });
+});
+
+describe("code-classifier.md — references principles.md", () => {
+  it("mentions references/principles.md", () => {
+    expect(readCodeClassifier()).toContain("references/principles.md");
+  });
+});
+
+describe("layer-criteria.md — references principles.md", () => {
+  it("mentions references/principles.md", () => {
+    expect(readLayerCriteria()).toContain("references/principles.md");
+  });
+
+  it("references principles.md near the four-layer definitions (## The four layers)", () => {
+    const content = readLayerCriteria();
+    const stepIndex = content.indexOf("## The four layers");
+    const nextStepIndex = content.indexOf("## The canonical-layer rule");
+    expect(stepIndex).toBeGreaterThan(-1);
+    expect(nextStepIndex).toBeGreaterThan(stepIndex);
+    const section = content.slice(stepIndex, nextStepIndex);
+    expect(section).toContain("references/principles.md");
+  });
+});
+
+describe("test-inventory/SKILL.md — documents the CLAUDE.md layer-declaration convention", () => {
+  it("mentions CLAUDE.md and layer structure together", () => {
+    const content = readTestInventorySkill();
+    expect(content).toContain("CLAUDE.md");
+    expect(content.toLowerCase()).toContain("layer structure");
+  });
+
+  it("documents that the convention is kept accurate via the docs-refresher/research-docs mechanism", () => {
+    const content = readTestInventorySkill();
+    expect(content).toContain("docs-refresher");
+  });
+});

--- a/plugins/shipwright/skills/test-inventory/SKILL.md
+++ b/plugins/shipwright/skills/test-inventory/SKILL.md
@@ -28,6 +28,8 @@ Read these signals to determine language and frameworks:
 
 Record stack profile (language, package manager, primary framework if obvious — e.g., Hono, Express, FastAPI, Rails).
 
+**CLAUDE.md layer-declaration convention:** also check the target repo's root `CLAUDE.md` for a section declaring its concrete layer structure (e.g. "handler → service → data", or whatever naming that repo uses — `architecture_layering` in `references/principles.md` is explicit that the layering principle concerns the *relationship* between layers, not literal names, and each repo's own `CLAUDE.md` should declare its concrete layer names). This mirrors the existing "## Testing" section pattern: `commands/review.md` extracts a repo's CLAUDE.md Testing section into `testReadinessContext` for `code-reviewer.md`'s test-readiness rule to consume, falling back to the universal baseline in `references/principles.md` when no such section exists. Apply the same fallback here — if the repo's CLAUDE.md declares a layer structure, use its concrete names when classifying and reporting; if it doesn't, fall back to the generic handler/service/data naming from `code-classifier.md`/`layer-criteria.md`. Like the Testing section, a CLAUDE.md layer-structure declaration is kept accurate as the repo evolves via the existing docs-refresher (`agents/docs-refresher.md`, invoked from `/shipwright:dev-task` Step 8.5) and `research-docs` mechanisms — no new tooling is required; it is simply another doc surface those mechanisms already watch.
+
 ### Step 2 — discover code surfaces
 
 Use Glob + Grep to enumerate code areas. Source dirs vary; default to common conventions (`src/`, `app/`, `lib/`, `internal/`, language-specific). Exclude vendored deps, generated code, and existing test files.


### PR DESCRIPTION
## Summary
- Repoints `code-classifier.md` and `layer-criteria.md` at `references/principles.md`'s testing-domain (and `data_layer_*` architecture) entries as the canonical source for layer definitions, instead of duplicating that content inline
- Documents a new convention in `test-inventory/SKILL.md`: a target repo's `CLAUDE.md` should declare its own concrete layer structure, mirroring the existing "## Testing" section pattern that feeds `testReadinessContext` into `code-reviewer.md` — kept accurate via the existing docs-refresher/research-docs mechanism, no new tooling required
- Part of the `entropy-test-readiness-rework` session's PRN-2.x repoint tasks (depends on PRN-1.1, which introduced `principles.md`)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | code-classifier.md and layer-criteria.md reference principles.md as their source for layer definitions | MET |
| 2 | test-inventory/SKILL.md or a rubric file documents the CLAUDE.md layer-declaration convention and that docs-freshness keeps it accurate | MET |
| 3 | Test decision: add a unit test asserting the rubric files reference principles.md — no existing tests to retire | MET |

## Test Plan
- New `plugins/shipwright/assets/rubrics/test-inventory-rubrics-wiring.unit.test.ts` (8 tests) — confirmed RED before the content edits, GREEN after
- `bunx biome lint` clean, `bun run --filter='*' typecheck` clean
- Full `bun test`: 3129 pass / 14 fail — the 14 failures are pre-existing on `main` (agent/plugin-install + k8s client tests), confirmed identical before this branch's changes
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
