### PR TITLE
fix: filter GET /mcp/tools through the tool allowlist

### DIFF
--- a/mcp-server/src/index.smoke.test.ts
+++ b/mcp-server/src/index.smoke.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "bun:test";
 import { app } from "./index.js";
+import { EXCLUDED_TOOLS } from "./tool-allowlist.js";
+
+const ALLOWED_TOOL_NAMES = [
+  "tasks_list",
+  "tasks_create",
+  "tasks_bulk",
+  "tasks_distinct",
+  "tasks_get",
+  "tasks_update",
+  "prs_list",
+  "prs_get",
+  "prs_update",
+] as const;
 
 describe("mcp-server", () => {
   it("exports an app", () => {
@@ -10,5 +23,26 @@ describe("mcp-server", () => {
   it("responds to a health check", async () => {
     const res = await app.request("/health");
     expect(res.status).toBe(200);
+  });
+
+  it("GET /mcp/tools returns only the 9 allowed tools", async () => {
+    const res = await app.request("/mcp/tools");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { tools: Array<{ name: string; description: string }> };
+    const toolNames = body.tools.map((t) => t.name);
+
+    // Verify we have exactly 9 tools
+    expect(toolNames).toHaveLength(9);
+
+    // Verify all allowed tools are present
+    for (const name of ALLOWED_TOOL_NAMES) {
+      expect(toolNames).toContain(name);
+    }
+
+    // Verify no excluded tools are present
+    for (const excluded of EXCLUDED_TOOLS) {
+      expect(toolNames).not.toContain(excluded);
+    }
   });
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { generatedTools } from "./generated-tools.ts";
+import { allowedTools } from "./tool-allowlist.ts";
 import { createMcpServer } from "./mcp-server.ts";
 
 export const app = new Hono();
@@ -12,8 +13,9 @@ app.get("/health", (c) => {
 // The MCP protocol itself is served over a transport (stdio / Streamable HTTP /
 // in-memory) via `createMcpServer()`; this endpoint is a convenience for humans.
 app.get("/mcp/tools", (c) => {
+  const tools = allowedTools(generatedTools);
   return c.json({
-    tools: generatedTools.map((t) => ({
+    tools: tools.map((t) => ({
       name: t.name,
       description: t.description,
     })),


### PR DESCRIPTION
## Summary
- `GET /mcp/tools` in `mcp-server/src/index.ts` now filters through `allowedTools()` (the same filter `mcp-server.ts` already uses for the stdio/Streamable HTTP MCP surface) instead of mapping over the raw 25-tool `generatedTools` array.
- The HTTP discovery endpoint now matches the actual MCP protocol surface: 9 tools (`tasks_list`, `tasks_create`, `tasks_bulk`, `tasks_distinct`, `tasks_get`, `tasks_update`, `prs_list`, `prs_get`, `prs_update`) instead of leaking pipeline-internal lifecycle ops, `tasks_delete`, and all `tokens_*` routes.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /mcp/tools filters through allowedTools() instead of the raw generatedTools array | MET | `mcp-server/src/index.ts`: `const tools = allowedTools(generatedTools);` |
| 2 | Response only lists the 9 allowed tools | MET | New smoke test asserts `toHaveLength(9)` and all 9 expected names present |
| 3 | Test asserting the endpoint returns exactly the allowlisted set and excludes at least one lifecycle/token/destructive op | MET | `mcp-server/src/index.smoke.test.ts` asserts every `EXCLUDED_TOOLS` entry is absent from the response |

## Test Plan
- `bun test mcp-server/src/index.smoke.test.ts` — 3/3 pass (new test written RED-first, confirmed failing against the unfixed handler before the fix)
- `task lint`, `task typecheck`, `task check-config-docs`, `task check-version-sync`, `task check-strings` — all pass
- `task test` (full suite) — 15 pre-existing failures unrelated to this change (metrics integration tests hitting live endpoints, reproduced identically on `main`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
