### PR TITLE
feat: repoint code-reviewer Rule 6, add architecture review rule

### DIFF
--- a/plugins/shipwright/agents/code-reviewer.md
+++ b/plugins/shipwright/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues. Shipwright-specific rules include breaking API change detection, acceptance criteria verification, silent-failure detection, base-branch pre-existing issue filtering, CLAUDE.md explicit-endorsement awareness, and test-readiness adherence for PRs touching tests or adding untested logic.
+description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues. Shipwright-specific rules include breaking API change detection, acceptance criteria verification, silent-failure detection, base-branch pre-existing issue filtering, CLAUDE.md explicit-endorsement awareness, test-readiness adherence for PRs touching tests or adding untested logic, and architecture-layering adherence for PRs that skip a layer boundary.
 tools: Glob, Grep, LS, Read, NotebookRead, TodoWrite, KillShell, BashOutput
 model: sonnet
 color: red
@@ -41,7 +41,9 @@ These apply in addition to generic review:
 
 5. **CLAUDE.md explicit-endorsement check.** Before flagging a style or pattern issue, check whether the project's CLAUDE.md explicitly endorses that pattern. If endorsed, drop the finding.
 
-6. **Test-readiness adherence.** Activation gate: fires only when the PR touches files matching `*.test.*`, `*.spec.*`, or `tests/` directories, OR when the PR adds production logic with no corresponding test additions. When `testReadinessContext` is present (passed by the caller from `docs/test-readiness/test-system.md` + the CLAUDE.md Testing section), check the diff against those tenets. When `testReadinessContext` is absent, apply the universal baseline from `references/test-readiness-tenets.md` instead. Apply the Rule 4 pre-existing issue filter before reporting — do not flag violations that exist unchanged on the base branch. Apply the Rule 5 CLAUDE.md endorsement filter — do not flag patterns explicitly endorsed by the project.
+6. **Test-readiness adherence.** Activation gate: fires only when the PR touches files matching `*.test.*`, `*.spec.*`, or `tests/` directories, OR when the PR adds production logic with no corresponding test additions. When `testReadinessContext` is present (passed by the caller from `docs/test-readiness/test-system.md` + the CLAUDE.md Testing section), check the diff against those tenets. When `testReadinessContext` is absent, apply the universal baseline from the testing-domain entries in `references/principles.md` instead. Apply the Rule 4 pre-existing issue filter before reporting — do not flag violations that exist unchanged on the base branch. Apply the Rule 5 CLAUDE.md endorsement filter — do not flag patterns explicitly endorsed by the project.
+
+7. **Architecture-layering adherence.** Activation gate: fires only when the diff adds a call from one layer directly into a layer below the one immediately beneath it — e.g. a handler/transport file (an HTTP route, a CLI command, a message/event handler) calling a database client, ORM, or external-service SDK directly, skipping the service layer. When the repo's CLAUDE.md declares a concrete layer structure (handler/service/data, or an equivalent naming the repo uses), check the diff against the architecture-domain entries in `references/principles.md`. When the repo's CLAUDE.md has no declared layer structure, do not flag layering issues at all — there is no violable boundary to check against. Apply the Rule 4 pre-existing issue filter before reporting — do not flag violations that exist unchanged on the base branch. Apply the Rule 5 CLAUDE.md endorsement filter — do not flag patterns explicitly endorsed by the project.
 
 ## Confidence Scoring
 
@@ -79,7 +81,7 @@ Return a single JSON object:
       "line": {integer or null},
       "severity": "critical|important|suggestion",
       "confidence": {0-100},
-      "category": "bug|security|api-break|acceptance-criteria|silent-failure|claude-md|quality|test-readiness",
+      "category": "bug|security|api-break|acceptance-criteria|silent-failure|claude-md|quality|test-readiness|architecture",
       "description": "{what's wrong, with enough context that the main thread can format it}",
       "suggestion": "{optional one-line fix; null if none}"
     }

