### PR TITLE
docs: generate mcp-server tool reference from OpenAPI schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/agent.md** — Shipwright agent (C): runtime + admin CRUD APIs, the ten-model Prisma store, and encryption/env notes
 - **docs/agent-api.md** — the admin CRUD API (D): agents, envs, crons, cron runs, tools, tokens, plugins, and chat-token-usage endpoints, plus auth paths
 - **docs/task-store.md** — task store service (D): the sole HTTP-service backend — tasks, PR tracking, tokens, ephemeral docs — and troubleshooting
+- **docs/mcp-tools.md** — generated MCP server tool reference (name, description, HTTP method/path, parameters, body) derived from task-store/openapi.json + the tool allowlist; regenerate with `bun run generate:mcp-docs`
 - **docs/chat.md** — chat service (D): auth model (admin vs. agent tokens, scope resolver), thread/message/token endpoints (incl. attachment streaming and the claim/reply queue), data model, and environment
 - **docs/deploy-kubernetes.md** — Kubernetes deployment guide: Minikube / GKE (Gateway API + cert-manager) / EKS (ALB), the agent runtime-provisioning RBAC model, and auth modes
 - **docs/helm-repo.md** — installing the published `shipwright` Helm chart, how chart publishing and version bumps are automated

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,9 @@ A small in-memory HTML store for short-lived, regenerable artifacts (one-pagers,
 
 ## MCP Server
 
-A Model Context Protocol (MCP) server that exposes a curated subset of the task-store HTTP API as discoverable MCP tools (`@shipwright/mcp-server`). Tools are generated automatically from the task-store OpenAPI specification — the `generate-mcp-tools` script (`scripts/generate-mcp-tools.ts`) reads `task-store/openapi.json` and emits tool definitions (name, description, JSON-Schema) plus routing metadata (HTTP method, path template, query/path parameters). The allowlist (`mcp-server/src/tool-allowlist.ts`) then filters the generated set down to the agreed public surface: read operations (`tasks_list`, `tasks_get`, `prs_list`, `prs_get`), ordinary field edits (`tasks_create`, `tasks_update`, `prs_update`), and bulk reads (`tasks_bulk`, `tasks_distinct`). Pipeline-internal lifecycle ops (claim, heartbeat, complete, fail, release), destructive ops (delete), and all token-management routes are excluded.
+A Model Context Protocol (MCP) server that exposes a curated subset of the task-store HTTP API as discoverable MCP tools (`@shipwright/mcp-server`). Tools are generated automatically from the task-store OpenAPI specification — the `generate-mcp-tools` script (`scripts/generate-mcp-tools.ts`) reads `task-store/openapi.json` and emits tool definitions (name, description, JSON-Schema) plus routing metadata (HTTP method, path template, query/path parameters). The allowlist (`mcp-server/src/tool-allowlist.ts`) then filters the generated set down to the agreed public surface, excluding pipeline-internal lifecycle ops (claim, heartbeat, complete, fail, release), destructive ops (delete), and all token-management routes.
+
+For the current tool-by-tool reference (name, description, HTTP method, path, parameters, body) — kept in sync automatically as tools are added or removed — see the generated **[mcp-tools.md](./mcp-tools.md)**. Regenerate it with `bun run generate:mcp-docs` after any change to the OpenAPI spec or the allowlist.
 
 **Transport:**
 
@@ -118,5 +120,6 @@ shipwright/
 - **[testing.md](./testing.md)** — the four-layer test architecture and isolation contract.
 - **[metrics.md](./metrics.md)** — metrics service API and dashboard.
 - **[agent.md](./agent.md)** — Shipwright agent runtime + admin APIs and data model.
+- **[mcp-tools.md](./mcp-tools.md)** — generated MCP server tool reference (name, method, path, params, body).
 - **[configuration.md](./configuration.md)** — all configuration options: plugin env vars, agent env vars, and policy fields.
 - `CLAUDE.md` — contributor conventions and the pre-public scrub rule.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,91 @@
+<!-- GENERATED FILE — do not edit by hand. -->
+<!-- Produced by scripts/generate-mcp-docs.ts from mcp-server/src/generated-tools.ts -->
+<!-- (itself generated from task-store/openapi.json) filtered through -->
+<!-- mcp-server/src/tool-allowlist.ts. Regenerate with: bun run generate:mcp-docs -->
+
+# MCP Server Tool Reference
+
+This is the public tool surface exposed by the MCP server (`@shipwright/mcp-server`)
+after allowlist filtering. See [architecture.md](./architecture.md#mcp-server) for
+how the server is generated, wired, and executed.
+
+## `prs_get`
+
+Fetch a single pull request
+
+- **Method:** GET
+- **Path:** `/prs/{id}`
+- **Has body:** No
+- **Parameters:** `id` (path)
+
+## `prs_list`
+
+List pull requests
+
+- **Method:** GET
+- **Path:** `/prs`
+- **Has body:** No
+- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query)
+
+## `prs_update`
+
+Update pull request fields
+
+- **Method:** PATCH
+- **Path:** `/prs/{id}`
+- **Has body:** Yes
+- **Parameters:** `id` (path)
+
+## `tasks_bulk`
+
+Bulk insert tasks
+
+- **Method:** POST
+- **Path:** `/tasks/bulk`
+- **Has body:** Yes (JSON array body via `items`)
+- **Parameters:** None
+
+## `tasks_create`
+
+Create a task
+
+- **Method:** POST
+- **Path:** `/tasks`
+- **Has body:** Yes
+- **Parameters:** None
+
+## `tasks_distinct`
+
+Get distinct session and repo values
+
+- **Method:** GET
+- **Path:** `/tasks/distinct`
+- **Has body:** No
+- **Parameters:** None
+
+## `tasks_get`
+
+Get a task by ID
+
+- **Method:** GET
+- **Path:** `/tasks/{id}`
+- **Has body:** No
+- **Parameters:** `id` (path)
+
+## `tasks_list`
+
+List tasks
+
+- **Method:** GET
+- **Path:** `/tasks`
+- **Has body:** No
+- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query)
+
+## `tasks_update`
+
+Update a task
+
+- **Method:** PATCH
+- **Path:** `/tasks/{id}`
+- **Has body:** Yes
+- **Parameters:** `id` (path)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "generate:admin-types": "bunx openapi-typescript ./admin/openapi.json --output ./lib/admin-types.ts",
     "generate:task-store-spec": "bun run scripts/generate-task-store-spec.ts",
     "generate:task-store-types": "bunx openapi-typescript ./task-store/openapi.json --output ./lib/task-store-types.ts",
