### PR TITLE
feat: add 80/80 aggregate coverage gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           bunx prisma migrate deploy --schema=task-store/prisma/schema.prisma
 
       - name: Test
-        run: task test
+        run: task test:coverage
 
       - name: Secret scan
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ go-task (`Taskfile.yml`) is the single local entrypoint; the root `package.json`
 
 ```bash
 task setup        # bun install across all workspaces
-task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan (the merge-blocking gate; CI runs this exact chain)
+task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan (the merge-blocking gate; CI runs this exact chain)
 task test         # bun test            (single file: bun test path/to/file.test.ts)
+task test:coverage  # bun test --coverage --coverage-reporter=lcov, then gate on aggregate 80/80 lines/functions (scripts/check-coverage.ts)
 task lint         # bunx biome lint .
 task format       # bunx biome format --write .
 task typecheck    # bun run --filter='*' typecheck

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,6 +26,12 @@ tasks:
     cmds:
       - bun test
 
+  test:coverage:
+    desc: Run all tests with coverage, then gate on aggregate 80/80 lines/functions (scripts/check-coverage.ts)
+    cmds:
+      - bun test --coverage --coverage-reporter=lcov
+      - bun run scripts/check-coverage.ts
+
   check-strings:
     desc: Scan entire repo for banned strings (confidential identifiers, client names)
     cmds:
@@ -42,14 +48,14 @@ tasks:
       - bun run scripts/sync-version.ts --check
 
   ci:
-    desc: Run all CI checks (lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan)
+    desc: Run all CI checks (lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan)
     cmds:
       - task: lint
       - task: check-strings
       - task: typecheck
       - task: check-config-docs
       - task: check-version-sync
-      - task: test
+      - task: test:coverage
       - task: secret-scan
 
   api:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,8 +19,9 @@ go-task (`Taskfile.yml`) is the single local entrypoint:
 
 ```bash
 task setup        # bun install across all workspaces
-task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan (the merge-blocking gate)
+task ci           # lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan (the merge-blocking gate)
 task test         # bun test (all packages)
