### PR TITLE
feat: generate MCP tools from task-store OpenAPI spec (TSM-2.2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.144.0",
+      "version": "0.146.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -85,6 +85,7 @@
       "name": "@shipwright/mcp-server",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "hono": "^4.12.26",
       },
       "devDependencies": {
@@ -94,7 +95,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.144.0",
+      "version": "0.146.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@shipwright/lib": "*",
@@ -110,7 +111,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.144.0",
+      "version": "0.146.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -176,11 +177,15 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@hono/zod-openapi": ["@hono/zod-openapi@0.18.4", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^7.1.0", "@hono/zod-validator": "^0.4.1" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "3.*" } }, "sha512-6NHMHU96Hh32B1yDhb94Z4Z5/POsmEu2AXpWLWcBq9arskRnOMt2752yEoXoADV8WUAc7H1IkNaQHGj1ytXbYw=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@octokit/auth-app": ["@octokit/auth-app@8.2.0", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g=="],
 
@@ -370,6 +375,10 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
@@ -456,7 +465,7 @@
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
-    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
 
@@ -475,6 +484,8 @@
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
@@ -552,15 +563,23 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -654,6 +673,8 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
@@ -684,6 +705,8 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -695,6 +718,8 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
@@ -873,6 +898,8 @@
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-conf": ["pkg-conf@2.1.0", "", { "dependencies": { "find-up": "^2.0.0", "load-json-file": "^4.0.0" } }, "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g=="],
 
@@ -1098,7 +1125,11 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@actions/http-client/undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
+
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
@@ -1120,8 +1151,6 @@
 
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
-    "body-parser/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
@@ -1139,8 +1168,6 @@
     "execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
-
-    "express/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "fdir/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
@@ -1465,6 +1492,8 @@
     "tempy/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,22 @@ A small in-memory HTML store for short-lived, regenerable artifacts (one-pagers,
 
 > ⚠️ **Single-replica caveat.** Storage is process-local (a plain `Map` in `task-store/src/doc-store.ts`) — a document POSTed to one replica is **not** visible from another, and all documents are lost on restart. Acceptable for the ephemeral MVP; it requires a single replica or sticky routing, and is flagged for a future durable backend (object storage / DB-backed blob).
 
+## MCP Server
+
+A Model Context Protocol (MCP) server that exposes the task-store HTTP API as discoverable MCP tools (`@shipwright/mcp-server`). Tools are generated automatically from the task-store OpenAPI specification — the `generate-mcp-tools` script (`scripts/generate-mcp-tools.ts`) reads `task-store/openapi.json` and emits tool definitions (name, description, JSON-Schema) plus routing metadata (HTTP method, path template, query/path parameters).
+
+**Transport:**
+
+The server is transport-agnostic. The primary entry point is `mcp-server/src/serve.ts`, which launches the server over **stdio** — the standard transport MCP clients (e.g. Claude Code) expect.
+
+**Tool execution:**
+
+The server proxies tool calls to the task-store HTTP API; `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` env vars are resolved at startup. Tools use bearer auth; the token is injected into all downstream requests.
+
+**Discovery:**
+
+The Hono app (`mcp-server/src/index.ts`) also exposes a lightweight `GET /mcp/tools` endpoint for humans to inspect the tool catalog without speaking the MCP protocol.
+
 ## Chat Service
 
 Postgres-backed service for web chat conversations (`chat/`). Owns three Prisma models (`ChatToken`, `Thread`, `Message`) on a **dedicated database** (`DATABASE_URL_SHIPWRIGHT_CHAT`). The Hono app is composed from injected services by `createChatServiceApp` (`chat/src/app.ts`); `/health` is unauthenticated, all other routes require a valid bearer token (scoped to agents via `agentId`). Provides `/tokens/*` (admin token create/list/revoke/update), `/threads/*` (thread CRUD), and `/threads/:threadId/messages/*` (message CRUD + attachment streaming) endpoints.
@@ -78,7 +94,7 @@ Postgres-backed service for web chat conversations (`chat/`). Owns three Prisma 
 
 ## Workspace layout
 
-The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the single local entrypoint. Six workspaces — `plugins/shipwright`, `metrics`, `agent`, `admin`, `task-store`, `chat` — are wired into the root `package.json`. The `site/` is intentionally excluded from the root `bun test` scan (its Playwright `*.spec.ts` files would crash Bun's runner).
+The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the single local entrypoint. Seven workspaces — `plugins/shipwright`, `metrics`, `agent`, `admin`, `task-store`, `chat`, `mcp-server` — are wired into the root `package.json`. The `site/` is intentionally excluded from the root `bun test` scan (its Playwright `*.spec.ts` files would crash Bun's runner).
 
 ```
 shipwright/
@@ -87,6 +103,7 @@ shipwright/
 ├── agent/                C — Shipwright agent runtime (entrypoint, cron, Slack, GitHub auth)
 ├── admin/                C — Admin service: CRUD API, admin UI, Prisma store (@shipwright/admin)
 ├── task-store/           D — Task queue service: Postgres + Prisma, exports @shipwright/task-store
+├── mcp-server/           D — MCP server: exposes task-store API as Model Context Protocol tools (generated from OpenAPI spec)
 ├── chat/                 Chat service: web conversation threads, Postgres + Prisma
 ├── site/                 marketing site (Astro, separate toolchain)
 ├── brand/                locked design system

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.26"
   },
   "devDependencies": {

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -25,6 +25,10 @@ export interface GeneratedTool {
   pathParams: string[];
   /** True if the operation accepts a JSON request body. */
   hasBody: boolean;
+  /** True when the request body is a JSON array (not an object).
+   * The input schema exposes an `items` property of type `array`;
+   * `callTool` sends `args.items` directly as the body. */
+  hasArrayBody?: boolean;
 }
 
 export const generatedTools: GeneratedTool[] = [
@@ -183,7 +187,31 @@ export const generatedTools: GeneratedTool[] = [
     description: "Bulk insert tasks",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        items: {
+          type: "array",
+          description: "Array of items to submit as the request body.",
+          items: {
+            type: "object",
+            properties: {
+              title: {
+                type: "string",
+                minLength: 1,
+                example: "Implement feature X",
+              },
+              status: {
+                type: "string",
+                minLength: 1,
+                example: "pending",
+              },
+              repo: {
+                type: ["string", "null"],
+                example: "org/repo",
+              },
+            },
+          },
+        },
+      },
       required: [],
       additionalProperties: false,
     },
@@ -192,6 +220,7 @@ export const generatedTools: GeneratedTool[] = [
     queryParams: [],
     pathParams: [],
     hasBody: true,
+    hasArrayBody: true,
   },
   {
     name: "tasks_distinct",

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -1,0 +1,718 @@
+// GENERATED FILE — do not edit by hand.
+// Produced by scripts/generate-mcp-tools.ts from task-store/openapi.json.
+// Regenerate with: bun run generate:mcp-tools
+
+/** An MCP tool derived from a single task-store OpenAPI operation. */
+export interface GeneratedTool {
+  /** snake_case tool name, e.g. "tasks_list". */
+  name: string;
+  /** Human-readable description (from the OpenAPI operation summary). */
+  description: string;
+  /** JSON Schema for the tool's arguments. */
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: string[];
+    additionalProperties?: boolean;
+  };
+  /** HTTP method to call on the task-store API. */
+  method: string;
+  /** Original OpenAPI path template, e.g. "/tasks/{id}/claim". */
+  pathTemplate: string;
+  /** Names of query-string parameters. */
+  queryParams: string[];
+  /** Names of path parameters (substituted into pathTemplate). */
+  pathParams: string[];
+  /** True if the operation accepts a JSON request body. */
+  hasBody: boolean;
+}
+
+export const generatedTools: GeneratedTool[] = [
+  {
+    name: "tasks_list",
+    description: "List tasks",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: {
+          type: "string",
+          example: "pending",
+        },
+        state: {
+          type: "string",
+          enum: ["open", "closed", "in_progress", "ready", "blocked"],
+          example: "open",
+        },
+        session: {
+          type: "string",
+          example: "session-123",
+        },
+        repo: {
+          type: "string",
+          example: "org/repo",
+        },
+        assignee: {
+          type: "string",
+          example: "user@example.com",
+        },
+        claimedBy: {
+          type: "string",
+          example: "agent-id-123",
+        },
+        branch: {
+          type: "string",
+          example: "feat/feature-x",
+        },
+        pr: {
+          type: "string",
+          example: "42",
+        },
+        limit: {
+          type: "string",
+          example: "50",
+        },
+        offset: {
+          type: "string",
+          example: "0",
+        },
+        ready: {
+          type: "string",
+          enum: ["true", "false"],
+          example: "true",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/tasks",
+    queryParams: [
+      "status",
+      "state",
+      "session",
+      "repo",
+      "assignee",
+      "claimedBy",
+      "branch",
+      "pr",
+      "limit",
+      "offset",
+      "ready",
+    ],
+    pathParams: [],
+    hasBody: false,
+  },
+  {
+    name: "tasks_create",
+    description: "Create a task",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          minLength: 1,
+          example: "Implement feature X",
+        },
+        status: {
+          type: "string",
+          minLength: 1,
+          example: "pending",
+        },
+        repo: {
+          type: ["string", "null"],
+          example: "org/repo",
+        },
+        session: {
+          type: "string",
+          example: "session-123",
+        },
+        description: {
+          type: "string",
+          example: "Task description",
+        },
+        layer: {
+          type: "string",
+          example: "service",
+        },
+        branch: {
+          type: "string",
+          example: "feat/feature-x",
+        },
+        dependencies: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          example: [],
+        },
+        acceptanceCriteria: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          example: [],
+        },
+        assignee: {
+          type: "string",
+          example: "user@example.com",
+        },
+        priority: {
+          type: "string",
+          example: "high",
+        },
+        type: {
+          type: "string",
+          example: "feature",
+        },
+        source: {
+          type: "string",
+          example: "manual",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks",
+    queryParams: [],
+    pathParams: [],
+    hasBody: true,
+  },
+  {
+    name: "tasks_bulk",
+    description: "Bulk insert tasks",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/bulk",
+    queryParams: [],
+    pathParams: [],
+    hasBody: true,
+  },
+  {
+    name: "tasks_distinct",
+    description: "Get distinct session and repo values",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/tasks/distinct",
+    queryParams: [],
+    pathParams: [],
+    hasBody: false,
+  },
+  {
+    name: "tasks_get",
+    description: "Get a task by ID",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/tasks/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "tasks_update",
+    description: "Update a task",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "PATCH",
+    pathTemplate: "/tasks/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: true,
+  },
+  {
+    name: "tasks_delete",
+    description: "Delete a task",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "DELETE",
+    pathTemplate: "/tasks/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "tasks_claim",
+    description: "Atomically claim a task",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+        claimedBy: {
+          type: "string",
+          example: "agent-id-123",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/claim",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: true,
+  },
+  {
+    name: "tasks_heartbeat",
+    description: "Touch heartbeatAt on a claimed task",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/heartbeat",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "tasks_complete",
+    description: "Mark a task as done",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/complete",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "tasks_fail",
+    description: "Mark a task as blocked",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+        reason: {
+          type: "string",
+          example: "build failed",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/fail",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: true,
+  },
+  {
+    name: "tasks_release",
+    description: "Release a task back to pending",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/release",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "tokens_list",
+    description: "List all tokens",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/tokens",
+    queryParams: [],
+    pathParams: [],
+    hasBody: false,
+  },
+  {
+    name: "tokens_create",
+    description: "Create a new token — raw value returned exactly once",
+    inputSchema: {
+      type: "object",
+      properties: {
+        label: {
+          type: "string",
+          example: "ci-runner",
+        },
+        agentId: {
+          type: "string",
+          example: "agent-id-123",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tokens",
+    queryParams: [],
+    pathParams: [],
+    hasBody: true,
+  },
+  {
+    name: "tokens_update",
+    description: "Update token label and/or agentId",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clxtoken123456",
+        },
+        label: {
+          type: "string",
+          example: "ci-runner",
+        },
+        agentId: {
+          type: "string",
+          example: "agent-id-123",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "PATCH",
+    pathTemplate: "/tokens/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: true,
+  },
+  {
+    name: "tokens_delete",
+    description: "Revoke a token",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clxtoken123456",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "DELETE",
+    pathTemplate: "/tokens/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_list",
+    description: "List pull requests",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repo: {
+          type: "string",
+          example: "org/repo",
+        },
+        prNumber: {
+          type: "string",
+          description: "PR number (parsed as integer)",
+          example: "42",
+        },
+        taskId: {
+          type: "string",
+          example: "clx1234567890",
+        },
+        state: {
+          type: "string",
+          enum: ["open", "merged", "closed"],
+          example: "open",
+        },
+        reviewState: {
+          type: "string",
+          enum: ["pending", "in_progress", "posted", "approved"],
+          example: "pending",
+        },
+        staged: {
+          type: "string",
+          enum: ["true", "false"],
+          description: "Filter by staged flag",
+          example: "false",
+        },
+        limit: {
+          type: "string",
+          description: "Max records to return",
+          example: "50",
+        },
+        offset: {
+          type: "string",
+          description: "Pagination offset",
+          example: "0",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/prs",
+    queryParams: [
+      "repo",
+      "prNumber",
+      "taskId",
+      "state",
+      "reviewState",
+      "staged",
+      "limit",
+      "offset",
+    ],
+    pathParams: [],
+    hasBody: false,
+  },
+  {
+    name: "prs_claim",
+    description: "Claim a pull request (atomic)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repo: {
+          type: "string",
+          description: "Repository in org/repo format",
+          example: "org/repo",
+        },
+        prNumber: {
+          type: "integer",
+          description: "Pull request number",
+          example: 42,
+        },
+        commitSha: {
+          type: "string",
+          description: "Commit SHA to associate",
+          example: "abc123def456",
+        },
+        claimedBy: {
+          type: "string",
+          description: "Agent claiming this PR (admin tokens only)",
+          example: "agent-id-123",
+        },
+        taskId: {
+          type: "string",
+          description: "Associated task ID",
+          example: "clx1234567890",
+        },
+      },
+      required: ["repo", "prNumber", "commitSha"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/claim",
+    queryParams: [],
+    pathParams: [],
+    hasBody: true,
+  },
+  {
+    name: "prs_claim_next",
+    description: "Atomic find-and-claim of oldest eligible PR",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: {
+          type: "string",
+          description:
+            "Agent ID (admin tokens only; agent tokens use token identity)",
+          example: "agent-id-123",
+        },
+        maxConcurrent: {
+          type: "integer",
+          description: "Maximum concurrent PRs to claim",
+          example: 1,
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/claim-next",
+    queryParams: [],
+    pathParams: [],
+    hasBody: true,
+  },
+  {
+    name: "prs_get",
+    description: "Fetch a single pull request",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/prs/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_update",
+    description: "Update pull request fields",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "PATCH",
+    pathTemplate: "/prs/{id}",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: true,
+  },
+  {
+    name: "prs_heartbeat",
+    description: "Touch heartbeatAt for a claimed PR",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/{id}/heartbeat",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_complete",
+    description: "Mark PR review as complete (reviewState=posted)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/{id}/complete",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_patch",
+    description: "Increment patchCycles and reset reviewState=pending",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/{id}/patch",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_release",
+    description: "Release a claim (reviewState=pending, claimedBy cleared)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/{id}/release",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+];

--- a/mcp-server/src/generated-tools.unit.test.ts
+++ b/mcp-server/src/generated-tools.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { generatedTools } from "./generated-tools.ts";
+
+describe("generatedTools", () => {
+  it("emits one tool per OpenAPI operation (25 total)", () => {
+    expect(generatedTools).toHaveLength(25);
+  });
+
+  it("has unique tool names", () => {
+    const names = generatedTools.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("names every tool in snake_case", () => {
+    for (const tool of generatedTools) {
+      expect(tool.name).toMatch(/^[a-z]+(_[a-z]+)*$/);
+    }
+  });
+
+  it("derives tasks_list with the correct description and query params", () => {
+    const tool = generatedTools.find((t) => t.name === "tasks_list");
+    expect(tool).toBeDefined();
+    expect(tool?.description).toBe("List tasks");
+    expect(tool?.method).toBe("GET");
+    expect(tool?.pathTemplate).toBe("/tasks");
+    expect(tool?.hasBody).toBe(false);
+    // Query params are surfaced in the input schema but not required.
+    expect(tool?.inputSchema.properties).toHaveProperty("status");
+    expect(tool?.inputSchema.properties).toHaveProperty("state");
+    expect(tool?.inputSchema.required).toHaveLength(0);
+    expect(tool?.queryParams).toContain("status");
+  });
+
+  it("marks the id path param as required on tasks_claim", () => {
+    const tool = generatedTools.find((t) => t.name === "tasks_claim");
+    expect(tool).toBeDefined();
+    expect(tool?.method).toBe("POST");
+    expect(tool?.pathTemplate).toBe("/tasks/{id}/claim");
+    expect(tool?.pathParams).toEqual(["id"]);
+    expect(tool?.inputSchema.properties).toHaveProperty("id");
+    expect(tool?.inputSchema.required).toContain("id");
+    // requestBody (ClaimBody) is optional so its fields are surfaced but not required.
+    expect(tool?.hasBody).toBe(true);
+    expect(tool?.inputSchema.properties).toHaveProperty("claimedBy");
+    expect(tool?.inputSchema.required).not.toContain("claimedBy");
+  });
+
+  it("inlines a required requestBody's required fields (prs_claim)", () => {
+    const tool = generatedTools.find((t) => t.name === "prs_claim");
+    expect(tool).toBeDefined();
+    expect(tool?.method).toBe("POST");
+    expect(tool?.hasBody).toBe(true);
+    // ClaimPrBody requires repo, prNumber, commitSha.
+    expect(tool?.inputSchema.properties).toHaveProperty("repo");
+    expect(tool?.inputSchema.required).toEqual(
+      expect.arrayContaining(["repo", "prNumber", "commitSha"]),
+    );
+  });
+
+  it("derives create/get/update/delete verbs for the tasks resource", () => {
+    const names = generatedTools.map((t) => t.name);
+    expect(names).toContain("tasks_create");
+    expect(names).toContain("tasks_get");
+    expect(names).toContain("tasks_update");
+    expect(names).toContain("tasks_delete");
+  });
+
+  it("gives every tool a valid object input schema", () => {
+    for (const tool of generatedTools) {
+      expect(tool.inputSchema.type).toBe("object");
+      expect(typeof tool.inputSchema.properties).toBe("object");
+      expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+      expect(typeof tool.description).toBe("string");
+      expect(tool.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/mcp-server/src/generated-tools.unit.test.ts
+++ b/mcp-server/src/generated-tools.unit.test.ts
@@ -74,4 +74,18 @@ describe("generatedTools", () => {
       expect(tool.description.length).toBeGreaterThan(0);
     }
   });
+
+  it("tasks_bulk has a usable array-body inputSchema", () => {
+    const tool = generatedTools.find((t) => t.name === "tasks_bulk");
+    expect(tool).toBeDefined();
+    expect(tool?.hasBody).toBe(true);
+    expect(tool?.hasArrayBody).toBe(true);
+    // items property must be present and typed as array
+    expect(tool?.inputSchema.properties).toHaveProperty("items");
+    const itemsProp = tool?.inputSchema.properties.items as Record<string, unknown>;
+    expect(itemsProp?.type).toBe("array");
+    // the spec's requestBody has no required:true, so items is optional
+    // but the property must be present and well-typed
+    expect(tool?.inputSchema.required).not.toContain("items");
+  });
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,7 +1,23 @@
 import { Hono } from "hono";
+import { generatedTools } from "./generated-tools.ts";
+import { createMcpServer } from "./mcp-server.ts";
 
 export const app = new Hono();
 
 app.get("/health", (c) => {
   return c.json({ status: "ok" });
 });
+
+// Lightweight discovery route: lists the MCP tools this server exposes.
+// The MCP protocol itself is served over a transport (stdio / Streamable HTTP /
+// in-memory) via `createMcpServer()`; this endpoint is a convenience for humans.
+app.get("/mcp/tools", (c) => {
+  return c.json({
+    tools: generatedTools.map((t) => ({
+      name: t.name,
+      description: t.description,
+    })),
+  });
+});
+
+export { createMcpServer, generatedTools };

--- a/mcp-server/src/mcp-server.smoke.test.ts
+++ b/mcp-server/src/mcp-server.smoke.test.ts
@@ -5,7 +5,11 @@ import { createMcpServer } from "./mcp-server.ts";
 
 describe("MCP server tools/list", () => {
   it("lists the generated tools over a JSON-RPC connection", async () => {
-    const server = createMcpServer();
+    // Pass a stub config so configFromEnv() is not called in CI where
+    // SHIPWRIGHT_TASK_STORE_URL / SHIPWRIGHT_TASK_STORE_TOKEN are unset.
+    const server = createMcpServer({
+      config: { baseUrl: "http://localhost:3002", token: "test-token" },
+    });
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
 

--- a/mcp-server/src/mcp-server.smoke.test.ts
+++ b/mcp-server/src/mcp-server.smoke.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "./mcp-server.ts";
+
+describe("MCP server tools/list", () => {
+  it("lists the generated tools over a JSON-RPC connection", async () => {
+    const server = createMcpServer();
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+
+    expect(tools.length).toBe(25);
+    expect(names).toContain("tasks_list");
+    expect(names).toContain("tasks_claim");
+    expect(names).toContain("prs_claim");
+
+    const tasksList = tools.find((t) => t.name === "tasks_list");
+    expect(tasksList?.description).toBe("List tasks");
+    expect(tasksList?.inputSchema.type).toBe("object");
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/mcp-server/src/mcp-server.ts
+++ b/mcp-server/src/mcp-server.ts
@@ -1,0 +1,70 @@
+/**
+ * mcp-server.ts
+ * Build an MCP server that exposes the task-store API as MCP tools.
+ *
+ * Tools are generated from task-store/openapi.json (see generated-tools.ts).
+ * `tools/list` returns the generated definitions verbatim; `tools/call` proxies
+ * to the task-store HTTP API with bearer auth resolved from the standard
+ * SHIPWRIGHT_TASK_STORE_URL / SHIPWRIGHT_TASK_STORE_TOKEN env vars.
+ *
+ * The factory uses the low-level `Server` so JSON-Schema inputSchemas from the
+ * OpenAPI spec pass through unchanged (no Zod round-trip). The returned server
+ * is transport-agnostic — callers connect it to stdio, Streamable HTTP, or an
+ * in-memory transport (used by the smoke test).
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { generatedTools } from "./generated-tools.ts";
+import {
+  type ToolCallerConfig,
+  callTool,
+  configFromEnv,
+} from "./tool-caller.ts";
+
+export interface CreateMcpServerOptions {
+  /** Override the tool-caller config (defaults to the task-store env vars). */
+  config?: ToolCallerConfig;
+}
+
+export function createMcpServer(options: CreateMcpServerOptions = {}): Server {
+  const config = options.config ?? configFromEnv();
+
+  const server = new Server(
+    { name: "shipwright-task-store", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: generatedTools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    })),
+  }));
+
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request): Promise<CallToolResult> => {
+      const tool = generatedTools.find((t) => t.name === request.params.name);
+      if (!tool) {
+        return {
+          content: [
+            { type: "text", text: `Unknown tool: ${request.params.name}` },
+          ],
+          isError: true,
+        };
+      }
+      const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+      // ToolResult is a structural subset of the SDK's passthrough result type
+      // (which carries an open index signature); the cast bridges that gap.
+      return (await callTool(tool, args, config)) as CallToolResult;
+    },
+  );
+
+  return server;
+}

--- a/mcp-server/src/serve.ts
+++ b/mcp-server/src/serve.ts
@@ -1,0 +1,26 @@
+/**
+ * serve.ts
+ * Stdio entry point for the Shipwright task-store MCP server.
+ *
+ * Launches the generated MCP server over stdio — the standard transport MCP
+ * clients (e.g. Claude Code) expect. Bearer auth is resolved from
+ * SHIPWRIGHT_TASK_STORE_URL / SHIPWRIGHT_TASK_STORE_TOKEN.
+ *
+ *   bun run mcp-server/src/serve.ts
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMcpServer } from "./mcp-server.ts";
+
+async function main(): Promise<void> {
+  const server = createMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("MCP server failed to start:", err);
+    process.exit(1);
+  });
+}

--- a/mcp-server/src/tool-caller.ts
+++ b/mcp-server/src/tool-caller.ts
@@ -24,14 +24,25 @@ export interface ToolResult {
   isError?: boolean;
 }
 
-/** Resolve caller config from the standard task-store env vars. */
+/** Resolve caller config from the standard task-store env vars.
+ * Throws a clear error at startup if either required var is missing,
+ * rather than failing deep inside the first `callTool` invocation. */
 export function configFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): ToolCallerConfig {
-  return {
-    baseUrl: env.SHIPWRIGHT_TASK_STORE_URL ?? "",
-    token: env.SHIPWRIGHT_TASK_STORE_TOKEN ?? "",
-  };
+  const baseUrl = env.SHIPWRIGHT_TASK_STORE_URL;
+  const token = env.SHIPWRIGHT_TASK_STORE_TOKEN;
+  if (!baseUrl) {
+    throw new Error(
+      "SHIPWRIGHT_TASK_STORE_URL is not set. Set it to the task-store base URL before starting the MCP server.",
+    );
+  }
+  if (!token) {
+    throw new Error(
+      "SHIPWRIGHT_TASK_STORE_TOKEN is not set. Set it to a valid task-store bearer token before starting the MCP server.",
+    );
+  }
+  return { baseUrl, token };
 }
 
 export async function callTool(
@@ -71,15 +82,27 @@ export async function callTool(
   const init: RequestInit = { method: tool.method, headers };
 
   if (tool.hasBody) {
-    // Body fields are everything that isn't a path or query param.
-    const consumed = new Set([...tool.pathParams, ...tool.queryParams]);
-    const body: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(args)) {
-      if (!consumed.has(key)) body[key] = value;
-    }
-    if (Object.keys(body).length > 0) {
+    if (tool.hasArrayBody) {
+      // Array-typed body: the caller passes `args.items`; send the array directly.
+      const items = args.items;
+      if (!Array.isArray(items)) {
+        return errorResult(
+          `${tool.name} expects an array body — pass items as an array in the "items" argument.`,
+        );
+      }
       headers["content-type"] = "application/json";
-      init.body = JSON.stringify(body);
+      init.body = JSON.stringify(items);
+    } else {
+      // Object body fields are everything that isn't a path or query param.
+      const consumed = new Set([...tool.pathParams, ...tool.queryParams]);
+      const body: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(args)) {
+        if (!consumed.has(key)) body[key] = value;
+      }
+      if (Object.keys(body).length > 0) {
+        headers["content-type"] = "application/json";
+        init.body = JSON.stringify(body);
+      }
     }
   }
 

--- a/mcp-server/src/tool-caller.ts
+++ b/mcp-server/src/tool-caller.ts
@@ -1,0 +1,113 @@
+/**
+ * tool-caller.ts
+ * Proxy an MCP tool call to the task-store HTTP API.
+ *
+ * Given a generated tool definition and the caller's arguments, build the HTTP
+ * request (path-param substitution, query string, JSON body), attach a bearer
+ * token, and return the response shaped as an MCP tool result. `fetchImpl` is
+ * injected so tests can supply a double — no `global.fetch` override.
+ */
+
+import type { GeneratedTool } from "./generated-tools.ts";
+
+export interface ToolCallerConfig {
+  /** Base URL of the task-store API (SHIPWRIGHT_TASK_STORE_URL). */
+  baseUrl: string;
+  /** Bearer token for the task-store API (SHIPWRIGHT_TASK_STORE_TOKEN). */
+  token: string;
+  /** Injected fetch (defaults to the global). */
+  fetchImpl?: typeof fetch;
+}
+
+export interface ToolResult {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}
+
+/** Resolve caller config from the standard task-store env vars. */
+export function configFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ToolCallerConfig {
+  return {
+    baseUrl: env.SHIPWRIGHT_TASK_STORE_URL ?? "",
+    token: env.SHIPWRIGHT_TASK_STORE_TOKEN ?? "",
+  };
+}
+
+export async function callTool(
+  tool: GeneratedTool,
+  args: Record<string, unknown>,
+  config: ToolCallerConfig,
+): Promise<ToolResult> {
+  const fetchImpl = config.fetchImpl ?? fetch;
+
+  // Substitute path params into the template.
+  let path = tool.pathTemplate;
+  for (const name of tool.pathParams) {
+    const value = args[name];
+    if (value === undefined || value === null) {
+      return errorResult(`Missing required path parameter: ${name}`);
+    }
+    path = path.replace(`{${name}}`, encodeURIComponent(String(value)));
+  }
+
+  // Concatenate rather than resolve so a base URL with its own path prefix
+  // (e.g. ".../api") is preserved instead of being discarded by URL resolution.
+  const url = new URL(
+    stripTrailingSlash(config.baseUrl) + ensureLeadingSlash(path),
+  );
+  for (const name of tool.queryParams) {
+    const value = args[name];
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(name, String(value));
+    }
+  }
+
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${config.token}`,
+    accept: "application/json",
+  };
+
+  const init: RequestInit = { method: tool.method, headers };
+
+  if (tool.hasBody) {
+    // Body fields are everything that isn't a path or query param.
+    const consumed = new Set([...tool.pathParams, ...tool.queryParams]);
+    const body: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(args)) {
+      if (!consumed.has(key)) body[key] = value;
+    }
+    if (Object.keys(body).length > 0) {
+      headers["content-type"] = "application/json";
+      init.body = JSON.stringify(body);
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url.toString(), init);
+  } catch (err) {
+    return errorResult(
+      `Request to ${tool.name} failed: ${(err as Error).message}`,
+    );
+  }
+
+  const text = await response.text();
+  if (!response.ok) {
+    return errorResult(`${tool.name} returned ${response.status}: ${text}`);
+  }
+
+  return { content: [{ type: "text", text: text || "" }] };
+}
+
+function errorResult(message: string): ToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+function stripTrailingSlash(base: string): string {
+  return base.endsWith("/") ? base.slice(0, -1) : base;
+}
+
+function ensureLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path : `/${path}`;
+}

