### PR TITLE
fix: show skipped badge on agent detail cron list

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -157,9 +157,7 @@ function cronOutcomeStyle(outcome: string | null | undefined): string {
 }
 
 /** Label for a cron run's outcome badge — "skipped" takes priority over outcome. */
-function cronRunOutcomeLabel(
-  run: { skipped: boolean; outcome: string | null },
-): string {
+function cronRunOutcomeLabel(run: { skipped: boolean; outcome: string | null }): string {
   return run.skipped ? "skipped" : (run.outcome ?? "unknown");
 }
 
@@ -626,11 +624,12 @@ export function renderAgentDetailPage(
           <button type="submit" class="btn btn-primary" style="font-size:11px;padding:3px 8px;align-self:flex-start">Save</button>
         </form>
       </details>`;
+    const lastRunOutcomeLabel = c.lastRun ? cronRunOutcomeLabel(c.lastRun) : null;
     const lastRunHtml = c.lastRun?.startedAt
       ? `
       <div style="font-size:11px;color:#6b7280;margin-bottom:4px">${relativeTime(c.lastRun.startedAt, now)}</div>
       <div>
-        <span class="badge" style="${cronOutcomeStyle(cronRunOutcomeLabel(c.lastRun))}">${escapeHtml(cronRunOutcomeLabel(c.lastRun))}</span>
+        <span class="badge" style="${cronOutcomeStyle(lastRunOutcomeLabel)}">${escapeHtml(lastRunOutcomeLabel ?? "unknown")}</span>
       </div>
       <div style="font-size:11px;color:#6b7280;margin-top:4px">${c.runCountToday ?? 0} run${(c.runCountToday ?? 0) === 1 ? "" : "s"}</div>`
       : `<div style="color:#d1d5db">never</div>`;

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -156,6 +156,13 @@ function cronOutcomeStyle(outcome: string | null | undefined): string {
   return CRON_OUTCOME_STYLE[outcome ?? ""] ?? CRON_OUTCOME_STYLE_DEFAULT;
 }
 
+/** Label for a cron run's outcome badge — "skipped" takes priority over outcome. */
+function cronRunOutcomeLabel(
+  run: { skipped: boolean; outcome: string | null },
+): string {
+  return run.skipped ? "skipped" : (run.outcome ?? "unknown");
+}
+
 // Inline CSS for per-model cost badges on the cron runs page. A single run can
 // span multiple models, so each gets its own neutral badge — no outcome-style
 // color coding needed here.
@@ -623,7 +630,7 @@ export function renderAgentDetailPage(
       ? `
       <div style="font-size:11px;color:#6b7280;margin-bottom:4px">${relativeTime(c.lastRun.startedAt, now)}</div>
       <div>
-        <span class="badge" style="${cronOutcomeStyle(c.lastRun.outcome)}">${escapeHtml(c.lastRun.outcome || "unknown")}</span>
+        <span class="badge" style="${cronOutcomeStyle(cronRunOutcomeLabel(c.lastRun))}">${escapeHtml(cronRunOutcomeLabel(c.lastRun))}</span>
       </div>
       <div style="font-size:11px;color:#6b7280;margin-top:4px">${c.runCountToday ?? 0} run${(c.runCountToday ?? 0) === 1 ? "" : "s"}</div>`
       : `<div style="color:#d1d5db">never</div>`;
@@ -2254,7 +2261,7 @@ export function renderCronRunsPage(opts: {
   }
 
   function row(r: CronRunItem): string {
-    const outcomeLabel = r.skipped ? "skipped" : (r.outcome ?? "unknown");
+    const outcomeLabel = cronRunOutcomeLabel(r);
     const badgeStyle = cronOutcomeStyle(outcomeLabel);
     const badgeTitle = r.skipped && r.skipReason ? r.skipReason : outcomeLabel;
     const outcomeCell = `<span class="badge" style="${badgeStyle}" title="${escapeHtml(badgeTitle)}">${escapeHtml(outcomeLabel)}</span>`;

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -815,6 +815,35 @@ describe("renderAgentDetailPage — crons", () => {
     );
     expect(html).toContain("1 run");
   });
+
+  test("renderCronRow with lastRun skipped: shows 'skipped' badge (not 'unknown')", () => {
+    const fixedNow = new Date("2024-06-01T12:00:00Z");
+    const twoHoursAgo = new Date(fixedNow.getTime() - 2 * 3600 * 1000);
+    const cronWithSkippedRun: CronJobItem = {
+      ...CUSTOM_CRON,
+      lastRun: {
+        startedAt: twoHoursAgo,
+        completedAt: new Date(twoHoursAgo.getTime() + 1000),
+        skipped: true,
+        outcome: null,
+      },
+      runCountToday: 0,
+    };
+    const html = renderAgentDetailPage(
+      AGENT,
+      {},
+      [cronWithSkippedRun],
+      [],
+      [],
+      [],
+      [],
+      USER_NAME,
+      true,
+      { now: fixedNow, timezone: "UTC" },
+    );
+    expect(html).toContain(">skipped<");
+    expect(html).not.toContain(">unknown<");
+  });
 });
 
 // ─── renderAgentDetailPage — tools section ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Added a shared `cronRunOutcomeLabel()` helper next to `cronOutcomeStyle()` in `admin/src/admin-ui-pages.ts` that prioritizes `skipped` over `outcome` when labeling a cron run's badge
- Updated both call sites — `renderAgentDetailPage`'s cron list and `renderCronRunsPage`'s row rendering — to use the shared helper, removing the duplicated ternary and fixing the agent detail page (which previously showed "unknown" for precheck-skipped runs instead of "skipped")

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Agent detail page's cron list badge shows "skipped" (amber) for a lastRun with skipped: true, outcome: null | MET |
| 2 | Both call sites use the shared cronRunOutcomeLabel() helper — no duplicated ternary | MET |
| 3 | Unit test added in admin-ui-pages.unit.test.ts covering the skipped: true, outcome: null case on renderAgentDetailPage | MET |

## Test Plan
- Added unit test: `renderCronRow with lastRun skipped: shows 'skipped' badge (not 'unknown')` — asserts the badge renders `>skipped<` and not `>unknown<`
- Full admin-ui-pages test suite: 325 pass, 0 fail
- `bunx biome lint .`: clean
- `bun run --filter='*' typecheck`: clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
