### PR TITLE
docs(agent-admin): fix PATCH /envs body shape, document GET /agents

### DIFF
--- a/.claude/skills/marketplace-dev/references/version-sync-checklist.md
+++ b/.claude/skills/marketplace-dev/references/version-sync-checklist.md
@@ -1,31 +1,47 @@
 # Version Sync Checklist
 
-In this repo, **semantic-release owns the version** — you do not bump it by hand.
+In this repo, **CI owns the version** — you do not bump it by hand.
 This document explains what actually happens on release and how to verify that a
 release landed cleanly.
 
 ## How Versioning Works
 
-On every merge to `main`, the CI release job runs:
+The live path is tag-driven, not the `release.yml` semantic-release job you'll see in
+`.releaserc.json` — that job is `workflow_dispatch`-only, admin-gated, and requires
+`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` secrets that aren't provisioned. It exists
+as a manual escape hatch, not the thing that runs on every merge.
 
-1. **`@semantic-release/commit-analyzer`** reads all conventional commits since the
-   last tag and determines the next version (patch / minor / major).
-2. **`prepareCmd`** in `.releaserc.json` calls:
+What actually runs on every merge to `main`:
+
+1. **`.github/workflows/build-agent.yml`** fires once the `CI` workflow succeeds on
+   `main` and the merge touched a relevant path (`agent/**`, `plugins/**`,
+   `.claude-plugin/**`, `package.json`, `bun.lock`). It uses
+   `mathieudutour/github-tag-action` to compute the next version from conventional
+   commits since the last `agent-v*` tag (`default_bump: patch`), builds and pushes the
+   agent Docker image stamped with that version, then pushes a new `agent-v*` git tag.
+2. **`.github/workflows/sync-plugin-version.yml`** triggers on that `agent-v*` tag push.
+   It checks out `main`, runs:
    ```
-   bun scripts/sync-version.ts ${nextRelease.version}
+   bun run scripts/sync-version.ts <version>
    ```
-3. **`scripts/sync-version.ts`** writes the new version to five files:
+3. **`scripts/sync-version.ts`** writes the new version into six files:
 
    | File | What it updates |
    |------|----------------|
    | `package.json` | Root `"version"` field |
    | `plugins/shipwright/package.json` | Plugin workspace `"version"` field |
+   | `plugins/shipwright/.claude-plugin/plugin.json` | Plugin manifest `"version"` field |
    | `metrics/package.json` | Metrics workspace `"version"` field |
    | `agent/package.json` | Agent workspace `"version"` field |
    | `version.txt` | Plain-text version string |
 