--- a/mcp-server/src/tool-caller.unit.test.ts
+++ b/mcp-server/src/tool-caller.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { callTool } from "./tool-caller.ts";
+import { callTool, configFromEnv } from "./tool-caller.ts";
 import type { GeneratedTool } from "./generated-tools.ts";
 
 const claimTool: GeneratedTool = {
@@ -26,6 +26,25 @@ const listTool: GeneratedTool = {
   queryParams: ["status", "limit"],
   pathParams: [],
   hasBody: false,
+};
+
+const bulkTool: GeneratedTool = {
+  name: "tasks_bulk",
+  description: "Bulk insert tasks",
+  inputSchema: {
+    type: "object",
+    properties: {
+      items: { type: "array", description: "Array of items to submit as the request body." },
+    },
+    required: ["items"],
+    additionalProperties: false,
+  },
+  method: "POST",
+  pathTemplate: "/tasks/bulk",
+  queryParams: [],
+  pathParams: [],
+  hasBody: true,
+  hasArrayBody: true,
 };
 
 /** Build an injected fetch double that records the request and returns a JSON body. */
@@ -98,5 +117,57 @@ describe("callTool", () => {
       },
     );
     expect(result.isError).toBe(true);
+  });
+
+  it("sends array body directly for hasArrayBody tools", async () => {
+    const { fn, calls } = fakeFetch([{ id: "t1" }, { id: "t2" }]);
+    const tasks = [{ title: "Task A", status: "pending" }, { title: "Task B", status: "pending" }];
+    const result = await callTool(
+      bulkTool,
+      { items: tasks },
+      { ...config, fetchImpl: fn },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://tasks.example.com/tasks/bulk");
+    expect(calls[0].init?.method).toBe("POST");
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(calls[0].init?.body).toBe(JSON.stringify(tasks));
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns an error for hasArrayBody tools when items is not an array", async () => {
+    const { fn } = fakeFetch({});
+    const result = await callTool(
+      bulkTool,
+      { items: "not-an-array" },
+      { ...config, fetchImpl: fn },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("array");
+  });
+});
+
+describe("configFromEnv", () => {
+  it("throws when SHIPWRIGHT_TASK_STORE_URL is missing", () => {
+    expect(() =>
+      configFromEnv({ SHIPWRIGHT_TASK_STORE_TOKEN: "tok" }),
+    ).toThrow("SHIPWRIGHT_TASK_STORE_URL");
+  });
+
+  it("throws when SHIPWRIGHT_TASK_STORE_TOKEN is missing", () => {
+    expect(() =>
+      configFromEnv({ SHIPWRIGHT_TASK_STORE_URL: "https://example.com" }),
+    ).toThrow("SHIPWRIGHT_TASK_STORE_TOKEN");
+  });
+
+  it("returns config when both vars are set", () => {
+    const cfg = configFromEnv({
+      SHIPWRIGHT_TASK_STORE_URL: "https://example.com",
+      SHIPWRIGHT_TASK_STORE_TOKEN: "tok",
+    });
+    expect(cfg.baseUrl).toBe("https://example.com");
+    expect(cfg.token).toBe("tok");
   });
 });

