### PR TITLE
fix: point admin Tasks nav link at the Ready-state filter

### DIFF
--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -216,7 +216,7 @@ export function renderShipwrightToolbar(
     <div id="vos-nav-content" class="vos-nav">
       <a href="${adminBase}/admin/agents" class="vos-nav-link${active("/admin/agents")}">Agents</a>
       <a href="${adminBase}/admin/provision" class="vos-nav-link${active("/admin/provision")}">Provision</a>
-      <a href="${adminBase}/admin/tasks" class="vos-nav-link${active("/admin/tasks")}">Tasks</a>
+      <a href="${adminBase}/admin/tasks?state=ready" class="vos-nav-link${active("/admin/tasks")}">Tasks</a>
       <a href="${adminBase}/admin/prs" class="vos-nav-link${active("/admin/prs")}">PRs</a>
       <a href="${adminBase}/admin/chat" class="vos-nav-link${active("/admin/chat")}">Chat</a>
       <a href="${adminBase}/admin/tokens" class="vos-nav-link${active("/admin/tokens")}">Task Store Tokens</a>

--- a/metrics/src/dashboard-dev-auth.smoke.test.ts
+++ b/metrics/src/dashboard-dev-auth.smoke.test.ts
@@ -58,7 +58,7 @@ describe("dashboardDevAuth — /dashboard", () => {
     const res = await app.request("/dashboard");
     const body = await res.text();
     expect(body).toContain('href="http://localhost:3001/admin/agents"');
-    expect(body).toContain('href="http://localhost:3001/admin/tasks"');
+    expect(body).toContain('href="http://localhost:3001/admin/tasks?state=ready"');
     expect(body).toContain('href="http://localhost:3001/admin/prs"');
   });
 

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -164,7 +164,7 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
-      <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
+      <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
       <a href="/admin/tokens" class="vos-nav-link">Task Store Tokens</a>
@@ -657,7 +657,7 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
-      <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
+      <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
       <a href="/admin/tokens" class="vos-nav-link">Task Store Tokens</a>
@@ -1150,7 +1150,7 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
-      <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
+      <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
       <a href="/admin/tokens" class="vos-nav-link">Task Store Tokens</a>
@@ -1643,7 +1643,7 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
       <a href="/admin/provision" class="vos-nav-link">Provision</a>
-      <a href="/admin/tasks" class="vos-nav-link">Tasks</a>
+      <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
       <a href="/admin/tokens" class="vos-nav-link">Task Store Tokens</a>

--- a/metrics/src/dashboard/dashboard-page.unit.test.ts
+++ b/metrics/src/dashboard/dashboard-page.unit.test.ts
@@ -432,7 +432,7 @@ describe("renderDashboardPage — adminBaseUrl cross-origin nav (local stack)", 
       adminBaseUrl: "http://localhost:3001",
     });
     expect(html).toContain('href="http://localhost:3001/admin/agents"');
-    expect(html).toContain('href="http://localhost:3001/admin/tasks"');
+    expect(html).toContain('href="http://localhost:3001/admin/tasks?state=ready"');
     expect(html).toContain('href="http://localhost:3001/admin/prs"');
   });
 


### PR DESCRIPTION
## Summary
- Point the admin toolbar's "Tasks" nav link at `?state=ready`, matching the existing convention used by the in-page Ready filter tab
- Active-highlight logic is untouched — it still matches on the bare `/admin/tasks` prefix, so highlighting behavior is unaffected by the added query param
- Updated the two existing test assertions checking the literal href and regenerated the stale dashboard snapshot (4 occurrences)

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Tasks nav link href includes `?state=ready` | MET | `lib/web/toolbar.ts:219` |
| 2 | Active-highlight behavior unchanged | MET | `active("/admin/tasks")` call untouched |
| 3 | Test/snapshot updates | MET | Both assertions updated + 4 snapshot occurrences regenerated |

## Test Plan
- `bun test lib/web metrics/src/dashboard` — 107 pass, 0 fail
- `bun run --filter='*' typecheck` — all packages pass
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
