### PR TITLE
test: backfill coverage for admin external-client wrappers

### DIFF
--- a/admin/src/fixtures/google-auth-cassette.json
+++ b/admin/src/fixtures/google-auth-cassette.json
@@ -1,0 +1,36 @@
+{
+  "exchangeCode_success": {
+    "status": 200,
+    "body": {
+      "access_token": "ya29.test-access-token",
+      "refresh_token": "1//test-refresh-token",
+      "id_token": "test-id-token-jwt",
+      "expires_in": 3599
+    }
+  },
+  "exchangeCode_success_no_optional_fields": {
+    "status": 200,
+    "body": {
+      "access_token": "ya29.test-access-token-minimal",
+      "expires_in": 3599
+    }
+  },
+  "exchangeCode_400": {
+    "status": 400,
+    "body": "{\"error\":\"invalid_grant\",\"error_description\":\"Malformed auth code.\"}"
+  },
+  "getUserInfo_success": {
+    "status": 200,
+    "body": {
+      "sub": "1234567890",
+      "email": "user@example.com",
+      "email_verified": true,
+      "name": "Test User",
+      "picture": "https://example.com/photo.jpg"
+    }
+  },
+  "getUserInfo_401": {
+    "status": 401,
+    "body": "{\"error\":\"invalid_token\"}"
+  }
+}

--- a/admin/src/fixtures/slack-provisioning-http-cassette.json
+++ b/admin/src/fixtures/slack-provisioning-http-cassette.json
@@ -1,0 +1,70 @@
+{
+  "exchangeOAuthCode_success": {
+    "status": 200,
+    "body": { "ok": true, "access_token": "xoxb-test-bot-token" }
+  },
+  "exchangeOAuthCode_http_error": {
+    "status": 500,
+    "body": { "ok": false, "error": "internal_error" }
+  },
+  "exchangeOAuthCode_slack_error": {
+    "status": 200,
+    "body": { "ok": false, "error": "invalid_code" }
+  },
+  "exchangeOAuthCode_missing_access_token": {
+    "status": 200,
+    "body": { "ok": true }
+  },
+  "updateAppManifest_success": {
+    "status": 200,
+    "body": { "ok": true }
+  },
+  "updateAppManifest_http_error": {
+    "status": 500,
+    "body": { "ok": false, "error": "internal_error" }
+  },
+  "updateAppManifest_slack_error": {
+    "status": 200,
+    "body": { "ok": false, "error": "invalid_manifest" }
+  },
+  "createAppManifest_success": {
+    "status": 200,
+    "body": {
+      "ok": true,
+      "app_id": "A0123456789",
+      "oauth_authorize_url": "https://slack.com/oauth/authorize?client_id=123",
+      "credentials": {
+        "client_id": "123456789.987654321",
+        "client_secret": "test-client-secret",
+        "signing_secret": "test-signing-secret"
+      }
+    }
+  },
+  "createAppManifest_http_error": {
+    "status": 500,
+    "body": { "ok": false, "error": "internal_error" }
+  },
+  "createAppManifest_slack_error": {
+    "status": 200,
+    "body": { "ok": false, "error": "invalid_manifest" }
+  },
+  "createAppManifest_missing_app_id": {
+    "status": 200,
+    "body": {
+      "ok": true,
+      "credentials": {
+        "client_id": "123456789.987654321",
+        "client_secret": "test-client-secret",
+        "signing_secret": "test-signing-secret"
+      }
+    }
+  },
+  "createAppManifest_missing_credentials": {
+    "status": 200,
+    "body": {
+      "ok": true,
+      "app_id": "A0123456789",
+      "oauth_authorize_url": "https://slack.com/oauth/authorize?client_id=123"
+    }
+  }
+}

