### PR TITLE
feat: add check-dependabot-triage precheck

### DIFF
--- a/plugins/shipwright/scripts/check-dependabot-triage.test.ts
+++ b/plugins/shipwright/scripts/check-dependabot-triage.test.ts
@@ -1,0 +1,281 @@
+/**
+ * plugins/shipwright/scripts/check-dependabot-triage.test.ts
+ *
+ * Unit tests for check-dependabot-triage.ts
+ *
+ * Design: the script exports a `run(deps)` function with injectable deps for
+ * listing open Dependabot PRs per repo and reading the local triage state file.
+ * Mirrors the skill's own Step 3 dedup logic: an open PR is "untriaged" when
+ * no entry in state/dependabot-reviews.json matches it by (pr number, repo)
+ * with a non-terminal status (anything other than "merged" or "closed").
+ */
+
+import { describe, expect, test } from "bun:test";
+import { run } from "./check-dependabot-triage.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DependabotPr {
+  number: number;
+  title: string;
+  headRefName: string;
+}
+
+type TriageStatus = "pending" | "staged" | "posted" | "merged" | "closed";
+
+interface DependabotReviewEntry {
+  pr: number;
+  repo: string;
+  org: string;
+  title: string;
+  branch: string;
+  status: TriageStatus;
+  firstSeen: string | null;
+  lastTriagedAt: string | null;
+  recommendation: string | null;
+  stagedFile: string | null;
+  postedAt: string | null;
+  mergedAt: string | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeReviewEntry(
+  overrides: Partial<DependabotReviewEntry> = {},
+): DependabotReviewEntry {
+  return {
+    pr: 42,
+    repo: "example-repo",
+    org: "acme",
+    title: "Bump axios 1.6→1.7",
+    branch: "dependabot/npm_and_yarn/axios-1.7.0",
+    status: "pending",
+    firstSeen: "2026-07-01T00:00:00Z",
+    lastTriagedAt: null,
+    recommendation: null,
+    stagedFile: null,
+    postedAt: null,
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+interface MakeDepsOptions {
+  prsByRepo?: Record<string, DependabotPr[]>;
+  reviewState?: DependabotReviewEntry[];
+  repos?: string[];
+}
+
+function makeDeps({
+  prsByRepo = {},
+  reviewState = [],
+  repos = ["acme/example-repo"],
+}: MakeDepsOptions = {}) {
+  return {
+    resolveRepos: () => repos,
+    listDependabotPrs: async (repo: string): Promise<DependabotPr[]> => {
+      return prsByRepo[repo] ?? [];
+    },
+    readTriageState: (): DependabotReviewEntry[] => reviewState,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("check-dependabot-triage", () => {
+  test("exits 1 when there are no open dependabot PRs in any repo", async () => {
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [] },
+        reviewState: [],
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when all open dependabot PRs already have a non-terminal triage entry", async () => {
+    const pr: DependabotPr = {
+      number: 42,
+      title: "Bump axios 1.6→1.7",
+      headRefName: "dependabot/npm_and_yarn/axios-1.7.0",
+    };
+    const entry = makeReviewEntry({
+      pr: 42,
+      repo: "example-repo",
+      status: "staged",
+    });
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [entry],
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when at least one open dependabot PR has no corresponding non-terminal entry", async () => {
+    const pr: DependabotPr = {
+      number: 43,
+      title: "Bump webpack 4→5",
+      headRefName: "dependabot/npm_and_yarn/webpack-5.0.0",
+    };
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [],
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 when an open PR's only matching state entry has a terminal status (merged)", async () => {
+    // Same PR number reopened after a prior merge — the old "merged" entry
+    // doesn't count as a non-terminal dedup match, so it's untriaged again.
+    const pr: DependabotPr = {
+      number: 42,
+      title: "Bump axios 1.6→1.7",
+      headRefName: "dependabot/npm_and_yarn/axios-1.7.0",
+    };
+    const entry = makeReviewEntry({
+      pr: 42,
+      repo: "example-repo",
+      status: "merged",
+    });
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [entry],
+      }),
+    );
+    expect(result.exit).toBe(0);
+  });
+
+  test("exits 0 when an open PR's only matching state entry has a terminal status (closed)", async () => {
+    const pr: DependabotPr = {
+      number: 42,
+      title: "Bump axios 1.6→1.7",
+      headRefName: "dependabot/npm_and_yarn/axios-1.7.0",
+    };
+    const entry = makeReviewEntry({
+      pr: 42,
+      repo: "example-repo",
+      status: "closed",
+    });
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [entry],
+      }),
+    );
+    expect(result.exit).toBe(0);
+  });
+
+  test("does not match a triage entry from a different repo with the same PR number", async () => {
+    const pr: DependabotPr = {
+      number: 42,
+      title: "Bump axios 1.6→1.7",
+      headRefName: "dependabot/npm_and_yarn/axios-1.7.0",
+    };
+    const entry = makeReviewEntry({
+      pr: 42,
+      repo: "other-repo", // different repo, same PR number
+      status: "staged",
+    });
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [entry],
+      }),
+    );
+    expect(result.exit).toBe(0);
+  });
+
+  test("treats a missing/empty state file as [] — untriaged PR still triggers exit 0", async () => {
+    const pr: DependabotPr = {
+      number: 1,
+      title: "Bump lodash",
+      headRefName: "dependabot/npm_and_yarn/lodash-4.17.21",
+    };
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [],
+      }),
+    );
+    expect(result.exit).toBe(0);
+  });
+
+  test("exits 1 across multiple repos when every open PR is already triaged", async () => {
+    const prA: DependabotPr = {
+      number: 1,
+      title: "Bump a",
+      headRefName: "dependabot/npm_and_yarn/a-1.0.0",
+    };
+    const prB: DependabotPr = {
+      number: 2,
+      title: "Bump b",
+      headRefName: "dependabot/npm_and_yarn/b-2.0.0",
+    };
+    const result = await run(
+      makeDeps({
+        repos: ["acme/repo-a", "acme/repo-b"],
+        prsByRepo: {
+          "acme/repo-a": [prA],
+          "acme/repo-b": [prB],
+        },
+        reviewState: [
+          makeReviewEntry({ pr: 1, repo: "repo-a", status: "posted" }),
+          makeReviewEntry({ pr: 2, repo: "repo-b", status: "pending" }),
+        ],
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 across multiple repos when one repo has an untriaged PR", async () => {
+    const prA: DependabotPr = {
+      number: 1,
+      title: "Bump a",
+      headRefName: "dependabot/npm_and_yarn/a-1.0.0",
+    };
+    const prB: DependabotPr = {
+      number: 2,
+      title: "Bump b",
+      headRefName: "dependabot/npm_and_yarn/b-2.0.0",
+    };
+    const result = await run(
+      makeDeps({
+        repos: ["acme/repo-a", "acme/repo-b"],
+        prsByRepo: {
+          "acme/repo-a": [prA],
+          "acme/repo-b": [prB],
+        },
+        reviewState: [
+          makeReviewEntry({ pr: 1, repo: "repo-a", status: "posted" }),
+          // repo-b's PR 2 has no matching entry at all — untriaged
+        ],
+      }),
+    );
+    expect(result.exit).toBe(0);
+  });
+
+  test("prompt output mentions dependabot triage", async () => {
+    const pr: DependabotPr = {
+      number: 43,
+      title: "Bump webpack 4→5",
+      headRefName: "dependabot/npm_and_yarn/webpack-5.0.0",
+    };
+    const result = await run(
+      makeDeps({
+        prsByRepo: { "acme/example-repo": [pr] },
+        reviewState: [],
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output.toLowerCase()).toContain("dependabot");
+  });
+});

--- a/plugins/shipwright/scripts/check-dependabot-triage.ts
+++ b/plugins/shipwright/scripts/check-dependabot-triage.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * plugins/shipwright/scripts/check-dependabot-triage.ts
+ *
+ * Pre-check for the dependabot-triage cron.
+ *
+ * Lifts the triage-dependabot-prs skill's own Step 3 ("Discover open
+ * Dependabot PRs") into a cheap, side-effect-free precheck: for each repo,
+ * list open Dependabot-authored PRs and diff them against the non-terminal
+ * entries in state/dependabot-reviews.json. A PR is "untriaged" when no
+ * entry in that file matches it by (pr number, repo) with a non-terminal
+ * status — mirroring the skill's own dedup logic exactly.
+ *
+ * Non-terminal statuses: "pending", "staged", "posted".
+ * Terminal statuses: "merged", "closed".
+ *
+ * Exit 0 + one-line prompt → at least one open Dependabot PR is untriaged
+ * Exit 1 + no output       → nothing to do
+ *
+ * Usage:
+ *   bun plugins/shipwright/scripts/check-dependabot-triage.ts
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ghJson, resolveAllRepos, resolveWorkspacePath } from "./check-helpers.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DependabotPr {
+  number: number;
+  title: string;
+  headRefName: string;
+}
+
+export interface DependabotReviewEntry {
+  pr: number;
+  repo: string;
+  org: string;
+  title: string;
+  branch: string;
+  status: "pending" | "staged" | "posted" | "merged" | "closed";
+  firstSeen: string | null;
+  lastTriagedAt: string | null;
+  recommendation: string | null;
+  stagedFile: string | null;
+  postedAt: string | null;
+  mergedAt: string | null;
+}
+
+export interface Deps {
+  resolveRepos: () => string[];
+  listDependabotPrs: (repo: string) => Promise<DependabotPr[]>;
+  readTriageState: () => DependabotReviewEntry[];
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+interface RunResult {
+  exit: 0 | 1;
+  output: string;
+}
+
+const TERMINAL_STATUSES = new Set(["merged", "closed"]);
+
+/**
+ * True when the state file already has a non-terminal entry for this exact
+ * (pr number, repo short-name) pair — matching the skill's own "not already
+ * present in state with a non-terminal status" dedup check.
+ */
+function isAlreadyTriaged(
+  pr: DependabotPr,
+  repoShortName: string,
+  state: DependabotReviewEntry[],
+): boolean {
+  return state.some(
+    (entry) =>
+      entry.pr === pr.number &&
+      entry.repo === repoShortName &&
+      !TERMINAL_STATUSES.has(entry.status),
+  );
+}
+
+export async function run(deps: Deps): Promise<RunResult> {
+  const state = deps.readTriageState();
+  const repos = deps.resolveRepos();
+
+  for (const repo of repos) {
+    const repoShortName = repo.includes("/") ? repo.split("/", 2)[1] : repo;
+    const prs = await deps.listDependabotPrs(repo);
+
+    for (const pr of prs) {
+      if (!isAlreadyTriaged(pr, repoShortName, state)) {
+        return {
+          exit: 0,
+          output:
+            "Open Dependabot PRs need triage — run /shipwright:triage-dependabot-prs",
+        };
+      }
+    }
+  }
+
+  return { exit: 1, output: "" };
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+export function buildProductionDeps(): Deps {
+  const workspacePath = resolveWorkspacePath();
+
+  return {
+    resolveRepos: () => resolveAllRepos(workspacePath),
+    listDependabotPrs: async (repo: string) => {
+      try {
+        return ghJson<DependabotPr[]>([
+          "pr",
+          "list",
+          "--repo",
+          repo,
+          "--author",
+          "app/dependabot",
+          "--state",
+          "open",
+          "--json",
+          "number,title,headRefName",
+        ]);
+      } catch (err) {
+        process.stderr.write(
+          `check-dependabot-triage: gh pr list failed for ${repo}: ${String(err)}\n`,
+        );
+        return [];
+      }
+    },
+    readTriageState: () => {
+      const statePath = join(workspacePath, "state", "dependabot-reviews.json");
+      if (!existsSync(statePath)) return [];
+      try {
+        return JSON.parse(
+          readFileSync(statePath, "utf-8"),
+        ) as DependabotReviewEntry[];
+      } catch (err) {
+        process.stderr.write(
+          `check-dependabot-triage: failed to read/parse ${statePath}: ${String(err)}\n`,
+        );
+        return [];
+      }
+    },
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const deps = buildProductionDeps();
+  const result = await run(deps);
+  if (result.exit === 0) {
+    process.stdout.write(`${result.output}\n`);
+  }
+  process.exit(result.exit);
+}
+
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `check-dependabot-triage.ts` — a cheap precheck for the `triage-dependabot-prs` cron, lifting the skill's own Step 3 discovery/dedup logic so scheduled firings can skip a full session when there's nothing new to triage.
- Reuses `resolveAllRepos` and `ghJson` from `check-helpers.ts` rather than reimplementing repo discovery or gh CLI wrapping.
- Adds a sibling `check-dependabot-triage.test.ts` using the deps-injection pattern (no global mocking).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Scans all repos via `resolveAllRepos`, lists dependabot PRs via `ghJson`, matching the skill's Step 3 query exactly | MET |
| 2 | Diffs found PRs against `state/dependabot-reviews.json`'s non-terminal entries, matching the skill's dedup logic | MET |
| 3 | Exits 1 when no open dependabot PRs, or all already have a non-terminal triage entry | MET |
| 4 | Exits 0 when at least one open dependabot PR has no corresponding non-terminal entry | MET |
| 5 | `check-dependabot-triage.test.ts` (deps-injection, no global mocking) covers all three scenarios plus edge cases | MET |

Out of scope (per task): wiring the live cron's `preCheck` field — done post-merge via the agent-admin API.

## Test Plan
- [x] `bun test plugins/shipwright/scripts/check-dependabot-triage.test.ts` — 10/10 pass
- [x] `bunx biome lint .` — clean
- [x] `bun run --filter='*' typecheck` — all workspaces pass
- [x] `bun test` (full suite) — same pre-existing 15 failures as on `main` (unrelated, isolation-order flakiness in task-store/metrics test files not touched by this change)

Generated with [Claude Code](https://claude.com/claude-code)