-4. A sixth file, `.claude-plugin/marketplace.json`, will also be synced once
-   MKT-1.2 lands (the file does not exist yet).
+   Plus a seventh, `.claude-plugin/marketplace.json` — this one is already live (not
+   pending any follow-up work); external installs via `claude plugin marketplace add`
+   read this file directly, so it's the reason `sync-plugin-version.yml` exists at all
+   rather than relying solely on the build-time stamp in the Docker image.
+4. The workflow commits the change to a branch (`chore/plugin-version-v<version>`),
+   opens a PR, waits for required checks, and self-merges with `--admin` (squash,
+   `[skip ci]` on the subject so the merge doesn't re-trigger build workflows).
 
 ## Commit Types and the Bump They Trigger
 
@@ -37,26 +53,26 @@ On every merge to `main`, the CI release job runs:
 | `docs:`, `chore:`, `ci:`, `build:`, `refactor:`, `test:` | No release | Automation ignores these |
 
 If you intended a release but none fired, confirm that at least one commit in the
-batch uses a release-triggering prefix (`fix:`, `feat:`, `perf:`, `revert:`).
+batch uses a release-triggering prefix (`fix:`, `feat:`, `perf:`, `revert:`), and that
+the merge actually touched one of `build-agent.yml`'s trigger paths — a docs-only PR to
+an unrelated path never fires a release regardless of commit prefix.
 
 ## Post-Release Verification
 
-After a release merges and the CI release job completes:
+After a release merges and `sync-plugin-version.yml` completes:
 
 ```bash
 # 1. Check the new git tag
 git fetch --tags
 git tag --sort=-creatordate | head -5
 
-# 2. Verify all five files match the new tag
-grep '"version"' package.json
-grep '"version"' plugins/shipwright/package.json
-grep '"version"' metrics/package.json
-grep '"version"' agent/package.json
-cat version.txt
+# 2. Verify all files match the new tag
+bun run scripts/sync-version.ts --check
 ```
 
-All five should show the same version string.
+`--check` compares `version.txt` (canonical) against all six package.json/plugin.json
+files and `marketplace.json`, and is wired into CI as the `check-version-sync` task
+(`Taskfile.yml`) — so drift fails CI on its own, independent of this checklist.
 
 ## What to Do If Files Are Out of Sync
 
@@ -64,13 +80,15 @@ If a file shows the wrong version after a release:
 
 1. **Do not hand-edit** the version field — run the script instead:
    ```bash
-   bun scripts/sync-version.ts <correct-version>
+   bun run scripts/sync-version.ts <correct-version>
    ```
 2. Commit the fix with `chore: resync version to <version>` (no release triggered).
 3. The next `feat:` or `fix:` commit will cut a fresh release from the corrected base.
 
 ## Reminder: Never Manually Bump Versions
 
-Do not edit `"version"` in `package.json`, `plugin.json`, or `marketplace.json` by
-hand. The automation owns these. Write correct conventional commits and let
-semantic-release do its job.
+Do not edit `"version"` in any `package.json`, `plugin.json`, or `marketplace.json` by
+hand — the automation owns these and a manual edit just conflicts with (or gets
+overwritten by) the next tag-triggered sync. Write correct conventional commits and let
+`build-agent.yml` / `sync-plugin-version.yml` do the job. Confirmed the hard way in PR
+#1296, where a manual patch bump had to be reverted.

--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "0.156.0",
+  "version": "0.156.1",
   "description": "The autonomous delivery agent for Claude Code — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project.",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipwright",
-  "version": "0.156.1",
+  "version": "0.156.0",
   "description": "The autonomous delivery agent for Claude Code — conversational planning, queue-driven execution, policy-controlled code review, a five-phase test-readiness pipeline, and autonomous deploy (merge → canary → promote) for any software project.",
   "author": {
     "name": "App Vitals",

--- a/plugins/shipwright/skills/agent-admin/SKILL.md
+++ b/plugins/shipwright/skills/agent-admin/SKILL.md
@@ -52,6 +52,20 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq .
 ```
 
+## Finding Other Agents
+
+To manage another agent (e.g. resolve a name like "warchild" to an ID), list all agents:
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents" | jq .
+# Returns: [{ id, name, selfHosted }, ...]
+```
+
+**Admin-scoped keys only** — this 403s unless your `SHIPWRIGHT_AGENT_API_KEY` is registered
+in `SHIPWRIGHT_ADMIN_API_KEYS` with `scope: "*"`. Most per-agent keys don't have this; check
+with whoever manages the admin service if you get a 403.
+
 ---
 
 ## Cron Jobs
@@ -213,11 +227,19 @@ curl -sf -X POST \
   -d '{"SLACK_BOT_TOKEN": "xoxb-...", "GH_TOKEN": "ghp_..."}' | jq .
 
 # Merge — update specific keys, leave unmentioned keys unchanged
+# Note: unlike POST, the PATCH body wraps keys under "env" — a flat body 400s with "env: Required"
 curl -sf -X PATCH \
   -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/envs" \
-  -d '{"GH_TOKEN": "ghp_new_token"}' | jq .
+  -d '{"env": {"GH_TOKEN": "ghp_new_token"}}' | jq .
+
+# Merge and flag a key as secret (masked in future GETs) — secretKeys is optional
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/envs" \
+  -d '{"env": {"GH_TOKEN": "ghp_new_token"}, "secretKeys": ["GH_TOKEN"]}' | jq .
 
 # Delete a single key
 curl -sf -X DELETE \


### PR DESCRIPTION
## Summary
- The \`agent-admin\` skill showed \`PATCH /agents/{id}/envs\` taking a flat body like \`POST\`, but the API requires \`{"env": {...}}\` — confirmed against \`AgentEnvPatchBodySchema\` in \`admin/src/openapi-schemas.ts\` and by hitting the endpoint directly (flat body 400s with \`"env: Required"\`).
- Documents the previously-undocumented \`GET /agents\` list-all endpoint (admin-scoped keys only) — useful for resolving an agent name to an ID before hitting per-agent endpoints.
- Fixes \`.claude/skills/marketplace-dev/references/version-sync-checklist.md\`, which credited semantic-release as the live version-bump mechanism (it's actually a dormant, secret-gated \`workflow_dispatch\`-only fallback), was missing \`plugin.json\` from its file table, and said \`marketplace.json\` sync was pending a future ticket when it's already live. Rewritten to describe the actual \`build-agent.yml\` → \`sync-plugin-version.yml\` → \`scripts/sync-version.ts\` flow.

Found while setting \`ANTHROPIC_MODEL\` on two agents via the agent-admin skill; the documented flat PATCH body 400'd, which led to also verifying (and finding stale) the version-sync docs.

Note: plugin version is not bumped here — it's synced automatically by CI (\`build-agent.yml\` tags a semver bump on merge, \`sync-plugin-version.yml\` writes it into \`plugin.json\` and friends).

## Test plan
- [x] \`bunx biome check\` on changed files — clean
- [x] Verified corrected PATCH body shape against \`AgentEnvPatchBodySchema\` in \`admin/src/openapi-schemas.ts\` and live API response
- [x] Verified version-sync-checklist rewrite against \`build-agent.yml\`, \`sync-plugin-version.yml\`, \`scripts/sync-version.ts\`, \`.releaserc.json\`, and \`Taskfile.yml\` source
- [x] Docs-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)