--- a/admin/src/fixtures/task-store-provisioning-cassette.json
+++ b/admin/src/fixtures/task-store-provisioning-cassette.json
@@ -1,0 +1,26 @@
+{
+  "mintToken_success": {
+    "status": 201,
+    "body": { "id": "tok_abc123", "rawToken": "sts_raw_test_token_value" }
+  },
+  "mintToken_success_with_agentId": {
+    "status": 201,
+    "body": { "id": "tok_def456", "rawToken": "sts_raw_test_token_agent_scoped" }
+  },
+  "mintToken_500": {
+    "status": 500,
+    "body": { "error": "internal server error" }
+  },
+  "revokeToken_success": {
+    "status": 204,
+    "body": {}
+  },
+  "revokeToken_404": {
+    "status": 404,
+    "body": { "error": "not found" }
+  },
+  "revokeToken_500": {
+    "status": 500,
+    "body": { "error": "internal server error" }
+  }
+}

--- a/admin/src/google-auth-client.integration.test.ts
+++ b/admin/src/google-auth-client.integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * admin/src/google-auth-client.integration.test.ts
+ * Integration tests for HttpGoogleAuthClient against recorded Google OAuth
+ * API fixtures.
+ *
+ * Drives the client through an INJECTED fetchFn that replays canned Responses
+ * from a cassette keyed by scenario — no live API server, no global.fetch
+ * override, no mock.module(). Mirrors the pattern in
+ * kubernetes-client.integration.test.ts.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { HttpGoogleAuthClient } from "./google-auth-client.ts";
+
+// ─── Cassette ───────────────────────────────────────────────────────────────
+
+interface CassetteEntry {
+  status: number;
+  body: unknown;
+}
+
+const CASSETTE_PATH = new URL(
+  "./fixtures/google-auth-cassette.json",
+  import.meta.url,
+).pathname;
+
+const cassette: Record<string, CassetteEntry> = JSON.parse(
+  readFileSync(CASSETTE_PATH, "utf-8"),
+);
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+/**
+ * Build an injected fetchFn that returns the cassette entry for `key`.
+ * Records the last request so tests can assert URL/method/headers/body.
+ */
+function cassetteFetch(key: string): {
+  fetchFn: typeof fetch;
+  lastRequest: () => RecordedRequest;
+} {
+  let last: RecordedRequest | undefined;
+  const entry = cassette[key];
+  if (!entry) throw new Error(`cassette key not found: ${key}`);
+
+  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    last = {
+      url,
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body:
+        typeof init?.body === "string"
+          ? init.body
+          : init?.body instanceof URLSearchParams
+            ? init.body.toString()
+            : undefined,
+    };
+    // A string body is replayed verbatim (e.g. a raw error payload) so the
+    // client sees genuinely non-JSON-object bytes when relevant; here all
+    // cassette bodies are either objects (JSON-encoded) or raw strings.
+    const isRaw = typeof entry.body === "string";
+    return new Response(
+      isRaw ? (entry.body as string) : JSON.stringify(entry.body),
+      {
+        status: entry.status,
+        headers: { "Content-Type": isRaw ? "text/plain" : "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  return {
+    fetchFn,
+    lastRequest: () => {
+      if (!last) throw new Error("fetchFn was not called");
+      return last;
+    },
+  };
+}
+
+function makeClient(key: string): {
+  client: HttpGoogleAuthClient;
+  lastRequest: () => RecordedRequest;
+} {
+  const { fetchFn, lastRequest } = cassetteFetch(key);
+  const client = new HttpGoogleAuthClient({ fetchFn });
+  return { client, lastRequest };
+}
+
+// ─── exchangeCode ────────────────────────────────────────────────────────────
+
+describe("HttpGoogleAuthClient — exchangeCode", () => {
+  it("POSTs form-encoded params to the Google token endpoint and maps the response", async () => {
+    const { client, lastRequest } = makeClient("exchangeCode_success");
+    const result = await client.exchangeCode({
+      code: "auth-code-123",
+      clientId: "client-id-abc",
+      clientSecret: "client-secret-xyz",
+      redirectUri: "https://example.com/callback",
+    });
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://oauth2.googleapis.com/token");
+    expect(req.headers.get("content-type")).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const params = new URLSearchParams(req.body);
+    expect(params.get("code")).toBe("auth-code-123");
+    expect(params.get("client_id")).toBe("client-id-abc");
+    expect(params.get("client_secret")).toBe("client-secret-xyz");
+    expect(params.get("redirect_uri")).toBe("https://example.com/callback");
+    expect(params.get("grant_type")).toBe("authorization_code");
+
+    expect(result).toEqual({
+      accessToken: "ya29.test-access-token",
+      refreshToken: "1//test-refresh-token",
+      idToken: "test-id-token-jwt",
+      expiresIn: 3599,
+    });
+  });
+
+  it("maps a response missing optional fields (no refresh/id token)", async () => {
+    const { client } = makeClient("exchangeCode_success_no_optional_fields");
+    const result = await client.exchangeCode({
+      code: "auth-code-123",
+      clientId: "client-id-abc",
+      clientSecret: "client-secret-xyz",
+      redirectUri: "https://example.com/callback",
+    });
+
+    expect(result.accessToken).toBe("ya29.test-access-token-minimal");
+    expect(result.refreshToken).toBeUndefined();
+    expect(result.idToken).toBeUndefined();
+    expect(result.expiresIn).toBe(3599);
+  });
+
+  it("throws on a non-ok response, including the status and body text", async () => {
+    const { client } = makeClient("exchangeCode_400");
+    await expect(
+      client.exchangeCode({
+        code: "bad-code",
+        clientId: "client-id-abc",
+        clientSecret: "client-secret-xyz",
+        redirectUri: "https://example.com/callback",
+      }),
+    ).rejects.toThrow(/Token exchange failed: 400/);
+  });
+});
+
+// ─── getUserInfo ─────────────────────────────────────────────────────────────
+
+describe("HttpGoogleAuthClient — getUserInfo", () => {
+  it("GETs the userinfo endpoint with a Bearer token and returns the profile", async () => {
+    const { client, lastRequest } = makeClient("getUserInfo_success");
+    const result = await client.getUserInfo("test-access-token");
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.url).toBe("https://www.googleapis.com/oauth2/v3/userinfo");
+    expect(req.headers.get("authorization")).toBe("Bearer test-access-token");
+
+    expect(result).toEqual({
+      sub: "1234567890",
+      email: "user@example.com",
+      email_verified: true,
+      name: "Test User",
+      picture: "https://example.com/photo.jpg",
+    });
+  });
+
+  it("throws on a non-ok response", async () => {
+    const { client } = makeClient("getUserInfo_401");
+    await expect(client.getUserInfo("bad-token")).rejects.toThrow(
+      /Userinfo fetch failed: 401/,
+    );
+  });
+});
+
+// ─── Default construction (no opts) ─────────────────────────────────────────
+
+describe("HttpGoogleAuthClient — default construction", () => {
+  it("can be constructed with no arguments (defaults fetchFn to global fetch)", () => {
+    expect(() => new HttpGoogleAuthClient()).not.toThrow();
+  });
+
+  it("can be constructed with empty opts", () => {
+    expect(() => new HttpGoogleAuthClient({})).not.toThrow();
+  });
+});

--- a/admin/src/google-auth-client.ts
+++ b/admin/src/google-auth-client.ts
@@ -56,13 +56,19 @@ class GoogleAuthClientError extends Error {
 // ─── HTTP implementation ────────────────────────────────────────────────────
 
 export class HttpGoogleAuthClient implements GoogleAuthClient {
+  private readonly fetchFn: typeof fetch;
+
+  constructor(opts?: { fetchFn?: typeof fetch }) {
+    this.fetchFn = opts?.fetchFn ?? fetch;
+  }
+
   async exchangeCode(params: {
     code: string;
     clientId: string;
     clientSecret: string;
     redirectUri: string;
   }): Promise<GoogleTokenResponse> {
-    const res = await fetch(GOOGLE_TOKEN_URL, {
+    const res = await this.fetchFn(GOOGLE_TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -98,7 +104,7 @@ export class HttpGoogleAuthClient implements GoogleAuthClient {
   }
 
   async getUserInfo(accessToken: string): Promise<GoogleUserInfo> {
-    const res = await fetch(GOOGLE_USERINFO_URL, {
+    const res = await this.fetchFn(GOOGLE_USERINFO_URL, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 

--- a/admin/src/slack-provisioning-client.integration.test.ts
+++ b/admin/src/slack-provisioning-client.integration.test.ts
@@ -1,0 +1,238 @@
+/**
+ * admin/src/slack-provisioning-client.integration.test.ts
+ * Integration tests for HttpSlackProvisioningClient against recorded Slack
+ * API fixtures.
+ *
+ * Drives the client through an INJECTED fetchFn that replays canned Responses
+ * from a cassette keyed by scenario — no live API server, no global.fetch
+ * override, no mock.module(). Mirrors the pattern in
+ * kubernetes-client.integration.test.ts.
+ *
+ * Distinct from slack-provisioning.integration.test.ts, which tests the
+ * admin-ui route flow via a hand-written RecordedSlackClient double and does
+ * not exercise HttpSlackProvisioningClient's actual HTTP/fetch logic.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { HttpSlackProvisioningClient } from "./slack-provisioning-client.ts";
+import type { AppManifest } from "./slack-provisioning-client.ts";
+
+// ─── Cassette ───────────────────────────────────────────────────────────────
+
+interface CassetteEntry {
+  status: number;
+  body: unknown;
+}
+
+const CASSETTE_PATH = new URL(
+  "./fixtures/slack-provisioning-http-cassette.json",
+  import.meta.url,
+).pathname;
+
+const cassette: Record<string, CassetteEntry> = JSON.parse(
+  readFileSync(CASSETTE_PATH, "utf-8"),
+);
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+/**
+ * Build an injected fetchFn that returns the cassette entry for `key`.
+ * Records the last request so tests can assert URL/method/headers/body.
+ */
+function cassetteFetch(key: string): {
+  fetchFn: typeof fetch;
+  lastRequest: () => RecordedRequest;
+} {
+  let last: RecordedRequest | undefined;
+  const entry = cassette[key];
+  if (!entry) throw new Error(`cassette key not found: ${key}`);
+
+  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    last = {
+      url,
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    };
+    return new Response(JSON.stringify(entry.body), {
+      status: entry.status,
+      statusText: `status-${entry.status}`,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  return {
+    fetchFn,
+    lastRequest: () => {
+      if (!last) throw new Error("fetchFn was not called");
+      return last;
+    },
+  };
+}
+
+function makeClient(key: string): {
+  client: HttpSlackProvisioningClient;
+  lastRequest: () => RecordedRequest;
+} {
+  const { fetchFn, lastRequest } = cassetteFetch(key);
+  const client = new HttpSlackProvisioningClient({ fetchFn });
+  return { client, lastRequest };
+}
+
+const MANIFEST: AppManifest = {
+  display_information: { name: "test-agent" },
+};
+
+// ─── exchangeOAuthCode ───────────────────────────────────────────────────────
+
+describe("HttpSlackProvisioningClient — exchangeOAuthCode", () => {
+  it("POSTs Basic-auth form-encoded params to oauth.v2.access and returns the bot token", async () => {
+    const { client, lastRequest } = makeClient("exchangeOAuthCode_success");
+    const result = await client.exchangeOAuthCode(
+      "auth-code",
+      "client-id",
+      "client-secret",
+      "https://example.com/callback",
+    );
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://slack.com/api/oauth.v2.access");
+    const expectedAuth = `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`;
+    expect(req.headers.get("authorization")).toBe(expectedAuth);
+    expect(req.headers.get("content-type")).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const params = new URLSearchParams(req.body);
+    expect(params.get("code")).toBe("auth-code");
+    expect(params.get("redirect_uri")).toBe("https://example.com/callback");
+
+    expect(result).toEqual({ botToken: "xoxb-test-bot-token" });
+  });
+
+  it("throws on an HTTP error response", async () => {
+    const { client } = makeClient("exchangeOAuthCode_http_error");
+    await expect(
+      client.exchangeOAuthCode("code", "id", "secret", "https://x.com"),
+    ).rejects.toThrow(/Slack oauth\.v2\.access HTTP error: 500/);
+  });
+
+  it("throws when Slack returns ok: false", async () => {
+    const { client } = makeClient("exchangeOAuthCode_slack_error");
+    await expect(
+      client.exchangeOAuthCode("code", "id", "secret", "https://x.com"),
+    ).rejects.toThrow(/Slack oauth\.v2\.access failed: invalid_code/);
+  });
+
+  it("throws when access_token is missing from an ok response", async () => {
+    const { client } = makeClient("exchangeOAuthCode_missing_access_token");
+    await expect(
+      client.exchangeOAuthCode("code", "id", "secret", "https://x.com"),
+    ).rejects.toThrow(/response missing access_token/);
+  });
+});
+
+// ─── updateAppManifest ───────────────────────────────────────────────────────
+
+describe("HttpSlackProvisioningClient — updateAppManifest", () => {
+  it("POSTs Bearer-auth JSON to apps.manifest.update", async () => {
+    const { client, lastRequest } = makeClient("updateAppManifest_success");
+    await client.updateAppManifest("xoxp-token", "A0123456789", MANIFEST);
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://slack.com/api/apps.manifest.update");
+    expect(req.headers.get("authorization")).toBe("Bearer xoxp-token");
+    expect(req.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    const body = JSON.parse(req.body ?? "{}");
+    expect(body.app_id).toBe("A0123456789");
+    expect(JSON.parse(body.manifest)).toEqual(MANIFEST);
+  });
+
+  it("throws on an HTTP error response", async () => {
+    const { client } = makeClient("updateAppManifest_http_error");
+    await expect(
+      client.updateAppManifest("xoxp-token", "A0123456789", MANIFEST),
+    ).rejects.toThrow(/Slack apps\.manifest\.update HTTP error: 500/);
+  });
+
+  it("throws when Slack returns ok: false", async () => {
+    const { client } = makeClient("updateAppManifest_slack_error");
+    await expect(
+      client.updateAppManifest("xoxp-token", "A0123456789", MANIFEST),
+    ).rejects.toThrow(/Slack apps\.manifest\.update failed: invalid_manifest/);
+  });
+});
+
+// ─── createAppManifest ───────────────────────────────────────────────────────
+
+describe("HttpSlackProvisioningClient — createAppManifest", () => {
+  it("POSTs Bearer-auth JSON to apps.manifest.create and returns credentials", async () => {
+    const { client, lastRequest } = makeClient("createAppManifest_success");
+    const result = await client.createAppManifest("xoxp-token", MANIFEST);
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://slack.com/api/apps.manifest.create");
+    expect(req.headers.get("authorization")).toBe("Bearer xoxp-token");
+    const body = JSON.parse(req.body ?? "{}");
+    expect(JSON.parse(body.manifest)).toEqual(MANIFEST);
+
+    expect(result).toEqual({
+      appId: "A0123456789",
+      oauthRedirectUrl: "https://slack.com/oauth/authorize?client_id=123",
+      clientId: "123456789.987654321",
+      clientSecret: "test-client-secret",
+      signingSecret: "test-signing-secret",
+    });
+  });
+
+  it("throws on an HTTP error response", async () => {
+    const { client } = makeClient("createAppManifest_http_error");
+    await expect(
+      client.createAppManifest("xoxp-token", MANIFEST),
+    ).rejects.toThrow(/Slack apps\.manifest\.create HTTP error: 500/);
+  });
+
+  it("throws when Slack returns ok: false", async () => {
+    const { client } = makeClient("createAppManifest_slack_error");
+    await expect(
+      client.createAppManifest("xoxp-token", MANIFEST),
+    ).rejects.toThrow(/Slack apps\.manifest\.create failed: invalid_manifest/);
+  });
+
+  it("throws when app_id or oauth_authorize_url is missing", async () => {
+    const { client } = makeClient("createAppManifest_missing_app_id");
+    await expect(
+      client.createAppManifest("xoxp-token", MANIFEST),
+    ).rejects.toThrow(/response missing app_id or oauth_authorize_url/);
+  });
+
+  it("throws when credentials are missing", async () => {
+    const { client } = makeClient("createAppManifest_missing_credentials");
+    await expect(
+      client.createAppManifest("xoxp-token", MANIFEST),
+    ).rejects.toThrow(/response missing credentials/);
+  });
+});
+
+// ─── Default construction (no opts) ─────────────────────────────────────────
+
+describe("HttpSlackProvisioningClient — default construction", () => {
+  it("can be constructed with no arguments (defaults apiBase and fetchFn)", () => {
+    expect(() => new HttpSlackProvisioningClient()).not.toThrow();
+  });
+
+  it("can be constructed with empty opts", () => {
+    expect(() => new HttpSlackProvisioningClient({})).not.toThrow();
+  });
+});

--- a/admin/src/slack-provisioning-client.ts
+++ b/admin/src/slack-provisioning-client.ts
@@ -189,9 +189,11 @@ export function buildAgentManifest(
  */
 export class HttpSlackProvisioningClient implements SlackProvisioningClient {
   private readonly apiBase: string;
+  private readonly fetchFn: typeof fetch;
 
-  constructor(opts?: { apiBase?: string }) {
+  constructor(opts?: { apiBase?: string; fetchFn?: typeof fetch }) {
     this.apiBase = opts?.apiBase ?? "https://slack.com/api";
+    this.fetchFn = opts?.fetchFn ?? fetch;
   }
 
   async exchangeOAuthCode(
@@ -209,7 +211,7 @@ export class HttpSlackProvisioningClient implements SlackProvisioningClient {
     const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
       "base64",
     );
-    const resp = await fetch(url, {
+    const resp = await this.fetchFn(url, {
       method: "POST",
       headers: {
         Authorization: `Basic ${credentials}`,
@@ -247,7 +249,7 @@ export class HttpSlackProvisioningClient implements SlackProvisioningClient {
     manifest: AppManifest,
   ): Promise<void> {
     const url = `${this.apiBase}/apps.manifest.update`;
-    const resp = await fetch(url, {
+    const resp = await this.fetchFn(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${xoxpToken}`,
@@ -283,7 +285,7 @@ export class HttpSlackProvisioningClient implements SlackProvisioningClient {
     signingSecret: string;
   }> {
     const url = `${this.apiBase}/apps.manifest.create`;
-    const resp = await fetch(url, {
+    const resp = await this.fetchFn(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${xoxpToken}`,

--- a/admin/src/task-store-provisioning-client.integration.test.ts
+++ b/admin/src/task-store-provisioning-client.integration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * admin/src/task-store-provisioning-client.integration.test.ts
+ * Integration tests for HttpTaskStoreProvisioningClient against recorded
+ * task-store token API fixtures.
+ *
+ * Drives the client through an INJECTED fetchFn that replays canned Responses
+ * from a cassette keyed by scenario — no live API server, no global.fetch
+ * override, no mock.module(). Mirrors the pattern in
+ * kubernetes-client.integration.test.ts.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  HttpTaskStoreProvisioningClient,
+  NoopTaskStoreProvisioningClient,
+} from "./task-store-provisioning-client.ts";
+
+// ─── Cassette ───────────────────────────────────────────────────────────────
+
+interface CassetteEntry {
+  status: number;
+  body: unknown;
+}
+
+const CASSETTE_PATH = new URL(
+  "./fixtures/task-store-provisioning-cassette.json",
+  import.meta.url,
+).pathname;
+
+const cassette: Record<string, CassetteEntry> = JSON.parse(
+  readFileSync(CASSETTE_PATH, "utf-8"),
+);
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+/**
+ * Build an injected fetchFn that returns the cassette entry for `key`.
+ * Records the last request so tests can assert URL/method/headers/body.
+ */
+function cassetteFetch(key: string): {
+  fetchFn: typeof fetch;
+  lastRequest: () => RecordedRequest;
+} {
+  let last: RecordedRequest | undefined;
+  const entry = cassette[key];
+  if (!entry) throw new Error(`cassette key not found: ${key}`);
+
+  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    last = {
+      url,
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    };
+    return new Response(JSON.stringify(entry.body), {
+      status: entry.status,
+      statusText: `status-${entry.status}`,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  return {
+    fetchFn,
+    lastRequest: () => {
+      if (!last) throw new Error("fetchFn was not called");
+      return last;
+    },
+  };
+}
+
+function makeClient(key: string): {
+  client: HttpTaskStoreProvisioningClient;
+  lastRequest: () => RecordedRequest;
+} {
+  const { fetchFn, lastRequest } = cassetteFetch(key);
+  const client = new HttpTaskStoreProvisioningClient(
+    "https://task-store.example.com",
+    "admin-token-xyz",
+    { fetchFn },
+  );
+  return { client, lastRequest };
+}
+
+// ─── mintToken ───────────────────────────────────────────────────────────────
+
+describe("HttpTaskStoreProvisioningClient — mintToken", () => {
+  it("POSTs to /tokens with Bearer auth and returns id/rawToken", async () => {
+    const { client, lastRequest } = makeClient("mintToken_success");
+    const result = await client.mintToken("agent-abc label");
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://task-store.example.com/tokens");
+    expect(req.headers.get("authorization")).toBe("Bearer admin-token-xyz");
+    expect(req.headers.get("content-type")).toBe("application/json");
+    expect(JSON.parse(req.body ?? "{}")).toEqual({ label: "agent-abc label" });
+    expect(result).toEqual({
+      id: "tok_abc123",
+      rawToken: "sts_raw_test_token_value",
+    });
+  });
+
+  it("includes agentId in the body when provided", async () => {
+    const { client, lastRequest } = makeClient(
+      "mintToken_success_with_agentId",
+    );
+    const result = await client.mintToken("agent-scoped label", "agent-123");
+
+    const req = lastRequest();
+    expect(JSON.parse(req.body ?? "{}")).toEqual({
+      label: "agent-scoped label",
+      agentId: "agent-123",
+    });
+    expect(result.id).toBe("tok_def456");
+  });
+
+  it("throws on a non-ok response", async () => {
+    const { client } = makeClient("mintToken_500");
+    await expect(client.mintToken("label")).rejects.toThrow(
+      /task-store POST \/tokens failed: 500/,
+    );
+  });
+});
+
+// ─── revokeToken ─────────────────────────────────────────────────────────────
+
+describe("HttpTaskStoreProvisioningClient — revokeToken", () => {
+  it("DELETEs /tokens/:id with Bearer auth", async () => {
+    const { client, lastRequest } = makeClient("revokeToken_success");
+    await client.revokeToken("tok_abc123");
+
+    const req = lastRequest();
+    expect(req.method).toBe("DELETE");
+    expect(req.url).toBe("https://task-store.example.com/tokens/tok_abc123");
+    expect(req.headers.get("authorization")).toBe("Bearer admin-token-xyz");
+  });
+
+  it("treats 404 as success (already revoked / not found is not an error)", async () => {
+    const { client } = makeClient("revokeToken_404");
+    await expect(client.revokeToken("tok_missing")).resolves.toBeUndefined();
+  });
+
+  it("throws on a non-ok, non-404 response", async () => {
+    const { client } = makeClient("revokeToken_500");
+    await expect(client.revokeToken("tok_abc123")).rejects.toThrow(
+      /task-store DELETE \/tokens\/tok_abc123 failed: 500/,
+    );
+  });
+});
+
+// ─── NoopTaskStoreProvisioningClient ─────────────────────────────────────────
+
+describe("NoopTaskStoreProvisioningClient", () => {
+  it("mintToken returns empty id/rawToken", async () => {
+    const client = new NoopTaskStoreProvisioningClient();
+    const result = await client.mintToken("label");
+    expect(result).toEqual({ id: "", rawToken: "" });
+  });
+
+  it("mintToken accepts an agentId without erroring", async () => {
+    const client = new NoopTaskStoreProvisioningClient();
+    const result = await client.mintToken("label", "agent-1");
+    expect(result).toEqual({ id: "", rawToken: "" });
+  });
+
+  it("revokeToken resolves without error", async () => {
+    const client = new NoopTaskStoreProvisioningClient();
+    await expect(client.revokeToken("any-id")).resolves.toBeUndefined();
+  });
+});

--- a/admin/src/task-store-provisioning-client.ts
+++ b/admin/src/task-store-provisioning-client.ts
@@ -47,16 +47,21 @@ export interface TaskStoreProvisioningClient {
 export class HttpTaskStoreProvisioningClient
   implements TaskStoreProvisioningClient
 {
+  private readonly fetchFn: typeof fetch;
+
   constructor(
     private readonly baseUrl: string,
     private readonly adminToken: string,
-  ) {}
+    opts?: { fetchFn?: typeof fetch },
+  ) {
+    this.fetchFn = opts?.fetchFn ?? fetch;
+  }
 
   async mintToken(
     label: string,
     agentId?: string,
   ): Promise<{ id: string; rawToken: string }> {
-    const res = await fetch(`${this.baseUrl}/tokens`, {
+    const res = await this.fetchFn(`${this.baseUrl}/tokens`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -74,7 +79,7 @@ export class HttpTaskStoreProvisioningClient
   }
 
   async revokeToken(id: string): Promise<void> {
-    const res = await fetch(`${this.baseUrl}/tokens/${id}`, {
+    const res = await this.fetchFn(`${this.baseUrl}/tokens/${id}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${this.adminToken}`,


### PR DESCRIPTION
## Summary
- Add an injectable `fetchFn` constructor seam (defaulting to global `fetch`) to `HttpGoogleAuthClient`, `HttpTaskStoreProvisioningClient`, and `HttpSlackProvisioningClient` — additive, backward-compatible, no existing call sites or method signatures changed.
- Add `*.integration.test.ts` files for each client, following the recorded-fixture/cassette pattern established in `kubernetes-client.integration.test.ts` (no `mock.module()`, no `global.fetch` overrides), with cassette fixtures under `admin/src/fixtures/`.
- Cover success paths, non-ok HTTP responses, `{ok:false, error}`-shaped Slack failures, missing-required-field guards, and the 404-is-not-an-error case for `revokeToken`.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | google-auth-client.ts ≥80% functions/lines | MET | 100% / 100% |
| 2 | task-store-provisioning-client.ts ≥80% functions/lines | MET | 87.5% / 100% |
| 3 | slack-provisioning-client.ts ≥80% functions/lines | MET | 100% / 100% |
| 4 | Test decision: *.integration.test.ts per client, recorded-fixture doubles, no existing tests removed | MET | 3 new integration test files + fixtures added; existing `slack-provisioning.integration.test.ts` untouched |

## Test Plan
- `bun test admin` — 1009 pass (30 new), 1 pre-existing environment-specific failure unrelated to this change (`kubernetes-client.integration.test.ts` CA fallback test, fails identically on `main` in this sandbox).
- `bun test --coverage` (admin) confirms all three target files clear 80%/80%.
- `bunx tsc --noEmit` — clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
