### PR TITLE
feat: guard Sentry init against NODE_ENV=test

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Every Shipwright service (`admin`, `metrics`, `task-store`, `agent`) can report to Sentry when `SENTRY_DSN` is set in its own environment. Each service reads its own `SENTRY_DSN` — there is no shared/global toggle. When `SENTRY_DSN` is unset (the default), Sentry is fully inert: no init call, zero telemetry, zero overhead.
+Every Shipwright service (`admin`, `metrics`, `task-store`, `agent`) can report to Sentry when `SENTRY_DSN` is set in its own environment. Each service reads its own `SENTRY_DSN` — there is no shared/global toggle. When `SENTRY_DSN` is unset (the default), or when `NODE_ENV` is `"test"` (auto-set by `bun test`), Sentry is fully inert: no init call, zero telemetry, zero overhead. The test guard prevents test error-path assertions from leaking to production Sentry as real events.
 
 All services share the same init options and scrub hooks via `buildSentryInitOptions()` / `initSentry()` in `lib/sentry.ts`, so behavior is identical regardless of which service reports.
 
@@ -24,7 +24,7 @@ When `SENTRY_DSN` is set, a service reports:
 
 ## Disabling Sentry
 
-Unset `SENTRY_DSN` (or never set it) for the service in question. This is the default — no other configuration is required to keep a service fully offline from Sentry's perspective.
+Unset `SENTRY_DSN` (or never set it) for the service in question. This is the default — no other configuration is required to keep a service fully offline from Sentry's perspective. Alternatively, `Sentry` is automatically disabled during test runs (when `NODE_ENV` is `"test"`, auto-set by `bun test`) even if `SENTRY_DSN` is present in the environment, preventing test assertions from polluting production Sentry with unintended error events.
 
 ## Self-hosted Sentry
 

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -125,11 +125,16 @@ export function scrubLog(log: SentryLog): SentryLog {
  * with callers (like `@sentry/hono`'s `sentry()` middleware) that must
  * perform their own `Sentry.init` call, so every init site gets the same
  * enableLogs/environment/scrub-hook config instead of each duplicating it.
- * Returns `undefined` when SENTRY_DSN is unset (nothing to init).
+ * Returns `undefined` when SENTRY_DSN is unset (nothing to init), or when
+ * NODE_ENV is "test" — Bun auto-sets this for `bun test`, and without this
+ * guard any SENTRY_DSN present in the environment would leak intentional
+ * error-path test assertions to production Sentry as real events.
  */
 export function buildSentryInitOptions(
   opts: InitSentryOptions,
 ): Record<string, unknown> | undefined {
+  if (process.env.NODE_ENV === "test") return undefined;
+
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return undefined;
 

--- a/lib/sentry.unit.test.ts
+++ b/lib/sentry.unit.test.ts
@@ -46,6 +46,18 @@ describe("initSentry — SENTRY_DSN unset", () => {
   });
 });
 
+describe("initSentry — NODE_ENV=test", () => {
+  test("never calls sentryClient.init even with SENTRY_DSN set", () => {
+    process.env.NODE_ENV = "test";
+    process.env.SENTRY_DSN = "https://example@o0.ingest.sentry.io/0";
+    const fakeClient = createFakeSentryClient();
+
+    initSentry({ service: "metrics" }, fakeClient);
+
+    expect(fakeClient.calls.length).toBe(0);
+  });
+});
+
 describe("initSentry — SENTRY_DSN set", () => {
   test("calls sentryClient.init with enableLogs, service tag, and scrub hooks wired", () => {
     process.env.SENTRY_DSN = "https://example@o0.ingest.sentry.io/0";


### PR DESCRIPTION
## Summary
- Add a `NODE_ENV=test` guard to `buildSentryInitOptions()` in `lib/sentry.ts`, the shared choke point behind `initSentry()` and the `@sentry/hono` middleware mount
- Prevents intentional error-path test assertions from leaking to production Sentry when `SENTRY_DSN` is present during `bun test` (which Bun auto-sets `NODE_ENV=test` for)
- Refresh `docs/observability.md` to document the new test guard behavior

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | buildSentryInitOptions returns undefined when NODE_ENV === 'test', regardless of SENTRY_DSN | MET |
| 2 | Behavior for all other NODE_ENV values (including unset) is unchanged | MET |
| 3 | Test case added to lib/sentry.unit.test.ts mirroring the existing 'SENTRY_DSN unset' shape, nothing retired | MET |

## Test Plan
- Added `describe("initSentry — NODE_ENV=test", ...)` asserting `sentryClient.init` is never called when `NODE_ENV=test` even with `SENTRY_DSN` set
- `bun test lib/sentry.unit.test.ts` — 13 pass, 0 fail, 100% line/function coverage on `lib/sentry.ts`
- `bun run lint` and `bun run typecheck` pass clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
