### PR TITLE
feat(ci): debounce chart-bump bursts into a single PR

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -7,25 +7,51 @@ name: Auto-Bump Chart Version
 # successful image push. This workflow detects those tags and
 # opens a chart-version bump PR so no manual bump-chart.sh invocation is needed.
 #
+# Debounce: services release independently, so it's common for two or three
+# tags to land within seconds/minutes of each other (e.g. admin-v0.156.0
+# immediately followed by agent-v0.144.0). Bumping the chart once per tag in
+# that situation produces a chart-bump PR/merge/publish cycle per tag for what
+# is really one release event — multiplying merge noise and Deploy runs for no
+# added safety. The `debounce` job absorbs bursts: it sleeps for
+# DEBOUNCE_SECONDS, and its `chart-bump-debounce` concurrency group
+# (cancel-in-progress: true) means a newer tag arriving during that sleep
+# cancels the older run outright — only the *last* tag in a burst survives to
+# reach the `bump-chart` job. `bump-chart` then credits every release tag that
+# landed since the previous chart-bump commit (not just its own triggering
+# tag) so the batch is still fully traceable, just collapsed into a single
+# version bump.
+#
+# Known limitation: if tags land continuously faster than DEBOUNCE_SECONDS
+# apart, no run ever clears the debounce window and no bump lands. This is an
+# accepted tradeoff — release cadence here is a handful of tags a day, not a
+# continuous stream. If that changes, add a max-wait fallback.
+#
 # Flow:
-#   tag push (agent-v* / admin-v* / metrics-v*)
-#     → this workflow
-#       → bump patch version in Chart.yaml
-#       → open PR (chore/chart-v{new_version})
+#   tag push (agent-v* / admin-v* / metrics-v* / task-store-v* / chat-v*)
+#     → debounce job: sleep DEBOUNCE_SECONDS
+#       → superseded by a newer tag push? cancelled, bump-chart never runs.
+#       → quiet period elapsed? proceeds to bump-chart.
+#     → bump-chart job
+#       → collect every release tag pushed since the last chart-bump commit
+#       → bump patch version in Chart.yaml once for the whole batch
+#       → open PR (chore/chart-v{new_version}) crediting all batched tags
 #       → wait for required checks, then merge (squash)
 #     → PR merges to main
 #       → chart-release.yml triggers (paths: charts/shipwright/**)
 #         → packages the chart + commits .tgz + index.yaml to gh-pages
 #
-# Manual test plan (cannot be tested in CI without real tag + secrets):
-#   1. Push a dummy tag matching one of the trigger patterns:
-#        git tag agent-v9.9.9 && git push origin agent-v9.9.9
-#   2. Observe this workflow runs, creates branch chore/chart-v{N},
-#      opens a PR, and merges it once checks pass.
-#   3. Verify PR description includes the triggering tag name.
-#   4. After merge, confirm chart-release.yml fires and publishes the new version.
-#   5. Delete the dummy tag to clean up:
-#        git push origin --delete agent-v9.9.9
+# Manual test plan (cannot be tested in CI without real tags + secrets):
+#   1. Push two dummy tags a few seconds apart to simulate a burst:
+#        git tag agent-v9.9.8 && git push origin agent-v9.9.8
+#        git tag admin-v9.9.9 && git push origin admin-v9.9.9
+#   2. Observe the first run's `debounce` job gets cancelled (superseded) and
+#      only the second run's `debounce` job completes and proceeds.
+#   3. Observe `bump-chart` opens exactly one PR, and its body/CHANGELOG entry
+#      credits both agent-v9.9.8 and admin-v9.9.9.
+#   4. Verify the PR merges once checks pass, and chart-release.yml fires
+#      exactly once.
+#   5. Delete the dummy tags to clean up:
+#        git push origin --delete agent-v9.9.8 admin-v9.9.9
 #
 # Logic tests live in .github/workflows/test-auto-bump-chart.sh.
 # Run locally: bash .github/workflows/test-auto-bump-chart.sh
