### PR TITLE
feat: wire shared Caller into metrics onError logging

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,7 +15,7 @@ When `SENTRY_DSN` is set, a service reports:
 - **Unhandled exceptions and 5xx errors**, with stack traces, after scrubbing (see below).
 - **`console.log` / `console.warn` / `console.error` calls**, forwarded as structured Sentry Logs via `consoleLoggingIntegration`.
 - **Request path and method** for errors that occur inside an HTTP handler (via `@sentry/hono`'s `sentry()` middleware, or the app's own `onError` hook).
-- **Caller identity** (admin or agent token) in error logs from task-store, for tracing which token triggered an unhandled error.
+- **Caller identity** (admin or agent token) in error logs from task-store and metrics services, for tracing which token triggered an unhandled error.
 
 ## What is never collected
 

--- a/metrics/src/lib/api-auth.ts
+++ b/metrics/src/lib/api-auth.ts
@@ -16,6 +16,7 @@
  */
 
 import type { RouteConfig, RouteHandler } from "@hono/zod-openapi";
+import type { Caller } from "@shipwright/lib/request-context";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { AccountsClient } from "./accounts-client.ts";
@@ -25,11 +26,11 @@ import { ForbiddenError } from "./errors.ts";
  * Represents an authenticated API caller.
  * scope === "*" → admin (all clients)
  * scope === "<clientId>" → scoped to a single client
+ *
+ * Re-exported so existing `import type { Caller } from "./lib/api-auth.ts"`
+ * consumers keep working unchanged.
  */
-export interface Caller {
-  name: string;
-  scope: string; // "*" or a clientId
-}
+export type { Caller };
 
 // Hono env type for routes that use the auth middleware
 export type AuthEnv = { Variables: { caller: Caller } };

--- a/metrics/src/lib/errors.ts
+++ b/metrics/src/lib/errors.ts
@@ -3,6 +3,7 @@
  * Typed HTTP error classes for use across all service handlers.
  */
 
+import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import type { Context } from "hono";
 import type { AuthEnv } from "./api-auth.ts";
@@ -83,7 +84,10 @@ export function makeOnError(
         err.statusCode as 400 | 401 | 403 | 404 | 409 | 422 | 500 | 502,
       );
     }
-    console.error(`[${servicePrefix}] unhandled error:`, err);
+    console.error(
+      `[${servicePrefix}] unhandled error (caller: ${callerLabel(c.get("caller"))}):`,
+      err,
+    );
     sentryClient?.captureException(err);
     return c.json({ error: err.message }, 500);
   };

--- a/metrics/src/lib/errors.unit.test.ts
+++ b/metrics/src/lib/errors.unit.test.ts
@@ -219,42 +219,41 @@ describe("makeOnError", () => {
     });
   });
 
+  /** Captures console.error calls during `fn`, restoring the original after. */
+  function withCapturedConsoleError(fn: () => void): string {
+    const originalError = console.error;
+    const logCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      logCalls.push(args);
+    };
+    try {
+      fn();
+    } finally {
+      console.error = originalError;
+    }
+    return logCalls.flat().join(" ");
+  }
+
   describe("caller label in unhandled-error log line", () => {
     it("includes the resolved caller label when a caller is injected via context", () => {
-      const originalError = console.error;
-      const logCalls: unknown[][] = [];
-      console.error = (...args: unknown[]) => {
-        logCalls.push(args);
-      };
-      try {
-        const handler = makeOnError("test");
-        const caller = { name: "bodhi", scope: "client-xyz" };
-        const { ctx } = makeCtx(caller);
-        const err = new Error("Something unexpected");
-        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]);
-        const logged = logCalls.flat().join(" ");
-        expect(logged).toContain(callerLabel(caller));
-      } finally {
-        console.error = originalError;
-      }
+      const handler = makeOnError("test");
+      const caller = { name: "bodhi", scope: "client-xyz" };
+      const { ctx } = makeCtx(caller);
+      const err = new Error("Something unexpected");
+      const logged = withCapturedConsoleError(() =>
+        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]),
+      );
+      expect(logged).toContain(callerLabel(caller));
     });
 
     it("logs 'anonymous' when no caller is present on the context", () => {
-      const originalError = console.error;
-      const logCalls: unknown[][] = [];
-      console.error = (...args: unknown[]) => {
-        logCalls.push(args);
-      };
-      try {
-        const handler = makeOnError("test");
-        const { ctx } = makeCtx();
-        const err = new Error("Something unexpected");
-        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]);
-        const logged = logCalls.flat().join(" ");
-        expect(logged).toContain(callerLabel(undefined));
-      } finally {
-        console.error = originalError;
-      }
+      const handler = makeOnError("test");
+      const { ctx } = makeCtx();
+      const err = new Error("Something unexpected");
+      const logged = withCapturedConsoleError(() =>
+        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]),
+      );
+      expect(logged).toContain(callerLabel(undefined));
     });
   });
 });

