### PR TITLE
docs: fix task-store SKILL.md lifecycle docs to use atomic claim

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -116,7 +116,7 @@ Returns `204`. Agent tokens can only delete their own tasks.
 POST /tasks/:id/claim
 ```
 
-Atomically sets `claimedBy` and `claimedAt` if the task is currently unclaimed. Returns `409` if already claimed. Agent tokens pin `claimedBy` to their own ID. Admin tokens must supply `{ claimedBy: string }` in the body.
+Atomically claims a pending task — a single conditional `UPDATE ... WHERE status='pending'`. Sets `status=in_progress`, `claimedBy`, `claimedAt`, `heartbeatAt`, and `startedAt` (or keeps existing if already set) in one round-trip. No request body is sent by agent tokens — the service pins `claimedBy` to the calling agent's ID server-side. Admin tokens must supply `{ claimedBy: string }` in the body. Returns `200` with the updated task on success, or `409` if already claimed or not in pending status.
 
 #### Heartbeat
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -86,13 +86,20 @@ All list calls return an envelope with a `.tasks` array. Paginated calls (`?stat
 
 ### Start a task
 
+Claim atomically instead of a plain PATCH — a read-modify-write PATCH races any other
+concurrent runner that read the same `ready=true` list. The claim is a single conditional
+`UPDATE ... WHERE status='pending'`; it also sets `claimedAt`, `heartbeatAt`, and
+`startedAt`, so no separate PATCH is needed:
+
 ```bash
-curl -sf -X PATCH \
+curl -sf -X POST \
   -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
-  -d "{\"status\": \"in_progress\", \"startedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | jq .
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}/claim" | jq .
 ```
+
+No request body is sent — with an agent token, the task-store pins `claimedBy` to the
+calling agent's own ID server-side and ignores the body. A `409` means another agent
+already claimed the task since it was read as `ready` — skip it and pick the next one.
 
 ### Open a PR
 


### PR DESCRIPTION
## Summary
- Updated the "Standard lifecycle → Start a task" example in `plugins/shipwright/skills/task-store/SKILL.md` to use the atomic `POST /tasks/:id/claim` endpoint instead of a plain PATCH status change, removing the contradiction with the "Full API reference" table's documented claim endpoint.
- Refreshed `docs/task-store.md`'s claim endpoint description to accurately reflect that it sets `status`, `heartbeatAt`, and `startedAt` in addition to `claimedBy`/`claimedAt`, and clarifies agent-token body semantics.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Start-a-task example uses POST /tasks/:id/claim instead of plain PATCH | MET | SKILL.md "Start a task" section replaced |
| 2 | No contradiction with Full API reference table entry | MET | Table entry already documented POST /tasks/:id/claim; now matches |
| 3 | No test added, explicitly stated | MET | Docs-only diff, no test files touched |

## Test Plan
- Docs-only change — no test added (per acceptance criteria, no existing test covers SKILL.md content)
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` passing
- [x] `bun run scripts/sync-version.ts --check` passing
- [x] `bun test plugins/shipwright` — 681 pass, 0 fail

Generated with [Claude Code](https://claude.com/claude-code)
