### PR TITLE
fix: mask agent secret env vars and stop minting duplicate provisioning tokens

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -12,13 +12,13 @@ import {
   escapeHtml,
   renderAdminToolbar,
 } from "./admin-ui-styles.ts";
+import { parseChatMarkers } from "./chat-markers.ts";
 import type {
   ChatMessage,
   ChatThread,
   MessageTokens,
   ThreadStats,
 } from "./http-chat-client.ts";
-import { parseChatMarkers } from "./chat-markers.ts";
 import type { ModelBreakdownEntry } from "./openapi-schemas.ts";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -2373,41 +2373,15 @@ export function renderProvisionCompletePage(
     success: boolean;
     agentId?: string;
     error?: string;
-    rawToken?: string;
-    alreadyConfigured?: boolean;
   },
 ): string {
-  const tokenStatusHtml = opts.rawToken
-    ? `<div class="alert alert-success" style="margin-top:16px">
-        <strong>Internal API Key — copy it now, it will not be shown again.</strong><br />
-        <code
-          id="raw-token"
-          class="mono"
-          style="display:block;margin-top:8px;font-size:13px;word-break:break-all;padding:8px;background:#f0fdf4;border-radius:4px"
-        >${escapeHtml(opts.rawToken)}</code>
-        <button
-          type="button"
-          onclick="navigator.clipboard.writeText(document.getElementById('raw-token').textContent)"
-          class="btn btn-secondary"
-          style="margin-top:8px;font-size:12px"
-        >Copy to clipboard</button>
-        <p style="font-size:12px;color:#6b7280;margin-top:8px">
-          Store this as <code class="mono">SHIPWRIGHT_AGENT_API_KEY</code> in your agent configuration.
-        </p>
-      </div>`
-    : opts.alreadyConfigured
-      ? `<div class="alert alert-success" style="margin-top:16px">
-        An API key is already configured for this agent — no new key was minted.
-      </div>`
-      : "";
-
   const bodyHtml = opts.success
     ? `<div class="alert alert-success">
         <strong>Provisioning complete!</strong> — Slack app credentials and tokens stored.
       </div>
-      ${tokenStatusHtml}
       <p style="font-size:14px;margin-bottom:16px;margin-top:16px">
         All credentials have been saved to the agent's env vars and system crons have been seeded.
+        For a self-hosted agent, mint its own API key from the agent's detail page.
       </p>
       ${opts.agentId ? `<a href="/admin/agents/${escapeHtml(opts.agentId)}" class="btn btn-primary">View Agent →</a>` : ""}
       <a href="/admin/agents" class="btn btn-secondary" style="margin-left:8px">Back to Agents</a>`

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -21,6 +21,8 @@ import {
   type ToolItem,
   renderAgentDetailPage,
   renderAgentsPage,
+  renderChatPage,
+  renderChatThreadPage,
   renderCronRunsPage,
   renderLoginPage,
   renderPrDetailPage,
@@ -30,11 +32,9 @@ import {
   renderPrsPage,
   renderTaskDetailPage,
   renderTasksPage,
-  renderChatPage,
-  renderChatThreadPage,
 } from "./admin-ui-pages.ts";
-import type { ChatMessage, ChatThread } from "./http-chat-client.ts";
 import { renderAdminToolbar } from "./admin-ui-styles.ts";
+import type { ChatMessage, ChatThread } from "./http-chat-client.ts";
 
 // ─── Shared fixtures ──────────────────────────────────────────────────────────
 
@@ -1374,37 +1374,6 @@ describe("renderProvisionCompletePage", () => {
     });
     expect(html).not.toContain('"><script>xss()</script>');
     expect(html).toContain("&lt;script&gt;");
-  });
-
-  test("success + alreadyConfigured + no rawToken: shows 'already configured' message", () => {
-    const html = renderProvisionCompletePage(USER_NAME, {
-      success: true,
-      agentId: "agent-new",
-      alreadyConfigured: true,
-    });
-    expect(html).toContain("already configured");
-  });
-
-  test("success + alreadyConfigured + no rawToken: does not show copy-this-now block", () => {
-    const html = renderProvisionCompletePage(USER_NAME, {
-      success: true,
-      agentId: "agent-new",
-      alreadyConfigured: true,
-    });
-    expect(html).not.toContain("copy it now");
-    expect(html).not.toContain('id="raw-token"');
-  });
-
-  test("success + rawToken present: shows copy-this-now block even if alreadyConfigured is also passed", () => {
-    const html = renderProvisionCompletePage(USER_NAME, {
-      success: true,
-      agentId: "agent-new",
-      rawToken: "sw_raw123456",
-      alreadyConfigured: false,
-    });
-    expect(html).toContain("copy it now");
-    expect(html).toContain("sw_raw123456");
-    expect(html).not.toContain("already configured");
   });
 });
 

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -3271,7 +3271,7 @@ describe("admin UI — xapp-token route", () => {
     adminCookie = await makeSessionCookie();
   });
 