--- a/plugins/shipwright/agents/code-reviewer.unit.test.ts
+++ b/plugins/shipwright/agents/code-reviewer.unit.test.ts
@@ -57,11 +57,15 @@ describe("code-reviewer.md — Rule 6 test-readiness adherence", () => {
 
   it("documents fallback to universal baseline when context is absent", () => {
     const hasFallback =
-      reviewerContent.includes("test-readiness-tenets.md") &&
+      reviewerContent.includes("principles.md") &&
       (reviewerContent.includes("absent") ||
         reviewerContent.includes("fallback") ||
         reviewerContent.includes("falls back"));
     expect(hasFallback).toBe(true);
+  });
+
+  it("references principles.md as the source for testing-domain entries", () => {
+    expect(reviewerContent.includes("principles.md")).toBe(true);
   });
 
   it("references the pre-existing issue filter from Rule 4", () => {
@@ -79,6 +83,74 @@ describe("code-reviewer.md — Rule 6 test-readiness adherence", () => {
         reviewerContent.includes("endorsement") &&
         reviewerContent.includes("filter"));
     expect(hasRule5Reference).toBe(true);
+  });
+});
+
+describe("code-reviewer.md — Rule 7 architecture-layering adherence", () => {
+  it("contains a Rule 7 Architecture-layering adherence section", () => {
+    const hasRule7 =
+      reviewerContent.includes("Rule 7") ||
+      (reviewerContent.toLowerCase().includes("architecture") &&
+        reviewerContent.toLowerCase().includes("layering"));
+    expect(hasRule7).toBe(true);
+  });
+
+  it("has the new rule labeled as Architecture-layering adherence", () => {
+    const hasLabel =
+      reviewerContent.includes("Architecture-layering adherence") ||
+      reviewerContent.toLowerCase().includes("architecture-layering adherence");
+    expect(hasLabel).toBe(true);
+  });
+
+  it("documents an activation gate for direct layer-skipping calls", () => {
+    const hasActivationGate =
+      reviewerContent.toLowerCase().includes("activation gate") &&
+      reviewerContent.toLowerCase().includes("layer") &&
+      (reviewerContent.toLowerCase().includes("handler") ||
+        reviewerContent.toLowerCase().includes("skip"));
+    expect(hasActivationGate).toBe(true);
+  });
+
+  it("references principles.md as the source for architecture-domain entries", () => {
+    expect(reviewerContent.includes("principles.md")).toBe(true);
+  });
+
+  it("documents graceful degradation when no declared layer structure exists", () => {
+    const hasDegradation =
+      reviewerContent.toLowerCase().includes("no declared layer structure") ||
+      (reviewerContent.toLowerCase().includes("no layer structure") ||
+        (reviewerContent.toLowerCase().includes("layer structure") &&
+          (reviewerContent.toLowerCase().includes("no ") ||
+            reviewerContent.toLowerCase().includes("does not"))));
+    expect(hasDegradation).toBe(true);
+  });
+
+  it("applies the Rule 4 pre-existing issue filter to the new rule", () => {
+    const rule7Section = reviewerContent.slice(
+      reviewerContent.indexOf("Architecture-layering adherence"),
+    );
+    const hasRule4Reference =
+      rule7Section.includes("Rule 4") ||
+      (rule7Section.includes("pre-existing") && rule7Section.includes("filter"));
+    expect(hasRule4Reference).toBe(true);
+  });
+
+  it("applies the Rule 5 CLAUDE.md endorsement filter to the new rule", () => {
+    const rule7Section = reviewerContent.slice(
+      reviewerContent.indexOf("Architecture-layering adherence"),
+    );
+    const hasRule5Reference =
+      rule7Section.includes("Rule 5") ||
+      (rule7Section.includes("CLAUDE.md") &&
+        rule7Section.includes("endorsement") &&
+        rule7Section.includes("filter"));
+    expect(hasRule5Reference).toBe(true);
+  });
+});
+
+describe("code-reviewer.md — architecture category in output format", () => {
+  it("includes architecture in the category enum", () => {
+    expect(reviewerContent).toContain("architecture");
   });
 });
 

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -386,7 +386,8 @@ a single prompt block containing:
 - **`testReadinessContext`** — contents of `docs/test-readiness/test-system.md` plus the
   Testing section of the repo's CLAUDE.md (gathered in Step 5.7); omit this field entirely
   when no test-readiness content was gathered (the subagent falls back to the universal
-  baseline in `references/test-readiness-tenets.md` when the field is absent)
+  baseline in the testing-domain entries of `references/principles.md` when the field is
+  absent)
 - **Policy** — pass `min_confidence` and `max_findings` from Step 1
 
 The subagent returns a JSON object with `summary`, `findings[]`, `strengths[]`,

