### PR TITLE
docs: refresh stale documentation

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -253,7 +253,7 @@ GET /agents/:id/crons/:cronId/runs
 
 Query params: `limit` (default 20), `offset` (default 0). Returns `{ items: AgentCronRun[], total: number }`.
 
-Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `phase`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`, `modelBreakdown` (optional per-model token and cost breakdown array, each entry: `{ model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd }`).
+Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `phase`, `createdAt`, `modelBreakdown` (per-model token and cost breakdown array, each entry: `{ model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd }`). Top-level token fields (`inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`/`model`) were dropped from `AgentCronRun` — all token accounting now lives on `modelBreakdown`.
 
 ### Update cron run
 
@@ -261,7 +261,7 @@ Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`,
 PATCH /agents/:id/crons/:cronId/runs/:runId
 ```
 
-Used to record completion data after a run finishes. Updatable fields: `completedAt`, `outcome`, `error`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `model`. Returns the updated run.
+Used to record completion data after a run finishes. Updatable fields: `completedAt`, `outcome`, `error`, `skipped`, `skipReason`, `modelBreakdown` (array of `{ model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd }` — upserted per `[cronRunId, model]`). The legacy top-level `inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`/`model` fields are still accepted for backward compatibility with older agent builds but are silently ignored (not persisted) — send `modelBreakdown` instead. Returns the updated run.
 
 ### Cron run stats
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The agent owns nine first-class Prisma models (`Agent` and its `Env` / `CronJob` / `CronRun` / `Tool` / `Token` / `Plugin` / `Member` children, plus `AgentChatTokenUsageDailyByModel` for daily token usage rollups) on a **dedicated database** (`DATABASE_URL_SHIPWRIGHT_ADMIN`). Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer; agent API tokens are stored only as SHA-256 hashes.
+The agent owns ten first-class Prisma models (`Agent` and its `Env` / `CronJob` / `CronRun` / `Tool` / `Token` / `Plugin` / `Member` children, plus `AgentCronRunModelBreakdown` for per-model token/cost breakdown and `AgentChatTokenUsageDailyByModel` for daily token usage rollups) on a **dedicated database** (`DATABASE_URL_SHIPWRIGHT_ADMIN`). Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer; agent API tokens are stored only as SHA-256 hashes.
 
 > The Dockerfile `ENTRYPOINT` is `bun run admin/src/main.ts`, which runs migrations, constructs all services, and mounts all admin + runtime routes. The implemented HTTP surfaces are the admin CRUD API (`admin/src/agents-api.ts`, auth via `api-auth.ts`), the runtime API (`admin/src/api.ts`), the server-rendered admin UI (`admin/src/admin-ui.ts`), the public read-only task board (`GET /public/tasks` — no auth, configurable repo scope), the Prisma store + service classes (all in the `@shipwright/admin` package), the Slack event handler (`slack.ts`), and the cron runtime (`cron-handler.ts`). On startup the runner calls `POST /agents/:id/crons/reconcile` to sync system crons.
 


### PR DESCRIPTION
## Summary

Automated docs-freshness pass (`/shipwright:research-docs --auto`), diffed against sync anchor `84d1d7e`..`f63f4416` (2026-07-06 → 2026-07-09).

- **docs/agent-api.md**: `GET /agents/:id/crons/:cronId/runs` and `PATCH /agents/:id/crons/:cronId/runs/:runId` still documented `inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`/`model` as live top-level `AgentCronRun` fields. Migrations `20260706000000_consolidate_cron_run_token_accounting` and `20260709000000_add_phase_to_agent_cron_run` dropped those columns in favor of the `AgentCronRunModelBreakdown` child table (PATCH now silently ignores the legacy fields rather than persisting them). Updated both endpoint descriptions to reflect the current schema and note the backward-compat accept-and-drop behavior.
- **docs/agent.md**: overview said "nine first-class Prisma models" and omitted `AgentCronRunModelBreakdown` from the list — schema actually has ten (the Key Files table elsewhere in the same doc already correctly said "ten-model"). Fixed the count and added the missing model.

Audited every other candidate doc (`architecture.md`, `chat.md`, `configuration.md`, `deploy-kubernetes.md`, `helm-repo.md`, `mcp-tools.md`, `metrics.md`, `migration.md`, `observability.md`, `quickstart.md`, `task-store.md`, `testing.md`) — file paths, endpoint tables, env vars, and CLI commands all verified against current source, no other drift found. CLAUDE.md's doc reference section already lists every doc under `docs/`; no update needed. No new top-level module/service directories lack a doc, so no missing-doc task filed.

## Test plan

- [x] Verified `AgentCronRun` schema (`admin/prisma/schema.prisma`) has no top-level token/model fields — confirmed via the two new migrations
- [x] Verified `agent-cron-runs.ts` service: `patch()` accepts but discards legacy token fields, persists only via `modelBreakdown` upserts
- [x] Verified ten `model` blocks in `admin/prisma/schema.prisma`
- [x] Cross-checked remaining candidate docs' endpoint tables, file references, and env vars against source — no other findings
- [x] Doc-only change; no code touched, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)