### PR TITLE
feat(task-store): add zod-openapi schemas for Task, PullRequest, and TaskToken

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,13 +108,13 @@
       "name": "@shipwright/task-store",
       "version": "0.1.0",
       "dependencies": {
-        "@hono/zod-openapi": "^1.2.4",
+        "@hono/zod-openapi": "^0.18.3",
         "@prisma/client": "^6.19.2",
         "@sentry/bun": "^10.63.0",
         "@sentry/hono": "^10.63.0",
         "@shipwright/lib": "*",
         "hono": "^4.12.26",
-        "zod": "^4.3.6",
+        "zod": "^3",
       },
       "devDependencies": {
         "bun-types": "^1.3.14",
@@ -1106,10 +1106,6 @@
 
     "@shipwright/agent/hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
-    "@shipwright/task-store/@hono/zod-openapi": ["@hono/zod-openapi@1.4.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.8.0", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-AFchqR1N/NxfI4hUOSGI2/g8zLROxA1OE7Oh5JJFlTaGxhrdRyH+93gd0tIBpb0z8s9r8hUoNnaOBfHbdb4NMw=="],
-
-    "@shipwright/task-store/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "body-parser/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
@@ -1485,10 +1481,6 @@
     "@semantic-release/npm/read-pkg/type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
 
     "@semantic-release/npm/read-pkg/unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
-
-    "@shipwright/task-store/@hono/zod-openapi/@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
-
-    "@shipwright/task-store/@hono/zod-openapi/@hono/zod-validator": ["@hono/zod-validator@0.8.0", "", { "peerDependencies": { "hono": ">=4.10.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w=="],
 
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@shipwright/admin": "workspace:*",
@@ -82,7 +82,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@shipwright/lib": "*",
@@ -98,7 +98,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.134.0",
+      "version": "0.135.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -108,11 +108,13 @@
       "name": "@shipwright/task-store",
       "version": "0.1.0",
       "dependencies": {
+        "@hono/zod-openapi": "^1.2.4",
         "@prisma/client": "^6.19.2",
         "@sentry/bun": "^10.63.0",
         "@sentry/hono": "^10.63.0",
         "@shipwright/lib": "*",
         "hono": "^4.12.26",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "bun-types": "^1.3.14",
@@ -1104,6 +1106,10 @@
 
     "@shipwright/agent/hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
+    "@shipwright/task-store/@hono/zod-openapi": ["@hono/zod-openapi@1.4.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.8.0", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-AFchqR1N/NxfI4hUOSGI2/g8zLROxA1OE7Oh5JJFlTaGxhrdRyH+93gd0tIBpb0z8s9r8hUoNnaOBfHbdb4NMw=="],
+
+    "@shipwright/task-store/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "body-parser/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
@@ -1479,6 +1485,10 @@
     "@semantic-release/npm/read-pkg/type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
 
     "@semantic-release/npm/read-pkg/unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
+
+    "@shipwright/task-store/@hono/zod-openapi/@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
+
+    "@shipwright/task-store/@hono/zod-openapi/@hono/zod-validator": ["@hono/zod-validator@0.8.0", "", { "peerDependencies": { "hono": ">=4.10.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w=="],
 
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 

--- a/task-store/package.json
+++ b/task-store/package.json
@@ -13,11 +13,13 @@
     "db:migrate": "prisma migrate deploy --schema=prisma/schema.prisma"
   },
   "dependencies": {
+    "@hono/zod-openapi": "^0.18.3",
     "@prisma/client": "^6.19.2",
     "@sentry/bun": "^10.63.0",
     "@sentry/hono": "^10.63.0",
     "@shipwright/lib": "*",
-    "hono": "^4.12.26"
+    "hono": "^4.12.26",
+    "zod": "^3"
   },
   "devDependencies": {
     "bun-types": "^1.3.14",

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -1,0 +1,364 @@
+/**
+ * task-store/src/openapi-schemas.ts
+ * Zod schemas for the task-store API — Task, PullRequest, and TaskToken response shapes.
+ * Mirrors admin/src/openapi-schemas.ts pattern: Zod schemas with OpenAPI metadata.
+ *
+ * Import z from "@hono/zod-openapi" so .openapi() metadata is available.
+ */
+
+import { z } from "@hono/zod-openapi";
+
+// ─── Common ───────────────────────────────────────────────────────────────────
+
+export const ErrorSchema = z
+  .object({
+    error: z.string().openapi({ example: "not found" }),
+  })
+  .openapi("Error");
+
+export type ErrorResponse = z.infer<typeof ErrorSchema>;
+
+export const OkSchema = z
+  .object({
+    ok: z.literal(true),
+  })
+  .openapi("Ok");
+
+export type OkResponse = z.infer<typeof OkSchema>;
+
+// ─── Task ─────────────────────────────────────────────────────────────────────
+
+export const TaskSchema = z
+  .object({
+    id: z.string().openapi({ example: "clx1234567890" }),
+    title: z.string().openapi({ example: "Implement feature X" }),
+    status: z
+      .enum([
+        "pending",
+        "in_progress",
+        "pr_open",
+        "approved",
+        "merged",
+        "done",
+        "deploying",
+        "deployed",
+        "blocked",
+        "cancelled",
+      ])
+      .openapi({ example: "pending" }),
+    source: z.string().nullable().optional().openapi({ example: "manual" }),
+    session: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "session-123" }),
+    repo: z.string().nullable().optional().openapi({ example: "org/repo" }),
+    description: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "Task description" }),
+    acceptanceCriteria: z
+      .array(z.string())
+      .optional()
+      .openapi({ example: ["Criterion 1", "Criterion 2"] }),
+    layer: z.string().nullable().optional().openapi({ example: "feature" }),
+    branch: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "feat/feature-x" }),
+    dependencies: z
+      .array(z.string())
+      .optional()
+      .openapi({ example: ["task-1", "task-2"] }),
+    pr: z.number().int().nullable().optional().openapi({ example: 42 }),
+    hours: z.number().nullable().optional().openapi({ example: 5.5 }),
+    addedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
+    startedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-02T00:00:00.000Z" }),
+    prCreatedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-03T00:00:00.000Z" }),
+    mergedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-04T00:00:00.000Z" }),
+    blockedAt: z.string().nullable().optional().openapi({ example: null }),
+    blockedReason: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "Waiting on dependency" }),
+    note: z.string().nullable().optional().openapi({ example: "Some notes" }),
+    type: z.string().nullable().optional().openapi({ example: "feature" }),
+    priority: z.string().nullable().optional().openapi({ example: "high" }),
+    cancelledAt: z.string().nullable().optional().openapi({ example: null }),
+    completedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-05T00:00:00.000Z" }),
+    deployingAt: z.string().nullable().optional().openapi({ example: null }),
+    deployedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-06T00:00:00.000Z" }),
+    ciFixAttempts: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 2 }),
+    mergeCommit: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "abc123def456" }),
+    prUrl: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "https://github.com/org/repo/pull/42" }),
+    assignee: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "user@example.com" }),
+    issue: z.string().nullable().optional().openapi({ example: "GH-123" }),
+    model: z.string().nullable().optional().openapi({ example: "sonnet" }),
+    complexity: z.number().int().nullable().optional().openapi({ example: 7 }),
+    hitl: z.boolean().nullable().optional().openapi({ example: true }),
+    hitlNotifiedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-02T00:00:00.000Z" }),
+    claimedBy: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "agent-id-123" }),
+    agentHint: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "prefer-sonnet" }),
+    claimedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-02T00:00:00.000Z" }),
+    heartbeatAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+    simplifyTotal: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 10 }),
+    simplifyDry: z.number().int().nullable().optional().openapi({ example: 2 }),
+    simplifyDeadCode: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 3 }),
+    simplifyNaming: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 1 }),
+    simplifyComplexity: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 2 }),
+    simplifyConsistency: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 2 }),
+    coverageDelta: z.number().nullable().optional().openapi({ example: 5.5 }),
+    effortLevel: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "medium" }),
+    inputTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 1000 }),
+    outputTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 500 }),
+    cacheReadTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 100 }),
+    cacheCreationTokens: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .openapi({ example: 50 }),
+    costUsd: z.number().nullable().optional().openapi({ example: 0.02 }),
+    metadata: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .optional()
+      .openapi({ example: { customKey: "customValue" } }),
+    createdAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
+    updatedAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+  })
+  .openapi("Task");
+
+export type Task = z.infer<typeof TaskSchema>;
+
+// ─── Pull Request ─────────────────────────────────────────────────────────────
+
+export const PullRequestSchema = z
+  .object({
+    id: z.string().openapi({ example: "clx0987654321" }),
+    repo: z.string().openapi({ example: "org/repo" }),
+    prNumber: z.number().int().openapi({ example: 42 }),
+    taskId: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "clx1234567890" }),
+    staged: z.boolean().default(false).openapi({ example: false }),
+    state: z
+      .enum(["open", "merged", "closed"])
+      .default("open")
+      .openapi({ example: "open" }),
+    reviewState: z
+      .enum(["pending", "in_progress", "posted", "approved"])
+      .default("pending")
+      .openapi({ example: "pending" }),
+    commitSha: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "abc123def456" }),
+    patchCycles: z.number().int().default(0).openapi({ example: 1 }),
+    reviewCycles: z.number().int().default(0).openapi({ example: 0 }),
+    agentId: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "agent-id-123" }),
+    reviewedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-03T00:00:00.000Z" }),
+    patchedAt: z.string().nullable().optional().openapi({ example: null }),
+    mergedAt: z.string().nullable().optional().openapi({ example: null }),
+    claimedBy: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "agent-id-123" }),
+    claimedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-02T00:00:00.000Z" }),
+    heartbeatAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+    phase: z
+      .enum(["review", "patch", "deploy"])
+      .nullable()
+      .optional()
+      .openapi({ example: "review" }),
+    readyForReviewAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-02T00:00:00.000Z" }),
+    readyForPatchAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: null }),
+    readyForDeployAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: null }),
+    createdAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
+    updatedAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+  })
+  .openapi("PullRequest");
+
+export type PullRequest = z.infer<typeof PullRequestSchema>;
+
+// ─── Task Token ───────────────────────────────────────────────────────────────
+
+/**
+ * Token metadata returned from list/create (never the hash).
+ * The `token` field (the SHA-256 hash) is NEVER exposed via the API.
+ */
+export const TaskTokenSchema = z
+  .object({
+    id: z.string().openapi({ example: "clxtoken123456" }),
+    label: z.string().nullable().optional().openapi({ example: "ci-runner" }),
+    agentId: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "agent-id-123" }),
+    createdAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
+    revokedAt: z
+      .string()
+      .datetime()
+      .nullable()
+      .optional()
+      .openapi({ example: null }),
+  })
+  .openapi("TaskToken");
+
+export type TaskToken = z.infer<typeof TaskTokenSchema>;

