### PR TITLE
fix: close the tag-before-build race in build-*.yml workflows

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Bump version and push tag
+      - name: Compute next tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -59,6 +59,7 @@ jobs:
           tag_prefix: "admin-v"
           default_bump: patch
           fetch_all_tags: true
+          dry_run: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -79,3 +80,14 @@ jobs:
       - name: Push Docker image
         run: |
           docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-admin:${{ steps.tag.outputs.new_tag }}
+
+      - name: Tag release
+        # Only create the git tag once the image has actually pushed. A tag with
+        # no image behind it silently breaks any downstream consumer that trusts
+        # the tag without verifying the image exists.
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
+            -f sha="${{ github.event.workflow_run.head_sha }}"

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -52,7 +52,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Bump version and push tag
+      - name: Compute next tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -60,6 +60,7 @@ jobs:
           tag_prefix: "agent-v"
           default_bump: patch
           fetch_all_tags: true
+          dry_run: true
 
       # Bare semver off the tag (agent-v0.117.0 → 0.117.0), stamped into the
       # image at build time below so the deployed artifact's plugin.json
@@ -94,6 +95,18 @@ jobs:
       - name: Push Docker image
         run: |
           docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }}
+
+      - name: Tag release
+        # Only create the git tag once the image has actually pushed. A tag with
+        # no image behind it silently breaks any downstream consumer that trusts
+        # the tag without verifying the image exists — including the dispatch
+        # below, which downstream repos use to pick up "the latest agent tag".
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
+            -f sha="${{ github.event.workflow_run.head_sha }}"
 
       - name: Dispatch agent-released to downstream
         env:

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Bump version and push tag
+      - name: Compute next tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -59,6 +59,7 @@ jobs:
           tag_prefix: "chat-v"
           default_bump: patch
           fetch_all_tags: true
+          dry_run: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -79,3 +80,14 @@ jobs:
       - name: Push Docker image
         run: |
           docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-chat:${{ steps.tag.outputs.new_tag }}
+
+      - name: Tag release
+        # Only create the git tag once the image has actually pushed. A tag with
+        # no image behind it silently breaks any downstream consumer that trusts
+        # the tag without verifying the image exists.
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
+            -f sha="${{ github.event.workflow_run.head_sha }}"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Bump version and push tag
+      - name: Compute next tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -59,6 +59,7 @@ jobs:
           tag_prefix: "metrics-v"
           default_bump: patch
           fetch_all_tags: true
+          dry_run: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -79,3 +80,14 @@ jobs:
       - name: Push Docker image
         run: |
           docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-metrics:${{ steps.tag.outputs.new_tag }}
+
+      - name: Tag release
+        # Only create the git tag once the image has actually pushed. A tag with
+        # no image behind it silently breaks any downstream consumer that trusts
+        # the tag without verifying the image exists.
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
+            -f sha="${{ github.event.workflow_run.head_sha }}"

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Bump version and push tag
+      - name: Compute next tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -59,6 +59,7 @@ jobs:
           tag_prefix: "task-store-v"
           default_bump: patch
           fetch_all_tags: true
+          dry_run: true
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -79,3 +80,15 @@ jobs:
       - name: Push Docker image
         run: |
           docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-task-store:${{ steps.tag.outputs.new_tag }}
+
+      - name: Tag release
+        # Only create the git tag once the image has actually pushed. A tag with
+        # no image behind it (as happened when this step ran before the build)
+        # silently breaks any downstream consumer that trusts the tag without
+        # verifying the image exists.
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
+            -f sha="${{ github.event.workflow_run.head_sha }}"

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -26,6 +26,7 @@ COPY agent/package.json ./agent/
 COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
+COPY mcp-server/package.json ./mcp-server/
 
 RUN bun install --frozen-lockfile
 

--- a/task-store/Dockerfile
+++ b/task-store/Dockerfile
@@ -26,6 +26,7 @@ COPY agent/package.json ./agent/
 COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
+COPY mcp-server/package.json ./mcp-server/
 
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- `task-store/Dockerfile` and `chat/Dockerfile` were missing `COPY mcp-server/package.json ./mcp-server/`, which `admin`, `metrics`, and `agent` already had. Any real (non-skipped) build of task-store or chat since mcp-server was added as a workspace (#1165) fails `bun install --frozen-lockfile` with `Workspace not found "mcp-server"`.
- This surfaced a race: all five `build-*.yml` workflows push the git tag via `mathieudutour/github-tag-action` **before** building/pushing the image. A build failure after that point leaves a tag with no image behind it. That's exactly what happened to `task-store-v0.61.0` — the tag exists, the image never got pushed, and vitals-os's auto-bump picked up the dangling tag, breaking every deploy since (`ImagePullBackOff` → `helm upgrade --wait` timeout).
- Reordered all five `build-*.yml` workflows: the tag action now runs with `dry_run: true` (just computes `new_tag`), and a new `Tag release` step creates/pushes the real git tag via `gh api .../git/refs` only after the Docker push succeeds.

## Test plan
- [ ] CI passes on this PR
- [ ] Merge, then confirm `Build and Push Task-Store Image` actually runs (touches `task-store/**`) and pushes a new tag + image successfully
- [ ] Verify no tag is created if a build step is made to fail deliberately (spot check on one workflow, optional)