### PR TITLE
fix: retry stale-base merge race in sync-plugin-version and auto-bump-chart

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -258,6 +258,19 @@ jobs:
       # protection otherwise rejects the merge outright — confirmed via
       # PR #1084, where `gh pr merge --squash` (no `--admin`) failed with
       # "the base branch policy prohibits the merge" even after checks passed.
+      #
+      # Retry on stale-base races: this workflow and sync-plugin-version.yml
+      # both trigger off the same tag pushes and race to merge onto main.
+      # When the other workflow's PR lands first, main moves out from under
+      # this PR (no textual conflict — just a stale base ref) and
+      # `gh pr merge` fails with a transient GraphQL error: "Base branch was
+      # modified. Review and try the merge again." Confirmed via run
+      # 28703925995 (agent-v0.129.0, 2026-07-04 10:54). Retry a few times
+      # with a short sleep to absorb that window. Any other failure (real
+      # conflict, auth error, branch protection rejection, etc.) is NOT
+      # retried — fail immediately so a human is alerted, same as before this
+      # change. If the stale-base error persists past all retries, the step
+      # still ultimately fails for the same reason.
       - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
@@ -281,4 +294,35 @@ jobs:
           echo "Waiting for required checks on ${PR_URL}..."
           gh pr checks "$PR_URL" --watch --interval 15 --required
           echo "Checks passed — merging ${PR_URL}."