@@ -39,24 +65,43 @@ on:
       - "task-store-v*"
       - "chat-v*"
 
-# Queue concurrent bumps rather than cancelling them — if multiple tags land
-# at nearly the same time, each should produce its own chart bump PR. Using
-# cancel-in-progress: false ensures they queue up and run sequentially. The
-# "Wait for PR to merge" step at the end of the job holds the slot until the
-# merge actually lands on main, so the next queued run always reads the
-# post-merge chart version and computes a fresh increment.
-concurrency:
-  group: chart-bump
-  cancel-in-progress: false
-
 permissions:
   contents: write      # push branch + commit
   pull-requests: write # open PR + enable auto-merge
 
 jobs:
+  # Absorbs bursts of near-simultaneous release tags into a single downstream
+  # bump. Deliberately does no repo work itself — cancellation here must never
+  # leave a half-done Chart.yaml/branch/PR behind, so all mutating work lives
+  # in bump-chart, which only ever starts after a debounce job actually
+  # completes (not merely starts).
+  debounce:
+    name: debounce burst of release tags
+    runs-on: ubuntu-latest
+    concurrency:
+      group: chart-bump-debounce
+      cancel-in-progress: true
+    steps:
+      - name: Wait for quiet period
+        env:
+          DEBOUNCE_SECONDS: 90
+        run: |
+          echo "Tag ${GITHUB_REF_NAME} landed — waiting ${DEBOUNCE_SECONDS}s for other releases to land before bumping the chart."
+          sleep "${DEBOUNCE_SECONDS}"
+          echo "Quiet period elapsed with no superseding tag — proceeding to bump-chart."
+
   bump-chart:
     name: bump chart version
+    needs: debounce
     runs-on: ubuntu-latest
+    # Separate from the debounce group and still queued (not cancelled): once
+    # we're doing real repo mutation, a run must always finish rather than be
+    # cancelled mid-PR/mid-merge. This is only a safety net for the rare case
+    # where two debounce windows resolve close together — the common case is
+    # exactly one bump-chart run per burst.
+    concurrency:
+      group: chart-bump
+      cancel-in-progress: false
     steps:
       # Check out main (not the tag's commit) so we always bump from the
       # latest chart version on main rather than whatever state the tag points at.
@@ -72,6 +117,51 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # Credit every release tag that landed since the last chart-bump commit,
+      # not just the tag that happened to trigger this run — that's everything
+      # the debounce window batched together. Falls back to the triggering tag
+      # alone if no prior bump commit exists (e.g. first-ever bump).
+      - name: Collect release tags in this batch
+        id: batch
+        run: |
+          PATTERNS=("agent-v*" "admin-v*" "metrics-v*" "task-store-v*" "chat-v*")
+
+          LAST_BUMP_SHA=$(git log -1 --format=%H --grep='^chore(chart): bump chart version' -- charts/shipwright/Chart.yaml || true)
+
+          SINCE=""
+          if [ -n "$LAST_BUMP_SHA" ]; then
+            SINCE=$(git log -1 --format=%cI "$LAST_BUMP_SHA")
+          fi
+
+          TAGS=()
+          if [ -n "$SINCE" ]; then
+            for PATTERN in "${PATTERNS[@]}"; do
+              while IFS= read -r LINE; do
+                [ -z "$LINE" ] && continue
+                TAGS+=("$LINE")
+              done < <(git for-each-ref "refs/tags/${PATTERN}" \
+                --format='%(creatordate:iso-strict)|%(refname:short)' \
+                | awk -F'|' -v since="$SINCE" '$1 > since { print $2 }')
+            done
+          fi
+
+          # Always include the triggering tag even if it fell outside the
+          # window (clock skew, first-ever bump) — never silently drop the
+          # tag that fired this run.
+          TRIGGER="${GITHUB_REF_NAME}"
+          FOUND=false
+          for T in "${TAGS[@]:-}"; do
+            [ "$T" = "$TRIGGER" ] && FOUND=true
+          done
+          if [ "$FOUND" = "false" ]; then
+            TAGS+=("$TRIGGER")
+          fi
+
+          TAGS_CSV=$(printf '%s\n' "${TAGS[@]}" | sort -u | paste -sd, -)
+
+          echo "tags=${TAGS_CSV}" >> "$GITHUB_OUTPUT"
+          echo "Batched tags for this bump: ${TAGS_CSV}"
+
       # Read the current chart version using grep+sed — avoids a yq dependency.
       # The version line in Chart.yaml is always "version: X.Y.Z" (no spaces
       # before the key, plain value — no quoting).
