### PR TITLE
feat: wire shared Caller into metrics onError logging

### DIFF
--- a/metrics/src/lib/api-auth.ts
+++ b/metrics/src/lib/api-auth.ts
@@ -16,9 +16,9 @@
  */
 
 import type { RouteConfig, RouteHandler } from "@hono/zod-openapi";
+import type { Caller } from "@shipwright/lib/request-context";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
-import type { Caller } from "@shipwright/lib/request-context";
 import type { AccountsClient } from "./accounts-client.ts";
 import { ForbiddenError } from "./errors.ts";
 

--- a/metrics/src/lib/api-auth.ts
+++ b/metrics/src/lib/api-auth.ts
@@ -18,18 +18,12 @@
 import type { RouteConfig, RouteHandler } from "@hono/zod-openapi";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
+import type { Caller } from "@shipwright/lib/request-context";
 import type { AccountsClient } from "./accounts-client.ts";
 import { ForbiddenError } from "./errors.ts";
 
-/**
- * Represents an authenticated API caller.
- * scope === "*" → admin (all clients)
- * scope === "<clientId>" → scoped to a single client
- */
-export interface Caller {
-  name: string;
-  scope: string; // "*" or a clientId
-}
+// Re-export the shared Caller type for consumers of this module
+export type { Caller } from "@shipwright/lib/request-context";
 
 // Hono env type for routes that use the auth middleware
 export type AuthEnv = { Variables: { caller: Caller } };

--- a/metrics/src/lib/errors.ts
+++ b/metrics/src/lib/errors.ts
@@ -3,6 +3,7 @@
  * Typed HTTP error classes for use across all service handlers.
  */
 
+import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import type { Context } from "hono";
 import type { AuthEnv } from "./api-auth.ts";
@@ -83,7 +84,11 @@ export function makeOnError(
         err.statusCode as 400 | 401 | 403 | 404 | 409 | 422 | 500 | 502,
       );
     }
-    console.error(`[${servicePrefix}] unhandled error:`, err);
+    const caller = callerLabel(c.get("caller"));
+    console.error(
+      `[${servicePrefix}] unhandled error (${caller}):`,
+      err,
+    );
     sentryClient?.captureException(err);
     return c.json({ error: err.message }, 500);
   };

--- a/metrics/src/lib/errors.ts
+++ b/metrics/src/lib/errors.ts
@@ -85,10 +85,7 @@ export function makeOnError(
       );
     }
     const caller = callerLabel(c.get("caller"));
-    console.error(
-      `[${servicePrefix}] unhandled error (${caller}):`,
-      err,
-    );
+    console.error(`[${servicePrefix}] unhandled error (${caller}):`, err);
     sentryClient?.captureException(err);
     return c.json({ error: err.message }, 500);
   };

--- a/metrics/src/lib/errors.unit.test.ts
+++ b/metrics/src/lib/errors.unit.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from "bun:test";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
+import type { Caller } from "./api-auth.ts";
 import {
   ApiError,
   BadGatewayError,
@@ -87,13 +88,14 @@ describe("BadGatewayError", () => {
 });
 
 describe("makeOnError", () => {
-  function makeCtx() {
+  function makeCtx(caller?: Caller) {
     const calls: Array<{ body: unknown; status: number }> = [];
     const ctx = {
       json: (body: unknown, status: number) => {
         calls.push({ body, status });
         return { body, status };
       },
+      get: (_key: string) => caller,
     };
     return { ctx, calls };
   }
@@ -211,6 +213,46 @@ describe("makeOnError", () => {
         handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]),
       ).not.toThrow();
       expect(calls[0]?.status).toBe(502);
+    });
+  });
+
+  describe("caller label in unhandled error log", () => {
+    it("includes caller label in logged unhandled-error line", () => {
+      const errorMsgs: string[] = [];
+      const origError = console.error;
+      console.error = (...args: unknown[]) => {
+        errorMsgs.push(String(args[0]));
+      };
+
+      try {
+        const handler = makeOnError("test");
+        const { ctx } = makeCtx({ name: "bodhi", scope: "*" });
+        const err = new Error("Something unexpected");
+        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]);
+
+        expect(errorMsgs[0]).toContain("bodhi (*)");
+      } finally {
+        console.error = origError;
+      }
+    });
+
+    it("logs anonymous when no caller is provided", () => {
+      const errorMsgs: string[] = [];
+      const origError = console.error;
+      console.error = (...args: unknown[]) => {
+        errorMsgs.push(String(args[0]));
+      };
+
+      try {
+        const handler = makeOnError("test");
+        const { ctx } = makeCtx(undefined);
+        const err = new Error("Something unexpected");
+        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]);
+
+        expect(errorMsgs[0]).toContain("anonymous");
+      } finally {
+        console.error = origError;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- `metrics/src/lib/api-auth.ts` now imports `Caller` from the shared `@shipwright/lib/request-context` module instead of declaring its own local type (re-exported for backward compatibility with in-package imports); `AuthEnv`'s shape is unchanged.
- `makeOnError`'s unhandled-error log line (`metrics/src/lib/errors.ts`) now includes the resolved caller label via `callerLabel(c.get("caller"))`, so unhandled 500s are traceable to the calling client/agent. The `ApiError` and `Malformed JSON` branches are untouched.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | api-auth.ts imports Caller from @shipwright/lib/request-context; AuthEnv unchanged | MET | Local `Caller` interface removed, replaced with shared import + re-export; `AuthEnv` shape unchanged |
| 2 | makeOnError's unhandled-error log includes resolved caller label | MET | `console.error(\`[${servicePrefix}] unhandled error (${caller}):\`, err)` |
| 3 | Existing status-code / ApiError / Malformed JSON behavior unchanged | MET | Only the unhandled-error branch touched; full metrics suite (313 tests) passes |
| 4 | Test decision: extend existing tests with caller-label case; nothing retired | MET | `makeCtx()` extended with optional caller + `.get()`; 2 new tests added, no tests removed |

## Test Plan
- `bun test metrics/` — 313 pass, 0 fail
- `bun run --filter='*' typecheck` — all workspaces pass
- `bunx biome lint .` — clean on touched files
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