-          gh pr merge "$PR_URL" --squash --admin
+
+          # Detects the transient stale-base GraphQL error (see comment
+          # above). Mirrors .github/workflows/test-auto-bump-chart.sh — keep
+          # both copies in sync.
+          is_stale_base_error() {
+            local output="$1"
+            if echo "$output" | grep -qi "Base branch was modified" || \
+               echo "$output" | grep -qi "try the merge again"; then
+              return 0
+            fi
+            return 1
+          }
+
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            MERGE_OUTPUT=$(gh pr merge "$PR_URL" --squash --admin 2>&1) && {
+              echo "$MERGE_OUTPUT"
+              echo "Merged ${PR_URL}."
+              exit 0
+            }
+
+            echo "$MERGE_OUTPUT" >&2
+
+            if is_stale_base_error "$MERGE_OUTPUT" && [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Stale-base race detected (attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in 5s..."
+              sleep 5
+              continue
+            fi
+
+            echo "Merge failed on attempt ${attempt}/${MAX_ATTEMPTS} — not retrying (either not a stale-base error, or retries exhausted)."
+            exit 1
+          done

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -219,6 +219,19 @@ jobs:
       # protection otherwise rejects the merge outright — confirmed via
       # PR #1084, where `gh pr merge --squash` (no `--admin`) failed with
       # "the base branch policy prohibits the merge" even after checks passed.
+      #
+      # Retry on stale-base races: this workflow and auto-bump-chart.yml both
+      # trigger off the same tag pushes and race to merge onto main. When the
+      # other workflow's PR lands first, main moves out from under this PR
+      # (no textual conflict — just a stale base ref) and `gh pr merge` fails
+      # with a transient GraphQL error: "Base branch was modified. Review and
+      # try the merge again." Confirmed via PR #1127 and agent-v0.130.0/
+      # 0.128.0/0.125.0 (all 2026-07-04). Retry a few times with a short sleep
+      # to absorb that window. Any other failure (real conflict, auth error,
+      # branch protection rejection, etc.) is NOT retried — fail immediately
+      # so a human is alerted, same as before this change. If the stale-base
+      # error persists past all retries, the step still ultimately fails for
+      # the same reason.
       - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.diff.outputs.changed == 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
@@ -243,5 +256,36 @@ jobs:
           echo "Waiting for required checks on ${PR_URL}..."
           gh pr checks "$PR_URL" --watch --interval 15 --required
           echo "Checks passed — merging ${PR_URL}."
-          gh pr merge "$PR_URL" --squash --admin \
-            --subject "chore(plugin): sync version to ${VERSION} [skip ci]"
+
+          # Detects the transient stale-base GraphQL error (see comment
+          # above). Mirrors .github/workflows/test-sync-plugin-version.sh —
+          # keep both copies in sync.
+          is_stale_base_error() {
+            local output="$1"
+            if echo "$output" | grep -qi "Base branch was modified" || \
+               echo "$output" | grep -qi "try the merge again"; then
+              return 0
+            fi
+            return 1
+          }
+
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            MERGE_OUTPUT=$(gh pr merge "$PR_URL" --squash --admin \
+              --subject "chore(plugin): sync version to ${VERSION} [skip ci]" 2>&1) && {
+              echo "$MERGE_OUTPUT"
+              echo "Merged ${PR_URL}."
+              exit 0
+            }
+
+            echo "$MERGE_OUTPUT" >&2
+
+            if is_stale_base_error "$MERGE_OUTPUT" && [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Stale-base race detected (attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in 5s..."
+              sleep 5
+              continue
+            fi
+
+            echo "Merge failed on attempt ${attempt}/${MAX_ATTEMPTS} — not retrying (either not a stale-base error, or retries exhausted)."
+            exit 1
+          done

--- a/.github/workflows/test-auto-bump-chart.sh
+++ b/.github/workflows/test-auto-bump-chart.sh
@@ -100,6 +100,51 @@ PYEOF
 }
 
 # ---------------------------------------------------------------------------
+# Stale-base merge-retry logic (mirrors the "Wait for checks and merge" step)
+#
+# gh pr merge --admin can fail with a transient GraphQL error when a
+# concurrent workflow (e.g. sync-plugin-version.yml) merges its own PR first
+# and moves main out from under this one — "Base branch was modified. Review
+# and try the merge again." This is NOT a real conflict; it resolves itself on
+# retry once the base ref settles. is_stale_base_error() detects that specific
+# signature so the workflow can retry instead of failing outright on a
+# transient race. Any other merge failure (real conflict, auth error, branch
+# protection rejection, etc.) must NOT match — those should fail fast.
+# ---------------------------------------------------------------------------
+
+# Mirrors the function of the same name inlined in auto-bump-chart.yml's
+# "Wait for checks and merge" step. Keep both copies in sync.
+is_stale_base_error() {
+  local output="$1"
+  if echo "$output" | grep -qi "Base branch was modified" || \
+     echo "$output" | grep -qi "try the merge again"; then
+    return 0
+  fi
+  return 1
+}
+
+echo ""
+echo "=== is_stale_base_error tests ==="
+
+if is_stale_base_error "GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)"; then
+  pass "real stale-base GraphQL error text → true"
+else
+  fail "real stale-base GraphQL error text → true" "true (match)" "false (no match)"
+fi
+
+if is_stale_base_error "GraphQL: the base branch policy prohibits the merge (mergePullRequest)"; then
+  fail "unrelated error text → false" "false (no match)" "true (match)"
+else
+  pass "unrelated error text → false"
+fi
+
+if is_stale_base_error ""; then
+  fail "empty string → false" "false (no match)" "true (match)"
+else
+  pass "empty string → false"
+fi
+
+# ---------------------------------------------------------------------------
 # Test fixtures
 # ---------------------------------------------------------------------------
 

--- a/.github/workflows/test-sync-plugin-version.sh
+++ b/.github/workflows/test-sync-plugin-version.sh
@@ -69,6 +69,51 @@ assert_eq "branch for 0.116.0" "chore/plugin-version-v0.116.0" "$(branch_name '0
 assert_eq "branch for 1.0.0"   "chore/plugin-version-v1.0.0"   "$(branch_name '1.0.0')"
 
 # ---------------------------------------------------------------------------
+# Stale-base merge-retry logic (mirrors the "Wait for checks and merge" step)
+#
+# gh pr merge --admin can fail with a transient GraphQL error when a
+# concurrent workflow (e.g. auto-bump-chart.yml) merges its own PR first and
+# moves main out from under this one — "Base branch was modified. Review and
+# try the merge again." This is NOT a real conflict; it resolves itself on
+# retry once the base ref settles. is_stale_base_error() detects that specific
+# signature so the workflow can retry instead of failing outright on a
+# transient race. Any other merge failure (real conflict, auth error, branch
+# protection rejection, etc.) must NOT match — those should fail fast.
+# ---------------------------------------------------------------------------
+
+# Mirrors the function of the same name inlined in sync-plugin-version.yml's
+# "Wait for checks and merge" step. Keep both copies in sync.
+is_stale_base_error() {
+  local output="$1"
+  if echo "$output" | grep -qi "Base branch was modified" || \
+     echo "$output" | grep -qi "try the merge again"; then
+    return 0
+  fi
+  return 1
+}
+
+echo ""
+echo "=== is_stale_base_error tests ==="
+
+if is_stale_base_error "GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)"; then
+  pass "real stale-base GraphQL error text → true"
+else
+  fail "real stale-base GraphQL error text → true" "true (match)" "false (no match)"
+fi
+
+if is_stale_base_error "GraphQL: the base branch policy prohibits the merge (mergePullRequest)"; then
+  fail "unrelated error text → false" "false (no match)" "true (match)"
+else
+  pass "unrelated error text → false"
+fi
+
+if is_stale_base_error ""; then
+  fail "empty string → false" "false (no match)" "true (match)"
+else
+  pass "empty string → false"
+fi
+
+# ---------------------------------------------------------------------------
 # Tests: idempotency guard (git ls-remote --heads matching, no network)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Both `sync-plugin-version.yml` and `auto-bump-chart.yml` trigger off the same tag pushes and race to merge onto `main`, so either can fail with a transient `GraphQL: Base branch was modified. Review and try the merge again.` error when the other lands first — leaving a green-checks PR stuck open until a human notices.
- Wrap the `gh pr merge --squash --admin` call in both workflows in a 3-attempt retry loop with a 5s sleep, gated by a new `is_stale_base_error()` helper that matches only that specific transient GraphQL error text. Any other failure (real conflict, auth error, branch protection rejection) still fails immediately, unchanged from before.
- Mirror the same `is_stale_base_error()` logic and test cases into `test-sync-plugin-version.sh` and `test-auto-bump-chart.sh`, matching this repo's existing convention of duplicating inline workflow bash logic into a paired test script.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | sync-plugin-version.yml merge wrapped in retry loop (2-3 attempts, short sleep) | MET | `MAX_ATTEMPTS=3` for-loop with `sleep 5` |
| 2 | auto-bump-chart.yml merge wrapped in retry loop (2-3 attempts, short sleep) | MET | Same pattern |
| 3 | Retry only on stale-base GraphQL error; other failures fail immediately | MET | `is_stale_base_error()` grep-matches specific error text |
| 4 | Test coverage for the new logic | MET | Both test scripts updated with 3 new assertions each; full suites pass (13/13, 16/16) |

## Test Plan
- `bash .github/workflows/test-sync-plugin-version.sh` — 13/13 passed
- `bash .github/workflows/test-auto-bump-chart.sh` — 16/16 passed
- Manually simulated the retry loop against a mocked `gh` failing twice with the stale-base error then succeeding on the 3rd attempt — confirmed it retries and exits 0
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
