### PR TITLE
docs: refresh stale documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ go-task (`Taskfile.yml`) is the single local entrypoint; the root `package.json`
 
 ```bash
 task setup        # bun install across all workspaces
-task ci           # lint → check-strings → typecheck → test → secret-scan → doctor (the merge-blocking gate; CI runs this exact chain)
+task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan (the merge-blocking gate; CI runs this exact chain)
 task test         # bun test            (single file: bun test path/to/file.test.ts)
 task lint         # bunx biome lint .
 task format       # bunx biome format --write .
@@ -162,7 +162,11 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/architecture.md** — the four-artifact A→B→C→D design (plugin / metrics / agent / task-store), supporting surfaces, and workspace layout
 - **docs/testing.md** — the four-layer test model (unit / integration / smoke / e2e), run commands, speed budgets, and the isolation contract
 - **docs/metrics.md** — metrics service (B): JSON endpoints, server-rendered dashboard, dual auth (Bearer / session), and environment
-- **docs/agent.md** — Shipwright agent (C): runtime + admin CRUD APIs, the six-model Prisma store, and encryption/env notes
+- **docs/agent.md** — Shipwright agent (C): runtime + admin CRUD APIs, the ten-model Prisma store, and encryption/env notes
+- **docs/agent-api.md** — the admin CRUD API (D): agents, envs, crons, cron runs, tools, tokens, plugins, and chat-token-usage endpoints, plus auth paths
+- **docs/task-store.md** — task store service (D): HTTP service API (tasks, PRs, tokens, ephemeral docs) and plugin backends (JSON file, Jira), CLI reference, and troubleshooting
 - **docs/deploy-kubernetes.md** — Kubernetes deployment guide: Minikube / GKE (Gateway API + cert-manager) / EKS (ALB), the agent runtime-provisioning RBAC model, and auth modes
+- **docs/helm-repo.md** — installing the published `shipwright` Helm chart, how chart publishing and version bumps are automated
+- **docs/quickstart.md** — local onboarding: metrics-only quickstart and the full dev stack (`task stack`)
 - **docs/test-readiness/test-system.md** — the authoritative test blueprint: layer matrix, boundary rules, per-component budgets, CI pipeline shape, and the full isolation contract
 - **docs/migration.md** — breaking changes and migration steps across versions (e.g. `AgentProvisioner.reconcile()` interface change)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Shipwright Harness is the open-source autonomous delivery system in your own env
 ## Contents
 
 - **[Quickstart](./quickstart.md)** — prerequisites, step-by-step setup (clone → quickstart.sh → plugin install → task dev), and the copy-paste session prompt.
-- **[Architecture](./architecture.md)** — the three-artifact design (plugin → metrics → agent), supporting surfaces, and workspace layout.
+- **[Architecture](./architecture.md)** — the four-artifact design (plugin → metrics → agent → task-store), supporting surfaces, and workspace layout.
 - **[Testing](./testing.md)** — the four-layer test model (unit / integration / smoke / e2e), run commands, speed budgets, and the isolation contract.
 - **[Metrics dashboard](./metrics.md)** — the provider-agnostic metrics service (fixtures / task-store): JSON endpoints, dashboard, auth, and environment.
 - **[Shipwright agent](./agent.md)** — the autonomous runner: runtime + admin APIs, data model, and environment.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 # Metrics Dashboard
 
-> Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Five read-only JSON endpoints served by a backend-agnostic `MetricsProvider`, plus a session-gated server-rendered dashboard. Two modes: **fixtures** (offline) and **taskstore** (live task-store + admin APIs).
+> Hono service (artifact **B**) that turns Shipwright's pipeline events into analytics. Six read-only JSON endpoints served by a backend-agnostic `MetricsProvider`, plus a session-gated server-rendered dashboard. Two modes: **fixtures** (offline) and **taskstore** (live task-store + admin APIs).
 
 ## Overview
 

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -88,7 +88,7 @@ The agent is a thin runner with a Prisma-backed PostgreSQL database and a Hono H
 |---|---|---|
 | All layers, all packages | `bun test` | <2 min |
 | Single package | `bun test --filter <package-name>` | see per-component above |
-| CI gates (lint → check-strings → typecheck → test → secret-scan → doctor) | `task ci` | <5 min |
+| CI gates (lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan) | `task ci` | <5 min |
 
 ## CI pipeline shape
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -73,7 +73,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 
 ## CI gates
 
-CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan → doctor**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+.
+CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+.
 
 ## References
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ go-task (`Taskfile.yml`) is the single local entrypoint:
 
 ```bash
 task setup        # bun install across all workspaces
-task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan → doctor (the merge-blocking gate)
+task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan (the merge-blocking gate)
 task test         # bun test (all packages)
 ```
 


### PR DESCRIPTION
Automated docs-freshness pass — first full audit (no prior sync anchor). All 12 top-level `docs/*.md` files were checked against the current codebase (routes, Taskfile targets, chart files, Prisma schema).

## Updated

- **docs/README.md** — architecture line said "three-artifact design (plugin → metrics → agent)"; corrected to four-artifact (A→B→C→D, includes task-store)
- **docs/testing.md** — CI gates section still listed a `doctor` step at the end of the `task ci` chain; that step was removed from `Taskfile.yml` and `check-config-docs`/`check-version-sync` were added — updated to match
- **docs/metrics.md** — opening summary said "Five read-only JSON endpoints"; the `cost-efficiency` endpoint shipped later (#963) bringing the count to six — the endpoint table already had it, only the summary line was stale
- **CLAUDE.md** — the embedded `task ci` chain comment had the same stale `doctor` reference; the `## Reference` section was missing entries for `docs/agent-api.md`, `docs/task-store.md`, `docs/helm-repo.md`, and `docs/quickstart.md` (all of which exist and are current); also corrected the agent.md reference line's Prisma model count (ten models, not six)

## Not changed (verified current)

docs/architecture.md, docs/agent.md, docs/agent-api.md, docs/task-store.md, docs/configuration.md, docs/deploy-kubernetes.md, docs/helm-repo.md, docs/migration.md, docs/quickstart.md — spot-checked routes/files/chart values/Taskfile targets referenced in each against source; all resolved.

## Missing doc (task filed, not written here)

The chat service (`chat/`, `@shipwright/chat`) has ~27 HTTP endpoints (threads/messages/tokens) and its own Prisma schema, but no dedicated `docs/chat.md` unlike its sibling services. Filed as a task-store task (`docs-freshness-cron` session, title "Document chat module") rather than writing it in this pass.

## Test plan

- [x] Diff reviewed for client names / internal infra IDs / internal links / usernamed paths — clean, docs-only factual corrections
- [x] `task lint` / `task ci` not runnable in this environment (go-task unavailable); changes are markdown-only, no code touched