### PR TITLE
feat: scaffold mcp-server bun workspace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@shipwright/admin": "workspace:*",
@@ -80,9 +80,21 @@
         "@sentry/bun": "^10.63.0",
       },
     },
+    "mcp-server": {
+      "name": "@shipwright/mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shipwright/lib": "*",
+        "hono": "^4.12.26",
+      },
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+        "typescript": "*",
+      },
+    },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@shipwright/lib": "*",
@@ -98,7 +110,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -287,6 +299,8 @@
     "@shipwright/chat": ["@shipwright/chat@workspace:chat"],
 
     "@shipwright/lib": ["@shipwright/lib@workspace:lib"],
+
+    "@shipwright/mcp-server": ["@shipwright/mcp-server@workspace:mcp-server"],
 
     "@shipwright/metrics": ["@shipwright/metrics@workspace:metrics"],
 

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,59 @@
+# Shipwright MCP Server — container image
+#
+# Build from repo root:
+#   docker build -f mcp-server/Dockerfile -t shipwright-mcp-server .
+#
+# Run:
+#   docker run \
+#     -p 3000:3000 \
+#     shipwright-mcp-server
+
+# ─── Stage 1: dependencies ────────────────────────────────────────────────────
+FROM oven/bun:1-slim AS deps
+
+WORKDIR /app
+
+# Copy workspace manifests for dependency install
+COPY package.json bun.lock ./
+COPY admin/package.json ./admin/
+COPY task-store/package.json ./task-store/
+COPY chat/package.json ./chat/
+COPY agent/package.json ./agent/
+COPY metrics/package.json ./metrics/
+COPY mcp-server/package.json ./mcp-server/
+COPY plugins/shipwright/package.json ./plugins/shipwright/
+COPY lib/package.json ./lib/
+
+RUN bun install --frozen-lockfile
+
+# ─── Stage 2: production image ────────────────────────────────────────────────
+FROM oven/bun:1-slim AS production
+
+# Install system dependencies (ca-certificates only — no Claude Code, no gh CLI, no mise)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
+# install package-specific deps under the workspace dir (/app/mcp-server/node_modules),
+# NOT the hoisted root — both are required at runtime.
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/mcp-server/node_modules ./mcp-server/node_modules
+
+# Copy entire monorepo source
+COPY . .
+
+EXPOSE 3000
+
+# Run as a non-root user. The GKE deployment sets `runAsNonRoot: true`, and the
+# kubelet can only verify that when the image's USER is a numeric UID (it does
+# not read the image's /etc/passwd). uid 1000 is the `bun` user baked into the
+# oven/bun base image. Without this the container is refused at admission with
+# "container has runAsNonRoot and image will run as root".
+USER 1000
+
+ENTRYPOINT ["bun", "run", "mcp-server/src/main.ts"]

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@shipwright/mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "description": "Shipwright MCP server — Model Context Protocol server for task-store integration",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shipwright/lib": "*",
+    "hono": "^4.12.26"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14",
+    "typescript": "*"
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,1 @@
+export const name = "@shipwright/mcp-server";

--- a/mcp-server/src/index.unit.test.ts
+++ b/mcp-server/src/index.unit.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "bun:test";
+import { name } from "./index.ts";
+
+describe("mcp-server module", () => {
+  it("should export a name constant", () => {
+    expect(name).toBe("@shipwright/mcp-server");
+  });
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "agent",
     "admin",
     "task-store",
+    "mcp-server",
     "chat"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Creates `mcp-server/` as a new Bun workspace package (`@shipwright/mcp-server`)
- Adds `"mcp-server"` to the root `package.json` workspaces array
- Follows exact conventions of `task-store/` and `admin/` packages (tsconfig extends root, `type: "module"`, `bun test` + `tsc --noEmit` scripts, multi-stage Dockerfile)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | mcp-server/ bun workspace created | ✅ MET |
| 2 | Added to root package.json workspaces array | ✅ MET |
| 3 | Follows task-store/ and admin/ conventions | ✅ MET |

## Test Plan
- [x] Unit test: `mcp-server/src/index.unit.test.ts` — verifies module exports
- [x] Typecheck: `tsc --noEmit` passes in `mcp-server/`
- [x] Lint: `bunx biome lint mcp-server/` — no issues
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