+task test:coverage  # bun test --coverage --coverage-reporter=lcov, then gate on aggregate 80/80 lines/functions (scripts/check-coverage.ts)
 ```
 
 Run a single package or file directly:
@@ -73,7 +74,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 
 ## CI gates
 
-CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+.
+CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+. The coverage gate (80% lines + 80% functions on an aggregate basis) is enforced by `scripts/check-coverage.ts` on the LCOV report produced by `task test:coverage`.
 
 ## References
 

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+// Parse coverage/lcov.info and fail if aggregate coverage is below threshold.
+// Gate applies to the weighted aggregate (sum of LH/LF and FNH/FNF across all
+// counted files) — not a per-file check. Bun's native bunfig.toml
+// coverageThreshold enforces a PER-FILE minimum instead, which would fail CI
+// on individual low-coverage files regardless of overall coverage — hence
+// this separate aggregate gate.
+export {};
+
+const THRESHOLD_LINES = 80;
+const THRESHOLD_FUNCTIONS = 80;
+
+const EXCLUDE_PREFIXES = [
+  // Generated / vendor code
+  "node_modules/",
+
+  // Process entrypoints — start a real service or require live
+  // credentials/infra to run (DB connections, Docker, mise, GitHub auth,
+  // etc.); exercised in practice, not under unit/integration test.
+  "admin/src/server.ts",
+  "admin/src/main.ts",
+  "agent/src/entrypoint-main.ts",
+  "task-store/src/main.ts",
+  "chat/src/main.ts",
+  "mcp-server/src/serve.ts",
+  "metrics/src/server.ts",
+
+  // Local-dev-only seed scripts — invoked only by `task stack` against a
+  // live database; pure logic they contain is unit-tested and exported,
+  // only the import.meta.main CLI/DB-wiring block is uncovered here.
+  "scripts/seed-task-store-token.ts",
+  "scripts/seed-chat-tokens.ts",
+  "scripts/seed-dev-agent.ts",
+];
+
+// Paths containing this substring are excluded regardless of prefix
+const EXCLUDE_SUBSTRINGS = ["prisma/client/"];
+const LCOV_PATH = "coverage/lcov.info";
+
+const lcov = await Bun.file(LCOV_PATH)
+  .text()
+  .catch(() => {
+    console.error(
+      `No coverage file at ${LCOV_PATH}. Run: bun test --coverage --coverage-reporter=lcov`,
+    );
+    process.exit(1);
+  });
+
+type FileStats = {
+  lf: number;
+  lh: number;
+  fnf: number;
+  fnh: number;
+};
+const files: Record<string, FileStats> = {};
+let current = "";
+
+for (const line of lcov.split("\n")) {
+  if (line.startsWith("SF:")) {
+    current = line.slice(3);
+    files[current] = { lf: 0, lh: 0, fnf: 0, fnh: 0 };
+  } else if (line.startsWith("LF:")) {
+    files[current].lf = Number.parseInt(line.slice(3), 10);
+  } else if (line.startsWith("LH:")) {
+    files[current].lh = Number.parseInt(line.slice(3), 10);
+  } else if (line.startsWith("FNF:")) {
+    files[current].fnf = Number.parseInt(line.slice(4), 10);
+  } else if (line.startsWith("FNH:")) {
+    files[current].fnh = Number.parseInt(line.slice(4), 10);
+  }
+}
+
+const relevant = Object.entries(files).filter(
+  ([path]) =>
+    !EXCLUDE_PREFIXES.some((ex) => path.startsWith(ex)) &&
+    !EXCLUDE_SUBSTRINGS.some((sub) => path.includes(sub)),
+);
+
+if (relevant.length === 0) {
+  console.log("No source files in coverage report.");
+  process.exit(0);
+}
+
+let totalLf = 0;
+let totalLh = 0;
+let totalFnf = 0;
+let totalFnh = 0;
+
+for (const [path, { lf, lh, fnf, fnh }] of relevant) {
+  totalLf += lf;
+  totalLh += lh;
+  totalFnf += fnf;
+  totalFnh += fnh;
+
+  const linePct = lf === 0 ? 100 : (lh / lf) * 100;
+  const icon = linePct >= THRESHOLD_LINES ? "✅" : "⚠️";
+  console.log(`${icon}  ${linePct.toFixed(1).padStart(5)}%  ${path}`);
+}
+
+const overallLines = totalLf === 0 ? 100 : (totalLh / totalLf) * 100;
+const overallFunctions = totalFnf === 0 ? 100 : (totalFnh / totalFnf) * 100;
+
+console.log(`
+Lines:     ${overallLines.toFixed(2)}% (${totalLh}/${totalLf}) — threshold: ${THRESHOLD_LINES}%
+Functions: ${overallFunctions.toFixed(2)}% (${totalFnh}/${totalFnf}) — threshold: ${THRESHOLD_FUNCTIONS}%`);
+
+const failures: string[] = [];
+if (overallLines < THRESHOLD_LINES)
+  failures.push(`Lines ${overallLines.toFixed(2)}% < ${THRESHOLD_LINES}%`);
+if (overallFunctions < THRESHOLD_FUNCTIONS)
+  failures.push(
+    `Functions ${overallFunctions.toFixed(2)}% < ${THRESHOLD_FUNCTIONS}%`,
+  );
+
+if (failures.length > 0) {
+  console.error(`\n❌ Coverage gate failed: ${failures.join(", ")}`);
+  process.exit(1);
+}
+console.log("✅ Coverage gate passed");


### PR DESCRIPTION
## Summary
- Add `scripts/check-coverage.ts`, ported from app-vitals/vitals-os, parsing `coverage/lcov.info` and gating on the weighted aggregate lines/functions percentage (not a per-file check).
- Wire a `task test:coverage` (`bun test --coverage --coverage-reporter=lcov` + the check script) into `task ci` and CI's Test step.

## Why not bunfig.toml's coverageThreshold
Bun's native per-file threshold would fail CI today on individual low-coverage files (mostly DB-gated integration-tested modules and CLI entrypoints) regardless of aggregate coverage.

## Test plan
- [ ] CI passes at current coverage level (this PR is the live check)
- [x] `task lint` / biome clean on the new script
- [ ] Manual scratch verification that raising thresholds above current coverage fails the gate (done locally, not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)