### PR TITLE
fix: populate simplify category avg metrics (summary + trends + coverage trends)

### DIFF
--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -583,6 +583,8 @@ function makeTrendsHandler(
           simplifyAvgComplexity: toNumOrNull(row.simplify_avg_complexity),
           simplifyAvgConsistency: toNumOrNull(row.simplify_avg_consistency),
           avgReviewFindings: toNumOrNull(row.avg_review_findings),
+          coverageReports: toNum(row.coverage_reports),
+          avgCoverageDelta: toNumOrNull(row.avg_coverage_delta),
         };
       });
 

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -41,6 +41,11 @@ const TASKS: TaskRecord[] = [
     simplifyTotal: 2,
     addedAt: "2026-06-01T08:00:00.000Z",
     coverageDelta: 2.5,
+    simplifyDry: 4,
+    simplifyDeadCode: 2,
+    simplifyNaming: 6,
+    simplifyComplexity: 1,
+    simplifyConsistency: 3,
   },
   {
     id: "QS-1.2",
@@ -56,6 +61,11 @@ const TASKS: TaskRecord[] = [
     simplifyTotal: 1,
     addedAt: "2026-06-02T08:00:00.000Z",
     coverageDelta: null,
+    simplifyDry: 2,
+    simplifyDeadCode: 0,
+    simplifyNaming: 4,
+    simplifyComplexity: 3,
+    simplifyConsistency: 1,
   },
   {
     id: "MQ-2.1",
@@ -220,6 +230,12 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[colIndex(t, "avg_coverage_delta")]).toBe(2.5);
     // avg_review_iterations = avg(reviewCycles + patchCycles) = avg(2, 3) = 2.5
     expect(row[colIndex(t, "avg_review_iterations")]).toBe(2.5);
+    // simplify category averages: QS-1.1 (4,2,6,1,3) + QS-1.2 (2,0,4,3,1)
+    expect(row[colIndex(t, "simplify_avg_dry")]).toBe(3);
+    expect(row[colIndex(t, "simplify_avg_dead_code")]).toBe(1);
+    expect(row[colIndex(t, "simplify_avg_naming")]).toBe(5);
+    expect(row[colIndex(t, "simplify_avg_complexity")]).toBe(2);
+    expect(row[colIndex(t, "simplify_avg_consistency")]).toBe(2);
   });
 
   test("summary coverage aggregation excludes null coverageDelta tasks from the average", async () => {
@@ -274,6 +290,83 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[colIndex(t, "avg_coverage_delta")]).toBe(1);
   });
 
