### PR TITLE
feat(patch): add pre-work PR claim lock before dispatching fix subagents

### DIFF
--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -267,27 +267,36 @@ From `{worktree-path}`, detect the project toolchain:
 
 Refer to `references/toolchain-patterns.md` for the full detection lookup table.
 
-### Step 4a.6: Renew the Claim Heartbeat
+### Step 4a.6: Claim PR Record (pre-work lock)
 
-The conflict-resolution subagent dispatched next can run long enough to outlast a
-leftover claim on this PR's task-store record — e.g. a still-claimed `phase: "review"`
-record left behind by `/shipwright:review` after posting (the record stays claimed until
-released or reaped). If that claim goes stale mid-fix, the reaper resets `reviewState`
-back to `pending`, which can trigger a duplicate review. Renew it now, before starting the
-merge/resolve, so the claim survives the resolve-and-push that follows. Best-effort — warn
-and continue on failure:
+The conflict-resolution subagent dispatched next can run long enough to overlap with
+another patch run (or a stale leftover claim from `/shipwright:review`, e.g. a
+still-claimed `phase: "review"` record left behind after posting — the record stays
+claimed until released or reaped). Without a pre-work claim, two overlapping patch runs
+could both dispatch competing fix subagents against the same branch. Claim the PR record
+with `phase: "patch"` now, before starting the merge/resolve, mirroring deploy.md's Step
+4a pre-merge claim:
 
 ```bash
-PR_RECORD_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" 2>/dev/null \
-  | jq -r '.prs[0].id // empty')
-if [ -n "$PR_RECORD_ID" ]; then
-  curl -s -o /dev/null -X POST \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
-    echo "⚠ heartbeat renewal failed — continuing"
-fi
+HEAD_SHA_PRE_PATCH=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
+PR_CLAIM=$(curl -s -o /tmp/pr_claim_patch.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"$HEAD_SHA_PRE_PATCH\", \"phase\": \"patch\"}")
+PR_RECORD_ID=$(jq -r '.id // empty' /tmp/pr_claim_patch.json)
 ```
+
+**If `PR_CLAIM` is `409`** (another patch run already claimed this PR at phase `patch`):
+do NOT dispatch the conflict-resolution subagent. Print:
+```
+⏸ PR #{pr} is already claimed by another patch run — skipping.
+```
+Skip the rest of Step 4 for this PR. Move to the next candidate PR in List C. If no
+candidates remain, continue to Step 5.
+
+**Otherwise** (`200` or `201`): the claim succeeded. `PR_RECORD_ID` is reused by the
+post-fix update in Step 4c.5 — no second claim call is needed. Proceed to Step 4b.
 
 ### Step 4b: Dispatch Conflict Resolution Subagent
 
@@ -357,24 +366,22 @@ Parse the subagent's STATUS:
 
 ### Step 4c.5: Upsert PR Record
 
-After a successful push, upsert a PullRequest record in the task store to track that a
-patch cycle has occurred. Warn and continue on any failure — do not stop.
+The record was already claimed pre-work in Step 4a.6 — `PR_RECORD_ID` is already set, so
+this renews the claim's heartbeat and increments `patchCycles` rather than re-claiming.
+Warn and continue on any failure — do not stop.
 
 ```bash
-HEAD_SHA=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
-CLAIM_RESULT=$(curl -sf -X POST \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
-  -d "{\"repo\":\"{org}/{repo}\",\"prNumber\":{pr},\"commitSha\":\"$HEAD_SHA\",\"phase\":\"patch\"}" 2>/dev/null)
-PR_ID=$(echo "$CLAIM_RESULT" | jq -r '.id // empty' 2>/dev/null)
-if [ -n "$PR_ID" ]; then
+if [ -n "$PR_RECORD_ID" ]; then
+  curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
+    echo "⚠ heartbeat renewal failed — continuing"
   curl -sf -X POST \
     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_ID/patch" > /dev/null 2>&1 || \
-    echo "⚠ POST /prs/$PR_ID/patch failed — continuing"
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" > /dev/null 2>&1 || \
+    echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
 else
-  echo "⚠ POST /prs/claim failed — continuing"
+  echo "⚠ no PR_RECORD_ID from pre-work claim — skipping PR record update"
 fi
 ```
 
