### PR TITLE
fix: route agent repo clones and worktrees to the PVC

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -27,6 +27,15 @@ export const AGENT_HEALTH_PORT = 3459;
 /** Where the agent's persistent home volume is mounted in the container. */
 export const AGENT_HOME_MOUNT_PATH = "/data/agent-home";
 
+/**
+ * Repo clones and git worktrees must live on the PVC. The plugin commands
+ * default to `$HOME/src` / `$HOME/worktrees`, which sit on the container's
+ * ephemeral overlay layer — a single worktree with node_modules can exceed
+ * the pod's ephemeral-storage limit and get the pod evicted.
+ */
+export const AGENT_REPO_DIR = `${AGENT_HOME_MOUNT_PATH}/workspace/repos`;
+export const AGENT_WORKTREE_DIR = `${AGENT_HOME_MOUNT_PATH}/workspace/worktrees`;
+
 /** Non-root uid/gid the agent runs as (matches the agent image). */
 const AGENT_RUN_AS = 1000;
 
@@ -154,7 +163,7 @@ export interface AgentDeploymentOpts {
   /**
    * When set, inject SHIPWRIGHT_TASK_STORE_TOKEN (via secretKeyRef from the
    * agent Secret) and SHIPWRIGHT_TASK_STORE_URL (as a plain value) into the
-   * agent Deployment. Placed after AGENT_HOME and before voice env vars.
+   * agent Deployment. Placed after the base vars and before voice env vars.
    */
   taskStoreUrl?: string;
   /**
@@ -334,14 +343,17 @@ export function buildAgentDeploymentManifest(
                 },
                 // Tell the agent where its persistent home directory is mounted.
                 { name: "AGENT_HOME", value: AGENT_HOME_MOUNT_PATH },
-                // Task-store env — injected after AGENT_HOME when task-store is
-                // configured; omitted entirely when taskStoreUrl is absent.
+                // Route repo clones and worktrees to the PVC (see constants).
+                { name: "SHIPWRIGHT_REPO_DIR", value: AGENT_REPO_DIR },
+                { name: "SHIPWRIGHT_WORKTREE_DIR", value: AGENT_WORKTREE_DIR },
+                // Task-store env — injected after the base vars when task-store
+                // is configured; omitted entirely when taskStoreUrl is absent.
                 ...taskStoreEnvEntries(opts),
                 // Chat-service env — injected after task-store vars when chat
                 // service is configured; omitted entirely when chatServiceUrl is absent.
                 ...chatServiceEnvEntries(opts),
                 // Voice (STT/TTS) env — appended only for the keys that are set
-                // (none when voice is disabled, preserving the 4 base vars).
+                // (none when voice is disabled, preserving the 6 base vars).
                 ...voiceEnvEntries(opts.voice),
               ],
               volumeMounts: [

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -134,6 +134,18 @@ describe("buildAgentDeploymentManifest", () => {
     expect(agentHome?.value).toBe(AGENT_HOME_MOUNT_PATH);
   });
 
+  it("routes repo clones and worktrees to the PVC, not ephemeral $HOME", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const env = d.spec.template.spec.containers[0].env ?? [];
+    const byName = new Map(env.map((e) => [e.name, e]));
+    expect(byName.get("SHIPWRIGHT_REPO_DIR")?.value).toBe(
+      `${AGENT_HOME_MOUNT_PATH}/workspace/repos`,
+    );
+    expect(byName.get("SHIPWRIGHT_WORKTREE_DIR")?.value).toBe(
+      `${AGENT_HOME_MOUNT_PATH}/workspace/worktrees`,
+    );
+  });
+
   it("defines liveness and readiness probes on the health port", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
     const c = d.spec.template.spec.containers[0];
@@ -188,13 +200,15 @@ describe("buildAgentDeploymentManifest — voice env", () => {
   const envNames = (d: ReturnType<typeof buildAgentDeploymentManifest>) =>
     (d.spec.template.spec.containers[0].env ?? []).map((e) => e.name);
 
-  it("injects only the 4 base vars when no voice config is supplied (disabled)", () => {
+  it("injects only the 6 base vars when no voice config is supplied (disabled)", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
     expect(envNames(d)).toEqual([
       "SHIPWRIGHT_AGENT_ID",
       "SHIPWRIGHT_API_URL",
       "SHIPWRIGHT_AGENT_API_KEY",
       "AGENT_HOME",
+      "SHIPWRIGHT_REPO_DIR",
+      "SHIPWRIGHT_WORKTREE_DIR",
     ]);
   });
 
@@ -246,17 +260,19 @@ describe("buildAgentDeploymentManifest — voice env", () => {
     expect(byName.get("ELEVENLABS_VOICE_ID")?.value).toBe("voice-xyz");
   });
 
-  it("keeps the base 4 vars first and appends voice vars after AGENT_HOME", () => {
+  it("keeps the base 6 vars first and appends voice vars after them", () => {
     const d = buildAgentDeploymentManifest({
       ...deployOpts,
       voice: { whisperServiceUrl: "http://w:9000", elevenLabsApiKey: "k" },
     });
     const names = envNames(d);
-    expect(names.slice(0, 4)).toEqual([
+    expect(names.slice(0, 6)).toEqual([
       "SHIPWRIGHT_AGENT_ID",
       "SHIPWRIGHT_API_URL",
       "SHIPWRIGHT_AGENT_API_KEY",
       "AGENT_HOME",
+      "SHIPWRIGHT_REPO_DIR",
+      "SHIPWRIGHT_WORKTREE_DIR",
     ]);
     expect(names).toContain("WHISPER_SERVICE_URL");
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,9 @@ Configuration for the Shipwright Claude Code plugin (`plugins/shipwright/`). The
 
 | Name | Type | Default | Description |
 |---|---|---|---|
-| `SHIPWRIGHT_REPOS_DIR` | `string` | `<AGENT_HOME>/workspace/repos` | Override the workspace repos directory. Used by scripts that need to know where checked-out repos live. |
-| `SHIPWRIGHT_WORKTREE_DIR` | `string` | `<AGENT_HOME>/workspace/worktrees` | Override the workspace worktrees directory. |
+| `SHIPWRIGHT_REPOS_DIR` | `string` | `<workspace>/repos` | Fallback repos directory for plugin scripts when workspace discovery finds no `repos/` dir. |
+| `SHIPWRIGHT_REPO_DIR` | `string` | `$HOME/src` | Where the plugin commands (`dev-task`, `patch`, `deploy`) look for repo clones. The provisioner injects `<AGENT_HOME>/workspace/repos` for managed agents so clones live on the PVC. |
+| `SHIPWRIGHT_WORKTREE_DIR` | `string` | `$HOME/worktrees` | Where the plugin commands create git worktrees. The provisioner injects `<AGENT_HOME>/workspace/worktrees` for managed agents — `$HOME` is ephemeral overlay storage in the agent container, and worktrees there can trigger pod eviction. |
 | `GH_CMD` | `string` | `gh` | Override the `gh` CLI executable. Useful in environments where `gh` is installed to a non-default path. |
 | `AGENT_HOME` | `string` | `/data/agent-home` | Persistent storage root for workspace files, mise caches, and `~/.claude`. Set in the agent container; also used by plugin scripts for workspace discovery. |
 | `WORKSPACE_PATH` | `string` | — | Direct workspace path override. Takes precedence over `AGENT_HOME`-based discovery when set. |


### PR DESCRIPTION
## Summary
Agent pods were being evicted for exceeding their 1Gi ephemeral-storage limit — the plugin commands default worktrees to `$HOME/worktrees`, which sits on the container's ephemeral overlay, and a single worktree with node_modules (~471M observed) blows the limit.

- Provisioner now injects `SHIPWRIGHT_REPO_DIR=/data/agent-home/workspace/repos` and `SHIPWRIGHT_WORKTREE_DIR=/data/agent-home/workspace/worktrees` into every agent Deployment, routing clones/worktrees to the 40G PVC that `ensureAgentHome()` already prepares
- Unit tests updated (base env list 4 → 6) plus a new value assertion
- `docs/configuration.md` corrected: it claimed a `<AGENT_HOME>/workspace/worktrees` default that nothing actually set; also documents the previously missing `SHIPWRIGHT_REPO_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTU2q9nKhhShTdECQfCikm