### PR TITLE
fix: isSelfCleanApprove misses narrative Verdict: APPROVE self-reviews

### DIFF
--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -155,18 +155,21 @@ A PR has **no findings** (skip it) when ALL of the following are true:
 when `author.login == CURRENT_USER` (resolved in Step 1) AND its body is a clean APPROVE
 verdict, matched either by:
 - leading markdown bold markers (`**`) stripped, the body starts with `APPROVE`, or
-- a `Verdict: APPROVE` line appears anywhere in the body (case-insensitive, optional bold
-  markers around either word), e.g. a narrative summary that ends in
-  `"...no issues found.\n\nVerdict: APPROVE"` rather than leading with it.
+- a `Verdict: APPROVE` label appears anywhere in the body (case-insensitive, optional bold
+  markers around either word) — **not** anchored to end-of-line, since the agent's narrative
+  self-reviews often trail reasoning after the verdict on the same line, e.g.
+  `"...All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows
+  self-approval via the API)."` (verbatim from shipwright PR #1272, the case that motivated
+  this).
 
 Per review.md's Step 10 note ("Self-review event override"), GitHub rejects self-APPROVE via
 the API, so the agent's own clean approval of its own PR is always posted as `COMMENTED`
-with a body like `"APPROVE — looks good, no changes needed."` or a narrative ending in
+with a body like `"APPROVE — looks good, no changes needed."` or a narrative containing
 `"Verdict: APPROVE"` instead of an `APPROVED` review. Without this exclusion, that clean
 self-approval would look identical to a real finding and loop the patch cron forever on an
 already-approved PR. The exclusion is scoped to clean APPROVE verdicts only — a self-authored