@@ -451,26 +458,36 @@ From inside the worktree, collect the full picture of what needs fixing:
 4. **PR-level comments** (from Step 3a — already fetched, reuse):
    Include all non-bot comments as additional context.
 
-### Step 5a.6: Renew the Claim Heartbeat
+### Step 5a.6: Claim PR Record (pre-work lock)
 
-The fix subagent dispatched next can run long enough to outlast a leftover claim on this
-PR's task-store record — e.g. a still-claimed `phase: "review"` record left behind by
-`/shipwright:review` after posting (the record stays claimed until released or reaped).
-If that claim goes stale mid-fix, the reaper resets `reviewState` back to `pending`,
-which can trigger a duplicate review. Renew it now, before starting the fix, so the
-claim survives the fix-and-push that follows. Best-effort — warn and continue on failure:
+The fix subagent dispatched next can run long enough to overlap with another patch run
+(or a stale leftover claim from `/shipwright:review`, e.g. a still-claimed
+`phase: "review"` record left behind after posting — the record stays claimed until
+released or reaped). Without a pre-work claim, two overlapping patch runs could both
+dispatch competing fix subagents against the same branch. Claim the PR record with
+`phase: "patch"` now, before starting the fix, mirroring deploy.md's Step 4a pre-merge
+claim:
 
 ```bash
-PR_RECORD_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" 2>/dev/null \
-  | jq -r '.prs[0].id // empty')
-if [ -n "$PR_RECORD_ID" ]; then
-  curl -s -o /dev/null -X POST \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
-    echo "⚠ heartbeat renewal failed — continuing"
-fi
+HEAD_SHA_PRE_PATCH=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
+PR_CLAIM=$(curl -s -o /tmp/pr_claim_patch.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"$HEAD_SHA_PRE_PATCH\", \"phase\": \"patch\"}")
+PR_RECORD_ID=$(jq -r '.id // empty' /tmp/pr_claim_patch.json)
 ```
+
+**If `PR_CLAIM` is `409`** (another patch run already claimed this PR at phase `patch`):
+do NOT dispatch the fix subagent. Print:
+```
+⏸ PR #{pr} is already claimed by another patch run — skipping.
+```
+Skip the rest of Step 5 for this PR. Move to the next qualifying PR in List A. If no
+candidates remain, continue to Step 6.
+
+**Otherwise** (`200` or `201`): the claim succeeded. `PR_RECORD_ID` is reused by the
+post-fix update in Step 5c.5 — no second claim call is needed. Proceed to Step 5b.
 
 ### Step 5b: Dispatch Fix Subagent
 
@@ -597,24 +614,22 @@ Parse the subagent's STATUS:
 
 ### Step 5c.5: Upsert PR Record
 
-After a successful push, upsert a PullRequest record in the task store to track that a
-patch cycle has occurred. Warn and continue on any failure — do not stop.
+The record was already claimed pre-work in Step 5a.6 — `PR_RECORD_ID` is already set, so
+this renews the claim's heartbeat and increments `patchCycles` rather than re-claiming.
+Warn and continue on any failure — do not stop.
 
 ```bash
-HEAD_SHA=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
-CLAIM_RESULT=$(curl -sf -X POST \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
-  -d "{\"repo\":\"{org}/{repo}\",\"prNumber\":{pr},\"commitSha\":\"$HEAD_SHA\",\"phase\":\"patch\"}" 2>/dev/null)
-PR_ID=$(echo "$CLAIM_RESULT" | jq -r '.id // empty' 2>/dev/null)
-if [ -n "$PR_ID" ]; then
+if [ -n "$PR_RECORD_ID" ]; then
+  curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
+    echo "⚠ heartbeat renewal failed — continuing"
   curl -sf -X POST \
     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_ID/patch" > /dev/null 2>&1 || \
-    echo "⚠ POST /prs/$PR_ID/patch failed — continuing"
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" > /dev/null 2>&1 || \
+    echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
 else
-  echo "⚠ POST /prs/claim failed — continuing"
+  echo "⚠ no PR_RECORD_ID from pre-work claim — skipping PR record update"
 fi
 ```
 
