### PR TITLE
feat: convert threads routes to OpenAPIHono

### DIFF
--- a/chat/src/routes/threads.ts
+++ b/chat/src/routes/threads.ts
@@ -13,19 +13,218 @@
  * Admin token: full access; can filter by ?agentId or ?memberId.
  */
 
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { ChatAuthEnv } from "../auth.ts";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.ts";
+import {
+  ErrorSchema,
+  ThreadSchema,
+  ThreadStatsSchema,
+} from "../openapi-schemas.ts";
 import type { ThreadServiceLike } from "../thread-service.ts";
 import { parseIntParam } from "./utils.ts";
 
+// ─── Extra schemas for thread routes ──────────────────────────────────────────
+
+const ThreadListQuerySchema = z.object({
+  limit: z.string().optional().openapi({ example: "50" }),
+  offset: z.string().optional().openapi({ example: "0" }),
+  agentId: z.string().optional().openapi({ example: "agent-id-123" }),
+  memberId: z.string().optional().openapi({ example: "member-id-123" }),
+});
+
+const ThreadListResponseSchema = z
+  .object({
+    threads: z.array(ThreadSchema),
+    total: z.number().int().openapi({ example: 10 }),
+    limit: z.number().int().openapi({ example: 50 }),
+    offset: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("ThreadListResponse");
+
+const CreateThreadBodySchema = z
+  .object({
+    agentId: z.string().openapi({ example: "agent-id-123" }),
+    memberId: z.string().optional().openapi({ example: "member-id-123" }),
+    title: z.string().optional().openapi({ example: "Deployment question" }),
+  })
+  .openapi("CreateThreadBody");
+
+const UpdateThreadBodySchema = z
+  .object({
+    title: z.string().nullable().optional().openapi({ example: "New title" }),
+    memberId: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "member-id-123" }),
+  })
+  .openapi("UpdateThreadBody");
+
+const ThreadIdParamSchema = z.object({
+  id: z.string().openapi({ example: "clxthread123456" }),
+});
+
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const listThreadsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["threads"],
+  summary: "List threads (scoped to agentId for agent tokens)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: ThreadListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List of threads with total count",
+      content: { "application/json": { schema: ThreadListResponseSchema } },
+    },
+  },
+});
+
+const createThreadRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["threads"],
+  summary: "Create a thread",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      required: false,
+      content: { "application/json": { schema: CreateThreadBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Created thread",
+      content: { "application/json": { schema: ThreadSchema } },
+    },
+    400: {
+      description: "Bad request — agentId is required",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    403: {
+      description: "Forbidden — agent token may only create threads for itself",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getThreadStatsRoute = createRoute({
+  method: "get",
+  path: "/:id/stats",
+  tags: ["threads"],
+  summary: "Get aggregated stats for a thread",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: ThreadIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Aggregated thread stats",
+      content: { "application/json": { schema: ThreadStatsSchema } },
+    },
+    403: {
+      description: "Forbidden — agent token may not access this thread",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Thread not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getThreadRoute = createRoute({
+  method: "get",
+  path: "/:id",
+  tags: ["threads"],
+  summary: "Get a thread by id",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: ThreadIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Thread",
+      content: { "application/json": { schema: ThreadSchema } },
+    },
+    403: {
+      description: "Forbidden — agent token may not access this thread",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Thread not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const updateThreadRoute = createRoute({
+  method: "patch",
+  path: "/:id",
+  tags: ["threads"],
+  summary: "Update thread title and/or memberId",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: ThreadIdParamSchema,
+    body: {
+      required: false,
+      content: { "application/json": { schema: UpdateThreadBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated thread",
+      content: { "application/json": { schema: ThreadSchema } },
+    },
+    403: {
+      description: "Forbidden — agent token may not access this thread",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Thread not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const deleteThreadRoute = createRoute({
+  method: "delete",
+  path: "/:id",
+  tags: ["threads"],
+  summary: "Delete a thread",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: ThreadIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Deleted thread",
+      content: { "application/json": { schema: ThreadSchema } },
+    },
+    403: {
+      description: "Forbidden — agent token may not access this thread",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Thread not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
 export function createThreadsRoutes(
   threadService: ThreadServiceLike,
-): Hono<ChatAuthEnv> {
-  const app = new Hono<ChatAuthEnv>();
+): OpenAPIHono<ChatAuthEnv> {
+  const app = new OpenAPIHono<ChatAuthEnv>();
 
   // ─── List ──────────────────────────────────────────────────────────────────
-  app.get("/", async (c) => {
+  app.openapi(listThreadsRoute, async (c) => {
     const callerAgentId = c.get("agentId");
     const limit = parseIntParam(c.req.query("limit"), 50);
     const offset = parseIntParam(c.req.query("offset"), 0);
@@ -47,7 +246,7 @@ export function createThreadsRoutes(
   });
 
   // ─── Create ────────────────────────────────────────────────────────────────
-  app.post("/", async (c) => {
+  app.openapi(createThreadRoute, async (c) => {
     const callerAgentId = c.get("agentId");
 
     let body: Record<string, unknown> = {};
@@ -57,8 +256,7 @@ export function createThreadsRoutes(
       // empty body → fall through to validation below
     }
 
-    const agentId =
-      typeof body.agentId === "string" ? body.agentId : undefined;
+    const agentId = typeof body.agentId === "string" ? body.agentId : undefined;
     if (!agentId) throw new BadRequestError("agentId is required");
 
     // Agent tokens can only create threads for themselves.
@@ -77,7 +275,7 @@ export function createThreadsRoutes(
   });
 
   // ─── Stats ─────────────────────────────────────────────────────────────────
-  app.get("/:id/stats", async (c) => {
+  app.openapi(getThreadStatsRoute, async (c) => {
     const thread = await threadService.findById(c.req.param("id"));
     if (!thread) throw new NotFoundError("thread not found");
     enforceAgentScope(c.get("agentId"), thread.agentId);
@@ -86,7 +284,7 @@ export function createThreadsRoutes(
   });
 
   // ─── Get ───────────────────────────────────────────────────────────────────
-  app.get("/:id", async (c) => {
+  app.openapi(getThreadRoute, async (c) => {
     const thread = await threadService.findById(c.req.param("id"));
     if (!thread) throw new NotFoundError("thread not found");
     enforceAgentScope(c.get("agentId"), thread.agentId);
@@ -94,7 +292,7 @@ export function createThreadsRoutes(
   });
 
   // ─── Update ────────────────────────────────────────────────────────────────
-  app.patch("/:id", async (c) => {
+  app.openapi(updateThreadRoute, async (c) => {
     const thread = await threadService.findById(c.req.param("id"));
     if (!thread) throw new NotFoundError("thread not found");
     enforceAgentScope(c.get("agentId"), thread.agentId);
@@ -119,7 +317,7 @@ export function createThreadsRoutes(
   });
 
   // ─── Delete ────────────────────────────────────────────────────────────────
-  app.delete("/:id", async (c) => {
+  app.openapi(deleteThreadRoute, async (c) => {
     const thread = await threadService.findById(c.req.param("id"));
     if (!thread) throw new NotFoundError("thread not found");
     enforceAgentScope(c.get("agentId"), thread.agentId);


### PR DESCRIPTION
## Summary
- Converts `chat/src/routes/threads.ts` from plain `Hono` to `OpenAPIHono` + `createRoute()`
- All 6 thread routes (list, create, stats, get, update, delete) registered via `app.openapi()`, with route-specific Zod schemas co-located in the file following the `task-store/src/routes/tokens.ts` convention
- Handler bodies, query param parsing, and `enforceAgentScope` agent-scoping logic are unchanged — only route registration changed

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | createThreadsRoutes returns OpenAPIHono<ChatAuthEnv>, 6 routes via createRoute()/app.openapi() | MET | Factory returns `new OpenAPIHono<ChatAuthEnv>()`, all 6 routes registered via `app.openapi()` |
| 2 | Query param parsing & enforceAgentScope preserved exactly | MET | Handler logic and `enforceAgentScope` unchanged |
| 3 | Request/response shapes, status codes, error messages identical | MET | 19/19 threads.smoke.test.ts pass unchanged |
| 4 | No new test file; threads.smoke.test.ts is regression proof, passes unchanged | MET | Test file untouched; full chat suite 99/99 pass |

## Test Plan
- `bun test chat/src/threads.smoke.test.ts` — 19/19 pass
- `bun test chat/` (full chat suite) — 99/99 pass
- `cd chat && bun run typecheck` — clean
- `bunx biome lint chat/src/routes/threads.ts` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