-  it("fresh-mint path: no existing SHIPWRIGHT_AGENT_API_KEY → mints a token and shows it", async () => {
+  it("never mints SHIPWRIGHT_AGENT_API_KEY — K8s-managed agents already have it from provisioner.provision(), self-hosted agents mint their own from the agent detail page", async () => {
     let createCalled = false;
     const app = createAdminUIApp(
       makeMockDeps({
@@ -3309,56 +3309,8 @@ describe("admin UI — xapp-token route", () => {
       },
     });
     expect(res.status).toBe(200);
-    expect(createCalled).toBe(true);
-    const text = await res.text();
-    expect(text).toContain("copy it now");
-    expect(text).toContain("sw_raw123456");
-  });
-
-  it("already-set/skip-mint path: SHIPWRIGHT_AGENT_API_KEY already set → does not mint, shows already-configured message", async () => {
-    let createCalled = false;
-    const app = createAdminUIApp(
-      makeMockDeps({
-        agentEnvService: {
-          getByAgentId: async () => ({ env: {}, secretKeys: [] }),
-          upsert: async () => {},
-          patch: async () => {},
-          deleteKey: async () => {},
-          getConfigBundle: async () => ({
-            env: {
-              SLACK_BOT_TOKEN: "xoxb-existing",
-              SHIPWRIGHT_AGENT_API_KEY: "sw_already_set_abc123",
-            },
-            agentId: AGENT_ID,
-            allowedTools: [],
-          }),
-        },
-        agentTokenService: {
-          listForAgent: async () => [MOCK_TOKEN],
-          create: async () => {
-            createCalled = true;
-            return { token: MOCK_TOKEN, rawToken: "sw_raw123456" };
-          },
-          revoke: async () => MOCK_TOKEN,
-        },
-      }),
-    );
-    const body = new URLSearchParams({
-      agentId: AGENT_ID,
-      xappToken: "xapp-1-valid-token",
-    });
-    const res = await app.request("/admin/provision/xapp-token", {
-      method: "POST",
-      body: body.toString(),
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Cookie: `admin_session=${adminCookie}`,
-      },
-    });
-    expect(res.status).toBe(200);
     expect(createCalled).toBe(false);
     const text = await res.text();
-    expect(text).toContain("already configured");
     expect(text).not.toContain("sw_raw123456");
   });
 });

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -21,6 +21,7 @@
  */
 
 import { isOrgRepo } from "@shipwright/lib/org-repo";
+import { SECRET_ENV_VARS } from "@shipwright/lib/secret-env-vars";
 import { Hono, type MiddlewareHandler } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { sign, verify } from "hono/jwt";
@@ -47,8 +48,6 @@ import {
   renderTasksPage,
   renderTokensPage,
 } from "./admin-ui-pages.ts";
-import { validateAttachment } from "./attachment-validation.ts";
-import type { ChatClient, ChatThread } from "./http-chat-client.ts";
 import type { AgentCronJobService } from "./agent-cron-jobs.ts";
 import type { AgentCronRunService } from "./agent-cron-runs.ts";
 import type { AgentEnvService } from "./agent-envs.ts";
@@ -57,14 +56,15 @@ import type { AgentProvisioner } from "./agent-provisioner.ts";
 import type { AgentTokenService } from "./agent-tokens.ts";
 import type { AgentToolService } from "./agent-tools.ts";
 import { publicNoAuthMiddleware } from "./api-auth.ts";
+import { validateAttachment } from "./attachment-validation.ts";
 import { ForbiddenError, UnprocessableEntityError } from "./errors.ts";
 import type { GoogleAuthClient } from "./google-auth-client.ts";
+import type { ChatClient, ChatThread } from "./http-chat-client.ts";
 import type { AppManifest } from "./slack-provisioning-client.ts";
 import {
   AGENT_BOT_SCOPES,
   buildAgentManifest,
 } from "./slack-provisioning-client.ts";
-import type { TaskStoreProvisioningClient } from "./task-store-provisioning-client.ts";
 
 type AdminUIEnv = { Variables: { userEmail: string; isAdmin: boolean } };
 
@@ -307,13 +307,6 @@ export interface AdminUIDeps {
    * When absent, all chat routes render in degraded mode (notice, no table/messages).
    */
   chatClient?: ChatClient;
-  /**
-   * Task-store provisioning client used by the xapp-token handler to mint a
-   * per-agent task-store token during Slack wizard provisioning, mirroring
-   * the K8s provisioning path. When absent, provisioning proceeds without
-   * task-store credentials and a warning is logged.
-   */
-  taskStoreProvisioningClient?: TaskStoreProvisioningClient;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -422,7 +415,6 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     taskStoreBaseUrl,
     publicRepo,
     chatClient,
-    taskStoreProvisioningClient,
   } = deps;
 
   const app = new Hono<AdminUIEnv>();
@@ -1574,7 +1566,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       newEnv.CLAUDE_CODE_OAUTH_TOKEN = claudeCodeOauthToken;
     }
 
