### PR TITLE
fix: preserve AgentCronJob id in reconcileSystemCrons to keep cron run history

### DIFF
--- a/admin/src/agent-cron-jobs.integration.test.ts
+++ b/admin/src/agent-cron-jobs.integration.test.ts
@@ -297,4 +297,46 @@ describeOrSkip("AgentCronJobService (integration)", () => {
     expect(result.updated).toBeGreaterThan(0);
     expect(result.created).toBe(0);
   });
+
+  it("reconcileSystemCrons() preserves cron id and AgentCronRun history across a reconcile", async () => {
+    const agentId = await createAgent(prisma);
+    // First reconcile seeds all system crons
+    await service.reconcileSystemCrons(agentId);
+
+    const jobs = await service.list(agentId);
+    const target = jobs.find((j) => j.system && j.name);
+    if (!target) {
+      throw new Error("expected at least one system cron to be seeded");
+    }
+    const originalId = target.id;
+
+    // Record a run against this cron, as the runtime does after executing it.
+    const run = await prisma.agentCronRun.create({
+      data: {
+        cronId: originalId,
+        agentId,
+        startedAt: new Date(),
+        completedAt: new Date(),
+        skipped: false,
+        outcome: "success",
+      },
+    });
+
+    // Reconciling again (e.g. on agent restart) must not wipe history: it
+    // should update the existing row in place rather than delete+recreate it.
+    const result = await service.reconcileSystemCrons(agentId);
+    expect(result.updated).toBeGreaterThan(0);
+    expect(result.created).toBe(0);
+
+    const jobsAfter = await service.list(agentId);
+    const targetAfter = jobsAfter.find((j) => j.name === target.name);
+    expect(targetAfter).toBeDefined();
+    expect(targetAfter?.id).toBe(originalId);
+
+    const survivingRun = await prisma.agentCronRun.findUnique({
+      where: { id: run.id },
+    });
+    expect(survivingRun).not.toBeNull();
+    expect(survivingRun?.cronId).toBe(originalId);
+  });
 });