@@ -83,7 +173,8 @@ jobs:
           echo "Current chart version: ${VERSION}"
 
       # Increment the patch component only. Chart version bumps are always
-      # patch-level here — minor/major bumps remain a manual step.
+      # patch-level here — minor/major bumps remain a manual step. One bump
+      # covers the whole batch of tags collected above, however many landed.
       - name: Compute new chart version
         id: new
         run: |
@@ -98,11 +189,9 @@ jobs:
 
       # Idempotency guard: if the branch for this exact chart version already
       # exists on the remote, a prior run already opened the bump PR — skip.
-      # This handles the rare race where two runs slip past the concurrency
-      # group's ls-remote check before either has pushed (non-atomic window).
-      # With the "Wait for PR to merge" step holding the slot until the PR
-      # lands on main, this guard is only a safety net for true edge cases;
-      # under normal sequencing each run computes a distinct new version.
+      # With debounce collapsing bursts into a single bump-chart run, this is
+      # now only a safety net for the rare case of two debounce windows
+      # resolving close together, not the common path.
       - name: Check for existing bump branch
         id: idempotency
         env:
@@ -133,27 +222,28 @@ jobs:
               f.write(content)
           PYEOF
 
-      # Record which release tag triggered this bump in the Artifact Hub
-      # change log annotation. This surfaces the triggering tag in the
-      # Artifact Hub UI when the chart is published.
+      # Record every batched release tag in the Artifact Hub change log
+      # annotation — one "changed" entry per tag, so a burst-collapsed bump
+      # still surfaces exactly which releases it contains.
       - name: Update artifacthub.io/changes annotation
         if: steps.idempotency.outputs.skip != 'true'
         run: |
-          TAG="${{ github.ref_name }}"
+          TAGS_CSV="${{ steps.batch.outputs.tags }}"
           NEW_VERSION="${{ steps.new.outputs.version }}"
-          python3 - charts/shipwright/Chart.yaml "$TAG" "$NEW_VERSION" <<'PYEOF'
+          python3 - charts/shipwright/Chart.yaml "$TAGS_CSV" "$NEW_VERSION" <<'PYEOF'
           import sys, re
-          path, tag, ver = sys.argv[1], sys.argv[2], sys.argv[3]
+          path, tags_csv, ver = sys.argv[1], sys.argv[2], sys.argv[3]
+          tags = [t for t in tags_csv.split(',') if t]
           with open(path, 'r') as f:
               content = f.read()
-          new_block = (
-              "  artifacthub.io/changes: |\n"
-              f"    - kind: changed\n"
-              f'      description: "auto-bump to chart v{ver} triggered by release tag {tag}"\n'
-          )
+          lines = ["  artifacthub.io/changes: |"]
+          for tag in tags:
+              lines.append("    - kind: changed")
+              lines.append(f'      description: "auto-bump to chart v{ver} triggered by release tag {tag}"')
+          new_block = "\n".join(lines)
           content = re.sub(
               r'  artifacthub\.io/changes:.*?(?=\n\S|\Z)',
-              new_block.rstrip('\n'),
+              new_block,
               content,
               flags=re.DOTALL,
           )