--- a/metrics/src/lib/errors.unit.test.ts
+++ b/metrics/src/lib/errors.unit.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import {
   ApiError,
@@ -87,12 +88,16 @@ describe("BadGatewayError", () => {
 });
 
 describe("makeOnError", () => {
-  function makeCtx() {
+  function makeCtx(caller?: { name: string; scope: string }) {
     const calls: Array<{ body: unknown; status: number }> = [];
     const ctx = {
       json: (body: unknown, status: number) => {
         calls.push({ body, status });
         return { body, status };
+      },
+      get: (key: string) => {
+        if (key === "caller") return caller;
+        return undefined;
       },
     };
     return { ctx, calls };
@@ -211,6 +216,45 @@ describe("makeOnError", () => {
         handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]),
       ).not.toThrow();
       expect(calls[0]?.status).toBe(502);
+    });
+  });
+
+  describe("caller label in unhandled-error log line", () => {
+    it("includes the resolved caller label when a caller is injected via context", () => {
+      const originalError = console.error;
+      const logCalls: unknown[][] = [];
+      console.error = (...args: unknown[]) => {
+        logCalls.push(args);
+      };
+      try {
+        const handler = makeOnError("test");
+        const caller = { name: "bodhi", scope: "client-xyz" };
+        const { ctx } = makeCtx(caller);
+        const err = new Error("Something unexpected");
+        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]);
+        const logged = logCalls.flat().join(" ");
+        expect(logged).toContain(callerLabel(caller));
+      } finally {
+        console.error = originalError;
+      }
+    });
+
+    it("logs 'anonymous' when no caller is present on the context", () => {
+      const originalError = console.error;
+      const logCalls: unknown[][] = [];
+      console.error = (...args: unknown[]) => {
+        logCalls.push(args);
+      };
+      try {
+        const handler = makeOnError("test");
+        const { ctx } = makeCtx();
+        const err = new Error("Something unexpected");
+        handler(err, ctx as Parameters<ReturnType<typeof makeOnError>>[1]);
+        const logged = logCalls.flat().join(" ");
+        expect(logged).toContain(callerLabel(undefined));
+      } finally {
+        console.error = originalError;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Swapped metrics' locally-declared `Caller` interface in `metrics/src/lib/api-auth.ts` for the shared `@shipwright/lib/request-context` version (re-exported so existing `import type { Caller } from "./lib/api-auth.ts"` consumers keep working unchanged); `AuthEnv`'s shape is unchanged.
- Extended `makeOnError`'s unhandled-error log line in `metrics/src/lib/errors.ts` to include `callerLabel(c.get("caller"))`, matching the pattern already shipped for task-store (#1327).
- Refreshed `docs/observability.md` to note caller identity is now logged for both task-store and metrics services.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | api-auth.ts imports Caller from shared lib; AuthEnv unchanged | MET | `api-auth.ts` imports `Caller` from `@shipwright/lib/request-context`, re-exports it; `AuthEnv` type body untouched |
| 2 | makeOnError logs resolved caller label | MET | Unhandled-error `console.error` now includes `callerLabel(c.get("caller"))` |
| 3 | Existing status-code/ApiError/Malformed JSON behavior unchanged | MET | Those branches are untouched; full metrics suite passes |
| 4 | Extended existing unit tests with caller-label case, nothing retired | MET | Two new tests added to the existing `makeOnError` describe block in `errors.unit.test.ts`; all prior tests intact |

## Test Plan
- `metrics/src/lib/errors.unit.test.ts` — new cases assert the caller label (and "anonymous" fallback) appear in the unhandled-error log line via an injected context
- Full metrics suite: 313 pass / 0 fail
- `bun run typecheck` (whole monorepo): clean
- `bunx biome lint .`: clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