--- a/admin/src/agent-cron-jobs.ts
+++ b/admin/src/agent-cron-jobs.ts
@@ -357,9 +357,11 @@ export class AgentCronJobService {
    * Reconcile system crons for the given agent.
    *
    * For each entry in SYSTEM_CRONS:
-   *   - If an existing system cron with matching name exists: delete it and
-   *     recreate it with current SYSTEM_CRONS definition, preserving the
-   *     existing enabled state.
+   *   - If an existing system cron with matching name exists: update it in
+   *     place with the current SYSTEM_CRONS definition, preserving its id and
+   *     existing enabled state. Updating in place (rather than delete+create)
+   *     keeps the row's id stable across restarts so AgentCronRun history
+   *     (FK onDelete: Cascade) is never wiped out from under it.
    *   - If no matching cron exists: create it with SYSTEM_CRONS default enabled.
    *
    * Orphan pass: delete any cron with system=true whose name is no longer in SYSTEM_CRONS.
@@ -395,29 +397,38 @@ export class AgentCronJobService {
       // Reconcile each SYSTEM_CRON entry
       for (const systemCron of SYSTEM_CRONS) {
         const existing = existingByName.get(systemCron.name);
-        const enabled = existing ? existing.enabled : systemCron.enabled;
 
         if (existing) {
-          await tx.agentCronJob.delete({ where: { id: existing.id } });
+          // Update in place — preserves id (and thus AgentCronRun history,
+          // which cascade-deletes when its AgentCronJob is deleted) and the
+          // existing enabled state.
+          await tx.agentCronJob.update({
+            where: { id: existing.id },
+            data: {
+              schedule: systemCron.schedule,
+              prompt: systemCron.prompt,
+              silent: systemCron.silent ?? false,
+              preCheck: systemCron.preCheck ?? null,
+            },
+          });
           updated++;
         } else {
+          await tx.agentCronJob.create({
+            data: {
+              agentId,
+              name: systemCron.name,
+              system: true,
+              schedule: systemCron.schedule,
+              prompt: systemCron.prompt,
+              silent: systemCron.silent ?? false,
+              preCheck: systemCron.preCheck ?? null,
+              channel: null,
+              user: null,
+              enabled: systemCron.enabled,
+            },
+          });
           created++;
         }
-
-        await tx.agentCronJob.create({
-          data: {
-            agentId,
-            name: systemCron.name,
-            system: true,
-            schedule: systemCron.schedule,
-            prompt: systemCron.prompt,
-            silent: systemCron.silent ?? false,
-            preCheck: systemCron.preCheck ?? null,
-            channel: null,
-            user: null,
-            enabled,
-          },
-        });
       }
 
       // Orphan pass: delete any system cron whose name is not in SYSTEM_CRONS.

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -197,7 +197,21 @@ Returns `204`. System crons (flagged `isSystem=true`) cannot be deleted — retu
 POST /agents/:id/crons/reconcile
 ```
 
-Reconciles the agent's system crons against the `SYSTEM_CRONS` list in the harness. Called automatically on agent startup. Returns `204`.
+Reconciles the agent's system crons against the `SYSTEM_CRONS` list in the harness. Called automatically on agent startup. Returns `200` with a summary:
+
+```json
+{
+  "created": 0,
+  "updated": 2,
+  "deleted": 0
+}
+```
+
+**How reconciliation works:**
+
+- **Existing crons:** For each system cron that already exists (matched by name), the endpoint updates it in place with the current definition from `SYSTEM_CRONS`, preserving its ID and existing enabled state. Updating in place (rather than delete+recreate) keeps the cron's ID stable across agent restarts, so `AgentCronRun` history (linked by foreign key with cascade-delete) is never wiped out.
+- **New crons:** Crons in `SYSTEM_CRONS` that don't yet exist are created with their default enabled state.
+- **Orphaned crons:** System crons whose names are no longer in `SYSTEM_CRONS` are deleted.
 
 ### Cron summary
 


### PR DESCRIPTION
## Summary
- `AgentCronJobService.reconcileSystemCrons()` previously deleted and recreated every existing system cron on each reconcile (which runs on every agent process startup). Since `AgentCronRun.cron` has `onDelete: Cascade` back to `AgentCronJob`, this permanently wiped all cron run history on every agent restart.
- Fixed by updating the existing row in place (`tx.agentCronJob.update` keyed by `existing.id`) instead of delete+create, preserving the row's id — and therefore its `AgentCronRun` history — across reconciles. `create()` now only fires when no existing row matches by name; the orphan-delete pass and `created`/`updated`/`deleted` counters are unchanged.
- Refreshed `docs/agent-api.md` to document the corrected response shape (`200` with a summary object, not `204`) and the in-place reconciliation behavior.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | reconcileSystemCrons updates existing system crons in place (same id preserved) instead of delete+create | MET | existing branch now calls `tx.agentCronJob.update({ where: { id: existing.id }, ... })`; `delete()` removed from this path |
| 2 | Existing AgentCronRun history survives a reconcile for an unchanged/updated system cron | MET | update-in-place never triggers the cascade-delete FK; new integration test asserts the `AgentCronRun` row survives a second reconcile |
| 3 | create() path and orphan-delete path behavior unchanged | MET | `create()` still fires only on no-match; orphan-delete loop untouched; counters preserved |
| 4 | Integration test covering id-preservation and no-cascade-delete | MET | new test "reconcileSystemCrons() preserves cron id and AgentCronRun history across a reconcile" asserts both the id is unchanged and the `AgentCronRun` row still exists |
| 5 | Root cause and fix documented | MET | updated JSDoc + this PR description |

## Test Plan
- New integration test in `admin/src/agent-cron-jobs.integration.test.ts` verified red (failed against the pre-fix delete+create code, proving the cascade-delete) then green (passes with the fix), run against a real Postgres instance.
- Full admin suite: 973 pass / 1 fail (pre-existing, unrelated `kubernetes-client.integration.test.ts` CA-cert assertion — confirmed failing on `main` too).
- `bunx biome lint .` clean.
- `bun run --filter='@shipwright/admin' typecheck` clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