@@ -167,9 +257,10 @@ jobs:
         if: steps.idempotency.outputs.skip != 'true'
         run: |
           NEW_VERSION="${{ steps.new.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          TAGS_LIST=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/`/; s/$/`/' | paste -sd, - | sed 's/,/, /g')
           DATE=$(date -u +%Y-%m-%d)
-          ENTRY="## [${NEW_VERSION}] - ${DATE}\n\n### Changed\n\n- auto-bump to chart v${NEW_VERSION} triggered by release tag \`${TAG}\`\n"
+          ENTRY="## [${NEW_VERSION}] - ${DATE}\n\n### Changed\n\n- auto-bump to chart v${NEW_VERSION} triggered by release tag(s): ${TAGS_LIST}\n"
           # Prepend the new entry after the header block (after the last line starting with '#' in the preamble)
           python3 - charts/shipwright/CHANGELOG.md "$ENTRY" <<'PYEOF'
           import sys
@@ -194,13 +285,16 @@ jobs:
         run: |
           BRANCH="${{ steps.new.outputs.branch }}"
           NEW_VERSION="${{ steps.new.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/  - /')
 
           git checkout -b "$BRANCH"
           git add charts/shipwright/Chart.yaml charts/shipwright/CHANGELOG.md
           git commit -m "chore(chart): bump chart version to ${NEW_VERSION}
 
-          Auto-bump triggered by release tag ${TAG}.
+          Auto-bump triggered by release tag(s):
+          ${TAGS_LINES}
+
           After merge, chart-release.yml will publish chart v${NEW_VERSION}."
 
           # Fault-tolerant push: if a concurrent run slips through the
