### PR TITLE
docs: add lib workspace to architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,10 +94,11 @@ Postgres-backed service for web chat conversations (`chat/`). Owns three Prisma 
 
 ## Workspace layout
 
-The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the single local entrypoint. Seven workspaces — `plugins/shipwright`, `metrics`, `agent`, `admin`, `task-store`, `chat`, `mcp-server` — are wired into the root `package.json`. The `site/` is intentionally excluded from the root `bun test` scan (its Playwright `*.spec.ts` files would crash Bun's runner).
+The repo is a Bun-workspaces monorepo with **go-task** (`Taskfile.yml`) as the single local entrypoint. Eight workspaces — `lib`, `plugins/shipwright`, `metrics`, `agent`, `admin`, `task-store`, `chat`, `mcp-server` — are wired into the root `package.json`. The `site/` is intentionally excluded from the root `bun test` scan (its Playwright `*.spec.ts` files would crash Bun's runner).
 
 ```
 shipwright/
+├── lib/                  shared utilities: admin-types, org-repo, pricing, sentry, web helpers (@shipwright/lib)
 ├── plugins/shipwright/   A — the plugin (commands, skills, agents, scripts)
 ├── metrics/              B — provider-agnostic Hono service (fixtures / taskstore)
 ├── agent/                C — Shipwright agent runtime (entrypoint, cron, Slack, GitHub auth)


### PR DESCRIPTION
## Summary
- `lib/` is a real Bun workspace (`@shipwright/lib`: admin-types, org-repo, pricing, sentry, web helpers) that was omitted from `docs/architecture.md`'s workspace list and count.
- Adds a one-line mention of `lib` to the workspace layout list/tree and corrects "Seven workspaces" to "Eight workspaces".

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `docs/architecture.md` workspace list includes a `lib` entry describing `@shipwright/lib` as a shared-utility workspace | MET |
| 2 | Workspace count/prose corrected to include `lib` ("Seven" → "Eight") | MET |
| 3 | No dedicated `docs/lib.md` added — mention-only scope | MET |
| 4 | Test decision: no test-layer changes — docs-only edit | MET |

## Test Plan
- Docs-only change; no test-layer changes required per scope.
- [x] `task ci` run locally — same 15 pre-existing test failures present on `main` (unrelated to this change, verified by running `bun test` on `main` directly); lint, check-strings, typecheck, check-config-docs, and check-version-sync all pass.

Generated with [Claude Code](https://claude.com/claude-code)
