### PR TITLE
feat(ci): skip app CI suite and agent review for automated bumps

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -230,6 +230,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore(chart): bump chart version to ${NEW_VERSION}" \
+            --label automated \
             --body "$(cat <<EOF
           ## Chart version bump: ${CURRENT_VERSION} → ${NEW_VERSION}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,70 @@ on:
   pull_request:
 
 jobs:
+  # Detects whether this run only touches the files auto-bump-chart.yml or
+  # sync-plugin-version.yml commit — chart-version bumps (Chart.yaml,
+  # CHANGELOG.md) and plugin-version syncs (package.json across workspaces,
+  # plugin.json, marketplace.json, version.txt). Both are fully automated,
+  # bot-authored, version-string-only changes that never touch application
+  # logic — so the app/docker/site jobs below are gated on this and skipped
+  # when nothing else changed. helm.yml (separately path-filtered on
+  # charts/**) still runs and is what actually validates a chart change.
+  #
+  # Fails open on purpose: any inability to compute the diff (unresolvable
+  # base ref, unexpected event shape) defaults `app=true`, running the full
+  # suite. Silently skipping real tests on an error would be worse than
+  # running them unnecessarily.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine whether app code changed
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # push to main: each merge here is one squash commit, so the
+            # parent is exactly "what main looked like before this merge."
+            BASE="HEAD^"
+            HEAD_SHA="HEAD"
+          fi
+
+          if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+            echo "Could not resolve base ref '${BASE}' — running full suite to be safe."
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD_SHA")
+          echo "Changed files (${BASE}...${HEAD_SHA}):"
+          echo "$CHANGED"
+
+          # Exact allowlist — the full set of files auto-bump-chart.yml and
+          # sync-plugin-version.yml ever touch. Anything else in the diff
+          # means real code changed, so the full suite runs.
+          PATTERN='^(charts/shipwright/Chart\.yaml|charts/shipwright/CHANGELOG\.md|package\.json|plugins/shipwright/package\.json|plugins/shipwright/\.claude-plugin/plugin\.json|metrics/package\.json|agent/package\.json|version\.txt|\.claude-plugin/marketplace\.json)$'
+
+          if [ -z "$CHANGED" ] || echo "$CHANGED" | grep -qvE "$PATTERN"; then
+            echo "app=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "app=false" >> "$GITHUB_OUTPUT"
+            echo "Only automated chart/plugin-version-bump files changed — skipping app-level CI jobs."
+          fi
+
   ci:
     name: lint / typecheck / test
     runs-on: ubuntu-latest
+    needs: changes
+    # always() so this still runs (fail-open) if the changes job itself
+    # errored rather than auto-skipping every job in the suite.
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     services:
       postgres:
         image: postgres:16
@@ -69,6 +130,8 @@ jobs:
   site:
     name: site build / brand-lint / smoke
     runs-on: ubuntu-latest
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
       - uses: actions/checkout@v4
 
@@ -94,6 +157,8 @@ jobs:
   admin-docker-build:
     name: admin docker build
     runs-on: ubuntu-latest
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
       - uses: actions/checkout@v4
 
@@ -103,6 +168,8 @@ jobs:
   agent-docker-build:
     name: agent docker build
     runs-on: ubuntu-latest
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
       - uses: actions/checkout@v4
 
@@ -112,6 +179,8 @@ jobs:
   metrics-docker-build:
     name: metrics docker build
     runs-on: ubuntu-latest
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -189,6 +189,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore(plugin): sync version to ${VERSION}" \
+            --label automated \
             --body "$(cat <<EOF
           ## Plugin version sync: → ${VERSION}
 

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -141,13 +141,17 @@ REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
 
 ```bash
 gh pr list --state open --repo {org}/{repo} \
-  --json number,title,author,headRefName,baseRefName,isDraft,reviews,createdAt,updatedAt,additions,deletions
+  --json number,title,author,headRefName,baseRefName,isDraft,reviews,createdAt,updatedAt,additions,deletions,labels
 ```
 
 Exclude:
 - Draft PRs
 - PRs where `author.login == CURRENT_USER` and `allow_self_review` is false
 - PRs where `author.login == "app/dependabot"` — handled exclusively by the dependabot-review plugin
+- PRs labeled `automated` — fully bot-authored, bot-merged infra bumps (chart-version bumps,
+  plugin-version syncs, image-tag bumps) with no application logic to review. Applied by the
+  automated workflows that create these PRs (e.g. `auto-bump-chart.yml`,
+  `sync-plugin-version.yml`, and downstream consumer repos' own bump workflows).
 
 When a PR is checked out for review, also query the task store for a task whose `pr`
 field matches the PR number — if found, record the `id` (used as `taskId` to link the PR

--- a/plugins/shipwright/scripts/check-review.test.ts
+++ b/plugins/shipwright/scripts/check-review.test.ts
@@ -20,6 +20,7 @@ interface PrInfo {
   headRefOid: string;
   repo?: string;
   isDraft: boolean;
+  labels?: { name: string }[];
 }
 
 interface PrRecord {
@@ -252,6 +253,35 @@ describe("check-review", () => {
       makePr({ number: 3, author: { login: "danmcaulay" } }),
     ];
     const result = await run(makeDeps(prs, async () => null));
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  // ─── automated label exclusion ────────────────────────────────────────────
+
+  test("exits 1 when all open PRs are labeled automated", async () => {
+    const prs = [
+      makePr({ number: 1, labels: [{ name: "automated" }] }),
+      makePr({ number: 2, labels: [{ name: "automated" }] }),
+    ];
+    const result = await run(makeDeps(prs, async () => null));
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when mix of automated/eligible PRs has one eligible non-automated PR", async () => {
+    const prs = [
+      makePr({ number: 1, labels: [{ name: "automated" }] }),
+      makePr({ number: 2, author: { login: "danmcaulay" } }),
+    ];
+    const result = await run(makeDeps(prs, async () => null));
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("exits 0 when PR has unrelated labels (not automated)", async () => {
+    const pr = makePr({ labels: [{ name: "bug" }, { name: "enhancement" }] });
+    const result = await run(makeDeps([pr], async () => null));
     expect(result.exit).toBe(0);
     expect(result.output).toBeTruthy();
   });

--- a/plugins/shipwright/scripts/check-review.ts
+++ b/plugins/shipwright/scripts/check-review.ts
@@ -38,6 +38,7 @@ interface PrInfo {
   headRefOid: string;
   repo?: string;
   isDraft: boolean;
+  labels?: { name: string }[];
 }
 
 interface PrRecord {
@@ -70,6 +71,7 @@ export async function run(deps: Deps): Promise<RunResult> {
   for (const pr of prs) {
     if (pr.isDraft) continue;
     if (pr.author.login === "app/dependabot") continue;
+    if (pr.labels?.some((l) => l.name === "automated")) continue;
     if (!deps.isSelfReviewAllowed && pr.author.login === currentUser) continue;
 
     let record: PrRecord | null = null;
@@ -125,7 +127,7 @@ export async function buildProductionDeps(): Promise<Deps> {
           "--repo",
           repo,
           "--json",
-          "number,title,author,headRefName,headRefOid,isDraft",
+          "number,title,author,headRefName,headRefOid,isDraft,labels",
         ]);
         allPrs.push(...repoPrs.map((pr) => ({ ...pr, repo })));
       }


### PR DESCRIPTION
## Why

Follow-up to #1236 (chart-bump debounce). `auto-bump-chart.yml` and
`sync-plugin-version.yml` only ever touch version strings — `Chart.yaml` /
`CHANGELOG.md`, or `package.json` (root + plugin/metrics/agent workspaces) /
`plugin.json` / `marketplace.json` / `version.txt` — never application logic.
Both still ran the **full** `ci.yml` suite (lint, typecheck, test, e2e,
site build, admin/agent/metrics docker builds) on every bump, and both PRs
were fair game for the review cron to pick up and spend a session reviewing,
despite being fully bot-authored and bot-merged.

## What changed

- `ci.yml` gets a `changes` job that diffs the PR (or `HEAD^..HEAD` on push to
  main) against an exact allowlist of the files these two workflows ever
  touch. When the diff matches, `ci`, `site`, `admin-docker-build`,
  `agent-docker-build`, and `metrics-docker-build` are skipped (`e2e` cascades
  automatically via its existing `needs: ci`). Fails open to the full suite on
  any diff-resolution error or if app code is touched alongside the bump.
  `helm.yml` (separately path-filtered on `charts/**`) is untouched — it's
  what actually validates a chart change.
- Both workflows now open their PR with `--label automated` (new label,
  matching the one already used in vitals-os for its changelog-sync PR).
- `plugins/shipwright/commands/review.md`'s PR queue now excludes PRs labeled
  `automated`, alongside the existing draft/dependabot exclusions.
- `check-review.ts` (the review cron's precheck) got the same exclusion, plus
  three new tests. Per the plugin's precheck contract, a qualification change
  in `review.md` requires auditing the precheck — done here.

Companion vitals-os PR (same shape, for `bump-shipwright-chart.yml` and
`update-agent-base-tag.yml`): app-vitals/vitals-os#2344

## Test plan

- [x] `bun test plugins/shipwright/scripts/` — 344/344 passing (26 in
      `check-review.test.ts`, including 3 new automated-label tests).
- [x] `bunx biome check` on changed scripts — clean.
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean.
- [x] Validated the new `ci.yml` YAML (job graph, `needs`, `if` conditions,
      `e2e`'s cascade-skip via `needs: ci`).
- [x] Replayed the changed-paths allowlist against scratch git repos:
      chart-only bump → skip, full plugin-version-sync file set → skip,
      chart bump + unrelated app file → full suite runs.
- [ ] Can't fully exercise the live push-to-main `HEAD^` path or confirm
      "skipped" jobs satisfy required status checks without an actual merge —
      worth watching the next real bump.

🤖 Generated with Claude Code (Doc, App Vitals agent)