### PR TITLE
feat: build merged age-ordered work-selector

### DIFF
--- a/agent/src/work-selector.ts
+++ b/agent/src/work-selector.ts
@@ -1,0 +1,109 @@
+/**
+ * agent/src/work-selector.ts
+ *
+ * Pure helper: selectNextWorkItem(tasks, prs) → WorkItem | null
+ *
+ * Given a list of ready tasks (aged by createdAt) and a list of ready PRs
+ * (aged by COALESCE(readyForReviewAt, readyForPatchAt, readyForDeployAt),
+ * already filtered by the caller to only the pipeline phases currently
+ * enabled), returns the single oldest ready-and-unblocked item across both
+ * entity types — strict age-based FIFO, no phase-priority bias.
+ *
+ * Deliberately simple v1 prioritization, expected to evolve. Kept isolated
+ * from the loop orchestrator (WL-3.3) so it stays cleanly testable via
+ * fixtures.
+ *
+ * A task is only selectable when status === "pending" AND its dependencies
+ * are satisfied (mirrors task-store/src/blocked-by.ts):
+ *   1. dep.status ∈ { merged, done, deploying, deployed, cancelled } → satisfied
+ *   2. same-branch dep with status ∈ { pr_open, approved } → satisfied (bundled)
+ *   3. anything else, including a missing dependency, → not satisfied
+ * This selector has no GitHub access, so a cross-branch pr_open dependency is
+ * never treated as satisfied here.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WorkTaskCandidate {
+  id: string;
+  status: string;
+  createdAt: string;
+  branch?: string | null;
+  dependencies?: string[];
+}
+
+export interface WorkPrCandidate {
+  id: string;
+  age: string;
+  claimedBy?: string | null;
+}
+
+export type WorkItem =
+  | { type: "task"; task: WorkTaskCandidate }
+  | { type: "pr"; pr: WorkPrCandidate };
+
+// ─── Terminal statuses ────────────────────────────────────────────────────────
+
+const TERMINAL_TASK_STATUSES = new Set<string>([
+  "merged",
+  "done",
+  "deploying",
+  "deployed",
+  "cancelled",
+]);
+
+// ─── Core helper ─────────────────────────────────────────────────────────────
+
+function isTaskUnblocked(
+  task: WorkTaskCandidate,
+  byId: Map<string, WorkTaskCandidate>,
+): boolean {
+  for (const depId of task.dependencies ?? []) {
+    const dep = byId.get(depId);
+    if (!dep) return false;
+
+    if (TERMINAL_TASK_STATUSES.has(dep.status)) continue;
+
+    if (
+      dep.branch &&
+      dep.branch === task.branch &&
+      (dep.status === "pr_open" || dep.status === "approved")
+    ) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Select the single oldest ready-and-unblocked item across tasks and PRs.
+ * Returns null when nothing is ready.
+ */
+export function selectNextWorkItem(
+  tasks: WorkTaskCandidate[],
+  prs: WorkPrCandidate[],
+): WorkItem | null {
+  const tasksById = new Map(tasks.map((task) => [task.id, task]));
+
+  let best: { age: string; item: WorkItem } | null = null;
+
+  for (const task of tasks) {
+    if (task.status !== "pending") continue;
+    if (!isTaskUnblocked(task, tasksById)) continue;
+    if (!best || task.createdAt < best.age) {
+      best = { age: task.createdAt, item: { type: "task", task } };
+    }
+  }
+
+  for (const pr of prs) {
+    if (pr.claimedBy != null) continue;
+    if (!best || pr.age < best.age) {
+      best = { age: pr.age, item: { type: "pr", pr } };
+    }
+  }
+
+  return best ? best.item : null;
+}

