### PR TITLE
feat: convert chat tokens routes to OpenAPIHono

### DIFF
--- a/chat/src/routes/tokens.ts
+++ b/chat/src/routes/tokens.ts
@@ -2,8 +2,8 @@
  * chat/src/routes/tokens.ts
  * Token management routes — admin tokens only.
  *
- * Returns a Hono sub-app mounted at /tokens by app.ts. Auth is applied by the
- * parent app. All routes here require an admin token (agentId === null).
+ * Returns an OpenAPIHono sub-app mounted at /tokens by app.ts. Auth is applied
+ * by the parent app. All routes here require an admin token (agentId === null).
  *
  * Routes:
  *   GET    /tokens       list (hash + metadata, never raw values)
@@ -12,15 +12,137 @@
  *   DELETE /tokens/:id   revoke
  */
 
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { ChatAuthEnv } from "../auth.ts";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.ts";
+import { ChatTokenSchema, ErrorSchema } from "../openapi-schemas.ts";
 import type { ChatTokenServiceLike } from "../token-service.ts";
+
+// ─── Extra schemas for token routes ───────────────────────────────────────────
+
+const ChatTokenWithRawSchema = ChatTokenSchema.extend({
+  rawToken: z.string().openapi({ example: "raw-token-value-shown-once" }),
+}).openapi("ChatTokenWithRaw");
+
+const TokenBodySchema = z
+  .object({
+    label: z.string().optional().openapi({ example: "ci-runner" }),
+    agentId: z.string().optional().openapi({ example: "agent-id-123" }),
+  })
+  .openapi("TokenBody");
+
+const TokenIdParamSchema = z.object({
+  id: z.string().openapi({ example: "clxtoken123456" }),
+});
+
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const listTokensRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["tokens"],
+  summary: "List all tokens",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Array of token metadata",
+      content: { "application/json": { schema: z.array(ChatTokenSchema) } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const createTokenRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["tokens"],
+  summary: "Create a new token — raw value returned exactly once",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      required: false,
+      content: { "application/json": { schema: TokenBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Created token including the one-time raw value",
+      content: { "application/json": { schema: ChatTokenWithRawSchema } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const updateTokenRoute = createRoute({
+  method: "patch",
+  path: "/:id",
+  tags: ["tokens"],
+  summary: "Update token label and/or agentId",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: TokenIdParamSchema,
+    body: {
+      required: false,
+      content: { "application/json": { schema: TokenBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated token metadata",
+      content: { "application/json": { schema: ChatTokenSchema } },
+    },
+    400: {
+      description: "Bad request — token is revoked",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Token not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const revokeTokenRoute = createRoute({
+  method: "delete",
+  path: "/:id",
+  tags: ["tokens"],
+  summary: "Revoke a token",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: TokenIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Revoked token metadata",
+      content: { "application/json": { schema: ChatTokenSchema } },
+    },
+    403: {
+      description: "Forbidden — admin token required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Token not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
 
 export function createTokensRoutes(
   tokenService: ChatTokenServiceLike,
-): Hono<ChatAuthEnv> {
-  const app = new Hono<ChatAuthEnv>();
+): OpenAPIHono<ChatAuthEnv> {
+  const app = new OpenAPIHono<ChatAuthEnv>();
 
   // All token management requires an admin token.
   app.use("*", async (c, next) => {
@@ -31,13 +153,13 @@ export function createTokensRoutes(
   });
 
   // ─── List ──────────────────────────────────────────────────────────────────
-  app.get("/", async (c) => {
+  app.openapi(listTokensRoute, async (c) => {
     const tokens = await tokenService.list();
     return c.json(tokens, 200);
   });
 
   // ─── Create ────────────────────────────────────────────────────────────────
-  app.post("/", async (c) => {
+  app.openapi(createTokenRoute, async (c) => {
     let label: string | undefined;
     let agentId: string | undefined;
     try {
@@ -56,7 +178,7 @@ export function createTokensRoutes(
   });
 
   // ─── Update ────────────────────────────────────────────────────────────────
-  app.patch("/:id", async (c) => {
+  app.openapi(updateTokenRoute, async (c) => {
     let label: string | undefined;
     let agentId: string | undefined;
     try {
@@ -89,7 +211,7 @@ export function createTokensRoutes(
   });
 
   // ─── Revoke ────────────────────────────────────────────────────────────────
-  app.delete("/:id", async (c) => {
+  app.openapi(revokeTokenRoute, async (c) => {
     const revoked = await tokenService.revoke(c.req.param("id"));
     if (!revoked) throw new NotFoundError("token not found");
     return c.json(revoked, 200);


### PR DESCRIPTION
## Summary
- Converted `chat/src/routes/tokens.ts` from plain `Hono` to `OpenAPIHono` + `createRoute()`, mirroring `task-store/src/routes/tokens.ts`'s pattern
- Added route-specific schemas (`ChatTokenWithRawSchema`, `TokenBodySchema`, `TokenIdParamSchema`) co-located in the route file, importing `ChatTokenSchema`/`ErrorSchema` from `chat/src/openapi-schemas.ts`
- Handler logic is unchanged — only the route registration mechanism moved from `app.get/post/patch/delete` to `app.openapi(route, handler)`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `createTokensRoutes` returns `OpenAPIHono<ChatAuthEnv>`, all 4 routes registered via `createRoute()`/`app.openapi()` | MET | All 4 handlers (list/create/update/revoke) registered via `app.openapi(route, handler)` |
| 2 | Request/response shapes, status codes, error messages byte-for-byte identical | MET | Handler bodies unchanged in diff — only wrapped in `createRoute()`/`app.openapi()` |
| 3 | `chat/src/tokens.smoke.test.ts` passes unchanged, no edits to assertions | MET | `git diff` confirms zero changes to the test file; 6/6 pass |
| 4 | No new test file needed — existing smoke test is the regression proof | MET | No tests added/retired |

## Test Plan
- `bun test chat/src/tokens.smoke.test.ts` — 6 pass, 0 fail (unchanged assertions)
- `bun test chat/` — 99 pass, 0 fail (full chat suite)
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — all packages pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