--- a/task-store/src/openapi-schemas.unit.test.ts
+++ b/task-store/src/openapi-schemas.unit.test.ts
@@ -1,0 +1,542 @@
+/**
+ * task-store/src/openapi-schemas.unit.test.ts
+ * Parse/reject tests for all Zod entity schemas in openapi-schemas.ts.
+ * Tests validate that good input parses cleanly and bad input produces typed errors.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type Task,
+  TaskSchema,
+  type PullRequest,
+  PullRequestSchema,
+  type TaskToken,
+  TaskTokenSchema,
+  ErrorSchema,
+  OkSchema,
+} from "./openapi-schemas.ts";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const now = new Date().toISOString();
+const yesterday = new Date(Date.now() - 86400000).toISOString();
+
+const validTask = {
+  id: "clx1234567890",
+  title: "Implement feature X",
+  status: "pending",
+  source: "manual",
+  session: "session-123",
+  repo: "org/repo",
+  description: "This is a task description",
+  acceptanceCriteria: ["Criterion 1", "Criterion 2"],
+  layer: "feature",
+  branch: "feat/feature-x",
+  dependencies: ["task-1", "task-2"],
+  pr: 42,
+  hours: 5.5,
+  addedAt: yesterday,
+  startedAt: yesterday,
+  prCreatedAt: yesterday,
+  mergedAt: null,
+  blockedAt: null,
+  blockedReason: null,
+  note: "Some notes",
+  type: "feature",
+  priority: "high",
+  cancelledAt: null,
+  completedAt: null,
+  deployingAt: null,
+  deployedAt: null,
+  ciFixAttempts: 2,
+  mergeCommit: "abc123def456",
+  prUrl: "https://github.com/org/repo/pull/42",
+  assignee: "user@example.com",
+  issue: "GH-123",
+  model: "sonnet",
+  complexity: 7,
+  hitl: true,
+  hitlNotifiedAt: yesterday,
+  claimedBy: "agent-id-123",
+  agentHint: "prefer-sonnet",
+  claimedAt: yesterday,
+  heartbeatAt: yesterday,
+  simplifyTotal: 10,
+  simplifyDry: 2,
+  simplifyDeadCode: 3,
+  simplifyNaming: 1,
+  simplifyComplexity: 2,
+  simplifyConsistency: 2,
+  coverageDelta: 5.5,
+  effortLevel: "medium",
+  inputTokens: 1000,
+  outputTokens: 500,
+  cacheReadTokens: 100,
+  cacheCreationTokens: 50,
+  costUsd: 0.02,
+  metadata: { customKey: "customValue", nested: { deep: true } },
+  createdAt: yesterday,
+  updatedAt: now,
+};
+
+const validPullRequest = {
+  id: "clx0987654321",
+  repo: "org/repo",
+  prNumber: 42,
+  taskId: "clx1234567890",
+  staged: false,
+  state: "open",
+  reviewState: "pending",
+  commitSha: "abc123def456",
+  patchCycles: 1,
+  reviewCycles: 0,
+  agentId: "agent-id-123",
+  reviewedAt: null,
+  patchedAt: null,
+  mergedAt: null,
+  claimedBy: "agent-id-123",
+  claimedAt: yesterday,
+  heartbeatAt: yesterday,
+  phase: "review",
+  readyForReviewAt: yesterday,
+  readyForPatchAt: null,
+  readyForDeployAt: null,
+  createdAt: yesterday,
+  updatedAt: now,
+};
+
+const validTaskToken = {
+  id: "clxtoken123456",
+  label: "ci-runner",
+  agentId: "agent-id-123",
+  createdAt: now,
+  revokedAt: null,
+};
+
+// ─── TaskSchema ───────────────────────────────────────────────────────────────
+
+describe("TaskSchema", () => {
+  test("parses valid task with all fields", () => {
+    const result = TaskSchema.safeParse(validTask);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const task: Task = result.data;
+      expect(task.id).toBe("clx1234567890");
+      expect(task.title).toBe("Implement feature X");
+      expect(task.status).toBe("pending");
+      expect(task.repo).toBe("org/repo");
+    }
+  });
+
+  test("parses task with minimal fields", () => {
+    const minimal = {
+      id: "clx1234567890",
+      title: "Minimal task",
+      status: "in_progress",
+      createdAt: now,
+      updatedAt: now,
+    };
+    const result = TaskSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const task: Task = result.data;
+      expect(task.title).toBe("Minimal task");
+    }
+  });
+
+  test("parses task with nullable fields as null", () => {
+    const withNulls = {
+      ...validTask,
+      mergedAt: null,
+      blockedReason: null,
+      agentHint: null,
+    };
+    const result = TaskSchema.safeParse(withNulls);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all valid TaskStatus enum values", () => {
+    const statuses = [
+      "pending",
+      "in_progress",
+      "pr_open",
+      "approved",
+      "merged",
+      "done",
+      "deploying",
+      "deployed",
+      "blocked",
+      "cancelled",
+    ];
+    for (const status of statuses) {
+      const result = TaskSchema.safeParse({
+        ...validTask,
+        status,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects invalid TaskStatus", () => {
+    const result = TaskSchema.safeParse({
+      ...validTask,
+      status: "invalid_status",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing id", () => {
+    const { id: _, ...noId } = validTask;
+    const result = TaskSchema.safeParse(noId);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing title", () => {
+    const { title: _, ...noTitle } = validTask;
+    const result = TaskSchema.safeParse(noTitle);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing status", () => {
+    const { status: _, ...noStatus } = validTask;
+    const result = TaskSchema.safeParse(noStatus);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing createdAt", () => {
+    const { createdAt: _, ...noCreatedAt } = validTask;
+    const result = TaskSchema.safeParse(noCreatedAt);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing updatedAt", () => {
+    const { updatedAt: _, ...noUpdatedAt } = validTask;
+    const result = TaskSchema.safeParse(noUpdatedAt);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string id", () => {
+    const result = TaskSchema.safeParse({ ...validTask, id: 123 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-boolean hitl", () => {
+    const result = TaskSchema.safeParse({ ...validTask, hitl: "yes" });
+    expect(result.success).toBe(false);
+  });
+
+  test("parses acceptanceCriteria as string array", () => {
+    const result = TaskSchema.safeParse({
+      ...validTask,
+      acceptanceCriteria: ["AC1", "AC2", "AC3"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.acceptanceCriteria).toHaveLength(3);
+    }
+  });
+
+  test("parses dependencies as string array", () => {
+    const result = TaskSchema.safeParse({
+      ...validTask,
+      dependencies: ["dep-1", "dep-2"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dependencies).toHaveLength(2);
+    }
+  });
+
+  test("parses metadata as record", () => {
+    const result = TaskSchema.safeParse({
+      ...validTask,
+      metadata: { key1: "value1", key2: 123, key3: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("does not expose sensitive fields", () => {
+    const withSecret = { ...validTask, apiKey: "secret-key" };
+    const result = TaskSchema.safeParse(withSecret);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).apiKey).toBeUndefined();
+    }
+  });
+});
+
+// ─── PullRequestSchema ─────────────────────────────────────────────────────────
+
+describe("PullRequestSchema", () => {
+  test("parses valid pull request with all fields", () => {
+    const result = PullRequestSchema.safeParse(validPullRequest);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const pr: PullRequest = result.data;
+      expect(pr.id).toBe("clx0987654321");
+      expect(pr.repo).toBe("org/repo");
+      expect(pr.prNumber).toBe(42);
+      expect(pr.state).toBe("open");
+    }
+  });
+
+  test("parses pull request with minimal fields", () => {
+    const minimal = {
+      id: "clx0987654321",
+      repo: "org/repo",
+      prNumber: 42,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const result = PullRequestSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+
+  test("parses pull request with nullable fields", () => {
+    const withNulls = {
+      ...validPullRequest,
+      taskId: null,
+      commitSha: null,
+      mergedAt: null,
+    };
+    const result = PullRequestSchema.safeParse(withNulls);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all valid PrState enum values", () => {
+    const states = ["open", "merged", "closed"];
+    for (const state of states) {
+      const result = PullRequestSchema.safeParse({
+        ...validPullRequest,
+        state,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects invalid PrState", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      state: "invalid_state",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts all valid PrReviewState enum values", () => {
+    const states = ["pending", "in_progress", "posted", "approved"];
+    for (const state of states) {
+      const result = PullRequestSchema.safeParse({
+        ...validPullRequest,
+        reviewState: state,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects invalid PrReviewState", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      reviewState: "invalid_review_state",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts all valid PrPhase enum values", () => {
+    const phases = ["review", "patch", "deploy"];
+    for (const phase of phases) {
+      const result = PullRequestSchema.safeParse({
+        ...validPullRequest,
+        phase,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("parses pull request with null phase", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      phase: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing id", () => {
+    const { id: _, ...noId } = validPullRequest;
+    const result = PullRequestSchema.safeParse(noId);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing repo", () => {
+    const { repo: _, ...noRepo } = validPullRequest;
+    const result = PullRequestSchema.safeParse(noRepo);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing prNumber", () => {
+    const { prNumber: _, ...noPrNumber } = validPullRequest;
+    const result = PullRequestSchema.safeParse(noPrNumber);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer prNumber", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      prNumber: "42",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-boolean staged", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      staged: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("parses patchCycles and reviewCycles as integers", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      patchCycles: 5,
+      reviewCycles: 3,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.patchCycles).toBe(5);
+      expect(result.data.reviewCycles).toBe(3);
+    }
+  });
+});
+
+// ─── TaskTokenSchema ──────────────────────────────────────────────────────────
+
+describe("TaskTokenSchema", () => {
+  test("parses valid token metadata", () => {
+    const result = TaskTokenSchema.safeParse(validTaskToken);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const token: TaskToken = result.data;
+      expect(token.id).toBe("clxtoken123456");
+      expect(token.label).toBe("ci-runner");
+      expect(token.agentId).toBe("agent-id-123");
+    }
+  });
+
+  test("parses token without label", () => {
+    const { label: _, ...noLabel } = validTaskToken;
+    const result = TaskTokenSchema.safeParse(noLabel);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.label).toBeUndefined();
+    }
+  });
+
+  test("parses token with null label", () => {
+    const result = TaskTokenSchema.safeParse({
+      ...validTaskToken,
+      label: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("parses token without agentId", () => {
+    const { agentId: _, ...noAgentId } = validTaskToken;
+    const result = TaskTokenSchema.safeParse(noAgentId);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agentId).toBeUndefined();
+    }
+  });
+
+  test("parses token with null agentId", () => {
+    const result = TaskTokenSchema.safeParse({
+      ...validTaskToken,
+      agentId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("parses token with revokedAt as ISO string", () => {
+    const result = TaskTokenSchema.safeParse({
+      ...validTaskToken,
+      revokedAt: now,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.revokedAt).toBe(now);
+    }
+  });
+
+  test("parses token with null revokedAt", () => {
+    const result = TaskTokenSchema.safeParse({
+      ...validTaskToken,
+      revokedAt: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("does not expose token hash", () => {
+    const withHash = { ...validTaskToken, token: "sha256_hash_value" };
+    const result = TaskTokenSchema.safeParse(withHash);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).token).toBeUndefined();
+    }
+  });
+
+  test("rejects missing id", () => {
+    const { id: _, ...noId } = validTaskToken;
+    const result = TaskTokenSchema.safeParse(noId);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing createdAt", () => {
+    const { createdAt: _, ...noCreatedAt } = validTaskToken;
+    const result = TaskTokenSchema.safeParse(noCreatedAt);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string id", () => {
+    const result = TaskTokenSchema.safeParse({ ...validTaskToken, id: 123 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── ErrorSchema ──────────────────────────────────────────────────────────────
+
+describe("ErrorSchema", () => {
+  test("parses valid error response", () => {
+    const result = ErrorSchema.safeParse({ error: "Not found" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.error).toBe("Not found");
+    }
+  });
+
+  test("rejects missing error string", () => {
+    const result = ErrorSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── OkSchema ──────────────────────────────────────────────────────────────────
+
+describe("OkSchema", () => {
+  test("parses valid ok response", () => {
+    const result = OkSchema.safeParse({ ok: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ok).toBe(true);
+    }
+  });
+
+  test("rejects missing ok field", () => {
+    const result = OkSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-literal true ok value", () => {
+    const result = OkSchema.safeParse({ ok: false });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `task-store/src/openapi-schemas.ts` with Zod schemas for `Task`, `PullRequest`, and `TaskToken` response shapes
- Mirrors the `@hono/zod-openapi` pattern already used in `admin/src/openapi-schemas.ts` — same import, same `.openapi()` metadata convention
- Excludes the sensitive `token` hash field from `TaskTokenSchema` (as with all token APIs)

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Task schema mirrors Prisma Task model | ✅ MET |
| 2 | PullRequest schema mirrors Prisma model | ✅ MET |
| 3 | TaskToken schema (public fields only, hash excluded) | ✅ MET |
| 4 | Mirrors admin's `@hono/zod-openapi` pattern | ✅ MET |
| 5 | Unit tests included | ✅ MET (47 tests) |

## Test Plan
- [x] 47 unit tests in `openapi-schemas.unit.test.ts` cover all schemas, enums, nullable/optional fields, and sensitive field exclusion
- [x] Full task-store suite: 261 pass, 0 fail
- [x] Typecheck passes (`bun run --filter='@shipwright/task-store' typecheck`)

Generated with [Claude Code](https://claude.com/claude-code)
