### PR TITLE
fix: copy lib/node_modules into task-store production image

### DIFF
--- a/task-store/Dockerfile
+++ b/task-store/Dockerfile
@@ -44,9 +44,14 @@ ENV NODE_ENV=production
 
 # Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
 # install package-specific deps under the workspace dir (/app/task-store/node_modules),
-# NOT the hoisted root — both are required at runtime.
+# NOT the hoisted root — both are required at runtime. lib/node_modules is also
+# required: task-store imports @shipwright/lib/sentry, which itself imports
+# @sentry/bun — bun nested that package under lib/node_modules (and separately
+# under task-store/node_modules) instead of hoisting it to root, so resolution
+# from lib/sentry.ts fails at runtime unless lib's own node_modules is present.
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/task-store/node_modules ./task-store/node_modules
+COPY --from=deps /app/lib/node_modules ./lib/node_modules
 
 # Copy entire monorepo source
 COPY . .


### PR DESCRIPTION
## Summary
The mcp-server build-failure race (#1181) was masking a second, independent bug: the first task-store image that actually built successfully (`task-store-v0.59.0`, pinned in vitals-os#2286 to unblock deploys) crash-loops on boot with:

```
error: Cannot find module '@sentry/bun' from '/app/lib/sentry.ts'
```

Root cause: `task-store/src/main.ts` imports `@shipwright/lib/sentry`, which imports `@sentry/bun`. Both `lib/package.json` and `task-store/package.json` declare `@sentry/bun` directly, and bun's resolver nests it under `lib/node_modules/@sentry/bun` *and* `task-store/node_modules/@sentry/bun` instead of hoisting it to the shared root `node_modules`. `task-store/Dockerfile`'s production stage copies root `node_modules` and `task-store/node_modules`, but never `lib/node_modules` — so resolution from `lib/sentry.ts` (which lives under `/app/lib/`) has nowhere to find the package.

Fix: copy `/app/lib/node_modules` into the production stage too.

Verified locally (not just build success): built the full image with `docker build`, ran it with `docker run`, and confirmed the Sentry import error is gone — it now proceeds to Sentry init and fails only on a fake `DATABASE_URL` (expected, no real DB in the sandbox).

## Test plan
- [ ] CI passes on this PR
- [ ] Merge, confirm `Build and Push Task-Store Image` builds and pushes a new tag
- [ ] Once vitals-os picks up the new tag, confirm the task-store pod reaches `Ready` instead of `CrashLoopBackOff`