### PR TITLE
feat: add shared Caller type + request-context module to @shipwright/lib

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -7,6 +7,7 @@
     "./admin-types": "./admin-types.ts",
     "./org-repo": "./org-repo.ts",
     "./pricing": "./pricing.ts",
+    "./request-context": "./request-context.ts",
     "./secret-env-vars": "./secret-env-vars.ts",
     "./sentry": "./sentry.ts",
     "./web/*": "./web/*"

--- a/lib/request-context.ts
+++ b/lib/request-context.ts
@@ -1,0 +1,21 @@
+/**
+ * Represents an authenticated request caller, shared across services that
+ * resolve caller identity in auth middleware (admin, task-store, metrics).
+ *
+ * scope === "*" → unrestricted/admin (all clients/agents)
+ * scope === "<id>" → scoped to a single identity (clientId, agentId, etc.)
+ */
+export interface Caller {
+  name: string;
+  scope: string; // "*" or a scoped identity such as a clientId/agentId
+}
+
+/**
+ * Produce a stable, readable label for a caller, suitable for log lines.
+ * Returns "anonymous" when no caller is present (e.g. unauthenticated or
+ * not-yet-resolved requests).
+ */
+export function callerLabel(caller?: Caller): string {
+  if (!caller) return "anonymous";
+  return `${caller.name} (${caller.scope})`;
+}

--- a/lib/request-context.unit.test.ts
+++ b/lib/request-context.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { callerLabel } from "./request-context.ts";
+
+describe("callerLabel — defined caller", () => {
+  test("formats an admin caller (scope '*')", () => {
+    expect(callerLabel({ name: "bodhi", scope: "*" })).toBe("bodhi (*)");
+  });
+
+  test("formats a caller scoped to a clientId", () => {
+    expect(callerLabel({ name: "sully", scope: "client-xyz" })).toBe(
+      "sully (client-xyz)",
+    );
+  });
+
+  test("formats a caller scoped to an agentId", () => {
+    expect(callerLabel({ name: "agent-123", scope: "agent-456" })).toBe(
+      "agent-123 (agent-456)",
+    );
+  });
+
+  test("is stable across repeated calls with the same input", () => {
+    const caller = { name: "bodhi", scope: "*" };
+    expect(callerLabel(caller)).toBe(callerLabel(caller));
+  });
+});
+
+describe("callerLabel — undefined caller", () => {
+  test("returns a distinct, readable label for undefined", () => {
+    const label = callerLabel(undefined);
+    expect(label).toBe("anonymous");
+  });
+
+  test("returns the same label when called with no argument", () => {
+    expect(callerLabel()).toBe("anonymous");
+  });
+
+  test("undefined label never collides with a defined caller's label", () => {
+    const anonymousLabel = callerLabel(undefined);
+    expect(callerLabel({ name: "anonymous", scope: "*" })).not.toBe(
+      anonymousLabel,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Promotes metrics' existing `Caller { name, scope }` shape into a new shared `lib/request-context.ts` module, ahead of unifying the three bespoke caller shapes currently in admin/task-store/metrics auth middleware
- Adds a pure `callerLabel(caller?: Caller): string` helper for consistent log formatting (`"name (scope)"` for defined callers, `"anonymous"` for undefined)
- Adds `./request-context` to `lib/package.json`'s exports map

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `Caller` and `callerLabel` exported from `lib/request-context.ts`, added to `lib/package.json` exports as `./request-context` | MET |
| 2 | `callerLabel` returns a stable, readable string for both defined and undefined callers | MET |
| 3 | New `lib/request-context.unit.test.ts` — pure unit tests on `callerLabel()` covering defined/undefined caller shapes | MET |

## Test Plan
- `lib/request-context.unit.test.ts` — 7 unit tests: admin scope (`*`), clientId scope, agentId scope, call-stability, undefined caller, no-arg call, anonymous-label non-collision
- [x] `bunx biome lint .` clean
- [x] `bun run --filter='*' typecheck` clean
- [x] `bun test` — 3557 pass (14 pre-existing failures on `main`, unrelated to this change — verified against a clean `main` checkout)
- [x] New module at 100% line coverage; repo aggregate coverage gate (78.80%) is a pre-existing shortfall already present on `main`, unaffected by this change
- No consumers wired up yet (explicitly out of scope for this task) — nothing retired

Generated with [Claude Code](https://claude.com/claude-code)