-    "generate:mcp-tools": "bun run scripts/generate-mcp-tools.ts"
+    "generate:mcp-tools": "bun run scripts/generate-mcp-tools.ts",
+    "generate:mcp-docs": "bun run scripts/generate-mcp-docs.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/scripts/generate-mcp-docs.ts
+++ b/scripts/generate-mcp-docs.ts
@@ -1,0 +1,95 @@
+/**
+ * scripts/generate-mcp-docs.ts
+ * Generate human-readable MCP tool reference docs from the already-generated
+ * task-store-derived tool set (TSM-2.2) filtered through the public allowlist
+ * (TSM-2.3).
+ *
+ * Reads `mcp-server/src/generated-tools.ts`'s `generatedTools` array (itself
+ * produced by `scripts/generate-mcp-tools.ts` from `task-store/openapi.json`),
+ * filters it through `allowedTools()` from `mcp-server/src/tool-allowlist.ts`,
+ * and renders one Markdown section per public tool: name, description,
+ * HTTP method + path template, parameters, and whether it has a body.
+ *
+ * Output: `docs/mcp-tools.md` — a committed Markdown file. Regenerate with:
+ *   bun run generate:mcp-docs
+ */
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { GeneratedTool } from "../mcp-server/src/generated-tools.ts";
+import { generatedTools } from "../mcp-server/src/generated-tools.ts";
+import { allowedTools } from "../mcp-server/src/tool-allowlist.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+const outPath = join(repoRoot, "docs", "mcp-tools.md");
+
+/** Render a single tool's parameter list as an inline comma-separated string, or "None". */
+function renderParams(tool: GeneratedTool): string {
+  const params = [
+    ...tool.pathParams.map((name) => `\`${name}\` (path)`),
+    ...tool.queryParams.map((name) => `\`${name}\` (query)`),
+  ];
+  if (params.length === 0) return "None";
+  return params.join(", ");
+}
+
+/** Render whether a tool accepts a request body, distinguishing array bodies. */
+function renderBody(tool: GeneratedTool): string {
+  if (!tool.hasBody) return "No";
+  if (tool.hasArrayBody) return "Yes (JSON array body via `items`)";
+  return "Yes";
+}
+
+/**
+ * Render the full MCP tools reference doc as Markdown.
+ *
+ * Pure function — no file I/O — so it can be unit-tested directly. Tools are
+ * sorted alphabetically by name so regeneration is diff-stable.
+ */
+export function renderMcpToolsDoc(tools: GeneratedTool[]): string {
+  const sorted = [...tools].sort((a, b) => a.name.localeCompare(b.name));
+
+  const header = `<!-- GENERATED FILE — do not edit by hand. -->
+<!-- Produced by scripts/generate-mcp-docs.ts from mcp-server/src/generated-tools.ts -->
+<!-- (itself generated from task-store/openapi.json) filtered through -->
+<!-- mcp-server/src/tool-allowlist.ts. Regenerate with: bun run generate:mcp-docs -->
+
+# MCP Server Tool Reference
+
+This is the public tool surface exposed by the MCP server (\`@shipwright/mcp-server\`)
+after allowlist filtering. See [architecture.md](./architecture.md#mcp-server) for
+how the server is generated, wired, and executed.
+
+`;
+
+  if (sorted.length === 0) {
+    return `${header}_No tools available._\n`;
+  }
+
+  const sections = sorted.map((tool) => {
+    return `## \`${tool.name}\`
+
+${tool.description}
+
+- **Method:** ${tool.method}
+- **Path:** \`${tool.pathTemplate}\`
+- **Has body:** ${renderBody(tool)}
+- **Parameters:** ${renderParams(tool)}
+`;
+  });
+
+  return `${header}${sections.join("\n")}`;
+}
+
+export function generateMcpDocs(): GeneratedTool[] {
+  const tools = allowedTools(generatedTools);
+  writeFileSync(outPath, renderMcpToolsDoc(tools));
+  return tools;
+}
+
+if (import.meta.main) {
+  const tools = generateMcpDocs();
+  console.log(`Wrote ${tools.length} MCP tools to ${outPath}`);
+}

