### PR TITLE
feat: add check-dependabot-triage precheck

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ Key surfaces (see `plugins/shipwright/README.md` and `plugins/shipwright/CLAUDE.
 
 - **Commands** (`commands/`) — `prd`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, the five-phase test-readiness pipeline (`test-inventory` → `test-design` → `test-migration` → `test-roadmap` → `test-publish`), `metrics`, `research`, `research-docs`, and more.
 - **Skills** (`skills/`) — autonomous behaviors including `pull-requests`, `review-staged`, `entropy-scan`, `entropy-fix`, `agent-admin`, `investigate-cron`, `learning-capture`, `task-store`, `test-readiness`, `test-debt`, `triage-dependabot-pr`, and `triage-dependabot-prs`.
-- **Scripts** (`scripts/`) — the task-store adapters, `check-dev-task.ts`, and supporting tooling.
+- **Scripts** (`scripts/`) — the task-store adapters, precheck scripts (`check-dev-task.ts`, `check-dependabot-triage.ts`), and supporting tooling.
 - **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, …).
 
 The plugin is pure TypeScript with **no server, no database, and no external HTTP in production code** — only `unit` and `integration` test layers apply.

--- a/plugins/shipwright/scripts/check-dependabot-triage.test.ts
+++ b/plugins/shipwright/scripts/check-dependabot-triage.test.ts
@@ -1,0 +1,231 @@
+/**
+ * plugins/shipwright/scripts/check-dependabot-triage.test.ts
+ *
+ * Unit tests for check-dependabot-triage.ts
+ *
+ * Design: the script exports a `run(deps)` function with injectable deps
+ * for repo resolution, open Dependabot PR listing, and state reading.
+ * No file I/O or gh CLI calls are made in tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Deps, PrInfo, StateEntry } from "./check-dependabot-triage.ts";
+import { run } from "./check-dependabot-triage.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
+  return {
+    number: 42,
+    title: "Bump axios from 1.6.0 to 1.7.0",
+    headRefName: "dependabot/npm_and_yarn/axios-1.7.0",
+    ...overrides,
+  };
+}
+
+function makeStateEntry(overrides: Partial<StateEntry> = {}): StateEntry {
+  return {
+    pr: 42,
+    repo: "example-repo",
+    org: "example-org",
+    title: "Bump axios from 1.6.0 to 1.7.0",
+    branch: "dependabot/npm_and_yarn/axios-1.7.0",
+    status: "pending",
+    firstSeen: "2026-07-01T00:00:00Z",
+    lastTriagedAt: null,
+    recommendation: null,
+    stagedFile: null,
+    postedAt: null,
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<Deps> = {}): Deps {
+  return {
+    resolveRepos:
+      overrides.resolveRepos ?? (() => ["example-org/example-repo"]),
+    listOpenDependabotPrs:
+      overrides.listOpenDependabotPrs ?? (async (_repo: string) => []),
+    readState: overrides.readState ?? (() => []),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("check-dependabot-triage", () => {
+  test("exits 1 when there are no open dependabot PRs (across all repos)", async () => {
+    const deps = makeDeps({
+      resolveRepos: () => ["example-org/example-repo"],
+      listOpenDependabotPrs: async () => [],
+      readState: () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when all open dependabot PRs already have a non-terminal state entry", async () => {
+    const pr = makePr({ number: 42 });
+    const deps = makeDeps({
+      resolveRepos: () => ["example-org/example-repo"],
+      listOpenDependabotPrs: async () => [pr],
+      readState: () => [
+        makeStateEntry({
+          pr: 42,
+          repo: "example-repo",
+          org: "example-org",
+          status: "staged",
+        }),
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when at least one open dependabot PR has no corresponding non-terminal entry", async () => {
+    const pr = makePr({ number: 42 });
+    const deps = makeDeps({
+      resolveRepos: () => ["example-org/example-repo"],
+      listOpenDependabotPrs: async () => [pr],
+      readState: () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("exits 0 when zero repos are configured is NOT the case — zero repos means zero PRs, exits 1", async () => {
+    const deps = makeDeps({
+      resolveRepos: () => [],
+      listOpenDependabotPrs: async () => {
+        throw new Error("should not be called for zero repos");
+      },
+      readState: () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when a PR has only a terminal (merged) state entry — still needs triage", async () => {
+    const pr = makePr({ number: 42 });
+    const deps = makeDeps({
+      resolveRepos: () => ["example-org/example-repo"],
+      listOpenDependabotPrs: async () => [pr],
+      readState: () => [
+        makeStateEntry({
+          pr: 42,
+          repo: "example-repo",
+          org: "example-org",
+          status: "merged",
+        }),
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("exits 0 when a PR has only a terminal (closed) state entry — still needs triage", async () => {
+    const pr = makePr({ number: 7 });
+    const deps = makeDeps({
+      resolveRepos: () => ["example-org/example-repo"],
+      listOpenDependabotPrs: async () => [pr],
+      readState: () => [
+        makeStateEntry({
+          pr: 7,
+          repo: "example-repo",
+          org: "example-org",
+          status: "closed",
+        }),
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("multi-repo: all PRs across repos already triaged (non-terminal) — exits 1", async () => {
+    const prA = makePr({ number: 1 });
+    const prB = makePr({ number: 2 });
+    const deps = makeDeps({
+      resolveRepos: () => ["org/repo-a", "org/repo-b"],
+      listOpenDependabotPrs: async (repo: string) =>
+        repo === "org/repo-a" ? [prA] : [prB],
+      readState: () => [
+        makeStateEntry({ pr: 1, repo: "repo-a", org: "org", status: "posted" }),
+        makeStateEntry({
+          pr: 2,
+          repo: "repo-b",
+          org: "org",
+          status: "pending",
+        }),
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("multi-repo: one repo has an untriaged PR — exits 0", async () => {
+    const prA = makePr({ number: 1 });
+    const prB = makePr({ number: 2 });
+    const deps = makeDeps({
+      resolveRepos: () => ["org/repo-a", "org/repo-b"],
+      listOpenDependabotPrs: async (repo: string) =>
+        repo === "org/repo-a" ? [prA] : [prB],
+      readState: () => [
+        makeStateEntry({ pr: 1, repo: "repo-a", org: "org", status: "posted" }),
+        // repo-b PR #2 has no entry at all
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("does not match a state entry from a different repo with the same PR number", async () => {
+    const pr = makePr({ number: 42 });
+    const deps = makeDeps({
+      resolveRepos: () => ["org/repo-a"],
+      listOpenDependabotPrs: async () => [pr],
+      readState: () => [
+        makeStateEntry({
+          pr: 42,
+          repo: "repo-b", // different repo, same PR number
+          org: "org",
+          status: "staged",
+        }),
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("exits 1 when repos exist but zero repos return any PRs", async () => {
+    const deps = makeDeps({
+      resolveRepos: () => ["org/repo-a", "org/repo-b"],
+      listOpenDependabotPrs: async () => [],
+      readState: () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 (permissive) when listOpenDependabotPrs throws (gh CLI failure)", async () => {
+    const deps = makeDeps({
+      resolveRepos: () => ["org/repo-a"],
+      listOpenDependabotPrs: async () => {
+        throw new Error("gh pr list failed");
+      },
+      readState: () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+});

--- a/plugins/shipwright/scripts/check-dependabot-triage.test.ts
+++ b/plugins/shipwright/scripts/check-dependabot-triage.test.ts
@@ -96,7 +96,7 @@ describe("check-dependabot-triage", () => {
     expect(result.output).toBeTruthy();
   });
 
-  test("exits 0 when zero repos are configured is NOT the case — zero repos means zero PRs, exits 1", async () => {
+  test("exits 1 when zero repos are configured (nothing to scan)", async () => {
     const deps = makeDeps({
       resolveRepos: () => [],
       listOpenDependabotPrs: async () => {

--- a/plugins/shipwright/scripts/check-dependabot-triage.ts
+++ b/plugins/shipwright/scripts/check-dependabot-triage.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * plugins/shipwright/scripts/check-dependabot-triage.ts
+ *
+ * Pre-check for the dependabot-triage cron.
+ *
+ * Mirrors the triage-dependabot-prs skill's own Step 3 ("Discover open
+ * Dependabot PRs"): for each repo, list open Dependabot-authored PRs and
+ * diff them against the non-terminal entries in
+ * state/dependabot-reviews.json. If every open PR already has a matching
+ * pending/staged/posted entry, there is nothing new to triage.
+ *
+ * Exit 0 + one-line prompt → at least one open Dependabot PR needs triage
+ * Exit 1 + no output       → nothing to do
+ *
+ * Usage:
+ *   bun plugins/shipwright/scripts/check-dependabot-triage.ts
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  ghJson,
+  resolveAllRepos,
+  resolveWorkspacePath,
+} from "./check-helpers.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PrInfo {
+  number: number;
+  title: string;
+  headRefName: string;
+}
+
+export type TriageStatus =
+  | "pending"
+  | "staged"
+  | "posted"
+  | "merged"
+  | "closed";
+
+export interface StateEntry {
+  pr: number;
+  repo: string;
+  org: string;
+  title: string;
+  branch: string;
+  status: TriageStatus;
+  firstSeen: string;
+  lastTriagedAt: string | null;
+  recommendation: string | null;
+  stagedFile: string | null;
+  postedAt: string | null;
+  mergedAt: string | null;
+}
+
+export interface Deps {
+  resolveRepos: () => string[];
+  listOpenDependabotPrs: (repo: string) => Promise<PrInfo[]>;
+  readState: () => StateEntry[];
+}
+
+interface RunResult {
+  exit: 0 | 1;
+  output: string;
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+const NON_TERMINAL_STATUSES: readonly TriageStatus[] = [
+  "pending",
+  "staged",
+  "posted",
+];
+
+function isNonTerminal(status: TriageStatus): boolean {
+  return (NON_TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+/**
+ * A PR is already triaged if the state has an entry for the same repo + PR
+ * number with a non-terminal status. A terminal entry (merged/closed) does
+ * not count — a new Dependabot PR reopening the same number after a prior
+ * one was merged/closed still needs triage.
+ */
+function isAlreadyTriaged(
+  repo: string,
+  prNumber: number,
+  state: StateEntry[],
+): boolean {
+  // repo passed in is "org/repo" (matching resolveAllRepos); state entries
+  // store org and repo separately, so compare against "org/repo".
+  return state.some(
+    (entry) =>
+      `${entry.org}/${entry.repo}` === repo &&
+      entry.pr === prNumber &&
+      isNonTerminal(entry.status),
+  );
+}
+
+const NEEDS_TRIAGE_OUTPUT =
+  "Open Dependabot PRs need triage — run /shipwright:triage-dependabot-prs";
+
+export async function run(deps: Deps): Promise<RunResult> {
+  const repos = deps.resolveRepos();
+  const state = deps.readState();
+
+  for (const repo of repos) {
+    let prs: PrInfo[];
+    try {
+      prs = await deps.listOpenDependabotPrs(repo);
+    } catch {
+      // gh CLI failure — unknown state, err permissive per the Precheck
+      // Contract rather than silently skipping this repo.
+      return { exit: 0, output: NEEDS_TRIAGE_OUTPUT };
+    }
+
+    for (const pr of prs) {
+      if (!isAlreadyTriaged(repo, pr.number, state)) {
+        return { exit: 0, output: NEEDS_TRIAGE_OUTPUT };
+      }
+    }
+  }
+
+  return { exit: 1, output: "" };
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+export function buildProductionDeps(): Deps {
+  const workspacePath = resolveWorkspacePath();
+
+  return {
+    resolveRepos: () => resolveAllRepos(workspacePath),
+    listOpenDependabotPrs: async (repo: string) => {
+      return ghJson<PrInfo[]>([
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--author",
+        "app/dependabot",
+        "--state",
+        "open",
+        "--json",
+        "number,title,headRefName",
+      ]);
+    },
+    readState: (): StateEntry[] => {
+      const statePath = join(workspacePath, "state", "dependabot-reviews.json");
+      if (!existsSync(statePath)) return [];
+      try {
+        const data = JSON.parse(readFileSync(statePath, "utf-8")) as unknown;
+        return Array.isArray(data) ? (data as StateEntry[]) : [];
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const deps = buildProductionDeps();
+  const result = await run(deps);
+  if (result.exit === 0) {
+    process.stdout.write(`${result.output}\n`);
+  }
+  process.exit(result.exit);
+}
+
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `check-dependabot-triage.ts`, a precheck script for the `dependabot-triage` cron that mirrors the `triage-dependabot-prs` skill's own Step 3 (discover open Dependabot PRs, diff against non-terminal `state/dependabot-reviews.json` entries) so a full session isn't spun up when there's nothing new to triage
- Reuses `resolveAllRepos` and `ghJson` from `check-helpers.ts` rather than reimplementing repo discovery or gh CLI wrapping
- Refreshes `docs/architecture.md`'s scripts section to mention the new precheck alongside `check-dev-task.ts`

Wiring the live cron's `preCheck` field happens post-merge via the agent-admin API — out of scope for this PR per the task description.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Scans all repos via `resolveAllRepos` and lists open dependabot-authored PRs per repo via `ghJson`, matching the skill's Step 3 query exactly | MET |
| 2 | Diffs found PRs against `state/dependabot-reviews.json`'s non-terminal entries, matching the skill's own dedup logic | MET |
| 3 | Exits 1 (nothing to do) when there are no open dependabot PRs, or all open ones already have a non-terminal triage entry | MET |
| 4 | Exits 0 when at least one open dependabot PR has no corresponding non-terminal entry in `state/dependabot-reviews.json` | MET |
| 5 | `check-dependabot-triage.test.ts` (Deps-injection pattern, no global mocking, sibling file-naming convention) covering: no open PRs → exit 1; all open PRs already triaged → exit 1; one untriaged PR → exit 0 | MET |

## Test Plan
- `bun test plugins/shipwright/scripts/check-dependabot-triage.test.ts` — 11 tests, all passing (core scenarios + edge cases: zero repos, terminal-status entries still needing triage, multi-repo, cross-repo PR-number collisions, permissive gh-failure handling)
- `bun run --filter='*' typecheck` — all packages pass
- `bunx biome lint .` — clean
- `bun scripts/check-banned-strings.ts` — clean
- `bun scripts/check-config-docs.ts` — 28 env vars documented, no new ones
- `bun run scripts/sync-version.ts --check` — passes
- Full `bun test` — 3265 pass / 15 pre-existing failures verified identical on a fresh-install `main` (unrelated: Kubernetes client CA fallback, plugin installer, chat token reporter — none touch the files in this diff)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
