### PR TITLE
feat(task-store): convert prs.ts routes to OpenAPIHono (TSM-1.3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.135.1",
+      "version": "0.139.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@shipwright/admin": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.135.1",
+      "version": "0.139.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@shipwright/lib": "*",
@@ -109,7 +109,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.135.1",
+      "version": "0.139.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -362,3 +362,92 @@ export const TaskTokenSchema = z
   .openapi("TaskToken");
 
 export type TaskToken = z.infer<typeof TaskTokenSchema>;
+
+// ─── PR Route Schemas ─────────────────────────────────────────────────────────
+
+export const PrIdParamSchema = z
+  .object({
+    id: z.string().openapi({ example: "clx0987654321" }),
+  })
+  .openapi("PrIdParam");
+
+export const PrListQuerySchema = z
+  .object({
+    repo: z.string().optional().openapi({ example: "org/repo" }),
+    prNumber: z
+      .string()
+      .optional()
+      .openapi({ example: "42", description: "PR number (parsed as integer)" }),
+    taskId: z.string().optional().openapi({ example: "clx1234567890" }),
+    state: z
+      .enum(["open", "merged", "closed"])
+      .optional()
+      .openapi({ example: "open" }),
+    reviewState: z
+      .enum(["pending", "in_progress", "posted", "approved"])
+      .optional()
+      .openapi({ example: "pending" }),
+    staged: z
+      .enum(["true", "false"])
+      .optional()
+      .openapi({ example: "false", description: "Filter by staged flag" }),
+    limit: z
+      .string()
+      .optional()
+      .openapi({ example: "50", description: "Max records to return" }),
+    offset: z
+      .string()
+      .optional()
+      .openapi({ example: "0", description: "Pagination offset" }),
+  })
+  .openapi("PrListQuery");
+
+export const PrListResponseSchema = z
+  .object({
+    prs: z.array(PullRequestSchema).openapi({ description: "Array of pull requests" }),
+    total: z.number().int().openapi({ example: 1 }),
+    limit: z.number().int().openapi({ example: 50 }),
+    offset: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("PrListResponse");
+
+export const ClaimPrBodySchema = z
+  .object({
+    repo: z
+      .string()
+      .openapi({ example: "org/repo", description: "Repository in org/repo format" }),
+    prNumber: z
+      .number()
+      .int()
+      .openapi({ example: 42, description: "Pull request number" }),
+    commitSha: z
+      .string()
+      .openapi({ example: "abc123def456", description: "Commit SHA to associate" }),
+    claimedBy: z
+      .string()
+      .optional()
+      .openapi({ example: "agent-id-123", description: "Agent claiming this PR (admin tokens only)" }),
+    taskId: z
+      .string()
+      .optional()
+      .openapi({ example: "clx1234567890", description: "Associated task ID" }),
+  })
+  .openapi("ClaimPrBody");
+
+export const ClaimNextBodySchema = z
+  .object({
+    agentId: z
+      .string()
+      .optional()
+      .openapi({ example: "agent-id-123", description: "Agent ID (admin tokens only; agent tokens use token identity)" }),
+    maxConcurrent: z
+      .number()
+      .int()
+      .optional()
+      .openapi({ example: 1, description: "Maximum concurrent PRs to claim" }),
+  })
+  .openapi("ClaimNextBody");
+
+export const UpdatePrBodySchema = z
+  .record(z.string(), z.unknown())
+  .openapi("UpdatePrBody");

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -451,3 +451,10 @@ export const ClaimNextBodySchema = z
 export const UpdatePrBodySchema = z
   .record(z.string(), z.unknown())
   .openapi("UpdatePrBody");
+
+export const ClaimNextResponseSchema = z
+  .object({
+    pr: PullRequestSchema,
+    phase: z.enum(["review", "patch", "deploy"]).openapi({ example: "review" }),
+  })
+  .openapi("ClaimNextResponse");

--- a/task-store/src/routes/prs.openapi.smoke.test.ts
+++ b/task-store/src/routes/prs.openapi.smoke.test.ts
@@ -1,0 +1,226 @@
+/**
+ * task-store/src/routes/prs.openapi.smoke.test.ts
+ *
+ * Verifies that prs.ts has been migrated to OpenAPIHono.
+ * The key assertion: createPrsRoutes must return an OpenAPIHono instance.
+ *
+ * All behavioural correctness is covered by prs.smoke.test.ts — this file
+ * focuses on the structural migration contract.
+ */
+
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { describe, expect, it } from "bun:test";
+import { NotFoundError } from "../errors.ts";
+import type { PullRequest } from "../index.ts";
+import type {
+  PullRequestListFilters,
+  PullRequestListResult,
+  PullRequestServiceLike,
+} from "../pull-request-service.ts";
+import { createPrsRoutes } from "./prs.ts";
+
+// ─── Minimal fake PR service ──────────────────────────────────────────────────
+
+function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    id: "pr-1",
+    repo: "org/repo",
+    prNumber: 42,
+    taskId: null,
+    staged: false,
+    state: "open",
+    reviewState: "pending",
+    commitSha: null,
+    patchCycles: 0,
+    reviewCycles: 0,
+    agentId: null,
+    reviewedAt: null,
+    patchedAt: null,
+    mergedAt: null,
+    claimedBy: null,
+    claimedAt: null,
+    heartbeatAt: null,
+    phase: null,
+    readyForReviewAt: null,
+    readyForPatchAt: null,
+    readyForDeployAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as PullRequest;
+}
+
+function fakePrService(
+  opts: {
+    store?: Map<string, PullRequest>;
+    claimResult?: { status: 200 | 201; record: PullRequest } | Error;
+  } = {},
+): PullRequestServiceLike {
+  const store = opts.store ?? new Map<string, PullRequest>();
+
+  return {
+    async list(filters?: PullRequestListFilters): Promise<PullRequestListResult> {
+      const prs = Array.from(store.values());
+      return { prs, total: prs.length, limit: 50, offset: 0 };
+    },
+
+    async get(id: string): Promise<PullRequest | null> {
+      return store.get(id) ?? null;
+    },
+
+    async update(id: string, data: Partial<PullRequest>): Promise<PullRequest> {
+      const existing = store.get(id);
+      if (!existing) throw new NotFoundError("pr not found");
+      const updated = { ...existing, ...data, updatedAt: new Date() } as PullRequest;
+      store.set(id, updated);
+      return updated;
+    },
+
+    async claim(
+      repo: string,
+      prNumber: number,
+      commitSha: string,
+      claimedBy: string,
+      taskId?: string,
+    ): Promise<{ status: 200 | 201; record: PullRequest }> {
+      if (opts.claimResult !== undefined) {
+        if (opts.claimResult instanceof Error) throw opts.claimResult;
+        return opts.claimResult;
+      }
+      const record = makePr({ id: `pr-${repo}-${prNumber}`, repo, prNumber, commitSha, claimedBy });
+      store.set(record.id, record);
+      return { status: 201, record };
+    },
+
+    async heartbeat(id: string): Promise<PullRequest> {
+      const pr = store.get(id) ?? makePr({ id });
+      const updated = { ...pr, heartbeatAt: new Date().toISOString(), updatedAt: new Date() } as PullRequest;
+      store.set(id, updated);
+      return updated;
+    },
+
+    async complete(id: string): Promise<PullRequest> {
+      const existing = store.get(id);
+      if (!existing) throw new NotFoundError("pr not found");
+      const updated = { ...existing, reviewState: "posted" as const, reviewedAt: new Date().toISOString(), updatedAt: new Date() } as PullRequest;
+      store.set(id, updated);
+      return updated;
+    },
+
+    async patch(id: string): Promise<PullRequest> {
+      const existing = store.get(id);
+      if (!existing) throw new NotFoundError("pr not found");
+      const updated = { ...existing, patchCycles: existing.patchCycles + 1, reviewState: "pending" as const, updatedAt: new Date() } as PullRequest;
+      store.set(id, updated);
+      return updated;
+    },
+
+    async release(id: string): Promise<PullRequest> {
+      const existing = store.get(id);
+      if (!existing) throw new NotFoundError("pr not found");
+      const updated = { ...existing, reviewState: "pending" as const, claimedBy: null, claimedAt: null, heartbeatAt: null, updatedAt: new Date() } as PullRequest;
+      store.set(id, updated);
+      return updated;
+    },
+
+    async claimNext(
+      _agentId: string,
+      _maxConcurrent: number,
+      _repos?: string[],
+    ): Promise<{ pr: PullRequest; phase: "review" | "patch" | "deploy" } | null> {
+      return null;
+    },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("createPrsRoutes — OpenAPIHono migration (TSM-1.3)", () => {
+  it("returns an OpenAPIHono instance (not plain Hono)", () => {
+    const app = createPrsRoutes(fakePrService());
+    expect(app).toBeInstanceOf(OpenAPIHono);
+  });
+
+  it("GET / responds to list requests (route registered correctly)", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    // The sub-app is mounted at /prs by app.ts; direct call uses '/'
+    const res = await app.request("/");
+    // Without auth middleware the status could be 200 (routes/handlers work)
+    expect([200, 401]).toContain(res.status);
+  });
+
+  it("GET /:id responds to single-record requests", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1");
+    expect([200, 401]).toContain(res.status);
+  });
+
+  it("POST /claim route is registered", async () => {
+    const app = createPrsRoutes(fakePrService());
+    const res = await app.request("/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo: "org/repo", prNumber: 1, commitSha: "abc", claimedBy: "agent-1" }),
+    });
+    // Not 404 — route exists
+    expect(res.status).not.toBe(404);
+  });
+
+  it("POST /claim-next route is registered", async () => {
+    const app = createPrsRoutes(fakePrService());
+    const res = await app.request("/claim-next", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-1" }),
+    });
+    expect(res.status).not.toBe(404);
+  });
+
+  it("PATCH /:id route is registered", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ staged: true }),
+    });
+    expect(res.status).not.toBe(404);
+  });
+
+  it("POST /:id/heartbeat route is registered", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1/heartbeat", { method: "POST" });
+    expect(res.status).not.toBe(404);
+  });
+
+  it("POST /:id/complete route is registered", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1/complete", { method: "POST" });
+    expect(res.status).not.toBe(404);
+  });
+
+  it("POST /:id/patch route is registered", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1/patch", { method: "POST" });
+    expect(res.status).not.toBe(404);
+  });
+
+  it("POST /:id/release route is registered", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1/release", { method: "POST" });
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -26,6 +26,7 @@ import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, NotFoundError } from "../errors.ts";
 import {
   ClaimNextBodySchema,
+  ClaimNextResponseSchema,
   ClaimPrBodySchema,
   ErrorSchema,
   PrIdParamSchema,
@@ -127,7 +128,7 @@ const claimNextRoute = createRoute({
     200: {
       content: {
         "application/json": {
-          schema: PullRequestSchema,
+          schema: ClaimNextResponseSchema,
         },
       },
       description: "PR claimed — returns {pr, phase}",

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -2,8 +2,8 @@
  * task-store/src/routes/prs.ts
  * PR tracking routes — review claim/heartbeat/complete/patch/release lifecycle.
  *
- * Returns a Hono sub-app mounted at /prs by app.ts. Auth is applied by the
- * parent app, so these handlers assume the caller is already authenticated.
+ * Returns an OpenAPIHono sub-app mounted at /prs by app.ts. Auth is applied by
+ * the parent app, so these handlers assume the caller is already authenticated.
  *
  * Agent tokens (agentId set) are repo-scoped:
  *   - writes validate that the PR's repo is in c.get('repos')
@@ -21,9 +21,19 @@
  *   POST   /prs/:id/release   unclaim → reviewState=pending
  */
 
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, NotFoundError } from "../errors.ts";
+import {
+  ClaimNextBodySchema,
+  ClaimPrBodySchema,
+  ErrorSchema,
+  PrIdParamSchema,
+  PrListQuerySchema,
+  PrListResponseSchema,
+  PullRequestSchema,
+  UpdatePrBodySchema,
+} from "../openapi-schemas.ts";
 import type { PullRequest } from "../index.ts";
 import type { PullRequestServiceLike } from "../pull-request-service.ts";
 import { isOrgRepo } from "../validate.ts";
@@ -53,13 +63,219 @@ function validateRepo(repo: unknown, repos: string[] | null): void {
   }
 }
 
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["PRs"],
+  summary: "List pull requests",
+  request: {
+    query: PrListQuerySchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PrListResponseSchema } },
+      description: "List of pull requests",
+    },
+  },
+});
+
+const claimRoute = createRoute({
+  method: "post",
+  path: "/claim",
+  tags: ["PRs"],
+  summary: "Claim a pull request (atomic)",
+  request: {
+    body: {
+      content: { "application/json": { schema: ClaimPrBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "Updated existing claim",
+    },
+    201: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "New claim created",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Bad request",
+    },
+    409: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Conflict — already claimed with same commitSha",
+    },
+  },
+});
+
+const claimNextRoute = createRoute({
+  method: "post",
+  path: "/claim-next",
+  tags: ["PRs"],
+  summary: "Atomic find-and-claim of oldest eligible PR",
+  request: {
+    body: {
+      content: { "application/json": { schema: ClaimNextBodySchema } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: PullRequestSchema,
+        },
+      },
+      description: "PR claimed — returns {pr, phase}",
+    },
+    204: {
+      description: "No eligible PR found",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Bad request",
+    },
+  },
+});
+
+const getOneRoute = createRoute({
+  method: "get",
+  path: "/:id",
+  tags: ["PRs"],
+  summary: "Fetch a single pull request",
+  request: {
+    params: PrIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "Pull request record",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+const updateRoute = createRoute({
+  method: "patch",
+  path: "/:id",
+  tags: ["PRs"],
+  summary: "Update pull request fields",
+  request: {
+    params: PrIdParamSchema,
+    body: {
+      content: { "application/json": { schema: UpdatePrBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "Updated pull request",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Bad request",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+const heartbeatRoute = createRoute({
+  method: "post",
+  path: "/:id/heartbeat",
+  tags: ["PRs"],
+  summary: "Touch heartbeatAt for a claimed PR",
+  request: {
+    params: PrIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "PR with updated heartbeatAt",
+    },
+  },
+});
+
+const completeRoute = createRoute({
+  method: "post",
+  path: "/:id/complete",
+  tags: ["PRs"],
+  summary: "Mark PR review as complete (reviewState=posted)",
+  request: {
+    params: PrIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "Completed PR",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+const patchRoute = createRoute({
+  method: "post",
+  path: "/:id/patch",
+  tags: ["PRs"],
+  summary: "Increment patchCycles and reset reviewState=pending",
+  request: {
+    params: PrIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "Patched PR",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+const releaseRoute = createRoute({
+  method: "post",
+  path: "/:id/release",
+  tags: ["PRs"],
+  summary: "Release a claim (reviewState=pending, claimedBy cleared)",
+  request: {
+    params: PrIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PullRequestSchema } },
+      description: "Released PR",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
 export function createPrsRoutes(
   prService: PullRequestServiceLike,
-): Hono<TaskStoreAuthEnv> {
-  const app = new Hono<TaskStoreAuthEnv>();
+): OpenAPIHono<TaskStoreAuthEnv> {
+  const app = new OpenAPIHono<TaskStoreAuthEnv>();
 
   // ─── List ──────────────────────────────────────────────────────────────────
-  app.get("/", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(listRoute, async (c): Promise<any> => {
     const limitRaw = c.req.query("limit");
     const offsetRaw = c.req.query("offset");
     const prNumberRaw = c.req.query("prNumber");
@@ -91,7 +307,8 @@ export function createPrsRoutes(
   });
 
   // ─── Claim (atomic) — must be before /:id to avoid param capture ───────────
-  app.post("/claim", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(claimRoute, async (c): Promise<any> => {
     const agentId = c.get("agentId");
     const repos = c.get("repos");
     const body = await readJson(c);
@@ -143,7 +360,8 @@ export function createPrsRoutes(
 
   // ─── Claim-next (atomic find-and-claim) ───────────────────────────────────
   // Must be before /:id to avoid param capture.
-  app.post("/claim-next", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(claimNextRoute, async (c): Promise<any> => {
     const agentId = c.get("agentId");
     const repos = c.get("repos");
     const body = await readJson(c);
@@ -182,7 +400,8 @@ export function createPrsRoutes(
   });
 
   // ─── Get one ───────────────────────────────────────────────────────────────
-  app.get("/:id", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(getOneRoute, async (c): Promise<any> => {
     const pr = await prService.get(c.req.param("id"));
     if (!pr) throw new NotFoundError("pr not found");
     return c.json(pr, 200);
@@ -213,7 +432,8 @@ export function createPrsRoutes(
     "readyForDeployAt",
   ];
 
-  app.patch("/:id", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(updateRoute, async (c): Promise<any> => {
     const agentId = c.get("agentId");
     const repos = c.get("repos");
     const body = await readJson(c);
@@ -241,25 +461,29 @@ export function createPrsRoutes(
   });
 
   // ─── Heartbeat ─────────────────────────────────────────────────────────────
-  app.post("/:id/heartbeat", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(heartbeatRoute, async (c): Promise<any> => {
     const pr = await prService.heartbeat(c.req.param("id"));
     return c.json(pr, 200);
   });
 
   // ─── Complete ──────────────────────────────────────────────────────────────
-  app.post("/:id/complete", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(completeRoute, async (c): Promise<any> => {
     const pr = await prService.complete(c.req.param("id"));
     return c.json(pr, 200);
   });
 
   // ─── Patch ─────────────────────────────────────────────────────────────────
-  app.post("/:id/patch", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(patchRoute, async (c): Promise<any> => {
     const pr = await prService.patch(c.req.param("id"));
     return c.json(pr, 200);
   });
 
   // ─── Release ───────────────────────────────────────────────────────────────
-  app.post("/:id/release", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(releaseRoute, async (c): Promise<any> => {
     const pr = await prService.release(c.req.param("id"));
     return c.json(pr, 200);
   });


### PR DESCRIPTION
## Summary
- Convert `task-store/src/routes/prs.ts` from plain `Hono` to `OpenAPIHono` using `createRoute` definitions for all 9 PR endpoints
- Add 6 PR-specific route schemas to `openapi-schemas.ts`: `PrIdParamSchema`, `PrListQuerySchema`, `PrListResponseSchema`, `ClaimPrBodySchema`, `ClaimNextBodySchema`, `UpdatePrBodySchema`
- Add `prs.openapi.smoke.test.ts` to verify the migration; all existing `prs.smoke.test.ts` tests continue to pass

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `createPrsRoutes` returns `OpenAPIHono<TaskStoreAuthEnv>` (not `Hono`) | MET |
| 2 | All 9 PR routes registered via `app.openapi(createRoute({...}), handler)` | MET |
| 3 | New PR-specific schemas added to `openapi-schemas.ts` | MET |
| 4 | Existing `prs.smoke.test.ts` continues to pass (behavior unchanged) | MET |
| 5 | New `prs.openapi.smoke.test.ts` verifies the OpenAPIHono migration | MET |

## Test Plan
- [x] `bun test` — 271 pass, 0 fail, 61 skip
- [x] `tsc --noEmit` — clean typecheck
- [x] Handler logic unchanged — additive typing only

Generated with [Claude Code](https://claude.com/claude-code)
