### PR TITLE
feat: wire shared Caller into admin auth + onError logging

### DIFF
--- a/admin/src/agents-api.sentry.smoke.test.ts
+++ b/admin/src/agents-api.sentry.smoke.test.ts
@@ -1,7 +1,8 @@
 /**
  * admin/src/agents-api.sentry.smoke.test.ts
  *
- * Smoke tests for the onError hook's Sentry wiring (SEN-1.3).
+ * Smoke tests for the onError hook's Sentry wiring (SEN-1.3) and caller
+ * logging (AOB-3.4).
  *
  * Asserts:
  *   - an unhandled (non-ApiError) error triggers sentryClient.captureException
@@ -12,9 +13,13 @@
  *     captureException
  *   - with no sentryClient dep (undefined — Sentry not initialized), onError
  *     does not throw and behaves exactly as before
+ *   - the unhandled-error console.error log line includes the resolved
+ *     caller's label (via callerLabel()), for both a DB agent token and an
+ *     admin env key
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
+import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import type { AgentEnvService } from "./agent-envs.ts";
 import type { AgentProvisioner, ProvisionResult } from "./agent-provisioner.ts";
@@ -239,5 +244,55 @@ describe("onError — Sentry capture wiring", () => {
     });
 
     expect(res.status).toBe(500);
+  });
+});
+
+describe("onError — caller label logging (AOB-3.4)", () => {
+  it("includes the DB agent token's caller label in the unhandled-error console.error line", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    try {
+      const app = createAdminApp(makeBaseDeps(throwingAgentEnvService()));
+
+      const res = await app.request(`/agents/${AGENT_ID}/envs`, {
+        headers: { Authorization: `Bearer ${VALID_BEARER_TOKEN}` },
+      });
+
+      expect(res.status).toBe(500);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const loggedArgs = consoleErrorSpy.mock.calls.flat().join(" ");
+      expect(loggedArgs).toContain(
+        callerLabel({ name: AGENT_ID, scope: AGENT_ID }),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("includes the admin env key's caller label in the unhandled-error console.error line", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    try {
+      const adminApiKeys = new Map([
+        ["admin-env-key-token", { name: "admin", scope: "*" }],
+      ]);
+      const app = createAdminApp({
+        ...makeBaseDeps(throwingAgentEnvService()),
+        adminApiKeys,
+      });
+
+      const res = await app.request(`/agents/${AGENT_ID}/envs`, {
+        headers: { Authorization: "Bearer admin-env-key-token" },
+      });
+
+      expect(res.status).toBe(500);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const loggedArgs = consoleErrorSpy.mock.calls.flat().join(" ");
+      expect(loggedArgs).toContain(callerLabel({ name: "admin", scope: "*" }));
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -20,6 +20,7 @@
  */
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import type { PrismaClient } from "../prisma/client/index.js";
 import type { AgentChatTokenService } from "./agent-chat-tokens.ts";
@@ -818,7 +819,10 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       );
     }
     sentryClient?.captureException(err);
-    console.error("[agents-api] unhandled error:", err);
+    console.error(
+      `[agents-api] unhandled error (caller: ${callerLabel(c.get("caller"))}):`,
+      err,
+    );
     return c.json({ error: "Internal server error" }, 500);
   });
 

--- a/admin/src/api-auth.ts
+++ b/admin/src/api-auth.ts
@@ -8,6 +8,7 @@
  * does NOT fall through to the cookie path.
  */
 
+import type { Caller } from "@shipwright/lib/request-context";
 import type { MiddlewareHandler } from "hono";
 import { getCookie } from "hono/cookie";
 import { verify } from "hono/jwt";
