### PR TITLE
docs: exclude self-review clean-APPROVE from patch.md unaddressed-findings definition

### DIFF
--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -142,14 +142,29 @@ From the response, extract:
 
 A PR has **unaddressed findings** when ANY of the following are true:
 - At least one inline thread has `isResolved == false`
-- At least one review with `state == "COMMENTED"` or `state == "CHANGES_REQUESTED"` has a non-empty `body` (a review body without matching inline threads is itself a finding)
+- At least one review with `state == "COMMENTED"` or `state == "CHANGES_REQUESTED"` has a
+  non-empty `body` (a review body without matching inline threads is itself a finding),
+  excluding self-authored clean-APPROVE reviews (see below)
 
 A PR has **no findings** (skip it) when ALL of the following are true:
 - All inline threads are resolved (`isResolved == true` for every thread)
-- No COMMENTED or CHANGES_REQUESTED review has a non-empty body
+- No COMMENTED or CHANGES_REQUESTED review has a non-empty body, other than self-authored
+  clean-APPROVE reviews (see below)
 
-If neither condition applies (e.g., no reviews at all, only approved reviews), skip the PR —
-it does not belong in List A.
+**Self-authored clean-APPROVE exclusion**: A review is excluded from the body check above
+when `author.login == CURRENT_USER` (resolved in Step 1) AND its body — leading markdown
+bold markers (`**`) stripped — starts with `APPROVE`. Per review.md's Step 10 note
+("Self-review event override"), GitHub rejects self-APPROVE via the API, so the agent's own
+clean approval of its own PR is always posted as `COMMENTED` with a body like
+`"APPROVE — looks good, no changes needed."` instead of an `APPROVED` review. Without this
+exclusion, that clean self-approval would look identical to a real finding and loop the
+patch cron forever on an already-approved PR. The exclusion is scoped to clean APPROVE
+verdicts only — a self-authored review whose body does **not** start with `APPROVE` (i.e.
+the agent found a real issue in its own PR) still counts as a finding, same as any other
+reviewer's.
+
+If neither condition applies (e.g., no reviews at all, only approved reviews, or only an
+excluded self-authored clean-APPROVE review), skip the PR — it does not belong in List A.
 
 If a PR has unaddressed findings, add it to **List A**. Store the unresolved threads (with their
 `id` — needed for the `resolveReviewThread` mutation in Step 5) and review bodies for use in


### PR DESCRIPTION
## Summary
- `check-patch.ts`'s self-review clean-APPROVE exclusion (added across prior PRs #998, #1016, #1049) was never mirrored in `commands/patch.md`'s prose "unaddressed findings" definition, leaving the skill's documented qualification logic out of sync with the precheck script's actual (correct) behavior.
- Updates `plugins/shipwright/commands/patch.md` Step 3a to state the same exclusion: a self-authored review whose body — with leading `**` stripped — starts with `APPROVE` is excluded from the unaddressed-findings check, since GitHub rejects self-APPROVE via the API and the agent's own clean approvals always post as `COMMENTED`. A self-authored review with a real (non-APPROVE) finding still counts, matching `isSelfCleanApprove()`'s scoping exactly.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | hasUnaddressedFindings() excludes self-authored clean-APPROVE reviews | MET | Already implemented on main via `isSelfCleanApprove()` in check-patch.ts (prior PRs #998/#1016); untouched by this diff since it was already correct |
| 2 | patch.md's "unaddressed findings" definition states the same author exclusion | MET | `commands/patch.md` Step 3a now has a "Self-authored clean-APPROVE exclusion" paragraph plus updated bullet lists |
| 3 | External reviewer's non-empty COMMENTED/CHANGES_REQUESTED still counts (no regression) | MET | check-patch.test.ts already covers this; confirmed still green |
| 4 | check-patch.test.ts case for self-review exit 1 / external exit 0, stale false-positive test updated | MET | Already present on main via prior merged PRs |

## Test Plan
- `bun test plugins/shipwright/scripts/check-patch.test.ts` — 30 pass, 0 fail (regression check; file untouched by this PR)
- `bunx biome lint plugins/shipwright/commands/patch.md` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