-    await agentEnvService.patch(resolvedAgentId, newEnv);
+    await agentEnvService.patch(
+      resolvedAgentId,
+      newEnv,
+      new Set(SECRET_ENV_VARS),
+    );
 
     // Use c.html() so the Set-Cookie header from setCookie() is included
     return c.html(
@@ -1686,9 +1682,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       provisionState.agentId,
     );
     // Use patch() to merge SLACK_BOT_TOKEN without overwriting other keys
-    await agentEnvService.patch(provisionState.agentId, {
-      SLACK_BOT_TOKEN: botToken,
-    });
+    await agentEnvService.patch(
+      provisionState.agentId,
+      { SLACK_BOT_TOKEN: botToken },
+      new Set(SECRET_ENV_VARS),
+    );
 
     // If SLACK_APP_TOKEN is already set this is a reinstall (not fresh provisioning).
     // Skip the xapp-token page and redirect directly to the agent detail page.
@@ -1751,56 +1749,22 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }
 
     try {
-      // If SHIPWRIGHT_AGENT_API_KEY is already set, skip minting a new one — the
-      // form has no CSRF/idempotency guard, so a resubmit must not mint (and
-      // silently orphan) a second key while the configured one stays valid.
-      const existingBundle = await agentEnvService.getConfigBundle(agentId);
-      const alreadyConfigured = Boolean(
-        existingBundle?.env.SHIPWRIGHT_AGENT_API_KEY,
-      );
-
-      let rawToken: string | undefined;
-      if (!alreadyConfigured) {
-        // Create scoped token first so both secrets land in one upsert
-        const created = await agentTokenService.create(agentId, "provision");
-        rawToken = created.rawToken;
-      }
-
-      // Mint a task-store token the same way the K8s provisioning path does
-      // (agent-provisioner.ts), gated on the same idempotency guard as
-      // SHIPWRIGHT_AGENT_API_KEY above so a resubmit can't orphan a second
-      // token. When the admin server has no task-store client configured,
-      // warn instead of silently skipping provisioning.
-      const alreadyHasTaskStoreToken = Boolean(
-        existingBundle?.env.SHIPWRIGHT_TASK_STORE_TOKEN,
-      );
-      let taskStoreToken: string | undefined;
-      if (!taskStoreProvisioningClient) {
-        console.warn(
-          "[admin] task-store not configured — skipping task-store provisioning for agent",
-          agentId,
-        );
-      } else if (!alreadyHasTaskStoreToken) {
-        const minted = await taskStoreProvisioningClient.mintToken(
-          `agent:${agentId}`,
-          agentId,
-        );
-        taskStoreToken = minted.rawToken;
-      }
+      // SHIPWRIGHT_AGENT_API_KEY and SHIPWRIGHT_TASK_STORE_TOKEN are NOT minted
+      // here. K8s-managed agents already have both minted straight into the K8s
+      // Secret by provisioner.provision() (agent-provisioner.ts) — that Secret is
+      // the sole source of truth (via secretKeyRef in the Deployment manifest).
+      // Self-hosted agents never run the containerized entrypoint that reads
+      // SHIPWRIGHT_AGENT_API_KEY (agent/src/entrypoint.ts), and use the
+      // GitHub-backed task-store CLI config instead of a bearer token, so they
+      // don't need either key in AgentEnv. Minting them here previously orphaned
+      // a second, different, unused live credential per key on every provision.
 
       // Use patch() to merge new keys without overwriting existing env vars
-      await agentEnvService.patch(agentId, {
-        SLACK_APP_TOKEN: xappToken,
-        ...(rawToken ? { SHIPWRIGHT_AGENT_API_KEY: rawToken } : {}),
-        ...(taskStoreToken
-          ? {
-              SHIPWRIGHT_TASK_STORE_TOKEN: taskStoreToken,
-              ...(taskStoreBaseUrl
-                ? { SHIPWRIGHT_TASK_STORE_URL: taskStoreBaseUrl }
-                : {}),
-            }
-          : {}),
-      });
+      await agentEnvService.patch(
+        agentId,
+        { SLACK_APP_TOKEN: xappToken },
+        new Set(SECRET_ENV_VARS),
+      );
 
       // Seed system crons
       await agentCronJobService.reconcileSystemCrons(agentId);
@@ -1809,8 +1773,6 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         renderProvisionCompletePage(userEmail, {
           success: true,
           agentId,
-          rawToken,
-          alreadyConfigured,
         }),
       );
     } catch (err) {
@@ -2166,7 +2128,9 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }));
 
     if (!chatClient) {
-      return html(renderChatPage(agents, selectedAgentId, null, c.var.userEmail, q));
+      return html(
+        renderChatPage(agents, selectedAgentId, null, c.var.userEmail, q),
+      );
     }
 
     let threads: ChatThread[] = [];