--- a/plugins/shipwright/references/principles.md
+++ b/plugins/shipwright/references/principles.md
@@ -4,8 +4,9 @@ The single source of truth for Shipwright's code-design and testing principles.
 Every consumer — `plan-session`, `dev-task`, `review`, `entropy-scan`/`entropy-fix`,
 and the test-readiness rubrics — reads its principles from this file.
 
-> **Status note:** This file is net-new and additive. Consumers are repointed at it
-> in later tasks (PRN-2.x / PRN-3.1). Until then nothing reads it — it is pure content.
+> **Status note:** This file is net-new and additive. As of PRN-2.2, code-reviewer Rules 6
+> and 7 read the testing-domain and architecture-domain entries from this file,
+> respectively. Remaining consumers are repointed at it in later tasks (PRN-2.x / PRN-3.1).
 
 ## How to read this file
 

--- a/plugins/shipwright/references/test-readiness-tenets.md
+++ b/plugins/shipwright/references/test-readiness-tenets.md
@@ -1,7 +1,12 @@
 # Test-Readiness Tenets — Universal Baseline
 
-Checklist of diff-checkable test quality tenets. Used by code-reviewer Rule 6 when
-`testReadinessContext` is absent (graceful degradation) or as a supplemental baseline.
+> **Superseded note (PRN-2.2):** Rule 6's graceful-degradation fallback now reads the
+> testing-domain entries in `references/principles.md` instead of this file. This file is
+> retained as a supplemental baseline / historical reference but is no longer the active
+> fallback source.
+
+Checklist of diff-checkable test quality tenets. Previously used by code-reviewer Rule 6
+when `testReadinessContext` is absent (graceful degradation) or as a supplemental baseline.
 
 ## Graceful Degradation
 


### PR DESCRIPTION
## Summary
- Repoints `code-reviewer.md` Rule 6 (test-readiness adherence) to load the testing-domain baseline from `references/principles.md` instead of `references/test-readiness-tenets.md`, keeping its activation gate and graceful-degradation behavior intact
- Adds a new Rule 7 (architecture-layering adherence), parallel in structure to Rule 6, with its own activation gate (handler skipping the service layer to call the DB/external client directly) and graceful degradation when the repo's CLAUDE.md declares no layer structure; applies the existing Rule 4 pre-existing-issue filter and Rule 5 CLAUDE.md-endorsement filter
- Adds `architecture` to the output format's category enum

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Rule 6 references principles.md instead of test-readiness-tenets.md | MET |
| 2 | A new architecture rule exists with its own activation gate and graceful-degradation behavior, applying Rule 4 and Rule 5 filters | MET |
| 3 | Test decision: unit test asserting code-reviewer.md contains both the updated Rule 6 reference and the new architecture rule section — no existing tests to retire | MET |

## Test Plan
- `bun test plugins/shipwright/agents/code-reviewer.unit.test.ts` — 29 pass
- `bun test` (full suite) — 3077 pass, 14 pre-existing failures unrelated to this change (confirmed identical on main)
- `bun run lint` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