-review whose body neither starts with `APPROVE` nor contains a `Verdict: APPROVE` line (e.g.
-it ends in `Verdict: CHANGES_REQUESTED`, meaning the agent found a real issue in its own PR)
+review whose body neither starts with `APPROVE` nor contains a `Verdict: APPROVE` label (e.g.
+it contains `Verdict: CHANGES_REQUESTED`, meaning the agent found a real issue in its own PR)
 still counts as a finding, same as any other reviewer's.
 
 If neither condition applies (e.g., no reviews at all, only approved reviews, or only an

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -152,16 +152,22 @@ A PR has **no findings** (skip it) when ALL of the following are true:
   clean-APPROVE reviews (see below)
 
 **Self-authored clean-APPROVE exclusion**: A review is excluded from the body check above
-when `author.login == CURRENT_USER` (resolved in Step 1) AND its body — leading markdown
-bold markers (`**`) stripped — starts with `APPROVE`. Per review.md's Step 10 note
-("Self-review event override"), GitHub rejects self-APPROVE via the API, so the agent's own
-clean approval of its own PR is always posted as `COMMENTED` with a body like
-`"APPROVE — looks good, no changes needed."` instead of an `APPROVED` review. Without this
-exclusion, that clean self-approval would look identical to a real finding and loop the
-patch cron forever on an already-approved PR. The exclusion is scoped to clean APPROVE
-verdicts only — a self-authored review whose body does **not** start with `APPROVE` (i.e.
-the agent found a real issue in its own PR) still counts as a finding, same as any other
-reviewer's.
+when `author.login == CURRENT_USER` (resolved in Step 1) AND its body is a clean APPROVE
+verdict, matched either by:
+- leading markdown bold markers (`**`) stripped, the body starts with `APPROVE`, or
+- a `Verdict: APPROVE` line appears anywhere in the body (case-insensitive, optional bold
+  markers around either word), e.g. a narrative summary that ends in
+  `"...no issues found.\n\nVerdict: APPROVE"` rather than leading with it.
+
+Per review.md's Step 10 note ("Self-review event override"), GitHub rejects self-APPROVE via
+the API, so the agent's own clean approval of its own PR is always posted as `COMMENTED`
+with a body like `"APPROVE — looks good, no changes needed."` or a narrative ending in
+`"Verdict: APPROVE"` instead of an `APPROVED` review. Without this exclusion, that clean
+self-approval would look identical to a real finding and loop the patch cron forever on an
+already-approved PR. The exclusion is scoped to clean APPROVE verdicts only — a self-authored
+review whose body neither starts with `APPROVE` nor contains a `Verdict: APPROVE` line (e.g.
+it ends in `Verdict: CHANGES_REQUESTED`, meaning the agent found a real issue in its own PR)
+still counts as a finding, same as any other reviewer's.
 
 If neither condition applies (e.g., no reviews at all, only approved reviews, or only an
 excluded self-authored clean-APPROVE review), skip the PR — it does not belong in List A.

--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -859,6 +859,37 @@ describe("check-patch", () => {
     expect(result.output).toBe("");
   });
 
+  test("exits 1 when self-authored review trails reasoning after Verdict: APPROVE on the same line (verbatim shipwright PR #1272 case)", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Clean, well-scoped PR. Verified the generator output is byte-identical to the committed `docs/mcp-tools.md` (no drift), all 9 sections match the allowlist's filtered tool set exactly, unit tests (10/10) and lint pass, and no Helm/Kubernetes content leaked into the doc. All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows self-approval via the API).",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: () => "the-agent",
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
   test("exits 0 when a narrative Verdict: APPROVE self-review coexists with a different reviewer's CHANGES_REQUESTED finding", async () => {
     const pr = makeOwnPr();
     const reviewData = makePrReviewData({

--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -825,6 +825,108 @@ describe("check-patch", () => {
     expect(result.exit).toBe(1);
     expect(result.output).toBe("");
   });
+
+  // ─── Narrative "Verdict: APPROVE" self-reviews (CPF-2.1) ───────────────────
+
+  test("exits 1 when only review is self-authored COMMENTED at current HEAD with a narrative ending in Verdict: APPROVE", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Reviewed the diff for correctness and style. Everything checks out, no issues found.\n\nVerdict: APPROVE",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: () => "the-agent",
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when a narrative Verdict: APPROVE self-review coexists with a different reviewer's CHANGES_REQUESTED finding", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Reviewed the diff for correctness and style. Everything checks out, no issues found.\n\nVerdict: APPROVE",
+          },
+          {
+            author: { login: "reviewer1" },
+            state: "CHANGES_REQUESTED",
+            submittedAt: "2026-05-26T11:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Please address these issues before merging.",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: () => "the-agent",
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("patch");
+  });
+
+  test("exits 0 when self-authored review has a narrative ending in Verdict: CHANGES_REQUESTED", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Reviewed the diff and found a race condition in the retry logic that needs a fix before merge.\n\nVerdict: CHANGES_REQUESTED",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: () => "the-agent",
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("patch");
+  });
 });
 
 // ─── hasFailingCi (CPC-1.1) ────────────────────────────────────────────────────

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -123,23 +123,24 @@ export function hasFailingCi(
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
 
 /**
- * Matches a standalone "Verdict: APPROVE" line anywhere in a review body
- * (case-insensitive, optional leading markdown bold markers around either
- * word, tolerant of trailing punctuation/whitespace after APPROVE). Used to
- * catch the agent's narrative self-review convention, which ends a summary
- * with a verdict line rather than leading with it — e.g. "...no issues found.
- * \n\nVerdict: APPROVE". Deliberately anchored on a `Verdict:` label so a
- * stray "approve" in prose (or a genuine "Verdict: CHANGES_REQUESTED") never
- * matches.
+ * Matches a "Verdict: APPROVE" label anywhere in a review body (case-
+ * insensitive, optional markdown bold markers around either word). Deliberately
+ * NOT anchored to end-of-line — the agent's real narrative self-reviews trail
+ * reasoning after the verdict on the same line, e.g. "...All 5 acceptance
+ * criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows
+ * self-approval via the API)." (verbatim from shipwright PR #1272, the case
+ * that motivated this). The trailing `\b` requires "approve" to end as a whole
+ * word, so a genuine "Verdict: CHANGES_REQUESTED" or "Verdict: DISAPPROVE" of
+ * X never matches.
  */
-const VERDICT_APPROVE_LINE = /^\s*\**\s*verdict\**\s*:\s*\**\s*approve\**\s*$/im;
+const VERDICT_APPROVE_LABEL = /verdict\**\s*:\s*\**approve\b/i;
 
 /**
  * True when a review is self-authored and is a clean APPROVE verdict, matched
  * either by:
  * - a leading `APPROVE` (`body.trimStart().startsWith("APPROVE")`, matching
  *   deploy.md's Step 3a convention), or
- * - a "Verdict: APPROVE" line anywhere in the body (the agent's narrative
+ * - a "Verdict: APPROVE" label anywhere in the body (the agent's narrative
  *   self-review convention, which ends a summary with the verdict rather than
  *   leading with it — CPF-2.1).
  *
@@ -161,7 +162,7 @@ function isSelfCleanApprove(
 
   return (
     review.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE") ||
-    VERDICT_APPROVE_LINE.test(review.body)
+    VERDICT_APPROVE_LABEL.test(review.body)
   );
 }
 

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -123,24 +123,45 @@ export function hasFailingCi(
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
 
 /**
- * True when a review is self-authored and its body is a clean APPROVE verdict
- * (`body.trimStart().startsWith("APPROVE")`, matching deploy.md's Step 3a
- * convention). GitHub blocks self-APPROVE via the API, so the agent's own clean
- * approvals are always posted as COMMENTED — treating those as findings would
- * create a permanent false positive. A self-review with a real (non-APPROVE)
- * verdict is not matched here, so it still counts as a finding.
+ * Matches a standalone "Verdict: APPROVE" line anywhere in a review body
+ * (case-insensitive, optional leading markdown bold markers around either
+ * word, tolerant of trailing punctuation/whitespace after APPROVE). Used to
+ * catch the agent's narrative self-review convention, which ends a summary
+ * with a verdict line rather than leading with it — e.g. "...no issues found.
+ * \n\nVerdict: APPROVE". Deliberately anchored on a `Verdict:` label so a
+ * stray "approve" in prose (or a genuine "Verdict: CHANGES_REQUESTED") never
+ * matches.
+ */
+const VERDICT_APPROVE_LINE = /^\s*\**\s*verdict\**\s*:\s*\**\s*approve\**\s*$/im;
+
+/**
+ * True when a review is self-authored and is a clean APPROVE verdict, matched
+ * either by:
+ * - a leading `APPROVE` (`body.trimStart().startsWith("APPROVE")`, matching
+ *   deploy.md's Step 3a convention), or
+ * - a "Verdict: APPROVE" line anywhere in the body (the agent's narrative
+ *   self-review convention, which ends a summary with the verdict rather than
+ *   leading with it — CPF-2.1).
  *
- * Leading markdown bold markers (`**`) are stripped before the check, mirroring
- * check-deploy.ts's `hasSelfApproveReview` — the review skill posts `**APPROVE**`
- * but the body must still be treated as APPROVE.
+ * GitHub blocks self-APPROVE via the API, so the agent's own clean approvals
+ * are always posted as COMMENTED — treating those as findings would create a
+ * permanent false positive. A self-review with a real (non-APPROVE) verdict
+ * (e.g. "Verdict: CHANGES_REQUESTED") is not matched here, so it still counts
+ * as a finding.
+ *
+ * Leading markdown bold markers (`**`) are stripped before the leading-prefix
+ * check, mirroring check-deploy.ts's `hasSelfApproveReview` — the review
+ * skill posts `**APPROVE**` but the body must still be treated as APPROVE.
  */
 function isSelfCleanApprove(
   review: Pick<PrReviewData["reviews"]["nodes"][number], "author" | "body">,
   currentUser: string,
 ): boolean {
+  if (review.author.login !== currentUser) return false;
+
   return (
-    review.author.login === currentUser &&
-    review.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE")
+    review.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE") ||
+    VERDICT_APPROVE_LINE.test(review.body)
   );
 }
 


### PR DESCRIPTION
## Summary
- Loosen `isSelfCleanApprove` in `check-patch.ts` to match a `Verdict: APPROVE` label anywhere in a self-authored review body, not just as a strict leading prefix — fixes a permanent false positive where the agent's narrative self-review convention (which ends a summary with the verdict, e.g. `"...All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows self-approval via the API)."`, verbatim from PR #1272) was misclassified as a real unaddressed finding on every `/shipwright:review-patch` cron cycle.
- The matching regex is deliberately **not** anchored to end-of-line, since real self-review bodies trail reasoning after the verdict on the same line; it requires a trailing word boundary after "approve" instead, so a genuine `Verdict: CHANGES_REQUESTED` or `Verdict: DISAPPROVE` never false-matches.
- Updated `patch.md`'s Step 3a "Self-authored clean-APPROVE exclusion" section to document both matching paths, keeping the precheck description in sync with the actual `check-patch.ts` implementation.
- `deploy.md`/`check-deploy.ts` intentionally left untouched — they serve a different purpose (PR-approval gating for deploy, not unaddressed-findings detection for patch) and are out of scope per the task's acceptance criteria.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Self-authored review with clean approve verdict anywhere (not just leading) is excluded | MET | `VERDICT_APPROVE_LABEL = /verdict\**\s*:\s*\**approve\b/i` matches "Verdict: APPROVE" anywhere in body, not anchored to line/string boundaries — verified against the real PR #1272 body with trailing reasoning |
| 2 | Self-authored review with genuine non-APPROVE verdict still counts as finding | MET | Trailing `\b` word boundary after "approve" prevents match on "CHANGES_REQUESTED"/"DISAPPROVE" |
| 3 | Third-party review behavior unchanged | MET | `isSelfCleanApprove` still gates on `review.author.login !== currentUser` before any body matching |
| 4 | Unit tests cover narrative "...Verdict: APPROVE" case (exit 1 alone, exit 0 with coexisting third-party finding) | MET | 4 new tests: narrative-ending self-review alone, verbatim PR #1272 trailing-reasoning case, narrative self-review coexisting with third-party finding, narrative self-review with non-APPROVE verdict |
| 5 | patch.md's Step 3a precheck logic updated to match | MET | "Self-authored clean-APPROVE exclusion" section rewritten to describe both leading-prefix and anywhere-label matching |

## Test Plan
- `bun test plugins/shipwright/scripts/check-patch.test.ts` — 34/34 pass (4 new tests added)
- `bunx biome lint` on changed files — clean
- `bun run --filter='@shipwright/plugin' typecheck` — exit 0
- Verified the fix regex against the actual `dmcaulay` review body on shipwright PR #1272 (the motivating case) — confirmed match
- Full-repo `task ci` has 14-15 pre-existing test failures (metrics error-handler logging tests, task-store `validateRepo`) reproduced identically on `main` — unrelated to this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
