### PR TITLE
feat: add draft/dependabot filters to check-review

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -127,8 +127,8 @@ Every new agent is seeded with ten system crons (the canonical definitions live 
 | Cron | Schedule (cron expr) | Default | What it does |
 |---|---|---|---|
 | `shipwright-dev-task` | `0,30 * * * *` (min 0, 30) | **on** | Picks the next ready task, builds it with tests, opens a PR. |
-| `shipwright-review-patch` | `10,40 * * * *` (min 10, 40) | **on** | Reviews open PRs and patches the ones failing CI or review. |
-| `shipwright-review` | `15,45 * * * *` (min 15, 45) | off | Review-only pass over open PRs. |
+| `shipwright-review-patch` | `10,40 * * * *` (min 10, 40) | **on** | Reviews open PRs (excluding drafts and Dependabot PRs) and patches the ones failing CI or review. |
+| `shipwright-review` | `15,45 * * * *` (min 15, 45) | off | Review-only pass over open PRs (excluding drafts and Dependabot PRs). |
 | `shipwright-patch` | `5,35 * * * *` (min 5, 35) | off | Fixes failing CI and unresolved review findings. |
 | `shipwright-deploy` | `20,50 * * * *` (min 20, 50) | off | Merges approved PRs and deploys them. |
 | `shipwright-test-readiness` | `0 6 * * *` (daily, 06:00) | off | Runs the full test-readiness audit (`--full --publish`). |

--- a/plugins/shipwright/scripts/check-review-patch.test.ts
+++ b/plugins/shipwright/scripts/check-review-patch.test.ts
@@ -22,6 +22,7 @@ interface PrInfo {
   author: { login: string };
   headRefName: string;
   headRefOid: string;
+  isDraft: boolean;
 }
 
 // ─── Types mirroring check-patch's Deps ───────────────────────────────────────
@@ -57,6 +58,7 @@ function makeReviewDepsTriggering() {
         author: { login: "other-user" },
         headRefName: "feat/thing",
         headRefOid: "sha-abc",
+        isDraft: false,
       },
     ],
     queryPrRecord: async (_repo: string, _prNumber: number) => null, // no record → triggers

--- a/plugins/shipwright/scripts/check-review.test.ts
+++ b/plugins/shipwright/scripts/check-review.test.ts
@@ -19,6 +19,7 @@ interface PrInfo {
   headRefName: string;
   headRefOid: string;
   repo?: string;
+  isDraft: boolean;
 }
 
 interface PrRecord {
@@ -36,6 +37,7 @@ function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
     headRefName: "feat/x",
     headRefOid: "abc123def456",
     repo: "example-repo",
+    isDraft: false,
     ...overrides,
   };
 }
@@ -217,6 +219,39 @@ describe("check-review", () => {
       isSelfReviewAllowed: false,
     };
     const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  // ─── draft / dependabot exclusions ───────────────────────────────────────────
+
+  test("exits 1 when all open PRs are drafts", async () => {
+    const prs = [
+      makePr({ number: 1, isDraft: true }),
+      makePr({ number: 2, isDraft: true }),
+    ];
+    const result = await run(makeDeps(prs, async () => null));
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when all open PRs are authored by app/dependabot", async () => {
+    const prs = [
+      makePr({ number: 1, author: { login: "app/dependabot" } }),
+      makePr({ number: 2, author: { login: "app/dependabot" } }),
+    ];
+    const result = await run(makeDeps(prs, async () => null));
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when mix of draft/dependabot/eligible PRs has one eligible non-draft non-dependabot PR", async () => {
+    const prs = [
+      makePr({ number: 1, isDraft: true }),
+      makePr({ number: 2, author: { login: "app/dependabot" } }),
+      makePr({ number: 3, author: { login: "danmcaulay" } }),
+    ];
+    const result = await run(makeDeps(prs, async () => null));
     expect(result.exit).toBe(0);
     expect(result.output).toBeTruthy();
   });

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -37,6 +37,7 @@ interface PrInfo {
   headRefName: string;
   headRefOid: string;
   repo?: string;
+  isDraft: boolean;
 }
 
 interface PrRecord {
@@ -67,6 +68,8 @@ export async function run(deps: Deps): Promise<RunResult> {
   const prs = await deps.listOpenPrs("default");
 
   for (const pr of prs) {
+    if (pr.isDraft) continue;
+    if (pr.author.login === "app/dependabot") continue;
     if (!deps.isSelfReviewAllowed && pr.author.login === currentUser) continue;
 
     let record: PrRecord | null = null;
@@ -122,7 +125,7 @@ export async function buildProductionDeps(): Promise<Deps> {
           "--repo",
           repo,
           "--json",
-          "number,title,author,headRefName,headRefOid",
+          "number,title,author,headRefName,headRefOid,isDraft",
         ]);
         allPrs.push(...repoPrs.map((pr) => ({ ...pr, repo })));
       }


### PR DESCRIPTION
## Summary
- `check-review.ts`'s `listOpenPrs` now requests `isDraft` from `gh pr list` and excludes draft PRs and PRs authored by `app/dependabot` from the "needs review" determination, mirroring `commands/review.md`'s exclusion list exactly.
- Refreshed `docs/agent.md`'s cron table to note that `shipwright-review-patch` and `shipwright-review` now skip drafts/Dependabot PRs.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `check-review.ts`'s PR fetch requests `isDraft` alongside existing fields | MET |
| 2 | Draft PRs are excluded from the 'needs review' determination | MET |
| 3 | PRs authored by `app/dependabot` are excluded from the 'needs review' determination | MET |
| 4 | New `check-review.test.ts` cases: all-draft -> exit 1, all-dependabot -> exit 1, mixed with one eligible PR -> exit 0 | MET |

## Test Plan
- `bun test plugins/shipwright/scripts/check-review.test.ts` — 23 pass (3 new cases added)
- Full `bun test` — 3273 pass / 14 pre-existing failures (identical failure set confirmed on `main`, unrelated to this change)
- `bun run --filter='*' typecheck` — clean
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
