### PR TITLE
feat: wire atomic claim into dev-task.md Step 2

### DIFF
--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -131,13 +131,33 @@ If the task's current status is already `in_progress`:
 
 ### Mark In-Progress
 
+This path is for the fresh-pending-task pick from Step 1 (the resume/orphan path above
+already owns an `in_progress` task and does not need to claim it). Claim the task
+atomically instead of a plain PATCH — a plain read-modify-write PATCH here would race
+against any other concurrent `dev-task` run that read the same `ready=true` list. The
+claim is a single conditional `UPDATE ... WHERE status='pending'`; it also sets
+`claimedAt`, `heartbeatAt`, and `startedAt` atomically, so no separate PATCH of
+`startedAt` is needed afterward:
+
 ```bash
-STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
-  -d "{\"status\": \"in_progress\", \"startedAt\": \"$STARTED_AT\"}" | jq .
+CLAIM_CODE=$(curl -s -o /tmp/task_claim.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}/claim")
 ```
+
+No request body is sent — with an agent token (what `$SHIPWRIGHT_TASK_STORE_TOKEN` is in
+this deployment), the task-store pins `claimedBy` to the calling agent's own ID
+server-side and ignores the body.
+
+- **200**: claimed successfully. Print the updated task: `jq . /tmp/task_claim.json`.
+- **409**: another agent already claimed this task since it was read as `ready` in
+  Step 1. Print:
+  ```
+  ⚠ Task {id} was claimed by another agent — picking next ready task.
+  ```
+  Do NOT proceed with this task. Loop back to Step 1 and pick the next ready task instead.
+- **404**: task not found (should not normally happen since Step 1 just fetched it).
+  Treat as a hard stop for this task — do not proceed to Step 3.
 
 ## Step 3: Build Feature-Dev Prompt
 

--- a/plugins/shipwright/commands/dev-task.test.ts
+++ b/plugins/shipwright/commands/dev-task.test.ts
@@ -28,6 +28,53 @@ describe("dev-task.md Step 1 — in_progress resume safeguard", () => {
   });
 });
 
+describe("dev-task.md Step 2 — atomic claim", () => {
+  it("no longer marks in-progress via a plain PATCH with a status body", () => {
+    // The old flow PATCHed the task with a status:in_progress body to mark it
+    // in progress. That specific PATCH invocation must be gone from Step 2 —
+    // scoped narrowly so it doesn't clash with Step 1's `?status=in_progress`
+    // query string check or other PATCH calls elsewhere in the doc (e.g. blocked).
+    expect(content).not.toContain('-d "{\\"status\\": \\"in_progress\\", \\"startedAt\\"');
+  });
+
+  it("calls POST /tasks/{id}/claim to atomically claim the task", () => {
+    expect(content).toContain("/tasks/{id}/claim");
+    // Must be a POST, not a PATCH.
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    const before = content.slice(Math.max(0, claimIdx - 400), claimIdx);
+    expect(before).toMatch(/-X POST/);
+  });
+
+  it("does not send a JSON body on the claim call (agent token pins claimedBy server-side)", () => {
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    expect(claimIdx).toBeGreaterThan(-1);
+    // Look at the surrounding claim command block only, not the whole doc.
+    const block = content.slice(Math.max(0, claimIdx - 400), claimIdx + 200);
+    expect(block).not.toContain('-d "{\\"claimedBy\\"');
+    expect(block).not.toContain("-d '{\"claimedBy\"");
+  });
+
+  it("handles 409 by instructing to loop back to Step 1 and pick the next ready task", () => {
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    expect(claimIdx).toBeGreaterThan(-1);
+    const after = content.slice(claimIdx, claimIdx + 1500);
+    expect(after).toContain("409");
+    expect(after).toMatch(/Step 1/);
+  });
+
+  it("captures the HTTP status code of the claim call (mirrors review.md's claim pattern)", () => {
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    const before = content.slice(Math.max(0, claimIdx - 400), claimIdx);
+    expect(before).toContain("%{http_code}");
+  });
+
+  it("does not separately PATCH startedAt after claiming (claim() sets it atomically)", () => {
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    const after = content.slice(claimIdx, claimIdx + 1500);
+    expect(after).not.toContain("startedAt");
+  });
+});
+
 describe("Step 4 — stale bundle branch detection", () => {
   it("checks --state merged before entering the bundled-task path", () => {
     // The merged-PR check must appear BEFORE the bundled worktree add command


### PR DESCRIPTION
## Summary
- Replace the read-modify-write `PATCH /tasks/{id}` in dev-task.md Step 2 with an atomic `POST /tasks/{id}/claim` call, closing a race window against concurrent `dev-task` runs picking the same `ready=true` task.
- On HTTP 409 (task claimed by another concurrent run), the doc now instructs looping back to Step 1 to pick the next ready task instead of proceeding.
- Mirrors the existing 409-handling pattern already used in review.md's PR claim flow.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 2 calls POST .../tasks/{id}/claim instead of PATCH with status:in_progress body | MET | dev-task.md Step 2 now issues `curl -X POST ... "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}/claim"`; old PATCH removed |
| 2 | On 409, doc instructs looping back to Step 1 to pick next ready task | MET | "Do NOT proceed with this task. Loop back to Step 1 and pick the next ready task instead." |
| 3 | dev-task.test.ts updated with matching assertions; Step 1 resume assertions unaffected | MET | New `describe("dev-task.md Step 2 — atomic claim")` block with 5 tests added; Step 1's existing 3 tests untouched and still pass |

## Test Plan
- `bun test plugins/shipwright/commands/` — 156 pass, 0 fail
- `bun test` (full repo) — 15 pre-existing failures (K8s client, plugin install, chat token reporter — unrelated, env-dependent), identical to main baseline
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — all workspaces pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
