### PR TITLE
feat: add prCreatedAt column to PullRequest and wire it into the claim endpoint

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -183,6 +183,7 @@ Body:
 | `claimedBy` | admin only | Agent ID (agent tokens pin to their own ID) |
 | `taskId` | no | Associated task ID |
 | `phase` | no | Pipeline phase (`review`, `patch`, or `deploy`; default: `review`). When set, the phase is updated and reviewState is preserved. |
+| `prCreatedAt` | no | ISO timestamp of the GitHub PR's actual creation time. Only applied when the claim creates a new record (`201`); ignored on subsequent claims (`200`) of an existing record since the field is immutable once set. |
 
 Claim semantics:
 - No existing record → creates and returns `201`
@@ -252,7 +253,7 @@ The following timestamp fields are managed by the task store:
 
 | Field | Managed by | Description |
 |-------|-----------|-------------|
-| `prCreatedAt` | Lifecycle endpoints | ISO timestamp of the GitHub PR's actual creation time (distinct from `createdAt`, which records when the task-store record itself was created). Read-only. |
+| `prCreatedAt` | `POST /prs/claim` | ISO timestamp of the GitHub PR's actual creation time (distinct from `createdAt`, which records when the task-store record itself was created). Set once via the optional `prCreatedAt` field on the first `POST /prs/claim` call that creates the record (`201`); read-only thereafter — later claims cannot modify it. Not currently populated by any Shipwright command; callers must supply GitHub's PR `createdAt` explicitly to use this field. |
 | `createdAt` | Auto | ISO timestamp when the task-store PR record was created. |
 | `updatedAt` | Auto | ISO timestamp when the task-store PR record was last modified. |
 | `reviewedAt` | `POST /prs/:id/complete` | Set when the review cycle completes. |

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -246,6 +246,21 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 
 `phase`: `review` | `patch` | `deploy` — tracks which pipeline phase the PR is currently in. Set via `PATCH /prs/:id`. The `readyForReviewAt`, `readyForPatchAt`, and `readyForDeployAt` timestamps record when the PR became ready for each phase; COALESCE across them gives a unified queue-entry time.
 
+#### PR timestamp fields
+
+The following timestamp fields are managed by the task store:
+
+| Field | Managed by | Description |
+|-------|-----------|-------------|
+| `prCreatedAt` | Lifecycle endpoints | ISO timestamp of the GitHub PR's actual creation time (distinct from `createdAt`, which records when the task-store record itself was created). Read-only. |
+| `createdAt` | Auto | ISO timestamp when the task-store PR record was created. |
+| `updatedAt` | Auto | ISO timestamp when the task-store PR record was last modified. |
+| `reviewedAt` | `POST /prs/:id/complete` | Set when the review cycle completes. |
+| `patchedAt` | `POST /prs/:id/patch` | Set when the patch cycle completes. |
+| `mergedAt` | Writable via `PATCH /prs/:id` | Manually set or updated when marking the PR as merged. |
+| `claimedAt` | `POST /prs/claim` | Set when the PR is claimed by an agent. |
+| `heartbeatAt` | `POST /prs/:id/heartbeat` | Updated to now whenever the claiming agent signals it is still working. |
+
 ### Token management (admin only)
 
 All `/tokens` endpoints require an admin token.

