### PR TITLE
feat: add secret checklist builder for agent deletion cleanup

### DIFF
--- a/admin/src/agent-deletion-checklist.ts
+++ b/admin/src/agent-deletion-checklist.ts
@@ -3,7 +3,7 @@
  *
  * Pure builder for the operator-facing "manual steps" checklist surfaced when
  * an agent is deleted. Several agent secrets (GH_TOKEN, LINEAR_API_KEY,
- * VITALS_OS_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, ...) are
+ * STRIPE_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, ...) are
  * hand-pasted into AgentEnv with no stored ID/owner metadata, so no automated
  * revocation is possible on agent delete. Rather than silently dropping them,
  * this module turns the agent's `AgentEnv` rows into a reminder checklist for

--- a/admin/src/agent-deletion-checklist.ts
+++ b/admin/src/agent-deletion-checklist.ts
@@ -1,0 +1,91 @@
+/**
+ * admin/src/agent-deletion-checklist.ts
+ *
+ * Pure builder for the operator-facing "manual steps" checklist surfaced when
+ * an agent is deleted. Several agent secrets (GH_TOKEN, LINEAR_API_KEY,
+ * VITALS_OS_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, ...) are
+ * hand-pasted into AgentEnv with no stored ID/owner metadata, so no automated
+ * revocation is possible on agent delete. Rather than silently dropping them,
+ * this module turns the agent's `AgentEnv` rows into a reminder checklist for
+ * the operator to work through by hand.
+ *
+ * Uses the existing `AgentEnv.secret` boolean (checked by default in the "add
+ * env var" admin UI form) — no schema changes needed.
+ *
+ * This function is PURE — no fs, no network, no Prisma, no clock. It only
+ * shapes plain objects from plain objects, so it's unit-tested in isolation
+ * without a DB. See ./agent-manifest.ts for the same "pure builder" pattern.
+ */
+
+/** A single operator-facing reminder produced for one AgentEnv row. */
+export interface ManualStep {
+  /** The AgentEnv key this reminder is about (e.g. "GH_TOKEN"). */
+  key: string;
+  /** Human-readable instructions for the operator. */
+  message: string;
+}
+
+/**
+ * Keys handled by the Slack app deletion step (ADC-2.1 / ADC-3.1) — excluded
+ * entirely from this checklist so operators aren't told to do the same
+ * cleanup twice.
+ */
+const SLACK_APP_MANAGED_KEYS = new Set([
+  "SLACK_APP_ID",
+  "SLACK_SIGNING_SECRET",
+  "SLACK_BOT_TOKEN",
+]);
+
+/**
+ * Named/standard keys with specific revocation instructions. Exact-match on
+ * key name — a differently-cased key (e.g. "gh_token") falls through to the
+ * generic custom-secret message rather than being matched here, since
+ * AgentEnv keys are conventionally upper-snake-case and we'd rather surface
+ * an unexpected casing than silently apply the wrong instructions.
+ */
+const NAMED_KEY_INSTRUCTIONS: Record<string, string> = {
+  GH_TOKEN:
+    "Revoke this GitHub personal access token at https://github.com/settings/tokens (or the fine-grained PAT settings page).",
+  ANTHROPIC_API_KEY: "Revoke/rotate this key in the Anthropic console.",
+  CLAUDE_CODE_OAUTH_TOKEN:
+    "Revoke this token via `claude auth logout` or the Anthropic console.",
+};
+
+/**
+ * Build the manual-steps checklist for the given `AgentEnv` rows.
+ *
+ * Bucketing:
+ * - Named/standard keys (GH_TOKEN, ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN)
+ *   get a specific instruction.
+ * - Slack-app-managed keys (SLACK_APP_ID, SLACK_SIGNING_SECRET,
+ *   SLACK_BOT_TOKEN) are excluded — handled by the Slack app deletion step.
+ * - Any other row with `secret: true` gets a generic "verify manually"
+ *   reminder, naming the key.
+ * - Rows with `secret: false` never produce an entry, regardless of key name.
+ *
+ * Order-preserving and non-deduplicating: one `ManualStep` per matching input
+ * row, in input order (duplicate keys produce duplicate entries).
+ */
+export function buildManualStepsChecklist(
+  envRows: { key: string; secret: boolean }[],
+): ManualStep[] {
+  const steps: ManualStep[] = [];
+
+  for (const row of envRows) {
+    if (!row.secret) continue;
+    if (SLACK_APP_MANAGED_KEYS.has(row.key)) continue;
+
+    const namedInstruction = NAMED_KEY_INSTRUCTIONS[row.key];
+    if (namedInstruction !== undefined) {
+      steps.push({ key: row.key, message: namedInstruction });
+      continue;
+    }
+
+    steps.push({
+      key: row.key,
+      message: `Custom secret '${row.key}' was added manually and has no automated revocation — verify whether it needs to be revoked at the source.`,
+    });
+  }
+
+  return steps;
+}

