### PR TITLE
feat: scaffold mcp-server bun workspace

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -31,6 +31,7 @@ COPY agent/package.json ./agent/
 COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
+COPY mcp-server/package.json ./mcp-server/
 
 RUN bun install --frozen-lockfile
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -95,6 +95,7 @@ COPY chat/package.json ./chat/
 COPY chat/prisma ./chat/prisma/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
+COPY mcp-server/package.json ./mcp-server/
 
 # Install all dependencies (including devDependencies for typecheck)
 RUN bun install --frozen-lockfile

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@shipwright/admin": "workspace:*",
@@ -80,9 +80,20 @@
         "@sentry/bun": "^10.63.0",
       },
     },
+    "mcp-server": {
+      "name": "@shipwright/mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.12.26",
+      },
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+        "typescript": "*",
+      },
+    },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@shipwright/lib": "*",
@@ -98,7 +109,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -287,6 +298,8 @@
     "@shipwright/chat": ["@shipwright/chat@workspace:chat"],
 
     "@shipwright/lib": ["@shipwright/lib@workspace:lib"],
+
+    "@shipwright/mcp-server": ["@shipwright/mcp-server@workspace:mcp-server"],
 
     "@shipwright/metrics": ["@shipwright/metrics@workspace:metrics"],
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@shipwright/mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "description": "Shipwright MCP server — Model Context Protocol service for agent integration",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.12.26"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14",
+    "typescript": "*"
+  }
+}

--- a/mcp-server/src/index.smoke.test.ts
+++ b/mcp-server/src/index.smoke.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "bun:test";
+import { app } from "./index.js";
+
+describe("mcp-server", () => {
+  it("exports an app", () => {
+    expect(app).toBeDefined();
+    expect(typeof app).toBe("object");
+  });
+
+  it("responds to a health check", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+  });
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * mcp-server/src/index.ts
+ *
+ * Entry point for the Shipwright MCP server.
+ * Exports a minimal Hono application.
+ */
+
+import { Hono } from "hono";
+
+export const app = new Hono();
+
+app.get("/health", (c) => {
+  return c.json({ status: "ok" });
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,10 +1,3 @@
-/**
- * mcp-server/src/index.ts
- *
- * Entry point for the Shipwright MCP server.
- * Exports a minimal Hono application.
- */
-
 import { Hono } from "hono";
 
 export const app = new Hono();

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -36,6 +36,7 @@ COPY chat/prisma ./chat/prisma/
 COPY agent/package.json ./agent/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
+COPY mcp-server/package.json ./mcp-server/
 
 RUN bun install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "agent",
     "admin",
     "task-store",
-    "chat"
+    "chat",
+    "mcp-server"
   ],
   "scripts": {
     "test": "bun test",


### PR DESCRIPTION
## Summary
- Adds `mcp-server/` as a new bun workspace package (`@shipwright/mcp-server`) to the monorepo
- Follows conventions of existing `task-store/` and `admin/` packages (tsconfig, scripts, Hono entry point)
- Registers the package in root `package.json` workspaces array

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | mcp-server/ workspace created | ✅ MET |
| 2 | Added to root workspaces array | ✅ MET |
| 3 | Follows task-store/admin conventions | ✅ MET |
| 4 | Has minimal Hono entry point | ✅ MET |
| 5 | Tests included | ✅ MET |

## Test Plan
- [x] 2 smoke tests pass (`bun test mcp-server/`)
- [x] 100% line coverage
- [x] Typechecks clean across all workspaces
- [x] Biome lint passes

Generated with [Claude Code](https://claude.com/claude-code)
