### PR TITLE
fix: reconcile drift-corrects agent container env/resources + memory limit

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -36,6 +36,19 @@ export const AGENT_HOME_MOUNT_PATH = "/data/agent-home";
 export const AGENT_REPO_DIR = `${AGENT_HOME_MOUNT_PATH}/workspace/repos`;
 export const AGENT_WORKTREE_DIR = `${AGENT_HOME_MOUNT_PATH}/workspace/worktrees`;
 
+/**
+ * Container resources. Requests mirror the GKE Autopilot defaults the agent
+ * ran with before these were explicit. The memory limit exists to contain a
+ * runaway Claude run to its own container (OOM-kill) rather than letting it
+ * grow until the kubelet evicts neighbouring pods under node memory pressure
+ * (observed: ~11.6Gi used against the 2Gi request). No CPU limit — CPU
+ * contention throttles instead of evicting.
+ */
+export const AGENT_CONTAINER_RESOURCES = {
+  requests: { cpu: "500m", memory: "2Gi", "ephemeral-storage": "1Gi" },
+  limits: { memory: "8Gi", "ephemeral-storage": "1Gi" },
+};
+
 /** Non-root uid/gid the agent runs as (matches the agent image). */
 const AGENT_RUN_AS = 1000;
 
@@ -332,6 +345,7 @@ export function buildAgentDeploymentManifest(
               name: AGENT_APP_NAME,
               image: `${opts.image}:${opts.imageTag}`,
               ports: [{ containerPort: AGENT_HEALTH_PORT, protocol: "TCP" }],
+              resources: AGENT_CONTAINER_RESOURCES,
               env: [
                 { name: "SHIPWRIGHT_AGENT_ID", value: opts.agentId },
                 { name: "SHIPWRIGHT_API_URL", value: opts.apiUrl },

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -146,6 +146,14 @@ describe("buildAgentDeploymentManifest", () => {
     );
   });
 
+  it("sets explicit container resources with a memory limit", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const resources = d.spec.template.spec.containers[0].resources;
+    expect(resources?.requests?.memory).toBe("2Gi");
+    expect(resources?.limits?.memory).toBe("8Gi");
+    expect(resources?.limits?.["ephemeral-storage"]).toBe("1Gi");
+  });
+
   it("defines liveness and readiness probes on the health port", () => {
     const d = buildAgentDeploymentManifest(deployOpts);
     const c = d.spec.template.spec.containers[0];

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -33,6 +33,8 @@ import type { AgentTokenService } from "./agent-tokens.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type {
   KubernetesClient,
+  KubernetesContainer,
+  KubernetesEnvVar,
   PvcSpec,
   SecretSpec,
 } from "./kubernetes-client.ts";
@@ -68,7 +70,10 @@ export interface ReconcileResult {
    * non-empty `failed` arrays.
    */
   failed: Array<{ agentId: string; error: string }>;
-  /** Agent IDs whose Deployments were stale and have been patched to the current image. */
+  /**
+   * Agent IDs whose Deployments had drifted from the desired container spec
+   * (image, env, or resources) and have been patched back to it.
+   */
   updated: string[];
 }
 
@@ -160,6 +165,47 @@ export interface KubernetesAgentProvisionerConfig {
   chatServiceUrl?: string;
 }
 
+function envEntryEqual(a: KubernetesEnvVar, b: KubernetesEnvVar): boolean {
+  return (
+    a.value === b.value &&
+    a.valueFrom?.secretKeyRef?.name === b.valueFrom?.secretKeyRef?.name &&
+    a.valueFrom?.secretKeyRef?.key === b.valueFrom?.secretKeyRef?.key
+  );
+}
+
+/**
+ * True when the live container is missing anything the desired container
+ * specifies (image, env entries, resource values).
+ *
+ * Subset semantics: extra live env vars (added manually via kubectl) and extra
+ * resource keys (injected by cluster autoscalers like GKE Autopilot) are NOT
+ * drift — reconcile must not fight other actors. Only a desired value that is
+ * absent or different counts.
+ */
+export function containerDrifted(
+  current: KubernetesContainer,
+  desired: KubernetesContainer,
+): boolean {
+  if (current.image !== desired.image) return true;
+
+  const currentEnv = new Map((current.env ?? []).map((e) => [e.name, e]));
+  for (const entry of desired.env ?? []) {
+    const live = currentEnv.get(entry.name);
+    if (!live || !envEntryEqual(live, entry)) return true;
+  }
+
+  const cur = current.resources ?? {};
+  for (const bucket of ["requests", "limits"] as const) {
+    for (const [key, value] of Object.entries(
+      desired.resources?.[bucket] ?? {},
+    )) {
+      if (cur[bucket]?.[key] !== value) return true;
+    }
+  }
+
+  return false;
+}
+
 function isConflict(err: unknown): boolean {
   return err instanceof ConflictError;
 }
@@ -195,6 +241,28 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     return this.config.pvcName
       ? this.config.pvcName(slug ? sanitizeAgentName(slug) : resourceName)
       : `${resourceName}-home`;
+  }
+
+  /**
+   * The desired Deployment manifest for an agent — the single source of truth
+   * used both to create (provision) and to drift-correct (reconcile).
+   */
+  private deploymentManifestFor(agentId: string, slug?: string) {
+    const resourceName = this.resourceName(agentId);
+    return buildAgentDeploymentManifest({
+      agentId,
+      namespace: this.config.namespace,
+      image: this.config.image,
+      imageTag: this.config.imageTag,
+      apiUrl: this.config.apiUrl,
+      pvcName: this.pvcNameFor(resourceName, slug),
+      secretName: this.secretNameFor(resourceName),
+      tokenSecretKey: this.tokenKey,
+      replicas: this.config.replicas,
+      voice: this.config.voice,
+      taskStoreUrl: this.config.taskStoreUrl,
+      chatServiceUrl: this.config.chatServiceUrl,
+    });
   }
 
   async provision(
@@ -286,20 +354,7 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
     try {
       await this.k8s.createDeploymentManifest(
         this.config.namespace,
-        buildAgentDeploymentManifest({
-          agentId,
-          namespace: this.config.namespace,
-          image: this.config.image,
-          imageTag: this.config.imageTag,
-          apiUrl: this.config.apiUrl,
-          pvcName: this.pvcNameFor(resourceName, opts?.slug),
-          secretName,
-          tokenSecretKey: this.tokenKey,
-          replicas: this.config.replicas,
-          voice: this.config.voice,
-          taskStoreUrl: this.config.taskStoreUrl,
-          chatServiceUrl: this.config.chatServiceUrl,
-        }),
+        this.deploymentManifestFor(agentId, opts?.slug),
       );
     } catch (err) {
       if (isConflict(err)) {
@@ -386,16 +441,21 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
           });
         }
       } else {
-        // Deployment already exists — check for a stale image and patch if needed.
+        // Deployment already exists — re-apply the desired container spec when
+        // it has drifted. The manifest builder is the single source of truth
+        // for image, env, and resources; the strategic-merge patch upserts env
+        // entries by name, so manually-added extra vars survive. (Patching only
+        // the image here would mean existing Deployments never pick up env or
+        // resource changes shipped in a new admin version.)
         try {
           const deployment = await this.k8s.getDeployment(
             this.config.namespace,
             resourceName,
           );
-          const currentImage =
-            deployment.spec.template.spec.containers[0]?.image;
-          const desiredImage = `${this.config.image}:${this.config.imageTag}`;
-          if (currentImage !== desiredImage) {
+          const current = deployment.spec.template.spec.containers[0];
+          const desired = this.deploymentManifestFor(agent.id, agent.slug).spec
+            .template.spec.containers[0];
+          if (current && desired && containerDrifted(current, desired)) {
             await this.k8s.patchDeployment(
               this.config.namespace,
               resourceName,
@@ -404,7 +464,12 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
                   template: {
                     spec: {
                       containers: [
-                        { name: "shipwright-agent", image: desiredImage },
+                        {
+                          name: desired.name,
+                          image: desired.image,
+                          env: desired.env,
+                          resources: desired.resources,
+                        },
                       ],
                     },
                   },

--- a/admin/src/agent-provisioner.unit.test.ts
+++ b/admin/src/agent-provisioner.unit.test.ts
@@ -408,6 +408,56 @@ describe("KubernetesAgentProvisioner.reconcile() — image-update detection", ()
     // The manually-added var survives the strategic-merge patch.
     expect(names).toContain("STARTUP_TIMEOUT_MS");
   });
+
+  it("patches a Deployment with drifted resources, preserving Autopilot-injected resource keys", async () => {
+    const agentId = "cmqalfjcm000m4101iharq28k";
+    const resourceName = sanitizeAgentName(agentId);
+
+    // Seed the desired manifest, then simulate GKE Autopilot having injected a
+    // cpu key into requests and limits that the manifest doesn't specify.
+    const stale = buildAgentDeploymentManifest({
+      agentId,
+      namespace: NAMESPACE,
+      image: BASE_CONFIG.image,
+      imageTag: BASE_CONFIG.imageTag,
+      apiUrl: BASE_CONFIG.apiUrl,
+      pvcName: `${resourceName}-home`,
+      secretName: `${resourceName}-token`,
+      tokenSecretKey: "token",
+    });
+    const container = stale.spec.template.spec.containers[0];
+    // Simulate Autopilot injecting cpu — and also strip the memory limit so
+    // containerDrifted() detects drift and triggers a patch.
+    container.resources = {
+      requests: { ...container.resources?.requests, cpu: "500m" },
+      limits: { cpu: "2" }, // missing memory limit → drift
+    };
+
+    const k8s = new RecordedKubernetesClient({
+      deployments: { [`${NAMESPACE}/${resourceName}`]: stale },
+      secrets: {},
+      pvcs: {},
+    });
+    const provisioner = new KubernetesAgentProvisioner(
+      k8s,
+      stubTokens() as AgentTokenService,
+      BASE_CONFIG,
+    );
+
+    const result = await provisioner.reconcile([{ id: agentId }]);
+
+    expect(result.updated).toEqual([agentId]);
+    expect(result.failed).toEqual([]);
+
+    const dep = await k8s.getDeployment(NAMESPACE, resourceName);
+    const resources = dep.spec.template.spec.containers[0].resources;
+    // Desired manifest values are applied.
+    expect(resources?.requests?.memory).toBe("2Gi");
+    expect(resources?.limits?.memory).toBe("8Gi");
+    // Autopilot-injected cpu key survives the strategic-merge patch.
+    expect(resources?.requests?.cpu).toBe("500m");
+    expect(resources?.limits?.cpu).toBe("2");
+  });
 });
 
 // ─── containerDrifted ─────────────────────────────────────────────────────────

--- a/admin/src/agent-provisioner.unit.test.ts
+++ b/admin/src/agent-provisioner.unit.test.ts
@@ -8,8 +8,12 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { sanitizeAgentName } from "./agent-manifest.ts";
 import {
+  buildAgentDeploymentManifest,
+  sanitizeAgentName,
+} from "./agent-manifest.ts";
+import {
+  containerDrifted,
   KubernetesAgentProvisioner,
   type KubernetesAgentProvisionerConfig,
 } from "./agent-provisioner.ts";
@@ -228,34 +232,25 @@ describe("KubernetesAgentProvisioner.reconcile() — image-update detection", ()
     );
   });
 