--- a/admin/src/agent-deletion-checklist.unit.test.ts
+++ b/admin/src/agent-deletion-checklist.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * admin/src/agent-deletion-checklist.unit.test.ts
+ * Unit tests for the pure agent-deletion manual-steps checklist builder. No
+ * I/O, no network, no fs — these assert output shape/content only.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  type ManualStep,
+  buildManualStepsChecklist,
+} from "./agent-deletion-checklist.ts";
+
+describe("buildManualStepsChecklist — named keys", () => {
+  it("produces a specific instruction for GH_TOKEN", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "GH_TOKEN", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("GH_TOKEN");
+    expect(steps[0].message).toContain("github.com/settings/tokens");
+  });
+
+  it("produces a specific instruction for ANTHROPIC_API_KEY", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "ANTHROPIC_API_KEY", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("ANTHROPIC_API_KEY");
+    expect(steps[0].message.toLowerCase()).toContain("anthropic console");
+  });
+
+  it("produces a specific instruction for CLAUDE_CODE_OAUTH_TOKEN", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "CLAUDE_CODE_OAUTH_TOKEN", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(steps[0].message).toContain("claude auth logout");
+  });
+});
+
+describe("buildManualStepsChecklist — excluded Slack keys", () => {
+  it("produces no checklist entry for SLACK_APP_ID, SLACK_SIGNING_SECRET, SLACK_BOT_TOKEN even when secret: true", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "SLACK_APP_ID", secret: true },
+      { key: "SLACK_SIGNING_SECRET", secret: true },
+      { key: "SLACK_BOT_TOKEN", secret: true },
+    ]);
+    expect(steps).toHaveLength(0);
+  });
+});
+
+describe("buildManualStepsChecklist — generic/custom secrets", () => {
+  it("produces the generic message for LINEAR_API_KEY", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "LINEAR_API_KEY", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("LINEAR_API_KEY");
+    expect(steps[0].message).toBe(
+      "Custom secret 'LINEAR_API_KEY' was added manually and has no automated revocation — verify whether it needs to be revoked at the source.",
+    );
+  });
+
+  it("produces the generic message for VITALS_OS_API_KEY", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "VITALS_OS_API_KEY", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("VITALS_OS_API_KEY");
+    expect(steps[0].message).toContain("VITALS_OS_API_KEY");
+  });
+
+  it("produces the generic message for an arbitrary unknown custom secret key", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "SOME_FUTURE_SECRET", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("SOME_FUTURE_SECRET");
+    expect(steps[0].message).toContain("SOME_FUTURE_SECRET");
+    expect(steps[0].message).toContain(
+      "has no automated revocation — verify whether it needs to be revoked at the source.",
+    );
+  });
+});
+
+describe("buildManualStepsChecklist — non-secret rows", () => {
+  it("produces no checklist entry for secret: false rows regardless of key name", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "GH_TOKEN", secret: false },
+      { key: "LINEAR_API_KEY", secret: false },
+      { key: "SOME_RANDOM_KEY", secret: false },
+    ]);
+    expect(steps).toHaveLength(0);
+  });
+});
+
+describe("buildManualStepsChecklist — general behavior", () => {
+  it("returns an empty array for an empty envRows array", () => {
+    expect(buildManualStepsChecklist([])).toEqual([]);
+  });
+
+  it("processes a mixed set of rows end-to-end", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "GH_TOKEN", secret: true },
+      { key: "ANTHROPIC_API_KEY", secret: true },
+      { key: "CLAUDE_CODE_OAUTH_TOKEN", secret: true },
+      { key: "SLACK_APP_ID", secret: true },
+      { key: "SLACK_SIGNING_SECRET", secret: true },
+      { key: "SLACK_BOT_TOKEN", secret: true },
+      { key: "LINEAR_API_KEY", secret: true },
+      { key: "VITALS_OS_API_KEY", secret: true },
+      { key: "NON_SECRET_VALUE", secret: false },
+    ]);
+    const keys = steps.map((s) => s.key);
+    expect(keys).toEqual([
+      "GH_TOKEN",
+      "ANTHROPIC_API_KEY",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "LINEAR_API_KEY",
+      "VITALS_OS_API_KEY",
+    ]);
+  });
+
+  it("preserves each entry's key on the returned ManualStep", () => {
+    const steps: ManualStep[] = buildManualStepsChecklist([
+      { key: "GH_TOKEN", secret: true },
+    ]);
+    expect(steps[0]).toMatchObject({ key: "GH_TOKEN" });
+  });
+
+  it("treats key matching as case-sensitive exact match (lowercase gh_token is treated as a generic custom secret)", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "gh_token", secret: true },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].message).toContain("gh_token");
+    expect(steps[0].message).not.toContain("github.com/settings/tokens");
+  });
+
+  it("produces one entry per row when the same secret key appears twice (duplicates are not deduplicated)", () => {
+    const steps = buildManualStepsChecklist([
+      { key: "GH_TOKEN", secret: true },
+      { key: "GH_TOKEN", secret: true },
+    ]);
+    expect(steps).toHaveLength(2);
+  });
+});

