### PR TITLE
docs: repoint speed-budgets, canary-execution, and test-migration to principles.md

### DIFF
--- a/plugins/shipwright/references/principles.md
+++ b/plugins/shipwright/references/principles.md
@@ -2,12 +2,14 @@
 
 The single source of truth for Shipwright's code-design and testing principles.
 Every consumer — `plan-session`, `dev-task`, `review`, `entropy-scan`/`entropy-fix`,
-and the test-readiness rubrics — reads its principles from this file.
+`speed-budgets`, `canary-execution`, `test-migration`, and the test-readiness rubrics — reads its principles from this file.
 
 > **Status note:** This file is net-new and additive. As of PRN-2.2 and SEC-1.2,
 > code-reviewer Rules 6, 7, and 8 read the testing-domain, architecture-domain, and
-> security-domain entries from this file, respectively. Remaining consumers are repointed
-> at it in later tasks (PRN-2.x / PRN-3.1).
+> security-domain entries from this file, respectively. As of PRN-5.1, all consumers
+> — `plan-session`, `dev-task`, `review`, `entropy-scan`/`entropy-fix`, `speed-budgets`,
+> `canary-execution`, `test-migration`, and the test-readiness rubrics — cite this file
+> as their canonical source for overlapping principles.
 
 ## How to read this file
 

--- a/plugins/shipwright/references/principles.md
+++ b/plugins/shipwright/references/principles.md
@@ -2,7 +2,8 @@
 
 The single source of truth for Shipwright's code-design and testing principles.
 Every consumer — `plan-session`, `dev-task`, `review`, `entropy-scan`/`entropy-fix`,
-`speed-budgets`, `canary-execution`, `test-migration`, and the test-readiness rubrics — reads its principles from this file.
+`speed-budgets`, `canary-execution`, `test-migration`, and the test-readiness
+rubrics — reads its principles from this file.
 
 > **Status note:** This file is net-new and additive. As of PRN-2.2 and SEC-1.2,
 > code-reviewer Rules 6, 7, and 8 read the testing-domain, architecture-domain, and

--- a/plugins/shipwright/skills/canary-execution/SKILL.md
+++ b/plugins/shipwright/skills/canary-execution/SKILL.md
@@ -40,6 +40,8 @@ A test is canary-eligible iff **all** of the following hold:
 5. **Tolerates eventual consistency.** Deployed envs may have queues, CDN caches, etc. that local-mode does not. Use retry-with-backoff in the assertion if applicable, with a hard time cap.
 6. **Zero DB-dependent local tests.** A test that boots a local database in `local` mode is not canary-eligible. In canary mode there is no local database to boot — the test will fail at the setup step, not at the assertion. If a test currently boots a DB, it must be refactored to use the deployed service's API for any state setup before it can be promoted to the canary suite.
 
+Rules 3 and the cleanup discipline below are derived from `t7_canary_safety` in `references/principles.md` — canary-eligible tests must be wrapped with the canary-mode helper and must clean up after themselves. Treat `references/principles.md` as the canonical source for these safety principles.
+
 ### Budget
 
 - **Per-test 95p target**: <5 s smoke, <30 s E2E (same as local mode)

--- a/plugins/shipwright/skills/speed-budgets/SKILL.md
+++ b/plugins/shipwright/skills/speed-budgets/SKILL.md
@@ -23,6 +23,8 @@ Encode speed as a first-class design constraint, not an emergent property. Slow 
 
 A repo may tighten budgets in Phase 2 (`test-system.md`). It may never loosen them below these defaults — that's the point of "default."
 
+**Source of truth:** the per-layer speed budgets below are this skill's own content, but the testing-domain principle that justifies them — `t6_layer_speed_mismatch` — lives in `references/principles.md`. Tests must sit in the correct speed tier; a test exceeding its layer's hard cap is at the wrong layer regardless of correctness. Treat `references/principles.md` as canonical.
+
 ## Rationale baked in
 
 ### Why speed = trust