+  test("summary simplify category averages exclude tasks with null/undefined values", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "SX-1.1",
+        status: "merged",
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        addedAt: "2026-06-01T08:00:00.000Z",
+        simplifyDry: 6,
+        simplifyDeadCode: 4,
+        simplifyNaming: 8,
+        simplifyComplexity: 2,
+        simplifyConsistency: 5,
+      },
+      {
+        id: "SX-1.2",
+        status: "merged",
+        startedAt: "2026-06-03T08:00:00.000Z",
+        completedAt: "2026-06-03T12:00:00.000Z",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        addedAt: "2026-06-02T08:00:00.000Z",
+        simplifyDry: null,
+        simplifyDeadCode: null,
+        simplifyNaming: null,
+        simplifyComplexity: null,
+        simplifyConsistency: null,
+      },
+      {
+        id: "SX-1.3",
+        status: "merged",
+        startedAt: "2026-06-04T08:00:00.000Z",
+        completedAt: "2026-06-04T12:00:00.000Z",
+        mergedAt: "2026-06-04T12:00:00.000Z",
+        addedAt: "2026-06-03T08:00:00.000Z",
+        // simplify* fields intentionally omitted (undefined)
+      },
+    ];
+    const taskStore = new RecordedTaskStoreClient(tasks, []);
+    const admin = new RecordedAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "summary", range: RANGE });
+    const row = t.results[0];
+    // Only SX-1.1 has non-null simplify category values → average equals its
+    // own values, not diluted by the null/undefined tasks.
+    expect(row[colIndex(t, "simplify_avg_dry")]).toBe(6);
+    expect(row[colIndex(t, "simplify_avg_dead_code")]).toBe(4);
+    expect(row[colIndex(t, "simplify_avg_naming")]).toBe(8);
+    expect(row[colIndex(t, "simplify_avg_complexity")]).toBe(2);
+    expect(row[colIndex(t, "simplify_avg_consistency")]).toBe(5);
+  });
+
+  test("summary simplify category averages are null when no tasks have simplify data", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "SX-2.1",
+        status: "merged",
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        addedAt: "2026-06-01T08:00:00.000Z",
+      },
+    ];
+    const taskStore = new RecordedTaskStoreClient(tasks, []);
+    const admin = new RecordedAdminMetricsClient(CRON_STATS, CHAT_STATS);
+    const provider = new TaskStoreProvider(taskStore, admin, CLOCK);
+
+    const t = await provider.query({ kind: "summary", range: RANGE });
+    const row = t.results[0];
+    expect(row[colIndex(t, "simplify_avg_dry")]).toBeNull();
+    expect(row[colIndex(t, "simplify_avg_dead_code")]).toBeNull();
+    expect(row[colIndex(t, "simplify_avg_naming")]).toBeNull();
+    expect(row[colIndex(t, "simplify_avg_complexity")]).toBeNull();
+    expect(row[colIndex(t, "simplify_avg_consistency")]).toBeNull();
+  });
+
   test("summary coverage aggregation returns 0/null when no tasks have coverageDelta", async () => {
     const tasks: TaskRecord[] = [
       {
@@ -312,6 +405,68 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[colIndex(t, "tasks_approved")]).toBe(1);
     // task-store PR records carry no findings count → always null
     expect(row[colIndex(t, "avg_review_findings")]).toBeNull();
+  });
+
+  test("trends includes coverage_reports and avg_coverage_delta columns computed per period", async () => {
+    const provider = buildProvider();
+    const t = await provider.query({
+      kind: "trends",
+      range: RANGE,
+      groupBy: "day",
+    });
+
+    expect(t.columns).toContain("coverage_reports");
+    expect(t.columns).toContain("avg_coverage_delta");
+
+    // QS-1.1 completes on 2026-06-02 with coverageDelta=2.5.
+    const day1 = t.results.find(
+      (r) => r[colIndex(t, "period")] === "2026-06-02",
+    );
+    expect(day1).toBeDefined();
+    expect(day1?.[colIndex(t, "coverage_reports")]).toBe(1);
+    expect(day1?.[colIndex(t, "avg_coverage_delta")]).toBe(2.5);
+
+    // QS-1.2 completes on 2026-06-03 with coverageDelta=null → excluded, not
+    // treated as zero.
+    const day2 = t.results.find(
+      (r) => r[colIndex(t, "period")] === "2026-06-03",
+    );
+    expect(day2).toBeDefined();
+    expect(day2?.[colIndex(t, "coverage_reports")]).toBe(0);
+    expect(day2?.[colIndex(t, "avg_coverage_delta")]).toBeNull();
+  });
+
+  test("trends per-period simplify_avg_* columns are non-null when simplify data exists", async () => {
+    const provider = buildProvider();
+    const t = await provider.query({
+      kind: "trends",
+      range: RANGE,
+      groupBy: "day",
+    });
+
+    // QS-1.1 completes on 2026-06-02 with simplifyDry=4, simplifyDeadCode=2,
+    // simplifyNaming=6, simplifyComplexity=1, simplifyConsistency=3.
+    const day1 = t.results.find(
+      (r) => r[colIndex(t, "period")] === "2026-06-02",
+    );
+    expect(day1).toBeDefined();
+    expect(day1?.[colIndex(t, "simplify_avg_dry")]).toBe(4);
+    expect(day1?.[colIndex(t, "simplify_avg_dead_code")]).toBe(2);
+    expect(day1?.[colIndex(t, "simplify_avg_naming")]).toBe(6);
+    expect(day1?.[colIndex(t, "simplify_avg_complexity")]).toBe(1);
+    expect(day1?.[colIndex(t, "simplify_avg_consistency")]).toBe(3);
+
+    // QS-1.2 completes on 2026-06-03 with simplifyDry=2, simplifyDeadCode=0,
+    // simplifyNaming=4, simplifyComplexity=3, simplifyConsistency=1.
+    const day2 = t.results.find(
+      (r) => r[colIndex(t, "period")] === "2026-06-03",
+    );
+    expect(day2).toBeDefined();
+    expect(day2?.[colIndex(t, "simplify_avg_dry")]).toBe(2);
+    expect(day2?.[colIndex(t, "simplify_avg_dead_code")]).toBe(0);
+    expect(day2?.[colIndex(t, "simplify_avg_naming")]).toBe(4);
+    expect(day2?.[colIndex(t, "simplify_avg_complexity")]).toBe(3);
+    expect(day2?.[colIndex(t, "simplify_avg_consistency")]).toBe(1);
   });
 
   test("tokensTotals = cron + chat summed field-wise (no double counting)", async () => {

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -10,11 +10,10 @@
  * tokens (the "cron" session source) and chat-daily tokens (the "chat" session
  * source) are disjoint, so summing them field-wise is the correct total.
  *
- * Where a metric genuinely has no task-store equivalent (e.g. simplify
- * sub-scores, files-changed, retries, fix-cascade depth — those lived only in
- * the now-removed PostHog event stream), the column is kept and filled with a
- * neutral empty value (null/0) rather than dropped: every kind must return a
- * valid table (AC#1).
+ * Where a metric genuinely has no task-store equivalent (e.g. files-changed,
+ * retries, fix-cascade depth — those lived only in the now-removed PostHog
+ * event stream), the column is kept and filled with a neutral empty value
+ * (null/0) rather than dropped: every kind must return a valid table (AC#1).
  */
 
 import {
@@ -306,11 +305,11 @@ export class TaskStoreProvider implements MetricsProvider {
       avg(ciTasks.map((t) => num(t.ciFixAttempts))),
       completed.filter((t) => num(t.simplifyTotal) !== null).length, // simplify_total = tasks with a simplify pass
       sum(completed.map((t) => num(t.simplifyTotal))), // simplify_total_fixes
-      null, // simplify_avg_dry — no task-store source
-      null, // simplify_avg_dead_code — no task-store source
-      null, // simplify_avg_naming — no task-store source
-      null, // simplify_avg_complexity — no task-store source
-      null, // simplify_avg_consistency — no task-store source
+      avg(completed.map((t) => num(t.simplifyDry))),
+      avg(completed.map((t) => num(t.simplifyDeadCode))),
+      avg(completed.map((t) => num(t.simplifyNaming))),
+      avg(completed.map((t) => num(t.simplifyComplexity))),
+      avg(completed.map((t) => num(t.simplifyConsistency))),
       prs.length,
       shipIt,
       avgReviewIterations,
@@ -391,6 +390,8 @@ export class TaskStoreProvider implements MetricsProvider {
       "simplify_avg_complexity",
       "simplify_avg_consistency",
       "avg_review_findings",
+      "coverage_reports",
+      "avg_coverage_delta",
     ];
 
     const completedOn = (p: string) =>
@@ -456,12 +457,14 @@ export class TaskStoreProvider implements MetricsProvider {
         estAcc.length
           ? estAcc.reduce((a, b) => a + b, 0) / estAcc.length
           : null,
-        null, // simplify_avg_dry — no source
-        null, // simplify_avg_dead_code — no source
-        null, // simplify_avg_naming — no source
-        null, // simplify_avg_complexity — no source
-        null, // simplify_avg_consistency — no source
+        avg(c.map((t) => num(t.simplifyDry))),
+        avg(c.map((t) => num(t.simplifyDeadCode))),
+        avg(c.map((t) => num(t.simplifyNaming))),
+        avg(c.map((t) => num(t.simplifyComplexity))),
+        avg(c.map((t) => num(t.simplifyConsistency))),
         null, // avg_review_findings — task-store PR records carry no findings count
+        c.filter((t) => num(t.coverageDelta) !== null).length, // coverage_reports
+        avg(c.map((t) => num(t.coverageDelta))), // avg_coverage_delta
       ];
     });
 

--- a/metrics/src/schemas.ts
+++ b/metrics/src/schemas.ts
@@ -107,6 +107,8 @@ export const TrendsPeriodSchema = z.object({
   simplifyAvgComplexity: z.number().nullable(),
   simplifyAvgConsistency: z.number().nullable(),
   avgReviewFindings: z.number().nullable(),
+  coverageReports: z.number().int(),
+  avgCoverageDelta: z.number().nullable(),
 });
 
 export const TrendsResultSchema = z

--- a/metrics/src/server-offline-mode.smoke.test.ts
+++ b/metrics/src/server-offline-mode.smoke.test.ts
@@ -87,6 +87,29 @@ describe("server.ts fixture-branch — METRICS_OFFLINE=true + METRICS_DASHBOARD_
     expect(body.data.avgCoverageDelta).toBeCloseTo((5 + 3 + 8) / 3, 5);
   });
 
+  test("/metrics/trends?preset=7d&groupBy=day returns coverageReports and avgCoverageDelta per row", async () => {
+    const deps = buildFixtureDeps();
+    const app = createMetricsApp(new Map(), noopAccountsClient, deps);
+    const res = await app.request("/metrics/trends?preset=7d&groupBy=day");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data.rows)).toBe(true);
+    expect(body.data.rows.length).toBeGreaterThan(0);
+    for (const row of body.data.rows) {
+      expect(typeof row.coverageReports).toBe("number");
+      expect(
+        row.avgCoverageDelta === null || typeof row.avgCoverageDelta === "number",
+      ).toBe(true);
+    }
+    // Same fixture cassette as the summary test above: QS-1.1, QS-1.2, MQ-2.1
+    // collectively report 3 coverage deltas across the 7d window's per-day rows.
+    const totalCoverageReports = body.data.rows.reduce(
+      (sum: number, r: { coverageReports: number }) => sum + r.coverageReports,
+      0,
+    );
+    expect(totalCoverageReports).toBe(3);
+  });
+
   test("/dashboard returns 200 server-rendered HTML without credentials", async () => {
     const deps = buildFixtureDeps();
     const app = createMetricsApp(new Map(), noopAccountsClient, deps);


### PR DESCRIPTION
## Summary
- Replace hardcoded `null` values for `simplify_avg_dry/dead_code/naming/complexity/consistency` in `summary()` with real `avg()` computations sourced from task-store fields (dev-task populates these on every PATCH).
- Apply the same fix to the per-period simplify category averages in `trends()`.
- Add `coverage_reports` and `avg_coverage_delta` columns to `trends()`, mirroring the existing `summary()` coverage aggregation.
- Update the stale doc comment claiming these fields have "no task-store source".

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | summary() returns non-null simplify_avg_* for agents that ran simplify passes with non-zero values | MET |
| 2 | trends() returns non-null simplify category averages per period when data exists | MET |
| 3 | trends() response includes coverage_reports and avg_coverage_delta columns | MET |
| 4 | Add/update test covering simplify category values in summary response | MET |

## Test Plan
- Extended existing summary integration test with simplify category average assertions
- Added test for null/undefined exclusion from simplify averages (not treated as zero)
- Added test for all-null simplify data → averages return null
- Added test for trends coverage_reports/avg_coverage_delta columns
- Added test for trends per-period simplify_avg_* columns
- [x] `bun test metrics/src/providers/task-store-provider.integration.test.ts` — 20/20 pass
- [x] `bun run --filter='*' typecheck` — clean across all workspaces
- [x] `bunx biome lint .` — clean

Generated with [Claude Code](https://claude.com/claude-code)