@@ -15,7 +16,9 @@ import type { AgentTokenService } from "./agent-tokens.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type AdminAuthEnv = { Variables: { isAdmin: boolean } };
+export type AdminAuthEnv = {
+  Variables: { isAdmin: boolean; caller: Caller };
+};
 
 /**
  * Declarative authorization policy for the admin service.
@@ -133,6 +136,7 @@ export function createAdminAuthMiddleware(deps: {
           if (envKey.scope === "*") {
             // Admin key — bypass all scope checks.
             c.set("isAdmin", true);
+            c.set("caller", { name: envKey.name, scope: "*" });
             return next();
           }
           // Scoped key — enforce route agentId matches key scope.
@@ -143,6 +147,7 @@ export function createAdminAuthMiddleware(deps: {
           // Non-agent routes: scoped keys are permitted (no agentId to enforce against).
           // All current /agents/* routes match AGENT_ROUTE_RE — revisit if that changes.
           c.set("isAdmin", false);
+          c.set("caller", { name: envKey.name, scope: envKey.scope });
           return next();
         }
       }
@@ -163,6 +168,7 @@ export function createAdminAuthMiddleware(deps: {
       }
       // DB token path — per-agent bearer, not an admin.
       c.set("isAdmin", false);
+      c.set("caller", { name: result.agentId, scope: result.agentId });
       return next();
     }
 
@@ -171,6 +177,7 @@ export function createAdminAuthMiddleware(deps: {
     if (!sessionToken) {
       return c.json({ error: "Unauthorized" }, 401);
     }
+    let email: string;
     try {
       const payload = (await verify(
         sessionToken,
@@ -185,11 +192,13 @@ export function createAdminAuthMiddleware(deps: {
       ) {
         return c.json({ error: "Unauthorized" }, 401);
       }
+      email = payload.email;
     } catch {
       return c.json({ error: "Unauthorized" }, 401);
     }
     // Session cookie — admin.
     c.set("isAdmin", true);
+    c.set("caller", { name: email, scope: "session" });
     return next();
   };
 }

--- a/admin/src/api-auth.unit.test.ts
+++ b/admin/src/api-auth.unit.test.ts
@@ -7,9 +7,11 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import type { Caller } from "@shipwright/lib/request-context";
 import { Hono } from "hono";
 import { sign } from "hono/jwt";
 import type { AgentTokenService, AgentTokenValidated } from "./agent-tokens.ts";
+import type { AdminAuthEnv } from "./api-auth.ts";
 import { createAdminAuthMiddleware, parseAdminApiKeys } from "./api-auth.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -38,12 +40,12 @@ async function makeSessionJwt(secret = SESSION_SECRET): Promise<string> {
 function buildApp(
   validateFn: (raw: string) => Promise<AgentTokenValidated | null>,
   adminApiKeys?: Map<string, { name: string; scope: string }>,
-): Hono {
+): Hono<AdminAuthEnv> {
   const mockTokenService: Pick<AgentTokenService, "validate"> = {
     validate: validateFn,
   };
 
-  const app = new Hono();
+  const app = new Hono<AdminAuthEnv>();
   app.use(
     "*",
     createAdminAuthMiddleware({
@@ -52,9 +54,11 @@ function buildApp(
       adminApiKeys,
     }),
   );
-  app.get("/test", (c) => c.json({ ok: true }));
+  app.get("/test", (c) => c.json({ ok: true, caller: c.get("caller") }));
   // Scoped agent route — mirrors real admin API pattern
-  app.get("/agents/:id/envs", (c) => c.json({ agentId: c.req.param("id") }));
+  app.get("/agents/:id/envs", (c) =>
+    c.json({ agentId: c.req.param("id"), caller: c.get("caller") }),
+  );
   return app;
 }
 
@@ -367,5 +371,65 @@ describe("createAdminAuthMiddleware — admin API keys", () => {
     });
     expect(res.status).toBe(200);
     expect(validateCalled).toBe(true);
+  });
+});
+
+// ─── Shared Caller tests (AOB-3.4) ─────────────────────────────────────────────
+
+describe("createAdminAuthMiddleware — shared Caller", () => {
+  it("sets caller = {name, scope: '*'} for an admin env key", async () => {
+    const adminApiKeys = new Map([
+      [ADMIN_TOKEN, { name: "admin", scope: "*" }],
+    ]);
+    const app = buildApp(async () => null, adminApiKeys);
+
+    const res = await app.request("/test", {
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { caller: Caller };
+    expect(body.caller).toEqual({ name: "admin", scope: "*" });
+  });
+
+  it("sets caller = {name, scope: agentId} for a scoped env key", async () => {
+    const adminApiKeys = new Map([
+      [SCOPED_TOKEN, { name: "svc", scope: AGENT_ID }],
+    ]);
+    const app = buildApp(async () => null, adminApiKeys);
+
+    const res = await app.request(`/agents/${AGENT_ID}/envs`, {
+      headers: { Authorization: `Bearer ${SCOPED_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { caller: Caller };
+    expect(body.caller).toEqual({ name: "svc", scope: AGENT_ID });
+  });
+
+  it("sets caller = {name: agentId, scope: agentId} for a DB agent token", async () => {
+    const app = buildApp(async (raw) =>
+      raw === VALID_RAW_TOKEN ? { agentId: AGENT_ID } : null,
+    );
+
+    const res = await app.request("/test", {
+      headers: { Authorization: `Bearer ${VALID_RAW_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { caller: Caller };
+    expect(body.caller).toEqual({ name: AGENT_ID, scope: AGENT_ID });
+  });
+
+  it("sets caller = {name: email, scope: 'session'} for a session cookie", async () => {
+    const app = buildApp(async () => null);
+    const jwt = await makeSessionJwt();
+
+    const res = await app.request("/test", {
+      headers: { Cookie: `admin_session=${jwt}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { caller: Caller };
+    expect(body.caller).toEqual({
+      name: "admin@example.com",
+      scope: "session",
+    });
   });
 });

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,7 +15,7 @@ When `SENTRY_DSN` is set, a service reports:
 - **Unhandled exceptions and 5xx errors**, with stack traces, after scrubbing (see below).
 - **`console.log` / `console.warn` / `console.error` calls**, forwarded as structured Sentry Logs via `consoleLoggingIntegration`.
 - **Request path and method** for errors that occur inside an HTTP handler (via `@sentry/hono`'s `sentry()` middleware, or the app's own `onError` hook).
-- **Caller identity** (admin or agent token) in error logs from task-store, for tracing which token triggered an unhandled error.
+- **Caller identity** (admin or agent token) in error logs from admin and task-store, for tracing which token triggered an unhandled error.
 
 ## What is never collected
 


### PR DESCRIPTION
## Summary
- Extends `AdminAuthEnv.Variables` with a shared `caller: Caller` (see `lib/request-context.ts`), set on all 4 successful-auth branches in `createAdminAuthMiddleware`: admin env key (`scope: '*'`), scoped env key (`scope: envKey.scope`), DB agent token (`name`/`scope` = agentId), and session cookie (`name`: email, `scope: 'session'`)
- Logs `callerLabel(c.get("caller"))` in `agents-api.ts`'s `onError` handler so unhandled-error logs identify which caller triggered the request
- Mirrors the identical pattern already merged for task-store (AOB-3.3, #1327)
- Refreshes `docs/observability.md` to note caller-identity logging now covers admin, not just task-store

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | caller is set correctly on all 4 auth paths -- admin key, scoped key, DB token, session cookie | MET | `c.set("caller", ...)` added on all 4 branches; covered by 4 new unit tests |
| 2 | agents-api.ts's unhandled-error log line includes the resolved caller label | MET | `onError` now logs `callerLabel(c.get("caller"))`; asserted in 2 new sentry smoke tests |
| 3 | Existing isAdmin/scope-enforcement behavior (403 on mismatched scoped key vs. agentId) unchanged | MET | No changes to 403/`AGENT_ROUTE_RE` logic; existing scope-enforcement tests pass unmodified |
| 4 | Test decision: extend api-auth.unit.test.ts with 4 new cases + extend onError coverage; nothing retired | MET | 4 new cases (one per auth path) + 2 new onError caller-label tests; no existing tests removed |

## Test Plan
- `admin/src/api-auth.ts` coverage: 100% lines / 100% branches
- `admin/src/agents-api.ts` coverage: 98.85% lines / 98.33% branches
- Full repo test suite: 3567 pass, 14 pre-existing unrelated failures (kubernetes-client CA fallback test, installPlugins suite — confirmed failing on `main` too)
- `bunx biome lint .` clean; `bun run --filter='*' typecheck` clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
