### PR TITLE
feat: add check-test-readiness precheck script

### DIFF
--- a/plugins/shipwright/scripts/check-test-readiness.test.ts
+++ b/plugins/shipwright/scripts/check-test-readiness.test.ts
@@ -1,0 +1,90 @@
+/**
+ * plugins/shipwright/scripts/check-test-readiness.test.ts
+ *
+ * Unit tests for check-test-readiness.ts
+ *
+ * Design: the script exports a `run(deps)` function that accepts injected
+ * dependencies. Tests inject stub implementations — no file I/O is executed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ARTIFACT_PATHS, run, STALE_THRESHOLD_MS } from "./check-test-readiness.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const NOW = 1_000_000_000_000;
+
+function makeDeps(overrides: {
+  getMtimeMs?: (path: string) => number | null;
+  now?: () => number;
+}) {
+  return {
+    getMtimeMs: overrides.getMtimeMs ?? (() => NOW),
+    now: overrides.now ?? (() => NOW),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("check-test-readiness", () => {
+  test("exits 1 with empty output when all 4 artifacts are fresh", async () => {
+    const deps = makeDeps({
+      getMtimeMs: () => NOW,
+      now: () => NOW,
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 with a summary when one artifact is stale (old mtime)", async () => {
+    const staleMtime = NOW - (STALE_THRESHOLD_MS + 1);
+    const deps = makeDeps({
+      getMtimeMs: (path) =>
+        path === ARTIFACT_PATHS[1] ? staleMtime : NOW,
+      now: () => NOW,
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain(ARTIFACT_PATHS[1]);
+  });
+
+  test("exits 0 (treated as stale) when an artifact is missing entirely", async () => {
+    const deps = makeDeps({
+      getMtimeMs: (path) => (path === ARTIFACT_PATHS[2] ? null : NOW),
+      now: () => NOW,
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain(ARTIFACT_PATHS[2]);
+  });
+
+  test("exits 0 and lists all stale artifacts when multiple are stale", async () => {
+    const staleMtime = NOW - (STALE_THRESHOLD_MS + 1);
+    const deps = makeDeps({
+      getMtimeMs: (path) => {
+        if (path === ARTIFACT_PATHS[0]) return staleMtime;
+        if (path === ARTIFACT_PATHS[3]) return null;
+        return NOW;
+      },
+      now: () => NOW,
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain(ARTIFACT_PATHS[0]);
+    expect(result.output).toContain(ARTIFACT_PATHS[3]);
+    expect(result.output).not.toContain(ARTIFACT_PATHS[1]);
+    expect(result.output).not.toContain(ARTIFACT_PATHS[2]);
+  });
+
+  test("treats mtime exactly at the 24h boundary as fresh (permissive on boundary)", async () => {
+    const boundaryMtime = NOW - STALE_THRESHOLD_MS;
+    const deps = makeDeps({
+      getMtimeMs: () => boundaryMtime,
+      now: () => NOW,
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+});

--- a/plugins/shipwright/scripts/check-test-readiness.ts
+++ b/plugins/shipwright/scripts/check-test-readiness.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+/**
+ * plugins/shipwright/scripts/check-test-readiness.ts
+ *
+ * Pre-check for the test-readiness cron.
+ *
+ * Mirrors the staleness gate documented in
+ * skills/test-readiness/SKILL.md (Staleness check section): compares the
+ * mtimes of the 4 phase artifacts against a 24h threshold.
+ * - If all 4 artifacts are fresh (mtime within 24h) → exit 1 (nothing to do)
+ * - If any artifact is missing or stale (older than 24h) → exit 0 with a
+ *   summary of the stale artifact(s)
+ *
+ * Exit 0 + summary → run the test-readiness skill
+ * Exit 1 + no output → nothing to do
+ *
+ * Usage:
+ *   bun plugins/shipwright/scripts/check-test-readiness.ts
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Deps {
+  getMtimeMs: (path: string) => number | null;
+  now: () => number;
+}
+
+interface RunResult {
+  exit: 0 | 1;
+  output: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * The 4 phase artifacts, in phase order, as documented in
+ * skills/test-readiness/SKILL.md.
+ */
+export const ARTIFACT_PATHS = [
+  "docs/test-readiness/test-inventory.md",
+  "docs/test-readiness/test-system.md",
+  "docs/test-readiness/test-migration.md",
+  "docs/test-readiness/test-readiness-plan.md",
+] as const;
+
+export const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+function isStale(path: string, deps: Deps): boolean {
+  const mtimeMs = deps.getMtimeMs(path);
+  if (mtimeMs === null) return true;
+  return deps.now() - mtimeMs > STALE_THRESHOLD_MS;
+}
+
+export async function run(deps: Deps): Promise<RunResult> {
+  const staleArtifacts = ARTIFACT_PATHS.filter((path) => isStale(path, deps));
+
+  if (staleArtifacts.length === 0) {
+    return { exit: 1, output: "" };
+  }
+
+  const output = `Stale or missing test-readiness artifacts:\n${staleArtifacts.join("\n")}`;
+  return { exit: 0, output };
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+function buildProductionDeps(): Deps {
+  const cwd = process.cwd();
+
+  return {
+    getMtimeMs: (path: string): number | null => {
+      const fullPath = join(cwd, path);
+      if (!existsSync(fullPath)) return null;
+      try {
+        return statSync(fullPath).mtimeMs;
+      } catch {
+        return null;
+      }
+    },
+
+    now: (): number => Date.now(),
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const deps = buildProductionDeps();
+  const result = await run(deps);
+  if (result.exit === 0) {
+    process.stdout.write(`${result.output}\n`);
+  }
+  process.exit(result.exit);
+}
+
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `plugins/shipwright/scripts/check-test-readiness.ts`, a precheck script that ports the mtime-staleness gate already documented in `skills/test-readiness/SKILL.md` (4 phase artifacts vs. a 24h threshold) into the same pure `run(deps)` / `buildProductionDeps()` / `main()` shape used by `check-docs-freshness.ts`.
- Adds `check-test-readiness.test.ts` covering: all artifacts fresh → exit 1 (nothing to do); a single stale artifact → exit 0 with a summary; a missing artifact → exit 0 (treated as stale); multiple stale artifacts all listed; boundary mtime (exactly 24h) treated as fresh.
- Scope: this PR only adds the script and its tests. Wiring the live `shipwright-test-readiness` cron's `preCheck` field and removing `--full` from its prompt happens post-merge via the agent-admin API, per the task description.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Implements same 4-artifact mtime-vs-24h staleness check per SKILL.md:42-66 | MET | `ARTIFACT_PATHS` + `STALE_THRESHOLD_MS` match SKILL.md's 4 canonical paths and 24h threshold exactly |
| 2 | Exits 1 when all 4 fresh | MET | `run()` returns `{exit:1, output:""}` when no stale artifacts; unit test covers it |
| 3 | Exits 0 with summary when any missing/stale | MET | `run()` lists all stale/missing paths in output; covered by one-stale, missing, and multiple-stale tests |
| 4 | `check-test-readiness.test.ts` with Deps-injection, no global mocking, sibling naming convention | MET | Injected `makeDeps()` factory, no `mock.module()`/`global.*` overrides, named to match `check-docs-freshness.test.ts` convention |

## Test Plan
- `bun test plugins/shipwright/scripts/check-test-readiness.test.ts` — 5/5 pass
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — clean across all 7 workspaces
- `bun test` (full suite) — 3259 pass, 15 pre-existing failures (identical on `main`, unrelated to this change — Kubernetes client / plugin installer / chat token reporter tests)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