--- a/admin/src/agent-deletion-checklist.unit.test.ts
+++ b/admin/src/agent-deletion-checklist.unit.test.ts
@@ -62,13 +62,13 @@ describe("buildManualStepsChecklist — generic/custom secrets", () => {
     );
   });
 
-  it("produces the generic message for VITALS_OS_API_KEY", () => {
+  it("produces the generic message for STRIPE_API_KEY", () => {
     const steps = buildManualStepsChecklist([
-      { key: "VITALS_OS_API_KEY", secret: true },
+      { key: "STRIPE_API_KEY", secret: true },
     ]);
     expect(steps).toHaveLength(1);
-    expect(steps[0].key).toBe("VITALS_OS_API_KEY");
-    expect(steps[0].message).toContain("VITALS_OS_API_KEY");
+    expect(steps[0].key).toBe("STRIPE_API_KEY");
+    expect(steps[0].message).toContain("STRIPE_API_KEY");
   });
 
   it("produces the generic message for an arbitrary unknown custom secret key", () => {
@@ -109,7 +109,7 @@ describe("buildManualStepsChecklist — general behavior", () => {
       { key: "SLACK_SIGNING_SECRET", secret: true },
       { key: "SLACK_BOT_TOKEN", secret: true },
       { key: "LINEAR_API_KEY", secret: true },
-      { key: "VITALS_OS_API_KEY", secret: true },
+      { key: "STRIPE_API_KEY", secret: true },
       { key: "NON_SECRET_VALUE", secret: false },
     ]);
     const keys = steps.map((s) => s.key);
@@ -118,7 +118,7 @@ describe("buildManualStepsChecklist — general behavior", () => {
       "ANTHROPIC_API_KEY",
       "CLAUDE_CODE_OAUTH_TOKEN",
       "LINEAR_API_KEY",
-      "VITALS_OS_API_KEY",
+      "STRIPE_API_KEY",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Add pure function `buildManualStepsChecklist(envRows)` in `admin/src/agent-deletion-checklist.ts` that turns an agent's `AgentEnv` rows into an operator-facing manual-revocation checklist for secrets that have no automated revocation path
- Named keys (`GH_TOKEN`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`) get specific instructions; Slack-app-managed keys are excluded (handled elsewhere); any other `secret: true` row gets a generic reminder
- Scope is limited to the pure builder — not yet wired into `agent-provisioner.ts`'s `deprovision()` flow or any API route (follow-up task)

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Named keys produce specific instructions | MET | 3 dedicated unit tests; `NAMED_KEY_INSTRUCTIONS` map |
| 2 | Excluded Slack keys produce no entry | MET | Unit test; `SLACK_APP_MANAGED_KEYS` set + early skip |
| 3 | Other secret rows produce generic message | MET | Unit tests cover `LINEAR_API_KEY`, `VITALS_OS_API_KEY`, arbitrary key |
| 4 | Non-secret rows produce no entry | MET | Unit test; `if (!row.secret) continue` |
| 5 | Pure function, unit-tested only | MET | No fs/network/Prisma/clock imports |

## Test Plan
- 13 unit tests in `admin/src/agent-deletion-checklist.unit.test.ts`, 100% line/function coverage on the new file
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — all workspaces pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