@@ -688,26 +703,36 @@ gh run view "$RUN_ID" --log --failed --repo {org}/{repo} 2>&1 | tail -200
 
 Store the log output for use in the subagent prompt.
 
-### Step 6b.5: Renew the Claim Heartbeat
+### Step 6b.5: Claim PR Record (pre-work lock)
 
-The fix subagent dispatched next can run long enough to outlast a leftover claim on this
-PR's task-store record — e.g. a still-claimed `phase: "review"` record left behind by
-`/shipwright:review` after posting (the record stays claimed until released or reaped).
-If that claim goes stale mid-fix, the reaper resets `reviewState` back to `pending`,
-which can trigger a duplicate review. Renew it now, before starting the fix, so the
-claim survives the fix-and-push that follows. Best-effort — warn and continue on failure:
+The fix subagent dispatched next can run long enough to overlap with another patch run
+(or a stale leftover claim from `/shipwright:review`, e.g. a still-claimed
+`phase: "review"` record left behind after posting — the record stays claimed until
+released or reaped). Without a pre-work claim, two overlapping patch runs could both
+dispatch competing fix subagents against the same branch. Claim the PR record with
+`phase: "patch"` now, before starting the fix, mirroring deploy.md's Step 4a pre-merge
+claim:
 
 ```bash
-PR_RECORD_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" 2>/dev/null \
-  | jq -r '.prs[0].id // empty')
-if [ -n "$PR_RECORD_ID" ]; then
-  curl -s -o /dev/null -X POST \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
-    echo "⚠ heartbeat renewal failed — continuing"
-fi
+HEAD_SHA_PRE_PATCH=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
+PR_CLAIM=$(curl -s -o /tmp/pr_claim_patch.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"$HEAD_SHA_PRE_PATCH\", \"phase\": \"patch\"}")
+PR_RECORD_ID=$(jq -r '.id // empty' /tmp/pr_claim_patch.json)
 ```
+
+**If `PR_CLAIM` is `409`** (another patch run already claimed this PR at phase `patch`):
+do NOT dispatch the fix subagent. Print:
+```
+⏸ PR #{pr} is already claimed by another patch run — skipping.
+```
+Skip the rest of Step 6 for this PR. Move to the next PR in List D. If no candidates
+remain, continue to Step 7.
+
+**Otherwise** (`200` or `201`): the claim succeeded. `PR_RECORD_ID` is reused by the
+post-fix update in Step 6d.5 — no second claim call is needed. Proceed to Step 6c.
 
 ### Step 6c: Dispatch Fix Subagent
 
@@ -778,24 +803,22 @@ Parse the subagent's STATUS:
 
 ### Step 6d.5: Upsert PR Record
 
-After a successful push, upsert a PullRequest record in the task store to track that a
-patch cycle has occurred. Warn and continue on any failure — do not stop.
+The record was already claimed pre-work in Step 6b.5 — `PR_RECORD_ID` is already set, so
+this renews the claim's heartbeat and increments `patchCycles` rather than re-claiming.
+Warn and continue on any failure — do not stop.
 
 ```bash
-HEAD_SHA=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
-CLAIM_RESULT=$(curl -sf -X POST \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
-  -d "{\"repo\":\"{org}/{repo}\",\"prNumber\":{pr},\"commitSha\":\"$HEAD_SHA\",\"phase\":\"patch\"}" 2>/dev/null)
-PR_ID=$(echo "$CLAIM_RESULT" | jq -r '.id // empty' 2>/dev/null)
-if [ -n "$PR_ID" ]; then
+if [ -n "$PR_RECORD_ID" ]; then
+  curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
+    echo "⚠ heartbeat renewal failed — continuing"
   curl -sf -X POST \
     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_ID/patch" > /dev/null 2>&1 || \
-    echo "⚠ POST /prs/$PR_ID/patch failed — continuing"
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" > /dev/null 2>&1 || \
+    echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
 else
-  echo "⚠ POST /prs/claim failed — continuing"
+  echo "⚠ no PR_RECORD_ID from pre-work claim — skipping PR record update"
 fi
 ```
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -361,7 +361,15 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If the push already happened, log concerns and
   proceed to Step 4c.5 (upsert PR record). If the subagent did not push, note it in the
   final report and skip Step 4c.5.
