### PR TITLE
feat: wire shared Caller into task-store auth + onError logging

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,6 +15,7 @@ When `SENTRY_DSN` is set, a service reports:
 - **Unhandled exceptions and 5xx errors**, with stack traces, after scrubbing (see below).
 - **`console.log` / `console.warn` / `console.error` calls**, forwarded as structured Sentry Logs via `consoleLoggingIntegration`.
 - **Request path and method** for errors that occur inside an HTTP handler (via `@sentry/hono`'s `sentry()` middleware, or the app's own `onError` hook).
+- **Caller identity** (admin or agent token) in error logs from task-store, for tracing which token triggered an unhandled error.
 
 ## What is never collected
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -27,6 +27,8 @@ Two token types:
 
 Tokens are created via `POST /tokens` (admin only). The raw token is returned once at creation; only its SHA-256 hash is stored. Agent tokens are automatically repo-scoped when the admin service is configured — writes to tasks outside the agent's repo scope return `400`.
 
+On each authenticated request, the service resolves the request's caller — a shared `Caller` identity (from `lib/request-context.ts`) — and makes it available to handlers and error logging. Admin tokens resolve to `{name: 'admin', scope: '*'}` and agent tokens resolve to `{name: agentId, scope: agentId}`. Unhandled errors log the caller label for observability (e.g., `[task-store] unhandled error (caller: agent-42): ...`).
+
 ### Tasks
 
 #### List tasks