@@ -2204,15 +2168,23 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }
 
     try {
-      const [thread, messagesResult, threadListResult, statsResult] = await Promise.all([
-        chatClient.getThread(threadId),
-        chatClient.listMessages(threadId),
-        chatClient.listThreads(agentId).catch(() => null),
-        chatClient.getThreadStats(threadId).catch(() => null),
-      ]);
+      const [thread, messagesResult, threadListResult, statsResult] =
+        await Promise.all([
+          chatClient.getThread(threadId),
+          chatClient.listMessages(threadId),
+          chatClient.listThreads(agentId).catch(() => null),
+          chatClient.getThreadStats(threadId).catch(() => null),
+        ]);
       const threadList = threadListResult ? threadListResult.threads : null;
       return html(
-        renderChatThreadPage(agentId, thread, messagesResult.messages, threadList, c.var.userEmail, statsResult),
+        renderChatThreadPage(
+          agentId,
+          thread,
+          messagesResult.messages,
+          threadList,
+          c.var.userEmail,
+          statsResult,
+        ),
       );
     } catch {
       return html(
@@ -2227,7 +2199,10 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     const agentId = c.req.param("agentId");
 
     if (!chatClient) {
-      return c.redirect(`/admin/chat?agentId=${encodeURIComponent(agentId)}`, 302);
+      return c.redirect(
+        `/admin/chat?agentId=${encodeURIComponent(agentId)}`,
+        302,
+      );
     }
 
     let title: string | undefined;
@@ -2235,7 +2210,10 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       const formData = await c.req.formData();
       title = formData.get("title")?.toString()?.trim() || undefined;
     } catch {
-      return c.redirect(`/admin/chat?agentId=${encodeURIComponent(agentId)}`, 302);
+      return c.redirect(
+        `/admin/chat?agentId=${encodeURIComponent(agentId)}`,
+        302,
+      );
     }
 
     try {
@@ -2245,7 +2223,10 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         302,
       );
     } catch {
-      return c.redirect(`/admin/chat?agentId=${encodeURIComponent(agentId)}`, 302);
+      return c.redirect(
+        `/admin/chat?agentId=${encodeURIComponent(agentId)}`,
+        302,
+      );
     }
   });
 

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -457,17 +457,11 @@ async function startServer(): Promise<void> {
                 `task-store DELETE /tokens/${id} → ${res.status}`,
               );
           },
-          // Advertise the PUBLIC task-store URL in the mint-token env block so a
-          // local/laptop agent can resolve it; the in-cluster fetchers above keep
-          // using the internal SHIPWRIGHT_TASK_STORE_URL.
+          // Advertised on the manual Tokens page so a self-hosted/local agent's
+          // operator can read it and configure the local task-store CLI config
+          // themselves; the in-cluster fetchers above keep using the internal
+          // SHIPWRIGHT_TASK_STORE_URL.
           taskStoreBaseUrl: resolveTaskStoreBaseUrl(process.env),