-- **BLOCKED**: Log the blocker. Skip Steps 4c.5 and 4d. Move to the next PR in List C.
+- **BLOCKED**: Release the pre-work claim from Step 4a.6 so a subsequent patch/review-patch
+  run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
+  never completed, so nothing is actually in flight:
+  ```bash
+  [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+  ```
+  Log the blocker. Skip Steps 4c.5 and 4d. Move to the next PR in List C.
   Include the blocker in the final report.
 
 ### Step 4c.5: Upsert PR Record
@@ -609,7 +617,15 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If they are correctness gaps, log them in the
   report but proceed (the push already happened) to Step 5c.5 (upsert PR record). If the
   subagent did not push due to a concern, note it and skip Step 5c.5.
-- **BLOCKED**: Log the blocker. Skip Steps 5c.5 and 5d. Move to the next qualifying PR.
+- **BLOCKED**: Release the pre-work claim from Step 5a.6 so a subsequent patch/review-patch
+  run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
+  never completed, so nothing is actually in flight:
+  ```bash
+  [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+  ```
+  Log the blocker. Skip Steps 5c.5 and 5d. Move to the next qualifying PR.
   Include the blocker in the final report.
 
 ### Step 5c.5: Upsert PR Record
@@ -798,7 +814,15 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If the push already happened, log concerns and
   proceed to Step 6d.5 (upsert PR record). If the subagent did not push, note it in the
   final report and skip Step 6d.5.
-- **BLOCKED**: Log the blocker. Skip Steps 6d.5 and 6e. Move to the next PR in List D.
+- **BLOCKED**: Release the pre-work claim from Step 6b.5 so a subsequent patch/review-patch
+  run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
+  never completed, so nothing is actually in flight:
+  ```bash
+  [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+  ```
+  Log the blocker. Skip Steps 6d.5 and 6e. Move to the next PR in List D.
   Include the blocker in the final report.
 
 ### Step 6d.5: Upsert PR Record