-  it("skips patch when image is already up-to-date", async () => {
+  it("skips patch when the container already matches the manifest", async () => {
     const agentId = "cmqalfjcm000m4101iharq28k";
     const resourceName = sanitizeAgentName(agentId);
 
     let patchCalled = false;
     const recorded = new RecordedKubernetesClient({
       deployments: {
-        [`${NAMESPACE}/${resourceName}`]: {
-          apiVersion: "apps/v1",
-          kind: "Deployment",
-          metadata: { name: resourceName, namespace: NAMESPACE },
-          spec: {
-            replicas: 1,
-            selector: { matchLabels: { app: resourceName } },
-            template: {
-              metadata: { labels: { app: resourceName } },
-              spec: {
-                containers: [
-                  {
-                    name: "shipwright-agent",
-                    // Matches BASE_CONFIG: image:imageTag
-                    image: "ghcr.io/app-vitals/shipwright-agent:v1.0.0",
-                  },
-                ],
-              },
-            },
-          },
-        },
+        // Seed the exact desired manifest (image, env, resources) so there is
+        // no drift of any kind.
+        [`${NAMESPACE}/${resourceName}`]: buildAgentDeploymentManifest({
+          agentId,
+          namespace: NAMESPACE,
+          image: BASE_CONFIG.image,
+          imageTag: BASE_CONFIG.imageTag,
+          apiUrl: BASE_CONFIG.apiUrl,
+          pvcName: `${resourceName}-home`,
+          secretName: `${resourceName}-token`,
+          tokenSecretKey: "token",
+        }),
       },
       secrets: {},
       pvcs: {},
@@ -361,6 +356,122 @@ describe("KubernetesAgentProvisioner.reconcile() — image-update detection", ()
     expect(result.failed).toEqual([
       { agentId, error: "patch failed: server error" },
     ]);
+  });
+
+  it("patches a Deployment whose env is missing manifest vars, preserving manual extras", async () => {
+    const agentId = "cmqalfjcm000m4101iharq28k";
+    const resourceName = sanitizeAgentName(agentId);
+
+    // Seed the desired manifest, then simulate a Deployment provisioned by an
+    // older admin: strip the workspace-dir vars and add a manual kubectl var.
+    const stale = buildAgentDeploymentManifest({
+      agentId,
+      namespace: NAMESPACE,
+      image: BASE_CONFIG.image,
+      imageTag: BASE_CONFIG.imageTag,
+      apiUrl: BASE_CONFIG.apiUrl,
+      pvcName: `${resourceName}-home`,
+      secretName: `${resourceName}-token`,
+      tokenSecretKey: "token",
+    });
+    const container = stale.spec.template.spec.containers[0];
+    container.env = [
+      ...(container.env ?? []).filter(
+        (e) =>
+          e.name !== "SHIPWRIGHT_REPO_DIR" &&
+          e.name !== "SHIPWRIGHT_WORKTREE_DIR",
+      ),
+      { name: "STARTUP_TIMEOUT_MS", value: "300000" },
+    ];
+
+    const k8s = new RecordedKubernetesClient({
+      deployments: { [`${NAMESPACE}/${resourceName}`]: stale },
+      secrets: {},
+      pvcs: {},
+    });
+    const provisioner = new KubernetesAgentProvisioner(
+      k8s,
+      stubTokens() as AgentTokenService,
+      BASE_CONFIG,
+    );
+
+    const result = await provisioner.reconcile([{ id: agentId }]);
+
+    expect(result.updated).toEqual([agentId]);
+    expect(result.failed).toEqual([]);
+
+    const dep = await k8s.getDeployment(NAMESPACE, resourceName);
+    const env = dep.spec.template.spec.containers[0].env ?? [];
+    const names = env.map((e) => e.name);
+    expect(names).toContain("SHIPWRIGHT_REPO_DIR");
+    expect(names).toContain("SHIPWRIGHT_WORKTREE_DIR");
+    // The manually-added var survives the strategic-merge patch.
+    expect(names).toContain("STARTUP_TIMEOUT_MS");
+  });
+});
+
+// ─── containerDrifted ─────────────────────────────────────────────────────────
+
+describe("containerDrifted", () => {
+  const desired = () =>
+    buildAgentDeploymentManifest({
+      agentId: "agent-1",
+      namespace: NAMESPACE,
+      image: BASE_CONFIG.image,
+      imageTag: BASE_CONFIG.imageTag,
+      apiUrl: BASE_CONFIG.apiUrl,
+      pvcName: "agent-1-home",
+      secretName: "agent-1-token",
+      tokenSecretKey: "token",
+    }).spec.template.spec.containers[0];
+
+  it("no drift when current equals desired", () => {
+    expect(containerDrifted(desired(), desired())).toBe(false);
+  });
+
+  it("drifts on image change", () => {
+    const current = { ...desired(), image: "other:v0" };
+    expect(containerDrifted(current, desired())).toBe(true);
+  });
+
+  it("drifts when a desired env var is missing", () => {
+    const current = desired();
+    current.env = (current.env ?? []).filter(
+      (e) => e.name !== "SHIPWRIGHT_WORKTREE_DIR",
+    );
+    expect(containerDrifted(current, desired())).toBe(true);
+  });
+
+  it("drifts when a desired env value differs", () => {
+    const current = desired();
+    current.env = (current.env ?? []).map((e) =>
+      e.name === "SHIPWRIGHT_WORKTREE_DIR" ? { ...e, value: "/elsewhere" } : e,
+    );
+    expect(containerDrifted(current, desired())).toBe(true);
+  });
+
+  it("extra live env vars are not drift", () => {
+    const current = desired();
+    current.env = [
+      ...(current.env ?? []),
+      { name: "STARTUP_TIMEOUT_MS", value: "300000" },
+    ];
+    expect(containerDrifted(current, desired())).toBe(false);
+  });
+
+  it("extra live resource keys (e.g. Autopilot-injected) are not drift", () => {
+    const current = desired();
+    current.resources = {
+      requests: { ...current.resources?.requests, cpu: "500m" },
+      limits: { ...current.resources?.limits, cpu: "2" },
+    };
+    expect(containerDrifted(current, desired())).toBe(false);
+  });
+
+  it("drifts when a desired resource value is missing or different", () => {
+    const current = desired();
+    current.resources = { requests: current.resources?.requests }; // no limits
+    expect(containerDrifted(current, desired())).toBe(true);
   });
 });
 

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -72,6 +72,10 @@ export interface KubernetesContainer {
   name: string;
   image: string;
   env?: KubernetesEnvVar[];
+  resources?: {
+    requests?: Record<string, string>;
+    limits?: Record<string, string>;
+  };
   volumeMounts?: Array<{
     name: string;
     mountPath: string;
@@ -747,18 +751,24 @@ export class RecordedKubernetesClient implements KubernetesClient {
       spec?: {
         template?: {
           spec?: {
-            containers?: Array<{ name: string; image: string }>;
+            containers?: KubernetesContainer[];
           };
         };
       };
     };
-    const newImage = p.spec?.template?.spec?.containers?.[0]?.image;
+    // Emulate the strategic-merge semantics the real API server applies:
+    // container fields are replaced, except env, which merges by name
+    // (patched entries win, unmentioned live entries survive).
+    const patchContainer = p.spec?.template?.spec?.containers?.[0];
     const existing = dep.spec.template.spec.containers[0];
-    if (newImage !== undefined && existing !== undefined) {
-      dep.spec.template.spec.containers[0] = {
-        ...existing,
-        image: newImage,
-      };
+    if (patchContainer !== undefined && existing !== undefined) {
+      const merged: KubernetesContainer = { ...existing, ...patchContainer };
+      if (patchContainer.env && existing.env) {
+        const byName = new Map(existing.env.map((e) => [e.name, e]));
+        for (const entry of patchContainer.env) byName.set(entry.name, entry);
+        merged.env = [...byName.values()];
+      }
+      dep.spec.template.spec.containers[0] = merged;
     }
   }
 

--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -757,8 +757,9 @@ export class RecordedKubernetesClient implements KubernetesClient {
       };
     };
     // Emulate the strategic-merge semantics the real API server applies:
-    // container fields are replaced, except env, which merges by name
-    // (patched entries win, unmentioned live entries survive).
+    // container fields are replaced, except env (merges by name) and
+    // resources.requests/limits (merges key-by-key) — patched entries win,
+    // unmentioned live entries (e.g. Autopilot-injected cpu keys) survive.
     const patchContainer = p.spec?.template?.spec?.containers?.[0];
     const existing = dep.spec.template.spec.containers[0];
     if (patchContainer !== undefined && existing !== undefined) {
@@ -767,6 +768,18 @@ export class RecordedKubernetesClient implements KubernetesClient {
         const byName = new Map(existing.env.map((e) => [e.name, e]));
         for (const entry of patchContainer.env) byName.set(entry.name, entry);
         merged.env = [...byName.values()];
+      }
+      if (patchContainer.resources !== undefined) {
+        merged.resources = {
+          requests: {
+            ...existing.resources?.requests,
+            ...patchContainer.resources.requests,
+          },
+          limits: {
+            ...existing.resources?.limits,
+            ...patchContainer.resources.limits,
+          },
+        };
       }
       dep.spec.template.spec.containers[0] = merged;
     }

--- a/admin/src/kubernetes-client.unit.test.ts
+++ b/admin/src/kubernetes-client.unit.test.ts
@@ -432,6 +432,67 @@ describe("RecordedKubernetesClient.patchDeployment()", () => {
       }),
     ).rejects.toBeInstanceOf(NotFoundError);
   });
+
+  it("merges resources key-by-key, preserving live keys not in the patch", async () => {
+    const rec = new RecordedKubernetesClient({
+      deployments: {
+        "shipwright/agent-abc": {
+          apiVersion: "apps/v1" as const,
+          kind: "Deployment" as const,
+          metadata: { name: "agent-abc", namespace: "shipwright" },
+          spec: {
+            replicas: 1,
+            selector: { matchLabels: { app: "agent-abc" } },
+            template: {
+              metadata: { labels: { app: "agent-abc" } },
+              spec: {
+                containers: [
+                  {
+                    name: "agent-abc",
+                    image: "ghcr.io/example/agent:v1",
+                    resources: {
+                      requests: { memory: "1Gi", cpu: "500m" },
+                      limits: { memory: "4Gi", cpu: "2" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      secrets: {},
+    });
+
+    // Patch only mentions memory — cpu keys (Autopilot-injected) must survive.
+    await rec.patchDeployment("shipwright", "agent-abc", {
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: "agent-abc",
+                image: "ghcr.io/example/agent:v1",
+                resources: {
+                  requests: { memory: "2Gi" },
+                  limits: { memory: "8Gi" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const dep = await rec.getDeployment("shipwright", "agent-abc");
+    const resources = dep.spec.template.spec.containers[0]?.resources;
+    // Patched values applied.
+    expect(resources?.requests?.memory).toBe("2Gi");
+    expect(resources?.limits?.memory).toBe("8Gi");
+    // Live-only keys survived the patch.
+    expect(resources?.requests?.cpu).toBe("500m");
+    expect(resources?.limits?.cpu).toBe("2");
+  });
 });
 
 // ─── Request body shaping: Secrets ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
Follow-up to #1266. That fix added `SHIPWRIGHT_REPO_DIR`/`SHIPWRIGHT_WORKTREE_DIR` to the agent Deployment manifest, but `reconcile()` only ever patched a stale **image** on existing Deployments — so no existing agent would ever receive manifest env or resource changes. All 7 currently-deployed agents are in that state.

- `reconcile()` now compares the live container against the manifest builder's output (`containerDrifted`, exported + unit-tested) and strategic-merge patches image, env, and resources on drift
- Subset semantics: manually-added env vars and Autopilot-injected resource keys are not treated as drift, so reconcile doesn't fight other actors
- Adds explicit container resources with a **8Gi memory limit** (requests unchanged at Autopilot defaults) — a runaway Claude run now OOM-kills its own container instead of triggering node-pressure eviction (observed: 11.6Gi used against the 2Gi request evicted a pod overnight)
- `provision()` and `reconcile()` now share one `deploymentManifestFor()` source of truth
- `RecordedKubernetesClient.patchDeployment` fake now emulates strategic-merge env semantics

After this deploys, one `POST /agents/reconcile` rolls the env vars + memory limit out to all existing agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTU2q9nKhhShTdECQfCikm