--- a/scripts/generate-mcp-docs.unit.test.ts
+++ b/scripts/generate-mcp-docs.unit.test.ts
@@ -1,0 +1,168 @@
+/**
+ * scripts/generate-mcp-docs.unit.test.ts
+ *
+ * Unit tests for the pure rendering logic in generate-mcp-docs.ts.
+ * No I/O — all inputs are inline GeneratedTool fixtures.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { GeneratedTool } from "../mcp-server/src/generated-tools.ts";
+import { renderMcpToolsDoc } from "./generate-mcp-docs.ts";
+
+function tool(overrides: Partial<GeneratedTool>): GeneratedTool {
+  return {
+    name: "tasks_list",
+    description: "List tasks",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/tasks",
+    queryParams: [],
+    pathParams: [],
+    hasBody: false,
+    ...overrides,
+  };
+}
+
+describe("renderMcpToolsDoc", () => {
+  test("includes a GENERATED FILE header comment", () => {
+    const doc = renderMcpToolsDoc([tool({})]);
+    expect(doc).toMatch(/GENERATED FILE/);
+  });
+
+  test("renders every tool's name and description", () => {
+    const tools = [
+      tool({ name: "tasks_list", description: "List tasks" }),
+      tool({
+        name: "prs_get",
+        description: "Get a pull request",
+        method: "GET",
+        pathTemplate: "/prs/{id}",
+      }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    expect(doc).toContain("tasks_list");
+    expect(doc).toContain("List tasks");
+    expect(doc).toContain("prs_get");
+    expect(doc).toContain("Get a pull request");
+  });
+
+  test("renders the HTTP method and path template for each tool", () => {
+    const tools = [
+      tool({
+        name: "tasks_claim",
+        method: "POST",
+        pathTemplate: "/tasks/{id}/claim",
+      }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    expect(doc).toContain("POST");
+    expect(doc).toContain("/tasks/{id}/claim");
+  });
+
+  test("renders query and path parameters", () => {
+    const tools = [
+      tool({
+        name: "tasks_list",
+        queryParams: ["status", "state"],
+        pathParams: [],
+      }),
+      tool({
+        name: "tasks_get",
+        method: "GET",
+        pathTemplate: "/tasks/{id}",
+        pathParams: ["id"],
+      }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    expect(doc).toContain("status");
+    expect(doc).toContain("state");
+    expect(doc).toContain("id");
+  });
+
+  test("indicates whether a tool has a request body", () => {
+    const tools = [
+      tool({ name: "tasks_list", hasBody: false }),
+      tool({
+        name: "tasks_create",
+        method: "POST",
+        pathTemplate: "/tasks",
+        hasBody: true,
+      }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    // Body presence must be distinguishable per-tool in the rendered doc.
+    expect(doc).toMatch(/tasks_create[\s\S]*Yes/);
+    expect(doc).toMatch(/tasks_list[\s\S]*No/);
+  });
+
+  test("indicates array-bodied tools distinctly (hasArrayBody)", () => {
+    const tools = [
+      tool({
+        name: "tasks_bulk",
+        method: "POST",
+        pathTemplate: "/tasks/bulk",
+        hasBody: true,
+        hasArrayBody: true,
+      }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    expect(doc).toMatch(/tasks_bulk[\s\S]*array/i);
+  });
+
+  test("renders tools sorted alphabetically by name regardless of input order", () => {
+    const tools = [
+      tool({
+        name: "tasks_update",
+        method: "PATCH",
+        pathTemplate: "/tasks/{id}",
+      }),
+      tool({ name: "prs_get", method: "GET", pathTemplate: "/prs/{id}" }),
+      tool({ name: "tasks_list" }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    const iPrsGet = doc.indexOf("prs_get");
+    const iTasksList = doc.indexOf("tasks_list");
+    const iTasksUpdate = doc.indexOf("tasks_update");
+    expect(iPrsGet).toBeGreaterThan(-1);
+    expect(iTasksList).toBeGreaterThan(-1);
+    expect(iTasksUpdate).toBeGreaterThan(-1);
+    expect(iPrsGet).toBeLessThan(iTasksList);
+    expect(iTasksList).toBeLessThan(iTasksUpdate);
+  });
+
+  test("handles an empty tool list without throwing", () => {
+    expect(() => renderMcpToolsDoc([])).not.toThrow();
+    const doc = renderMcpToolsDoc([]);
+    expect(doc).toMatch(/GENERATED FILE/);
+  });
+
+  test("never renders any excluded/pipeline-internal tool names", () => {
+    // Simulates the allowlist already having filtered the input — the
+    // renderer itself must not reintroduce or reference excluded tools.
+    const tools = [
+      tool({ name: "tasks_list" }),
+      tool({ name: "tasks_create", method: "POST", hasBody: true }),
+    ];
+    const doc = renderMcpToolsDoc(tools);
+    for (const excluded of [
+      "tasks_claim",
+      "tasks_heartbeat",
+      "tasks_delete",
+      "tokens_list",
+    ]) {
+      expect(doc).not.toContain(excluded);
+    }
+  });
+
+  test("does not include Helm or deployment content", () => {
+    const doc = renderMcpToolsDoc([tool({})]);
+    expect(doc.toLowerCase()).not.toContain("helm");
+    expect(doc.toLowerCase()).not.toContain("kubernetes");
+    expect(doc.toLowerCase()).not.toContain("deployment");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `scripts/generate-mcp-docs.ts`, mirroring `generate-admin-spec.ts`'s pattern: reads the already-generated `mcp-server/src/generated-tools.ts` tool set (itself derived from `task-store/openapi.json`), filters through `allowedTools()` from `mcp-server/src/tool-allowlist.ts`, and writes a generated Markdown reference to `docs/mcp-tools.md`.
- Trim `docs/architecture.md`'s hand-written MCP Server tool-level detail down to a link to the generated reference, so it stays in sync automatically instead of drifting from hand-edited prose.
- Wire `generate:mcp-docs` into `package.json` and document the new doc file in `CLAUDE.md`'s reference index.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Generator script produces human-readable docs from openapi.json + tool-allowlist.ts | MET |
| 2 | Generated reference wired into docs/, regeneratable | MET |
| 3 | architecture.md trimmed to link, not duplicate | MET |
| 4 | No Helm/deployment content | MET |
| 5 | Test covering the generator | MET |

## Test Plan
- `scripts/generate-mcp-docs.unit.test.ts` — 10 unit tests on the pure `renderMcpToolsDoc` render function (tool count/names, exclusion of allowlisted-out tools, method/path/param rendering, body/array-body rendering, alphabetical sort, empty-list handling, no Helm/deployment strings)
- `bun test` — 3458 pass / 217 skip / 15 fail (same 15 pre-existing failures as `main`, unrelated to this change — verified by running `bun test` on `main` directly)
- `bunx biome lint .`, `bun run --filter='*' typecheck`, `check-config-docs`, `sync-version --check`, `check-banned-strings` — all clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