--- a/plugins/shipwright/skills/test-migration/SKILL.md
+++ b/plugins/shipwright/skills/test-migration/SKILL.md
@@ -48,6 +48,8 @@ Wrong fundamentals:
 
 A test contains assertions that re-assert functionality already covered at a lower (canonical) layer. Layer hierarchy: **unit > integration > smoke > E2E**. Higher-layer tests are kept — they prove wiring and user-visible outcomes that lower layers cannot — but redundant *assertions* inside them are trimmed.
 
+The no-duplicate-coverage principle (`t5_no_duplicate_coverage` in `references/principles.md`) is the authoritative source for this rule: each layer tests only what that layer can verify; don't re-assert business rules already covered by lower-layer unit tests. Treat `references/principles.md` as canonical.
+
 **Do not delete E2E tests.** E2E tests prove what unit and integration tests cannot: that pieces connect, that state persists correctly across requests, that the system delivers the user-visible outcome end-to-end. A unit test for a business rule does not make the E2E redundant — the E2E still validates the wire.
 
 **Check git history before any trim.** E2E tests added after production outages often document seam failures that unit tests missed — a DB constraint that wasn't tested, a middleware that dropped a header, a race condition across services. If a test has an outage-linked commit, its assertions are intentional. Mark it `reuse` and leave it.
@@ -136,7 +138,7 @@ Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-migration.md.tmpl`. Write to `
 
 ## Failure modes to avoid
 
-- **Don't auto-delete based on filename or directory.** Read the test. A `unit/foo.test.ts` that spins up a DB is integration, not unit.
+- **Don't auto-delete based on filename or directory.** Read the test. A `unit/foo.test.ts` that spins up a DB is integration, not unit. The file-naming convention principle (`t8_file_naming_convention` in `references/principles.md`) is about correctly encoding the layer in the filename, not inferring the layer from it; the code is the truth.
 - **Don't mark "passes locally" as reuse-grade.** It must pass locally AND assert behavior AND be at the canonical layer AND meet speed budget.
 - **Don't accept "we already have an E2E for that" as canary coverage.** Canary requires read-only or self-cleaning; most E2E tests are not.
 - **Don't skip the risk callout on `delete` verdicts.** A test currently flagged green being recommended for deletion is the single most reviewable judgment call in the report.


### PR DESCRIPTION
## Summary
- Cites `t6_layer_speed_mismatch`, `t7_canary_safety`, `t5_no_duplicate_coverage`, and `t8_file_naming_convention` from `references/principles.md` as the source-of-truth in `speed-budgets/SKILL.md`, `canary-execution/SKILL.md`, and `test-migration/SKILL.md`, which previously duplicated this content without citing it.
- Updates `references/principles.md`'s status note and "who reads this" consumer list to reflect that all consumers (including the three above) are now repointed, removing the stale "repointed at it in later tasks (PRN-2.x/PRN-3.1)" forward reference.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | speed-budgets.md cites t6_layer_speed_mismatch | MET | Source-of-truth citation added after budget table |
| 2 | canary-execution.md cites t7_canary_safety | MET | Citation added after eligibility rules, before Budget section |
| 3 | test-migration.md cites t5_no_duplicate_coverage and t8_file_naming_convention | MET | Two citations added: Trim section and Failure modes section |
| 4 | principles.md status note updated + consumer list expanded | MET | Stale PRN-2.x/PRN-3.1 forward reference removed; speed-budgets/canary-execution/test-migration added to both the intro consumer list and status note |
| 5 | No test changes needed (doc-only) | MET | Zero test files touched; existing principles-content/wiring/code-reviewer tests re-run and pass |

## Test Plan
- [x] `bun test` — 3172 pass, 15 pre-existing failures unrelated to this change (confirmed present on `main` baseline too: HttpKubernetesClient, installPlugins, HttpChatTokenReporter suites — none touch the changed files)
- [x] `bunx biome lint` on changed files — clean
- [x] `bun run --filter='*' typecheck` — all packages pass
- [x] `check-strings`, `check-config-docs`, `check-version-sync` — all pass
- [x] Doc-only prose change — no new logic, no test coverage gap

Generated with [Claude Code](https://claude.com/claude-code)
