### PR TITLE
feat(mcp-server): curate MCP tool allowlist — exclude lifecycle and token ops (TSM-2.3)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ A small in-memory HTML store for short-lived, regenerable artifacts (one-pagers,
 
 ## MCP Server
 
-A Model Context Protocol (MCP) server that exposes the task-store HTTP API as discoverable MCP tools (`@shipwright/mcp-server`). Tools are generated automatically from the task-store OpenAPI specification — the `generate-mcp-tools` script (`scripts/generate-mcp-tools.ts`) reads `task-store/openapi.json` and emits tool definitions (name, description, JSON-Schema) plus routing metadata (HTTP method, path template, query/path parameters).
+A Model Context Protocol (MCP) server that exposes a curated subset of the task-store HTTP API as discoverable MCP tools (`@shipwright/mcp-server`). Tools are generated automatically from the task-store OpenAPI specification — the `generate-mcp-tools` script (`scripts/generate-mcp-tools.ts`) reads `task-store/openapi.json` and emits tool definitions (name, description, JSON-Schema) plus routing metadata (HTTP method, path template, query/path parameters). The allowlist (`mcp-server/src/tool-allowlist.ts`) then filters the generated set down to the agreed public surface: read operations (`tasks_list`, `tasks_get`, `prs_list`, `prs_get`), ordinary field edits (`tasks_create`, `tasks_update`, `prs_update`), and bulk reads (`tasks_bulk`, `tasks_distinct`). Pipeline-internal lifecycle ops (claim, heartbeat, complete, fail, release), destructive ops (delete), and all token-management routes are excluded.
 
 **Transport:**
 

--- a/mcp-server/src/mcp-server.smoke.test.ts
+++ b/mcp-server/src/mcp-server.smoke.test.ts
@@ -22,10 +22,13 @@ describe("MCP server tools/list", () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
 
-    expect(tools.length).toBe(25);
+    // Only the 9 allowed tools are exposed; pipeline-internal ops are excluded.
+    expect(tools.length).toBe(9);
     expect(names).toContain("tasks_list");
-    expect(names).toContain("tasks_claim");
-    expect(names).toContain("prs_claim");
+    expect(names).toContain("prs_list");
+    expect(names).toContain("prs_update");
+    expect(names).not.toContain("tasks_claim");
+    expect(names).not.toContain("prs_claim");
 
     const tasksList = tools.find((t) => t.name === "tasks_list");
     expect(tasksList?.description).toBe("List tasks");

--- a/mcp-server/src/mcp-server.ts
+++ b/mcp-server/src/mcp-server.ts
@@ -20,6 +20,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { generatedTools } from "./generated-tools.ts";
+import { allowedTools } from "./tool-allowlist.ts";
 import {
   type ToolCallerConfig,
   callTool,
@@ -33,6 +34,7 @@ export interface CreateMcpServerOptions {
 
 export function createMcpServer(options: CreateMcpServerOptions = {}): Server {
   const config = options.config ?? configFromEnv();
+  const tools = allowedTools(generatedTools);
 
   const server = new Server(
     { name: "shipwright-task-store", version: "0.1.0" },
@@ -40,7 +42,7 @@ export function createMcpServer(options: CreateMcpServerOptions = {}): Server {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: generatedTools.map((tool) => ({
+    tools: tools.map((tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: tool.inputSchema,
@@ -50,7 +52,7 @@ export function createMcpServer(options: CreateMcpServerOptions = {}): Server {
   server.setRequestHandler(
     CallToolRequestSchema,
     async (request): Promise<CallToolResult> => {
-      const tool = generatedTools.find((t) => t.name === request.params.name);
+      const tool = tools.find((t) => t.name === request.params.name);
       if (!tool) {
         return {
           content: [

--- a/mcp-server/src/tool-allowlist.ts
+++ b/mcp-server/src/tool-allowlist.ts
@@ -1,0 +1,56 @@
+/**
+ * tool-allowlist.ts
+ * Curates the full generated MCP tool set down to the agreed public surface:
+ * reads plus ordinary field edits (create/update task, update PR fields).
+ *
+ * Pipeline-internal lifecycle ops (claim/heartbeat/complete/fail/release) and
+ * all token-management routes are excluded. The filter lives here — outside the
+ * generated file — so that regenerating generated-tools.ts never inadvertently
+ * re-exposes excluded ops.
+ */
+
+import type { GeneratedTool } from "./generated-tools.ts";
+
+/**
+ * Tools excluded from the public MCP surface.
+ *
+ * Excluded categories:
+ * - Pipeline-internal lifecycle ops: tasks_claim, tasks_heartbeat, tasks_complete,
+ *   tasks_fail, tasks_release
+ * - Destructive ops: tasks_delete
+ * - Token-management routes: tokens_list, tokens_create, tokens_update, tokens_delete
+ * - PR lifecycle ops: prs_claim, prs_claim_next, prs_heartbeat, prs_complete,
+ *   prs_patch, prs_release
+ */
+export const EXCLUDED_TOOLS: readonly string[] = [
+  // tasks: pipeline-internal lifecycle
+  "tasks_claim",
+  "tasks_heartbeat",
+  "tasks_complete",
+  "tasks_fail",
+  "tasks_release",
+  // tasks: destructive
+  "tasks_delete",
+  // tokens: all token-management
+  "tokens_list",
+  "tokens_create",
+  "tokens_update",
+  "tokens_delete",
+  // prs: pipeline-internal lifecycle
+  "prs_claim",
+  "prs_claim_next",
+  "prs_heartbeat",
+  "prs_complete",
+  "prs_patch",
+  "prs_release",
+] as const;
+
+/**
+ * Filter a generated tool list down to the agreed public surface.
+ * Allowed tools: tasks_list, tasks_create, tasks_bulk, tasks_distinct,
+ * tasks_get, tasks_update, prs_list, prs_get, prs_update (9 total).
+ */
+export function allowedTools(tools: GeneratedTool[]): GeneratedTool[] {
+  const excluded = new Set<string>(EXCLUDED_TOOLS);
+  return tools.filter((tool) => !excluded.has(tool.name));
+}

--- a/mcp-server/src/tool-allowlist.unit.test.ts
+++ b/mcp-server/src/tool-allowlist.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { generatedTools } from "./generated-tools.ts";
+import { createMcpServer } from "./mcp-server.ts";
+import { EXCLUDED_TOOLS, allowedTools } from "./tool-allowlist.ts";
+
+const ALLOWED_TOOL_NAMES = [
+  "tasks_list",
+  "tasks_create",
+  "tasks_bulk",
+  "tasks_distinct",
+  "tasks_get",
+  "tasks_update",
+  "prs_list",
+  "prs_get",
+  "prs_update",
+] as const;
+
+describe("allowedTools", () => {
+  it("returns only the 9 agreed tools", () => {
+    const result = allowedTools(generatedTools);
+    expect(result).toHaveLength(9);
+  });
+
+  it("excludes all EXCLUDED_TOOLS names", () => {
+    const result = allowedTools(generatedTools);
+    const resultNames = result.map((t) => t.name);
+    for (const excluded of EXCLUDED_TOOLS) {
+      expect(resultNames).not.toContain(excluded);
+    }
+  });
+
+  it("stays stable across regeneration — given all 25 generatedTools, only 9 come back", () => {
+    // This is the "across regeneration" invariant:
+    // even if generate:mcp-tools emits all 25 ops, only the 9 allowed ones are exposed.
+    expect(generatedTools).toHaveLength(25);
+    const result = allowedTools(generatedTools);
+    expect(result).toHaveLength(9);
+    const resultNames = result.map((t) => t.name);
+    for (const name of ALLOWED_TOOL_NAMES) {
+      expect(resultNames).toContain(name);
+    }
+  });
+
+  it("returns tools with the exact agreed names", () => {
+    const result = allowedTools(generatedTools);
+    const resultNames = result.map((t) => t.name).sort();
+    expect(resultNames).toEqual([...ALLOWED_TOOL_NAMES].sort());
+  });
+});
+
+describe("createMcpServer lists only allowed tools", () => {
+  it("tools/list returns exactly 9 names and none are in EXCLUDED_TOOLS", async () => {
+    const server = createMcpServer({
+      config: { baseUrl: "http://localhost:3002", token: "test-token" },
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+
+    expect(tools.length).toBe(9);
+    for (const excluded of EXCLUDED_TOOLS) {
+      expect(names).not.toContain(excluded);
+    }
+
+    await client.close();
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `tool-allowlist.ts` module with a stable `EXCLUDED_TOOLS` constant and `allowedTools()` filter function
- Update `mcp-server.ts` to expose only the 9 agreed tools (reads + ordinary field edits); pipeline-internal lifecycle ops and all token-management routes are excluded
- Add `tool-allowlist.unit.test.ts` with 5 tests including the "across regeneration" invariant (25 generated → 9 allowed)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | MCP server only lists/dispatches the 9 allowed tools | ✅ MET |
| 2 | Pipeline-internal lifecycle ops and token-management routes not exposed | ✅ MET |
| 3 | Unit test asserts excluded ops stay excluded across regeneration | ✅ MET |
| 4 | Filter in dedicated module (not in generated-tools.ts) | ✅ MET |

## Test Plan
- [x] `bun test mcp-server/src/` — 25/25 pass
- [x] `bun run --filter='*' typecheck` — clean
- [x] `bunx biome lint .` — no issues
- [x] "Stays stable across regeneration" invariant test explicitly verifies 25-in → 9-out
- [x] Smoke test updated to assert 9 tools with negative assertions for excluded ops

Generated with [Claude Code](https://claude.com/claude-code)
