### PR TITLE
feat(task-store): convert tokens routes to OpenAPIHono (TSM-1.4)

### DIFF
--- a/task-store/src/routes/tokens.ts
+++ b/task-store/src/routes/tokens.ts
@@ -2,8 +2,8 @@
  * task-store/src/routes/tokens.ts
  * Token management routes — admin tokens only.
  *
- * Returns a Hono sub-app mounted at /tokens by app.ts. Auth is applied by the
- * parent app. All routes here require an admin token (agentId === null).
+ * Returns an OpenAPIHono sub-app mounted at /tokens by app.ts. Auth is applied
+ * by the parent app. All routes here require an admin token (agentId === null).
  *
  * Routes:
  *   GET    /tokens       list (hash + metadata, never raw values)
@@ -12,15 +12,137 @@
  *   DELETE /tokens/:id   revoke
  */
 
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.ts";
+import { ErrorSchema, TaskTokenSchema } from "../openapi-schemas.ts";
 import type { TokenServiceLike } from "../token-service.ts";
+
+// ─── Extra schemas for token routes ───────────────────────────────────────────
+
+const TaskTokenWithRawSchema = TaskTokenSchema.extend({
+  rawToken: z.string().openapi({ example: "raw-token-value-shown-once" }),
+}).openapi("TaskTokenWithRaw");
+
+const TokenBodySchema = z
+  .object({
+    label: z.string().optional().openapi({ example: "ci-runner" }),
+    agentId: z.string().optional().openapi({ example: "agent-id-123" }),
+  })
+  .openapi("TokenBody");
+
+const TokenIdParamSchema = z.object({
+  id: z.string().openapi({ example: "clxtoken123456" }),
+});
+
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const listTokensRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["tokens"],
+  summary: "List all tokens",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Array of token metadata",
+      content: { "application/json": { schema: z.array(TaskTokenSchema) } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const createTokenRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["tokens"],
+  summary: "Create a new token — raw value returned exactly once",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      required: false,
+      content: { "application/json": { schema: TokenBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Created token including the one-time raw value",
+      content: { "application/json": { schema: TaskTokenWithRawSchema } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const updateTokenRoute = createRoute({
+  method: "patch",
+  path: "/:id",
+  tags: ["tokens"],
+  summary: "Update token label and/or agentId",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: TokenIdParamSchema,
+    body: {
+      required: false,
+      content: { "application/json": { schema: TokenBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated token metadata",
+      content: { "application/json": { schema: TaskTokenSchema } },
+    },
+    400: {
+      description: "Bad request — token is revoked",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Token not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const revokeTokenRoute = createRoute({
+  method: "delete",
+  path: "/:id",
+  tags: ["tokens"],
+  summary: "Revoke a token",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: TokenIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Revoked token metadata",
+      content: { "application/json": { schema: TaskTokenSchema } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Token not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
 
 export function createTokensRoutes(
   tokenService: TokenServiceLike,
-): Hono<TaskStoreAuthEnv> {
-  const app = new Hono<TaskStoreAuthEnv>();
+): OpenAPIHono<TaskStoreAuthEnv> {
+  const app = new OpenAPIHono<TaskStoreAuthEnv>();
 
   // All token management requires an admin token.
   app.use("*", async (c, next) => {
@@ -31,13 +153,13 @@ export function createTokensRoutes(
   });
 
   // ─── List ──────────────────────────────────────────────────────────────────
-  app.get("/", async (c) => {
+  app.openapi(listTokensRoute, async (c) => {
     const tokens = await tokenService.list();
     return c.json(tokens, 200);
   });
 
   // ─── Create ────────────────────────────────────────────────────────────────
-  app.post("/", async (c) => {
+  app.openapi(createTokenRoute, async (c) => {
     let label: string | undefined;
     let agentId: string | undefined;
     try {
@@ -59,7 +181,7 @@ export function createTokensRoutes(
   });
 
   // ─── Update ────────────────────────────────────────────────────────────────
-  app.patch("/:id", async (c) => {
+  app.openapi(updateTokenRoute, async (c) => {
     let label: string | undefined;
     let agentId: string | undefined;
     try {
@@ -93,7 +215,7 @@ export function createTokensRoutes(
   });
 
   // ─── Revoke ────────────────────────────────────────────────────────────────
-  app.delete("/:id", async (c) => {
+  app.openapi(revokeTokenRoute, async (c) => {
     const revoked = await tokenService.revoke(c.req.param("id"));
     if (!revoked) throw new NotFoundError("token not found");
     return c.json(revoked, 200);

--- a/task-store/src/tokens.smoke.test.ts
+++ b/task-store/src/tokens.smoke.test.ts
@@ -14,8 +14,10 @@
  *   - 400 when updating a revoked token
  */
 
+import { OpenAPIHono } from "@hono/zod-openapi";
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
+import { createTokensRoutes } from "./routes/tokens.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TaskToken, TokenServiceLike } from "./token-service.ts";
 
@@ -281,5 +283,14 @@ describe("PATCH /tokens/:id", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.rawToken).toBeUndefined();
+  });
+});
+
+// ─── OpenAPIHono instance check ───────────────────────────────────────────────
+
+describe("createTokensRoutes", () => {
+  it("returns an OpenAPIHono instance", () => {
+    const app = createTokensRoutes(fakeAdminTokenService());
+    expect(app).toBeInstanceOf(OpenAPIHono);
   });
 });


### PR DESCRIPTION
## Summary
- Converts `task-store/src/routes/tokens.ts` from plain `Hono` to `OpenAPIHono` with typed `createRoute` definitions
- Reuses `TaskTokenSchema` and `ErrorSchema` from `openapi-schemas.ts`; adds `TaskTokenWithRawSchema` and `TokenBodySchema` locally
- Zero behavior change — additive typing only; all handler logic preserved verbatim

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | tokens.ts uses OpenAPIHono instead of plain Hono | ✅ MET |
| 2 | Each route defined using createRoute | ✅ MET |
| 3 | Schemas from openapi-schemas.ts reused | ✅ MET |
| 4 | All existing smoke tests pass | ✅ MET (8/8) |
| 5 | Return type is OpenAPIHono | ✅ MET |
| 6 | No behavior changes | ✅ MET |

## Test Plan
- [x] All 8 tokens smoke tests pass (7 existing + 1 new instanceof check)
- [x] Full task-store suite: 262 pass, 0 fail
- [x] Typecheck: 0 errors
- [x] Biome lint: clean

Generated with [Claude Code](https://claude.com/claude-code)
