### PR TITLE
feat: convert messages routes to OpenAPIHono (incl. binary attachment)

### DIFF
--- a/chat/src/routes/messages.ts
+++ b/chat/src/routes/messages.ts
@@ -41,6 +41,20 @@ import { parseIntParam } from "./utils.ts";
 /** Maximum allowed size for message attachment bytes (10 MB). */
 export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 
+async function readJson(c: {
+  req: { json: () => Promise<unknown> };
+}): Promise<Record<string, unknown>> {
+  try {
+    const body = await c.req.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      return body as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
 // ─── Route-local schemas ──────────────────────────────────────────────────────
 
 /** Path param for routes with /:id */
@@ -345,12 +359,7 @@ export function createMessagesRoutes(
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
-    let body: Record<string, unknown> = {};
-    try {
-      body = (await c.req.json()) as Record<string, unknown>;
-    } catch {
-      // Non-JSON or empty body — validation below will catch missing fields.
-    }
+    const body = await readJson(c);
 
     const role = typeof body.role === "string" ? body.role : undefined;
     if (!role) throw new BadRequestError("role is required");
@@ -474,12 +483,7 @@ export function createMessagesRoutes(
     if (!existing || existing.threadId !== threadId)
       throw new NotFoundError("message not found");
 
-    let body: Record<string, unknown> = {};
-    try {
-      body = (await c.req.json()) as Record<string, unknown>;
-    } catch {
-      // empty body → no-op
-    }
+    const body = await readJson(c);
 
     const updated = await messageService.update(c.req.param("id"), {
       body: typeof body.body === "string" ? body.body : undefined,
@@ -527,12 +531,7 @@ export function createMessagesRoutes(
     if (existing.repliedAt !== null)
       throw new ConflictError("message already has a reply");
 
-    let body: Record<string, unknown> = {};
-    try {
-      body = (await c.req.json()) as Record<string, unknown>;
-    } catch {
-      // empty body → validation below catches missing body
-    }
+    const body = await readJson(c);
 
     const replyBody = typeof body.body === "string" ? body.body : undefined;
     if (replyBody === undefined) throw new BadRequestError("body is required");

--- a/chat/src/routes/messages.ts
+++ b/chat/src/routes/messages.ts
@@ -6,6 +6,7 @@
  *   GET    /                  list messages in thread
  *   POST   /                  create message
  *   POST   /claim             claim next unclaimed user message (queue API)
+ *   GET    /:id/attachment    stream (and clear) an ephemeral attachment
  *   GET    /:id               get message
  *   PATCH  /:id               update message
  *   DELETE /:id               delete message
@@ -16,9 +17,14 @@
  *
  * Attachment size guard: attachmentBytes maps to a Postgres bytea column loaded
  * in full on every Message read; cap at MAX_ATTACHMENT_BYTES to prevent WAL bloat.
+ *
+ * Schemas passed to createRoute() are for OpenAPI documentation only — handlers
+ * keep their existing manual body-parsing/validation logic (not c.req.valid())
+ * so that error messages and status codes stay byte-for-byte identical to the
+ * pre-conversion plain-Hono implementation.
  */
 
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { ChatAuthEnv } from "../auth.ts";
 import {
   BadRequestError,
@@ -28,20 +34,297 @@ import {
   PayloadTooLargeError,
 } from "../errors.ts";
 import type { JsonValue, MessageServiceLike } from "../message-service.ts";
+import { ErrorSchema, MessageSchema } from "../openapi-schemas.ts";
 import type { ThreadServiceLike } from "../thread-service.ts";
 import { parseIntParam } from "./utils.ts";
 
 /** Maximum allowed size for message attachment bytes (10 MB). */
 export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 
+// ─── Route-local schemas ──────────────────────────────────────────────────────
+
+/** Path param for routes with /:id */
+const MessageIdParamSchema = z.object({
+  id: z.string().openapi({ example: "clxmessage123456" }),
+});
+
+/** Query params for GET / (list) */
+const MessageListQuerySchema = z.object({
+  limit: z.string().optional().openapi({ example: "50" }),
+  offset: z.string().optional().openapi({ example: "0" }),
+});
+
+/** Response for GET / (list) */
+const MessageListResponseSchema = z
+  .object({
+    messages: z.array(MessageSchema),
+    total: z.number().int().openapi({ example: 10 }),
+    limit: z.number().int().openapi({ example: 50 }),
+    offset: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("MessageListResponse");
+
+/** Request body for POST / (create).
+ * Required fields (role, body) are validated by the handler rather than by
+ * Zod so custom error messages are returned instead of ZodError objects.
+ */
+const CreateMessageBodySchema = z
+  .object({
+    role: z.enum(["user", "assistant"]).optional().openapi({ example: "user" }),
+    body: z.string().optional().openapi({ example: "How do I deploy this?" }),
+    tokens: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .openapi({ example: { input_tokens: 10, output_tokens: 20 } }),
+    costUsd: z.number().optional().openapi({ example: 0.02 }),
+    attachmentFilename: z
+      .string()
+      .optional()
+      .openapi({ example: "screenshot.png" }),
+    attachmentSize: z.number().int().optional().openapi({ example: 1024 }),
+    attachmentBytes: z
+      .string()
+      .optional()
+      .openapi({ example: "base64-encoded-bytes" }),
+  })
+  .openapi("CreateMessageBody");
+
+/** Request body for PATCH /:id. All fields optional; handler applies partial updates. */
+const UpdateMessageBodySchema = z
+  .object({
+    body: z.string().optional().openapi({ example: "Updated text" }),
+    tokens: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .optional()
+      .openapi({ example: { input_tokens: 10, output_tokens: 20 } }),
+    costUsd: z.number().nullable().optional().openapi({ example: 0.03 }),
+    errorKind: z.string().nullable().optional().openapi({ example: null }),
+  })
+  .openapi("UpdateMessageBody");
+
+/** Request body for POST /:id/reply.
+ * `body` is required at runtime by the handler (custom error message), but
+ * kept optional here per the permissive-schema/manual-validation convention.
+ */
+const ReplyBodySchema = z
+  .object({
+    body: z.string().optional().openapi({ example: "Sure, here is the answer." }),
+    tokens: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .openapi({ example: { input_tokens: 10, output_tokens: 20 } }),
+    costUsd: z.number().optional().openapi({ example: 0.02 }),
+  })
+  .openapi("ReplyBody");
+
+/** Response for POST /:id/reply */
+const ReplyResponseSchema = z
+  .object({
+    userMessage: MessageSchema,
+    assistantMessage: MessageSchema,
+  })
+  .openapi("ReplyResponse");
+
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["messages"],
+  summary: "List messages in a thread",
+  request: {
+    query: MessageListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List of messages with pagination info",
+      content: { "application/json": { schema: MessageListResponseSchema } },
+    },
+    404: {
+      description: "Thread not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const createMessageRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["messages"],
+  summary: "Create a message",
+  request: {
+    body: {
+      content: { "application/json": { schema: CreateMessageBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Created message",
+      content: { "application/json": { schema: MessageSchema } },
+    },
+    400: {
+      description: "Bad request",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Thread not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    413: {
+      description: "Attachment exceeds size limit",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const claimRoute = createRoute({
+  method: "post",
+  path: "/claim",
+  tags: ["messages"],
+  summary: "Claim the next unclaimed user message in a thread",
+  responses: {
+    200: {
+      description: "Claimed message",
+      content: { "application/json": { schema: MessageSchema } },
+    },
+    404: {
+      description: "Thread not found, or no unclaimed messages in thread",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getAttachmentRoute = createRoute({
+  method: "get",
+  path: "/:id/attachment",
+  tags: ["messages"],
+  summary: "Stream a message's attachment (ephemeral — cleared after read)",
+  request: {
+    params: MessageIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Attachment bytes",
+      content: {
+        "application/octet-stream": {
+          schema: z.string().openapi({ format: "binary" }),
+        },
+      },
+    },
+    404: {
+      description: "Thread not found, message not found, or no attachment",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getOneRoute = createRoute({
+  method: "get",
+  path: "/:id",
+  tags: ["messages"],
+  summary: "Get a message by ID",
+  request: {
+    params: MessageIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Message",
+      content: { "application/json": { schema: MessageSchema } },
+    },
+    404: {
+      description: "Thread or message not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const updateRoute = createRoute({
+  method: "patch",
+  path: "/:id",
+  tags: ["messages"],
+  summary: "Update a message",
+  request: {
+    params: MessageIdParamSchema,
+    body: {
+      content: { "application/json": { schema: UpdateMessageBodySchema } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated message",
+      content: { "application/json": { schema: MessageSchema } },
+    },
+    404: {
+      description: "Thread or message not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/:id",
+  tags: ["messages"],
+  summary: "Delete a message",
+  request: {
+    params: MessageIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Deleted message",
+      content: { "application/json": { schema: MessageSchema } },
+    },
+    404: {
+      description: "Thread or message not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const replyRoute = createRoute({
+  method: "post",
+  path: "/:id/reply",
+  tags: ["messages"],
+  summary: "Post an agent reply to a user message",
+  request: {
+    params: MessageIdParamSchema,
+    body: {
+      content: { "application/json": { schema: ReplyBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "User message and the newly created assistant reply",
+      content: { "application/json": { schema: ReplyResponseSchema } },
+    },
+    400: {
+      description: "Bad request",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Thread or message not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    409: {
+      description: "Message already has a reply",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
 export function createMessagesRoutes(
   threadService: ThreadServiceLike,
   messageService: MessageServiceLike,
-): Hono<ChatAuthEnv> {
-  const app = new Hono<ChatAuthEnv>();
+): OpenAPIHono<ChatAuthEnv> {
+  const app = new OpenAPIHono<ChatAuthEnv>();
 
   // ─── List ──────────────────────────────────────────────────────────────────
-  app.get("/", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(listRoute, async (c): Promise<any> => {
     // threadId is always present — guaranteed by the /threads/:threadId/messages mount
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
@@ -57,7 +340,8 @@ export function createMessagesRoutes(
   });
 
   // ─── Create ────────────────────────────────────────────────────────────────
-  app.post("/", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(createMessageRoute, async (c): Promise<any> => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
@@ -122,7 +406,8 @@ export function createMessagesRoutes(
 
   // ─── Claim (queue API) ─────────────────────────────────────────────────────
   // Registered before /:id routes so "claim" is matched as a static segment.
-  app.post("/claim", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(claimRoute, async (c): Promise<any> => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
@@ -137,12 +422,14 @@ export function createMessagesRoutes(
   // ─── Get attachment (ephemeral) ──────────────────────────────────────────────
   // Registered before /:id so "/:id/attachment" matches. Streams the stored
   // bytes once, then drops them — content is not retained after the agent pulls
-  // it into its workspace.
-  app.get("/:id/attachment", async (c) => {
+  // it into its workspace. Registered via createRoute()/app.openapi(); the
+  // handler still returns a raw Response, which app.openapi() passes through
+  // unchanged (validated only against the documented schema, not enforced).
+  app.openapi(getAttachmentRoute, async (c) => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
-    const message = await messageService.findById(c.req.param("id") as string);
+    const message = await messageService.findById(c.req.param("id"));
     if (!message || message.threadId !== threadId)
       throw new NotFoundError("message not found");
 
@@ -166,22 +453,24 @@ export function createMessagesRoutes(
   });
 
   // ─── Get ───────────────────────────────────────────────────────────────────
-  app.get("/:id", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(getOneRoute, async (c): Promise<any> => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
-    const message = await messageService.findById(c.req.param("id") as string);
+    const message = await messageService.findById(c.req.param("id"));
     if (!message || message.threadId !== threadId)
       throw new NotFoundError("message not found");
     return c.json(message, 200);
   });
 
   // ─── Update ────────────────────────────────────────────────────────────────
-  app.patch("/:id", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(updateRoute, async (c): Promise<any> => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
-    const existing = await messageService.findById(c.req.param("id") as string);
+    const existing = await messageService.findById(c.req.param("id"));
     if (!existing || existing.threadId !== threadId)
       throw new NotFoundError("message not found");
 
@@ -192,7 +481,7 @@ export function createMessagesRoutes(
       // empty body → no-op
     }
 
-    const updated = await messageService.update(c.req.param("id") as string, {
+    const updated = await messageService.update(c.req.param("id"), {
       body: typeof body.body === "string" ? body.body : undefined,
       tokens:
         body.tokens !== undefined ? (body.tokens as JsonValue) : undefined,
@@ -210,25 +499,27 @@ export function createMessagesRoutes(
   });
 
   // ─── Delete ────────────────────────────────────────────────────────────────
-  app.delete("/:id", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(deleteRoute, async (c): Promise<any> => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
-    const existing = await messageService.findById(c.req.param("id") as string);
+    const existing = await messageService.findById(c.req.param("id"));
     if (!existing || existing.threadId !== threadId)
       throw new NotFoundError("message not found");
 
-    const deleted = await messageService.delete(c.req.param("id") as string);
+    const deleted = await messageService.delete(c.req.param("id"));
     if (!deleted) throw new NotFoundError("message not found");
     return c.json(deleted, 200);
   });
 
   // ─── Reply (queue API) ─────────────────────────────────────────────────────
-  app.post("/:id/reply", async (c) => {
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(replyRoute, async (c): Promise<any> => {
     const threadId = c.req.param("threadId") as string;
     await requireThread(c, threadService, threadId);
 
-    const existing = await messageService.findById(c.req.param("id") as string);
+    const existing = await messageService.findById(c.req.param("id"));
     if (!existing || existing.threadId !== threadId)
       throw new NotFoundError("message not found");
     if (existing.role !== "user")
@@ -246,7 +537,7 @@ export function createMessagesRoutes(
     const replyBody = typeof body.body === "string" ? body.body : undefined;
     if (replyBody === undefined) throw new BadRequestError("body is required");
 
-    const result = await messageService.reply(c.req.param("id") as string, {
+    const result = await messageService.reply(c.req.param("id"), {
       body: replyBody,
       tokens:
         body.tokens !== undefined ? (body.tokens as JsonValue) : undefined,


### PR DESCRIPTION
## Summary
- Converts `chat/src/routes/messages.ts` from plain `Hono` to `OpenAPIHono` + `createRoute()`, covering all 8 message routes (list, create, claim, get attachment, get, update, delete, reply)
- Route-specific schemas (list query, create/update/reply bodies, id param, list/reply response shapes) are co-located in the route file; `MessageSchema`/`ErrorSchema` are imported from `chat/src/openapi-schemas.ts`
- Mirrors the established `OpenAPIHono` conversion pattern from `task-store/src/routes/tasks.ts`, including a shared `readJson()` helper for permissive body parsing — handlers keep their existing manual validation logic (not `c.req.valid()`) so error messages and status codes stay byte-for-byte identical to the pre-conversion implementation
- The binary attachment route (`GET /:id/attachment`) is registered via `createRoute()`/`app.openapi()` directly — no fallback to plain `app.get()` was needed, so this route will be picked up by future OpenAPI spec generation without manual patching

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | createMessagesRoutes returns OpenAPIHono<ChatAuthEnv>, all 8 routes registered | MET | All 8 routes registered via `app.openapi()`, including the attachment route |
| 2 | Attachment ephemeral-read-then-clear unchanged | MET | `clearAttachmentBytes()` call preserved unchanged |
| 3 | Attachment size guard (MAX_ATTACHMENT_BYTES, PayloadTooLargeError) unchanged | MET | Guard logic copied verbatim for both base64-string and Uint8Array paths |
| 4 | Request/response shapes, status codes, error messages identical | MET | All handler logic copied verbatim; schemas are documentation-only |
| 5 | messages.smoke.test.ts passes unchanged, no tests retired | MET | 99/99 tests pass across 6 files; test file untouched |

## Test Plan
- `bun test chat/src` — 99/99 pass across 6 files (includes `messages.smoke.test.ts` covering all 8 routes, including the attachment stream and the 413 payload-too-large guard)
- `bun run --filter=@shipwright/chat typecheck` — clean
- `bunx biome lint chat/` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