-          // Mints a per-agent task-store token during Slack wizard provisioning
-          // (POST /admin/provision/xapp-token), mirroring the K8s provisioning
-          // path's taskStore wiring in buildProvisioner above.
-          taskStoreProvisioningClient: new HttpTaskStoreProvisioningClient(
-            taskStoreUrl,
-            taskStoreAdminToken,
-          ),
         }
       : {};
 

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -69,7 +69,11 @@ async function makeProvisionStateCookie(
 
 interface MockState {
   upsertCalls: Array<{ agentId: string; env: Record<string, string> }>;
-  patchCalls: Array<{ agentId: string; env: Record<string, string> }>;
+  patchCalls: Array<{
+    agentId: string;
+    env: Record<string, string>;
+    secretKeys: string[];
+  }>;
   reconcileCalls: string[];
   createTokenCalls: Array<{ agentId: string; label?: string }>;
 }
@@ -165,8 +169,16 @@ function makeMockDeps(
       upsert: async (agentId: string, env: Record<string, string>) => {
         state.upsertCalls.push({ agentId, env });
       },
-      patch: async (agentId: string, env: Record<string, string>) => {
-        state.patchCalls.push({ agentId, env });
+      patch: async (
+        agentId: string,
+        env: Record<string, string>,
+        secretKeys?: Set<string>,
+      ) => {
+        state.patchCalls.push({
+          agentId,
+          env,
+          secretKeys: secretKeys ? [...secretKeys] : [],
+        });
       },
       deleteKey: async () => {},
       getConfigBundle: async () => null,
@@ -297,8 +309,13 @@ describe("GET /admin/provision/complete — OAuth callback", () => {
 
     // SLACK_BOT_TOKEN should have been stored via patch()
     expect(state.patchCalls.length).toBeGreaterThan(0);
-    const storedEnv = state.patchCalls[state.patchCalls.length - 1].env;
-    expect(storedEnv).toHaveProperty("SLACK_BOT_TOKEN", "xoxb-mock-bot-token");
+    const lastPatch = state.patchCalls[state.patchCalls.length - 1];
+    expect(lastPatch.env).toHaveProperty(
+      "SLACK_BOT_TOKEN",
+      "xoxb-mock-bot-token",
+    );
+    // SLACK_BOT_TOKEN must be marked as a secret so it's masked on read
+    expect(lastPatch.secretKeys).toContain("SLACK_BOT_TOKEN");
   });
 
   it("absent cookie → renders error page (not blank form)", async () => {
@@ -401,8 +418,16 @@ describe("GET /admin/provision/complete — reinstall path (SLACK_APP_TOKEN alre
         upsert: async (agentId: string, env: Record<string, string>) => {
           state.upsertCalls.push({ agentId, env });
         },
-        patch: async (agentId: string, env: Record<string, string>) => {
-          state.patchCalls.push({ agentId, env });
+        patch: async (
+          agentId: string,
+          env: Record<string, string>,
+          secretKeys?: Set<string>,
+        ) => {
+          state.patchCalls.push({
+            agentId,
+            env,
+            secretKeys: secretKeys ? [...secretKeys] : [],
+          });
         },
         deleteKey: async () => {},
         getConfigBundle: async () => ({
@@ -434,8 +459,13 @@ describe("GET /admin/provision/complete — reinstall path (SLACK_APP_TOKEN alre
     expect(location).toContain(`/admin/agents/${AGENT_ID}`);
 
     // SLACK_BOT_TOKEN should still have been stored via patch() (new token)
-    const storedEnv = state.patchCalls[state.patchCalls.length - 1]?.env;
-    expect(storedEnv).toHaveProperty("SLACK_BOT_TOKEN", "xoxb-mock-bot-token");
+    const lastPatch = state.patchCalls[state.patchCalls.length - 1];
+    expect(lastPatch?.env).toHaveProperty(
+      "SLACK_BOT_TOKEN",
+      "xoxb-mock-bot-token",
+    );
+    // SLACK_BOT_TOKEN must be marked as a secret so it's masked on read
+    expect(lastPatch?.secretKeys).toContain("SLACK_BOT_TOKEN");
   });
 });
 
@@ -514,6 +544,8 @@ describe("POST /admin/provision/xapp-token", () => {
     expect(appTokenPatch?.env.SLACK_APP_TOKEN).toBe(
       "xapp-1-TEST-fake-socket-token",
     );
+    // SLACK_APP_TOKEN must be marked as a secret so it's masked on read
+    expect(appTokenPatch?.secretKeys).toContain("SLACK_APP_TOKEN");
 
     // Neither key gets minted here — K8s-managed agents already have both from
     // provisioner.provision() (Secret is the source of truth); self-hosted
@@ -625,6 +657,8 @@ describe("POST /admin/provision/xapp-token", () => {
     expect(slackAppTokenPatch?.env.SLACK_APP_TOKEN).toBe(
       "xapp-1-TEST-fake-socket-token",
     );
+    // SLACK_APP_TOKEN must be marked as a secret so it's masked on read
+    expect(slackAppTokenPatch?.secretKeys).toContain("SLACK_APP_TOKEN");
     expect(
       state.patchCalls.some((c) => "SHIPWRIGHT_AGENT_API_KEY" in c.env),
     ).toBe(false);

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -6,11 +6,10 @@
  * Services are injected as in-memory test doubles.
  */
 
-import { beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
 import { createAdminUIApp } from "./admin-ui.ts";
 import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
-import type { TaskStoreProvisioningClient } from "./task-store-provisioning-client.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -482,7 +481,7 @@ describe("POST /admin/provision/xapp-token", () => {
     sessionCookie = await makeSessionCookie();
   });
 
-  it("valid data → 200, SLACK_APP_TOKEN stored, SHIPWRIGHT_AGENT_API_KEY stored, crons reconciled, raw token shown", async () => {
+  it("valid data → 200, SLACK_APP_TOKEN stored, no agent API key or task-store token minted, crons reconciled", async () => {
     const state: MockState = {
       upsertCalls: [],
       patchCalls: [],
@@ -506,7 +505,6 @@ describe("POST /admin/provision/xapp-token", () => {
     });
 
     expect(res.status).toBe(200);
-    const html = await res.text();
 
     // SLACK_APP_TOKEN should be stored via patch()
     const appTokenPatch = state.patchCalls.find(
@@ -517,24 +515,19 @@ describe("POST /admin/provision/xapp-token", () => {
       "xapp-1-TEST-fake-socket-token",
     );
 
-    // SHIPWRIGHT_AGENT_API_KEY should be stored via patch()
-    const apiKeyPatch = state.patchCalls.find(
-      (c) => "SHIPWRIGHT_AGENT_API_KEY" in c.env,
-    );
-    expect(apiKeyPatch).toBeDefined();
-    expect(apiKeyPatch?.env.SHIPWRIGHT_AGENT_API_KEY).toBe(
-      "raw_test_token_abc123def456",
-    );
+    // Neither key gets minted here — K8s-managed agents already have both from
+    // provisioner.provision() (Secret is the source of truth); self-hosted
+    // agents mint their own token separately from the agent detail page.
+    expect(
+      state.patchCalls.some((c) => "SHIPWRIGHT_AGENT_API_KEY" in c.env),
+    ).toBe(false);
+    expect(
+      state.patchCalls.some((c) => "SHIPWRIGHT_TASK_STORE_TOKEN" in c.env),
+    ).toBe(false);
+    expect(state.createTokenCalls.length).toBe(0);
 
     // Crons should have been reconciled
     expect(state.reconcileCalls).toContain(AGENT_ID);
-
-    // agentTokenService.create should have been called
-    expect(state.createTokenCalls.length).toBeGreaterThan(0);
-    expect(state.createTokenCalls[0].agentId).toBe(AGENT_ID);
-
-    // Raw token should appear in the response HTML
-    expect(html).toContain("raw_test_token_abc123def456");
   });
 
   it("missing agentId → shows error in xapp-token page", async () => {
@@ -596,24 +589,15 @@ describe("POST /admin/provision/xapp-token", () => {
     expect(state.upsertCalls.length).toBe(0);
   });
 
-  it("taskStoreProvisioningClient configured → mints a task-store token, patches SHIPWRIGHT_TASK_STORE_TOKEN/URL", async () => {
+  it("xapp-token step never mints SHIPWRIGHT_AGENT_API_KEY or SHIPWRIGHT_TASK_STORE_TOKEN — K8s-managed agents already have both from provisioner.provision(), self-hosted agents don't use either", async () => {
     const state: MockState = {
       upsertCalls: [],
       patchCalls: [],
       reconcileCalls: [],
       createTokenCalls: [],
     };
-    const mintCalls: Array<{ label: string; agentId?: string }> = [];
-    const taskStoreProvisioningClient: TaskStoreProvisioningClient = {
-      mintToken: async (label: string, agentId?: string) => {
-        mintCalls.push({ label, agentId });
-        return { id: "ts-tok-1", rawToken: "ts-raw-token-xyz" };
-      },
-      revokeToken: async () => {},
-    };
     const app = createAdminUIApp(
       makeMockDeps(state, {
-        taskStoreProvisioningClient,
         taskStoreBaseUrl: "https://task-store.example.com",
       }),
     );
@@ -633,59 +617,19 @@ describe("POST /admin/provision/xapp-token", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(mintCalls).toEqual([
-      { label: `agent:${AGENT_ID}`, agentId: AGENT_ID },
-    ]);
+    expect(state.createTokenCalls.length).toBe(0);
 
-    const taskStorePatch = state.patchCalls.find(
-      (c) => "SHIPWRIGHT_TASK_STORE_TOKEN" in c.env,
+    const slackAppTokenPatch = state.patchCalls.find(
+      (c) => "SLACK_APP_TOKEN" in c.env,
     );
-    expect(taskStorePatch).toBeDefined();
-    expect(taskStorePatch?.env.SHIPWRIGHT_TASK_STORE_TOKEN).toBe(
-      "ts-raw-token-xyz",
+    expect(slackAppTokenPatch?.env.SLACK_APP_TOKEN).toBe(
+      "xapp-1-TEST-fake-socket-token",
     );
-    expect(taskStorePatch?.env.SHIPWRIGHT_TASK_STORE_URL).toBe(
-      "https://task-store.example.com",
-    );
-  });
-
-  it("no taskStoreProvisioningClient configured → logs a warning, no task-store env stored", async () => {
-    const state: MockState = {
-      upsertCalls: [],
-      patchCalls: [],
-      reconcileCalls: [],
-      createTokenCalls: [],
-    };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-    try {
-      const app = createAdminUIApp(makeMockDeps(state));
-
-      const body = new URLSearchParams({
-        agentId: AGENT_ID,
-        xappToken: "xapp-1-TEST-fake-socket-token",
-      });
-
-      const res = await app.request("/admin/provision/xapp-token", {
-        method: "POST",
-        body: body.toString(),
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Cookie: `admin_session=${sessionCookie}`,
-        },
-      });
-
-      expect(res.status).toBe(200);
-      expect(warnSpy).toHaveBeenCalledWith(
-        "[admin] task-store not configured — skipping task-store provisioning for agent",
-        AGENT_ID,
-      );
-
-      const taskStorePatch = state.patchCalls.find(
-        (c) => "SHIPWRIGHT_TASK_STORE_TOKEN" in c.env,
-      );
-      expect(taskStorePatch).toBeUndefined();
-    } finally {
-      warnSpy.mockRestore();
-    }
+    expect(
+      state.patchCalls.some((c) => "SHIPWRIGHT_AGENT_API_KEY" in c.env),
+    ).toBe(false);
+    expect(
+      state.patchCalls.some((c) => "SHIPWRIGHT_TASK_STORE_TOKEN" in c.env),
+    ).toBe(false);
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.155.0",
+      "version": "0.157.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -98,7 +98,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.155.0",
+      "version": "0.157.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -116,7 +116,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.155.0",
+      "version": "0.157.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/lib/package.json
+++ b/lib/package.json
@@ -7,6 +7,7 @@
     "./admin-types": "./admin-types.ts",
     "./org-repo": "./org-repo.ts",
     "./pricing": "./pricing.ts",
+    "./secret-env-vars": "./secret-env-vars.ts",
     "./sentry": "./sentry.ts",
     "./web/*": "./web/*"
   },

--- a/lib/secret-env-vars.ts
+++ b/lib/secret-env-vars.ts
@@ -1,0 +1,29 @@
+/**
+ * lib/secret-env-vars.ts
+ * Canonical list of well-known secret-shaped env var names used by the
+ * shipwright-agent framework. Shared by Sentry log/event scrubbing
+ * (lib/sentry.ts) and by admin's agent env storage (marks these keys as
+ * `secret` so they're masked in GET /agents/:id/envs responses).
+ */
+
+/** Secret-shaped env var names, redacted/masked wherever their value is currently set. */
+export const SECRET_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "GH_APP_PRIVATE_KEY",
+  "GH_TOKEN",
+  "SLACK_BOT_TOKEN",
+  "SLACK_APP_TOKEN",
+  "SLACK_SIGNING_SECRET",
+  "SLACK_CLIENT_SECRET",
+  "SLACK_ADMIN_TOKEN",
+  "SHIPWRIGHT_AGENT_API_KEY",
+  "SHIPWRIGHT_TASK_STORE_TOKEN",
+  "SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN",
+  "SHIPWRIGHT_CHAT_SERVICE_TOKEN",
+  "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN",
+  "SHIPWRIGHT_ADMIN_API_KEYS",
+  "SHIPWRIGHT_SESSION_SECRET",
+  "SHIPWRIGHT_ENCRYPTION_KEY",
+  "GOOGLE_CLIENT_SECRET",
+] as const;

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/bun";
 import { consoleLoggingIntegration } from "@sentry/bun";
 import type { BunOptions, ErrorEvent, EventHint } from "@sentry/bun";
+import { SECRET_ENV_VARS } from "./secret-env-vars.ts";
 
 /**
  * `@sentry/bun` doesn't re-export the `Log` type directly (it lives in `@sentry/core`, a
@@ -31,27 +32,6 @@ export interface SentryClient {
 export interface ErrorCapturingClient {
   captureException: (err: unknown) => void;
 }
-
-/** Secret-shaped env vars redacted from Sentry events/logs when currently set to a non-empty value. */
-export const SECRET_ENV_VARS = [
-  "ANTHROPIC_API_KEY",
-  "CLAUDE_CODE_OAUTH_TOKEN",
-  "GH_APP_PRIVATE_KEY",
-  "GH_TOKEN",
-  "SLACK_BOT_TOKEN",
-  "SLACK_APP_TOKEN",
-  "SLACK_SIGNING_SECRET",
-  "SLACK_ADMIN_TOKEN",
-  "SHIPWRIGHT_AGENT_API_KEY",
-  "SHIPWRIGHT_TASK_STORE_TOKEN",
-  "SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN",
-  "SHIPWRIGHT_CHAT_SERVICE_TOKEN",
-  "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN",
-  "SHIPWRIGHT_ADMIN_API_KEYS",
-  "SHIPWRIGHT_SESSION_SECRET",
-  "SHIPWRIGHT_ENCRYPTION_KEY",
-  "GOOGLE_CLIENT_SECRET",
-] as const;
 
 /** Max depth walked when scrubbing, so a pathological/deeply-nested object can't hang scrubbing. */
 const MAX_SCRUB_DEPTH = 20;

--- a/lib/sentry.unit.test.ts
+++ b/lib/sentry.unit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { SECRET_ENV_VARS, initSentry, scrubEvent, scrubLog } from "./sentry.ts";
+import { SECRET_ENV_VARS } from "./secret-env-vars.ts";
+import { initSentry, scrubEvent, scrubLog } from "./sentry.ts";
 
 function createFakeSentryClient() {
   const calls: unknown[] = [];


### PR DESCRIPTION
## Summary

Two related bugs found while diagnosing a prod agent crash-loop (chart 1.6.309 deploy):

- **Secret masking gap**: `GET /agents/:id/envs` returned real secrets (Slack bot/app/signing/client-secret tokens, GH tokens, Claude OAuth tokens, task-store/agent API keys, etc.) in cleartext for every agent except `SENTRY_DSN`, because none of the three provisioning-flow `patch()` calls in `admin-ui.ts` passed a `secretKeys` set. Extracted the canonical list out of `lib/sentry.ts` into a new shared `lib/secret-env-vars.ts` and wired it in everywhere secrets get written during provisioning.
- **Duplicate token minting**: the `/admin/provision/xapp-token` step independently minted a *second*, different `SHIPWRIGHT_AGENT_API_KEY` and `SHIPWRIGHT_TASK_STORE_TOKEN` into AgentEnv on every new K8s-managed agent — duplicating what `provisioner.provision()` had already minted straight into the K8s Secret moments earlier in the same flow. Its idempotency check looked at AgentEnv (always empty at that point for a fresh agent) instead of the Secret, so the check never actually prevented the double-mint. Removed the minting entirely: K8s-managed agents already get both credentials from the Secret via `secretKeyRef`, and self-hosted agents never read either (no containerized entrypoint, GitHub-backed task-store CLI instead of a bearer token). Also dropped the now-redundant `SHIPWRIGHT_TASK_STORE_URL` write, since the Deployment manifest already sets that unconditionally for every K8s-managed agent.

## Test plan

- [x] `bun run typecheck` clean across all 7 workspace packages
- [x] `bun test admin/src/ lib/` — 1186 pass, 0 fail (rewrote/removed 5 tests that asserted the old dual-mint behavior)
- [x] biome-formatted
- [x] Backfilled `secretKeys` for all 7 already-provisioned K8s-managed agents in prod (verified zero value changes, only the `secret` flag flipped) and removed the now-orphaned duplicate `SHIPWRIGHT_AGENT_API_KEY`/`SHIPWRIGHT_TASK_STORE_TOKEN`/`SHIPWRIGHT_TASK_STORE_URL` entries from AgentEnv where present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcART2JJwCDBHL8FL3DDFB