--- a/plugins/shipwright/commands/patch.test.ts
+++ b/plugins/shipwright/commands/patch.test.ts
@@ -84,6 +84,7 @@ describe("patch.md — pre-work PR claim lock (CLM-2.1)", () => {
       preDispatchSection.includes("skip") || preDispatchSection.includes("skipping");
     expect(hasSkipLanguage).toBe(true);
     expect(preDispatchSection.toLowerCase()).toContain("next");
+    expect(preDispatchSection).toContain("List A");
   });
 
   it("409 handling causes the PR to be skipped and the next candidate in the list to be tried (List D)", () => {

--- a/plugins/shipwright/commands/patch.test.ts
+++ b/plugins/shipwright/commands/patch.test.ts
@@ -24,22 +24,28 @@ describe("patch.md — pre-work PR claim lock (CLM-2.1)", () => {
   });
 
   it("Step 5 (review findings): claims the PR (phase: patch) before dispatching the fix subagent", () => {
+    const step5a6Idx = content.indexOf("### Step 5a.6:");
     const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    expect(step5a6Idx).toBeGreaterThan(-1);
     expect(step5bIdx).toBeGreaterThan(-1);
-    const preStep5b = content.slice(0, step5bIdx);
+    const preStep5b = content.slice(step5a6Idx, step5bIdx);
     const lastClaimBeforeStep5b = preStep5b.lastIndexOf("/prs/claim");
     expect(lastClaimBeforeStep5b).toBeGreaterThan(-1);
+    // The nearest preceding claim call must carry phase: "patch"
     const claimSnippet = preStep5b.slice(lastClaimBeforeStep5b, lastClaimBeforeStep5b + 400);
     expect(claimSnippet).toContain("phase");
     expect(claimSnippet).toContain("patch");
   });
 
   it("Step 6 (failing CI): claims the PR (phase: patch) before dispatching the CI-fix subagent", () => {
+    const step6b5Idx = content.indexOf("### Step 6b.5:");
     const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b5Idx).toBeGreaterThan(-1);
     expect(step6cIdx).toBeGreaterThan(-1);
-    const preStep6c = content.slice(0, step6cIdx);
+    const preStep6c = content.slice(step6b5Idx, step6cIdx);
     const lastClaimBeforeStep6c = preStep6c.lastIndexOf("/prs/claim");
     expect(lastClaimBeforeStep6c).toBeGreaterThan(-1);
+    // The nearest preceding claim call must carry phase: "patch"
     const claimSnippet = preStep6c.slice(lastClaimBeforeStep6c, lastClaimBeforeStep6c + 400);
     expect(claimSnippet).toContain("phase");
     expect(claimSnippet).toContain("patch");
@@ -97,6 +103,36 @@ describe("patch.md — pre-work PR claim lock (CLM-2.1)", () => {
     expect(hasSkipLanguage).toBe(true);
     expect(preDispatchSection.toLowerCase()).toContain("next");
     expect(preDispatchSection).toContain("List D");
+  });
+
+  it("Step 4c (merge conflicts): BLOCKED path releases the pre-work claim", () => {
+    const step4cIdx = content.indexOf("### Step 4c: Handle Subagent Status");
+    const step4c5Idx = content.indexOf("### Step 4c.5:");
+    expect(step4cIdx).toBeGreaterThan(-1);
+    expect(step4c5Idx).toBeGreaterThan(-1);
+    const section = content.slice(step4cIdx, step4c5Idx);
+    expect(section).toContain("BLOCKED");
+    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+  });
+
+  it("Step 5c (review findings): BLOCKED path releases the pre-work claim", () => {
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    const step5c5Idx = content.indexOf("### Step 5c.5:");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    expect(step5c5Idx).toBeGreaterThan(-1);
+    const section = content.slice(step5cIdx, step5c5Idx);
+    expect(section).toContain("BLOCKED");
+    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+  });
+
+  it("Step 6d (failing CI): BLOCKED path releases the pre-work claim", () => {
+    const step6dIdx = content.indexOf("### Step 6d: Handle Subagent Status");
+    const step6d5Idx = content.indexOf("### Step 6d.5:");
+    expect(step6dIdx).toBeGreaterThan(-1);
+    expect(step6d5Idx).toBeGreaterThan(-1);
+    const section = content.slice(step6dIdx, step6d5Idx);
+    expect(section).toContain("BLOCKED");
+    expect(section).toContain("/prs/$PR_RECORD_ID/release");
   });
 
   it("post-fix step 4c.5 reuses PR_RECORD_ID instead of re-calling POST /prs/claim", () => {

--- a/plugins/shipwright/commands/patch.test.ts
+++ b/plugins/shipwright/commands/patch.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PATCH_MD_PATH = join(import.meta.dir, "patch.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(PATCH_MD_PATH, "utf-8");
+});
+
+describe("patch.md — pre-work PR claim lock (CLM-2.1)", () => {
+  it("Step 4 (merge conflicts): claims the PR (phase: patch) before dispatching the conflict-resolution subagent", () => {
+    const step4bIdx = content.indexOf("### Step 4b: Dispatch Conflict Resolution Subagent");
+    expect(step4bIdx).toBeGreaterThan(-1);
+    const preStep4b = content.slice(0, step4bIdx);
+    const lastClaimBeforeStep4b = preStep4b.lastIndexOf("/prs/claim");
+    expect(lastClaimBeforeStep4b).toBeGreaterThan(-1);
+    // The nearest preceding claim call must carry phase: "patch"
+    const claimSnippet = preStep4b.slice(lastClaimBeforeStep4b, lastClaimBeforeStep4b + 400);
+    expect(claimSnippet).toContain("phase");
+    expect(claimSnippet).toContain("patch");
+  });
+
+  it("Step 5 (review findings): claims the PR (phase: patch) before dispatching the fix subagent", () => {
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    expect(step5bIdx).toBeGreaterThan(-1);
+    const preStep5b = content.slice(0, step5bIdx);
+    const lastClaimBeforeStep5b = preStep5b.lastIndexOf("/prs/claim");
+    expect(lastClaimBeforeStep5b).toBeGreaterThan(-1);
+    const claimSnippet = preStep5b.slice(lastClaimBeforeStep5b, lastClaimBeforeStep5b + 400);
+    expect(claimSnippet).toContain("phase");
+    expect(claimSnippet).toContain("patch");
+  });
+
+  it("Step 6 (failing CI): claims the PR (phase: patch) before dispatching the CI-fix subagent", () => {
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6cIdx).toBeGreaterThan(-1);
+    const preStep6c = content.slice(0, step6cIdx);
+    const lastClaimBeforeStep6c = preStep6c.lastIndexOf("/prs/claim");
+    expect(lastClaimBeforeStep6c).toBeGreaterThan(-1);
+    const claimSnippet = preStep6c.slice(lastClaimBeforeStep6c, lastClaimBeforeStep6c + 400);
+    expect(claimSnippet).toContain("phase");
+    expect(claimSnippet).toContain("patch");
+  });
+
+  it("all three pre-work claims occur before their respective dispatch points (ordering)", () => {
+    const claimIndices: number[] = [];
+    let searchFrom = 0;
+    for (;;) {
+      const idx = content.indexOf("/prs/claim", searchFrom);
+      if (idx === -1) break;
+      claimIndices.push(idx);
+      searchFrom = idx + 1;
+    }
+    const step4bIdx = content.indexOf("### Step 4b: Dispatch Conflict Resolution Subagent");
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+
+    expect(claimIndices.some((i) => i < step4bIdx)).toBe(true);
+    expect(claimIndices.some((i) => i < step5bIdx)).toBe(true);
+    expect(claimIndices.some((i) => i < step6cIdx)).toBe(true);
+  });
+
+  it("409 handling causes the PR to be skipped and the next candidate in the list to be tried (List C)", () => {
+    const step4aIdx = content.indexOf("### Step 4a: Set Up Worktree");
+    const step4bIdx = content.indexOf("### Step 4b: Dispatch Conflict Resolution Subagent");
+    const preDispatchSection = content.slice(step4aIdx, step4bIdx);
+    expect(preDispatchSection).toContain("409");
+    const hasSkipLanguage =
+      preDispatchSection.includes("skip") || preDispatchSection.includes("skipping");
+    expect(hasSkipLanguage).toBe(true);
+    expect(preDispatchSection.toLowerCase()).toContain("next");
+    expect(preDispatchSection).toContain("List C");
+  });
+
+  it("409 handling causes the PR to be skipped and the next candidate in the list to be tried (List A)", () => {
+    const step5aIdx = content.indexOf("### Step 5a: Set Up Worktree");
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    const preDispatchSection = content.slice(step5aIdx, step5bIdx);
+    expect(preDispatchSection).toContain("409");
+    const hasSkipLanguage =
+      preDispatchSection.includes("skip") || preDispatchSection.includes("skipping");
+    expect(hasSkipLanguage).toBe(true);
+    expect(preDispatchSection.toLowerCase()).toContain("next");
+  });
+
+  it("409 handling causes the PR to be skipped and the next candidate in the list to be tried (List D)", () => {
+    const step6aIdx = content.indexOf("### Step 6a: Set Up Worktree");
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    const preDispatchSection = content.slice(step6aIdx, step6cIdx);
+    expect(preDispatchSection).toContain("409");
+    const hasSkipLanguage =
+      preDispatchSection.includes("skip") || preDispatchSection.includes("skipping");
+    expect(hasSkipLanguage).toBe(true);
+    expect(preDispatchSection.toLowerCase()).toContain("next");
+    expect(preDispatchSection).toContain("List D");
+  });
+
+  it("post-fix step 4c.5 reuses PR_RECORD_ID instead of re-calling POST /prs/claim", () => {
+    const sectionIdx = content.indexOf("### Step 4c.5: Upsert PR Record");
+    expect(sectionIdx).toBeGreaterThan(-1);
+    const nextSectionIdx = content.indexOf("### Step 4d:", sectionIdx);
+    const section = content.slice(sectionIdx, nextSectionIdx);
+    expect(section.includes("/prs/claim")).toBe(false);
+    expect(section.includes("PR_RECORD_ID")).toBe(true);
+  });
+
+  it("post-fix step 5c.5 reuses PR_RECORD_ID instead of re-calling POST /prs/claim", () => {
+    const sectionIdx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    expect(sectionIdx).toBeGreaterThan(-1);
+    const nextSectionIdx = content.indexOf("### Step 5d:", sectionIdx);
+    const section = content.slice(sectionIdx, nextSectionIdx);
+    expect(section.includes("/prs/claim")).toBe(false);
+    expect(section.includes("PR_RECORD_ID")).toBe(true);
+  });
+
+  it("post-fix step 6d.5 reuses PR_RECORD_ID instead of re-calling POST /prs/claim", () => {
+    const sectionIdx = content.indexOf("### Step 6d.5: Upsert PR Record");
+    expect(sectionIdx).toBeGreaterThan(-1);
+    const nextSectionIdx = content.indexOf("### Step 6e:", sectionIdx);
+    const section = content.slice(sectionIdx, nextSectionIdx);
+    expect(section.includes("/prs/claim")).toBe(false);
+    expect(section.includes("PR_RECORD_ID")).toBe(true);
+  });
+
+  it("still calls POST /prs/{id}/patch in each post-fix step (patchCycles increment is patch.md-specific)", () => {
+    const matches = content.match(/\/prs\/\$PR_RECORD_ID\/patch/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -544,6 +544,10 @@ export const ClaimPrBodySchema = z
       .string()
       .optional()
       .openapi({ example: "clx1234567890", description: "Associated task ID" }),
+    phase: z
+      .enum(["review", "patch", "deploy"])
+      .optional()
+      .openapi({ example: "patch", description: "Pipeline phase this claim is for (defaults to 'review' when omitted)" }),
   })
   .openapi("ClaimPrBody");
 

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -136,6 +136,16 @@ function makeScopeResolver(
   return async (agentId: string) => (agentId === "agent-1" ? repos : []);
 }
 
+/** Captured args from each fakePrService.claim() call — for asserting phase forwarding. */
+interface CapturedClaimCall {
+  repo: string;
+  prNumber: number;
+  commitSha: string;
+  claimedBy: string;
+  taskId?: string;
+  phase?: "review" | "patch" | "deploy";
+}
+
 /** Minimal in-memory PullRequestServiceLike fake. */
 function fakePrService(
   opts: {
@@ -144,6 +154,7 @@ function fakePrService(
     getResult?: PullRequest | null;
     listResult?: PullRequest[];
     claimNextResult?: { pr: PullRequest; phase: "review" | "patch" | "deploy" } | null;
+    claimCalls?: CapturedClaimCall[];
   } = {},
 ): PullRequestServiceLike {
   const store = opts.store ?? new Map<string, PullRequest>();
@@ -191,7 +202,16 @@ function fakePrService(
       commitSha: string,
       claimedBy: string,
       taskId?: string,
+      phase?: "review" | "patch" | "deploy",
     ): Promise<{ status: 200 | 201; record: PullRequest }> {
+      opts.claimCalls?.push({
+        repo,
+        prNumber,
+        commitSha,
+        claimedBy,
+        taskId,
+        phase,
+      });
       if (opts.claimResult !== undefined) {
         if (opts.claimResult instanceof Error) throw opts.claimResult;
         return opts.claimResult;
@@ -204,6 +224,7 @@ function fakePrService(
         commitSha,
         claimedBy,
         taskId: taskId ?? null,
+        phase: phase ?? "review",
         reviewState: "in_progress",
         claimedAt: new Date().toISOString(),
         heartbeatAt: new Date().toISOString(),
@@ -482,6 +503,43 @@ describe("/prs routes (smoke)", () => {
       }),
     });
     expect(res.status).toBe(201);
+  });
+
+  it('POST /prs/claim forwards phase:"patch" from the request body to service.claim()', async () => {
+    const claimCalls: CapturedClaimCall[] = [];
+    const app = makeApp({ prService: fakePrService({ claimCalls }) });
+    const res = await app.request("/prs/claim", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        repo: ADMIN_REPO,
+        prNumber: 42,
+        commitSha: "abc123",
+        claimedBy: "agent-1",
+        phase: "patch",
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(claimCalls).toHaveLength(1);
+    expect(claimCalls[0]?.phase).toBe("patch");
+  });
+
+  it("POST /prs/claim without a phase field leaves phase undefined (service default applies)", async () => {
+    const claimCalls: CapturedClaimCall[] = [];
+    const app = makeApp({ prService: fakePrService({ claimCalls }) });
+    const res = await app.request("/prs/claim", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        repo: ADMIN_REPO,
+        prNumber: 42,
+        commitSha: "abc123",
+        claimedBy: "agent-1",
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(claimCalls).toHaveLength(1);
+    expect(claimCalls[0]?.phase).toBeUndefined();
   });
 
   // ─── POST /prs/:id/complete ───────────────────────────────────────────────

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -351,9 +351,8 @@ export function createPrsRoutes(
     // Only pass an explicit phase when the caller supplied one — leaving it
     // undefined lets the service's own `= "review"` default parameter apply,
     // matching callers (like review.md) that don't send phase at all.
-    // OpenAPIHono validates the body against ClaimPrBodySchema's phase enum
-    // before this handler runs, so a present value is already one of
-    // "review" | "patch" | "deploy".
+    // readJson reads the raw body, not the Zod-validated payload — this guard
+    // narrows phase to the allowed enum values before forwarding to the service.
     const resolvedPhase =
       phase === "review" || phase === "patch" || phase === "deploy"
         ? phase

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -314,7 +314,7 @@ export function createPrsRoutes(
     const repos = c.get("repos");
     const body = await readJson(c);
 
-    const { repo, prNumber, commitSha, claimedBy, taskId } = body;
+    const { repo, prNumber, commitSha, claimedBy, taskId, phase } = body;
 
     // Validate required fields
     if (typeof repo !== "string" || !repo) {
@@ -348,12 +348,24 @@ export function createPrsRoutes(
     const resolvedTaskId =
       typeof taskId === "string" && taskId ? taskId : undefined;
 
+    // Only pass an explicit phase when the caller supplied one — leaving it
+    // undefined lets the service's own `= "review"` default parameter apply,
+    // matching callers (like review.md) that don't send phase at all.
+    // OpenAPIHono validates the body against ClaimPrBodySchema's phase enum
+    // before this handler runs, so a present value is already one of
+    // "review" | "patch" | "deploy".
+    const resolvedPhase =
+      phase === "review" || phase === "patch" || phase === "deploy"
+        ? phase
+        : undefined;
+
     const { status, record } = await prService.claim(
       repo,
       prNumber,
       commitSha,
       resolvedClaimedBy,
       resolvedTaskId,
+      resolvedPhase,
     );
 
     return c.json(record, status);


### PR DESCRIPTION
## Summary
- Add a pre-work `POST /prs/claim` call (`phase: "patch"`) before each of `patch.md`'s three fix-subagent dispatch points (conflict resolution, review-finding fix, CI-failure fix), preventing two overlapping patch runs from dispatching competing fix subagents against the same branch — mirroring `deploy.md`'s pre-merge claim/409 pattern.
- Simplify the existing post-fix upsert steps (4c.5, 5c.5, 6d.5) to reuse the `PR_RECORD_ID` from the pre-work claim (heartbeat renewal + `/patch` call) instead of re-calling `POST /prs/claim`.
- Fix a real gap discovered during implementation: the `POST /prs/claim` HTTP route never accepted or forwarded a `phase` field, even though the service layer (`PullRequestService.claim()`) already supported it and `deploy.md` was already (silently, ineffectively) sending `phase: "deploy"`. Wired `phase` through `ClaimPrBodySchema` and the route handler so phase-scoped claims actually take effect.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | POST /prs/claim with phase:"patch" before each of the three dispatch points | MET |
| 2 | 409 response skips the PR and continues to the next candidate | MET |
| 3 | Post-fix upsert calls simplified to avoid re-claiming | MET |
| 4 | patch.test.ts added (content-assertion, mirrors deploy.test.ts) | MET |

## Test Plan
- `bun test task-store/src/prs.smoke.test.ts task-store/src/routes/prs.openapi.smoke.test.ts plugins/shipwright/commands/patch.test.ts plugins/shipwright/commands/deploy.test.ts` — all pass
- Full repo `bun test` — 3266 pass, 15 pre-existing/unrelated failures (confirmed present on `main` before this change)
- `bunx biome lint .`, `bun run --filter='*' typecheck`, `check-banned-strings.ts`, `check-config-docs.ts`, `sync-version.ts --check` — all pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
