### PR TITLE
fix: repoint review/deploy/patch skill docs to /config endpoint

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -19,7 +19,7 @@ metrics on success.
 
 Parse `$ARGUMENTS` to extract `org`, `repo`, and `pr` number:
 - `org/repo#number` (e.g. `app-vitals/shipwright#123`): explicit
-- `number` or `#number`: infer org/repo from the agent config (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[0] // empty'`),
+- `number` or `#number`: infer org/repo from the agent config (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[0] // empty'`),
   defaulting to `app-vitals/shipwright`.
   **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
 - _(no arguments)_: scan mode — find the next ready PR to deploy (see Step 1)
@@ -42,7 +42,7 @@ AGENT_LOGIN=$(gh api user --jq '.login')
 Resolve the configured repos:
 ```bash
 REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[]')
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[]')
 ```
 
 For each configured repo, fetch all open PRs authored by `AGENT_LOGIN`:

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -35,7 +35,7 @@ Resolve the list of repos to scan. Use the same resolver as other shipwright com
 
 ```bash
 REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[]')
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[]')
 ```
 
 Iterate over the results to scan each repo.

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -99,7 +99,7 @@ If `review_external_prs` is true, resolve the configured repos and fetch open PR
 
 ```bash
 REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[]')
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[]')
 ```
 
 ```bash
@@ -659,7 +659,7 @@ When invoked with a specific PR (e.g. `/shipwright:review app-vitals/shipwright#
    infer `org/repo` via:
    ```bash
    curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-     "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID" | jq -r '.repos[0] // empty'
+     "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[0] // empty'
    ```
    Fall back to the current workspace repo if the command fails.
    **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.


### PR DESCRIPTION
## Summary
- Repoint the 5 repo-resolution call sites in `review.md`, `deploy.md`, and `patch.md` from `GET /agents/$SHIPWRIGHT_AGENT_ID` (admin-only, 403s for per-agent tokens) to `GET /agents/$SHIPWRIGHT_AGENT_ID/config` (self-serve, agent-token-accessible)
- No other content or jq extraction logic changed — pure URL path swap

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | All 5 call sites call GET .../agents/$SHIPWRIGHT_AGENT_ID/config | MET | deploy.md:22, deploy.md:45, patch.md:38, review.md:102, review.md:662 |
| 2 | jq extraction expressions unchanged | MET | `.repos[]` and `.repos[0] // empty` preserved verbatim |
| 3 | No other content modified | MET | Diff is exactly +5/-5 lines |
| 4 | Test decision: manual review only, no tests affected | MET | Markdown-only change, no executable code touched |

## Test Plan
- Manual diff review confirming only the URL path changed at each of the 5 call sites
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — passes
- `bunx biome lint` on changed files — passes
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