--- a/task-store/src/app.sentry.smoke.test.ts
+++ b/task-store/src/app.sentry.smoke.test.ts
@@ -1,7 +1,8 @@
 /**
  * task-store/src/app.sentry.smoke.test.ts
  *
- * Smoke tests for the onError hook's Sentry wiring (SEN-1.2).
+ * Smoke tests for the onError hook's Sentry wiring (SEN-1.2) and caller
+ * logging (AOB-3.3).
  *
  * Asserts:
  *   - an unhandled (non-ApiError) error triggers sentryClient.captureException
@@ -10,9 +11,12 @@
  *     codes) do NOT trigger captureException
  *   - with no sentryClient dep (undefined — Sentry not initialized), onError
  *     does not throw and behaves exactly as before
+ *   - the unhandled-error console.error log line includes the resolved
+ *     caller's label (via callerLabel()), for both admin and agent tokens
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
+import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import { createTaskStoreApp } from "./app.ts";
 import { NotFoundError } from "./errors.ts";
@@ -20,6 +24,8 @@ import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
 const VALID_TOKEN = "valid-token";
+const AGENT_TOKEN = "agent-token";
+const AGENT_ID = "agent-42";
 
 function fakeTokenService(): TokenServiceLike {
   return {
@@ -38,6 +44,40 @@ function fakeTokenService(): TokenServiceLike {
     },
     async validate(raw: string) {
       return raw === VALID_TOKEN ? { id: "tok-1", agentId: null } : null;
+    },
+    async revoke() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+    async update() {
+      return null;
+    },
+  };
+}
+
+/** A token service that validates both an admin token and an agent token,
+ *  so onError caller-label coverage can assert both resolved callers. */
+function fakeTokenServiceWithAgent(): TokenServiceLike {
+  return {
+    async create(label?: string) {
+      return {
+        token: {
+          id: "tok-1",
+          token: "hash",
+          label: label ?? null,
+          agentId: null,
+          createdAt: new Date(),
+          revokedAt: null,
+        },
+        rawToken: "raw",
+      };
+    },
+    async validate(raw: string) {
+      if (raw === VALID_TOKEN) return { id: "tok-1", agentId: null };
+      if (raw === AGENT_TOKEN) return { id: "tok-2", agentId: AGENT_ID };
+      return null;
     },
     async revoke() {
       return null;
@@ -138,5 +178,55 @@ describe("onError — Sentry capture wiring", () => {
     });
 
     expect(res.status).toBe(500);
+  });
+});
+
+describe("onError — caller label logging (AOB-3.3)", () => {
+  it("includes the admin caller label in the unhandled-error console.error line", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    try {
+      const app = createTaskStoreApp({
+        taskService: throwingTaskService(),
+        tokenService: fakeTokenServiceWithAgent(),
+      });
+
+      const res = await app.request("/tasks/abc", {
+        headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+      });
+
+      expect(res.status).toBe(500);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const loggedArgs = consoleErrorSpy.mock.calls.flat().join(" ");
+      expect(loggedArgs).toContain(callerLabel({ name: "admin", scope: "*" }));
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("includes the agent caller label in the unhandled-error console.error line", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    try {
+      const app = createTaskStoreApp({
+        taskService: throwingTaskService(),
+        tokenService: fakeTokenServiceWithAgent(),
+      });
+
+      const res = await app.request("/tasks/abc", {
+        headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+      });
+
+      expect(res.status).toBe(500);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const loggedArgs = consoleErrorSpy.mock.calls.flat().join(" ");
+      expect(loggedArgs).toContain(
+        callerLabel({ name: AGENT_ID, scope: AGENT_ID }),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/task-store/src/app.sentry.smoke.test.ts
+++ b/task-store/src/app.sentry.smoke.test.ts
@@ -57,35 +57,14 @@ function fakeTokenService(): TokenServiceLike {
   };
 }
 
-/** A token service that validates both an admin token and an agent token,
- *  so onError caller-label coverage can assert both resolved callers. */
+/** Same as fakeTokenService, but also validates an agent token — so onError
+ *  caller-label coverage can assert both the admin and agent resolved caller. */
 function fakeTokenServiceWithAgent(): TokenServiceLike {
   return {
-    async create(label?: string) {
-      return {
-        token: {
-          id: "tok-1",
-          token: "hash",
-          label: label ?? null,
-          agentId: null,
-          createdAt: new Date(),
-          revokedAt: null,
-        },
-        rawToken: "raw",
-      };
-    },
+    ...fakeTokenService(),
     async validate(raw: string) {
       if (raw === VALID_TOKEN) return { id: "tok-1", agentId: null };
       if (raw === AGENT_TOKEN) return { id: "tok-2", agentId: AGENT_ID };
-      return null;
-    },
-    async revoke() {
-      return null;
-    },
-    async list() {
-      return [];
-    },
-    async update() {
       return null;
     },
   };

--- a/task-store/src/app.ts
+++ b/task-store/src/app.ts
@@ -22,6 +22,7 @@
  */
 
 import { sentry } from "@sentry/hono/bun";
+import { callerLabel } from "@shipwright/lib/request-context";
 import {
   type ErrorCapturingClient,
   buildSentryInitOptions,
@@ -114,7 +115,10 @@ export function createTaskStoreApp(
       return c.json({ error: err.message }, err.statusCode as 400);
     }
     deps.sentryClient?.captureException(err);
-    console.error("[task-store] unhandled error:", err);
+    console.error(
+      `[task-store] unhandled error (caller: ${callerLabel(c.get("caller"))}):`,
+      err,
+    );
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: message }, 500);
   });

--- a/task-store/src/auth.smoke.test.ts
+++ b/task-store/src/auth.smoke.test.ts
@@ -12,10 +12,14 @@
  *      b. No scope resolver (URL not set path) → repos defaults to []
  *      c. Scope resolver throws → repos defaults to [] (no crash)
  *      d. Admin token (agentId null) → repos = null (unrestricted), resolver not called
+ *   3. Shared Caller (AOB-3.3):
+ *      a. Admin token → caller = {name: 'admin', scope: '*'}
+ *      b. Agent token → caller = {name: agentId, scope: agentId}
  */
 
 import { describe, expect, it } from "bun:test";
 import { Hono } from "hono";
+import type { Caller } from "@shipwright/lib/request-context";
 import { createBearerAuthMiddleware } from "./auth.ts";
 import type { TaskStoreAuthEnv } from "./auth.ts";
 import type { TokenServiceLike } from "./token-service.ts";
@@ -57,6 +61,7 @@ function makeAuthApp(
       tokenId: c.get("tokenId"),
       agentId: c.get("agentId"),
       repos: c.get("repos"),
+      caller: c.get("caller"),
     });
   });
   return app;
@@ -183,5 +188,29 @@ describe("bearer auth middleware — scope resolver", () => {
     expect(body.agentId).toBeNull();
     expect(body.repos).toBeNull();
     expect(resolverCalled).toBe(false);
+  });
+});
+
+describe("bearer auth middleware — shared Caller", () => {
+  it("sets caller = {name: 'admin', scope: '*'} for admin tokens", async () => {
+    const app = makeAuthApp(fakeAdminTokenService());
+    const res = await app.request("/whoami", {
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { caller: Caller };
+    expect(body.caller).toEqual({ name: "admin", scope: "*" });
+  });
+
+  it("sets caller = {name: agentId, scope: agentId} for agent tokens", async () => {
+    const app = makeAuthApp(fakeAgentTokenService());
+    const res = await app.request("/whoami", {
+      headers: { Authorization: `Bearer ${AGENT_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { caller: Caller };
+    expect(body.caller).toEqual({ name: AGENT_ID, scope: AGENT_ID });
   });
 });

--- a/task-store/src/auth.ts
+++ b/task-store/src/auth.ts
@@ -14,9 +14,16 @@
  *   agent's repos from the agents service. The result is stored as `repos`.
  *   Admin tokens always get `repos: null` (unrestricted) and skip the lookup.
  *   On any error from the resolver, `repos` falls back to `[]` silently (fail-safe restrictive).
+ *
+ * Caller:
+ *   A shared `Caller` (see lib/request-context.ts) is also stored as `caller`,
+ *   for use in logging (e.g. app.ts's onError handler). Admin tokens resolve
+ *   to {name: 'admin', scope: '*'}; agent tokens resolve to {name: agentId,
+ *   scope: agentId}.
  */
 
 import type { MiddlewareHandler } from "hono";
+import type { Caller } from "@shipwright/lib/request-context";
 import type { TokenServiceLike } from "./token-service.ts";
 
 export type TaskStoreAuthEnv = {
@@ -31,6 +38,8 @@ export type TaskStoreAuthEnv = {
      * [...] = agent token with known repo scope.
      */
     repos: string[] | null;
+    /** Shared caller identity, derived from agentId — see lib/request-context.ts. */
+    caller: Caller;
   };
 };
 
@@ -66,6 +75,12 @@ export function createBearerAuthMiddleware(deps: {
 
     c.set("tokenId", result.id);
     c.set("agentId", result.agentId);
+    c.set(
+      "caller",
+      result.agentId === null
+        ? { name: "admin", scope: "*" }
+        : { name: result.agentId, scope: result.agentId },
+    );
 
     // Resolve repos for agent tokens when a scope resolver is configured.
     // Admin tokens (agentId null) get repos: null (unrestricted — skip the lookup).


### PR DESCRIPTION
## Summary
- Extend `createBearerAuthMiddleware` (task-store/src/auth.ts) to set a shared `Caller` on the Hono context (`{name: 'admin', scope: '*'}` for admin tokens, `{name: agentId, scope: agentId}` for agent tokens), alongside the existing `agentId`/`repos` variables.
- Include the resolved caller label (`callerLabel(...)`) in task-store's `onError` unhandled-error log line (task-store/src/app.ts).
- Refresh `docs/task-store.md` and `docs/observability.md` to document the new caller resolution and log format.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `TaskStoreAuthEnv.Variables` gains `caller: Caller`, set on every successful auth (admin and agent tokens) | MET | `task-store/src/auth.ts`: `caller: Caller` added to `Variables`; middleware sets it for both token types |
| 2 | app.ts's unhandled-error log line includes the resolved caller label | MET | `task-store/src/app.ts` onError now logs `[task-store] unhandled error (caller: ${callerLabel(c.get("caller"))}):` |
| 3 | Existing agentId/repos scoping behavior unchanged | MET | Diff is purely additive; no changes to the existing `agentId`/`repos` logic |
| 4 | Test decision: extend auth.smoke.test.ts (and/or integration) for caller on both token types; extend onError coverage for label; nothing retired | MET | `auth.smoke.test.ts` and `app.sentry.smoke.test.ts` both gained new describe blocks covering admin + agent caller resolution; no existing tests removed |

## Test Plan
- `bun test task-store` — full task-store suite passes (352 pass, 0 fail, pre-existing skips only)
- New smoke tests: `auth.smoke.test.ts` (caller set for admin/agent tokens), `app.sentry.smoke.test.ts` (caller label appears in onError console.error output for admin/agent tokens)
- `bunx biome lint .` clean
- `bun run --filter='*' typecheck` clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
