### PR TITLE
feat: port check-helpers.ts shared utilities into agent/src

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -1,0 +1,384 @@
+/**
+ * agent/src/check-helpers.ts
+ *
+ * Shared helpers ported from plugins/shipwright/scripts/check-helpers.ts —
+ * a native, directly-importable copy for the agent runtime. The plugin
+ * scripts remain the source of truth for agents that still run the
+ * check-*.ts scripts as separate processes; this module exists so
+ * in-process precheck ports (WL-2.2) can import the same logic without a
+ * subprocess hop.
+ *
+ * Behavior is unchanged from the plugin source except createTaskStoreClient,
+ * which gains an optional injectable fetch function so callers can supply a
+ * fake fetch in tests instead of overriding globalThis.fetch (agent/src test
+ * isolation rule: no global.fetch/global.* overrides). When no fetchFn is
+ * passed, it falls back to global fetch — identical behavior to the plugin
+ * version.
+ *
+ * Covers:
+ * - Workspace path resolution (WORKSPACE_PATH env var or cwd heuristic)
+ * - Org/repo resolution from repos/ dir
+ * - gh CLI execution helper
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Task types ───────────────────────────────────────────────────────────────
+
+export type TaskStatus =
+  | "pending"
+  | "in_progress"
+  | "pr_open"
+  | "approved"
+  | "merged"
+  | "done"
+  | "deploying"
+  | "deployed"
+  | "blocked"
+  | "cancelled";
+
+export interface Task {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  source?: string;
+  session?: string;
+  repo?: string;
+  description?: string;
+  acceptanceCriteria?: string[];
+  layer?: string;
+  branch?: string;
+  dependencies?: string[];
+  pr?: number;
+  hours?: number;
+  addedAt?: string;
+  startedAt?: string;
+  prCreatedAt?: string;
+  mergedAt?: string;
+  blockedAt?: string;
+  blockedReason?: string;
+  note?: string;
+  type?: string;
+  priority?: string;
+  size?: string;
+  file?: string;
+  cancelledAt?: string;
+  completedAt?: string;
+  deployingAt?: string;
+  deployedAt?: string;
+  ciFixAttempts?: number;
+  mergeCommit?: string;
+  prNumber?: number;
+  prOpenedAt?: string;
+  prUrl?: string;
+  assignee?: string;
+  issue?: string;
+  model?: "haiku" | "sonnet" | "opus";
+  complexity?: number;
+  hitl?: boolean;
+  hitlNotifiedAt?: string;
+}
+
+// ─── Policy helpers ───────────────────────────────────────────────────────────
+
+export function parseAllowSelfReview(content: string): boolean {
+  const match = content.match(
+    /(?:`allow_self_review`\s*\|\s*|\*\*allow_self_review\*\*:\s*)(true|false)/,
+  );
+  return match?.[1] !== "false"; // default true if missing
+}
+
+export function readAllowSelfReview(workspacePath: string): boolean {
+  try {
+    const content = readFileSync(
+      join(workspacePath, "state", "agent-policy.md"),
+      "utf-8",
+    );
+    return parseAllowSelfReview(content);
+  } catch {
+    return true;
+  }
+}
+
+// ─── Workspace path ───────────────────────────────────────────────────────────
+
+/**
+ * Resolve the agent workspace root.
+ *
+ * Priority:
+ * 1. WORKSPACE_PATH env var (explicit override)
+ * 2. AGENT_HOME/workspace (standard harness layout)
+ *
+ * Throws rather than falling back to a default path — a misconfigured agent
+ * (missing AGENT_HOME) should fail loudly rather than silently read from the
+ * wrong workspace and produce confusing results.
+ */
+export function resolveWorkspacePath(): string {
+  const envPath = (process.env.WORKSPACE_PATH ?? "").trim();
+  if (envPath) return envPath;
+  const agentHome = (process.env.AGENT_HOME ?? "").trim();
+  if (!agentHome)
+    throw new Error("AGENT_HOME is not set — cannot resolve workspace path");
+  return join(agentHome, "workspace");
+}
+
+// ─── Repos resolution ────────────────────────────────────────────────────────
+
+export function resolveAllRepos(workspacePath: string): string[] {
+  return resolveRepos(workspacePath);
+}
+
+/**
+ * Parse a git remote URL into "org/repo" format.
+ * Handles both HTTPS (https://github.com/org/repo.git) and
+ * SSH (git@github.com:org/repo.git) forms.
+ * Returns null if the URL cannot be parsed.
+ */
+function parseRemoteUrl(url: string): string | null {
+  // SSH: git@github.com:org/repo.git
+  const sshMatch = url.match(/^git@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+
+  // HTTPS: https://github.com/org/repo.git or https://github.com/org/repo
+  const httpsMatch = url.match(/^https?:\/\/[^/]+\/([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (httpsMatch) return httpsMatch[1];
+
+  return null;
+}
+
+/**
+ * Scan a directory for git clones and return ["org/repo", ...] strings
+ * by reading each clone's .git/config for the remote origin URL.
+ */
+function scanReposDir(dir: string): string[] {
+  const repos: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return repos;
+  }
+
+  for (const entry of entries) {
+    const gitConfigPath = join(dir, entry, ".git", "config");
+    if (!existsSync(gitConfigPath)) continue;
+    try {
+      const content = readFileSync(gitConfigPath, "utf-8");
+      // Look for the [remote "origin"] url line
+      const urlMatch = content.match(
+        /\[remote\s+"origin"\][^\[]*url\s*=\s*(.+)/,
+      );
+      if (!urlMatch) continue;
+      const remoteUrl = urlMatch[1].trim();
+      const orgRepo = parseRemoteUrl(remoteUrl);
+      if (orgRepo) repos.push(orgRepo);
+    } catch {
+      // Skip unreadable configs
+    }
+  }
+
+  return repos;
+}
+
+/**
+ * Resolve the list of "owner/repo" strings for this workspace.
+ *
+ * Priority:
+ * 1. workspace/repos/ — scans for git clones, reads remote origin URLs
+ * 2. SHIPWRIGHT_REPOS_DIR env var — same scan on an external directory
+ * 3. Returns [] if nothing found
+ */
+export function resolveRepos(workspacePath: string): string[] {
+  // 1. Try workspace/repos/ directory
+  const reposDir = join(workspacePath, "repos");
+  if (existsSync(reposDir)) {
+    const repos = scanReposDir(reposDir);
+    if (repos.length > 0) return repos;
+  }
+
+  // 2. Fall back to SHIPWRIGHT_REPOS_DIR env var
+  const envReposDir = (process.env.SHIPWRIGHT_REPOS_DIR ?? "").trim();
+  if (envReposDir && existsSync(envReposDir)) {
+    const repos = scanReposDir(envReposDir);
+    if (repos.length > 0) return repos;
+  }
+
+  return [];
+}
+
+// ─── Merge-only detection ────────────────────────────────────────────────────
+
+export interface CommitInfo {
+  sha: string;
+  parents: Array<{ sha: string }>;
+}
+
+/**
+ * Returns true if all commits after `lastReviewedCommit` are merge commits
+ * (parents.length >= 2). Returns false on error, missing anchor, or if there
+ * are no commits after the anchor.
+ *
+ * Shared by check-review (skip re-review after merge-from-main) and check-patch
+ * (still trigger patch when only merge commits landed since a stale review).
+ */
+export async function isMergeOnlyUpdate(
+  prNumber: number,
+  lastReviewedCommit: string,
+  deps: {
+    listPrCommits: (prNumber: number, repo?: string) => Promise<CommitInfo[]>;
+  },
+  repo?: string,
+): Promise<boolean> {
+  try {
+    const commits = await deps.listPrCommits(prNumber, repo);
+    const anchorIndex = commits.findIndex((c) => c.sha === lastReviewedCommit);
+    if (anchorIndex === -1) return false;
+    const subsequent = commits.slice(anchorIndex + 1);
+    if (subsequent.length === 0) return false;
+    return subsequent.every((c) => c.parents.length >= 2);
+  } catch {
+    return false;
+  }
+}
+
+// ─── Task store HTTP client ───────────────────────────────────────────────────
+
+type FetchFn = (
+  url: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Reads SHIPWRIGHT_TASK_STORE_URL and SHIPWRIGHT_TASK_STORE_TOKEN from the
+ * environment, validates they are present, and returns a minimal fetch client
+ * for the task-store HTTP API.
+ *
+ * Exits with code 1 if either variable is missing so callers (precheck scripts)
+ * get a clean error rather than a confusing undefined/TypeError at call-time.
+ *
+ * Accepts an optional `fetchFn` for dependency injection in tests; defaults to
+ * global fetch when not provided (identical behavior to the plugin version).
+ */
+export function createTaskStoreClient(opts?: { fetchFn?: FetchFn }): {
+  query(params: URLSearchParams): Promise<Task[]>;
+  update(id: string, fields: Record<string, unknown>): Promise<Task>;
+} {
+  const taskStoreUrl = (process.env.SHIPWRIGHT_TASK_STORE_URL ?? "").trim();
+  const taskStoreToken = (process.env.SHIPWRIGHT_TASK_STORE_TOKEN ?? "").trim();
+  if (!taskStoreUrl) {
+    process.stderr.write("error: SHIPWRIGHT_TASK_STORE_URL is required\n");
+    process.exit(1);
+  }
+  if (!taskStoreToken) {
+    process.stderr.write("error: SHIPWRIGHT_TASK_STORE_TOKEN is required\n");
+    process.exit(1);
+  }
+  const baseUrl = taskStoreUrl.replace(/\/$/, "");
+  const headers = {
+    Authorization: `Bearer ${taskStoreToken}`,
+    "Content-Type": "application/json",
+  };
+  const doFetch: FetchFn = opts?.fetchFn ?? fetch;
+
+  return {
+    async query(params: URLSearchParams): Promise<Task[]> {
+      const res = await doFetch(`${baseUrl}/tasks?${params}`, { headers });
+      if (!res.ok)
+        throw new Error(`task-store GET /tasks?${params} → ${res.status}`);
+      const data = (await res.json()) as unknown;
+      // Temporary: accept legacy bare Task[] from older task-store instances
+      if (Array.isArray(data)) return data as Task[];
+      if (
+        data !== null &&
+        typeof data === "object" &&
+        Array.isArray((data as Record<string, unknown>).tasks)
+      )
+        return (data as Record<string, unknown>).tasks as Task[];
+      throw new Error(
+        `Unexpected task-store response format: ${JSON.stringify(data)}`,
+      );
+    },
+    async update(id: string, fields: Record<string, unknown>): Promise<Task> {
+      const res = await doFetch(`${baseUrl}/tasks/${id}`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify(fields),
+      });
+      if (!res.ok)
+        throw new Error(`task-store PATCH /tasks/${id} → ${res.status}`);
+      return res.json() as Promise<Task>;
+    },
+  };
+}
+
+// ─── gh CLI helper ────────────────────────────────────────────────────────────
+
+/**
+ * Run a gh CLI command and return the parsed JSON output.
+ * Throws on non-zero exit.
+ */
+export function ghJson<T>(args: string[]): T {
+  const result = spawnSync("gh", args, {
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `gh ${args.join(" ")} failed (exit ${result.status}): ${result.stderr}`,
+    );
+  }
+  return JSON.parse(result.stdout) as T;
+}
+
+/**
+ * Run a gh CLI command without parsing output.
+ * Throws on non-zero exit.
+ */
+export function ghRun(args: string[]): void {
+  const result = spawnSync("gh", args, {
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `gh ${args.join(" ")} failed (exit ${result.status}): ${result.stderr}`,
+    );
+  }
+}
+
+/**
+ * Run a gh API graphql command and return the raw response.
+ */
+export function ghGraphql<T>(query: string): T {
+  const result = spawnSync("gh", ["api", "graphql", "-f", `query=${query}`], {
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `gh api graphql failed (exit ${result.status}): ${result.stderr}`,
+    );
+  }
+  return JSON.parse(result.stdout) as T;
+}
+
+/**
+ * Get the current authenticated GH user login.
+ *
+ * Uses GraphQL viewer (not REST /user) because installation tokens issued to
+ * GitHub Apps are rejected by /user with 403; the viewer query resolves to the
+ * app's bot identity under both PAT and installation-token auth.
+ *
+ * Normalises the bot identity format: GraphQL returns "name[bot]" but
+ * pr.author.login (and gh pr list --author) use "app/name", so we convert
+ * here once so every call-site sees a consistent format.
+ */
+export function getCurrentUser(): string {
+  const result = ghGraphql<{ data: { viewer: { login: string } } }>(
+    "query { viewer { login } }",
+  );
+  const login = result.data.viewer.login;
+  return login.endsWith("[bot]") ? `app/${login.slice(0, -5)}` : login;
+}

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -1,0 +1,747 @@
+/**
+ * agent/src/check-helpers.unit.test.ts
+ *
+ * Unit tests for resolveRepos(), getCurrentUser(), and createTaskStoreClient()
+ * in check-helpers.ts. Ported from
+ * plugins/shipwright/scripts/check-helpers.unit.test.ts — adapted so
+ * createTaskStoreClient() tests inject a fake fetch function instead of
+ * overriding globalThis.fetch (agent/src test isolation rule: no
+ * global.fetch/global.* overrides).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createTaskStoreClient,
+  getCurrentUser,
+  resolveAllRepos,
+  resolveRepos,
+} from "./check-helpers.ts";
+import * as checkHelpers from "./check-helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fake git repo in dir/repoName with a remote origin URL. */
+function makeGitClone(
+  parentDir: string,
+  repoName: string,
+  remoteUrl: string,
+): void {
+  const repoDir = join(parentDir, repoName);
+  mkdirSync(join(repoDir, ".git"), { recursive: true });
+  const gitConfig = `[core]
+\trepositoryformatversion = 0
+\tfilemode = true
+[remote "origin"]
+\turl = ${remoteUrl}
+\tfetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+\tremote = origin
+\tmerge = refs/heads/main
+`;
+  writeFileSync(join(repoDir, ".git", "config"), gitConfig);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveRepos", () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "resolve-repos-test-"));
+    savedEnv = process.env.SHIPWRIGHT_REPOS_DIR;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_REPOS_DIR;
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env.SHIPWRIGHT_REPOS_DIR = savedEnv;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_REPOS_DIR;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns empty array when workspace has no repos/ dir and no env var", () => {
+    const result = resolveRepos(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when workspace repos/ dir exists but is empty", () => {
+    mkdirSync(join(tmpDir, "repos"), { recursive: true });
+    const result = resolveRepos(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  test("parses HTTPS remote URL from git clone in repos/", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(
+      reposDir,
+      "example-repo",
+      "https://github.com/acme/example-repo.git",
+    );
+    const result = resolveRepos(tmpDir);
+    expect(result).toContain("acme/example-repo");
+  });
+
+  test("parses SSH remote URL from git clone in repos/", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(
+      reposDir,
+      "example-repo",
+      "git@github.com:acme/example-repo.git",
+    );
+    const result = resolveRepos(tmpDir);
+    expect(result).toContain("acme/example-repo");
+  });
+
+  test("parses HTTPS URL without .git suffix", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(reposDir, "my-repo", "https://github.com/myorg/my-repo");
+    const result = resolveRepos(tmpDir);
+    expect(result).toContain("myorg/my-repo");
+  });
+
+  test("returns multiple repos when multiple git clones exist", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(
+      reposDir,
+      "example-repo",
+      "https://github.com/acme/example-repo.git",
+    );
+    makeGitClone(
+      reposDir,
+      "other-repo",
+      "https://github.com/acme/other-repo.git",
+    );
+    const result = resolveRepos(tmpDir);
+    expect(result).toContain("acme/example-repo");
+    expect(result).toContain("acme/other-repo");
+    expect(result).toHaveLength(2);
+  });
+
+  test("skips subdirs without .git directory", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    // Not a git clone — just a regular dir
+    mkdirSync(join(reposDir, "not-a-repo"));
+    makeGitClone(
+      reposDir,
+      "example-repo",
+      "https://github.com/acme/example-repo.git",
+    );
+    const result = resolveRepos(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result).toContain("acme/example-repo");
+  });
+
+  test("falls back to SHIPWRIGHT_REPOS_DIR when repos/ is empty", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true }); // empty repos/ dir
+
+    const envReposDir = join(tmpDir, "env-repos");
+    mkdirSync(envReposDir, { recursive: true });
+    makeGitClone(
+      envReposDir,
+      "example-repo",
+      "https://github.com/acme/example-repo.git",
+    );
+
+    process.env.SHIPWRIGHT_REPOS_DIR = envReposDir;
+    const result = resolveRepos(tmpDir);
+    expect(result).toContain("acme/example-repo");
+  });
+
+  test("falls back to SHIPWRIGHT_REPOS_DIR when repos/ does not exist", () => {
+    // No repos/ dir at all
+    const envReposDir = join(tmpDir, "env-repos");
+    mkdirSync(envReposDir, { recursive: true });
+    makeGitClone(
+      envReposDir,
+      "example-repo",
+      "git@github.com:acme/example-repo.git",
+    );
+
+    process.env.SHIPWRIGHT_REPOS_DIR = envReposDir;
+    const result = resolveRepos(tmpDir);
+    expect(result).toContain("acme/example-repo");
+  });
+
+  test("repos/ takes priority over SHIPWRIGHT_REPOS_DIR when non-empty", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(
+      reposDir,
+      "example-repo",
+      "https://github.com/acme/example-repo.git",
+    );
+
+    const envReposDir = join(tmpDir, "env-repos");
+    mkdirSync(envReposDir, { recursive: true });
+    makeGitClone(
+      envReposDir,
+      "other-repo",
+      "https://github.com/acme/other-repo.git",
+    );
+
+    process.env.SHIPWRIGHT_REPOS_DIR = envReposDir;
+    const result = resolveRepos(tmpDir);
+    // repos/ is non-empty, so env var is ignored
+    expect(result).toContain("acme/example-repo");
+    expect(result).not.toContain("acme/other-repo");
+  });
+
+  test("returns empty array when SHIPWRIGHT_REPOS_DIR points to nonexistent path", () => {
+    process.env.SHIPWRIGHT_REPOS_DIR = "/no/such/path";
+    const result = resolveRepos(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  test("skips git clone with no remote origin configured", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    // Git dir without a remote
+    const repoDir = join(reposDir, "no-remote");
+    mkdirSync(join(repoDir, ".git"), { recursive: true });
+    writeFileSync(
+      join(repoDir, ".git", "config"),
+      "[core]\n\trepositoryformatversion = 0\n",
+    );
+
+    const result = resolveRepos(tmpDir);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAllRepos
+// ---------------------------------------------------------------------------
+
+describe("resolveAllRepos", () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "resolve-all-repos-test-"));
+    savedEnv = process.env.SHIPWRIGHT_REPOS_DIR;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.SHIPWRIGHT_REPOS_DIR;
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env.SHIPWRIGHT_REPOS_DIR = savedEnv;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.SHIPWRIGHT_REPOS_DIR;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns scanned repos", () => {
+    const reposDir = join(tmpDir, "repos");
+    mkdirSync(reposDir, { recursive: true });
+    makeGitClone(
+      reposDir,
+      "other-repo",
+      "https://github.com/acme/other-repo.git",
+    );
+    expect(resolveAllRepos(tmpDir)).toEqual(["acme/other-repo"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorkspacePath
+// ---------------------------------------------------------------------------
+
+describe("resolveWorkspacePath", () => {
+  let savedWorkspacePath: string | undefined;
+  let savedAgentHome: string | undefined;
+
+  beforeEach(() => {
+    savedWorkspacePath = process.env.WORKSPACE_PATH;
+    savedAgentHome = process.env.AGENT_HOME;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.WORKSPACE_PATH;
+    // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+    delete process.env.AGENT_HOME;
+  });
+
+  afterEach(() => {
+    if (savedWorkspacePath !== undefined) {
+      process.env.WORKSPACE_PATH = savedWorkspacePath;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.WORKSPACE_PATH;
+    }
+    if (savedAgentHome !== undefined) {
+      process.env.AGENT_HOME = savedAgentHome;
+    } else {
+      // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+      delete process.env.AGENT_HOME;
+    }
+  });
+
+  test("returns WORKSPACE_PATH when set, taking priority over AGENT_HOME", () => {
+    process.env.WORKSPACE_PATH = "/explicit/workspace";
+    process.env.AGENT_HOME = "/agent/home";
+    expect(checkHelpers.resolveWorkspacePath()).toBe("/explicit/workspace");
+  });
+
+  test("derives from AGENT_HOME/workspace when WORKSPACE_PATH is unset", () => {
+    process.env.AGENT_HOME = "/agent/home";
+    expect(checkHelpers.resolveWorkspacePath()).toBe(
+      join("/agent/home", "workspace"),
+    );
+  });
+
+  test("throws when neither WORKSPACE_PATH nor AGENT_HOME is set", () => {
+    expect(() => checkHelpers.resolveWorkspacePath()).toThrow(
+      "AGENT_HOME is not set",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAllowSelfReview / readAllowSelfReview
+// ---------------------------------------------------------------------------
+
+describe("parseAllowSelfReview", () => {
+  test("returns true when the table cell says true", () => {
+    expect(
+      checkHelpers.parseAllowSelfReview("| `allow_self_review` | true |"),
+    ).toBe(true);
+  });
+
+  test("returns false when the table cell says false", () => {
+    expect(
+      checkHelpers.parseAllowSelfReview("| `allow_self_review` | false |"),
+    ).toBe(false);
+  });
+
+  test("returns false for bold-style false", () => {
+    expect(
+      checkHelpers.parseAllowSelfReview("**allow_self_review**: false"),
+    ).toBe(false);
+  });
+
+  test("returns true for bold-style true", () => {
+    expect(
+      checkHelpers.parseAllowSelfReview("**allow_self_review**: true"),
+    ).toBe(true);
+  });
+
+  test("defaults to true when the field is missing entirely", () => {
+    expect(checkHelpers.parseAllowSelfReview("no policy here")).toBe(true);
+  });
+});
+
+describe("readAllowSelfReview", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "read-allow-self-review-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("reads and parses state/agent-policy.md when present", () => {
+    mkdirSync(join(tmpDir, "state"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "state", "agent-policy.md"),
+      "| `allow_self_review` | false |",
+    );
+    expect(checkHelpers.readAllowSelfReview(tmpDir)).toBe(false);
+  });
+
+  test("defaults to true when the policy file does not exist", () => {
+    expect(checkHelpers.readAllowSelfReview(tmpDir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMergeOnlyUpdate
+// ---------------------------------------------------------------------------
+
+describe("isMergeOnlyUpdate", () => {
+  test("returns true when every commit after the anchor is a merge commit", async () => {
+    const deps = {
+      listPrCommits: async () => [
+        { sha: "a", parents: [{ sha: "root" }] },
+        { sha: "b", parents: [{ sha: "a" }, { sha: "other" }] },
+        { sha: "c", parents: [{ sha: "b" }, { sha: "other2" }] },
+      ],
+    };
+    expect(await checkHelpers.isMergeOnlyUpdate(1, "a", deps)).toBe(true);
+  });
+
+  test("returns false when a non-merge commit follows the anchor", async () => {
+    const deps = {
+      listPrCommits: async () => [
+        { sha: "a", parents: [{ sha: "root" }] },
+        { sha: "b", parents: [{ sha: "a" }] },
+      ],
+    };
+    expect(await checkHelpers.isMergeOnlyUpdate(1, "a", deps)).toBe(false);
+  });
+
+  test("returns false when the anchor commit is not found", async () => {
+    const deps = {
+      listPrCommits: async () => [{ sha: "z", parents: [{ sha: "root" }] }],
+    };
+    expect(await checkHelpers.isMergeOnlyUpdate(1, "missing", deps)).toBe(
+      false,
+    );
+  });
+
+  test("returns false when there are no commits after the anchor", () => {
+    const deps = {
+      listPrCommits: async () => [{ sha: "a", parents: [{ sha: "root" }] }],
+    };
+    expect(checkHelpers.isMergeOnlyUpdate(1, "a", deps)).resolves.toBe(false);
+  });
+
+  test("returns false when listPrCommits throws", async () => {
+    const deps = {
+      listPrCommits: async () => {
+        throw new Error("network error");
+      },
+    };
+    expect(await checkHelpers.isMergeOnlyUpdate(1, "a", deps)).toBe(false);
+  });
+
+  test("passes the repo argument through to listPrCommits", async () => {
+    let receivedRepo: string | undefined;
+    const deps = {
+      listPrCommits: async (_prNumber: number, repo?: string) => {
+        receivedRepo = repo;
+        return [
+          { sha: "a", parents: [{ sha: "root" }] },
+          { sha: "b", parents: [{ sha: "a" }, { sha: "other" }] },
+        ];
+      },
+    };
+    await checkHelpers.isMergeOnlyUpdate(1, "a", deps, "acme/example-repo");
+    expect(receivedRepo).toBe("acme/example-repo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCurrentUser
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a fake `gh` binary into dir that returns the given GraphQL viewer
+ * response JSON. Returns the path to the fake binary.
+ *
+ * The fake binary is added to PATH by the test beforeEach/afterEach helpers.
+ */
+function writeFakeGhBinary(dir: string, viewerLogin: string): string {
+  const binPath = join(dir, "gh");
+  const response = JSON.stringify({ data: { viewer: { login: viewerLogin } } });
+  // A minimal shell script that ignores all args and prints the baked response.
+  writeFileSync(binPath, `#!/bin/sh\nprintf '%s\\n' '${response}'\n`);
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+/** Write a fake `gh` binary that always fails with a given exit code. */
+function writeFailingGhBinary(dir: string, exitCode: number, stderr: string): string {
+  const binPath = join(dir, "gh");
+  writeFileSync(
+    binPath,
+    `#!/bin/sh\nprintf '%s\\n' '${stderr}' >&2\nexit ${exitCode}\n`,
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+describe("getCurrentUser", () => {
+  let tmpDir: string;
+  let savedPath: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "get-current-user-test-"));
+    savedPath = process.env.PATH;
+  });
+
+  afterEach(() => {
+    if (savedPath !== undefined) {
+      process.env.PATH = savedPath;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns login as-is for a regular PAT user", () => {
+    writeFakeGhBinary(tmpDir, "dmcaulay");
+    process.env.PATH = `${tmpDir}:${savedPath}`;
+    const result = getCurrentUser();
+    expect(result).toBe("dmcaulay");
+  });
+
+  test("normalises [bot] suffix to app/ prefix for GitHub App identity", () => {
+    writeFakeGhBinary(tmpDir, "my-app[bot]");
+    process.env.PATH = `${tmpDir}:${savedPath}`;
+    const result = getCurrentUser();
+    expect(result).toBe("app/my-app");
+  });
+
+  test("handles hyphenated app name in [bot] normalisation", () => {
+    writeFakeGhBinary(tmpDir, "example-repo-agent[bot]");
+    process.env.PATH = `${tmpDir}:${savedPath}`;
+    const result = getCurrentUser();
+    expect(result).toBe("app/example-repo-agent");
+  });
+
+  test("throws when gh exits non-zero", () => {
+    writeFailingGhBinary(tmpDir, 1, "not authenticated");
+    process.env.PATH = `${tmpDir}:${savedPath}`;
+    expect(() => getCurrentUser()).toThrow("gh api graphql failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTaskStoreClient — query() response shape handling
+// ---------------------------------------------------------------------------
+
+describe("createTaskStoreClient query()", () => {
+  const FAKE_TASK = {
+    id: "T-1",
+    title: "Do the thing",
+    status: "pending" as const,
+  };
+
+  let savedEnv: { url?: string; token?: string };
+
+  beforeEach(() => {
+    savedEnv = {
+      url: process.env.SHIPWRIGHT_TASK_STORE_URL,
+      token: process.env.SHIPWRIGHT_TASK_STORE_TOKEN,
+    };
+    process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.com";
+    process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    if (savedEnv.url !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_URL = savedEnv.url;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_URL;
+    }
+    if (savedEnv.token !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_TOKEN = savedEnv.token;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    }
+  });
+
+  test("unwraps { tasks } envelope from ?ready=true", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ tasks: [FAKE_TASK], total: 1 }),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    const result = await client.query(new URLSearchParams({ ready: "true" }));
+    expect(result).toEqual([FAKE_TASK]);
+  });
+
+  test("unwraps paginated { tasks } envelope (returned by ?status=...)", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          tasks: [FAKE_TASK],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        }),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    const result = await client.query(
+      new URLSearchParams({ status: "in_progress" }),
+    );
+    expect(result).toEqual([FAKE_TASK]);
+  });
+
+  test("returns empty array when paginated envelope has empty tasks list", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ tasks: [], total: 0, limit: 50, offset: 0 }),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    const result = await client.query(
+      new URLSearchParams({ status: "in_progress" }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("throws on unrecognised response shape", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ unexpected: true }),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    await expect(
+      client.query(new URLSearchParams({ status: "in_progress" })),
+    ).rejects.toThrow("Unexpected task-store response format");
+  });
+
+  test("accepts a legacy bare Task[] response", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => [FAKE_TASK],
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    const result = await client.query(new URLSearchParams({ ready: "true" }));
+    expect(result).toEqual([FAKE_TASK]);
+  });
+
+  test("throws when the query response is not ok", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    await expect(
+      client.query(new URLSearchParams({ ready: "true" })),
+    ).rejects.toThrow("task-store GET /tasks");
+  });
+
+  test("update() PATCHes the task and returns the parsed response", async () => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+    const fakeFetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return {
+        ok: true,
+        json: async () => ({ ...FAKE_TASK, status: "in_progress" }),
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    const result = await client.update("T-1", { status: "in_progress" });
+
+    expect(capturedUrl).toBe(
+      "https://task-store.example.com/tasks/T-1",
+    );
+    expect(capturedInit?.method).toBe("PATCH");
+    expect(result).toEqual({ ...FAKE_TASK, status: "in_progress" });
+  });
+
+  test("throws when the update response is not ok", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    await expect(
+      client.update("T-1", { status: "in_progress" }),
+    ).rejects.toThrow("task-store PATCH /tasks/T-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTaskStoreClient — missing env vars
+// ---------------------------------------------------------------------------
+
+describe("createTaskStoreClient env validation", () => {
+  let savedEnv: { url?: string; token?: string };
+  let savedExit: typeof process.exit;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    savedEnv = {
+      url: process.env.SHIPWRIGHT_TASK_STORE_URL,
+      token: process.env.SHIPWRIGHT_TASK_STORE_TOKEN,
+    };
+    savedExit = process.exit;
+    exitCode = undefined;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.exit = savedExit;
+    if (savedEnv.url !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_URL = savedEnv.url;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_URL;
+    }
+    if (savedEnv.token !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_TOKEN = savedEnv.token;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    }
+  });
+
+  test("exits 1 when SHIPWRIGHT_TASK_STORE_URL is missing", () => {
+    // biome-ignore lint/performance/noDelete: intentional env cleanup
+    delete process.env.SHIPWRIGHT_TASK_STORE_URL;
+    process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "test-token";
+    expect(() => createTaskStoreClient()).toThrow();
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 when SHIPWRIGHT_TASK_STORE_TOKEN is missing", () => {
+    process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.com";
+    // biome-ignore lint/performance/noDelete: intentional env cleanup
+    delete process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    expect(() => createTaskStoreClient()).toThrow();
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Removed exports
+// ---------------------------------------------------------------------------
+
+describe("removed exports", () => {
+  test("readReviews is not exported from check-helpers", () => {
+    expect(
+      (checkHelpers as Record<string, unknown>).readReviews,
+    ).toBeUndefined();
+  });
+});

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -82,7 +82,7 @@ When `blockedBy` is empty, the task is ready to execute (assuming it has `status
 
 **What to update:**
 - Any code that calls `GET /tasks` and expects an array must unwrap `.tasks` from the response.
-- `check-helpers.ts` in the plugin is updated in this PR. Custom scripts or agents calling `/tasks` directly need the same fix.
+- `check-helpers.ts` in the plugin is updated in this PR. Agent in-process code can import shared helpers directly from `agent/src/check-helpers.ts` (a ported native copy); custom plugin scripts still depend on the plugin version.
 - Code that checks task readiness should use the `blockedBy` array instead of duplicating dependency logic.
 - `GET /tasks?ready=true` is unchanged — it still returns `Task[]` (filtered to ready tasks only, with `blockedBy` also present).
 


### PR DESCRIPTION
## Summary
- Add `agent/src/check-helpers.ts`, a native 1:1 port of `plugins/shipwright/scripts/check-helpers.ts` — the shared task-store client, gh CLI/GraphQL helpers, `getCurrentUser`, `readAllowSelfReview`, `resolveWorkspacePath`/`resolveAllRepos`, and `isMergeOnlyUpdate` — for in-process use by the upcoming precheck ports (WL-2.2), without a subprocess hop
- The only intentional behavior adjustment: `createTaskStoreClient` gains an optional injectable `fetchFn` param (defaults to global `fetch`) so tests can inject a fake fetch instead of overriding `globalThis.fetch`, per this repo's test-isolation rule
- `plugins/shipwright/scripts/check-helpers.ts` and its test file are left completely untouched — still required by the plugin's own check-*.ts scripts, review-patch's internal precheck orchestration, and the manual-only ship-loop skill
- Refresh `docs/migration.md` to note the new agent/src copy

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | agent/src gains a native module exposing the same functions as check-helpers.ts, adjusted only for import paths/module boundaries — no behavior change | MET | `agent/src/check-helpers.ts` ports all 11 exports 1:1; only deviation is the optional `fetchFn` DI param, defaulting to global fetch |
| 2 | plugins/shipwright/scripts/check-helpers.ts is untouched | MET | `git diff main...HEAD -- plugins/shipwright/scripts/check-helpers.ts` is empty |
| 3 | Existing unit tests ported alongside relocated functions, adapted to new module path; no coverage lost, no old tests retired | MET | `agent/src/check-helpers.unit.test.ts` (44 tests) covers every case in the plugin's suite plus more; plugin test file untouched |

## Test Plan
- [x] `bun test agent/src/check-helpers.unit.test.ts` — 44 pass / 0 fail
- [x] `task lint` — clean
- [x] `task typecheck` — all 7 workspaces pass
- [x] Coverage: 87.04% lines (vs. 56.10% baseline on the original plugin file — net improvement, no coverage lost)
- [x] Confirmed plugin source + test file byte-identical to `main`

Generated with [Claude Code](https://claude.com/claude-code)
