### PR TITLE
fix: defensively copy lib/node_modules in admin, metrics, chat Dockerfiles

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -49,9 +49,15 @@ ENV NODE_ENV=production
 
 # Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
 # install package-specific deps under the workspace dir (/app/admin/node_modules),
-# NOT the hoisted root — both are required at runtime.
+# NOT the hoisted root — both are required at runtime. lib/node_modules is also
+# copied defensively: bun nests a shared lib dependency under lib/node_modules
+# instead of hoisting it to root whenever a consuming service also declares that
+# same dependency directly (this broke task-store + @sentry/bun at runtime —
+# see app-vitals/shipwright#1187). admin doesn't hit that today, but copying
+# lib/node_modules here means it can't happen silently if that changes.
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/admin/node_modules ./admin/node_modules
+COPY --from=deps /app/lib/node_modules ./lib/node_modules
 
 # Copy entire monorepo source
 COPY . .

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -44,9 +44,15 @@ ENV NODE_ENV=production
 
 # Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
 # install package-specific deps under the workspace dir (/app/chat/node_modules),
-# NOT the hoisted root — both are required at runtime.
+# NOT the hoisted root — both are required at runtime. lib/node_modules is also
+# copied defensively: bun nests a shared lib dependency under lib/node_modules
+# instead of hoisting it to root whenever a consuming service also declares that
+# same dependency directly (this broke task-store + @sentry/bun at runtime —
+# see app-vitals/shipwright#1187). chat doesn't hit that today, but copying
+# lib/node_modules here means it can't happen silently if that changes.
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/chat/node_modules ./chat/node_modules
+COPY --from=deps /app/lib/node_modules ./lib/node_modules
 
 # Copy entire monorepo source
 COPY . .

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -54,9 +54,15 @@ ENV NODE_ENV=production
 
 # Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
 # install package-specific deps under the workspace dir (/app/metrics/node_modules),
-# NOT the hoisted root — both are required at runtime.
+# NOT the hoisted root — both are required at runtime. lib/node_modules is also
+# copied defensively: bun nests a shared lib dependency under lib/node_modules
+# instead of hoisting it to root whenever a consuming service also declares that
+# same dependency directly (this broke task-store + @sentry/bun at runtime —
+# see app-vitals/shipwright#1187). metrics doesn't hit that today, but copying
+# lib/node_modules here means it can't happen silently if that changes.
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/metrics/node_modules ./metrics/node_modules
+COPY --from=deps /app/lib/node_modules ./lib/node_modules
 
 # Copy entire monorepo source
 COPY . .


### PR DESCRIPTION
## Summary
Follow-up to #1187. task-store crash-looped at runtime because bun nests a shared `lib` dependency under `lib/node_modules` instead of hoisting it to root whenever a consuming service also declares that same dependency directly — task-store's production stage never copied `lib/node_modules`, so `lib/sentry.ts` couldn't resolve `@sentry/bun` at runtime.

`admin`, `metrics`, and `chat` Dockerfiles use the identical pattern (copy root + own service `node_modules`, never `lib`'s) and don't hit this today — none of them currently import anything from `lib` that needs an unhoisted package. But the same silent crash-loop would recur for any of them the moment that changes (e.g. if Sentry gets added to another service and it also declares `@sentry/bun` directly, mirroring task-store). Copying `lib/node_modules` defensively in all three closes the gap regardless of what `lib` ends up depending on.

`agent/Dockerfile` already copies `/app/lib` wholesale (source + any nested `node_modules`), so it's unaffected and untouched here.

## Test plan
- [ ] CI passes on this PR
- [ ] Merge, confirm `Build and Push Admin/Metrics/Chat Image` workflows build successfully (should be no-op runtime behavior change, just an extra COPY)