### PR TITLE
fix: require literal Verdict phrase in review body for check-patch dedup

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -538,12 +538,24 @@ regardless of the review outcome — GitHub rejects self-APPROVE via the API. Th
 (`APPROVE` or `COMMENT`) is still recorded faithfully in the review file so the deploy skill
 can read the verdict directly from the GitHub review body.
 
+**The `body` field MUST contain the literal phrase `Verdict: APPROVE` or `Verdict: COMMENT`**,
+matching whichever verdict was selected below in Event selection — not just implied wording or
+free-form approval prose. `check-patch.ts`'s `isSelfCleanApprove` (`VERDICT_APPROVE_LABEL =
+/verdict\**\s*:\s*\**approve\b/i`) scans the GitHub-posted review body for this exact phrase to
+recognize a clean self-approve on a self-authored PR (where `event` is forced to `COMMENT` above,
+since GitHub blocks self-APPROVE via the API). A body like "Clean conversion, all routes
+verified, no blocking issues." reads as a genuine approval to a human but contains neither
+`APPROVE` nor `Verdict: APPROVE`, so `isSelfCleanApprove` never matches it — the patch cron then
+treats it as an unaddressed finding forever. Always lead the body with the literal `Verdict: ...`
+label, on both the initial-review and re-review paths (Steps 10/11 run identically for both;
+see Step 14's re-review flow).
+
 Write `state/reviews/pr_review_{pr}.json`:
 
 ```json
 {
   "commit_id": "{head_sha}",
-  "body": "{concise verdict}",
+  "body": "Verdict: APPROVE — Looks good, approved.",
   "event": "APPROVE|COMMENT",
   "comments": [
     {
@@ -555,6 +567,9 @@ Write `state/reviews/pr_review_{pr}.json`:
   ]
 }
 ```
+
+For a COMMENT verdict, the `body` follows the same convention, e.g.
+`"body": "Verdict: COMMENT — {one-line summary of the most important finding}"`.
 
 **Diff-line mapping**: for each finding with a `file:line` reference, check if the
 line is in the diff (`git diff {base}...HEAD -- {file}`). Only lines within diff

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -66,7 +66,7 @@ describe("review.md — CPF-2.2 verdict phrase requirement", () => {
     ).toBe(true);
   });
 
-  it("the Slack message template's Verdict line renders literal 'Verdict: APPROVE' / 'Verdict: COMMENT' text", () => {
+  it("Slack message template has a *Verdict:* placeholder line", () => {
     const slackVerdictLine = content.includes("*Verdict:* {APPROVE|COMMENT}");
     expect(slackVerdictLine).toBe(true);
   });

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -29,3 +29,45 @@ describe("review.md — TRR-1.2 test-readiness context", () => {
     expect(hasTestReadinessContext).toBe(true);
   });
 });
+
+describe("review.md — CPF-2.2 verdict phrase requirement", () => {
+  let step10Section: string;
+
+  beforeAll(() => {
+    const startIdx = content.indexOf("## Step 10: Build Review JSON");
+    const endIdx = content.indexOf("## Step 11: Post or Stage");
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    step10Section = content.slice(startIdx, endIdx);
+  });
+
+  it("Step 10 requires the literal phrase 'Verdict: APPROVE' in the posted body", () => {
+    expect(step10Section.includes("Verdict: APPROVE")).toBe(true);
+  });
+
+  it("Step 10 requires the literal phrase 'Verdict: COMMENT' in the posted body", () => {
+    expect(step10Section.includes("Verdict: COMMENT")).toBe(true);
+  });
+
+  it("Step 10 ties the phrase requirement to check-patch.ts's isSelfCleanApprove matching", () => {
+    expect(step10Section.includes("isSelfCleanApprove")).toBe(true);
+    expect(step10Section.includes("check-patch.ts")).toBe(true);
+  });
+
+  it("Step 10's JSON template models the required phrase in the body placeholder", () => {
+    // The body field example itself should demonstrate the literal phrase,
+    // not just describe the requirement in prose.
+    const jsonBlockMatch = step10Section.match(/```json([\s\S]*?)```/);
+    expect(jsonBlockMatch).not.toBeNull();
+    const jsonBlock = jsonBlockMatch?.[1] ?? "";
+    expect(
+      jsonBlock.includes("Verdict: APPROVE") ||
+        jsonBlock.includes("Verdict: COMMENT"),
+    ).toBe(true);
+  });
+
+  it("the Slack message template's Verdict line renders literal 'Verdict: APPROVE' / 'Verdict: COMMENT' text", () => {
+    const slackVerdictLine = content.includes("*Verdict:* {APPROVE|COMMENT}");
+    expect(slackVerdictLine).toBe(true);
+  });
+});

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -41,7 +41,7 @@ Write to `state/reviews/pr_review_<number>.json`:
 ```json
 {
   "commit_id": "<head_sha>",
-  "body": "<concise verdict + one-liner>",
+  "body": "Verdict: APPROVE — <concise one-liner>",
   "event": "APPROVE|COMMENT",
   "comments": [
     {
@@ -56,13 +56,25 @@ Write to `state/reviews/pr_review_<number>.json`:
 
 ### Body Guidelines
 
-Keep the body minimal -- inline comments carry the detail. A good body is:
+Keep the body minimal -- inline comments carry the detail. The body MUST start with the
+literal phrase `Verdict: APPROVE` or `Verdict: COMMENT` (matching the verdict), followed
+by a short one-liner. A good body is:
 
-- **APPROVE**: "Looks good, approved." or "Looks good -- a few suggestions inline."
-- **COMMENT**: "A few issues to address before merging." + one-line summary of the
-  most important finding.
+- **APPROVE**: "Verdict: APPROVE — Looks good, approved." or "Verdict: APPROVE — Looks
+  good, a few suggestions inline."
+- **COMMENT**: "Verdict: COMMENT — A few issues to address before merging." + one-line
+  summary of the most important finding.
 
 Don't enumerate findings in the body -- the author sees both body and inline comments.
+
+**This literal phrase is load-bearing, not stylistic.** `check-patch.ts`'s
+`isSelfCleanApprove` matches `Verdict: APPROVE` (case-insensitive, optional `**` markdown
+bold) anywhere in a self-authored review body to recognize a clean self-approve -- this
+matters because GitHub blocks self-APPROVE via the API, so a self-review's clean approval
+is always posted as `event: COMMENT`. Free-form approval prose without the literal phrase
+(e.g. "Clean conversion, no blocking issues.") never matches, and the patch cron then
+treats the review as an unaddressed finding forever. Always lead with the `Verdict: ...`
+label -- don't paraphrase it away.
 
 ### Tone
 

--- a/plugins/shipwright/references/post-review-guide.unit.test.ts
+++ b/plugins/shipwright/references/post-review-guide.unit.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const POST_REVIEW_GUIDE_PATH = join(import.meta.dir, "post-review-guide.md");
+
+let content: string;
+let bodyGuidelinesSection: string;
+
+beforeAll(() => {
+  content = readFileSync(POST_REVIEW_GUIDE_PATH, "utf-8");
+
+  const startIdx = content.indexOf("### Body Guidelines");
+  const endIdx = content.indexOf("### Tone");
+  expect(startIdx).toBeGreaterThan(-1);
+  expect(endIdx).toBeGreaterThan(startIdx);
+  bodyGuidelinesSection = content.slice(startIdx, endIdx);
+});
+
+describe("post-review-guide.md — CPF-2.2 verdict phrase requirement", () => {
+  it("APPROVE example body includes the literal phrase 'Verdict: APPROVE'", () => {
+    expect(bodyGuidelinesSection.includes("Verdict: APPROVE")).toBe(true);
+  });
+
+  it("COMMENT example body includes the literal phrase 'Verdict: COMMENT'", () => {
+    expect(bodyGuidelinesSection.includes("Verdict: COMMENT")).toBe(true);
+  });
+
+  it("notes that the phrase is load-bearing for check-patch.ts's self-review dedup, not just stylistic", () => {
+    expect(bodyGuidelinesSection.includes("check-patch.ts")).toBe(true);
+    const mentionsLoadBearing =
+      bodyGuidelinesSection.includes("load-bearing") ||
+      bodyGuidelinesSection.includes("load bearing");
+    expect(mentionsLoadBearing).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `commands/review.md` Step 10 now requires the GitHub-posted review `body` to literally contain `Verdict: APPROVE` or `Verdict: COMMENT` (matching the selected verdict), tied explicitly to check-patch.ts's `isSelfCleanApprove`/`VERDICT_APPROVE_LABEL` regex so self-review agents can't accidentally phrase their way past the matcher.
- `references/post-review-guide.md` Body Guidelines updated with the same literal-phrase requirement and a note that it's load-bearing, not stylistic.
- Confirmed the existing Slack message template's `*Verdict:* {APPROVE|COMMENT}` line already renders the correct literal text — left unchanged.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | commands/review.md Step 10 JSON body template explicitly instructs the literal phrase "Verdict: APPROVE"/"Verdict: COMMENT" for both initial-review and re-review templates | MET |
| 2 | A self-review with a clean APPROVE outcome reliably matches isSelfCleanApprove without relying on agent phrasing | MET |
| 3 | No change to findings semantics — COMMENT verdicts with real findings still post normally | MET |

## Test Plan
- Added `describe("review.md — CPF-2.2 verdict phrase requirement", ...)` to `commands/review.unit.test.ts` (content-assertion tests against the Step 10 section, following this repo's existing pattern for markdown-spec testing)
- Added new `references/post-review-guide.unit.test.ts` asserting the Body Guidelines section requires the literal phrase
- `bun test plugins/shipwright` — 738 pass, 0 fail
- `tsc --noEmit` (plugin typecheck) — clean
- `bunx biome lint` on changed files — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
