### PR TITLE
fix: tighten stale-base error match to a single unambiguous phrase

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -266,11 +266,16 @@ jobs:
       # `gh pr merge` fails with a transient GraphQL error: "Base branch was
       # modified. Review and try the merge again." Confirmed via run
       # 28703925995 (agent-v0.129.0, 2026-07-04 10:54). Retry a few times
-      # with a short sleep to absorb that window. Any other failure (real
-      # conflict, auth error, branch protection rejection, etc.) is NOT
-      # retried — fail immediately so a human is alerted, same as before this
-      # change. If the stale-base error persists past all retries, the step
-      # still ultimately fails for the same reason.
+      # with a short sleep to absorb that window. Detection matches on "Base
+      # branch was modified" alone — that phrase is unambiguous and always
+      # present in the real error, so it's sufficient without also matching
+      # the more generic "try the merge again" (which could otherwise match
+      # unrelated errors and retry something that isn't a stale-base race).
+      # Any other failure (real conflict, auth error, branch protection
+      # rejection, etc.) is NOT retried — fail immediately so a human is
+      # alerted, same as before this change. If the stale-base error persists
+      # past all retries, the step still ultimately fails for the same
+      # reason.
       - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
@@ -300,8 +305,7 @@ jobs:
           # both copies in sync.
           is_stale_base_error() {
             local output="$1"
-            if echo "$output" | grep -qi "Base branch was modified" || \
-               echo "$output" | grep -qi "try the merge again"; then
+            if echo "$output" | grep -qi "Base branch was modified"; then
               return 0
             fi
             return 1

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -227,11 +227,15 @@ jobs:
       # with a transient GraphQL error: "Base branch was modified. Review and
       # try the merge again." Confirmed via PR #1127 and agent-v0.130.0/
       # 0.128.0/0.125.0 (all 2026-07-04). Retry a few times with a short sleep
-      # to absorb that window. Any other failure (real conflict, auth error,
-      # branch protection rejection, etc.) is NOT retried — fail immediately
-      # so a human is alerted, same as before this change. If the stale-base
-      # error persists past all retries, the step still ultimately fails for
-      # the same reason.
+      # to absorb that window. Detection matches on "Base branch was
+      # modified" alone — that phrase is unambiguous and always present in
+      # the real error, so it's sufficient without also matching the more
+      # generic "try the merge again" (which could otherwise match unrelated
+      # errors and retry something that isn't a stale-base race). Any other
+      # failure (real conflict, auth error, branch protection rejection,
+      # etc.) is NOT retried — fail immediately so a human is alerted, same
+      # as before this change. If the stale-base error persists past all
+      # retries, the step still ultimately fails for the same reason.
       - name: Wait for checks and merge
         if: steps.idempotency.outputs.skip != 'true' && steps.diff.outputs.changed == 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
@@ -262,8 +266,7 @@ jobs:
           # keep both copies in sync.
           is_stale_base_error() {
             local output="$1"
-            if echo "$output" | grep -qi "Base branch was modified" || \
-               echo "$output" | grep -qi "try the merge again"; then
+            if echo "$output" | grep -qi "Base branch was modified"; then
               return 0
             fi
             return 1

--- a/.github/workflows/test-auto-bump-chart.sh
+++ b/.github/workflows/test-auto-bump-chart.sh
@@ -106,18 +106,18 @@ PYEOF
 # concurrent workflow (e.g. sync-plugin-version.yml) merges its own PR first
 # and moves main out from under this one — "Base branch was modified. Review
 # and try the merge again." This is NOT a real conflict; it resolves itself on
-# retry once the base ref settles. is_stale_base_error() detects that specific
-# signature so the workflow can retry instead of failing outright on a
-# transient race. Any other merge failure (real conflict, auth error, branch
-# protection rejection, etc.) must NOT match — those should fail fast.
+# retry once the base ref settles. is_stale_base_error() matches on "Base
+# branch was modified" alone — that phrase is unambiguous and always present
+# in the real error text, so matching on it is sufficient. Any other merge
+# failure (real conflict, auth error, branch protection rejection, etc.) must
+# NOT match — those should fail fast.
 # ---------------------------------------------------------------------------
 
 # Mirrors the function of the same name inlined in auto-bump-chart.yml's
 # "Wait for checks and merge" step. Keep both copies in sync.
 is_stale_base_error() {
   local output="$1"
-  if echo "$output" | grep -qi "Base branch was modified" || \
-     echo "$output" | grep -qi "try the merge again"; then
+  if echo "$output" | grep -qi "Base branch was modified"; then
     return 0
   fi
   return 1
@@ -136,6 +136,12 @@ if is_stale_base_error "GraphQL: the base branch policy prohibits the merge (mer
   fail "unrelated error text → false" "false (no match)" "true (match)"
 else
   pass "unrelated error text → false"
+fi
+
+if is_stale_base_error "GraphQL: some other conflict, try the merge again later (mergePullRequest)"; then
+  fail "'try the merge again' without 'Base branch was modified' → false" "false (no match)" "true (match)"
+else
+  pass "'try the merge again' without 'Base branch was modified' → false"
 fi
 
 if is_stale_base_error ""; then

--- a/.github/workflows/test-sync-plugin-version.sh
+++ b/.github/workflows/test-sync-plugin-version.sh
@@ -75,18 +75,18 @@ assert_eq "branch for 1.0.0"   "chore/plugin-version-v1.0.0"   "$(branch_name '1
 # concurrent workflow (e.g. auto-bump-chart.yml) merges its own PR first and
 # moves main out from under this one — "Base branch was modified. Review and
 # try the merge again." This is NOT a real conflict; it resolves itself on
-# retry once the base ref settles. is_stale_base_error() detects that specific
-# signature so the workflow can retry instead of failing outright on a
-# transient race. Any other merge failure (real conflict, auth error, branch
-# protection rejection, etc.) must NOT match — those should fail fast.
+# retry once the base ref settles. is_stale_base_error() matches on "Base
+# branch was modified" alone — that phrase is unambiguous and always present
+# in the real error text, so matching on it is sufficient. Any other merge
+# failure (real conflict, auth error, branch protection rejection, etc.) must
+# NOT match — those should fail fast.
 # ---------------------------------------------------------------------------
 
 # Mirrors the function of the same name inlined in sync-plugin-version.yml's
 # "Wait for checks and merge" step. Keep both copies in sync.
 is_stale_base_error() {
   local output="$1"
-  if echo "$output" | grep -qi "Base branch was modified" || \
-     echo "$output" | grep -qi "try the merge again"; then
+  if echo "$output" | grep -qi "Base branch was modified"; then
     return 0
   fi
   return 1
@@ -105,6 +105,12 @@ if is_stale_base_error "GraphQL: the base branch policy prohibits the merge (mer
   fail "unrelated error text → false" "false (no match)" "true (match)"
 else
   pass "unrelated error text → false"
+fi
+
+if is_stale_base_error "GraphQL: some other conflict, try the merge again later (mergePullRequest)"; then
+  fail "'try the merge again' without 'Base branch was modified' → false" "false (no match)" "true (match)"
+else
+  pass "'try the merge again' without 'Base branch was modified' → false"
 fi
 
 if is_stale_base_error ""; then


### PR DESCRIPTION
## Summary
- Follow-up to #1135 per [dodizzle's review comment](https://github.com/app-vitals/shipwright/pull/1135#issuecomment-review): the second OR clause in `is_stale_base_error()` (`grep -qi "try the merge again"`) is broader than necessary and could silently retry a non-transient merge failure that happens to contain that generic phrase.
- The actual GraphQL error text always includes `"Base branch was modified"`, so matching on that phrase alone is sufficient and unambiguous.
- Applied identically in both `auto-bump-chart.yml` and `sync-plugin-version.yml`, plus their respective test scripts (kept in sync per the existing comment convention).
- Added a regression test case in both test scripts confirming a message containing "try the merge again" but not "Base branch was modified" now correctly returns false.

## Test plan
- [x] `bash .github/workflows/test-auto-bump-chart.sh` — 17/17 pass
- [x] `bash .github/workflows/test-sync-plugin-version.sh` — 14/14 pass