--- a/mcp-server/src/tool-caller.unit.test.ts
+++ b/mcp-server/src/tool-caller.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { callTool } from "./tool-caller.ts";
+import type { GeneratedTool } from "./generated-tools.ts";
+
+const claimTool: GeneratedTool = {
+  name: "tasks_claim",
+  description: "Atomically claim a task",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    required: ["id"],
+  },
+  method: "POST",
+  pathTemplate: "/tasks/{id}/claim",
+  queryParams: [],
+  pathParams: ["id"],
+  hasBody: true,
+};
+
+const listTool: GeneratedTool = {
+  name: "tasks_list",
+  description: "List tasks",
+  inputSchema: { type: "object", properties: {}, required: [] },
+  method: "GET",
+  pathTemplate: "/tasks",
+  queryParams: ["status", "limit"],
+  pathParams: [],
+  hasBody: false,
+};
+
+/** Build an injected fetch double that records the request and returns a JSON body. */
+function fakeFetch(body: unknown, status = 200) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fn = (async (url: string | URL, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+const config = {
+  baseUrl: "https://tasks.example.com",
+  token: "secret-token",
+};
+
+describe("callTool", () => {
+  it("substitutes path params and sends a bearer token", async () => {
+    const { fn, calls } = fakeFetch({ id: "abc", status: "in_progress" });
+    const result = await callTool(
+      claimTool,
+      { id: "abc", claimedBy: "agent-1" },
+      {
+        ...config,
+        fetchImpl: fn,
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://tasks.example.com/tasks/abc/claim");
+    expect(calls[0].init?.method).toBe("POST");
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer secret-token");
+    expect(calls[0].init?.body).toBe(JSON.stringify({ claimedBy: "agent-1" }));
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].type).toBe("text");
+  });
+
+  it("appends query params and omits a body for GET", async () => {
+    const { fn, calls } = fakeFetch({ tasks: [], total: 0 });
+    await callTool(
+      listTool,
+      { status: "pending", limit: "10" },
+      {
+        ...config,
+        fetchImpl: fn,
+      },
+    );
+
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe("/tasks");
+    expect(url.searchParams.get("status")).toBe("pending");
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(calls[0].init?.body).toBeUndefined();
+  });
+
+  it("marks non-2xx responses as errors", async () => {
+    const { fn } = fakeFetch({ error: "not found" }, 404);
+    const result = await callTool(
+      claimTool,
+      { id: "missing" },
+      {
+        ...config,
+        fetchImpl: fn,
+      },
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "typecheck": "bun run --filter='*' typecheck",
     "generate:admin-spec": "bun run scripts/generate-admin-spec.ts",
     "generate:admin-types": "bunx openapi-typescript ./admin/openapi.json --output ./lib/admin-types.ts",
-    "generate:task-store-spec": "bun run scripts/generate-task-store-spec.ts"
+    "generate:task-store-spec": "bun run scripts/generate-task-store-spec.ts",
+    "generate:mcp-tools": "bun run scripts/generate-mcp-tools.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/scripts/generate-mcp-tools.ts
+++ b/scripts/generate-mcp-tools.ts
@@ -1,0 +1,271 @@
+/**
+ * scripts/generate-mcp-tools.ts
+ * Generate MCP tool definitions from the task-store OpenAPI spec (TSM-2.2).
+ *
+ * Reads `task-store/openapi.json` and, for every operation, emits an MCP tool
+ * definition (name, description, JSON-Schema inputSchema) plus the metadata the
+ * MCP server needs to proxy the call to the task-store HTTP API (method,
+ * pathTemplate, query/path params, hasBody).
+ *
+ * Output: `mcp-server/src/generated-tools.ts` — a committed TypeScript module
+ * exporting the tools as a static `const` array. Regenerate with:
+ *   bun run generate:mcp-tools
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+const specPath = join(repoRoot, "task-store", "openapi.json");
+const outPath = join(repoRoot, "mcp-server", "src", "generated-tools.ts");
+
+type JsonSchema = Record<string, unknown>;
+
+interface OpenApiParam {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  required?: boolean;
+  schema?: JsonSchema;
+  description?: string;
+}
+
+interface OpenApiOperation {
+  summary?: string;
+  parameters?: OpenApiParam[];
+  requestBody?: {
+    required?: boolean;
+    content?: Record<string, { schema?: JsonSchema }>;
+  };
+}
+
+interface OpenApiSpec {
+  paths: Record<string, Record<string, OpenApiOperation>>;
+  components?: { schemas?: Record<string, JsonSchema> };
+}
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete"] as const;
+
+/**
+ * Derive a stable snake_case tool name from an HTTP method + path.
+ *
+ * Rules (see TSM-2.2 brief):
+ *   - Resource collection is the first path segment ("tasks", "prs", "tokens").
+ *   - A trailing action segment (e.g. "claim", "heartbeat") names the tool.
+ *   - Otherwise the verb depends on method + whether the path targets an id:
+ *       GET collection      -> <resource>_list
+ *       POST collection     -> <resource>_create
+ *       GET   /{id}         -> <resource>_get
+ *       PATCH /{id}         -> <resource>_update
+ *       DELETE /{id}        -> <resource>_delete
+ *   - Static sub-collections ("/tasks/bulk", "/tasks/distinct",
+ *     "/prs/claim", "/prs/claim-next") use the segment as the action.
+ */
+export function deriveToolName(method: string, path: string): string {
+  const segments = path.split("/").filter(Boolean);
+  const resource = segments[0];
+  const rest = segments.slice(1);
+  const slug = (s: string) => s.replace(/-/g, "_");
+
+  // Trailing non-param action segment: /tasks/{id}/claim -> tasks_claim
+  const last = rest[rest.length - 1];
+  if (last && !isParam(last)) {
+    // Distinguish a static sub-collection (/prs/claim) from an id action
+    // (/tasks/{id}/claim). Either way the last segment is the verb.
+    return `${resource}_${slug(last)}`;
+  }
+
+  const targetsId = rest.some(isParam);
+  const m = method.toLowerCase();
+  if (!targetsId) {
+    if (m === "get") return `${resource}_list`;
+    if (m === "post") return `${resource}_create`;
+    return `${resource}_${m}`;
+  }
+  if (m === "get") return `${resource}_get`;
+  if (m === "patch" || m === "put") return `${resource}_update`;
+  if (m === "delete") return `${resource}_delete`;
+  return `${resource}_${m}`;
+}
+
+function isParam(segment: string): boolean {
+  return segment.startsWith("{") && segment.endsWith("}");
+}
+
+/** Resolve a `$ref` like "#/components/schemas/Foo" against the spec. */
+function resolveRef(ref: string, spec: OpenApiSpec): JsonSchema | undefined {
+  const match = ref.match(/^#\/components\/schemas\/(.+)$/);
+  if (!match) return undefined;
+  return spec.components?.schemas?.[match[1]];
+}
+
+/** Inline an object schema's own `properties`/`required`, following one `$ref`
+ * and flattening a single level of `allOf`. Intentionally shallow — the
+ * task-store spec is flat. */
+function inlineObjectSchema(
+  schema: JsonSchema | undefined,
+  spec: OpenApiSpec,
+): { properties: Record<string, JsonSchema>; required: string[] } {
+  const properties: Record<string, JsonSchema> = {};
+  const required: string[] = [];
+  if (!schema) return { properties, required };
+
+  let resolved: JsonSchema | undefined = schema;
+  if (typeof schema.$ref === "string") {
+    resolved = resolveRef(schema.$ref, spec);
+  }
+  if (!resolved) return { properties, required };
+
+  if (Array.isArray(resolved.allOf)) {
+    for (const part of resolved.allOf as JsonSchema[]) {
+      const inner = inlineObjectSchema(part, spec);
+      Object.assign(properties, inner.properties);
+      required.push(...inner.required);
+    }
+    return { properties, required };
+  }
+
+  if (resolved.properties && typeof resolved.properties === "object") {
+    Object.assign(
+      properties,
+      resolved.properties as Record<string, JsonSchema>,
+    );
+  }
+  if (Array.isArray(resolved.required)) {
+    required.push(...(resolved.required as string[]));
+  }
+  return { properties, required };
+}
+
+export interface GeneratedTool {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, JsonSchema>;
+    required: string[];
+    additionalProperties?: boolean;
+  };
+  method: string;
+  pathTemplate: string;
+  queryParams: string[];
+  pathParams: string[];
+  hasBody: boolean;
+}
+
+export function generateTools(spec: OpenApiSpec): GeneratedTool[] {
+  const tools: GeneratedTool[] = [];
+
+  for (const [path, pathItem] of Object.entries(spec.paths)) {
+    for (const method of HTTP_METHODS) {
+      const op = pathItem[method];
+      if (!op) continue;
+
+      const properties: Record<string, JsonSchema> = {};
+      const required: string[] = [];
+      const queryParams: string[] = [];
+      const pathParams: string[] = [];
+
+      for (const param of op.parameters ?? []) {
+        const paramSchema: JsonSchema = param.schema
+          ? { ...param.schema }
+          : { type: "string" };
+        if (param.description) paramSchema.description = param.description;
+        properties[param.name] = paramSchema;
+        if (param.in === "path") {
+          pathParams.push(param.name);
+          required.push(param.name);
+        } else if (param.in === "query") {
+          queryParams.push(param.name);
+          if (param.required) required.push(param.name);
+        }
+      }
+
+      const bodySchema = op.requestBody?.content?.["application/json"]?.schema;
+      const hasBody = Boolean(bodySchema);
+      if (bodySchema) {
+        const inlined = inlineObjectSchema(bodySchema, spec);
+        for (const [key, value] of Object.entries(inlined.properties)) {
+          if (!(key in properties)) properties[key] = value;
+        }
+        if (op.requestBody?.required) {
+          for (const key of inlined.required) {
+            if (!required.includes(key)) required.push(key);
+          }
+        }
+      }
+
+      tools.push({
+        name: deriveToolName(method, path),
+        description: op.summary ?? "",
+        inputSchema: {
+          type: "object",
+          properties,
+          required,
+          additionalProperties: false,
+        },
+        method: method.toUpperCase(),
+        pathTemplate: path,
+        queryParams,
+        pathParams,
+        hasBody,
+      });
+    }
+  }
+
+  return tools;
+}
+
+function renderModule(tools: GeneratedTool[]): string {
+  const header = `// GENERATED FILE — do not edit by hand.
+// Produced by scripts/generate-mcp-tools.ts from task-store/openapi.json.
+// Regenerate with: bun run generate:mcp-tools
+
+/** An MCP tool derived from a single task-store OpenAPI operation. */
+export interface GeneratedTool {
+  /** snake_case tool name, e.g. "tasks_list". */
+  name: string;
+  /** Human-readable description (from the OpenAPI operation summary). */
+  description: string;
+  /** JSON Schema for the tool's arguments. */
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: string[];
+    additionalProperties?: boolean;
+  };
+  /** HTTP method to call on the task-store API. */
+  method: string;
+  /** Original OpenAPI path template, e.g. "/tasks/{id}/claim". */
+  pathTemplate: string;
+  /** Names of query-string parameters. */
+  queryParams: string[];
+  /** Names of path parameters (substituted into pathTemplate). */
+  pathParams: string[];
+  /** True if the operation accepts a JSON request body. */
+  hasBody: boolean;
+}
+
+export const generatedTools: GeneratedTool[] = ${JSON.stringify(tools, null, 2)};
+`;
+  return header;
+}
+
+export function generateMcpTools(): GeneratedTool[] {
+  const spec: OpenApiSpec = JSON.parse(readFileSync(specPath, "utf8"));
+  const tools = generateTools(spec);
+  writeFileSync(outPath, renderModule(tools));
+  // Normalize with biome so the committed output is reproducible and lint-clean.
+  Bun.spawnSync(["bunx", "biome", "format", "--write", outPath], {
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return tools;
+}
+
+if (import.meta.main) {
+  const tools = generateMcpTools();
+  console.log(`Wrote ${tools.length} MCP tools to ${outPath}`);
+}

--- a/scripts/generate-mcp-tools.ts
+++ b/scripts/generate-mcp-tools.ts
@@ -100,13 +100,26 @@ function resolveRef(ref: string, spec: OpenApiSpec): JsonSchema | undefined {
   return spec.components?.schemas?.[match[1]];
 }
 
+/** Resolve a request body schema to its canonical form, following `$ref`. */
+function resolveBodySchema(
+  schema: JsonSchema | undefined,
+  spec: OpenApiSpec,
+): JsonSchema | undefined {
+  if (!schema) return undefined;
+  if (typeof schema.$ref === "string") return resolveRef(schema.$ref, spec);
+  return schema;
+}
+
 /** Inline an object schema's own `properties`/`required`, following one `$ref`
  * and flattening a single level of `allOf`. Intentionally shallow — the
- * task-store spec is flat. */
+ * task-store spec is flat.
+ *
+ * Returns `null` when the resolved schema is array-typed — callers must
+ * special-case that path (see `generateTools`). */
 function inlineObjectSchema(
   schema: JsonSchema | undefined,
   spec: OpenApiSpec,
-): { properties: Record<string, JsonSchema>; required: string[] } {
+): { properties: Record<string, JsonSchema>; required: string[] } | null {
   const properties: Record<string, JsonSchema> = {};
   const required: string[] = [];
   if (!schema) return { properties, required };
@@ -117,9 +130,13 @@ function inlineObjectSchema(
   }
   if (!resolved) return { properties, required };
 
+  // Array-typed body: caller must use a dedicated property wrapper.
+  if (resolved.type === "array") return null;
+
   if (Array.isArray(resolved.allOf)) {
     for (const part of resolved.allOf as JsonSchema[]) {
       const inner = inlineObjectSchema(part, spec);
+      if (inner === null) continue; // skip array fragments (shouldn't occur in flat spec)
       Object.assign(properties, inner.properties);
       required.push(...inner.required);
     }
@@ -152,6 +169,10 @@ export interface GeneratedTool {
   queryParams: string[];
   pathParams: string[];
   hasBody: boolean;
+  /** True when the request body is a JSON array (not an object).
+   * The input schema will expose an `items` property of type `array`;
+   * `callTool` sends `args.items` directly as the body. */
+  hasArrayBody?: boolean;
 }
 
 export function generateTools(spec: OpenApiSpec): GeneratedTool[] {
@@ -184,14 +205,29 @@ export function generateTools(spec: OpenApiSpec): GeneratedTool[] {
 
       const bodySchema = op.requestBody?.content?.["application/json"]?.schema;
       const hasBody = Boolean(bodySchema);
+      let hasArrayBody = false;
       if (bodySchema) {
         const inlined = inlineObjectSchema(bodySchema, spec);
-        for (const [key, value] of Object.entries(inlined.properties)) {
-          if (!(key in properties)) properties[key] = value;
-        }
-        if (op.requestBody?.required) {
-          for (const key of inlined.required) {
-            if (!required.includes(key)) required.push(key);
+        if (inlined === null) {
+          // Array-typed request body: expose an `items` property so callers
+          // can pass the array as `{ items: [...] }`.
+          hasArrayBody = true;
+          const resolved = resolveBodySchema(bodySchema, spec);
+          properties.items = {
+            type: "array",
+            description:
+              "Array of items to submit as the request body.",
+            ...(resolved?.items ? { items: resolved.items } : {}),
+          };
+          if (op.requestBody?.required) required.push("items");
+        } else {
+          for (const [key, value] of Object.entries(inlined.properties)) {
+            if (!(key in properties)) properties[key] = value;
+          }
+          if (op.requestBody?.required) {
+            for (const key of inlined.required) {
+              if (!required.includes(key)) required.push(key);
+            }
           }
         }
       }
@@ -210,6 +246,7 @@ export function generateTools(spec: OpenApiSpec): GeneratedTool[] {
         queryParams,
         pathParams,
         hasBody,
+        ...(hasArrayBody ? { hasArrayBody: true } : {}),
       });
     }
   }
@@ -245,6 +282,10 @@ export interface GeneratedTool {
   pathParams: string[];
   /** True if the operation accepts a JSON request body. */
   hasBody: boolean;
+  /** True when the request body is a JSON array (not an object).
+   * The input schema exposes an \`items\` property of type \`array\`;
+   * \`callTool\` sends \`args.items\` directly as the body. */
+  hasArrayBody?: boolean;
 }
 
 export const generatedTools: GeneratedTool[] = ${JSON.stringify(tools, null, 2)};


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-mcp-tools.ts`: reads `task-store/openapi.json` and emits `mcp-server/src/generated-tools.ts` — 25 MCP tool definitions (one per OpenAPI operation) with snake_case names, descriptions from operation summaries, and JSON Schema inputSchemas (path params required, query params optional, requestBody inlined one level)
- Adds `mcp-server/src/mcp-server.ts`: transport-agnostic `createMcpServer()` factory using the low-level MCP SDK `Server` so JSON Schema inputSchemas pass through unchanged; handles `tools/list` and `tools/call`
- Adds `mcp-server/src/tool-caller.ts`: proxies tool calls to the task-store HTTP API using `SHIPWRIGHT_TASK_STORE_URL` + `SHIPWRIGHT_TASK_STORE_TOKEN` (no new secrets); fetch is injectable for test isolation
- Adds `mcp-server/src/serve.ts`: stdio entry point for real MCP clients (Claude Code, etc.)
- Wires `generate:mcp-tools` script in root `package.json`

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Generator script reads openapi.json → MCP tool definitions | ✅ MET |
| 2 | Each operation → one MCP tool with name, description, inputSchema | ✅ MET |
| 3 | MCP server registers the generated tools | ✅ MET |
| 4 | Bearer auth via SHIPWRIGHT_TASK_STORE_URL/TOKEN (no new secrets) | ✅ MET |
| 5 | Unit test for names/descriptions/inputSchemas | ✅ MET |
| 6 | Smoke test: MCP server lists tools via JSON-RPC tools/list | ✅ MET |

## Test Plan

- [x] `generated-tools.unit.test.ts` — 25 tools, unique names, snake_case, correct descriptions/inputSchemas for tasks_list, tasks_claim, prs_claim
- [x] `tool-caller.unit.test.ts` — path/query/body construction, Bearer auth header, error mapping via injected fetch
- [x] `mcp-server.smoke.test.ts` — JSON-RPC tools/list over InMemoryTransport returns 25 tools including tasks_list and prs_claim
- [x] Biome lint: clean
- [x] TypeScript typecheck: pass

Generated with [Claude Code](https://claude.com/claude-code)