@@ -223,7 +317,8 @@ jobs:
         run: |
           NEW_VERSION="${{ steps.new.outputs.version }}"
           CURRENT_VERSION="${{ steps.current.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/- `/; s/$/`/')
           BRANCH="${{ steps.new.outputs.branch }}"
 
           PR_URL=$(gh pr create \
@@ -233,7 +328,9 @@ jobs:
             --body "$(cat <<EOF
           ## Chart version bump: ${CURRENT_VERSION} → ${NEW_VERSION}
 
-          **Triggering tag:** \`${TAG}\`
+          **Triggering tags:**
+          ${TAGS_LINES}
+
           **New chart version:** \`${NEW_VERSION}\`
 
           ### What happens next

--- a/.github/workflows/test-auto-bump-chart.sh
+++ b/.github/workflows/test-auto-bump-chart.sh
@@ -67,29 +67,31 @@ with open(path, 'w') as f:
 PYEOF
 }
 
-# Update the artifacthub.io/changes annotation (uses python3 — same as the workflow).
+# Update the artifacthub.io/changes annotation with one entry per batched tag
+# (uses python3 — same as the workflow's "Update artifacthub.io/changes
+# annotation" step). tags_csv is a comma-separated list, e.g. "a-v1,b-v2".
 update_artifact_hub_changes() {
   local chart_yaml="$1"
-  local tag="$2"
-  python3 - "$chart_yaml" "$tag" <<'PYEOF'
+  local tags_csv="$2"
+  local ver="${3:-0.0.0}"
+  python3 - "$chart_yaml" "$tags_csv" "$ver" <<'PYEOF'
 import sys, re
 
-path = sys.argv[1]
-tag  = sys.argv[2]
+path, tags_csv, ver = sys.argv[1], sys.argv[2], sys.argv[3]
+tags = [t for t in tags_csv.split(',') if t]
 
 with open(path, 'r') as f:
     content = f.read()
 
-# Replace the multiline artifacthub.io/changes block
-new_block = (
-    "  artifacthub.io/changes: |\n"
-    f"    - kind: changed\n"
-    f'      description: "auto-bump triggered by {tag}"\n'
-)
+lines = ["  artifacthub.io/changes: |"]
+for tag in tags:
+    lines.append("    - kind: changed")
+    lines.append(f'      description: "auto-bump to chart v{ver} triggered by release tag {tag}"')
+new_block = "\n".join(lines)
 
 content = re.sub(
     r'  artifacthub\.io/changes:.*?(?=\n\S|\Z)',
-    new_block.rstrip('\n'),
+    new_block,
     content,
     flags=re.DOTALL,
 )
@@ -97,6 +99,53 @@ content = re.sub(
 with open(path, 'w') as f:
     f.write(content)
 PYEOF
+}
+
+# Formats a comma-separated tag list into the backtick-quoted, comma-space
+# joined form used in the CHANGELOG.md entry (mirrors the "Update
+# CHANGELOG.md" step's TAGS_LIST computation).
+format_changelog_tags() {
+  local tags_csv="$1"
+  echo "$tags_csv" | tr ',' '\n' | sed 's/^/`/; s/$/`/' | paste -sd, - | sed 's/,/, /g'
+}
+
+# Collects every release tag pushed since the last chart-bump commit, falling
+# back to the triggering tag alone if no prior bump commit exists. Mirrors
+# the "Collect release tags in this batch" step — must be run inside a git
+# repo with charts/shipwright/Chart.yaml present in history.
+collect_batch_tags() {
+  local trigger_tag="$1"
+  local patterns=("agent-v*" "admin-v*" "metrics-v*" "task-store-v*" "chat-v*")
+
+  local last_bump_sha
+  last_bump_sha=$(git log -1 --format=%H --grep='^chore(chart): bump chart version' -- charts/shipwright/Chart.yaml || true)
+
+  local since=""
+  if [ -n "$last_bump_sha" ]; then
+    since=$(git log -1 --format=%cI "$last_bump_sha")
+  fi
+
+  local tags=()
+  if [ -n "$since" ]; then
+    for pattern in "${patterns[@]}"; do
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        tags+=("$line")
+      done < <(git for-each-ref "refs/tags/${pattern}" \
+        --format='%(creatordate:iso-strict)|%(refname:short)' \
+        | awk -F'|' -v since="$since" '$1 > since { print $2 }')
+    done
+  fi
+
+  local found=false
+  for t in "${tags[@]:-}"; do
+    [ "$t" = "$trigger_tag" ] && found=true
+  done
+  if [ "$found" = "false" ]; then
+    tags+=("$trigger_tag")
+  fi
+
+  printf '%s\n' "${tags[@]}" | sort -u | paste -sd, -
 }
 
 # ---------------------------------------------------------------------------
@@ -225,7 +274,7 @@ echo ""
 echo "=== update_artifact_hub_changes tests ==="
 
 f5=$(make_chart_yaml "1.5.1")
-update_artifact_hub_changes "$f5" "agent-v1.2.3"
+update_artifact_hub_changes "$f5" "agent-v1.2.3" "1.5.2"
 
 CHANGES_CONTENT=$(grep -A3 'artifacthub.io/changes' "$f5" || true)
 if echo "$CHANGES_CONTENT" | grep -q 'agent-v1.2.3'; then
@@ -240,8 +289,80 @@ else
   fail "changes annotation has kind: changed" "kind: changed" "$CHANGES_CONTENT"
 fi
 
+f5b=$(make_chart_yaml "1.5.1")
+update_artifact_hub_changes "$f5b" "admin-v0.156.0,agent-v0.144.0" "1.5.2"
+
+BATCH_CONTENT=$(cat "$f5b")
+if echo "$BATCH_CONTENT" | grep -q 'admin-v0.156.0' && echo "$BATCH_CONTENT" | grep -q 'agent-v0.144.0'; then
+  pass "batched tags both appear in annotation"
+else
+  fail "batched tags both appear in annotation" "both admin-v0.156.0 and agent-v0.144.0 present" "$BATCH_CONTENT"
+fi
+
+ENTRY_COUNT=$(echo "$BATCH_CONTENT" | grep -c 'kind: changed')
+assert_eq "one 'kind: changed' entry per batched tag" "2" "$ENTRY_COUNT"
+
 # ---------------------------------------------------------------------------
-# Tests: full pipeline (read → bump → update → verify)
+# Tests: format_changelog_tags
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== format_changelog_tags tests ==="
+
+assert_eq "single tag" '`agent-v1.2.3`' "$(format_changelog_tags 'agent-v1.2.3')"
+assert_eq "two tags" '`admin-v0.156.0`, `agent-v0.144.0`' "$(format_changelog_tags 'admin-v0.156.0,agent-v0.144.0')"
+
+# ---------------------------------------------------------------------------
+# Tests: collect_batch_tags
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== collect_batch_tags tests ==="
+
+GIT_TEST_DIR="$TMPDIR_TEST/git-batch-test"
+mkdir -p "$GIT_TEST_DIR/charts/shipwright"
+(
+  cd "$GIT_TEST_DIR"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "test"
+
+  cat > charts/shipwright/Chart.yaml <<'EOF'
+apiVersion: v2
+name: shipwright
+version: 1.6.284
+EOF
+  git add -A
+  GIT_AUTHOR_DATE="2026-07-06T09:00:00-07:00" GIT_COMMITTER_DATE="2026-07-06T09:00:00-07:00" \
+    git commit -q -m "chore(chart): bump chart version to 1.6.284"
+
+  GIT_COMMITTER_DATE="2026-07-06T09:50:00-07:00" git tag -a admin-v0.156.0 -m "x"
+  GIT_COMMITTER_DATE="2026-07-06T09:52:00-07:00" git tag -a agent-v0.144.0 -m "x"
+)
+
+BATCHED=$(cd "$GIT_TEST_DIR" && collect_batch_tags "agent-v0.144.0")
+assert_eq "batches both tags landed after the last bump commit" "admin-v0.156.0,agent-v0.144.0" "$BATCHED"
+
+# Fresh repo with no prior chart-bump commit — falls back to the triggering
+# tag alone, even though a tag exists that would otherwise be in range.
+GIT_TEST_DIR2="$TMPDIR_TEST/git-fallback-test"
+mkdir -p "$GIT_TEST_DIR2"
+(
+  cd "$GIT_TEST_DIR2"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "test"
+  echo hi > README.md
+  git add -A
+  git commit -q -m "init"
+  git tag -a metrics-v1.0.0 -m "x"
+)
+
+FALLBACK=$(cd "$GIT_TEST_DIR2" && collect_batch_tags "metrics-v1.0.0")
+assert_eq "falls back to triggering tag with no prior bump commit" "metrics-v1.0.0" "$FALLBACK"
+
+# ---------------------------------------------------------------------------
+# Tests: full pipeline (read → bump → update → verify), batched tags
 # ---------------------------------------------------------------------------
 
 echo ""
@@ -251,14 +372,14 @@ f6=$(make_chart_yaml "1.5.1")
 CURRENT=$(read_chart_version "$f6")
 NEW=$(bump_patch "$CURRENT")
 update_chart_version "$f6" "$NEW"
-update_artifact_hub_changes "$f6" "metrics-v0.5.0"
+update_artifact_hub_changes "$f6" "metrics-v0.5.0,admin-v0.5.1" "$NEW"
 
 assert_eq "pipeline: final version" "1.5.2" "$(read_chart_version "$f6")"
 
-if grep -q "metrics-v0.5.0" "$f6"; then
-  pass "pipeline: tag appears in annotation"
+if grep -q "metrics-v0.5.0" "$f6" && grep -q "admin-v0.5.1" "$f6"; then
+  pass "pipeline: both batched tags appear in annotation"
 else
-  fail "pipeline: tag appears in annotation" "metrics-v0.5.0 in annotation" "not found"
+  fail "pipeline: both batched tags appear in annotation" "metrics-v0.5.0 and admin-v0.5.1 in annotation" "not found"
 fi
 
 # ---------------------------------------------------------------------------

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -41,11 +41,21 @@ packaged a `.tgz` is allowed to finish rather than being cancelled mid-publish.
 
 Chart version bumps are **automated** by the
 [`auto-bump-chart.yml`](../.github/workflows/auto-bump-chart.yml) workflow.
-Whenever a release tag is pushed matching `agent-v*`, `admin-v*`, or `metrics-v*`
-(created by the service build workflows on successful image push), the automation
-detects the tag, increments the chart patch version in `Chart.yaml`, opens a PR
-(targeting `main`), and enables auto-merge. Once the PR merges, `chart-release.yml`
-fires and publishes the new chart version. No manual version bump is required.
+Whenever a release tag is pushed matching `agent-v*`, `admin-v*`, `metrics-v*`,
+`task-store-v*`, or `chat-v*` (created by the service build workflows on
+successful image push), the automation detects the tag, increments the chart
+patch version in `Chart.yaml`, opens a PR (targeting `main`), and merges it
+once checks pass. Once the PR merges, `chart-release.yml` fires and publishes
+the new chart version. No manual version bump is required.
+
+Services release independently, so it's common for two or three tags to land
+within seconds or minutes of each other. Rather than bumping the chart once
+per tag (a PR/merge/publish cycle per tag for what's really one release
+event), the workflow **debounces**: a 90-second quiet period absorbs bursts,
+and only the last tag in a burst triggers the actual bump. The resulting PR
+credits every release tag that landed since the previous chart-bump commit,
+so the batch stays fully traceable even though it's collapsed into a single
+version bump.
 
 ## First-time setup (one-time)
 


### PR DESCRIPTION
## Why

Shipwright services release independently, so it's common for two or three
release tags to land within seconds/minutes of each other (e.g.
`admin-v0.156.0` immediately followed by `agent-v0.144.0`). Today each tag
triggers its own `auto-bump-chart.yml` run — its own PR, its own merge, its
own `chart-release.yml` publish, its own downstream vitals-os bump — for what
is really one release event. That's a lot of merge/Deploy noise for no added
safety.

## What changed

`auto-bump-chart.yml` now runs in two jobs:

1. **`debounce`** — sleeps 90s in a `chart-bump-debounce` concurrency group
   with `cancel-in-progress: true`. A newer tag arriving during that sleep
   cancels the older run outright, so only the *last* tag in a burst survives.
2. **`bump-chart`** — unchanged concurrency semantics (queued, never
   cancelled, so a run in progress always finishes). It now collects every
   release tag that landed since the previous chart-bump commit (not just its
   own triggering tag), and credits all of them in the PR body, commit
   message, CHANGELOG entry, and Artifact Hub `changes` annotation.

Net effect: a burst of releases collapses into one PR, one merge, one
`chart-release.yml` run, and one downstream vitals-os bump — same traceability
(every triggering tag is still listed), fewer deploys.

Known tradeoff (documented in the workflow's header comment): if tags land
continuously faster than the 90s window, no bump ever lands. Not a concern at
current release cadence (a handful of tags/day); flagged for anyone revisiting
this later.

## Test plan

- [x] `bash .github/workflows/test-auto-bump-chart.sh` — 23/23 passing,
      including new tests for `collect_batch_tags` (multi-tag batching +
      no-prior-bump fallback) and multi-tag annotation/changelog formatting.
- [x] Validated the new YAML structure (job graph, `needs`, concurrency
      groups) parses correctly.
- [x] Manually replayed the tag-collection and formatting logic against
      scratch git repos matching the real `admin-v0.156.0` /
      `agent-v0.144.0` burst that prompted this change.
- [ ] Can't fully exercise the live GitHub Actions burst/cancellation
      behavior without pushing real tags — see the manual test plan in the
      workflow's header comment for how to do that safely with dummy tags.

🤖 Generated with Claude Code (Doc, App Vitals agent)