--- a/agent/src/work-selector.unit.test.ts
+++ b/agent/src/work-selector.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * agent/src/work-selector.unit.test.ts
+ *
+ * Unit tests for the selectNextWorkItem() pure helper.
+ * No I/O — pure logic only.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  selectNextWorkItem,
+  type WorkPrCandidate,
+  type WorkTaskCandidate,
+} from "./work-selector.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<WorkTaskCandidate> = {}): WorkTaskCandidate {
+  return {
+    id: "task-1",
+    status: "pending",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    branch: null,
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+function makePr(overrides: Partial<WorkPrCandidate> = {}): WorkPrCandidate {
+  return {
+    id: "pr-1",
+    age: "2026-01-01T00:00:00.000Z",
+    claimedBy: null,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("selectNextWorkItem", () => {
+  it("returns null when both lists are empty", () => {
+    expect(selectNextWorkItem([], [])).toBeNull();
+  });
+
+  it("returns the oldest task when only tasks are ready", () => {
+    const older = makeTask({ id: "t-older", createdAt: "2026-01-01T00:00:00.000Z" });
+    const newer = makeTask({ id: "t-newer", createdAt: "2026-01-02T00:00:00.000Z" });
+    const result = selectNextWorkItem([newer, older], []);
+    expect(result).toEqual({ type: "task", task: older });
+  });
+
+  it("returns the oldest PR when only PRs are ready", () => {
+    const older = makePr({ id: "pr-older", age: "2026-01-01T00:00:00.000Z" });
+    const newer = makePr({ id: "pr-newer", age: "2026-01-02T00:00:00.000Z" });
+    const result = selectNextWorkItem([], [newer, older]);
+    expect(result).toEqual({ type: "pr", pr: older });
+  });
+
+  it("picks the oldest item across both entity types — strict FIFO, no phase bias", () => {
+    const task = makeTask({ id: "t1", createdAt: "2026-01-02T00:00:00.000Z" });
+    const olderPr = makePr({ id: "pr1", age: "2026-01-01T00:00:00.000Z" });
+    const result = selectNextWorkItem([task], [olderPr]);
+    expect(result).toEqual({ type: "pr", pr: olderPr });
+  });
+
+  it("picks the older task over a newer PR", () => {
+    const olderTask = makeTask({ id: "t1", createdAt: "2026-01-01T00:00:00.000Z" });
+    const newerPr = makePr({ id: "pr1", age: "2026-01-02T00:00:00.000Z" });
+    const result = selectNextWorkItem([olderTask], [newerPr]);
+    expect(result).toEqual({ type: "task", task: olderTask });
+  });
+
+  it("excludes a task blocked by an unsatisfied dependency", () => {
+    const dep = makeTask({ id: "dep-1", status: "in_progress" });
+    const blocked = makeTask({
+      id: "t-blocked",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      dependencies: ["dep-1"],
+    });
+    const unblocked = makeTask({
+      id: "t-unblocked",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    const result = selectNextWorkItem([dep, blocked, unblocked], []);
+    expect(result).toEqual({ type: "task", task: unblocked });
+  });
+
+  it("treats a task with a dependency in a terminal status as unblocked", () => {
+    const dep = makeTask({ id: "dep-1", status: "merged" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = selectNextWorkItem([dep, task], []);
+    expect(result).toEqual({ type: "task", task });
+  });
+
+  it("treats a same-branch pr_open/approved dependency as unblocked (bundled)", () => {
+    const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/shared" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/shared" });
+    const result = selectNextWorkItem([dep, task], []);
+    expect(result).toEqual({ type: "task", task });
+  });
+
+  it("treats a cross-branch pr_open dependency as still blocked", () => {
+    const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/other" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/main" });
+    const result = selectNextWorkItem([dep, task], []);
+    expect(result).toBeNull();
+  });
+
+  it("excludes a task whose dependency is missing from the candidate list", () => {
+    const task = makeTask({ id: "t1", dependencies: ["missing-dep"] });
+    const result = selectNextWorkItem([task], []);
+    expect(result).toBeNull();
+  });
+
+  it("excludes an already-claimed PR", () => {
+    const claimed = makePr({
+      id: "pr-claimed",
+      age: "2026-01-01T00:00:00.000Z",
+      claimedBy: "agent-x",
+    });
+    const unclaimed = makePr({
+      id: "pr-unclaimed",
+      age: "2026-01-02T00:00:00.000Z",
+      claimedBy: null,
+    });
+    const result = selectNextWorkItem([], [claimed, unclaimed]);
+    expect(result).toEqual({ type: "pr", pr: unclaimed });
+  });
+
+  it("returns null when every candidate is blocked or claimed", () => {
+    const dep = makeTask({ id: "dep-1", status: "in_progress" });
+    const blockedTask = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const claimedPr = makePr({ id: "pr1", claimedBy: "agent-x" });
+    const result = selectNextWorkItem([dep, blockedTask], [claimedPr]);
+    expect(result).toBeNull();
+  });
+
+  it("selects strictly by age across a larger mixed fixture set", () => {
+    const t1 = makeTask({ id: "t1", createdAt: "2026-03-01T00:00:00.000Z" });
+    const t2 = makeTask({ id: "t2", createdAt: "2026-01-15T00:00:00.000Z" });
+    const pr1 = makePr({ id: "pr1", age: "2026-02-01T00:00:00.000Z" });
+    const pr2 = makePr({ id: "pr2", age: "2026-01-10T00:00:00.000Z", claimedBy: "agent-y" });
+    const result = selectNextWorkItem([t1, t2], [pr1, pr2]);
+    expect(result).toEqual({ type: "task", task: t2 });
+  });
+});

--- a/agent/src/work-selector.unit.test.ts
+++ b/agent/src/work-selector.unit.test.ts
@@ -91,8 +91,15 @@ describe("selectNextWorkItem", () => {
     expect(result).toEqual({ type: "task", task });
   });
 
-  it("treats a same-branch pr_open/approved dependency as unblocked (bundled)", () => {
+  it("treats a same-branch pr_open dependency as unblocked (bundled)", () => {
     const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/shared" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/shared" });
+    const result = selectNextWorkItem([dep, task], []);
+    expect(result).toEqual({ type: "task", task });
+  });
+
+  it("treats a same-branch approved dependency as unblocked (bundled)", () => {
+    const dep = makeTask({ id: "dep-1", status: "approved", branch: "feat/shared" });
     const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/shared" });
     const result = selectNextWorkItem([dep, task], []);
     expect(result).toEqual({ type: "task", task });


### PR DESCRIPTION
## Summary
- Adds `selectNextWorkItem()` in `agent/src/work-selector.ts` — a pure helper that merges ready tasks and ready PRs and returns the single oldest ready-and-unblocked item across both entity types, strict age-based FIFO with no phase-priority bias
- Excludes tasks with unsatisfied dependencies (mirroring `task-store/src/blocked-by.ts`'s synchronous rules — terminal statuses and same-branch bundled `pr_open`/`approved` deps are satisfied; anything else, including a missing dependency or cross-branch `pr_open`, is not) and excludes already-claimed PRs
- Deliberately simple v1 prioritization, kept isolated from the loop orchestrator (WL-3.3) for clean fixture-based testability

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New pure function accepts ready tasks + ready PRs and returns the oldest unblocked item, or null when nothing is ready | MET | `selectNextWorkItem()` in work-selector.ts |
| 2 | Blocked/dependency-unsatisfied tasks and already-claimed PRs are excluded from selection | MET | `isTaskUnblocked()` + `pr.claimedBy != null` filter |
| 3 | Unit tests with fixture data spanning tasks+PRs, varied ages, strict oldest-first, blocked exclusion | MET | 14 unit tests in work-selector.unit.test.ts |

## Test Plan
- 14 unit tests covering: empty inputs, single-entity-type ordering, cross-entity-type FIFO ordering, dependency terminal/same-branch/cross-branch/missing cases, PR claim exclusion, and a larger mixed fixture set
- `bunx tsc --noEmit` clean, `bunx biome lint` clean across the repo
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