--- a/lib/task-store-types.ts
+++ b/lib/task-store-types.ts
@@ -1647,6 +1647,11 @@ export interface components {
             patchedAt?: string | null;
             /** @example null */
             mergedAt?: string | null;
+            /**
+             * @description ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            prCreatedAt?: string | null;
             /** @example agent-id-123 */
             claimedBy?: string | null;
             /** @example 2026-01-02T00:00:00.000Z */
@@ -1711,6 +1716,17 @@ export interface components {
              * @example clx1234567890
              */
             taskId?: string;
+            /**
+             * @description Pipeline phase this claim is for (defaults to 'review' when omitted)
+             * @example patch
+             * @enum {string}
+             */
+            phase?: "review" | "patch" | "deploy";
+            /**
+             * @description ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            prCreatedAt?: string;
         };
         ClaimNextResponse: {
             pr: components["schemas"]["PullRequest"];

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -2260,6 +2260,14 @@
             ],
             "example": null
           },
+          "prCreatedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.",
+            "example": "2026-01-01T00:00:00.000Z"
+          },
           "claimedBy": {
             "type": [
               "string",
@@ -2390,6 +2398,21 @@
             "type": "string",
             "description": "Associated task ID",
             "example": "clx1234567890"
+          },
+          "phase": {
+            "type": "string",
+            "enum": [
+              "review",
+              "patch",
+              "deploy"
+            ],
+            "description": "Pipeline phase this claim is for (defaults to 'review' when omitted)",
+            "example": "patch"
+          },
+          "prCreatedAt": {
+            "type": "string",
+            "description": "ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.",
+            "example": "2026-01-01T00:00:00.000Z"
           }
         },
         "required": [

--- a/task-store/prisma/migrations/20260708000000_add_pr_created_at_to_pull_request/migration.sql
+++ b/task-store/prisma/migrations/20260708000000_add_pr_created_at_to_pull_request/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add prCreatedAt (GitHub PR creation timestamp) to PullRequest
+ALTER TABLE "PullRequest" ADD COLUMN "prCreatedAt" TEXT;

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -160,6 +160,7 @@ model PullRequest {
   reviewedAt        String?
   patchedAt         String?
   mergedAt          String?
+  prCreatedAt       String? // ISO timestamp of the GitHub PR's actual creation (distinct from createdAt, the task-store record's creation)
   claimedBy         String?
   claimedAt         String?
   heartbeatAt       String?

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -285,6 +285,15 @@ export const PullRequestSchema = z
       .openapi({ example: "2026-01-03T00:00:00.000Z" }),
     patchedAt: z.string().nullable().optional().openapi({ example: null }),
     mergedAt: z.string().nullable().optional().openapi({ example: null }),
+    prCreatedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({
+        example: "2026-01-01T00:00:00.000Z",
+        description:
+          "ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.",
+      }),
     claimedBy: z
       .string()
       .nullable()
@@ -548,6 +557,14 @@ export const ClaimPrBodySchema = z
       .enum(["review", "patch", "deploy"])
       .optional()
       .openapi({ example: "patch", description: "Pipeline phase this claim is for (defaults to 'review' when omitted)" }),
+    prCreatedAt: z
+      .string()
+      .optional()
+      .openapi({
+        example: "2026-01-01T00:00:00.000Z",
+        description:
+          "ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.",
+      }),
   })
   .openapi("ClaimPrBody");
 

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -55,6 +55,7 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     reviewedAt: null,
     patchedAt: null,
     mergedAt: null,
+    prCreatedAt: null,
     claimedBy: null,
     claimedAt: null,
     heartbeatAt: null,
@@ -144,6 +145,7 @@ interface CapturedClaimCall {
   claimedBy: string;
   taskId?: string;
   phase?: "review" | "patch" | "deploy";
+  prCreatedAt?: string;
 }
 
 /** Minimal in-memory PullRequestServiceLike fake. */
@@ -203,6 +205,7 @@ function fakePrService(
       claimedBy: string,
       taskId?: string,
       phase?: "review" | "patch" | "deploy",
+      prCreatedAt?: string,
     ): Promise<{ status: 200 | 201; record: PullRequest }> {
       opts.claimCalls?.push({
         repo,
@@ -211,6 +214,7 @@ function fakePrService(
         claimedBy,
         taskId,
         phase,
+        prCreatedAt,
       });
       if (opts.claimResult !== undefined) {
         if (opts.claimResult instanceof Error) throw opts.claimResult;
@@ -228,6 +232,7 @@ function fakePrService(
         reviewState: "in_progress",
         claimedAt: new Date().toISOString(),
         heartbeatAt: new Date().toISOString(),
+        prCreatedAt: prCreatedAt ?? null,
       });
       store.set(record.id, record);
       return { status: 201, record };
@@ -540,6 +545,45 @@ describe("/prs routes (smoke)", () => {
     expect(res.status).toBe(201);
     expect(claimCalls).toHaveLength(1);
     expect(claimCalls[0]?.phase).toBeUndefined();
+  });
+
+  it("POST /prs/claim forwards prCreatedAt from the request body to service.claim() and returns it in the response", async () => {
+    const claimCalls: CapturedClaimCall[] = [];
+    const app = makeApp({ prService: fakePrService({ claimCalls }) });
+    const res = await app.request("/prs/claim", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        repo: ADMIN_REPO,
+        prNumber: 42,
+        commitSha: "abc123",
+        claimedBy: "agent-1",
+        prCreatedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(claimCalls).toHaveLength(1);
+    expect(claimCalls[0]?.prCreatedAt).toBe("2026-01-01T00:00:00.000Z");
+    const body = (await res.json()) as PullRequest;
+    expect(body.prCreatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("POST /prs/claim without prCreatedAt leaves it undefined (not persisted)", async () => {
+    const claimCalls: CapturedClaimCall[] = [];
+    const app = makeApp({ prService: fakePrService({ claimCalls }) });
+    const res = await app.request("/prs/claim", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        repo: ADMIN_REPO,
+        prNumber: 42,
+        commitSha: "abc123",
+        claimedBy: "agent-1",
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(claimCalls).toHaveLength(1);
+    expect(claimCalls[0]?.prCreatedAt).toBeUndefined();
   });
 
   // ─── POST /prs/:id/complete ───────────────────────────────────────────────

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -49,6 +49,7 @@ export interface PullRequestServiceLike {
     claimedBy: string,
     taskId?: string,
     phase?: PrPhase,
+    prCreatedAt?: string,
   ): Promise<{ status: 200 | 201; record: PullRequest }>;
   heartbeat(id: string): Promise<PullRequest>;
   complete(id: string): Promise<PullRequest>;
@@ -153,6 +154,7 @@ export class PullRequestService implements PullRequestServiceLike {
     claimedBy: string,
     taskId?: string,
     phase: PrPhase = "review",
+    prCreatedAt?: string,
   ): Promise<{ status: 200 | 201; record: PullRequest }> {
     const now = this.clock.now().toISOString();
 
@@ -227,6 +229,10 @@ export class PullRequestService implements PullRequestServiceLike {
           heartbeatAt: now,
           phase,
           ...(taskId !== undefined ? { taskId } : {}),
+          // prCreatedAt is only ever set here, at record creation — it is
+          // immutable thereafter (never touched by the update branch above),
+          // matching the "read-only via the API" contract in docs/task-store.md.
+          ...(prCreatedAt !== undefined ? { prCreatedAt } : {}),
         };
 
         if (phase === "review") {

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -419,6 +419,91 @@ describeOrSkip("PullRequestService.claim() phase support (integration)", () => {
   });
 });
 
+// ─── claim() prCreatedAt wiring ────────────────────────────────────────────────
+
+describeOrSkip("PullRequestService.claim() prCreatedAt wiring (integration)", () => {
+  let prisma: PrismaClient;
+  let service: PullRequestService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    service = new PullRequestService(prisma);
+    await prisma.pullRequest.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("claim() sets prCreatedAt on first claim (record creation) when provided", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 800;
+    const prCreatedAt = "2026-01-01T00:00:00.000Z";
+
+    const result = await service.claim(
+      repo,
+      prNumber,
+      "sha-1",
+      "agent-a",
+      undefined,
+      "review",
+      prCreatedAt,
+    );
+
+    expect(result.status).toBe(201);
+    expect(result.record.prCreatedAt).toBe(prCreatedAt);
+  });
+
+  it("claim() leaves prCreatedAt null on record creation when not provided", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 801;
+
+    const result = await service.claim(repo, prNumber, "sha-1", "agent-a");
+
+    expect(result.status).toBe(201);
+    expect(result.record.prCreatedAt).toBeNull();
+  });
+
+  it("claim() never overwrites an existing prCreatedAt on subsequent claims (immutable)", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 802;
+    const originalPrCreatedAt = "2026-01-01T00:00:00.000Z";
+
+    // First claim sets prCreatedAt.
+    await service.claim(
+      repo,
+      prNumber,
+      "sha-1",
+      "agent-a",
+      undefined,
+      "review",
+      originalPrCreatedAt,
+    );
+
+    // Release so a new claim can proceed, then claim again with a different
+    // sha and a different (bogus) prCreatedAt — it must not be applied since
+    // the field is read-only once set.
+    const releaseTarget = await prisma.pullRequest.findUnique({
+      where: { repo_prNumber: { repo, prNumber } },
+    });
+    if (!releaseTarget) throw new Error("expected record to exist");
+    await service.release(releaseTarget.id);
+
+    const second = await service.claim(
+      repo,
+      prNumber,
+      "sha-2",
+      "agent-b",
+      undefined,
+      "review",
+      "2026-12-31T00:00:00.000Z",
+    );
+
+    expect(second.status).toBe(200);
+    expect(second.record.prCreatedAt).toBe(originalPrCreatedAt);
+  });
+});
+
 // ─── complete() sets readyForPatchAt ──────────────────────────────────────────
 
 describeOrSkip("PullRequestService.complete() readyForPatchAt (integration)", () => {

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -69,6 +69,7 @@ describeOrSkip("PullRequest model (integration)", () => {
     expect(read.readyForReviewAt).toBeNull();
     expect(read.readyForPatchAt).toBeNull();
     expect(read.readyForDeployAt).toBeNull();
+    expect(read.prCreatedAt).toBeNull();
     expect(read.createdAt).toBeInstanceOf(Date);
     expect(read.updatedAt).toBeInstanceOf(Date);
   });
@@ -125,6 +126,27 @@ describeOrSkip("PullRequest model (integration)", () => {
     expect(rows[0].prNumber).toBe(602); // earliest: readyForReviewAt 01:00
     expect(rows[1].prNumber).toBe(601); // middle:   readyForPatchAt  02:00
     expect(rows[2].prNumber).toBe(603); // latest:   readyForDeployAt 03:00
+  });
+
+  it("round-trips prCreatedAt", async () => {
+    const prCreatedAt = "2026-06-15T08:30:00.000Z";
+
+    const created = await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 55,
+        prCreatedAt,
+      },
+    });
+
+    const read = await prisma.pullRequest.findUnique({
+      where: { id: created.id },
+    });
+
+    expect(read).not.toBeNull();
+    if (!read) return;
+
+    expect(read.prCreatedAt).toBe(prCreatedAt);
   });
 
   it("rejects duplicate (repo, prNumber)", async () => {

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -314,7 +314,7 @@ export function createPrsRoutes(
     const repos = c.get("repos");
     const body = await readJson(c);
 
-    const { repo, prNumber, commitSha, claimedBy, taskId, phase } = body;
+    const { repo, prNumber, commitSha, claimedBy, taskId, phase, prCreatedAt } = body;
 
     // Validate required fields
     if (typeof repo !== "string" || !repo) {
@@ -358,6 +358,9 @@ export function createPrsRoutes(
         ? phase
         : undefined;
 
+    const resolvedPrCreatedAt =
+      typeof prCreatedAt === "string" && prCreatedAt ? prCreatedAt : undefined;
+
     const { status, record } = await prService.claim(
       repo,
       prNumber,
@@ -365,6 +368,7 @@ export function createPrsRoutes(
       resolvedClaimedBy,
       resolvedTaskId,
       resolvedPhase,
+      resolvedPrCreatedAt,
     );
 
     return c.json(record, status);


### PR DESCRIPTION
## Summary
- Add a nullable `prCreatedAt String?` column to the `PullRequest` Prisma model, capturing the real GitHub PR-creation timestamp distinct from Prisma's own `createdAt` (task-store record creation time)
- Add the corresponding hand-authored migration (`ALTER TABLE ... ADD COLUMN "prCreatedAt" TEXT`) following the repo's existing convention for nullable timestamp columns on this model
- Refresh `docs/task-store.md` to document the new field alongside the other PR timestamp fields

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | PullRequest model gains prCreatedAt String? (nullable, additive) with a corresponding Prisma migration | MET | `schema.prisma` adds `prCreatedAt String?`; migration `20260708000000_add_pr_created_at_to_pull_request` adds a `TEXT` column |
| 2 | Migration applies cleanly against the existing schema and is reversible | MET | Bare `ADD COLUMN ... TEXT`, no default/constraint — reversible via `DROP COLUMN`; `prisma validate` passed |
| 3 | Integration test round-trips prCreatedAt; no existing tests retired | MET | New "round-trips prCreatedAt" test + added null-default assertion to the existing defaults test; no tests removed |

## Test Plan
- [x] New integration test creates a `PullRequest` row with `prCreatedAt` set and reads it back, asserting the value round-trips
- [x] Existing "inserts a PullRequest with all defaults" test extended to assert `prCreatedAt` defaults to `null`
- [x] `task typecheck` — all 7 workspaces pass
- [x] `task lint` — clean
- [x] `bun test task-store` — 346 pass / 75 skip / 0 fail
- [x] `bunx prisma validate` — schema consistent

Generated with [Claude Code](https://claude.com/claude-code)
