### PR TITLE
fix: recognize narrative Verdict: APPROVE self-reviews in deploy gate

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -55,13 +55,18 @@ For each PR, check in order:
 
 1. **Approval** — if `reviewDecision == "APPROVED"`: approved. Otherwise, if
    `allow_self_review` is true: fetch the PR's reviews and check if any review authored
-   by `AGENT_LOGIN` has a body where `trimStart().startsWith("APPROVE")` — stripping any
+   by `AGENT_LOGIN` has a clean APPROVE body — either a leading `APPROVE` (stripping
    leading markdown bold markers (`**`) first, since the review skill posts
-   `"**APPROVE**"` and the body must still be treated as APPROVE (mirrors
-   `check-deploy.ts`'s `hasSelfApproveReview`):
+   `"**APPROVE**"`) or a `Verdict: APPROVE` label anywhere in the body (the narrative
+   self-review convention, case-insensitive, optional `**` around either word — mirrors
+   `check-helpers.ts`'s `isCleanApproveBody`, shared by `check-deploy.ts`'s
+   `hasSelfApproveReview` and `check-patch.ts`'s `isSelfCleanApprove`):
    ```bash
    gh pr view {pr} --repo {org}/{repo} --json reviews \
-     --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | (.body | sub("^\\s*";"") | sub("^\\*+";""))] | any(startswith("APPROVE"))'
+     --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | .body] | any(
+       (sub("^\\s*";"") | sub("^\\*+";"") | startswith("APPROVE"))
+       or test("verdict\\**\\s*:\\s*\\**approve\\b"; "i")
+     )'
    ```
    Skip if neither source shows approval.
 
@@ -164,18 +169,24 @@ gh pr view {pr} --repo {org}/{repo} --json reviewDecision,reviews \
 **If `reviewDecision` is not `"APPROVED"`**: Read `allow_self_review` from
 `state/agent-policy.md` (default: true). If `allow_self_review` is true AND the PR is
 authored by the current agent (`PR_AUTHOR == AGENT_LOGIN` from Step 2a), fetch the PR's
-reviews from GitHub and check if any review from `AGENT_LOGIN` has a body where
-`trimStart().startsWith("APPROVE")` — strip any leading markdown bold markers (`**`)
-before this check, since the review skill posts `"**APPROVE**"` and the body must still
-be treated as APPROVE (mirrors `check-deploy.ts`'s `hasSelfApproveReview`, which does
-`r.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE")`):
+reviews from GitHub and check if any review from `AGENT_LOGIN` has a clean APPROVE body —
+either a leading `APPROVE` (strip any leading markdown bold markers (`**`) first, since
+the review skill posts `"**APPROVE**"`) or a `Verdict: APPROVE` label anywhere in the body
+(the narrative self-review convention, case-insensitive, optional `**` around either word
+— mirrors `check-helpers.ts`'s `isCleanApproveBody`, shared by `check-deploy.ts`'s
+`hasSelfApproveReview` and `check-patch.ts`'s `isSelfCleanApprove`):
 
 ```bash
 gh pr view {pr} --repo {org}/{repo} --json reviews \
-  --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | (.body | sub("^\\s*";"") | sub("^\\*+";""))]'
+  --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | .body] | any(
+    (sub("^\\s*";"") | sub("^\\*+";"") | startswith("APPROVE"))
+    or test("verdict\\**\\s*:\\s*\\**approve\\b"; "i")
+  )'
 ```
 
-A matching review is one whose stripped body `startsWith("APPROVE")`. If a matching review is found: Record `approval_source = "self_review"` and proceed to Step 3b.
+A matching review is one whose stripped body `startsWith("APPROVE")` or that contains a
+`Verdict: APPROVE` label. If a matching review is found: Record `approval_source =
+"self_review"` and proceed to Step 3b.
 Print:
 ```
 ℹ No GitHub approval (solo-authored PR). Proceeding on self-posted APPROVE review.

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -211,6 +211,55 @@ describe("check-deploy", () => {
     expect(result.exit).toBe(1);
   });
 
+  test("exits 0 when self-review body uses the narrative 'Verdict: APPROVE' label", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: null,
+    });
+    const reviews: GhReview[] = [
+      {
+        author: { login: "bodhi-agent" },
+        body: "All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows self-approval via the API).",
+        state: "COMMENTED",
+      },
+    ];
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        isSelfReviewAllowed: true,
+        prs: { "acme/example-repo": [pr] },
+        reviews: { 50: reviews },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
+  test("exits 1 when self-review has a non-APPROVE verdict label", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: null,
+    });
+    const reviews: GhReview[] = [
+      {
+        author: { login: "bodhi-agent" },
+        body: "Found a blocking issue. Verdict: CHANGES_REQUESTED",
+        state: "COMMENTED",
+      },
+    ];
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        isSelfReviewAllowed: true,
+        prs: { "acme/example-repo": [pr] },
+        reviews: { 50: reviews },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+    );
+    expect(result.exit).toBe(1);
+  });
+
   test("exits 1 when PR is approved but CI is not green (in_progress)", async () => {
     const pr = makeGhPr({ reviewDecision: "APPROVED" });
     const result = await run(

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -7,7 +7,8 @@
  * Lists open PRs across configured repos via GitHub. For each, checks:
  * 1. Approval: GitHub reviewDecision == "APPROVED" OR author is current user,
  *    allow_self_review is true in agent-policy.md, and author has a review
- *    with "APPROVE" in the body.
+ *    with a clean APPROVE body (leading "APPROVE" or "Verdict: APPROVE"
+ *    anywhere in the body — see check-helpers.ts's isCleanApproveBody).
  * 2. CI: at least one CI run with conclusion == "success" for the PR's HEAD SHA
  * 3. Deploying guard: a repo with an active Deploy workflow run is skipped
  *    for this pass — scoped per repo, so a busy repo does not block PRs in
@@ -21,6 +22,7 @@ import {
   createTaskStoreClient,
   getCurrentUser,
   ghJson,
+  isCleanApproveBody,
   readAllowSelfReview,
   resolveAllRepos,
   resolveWorkspacePath,
@@ -100,14 +102,7 @@ function isActiveRun(run: WorkflowRun, now: string): boolean {
 
 function hasSelfApproveReview(reviews: GhReview[], userLogin: string): boolean {
   return reviews.some(
-    (r) =>
-      r.author.login === userLogin &&
-      // Strip leading markdown bold markers (**) before checking — the review
-      // skill posts "**APPROVE**" but the body must still be treated as APPROVE.
-      r.body
-        .trimStart()
-        .replace(/^\*+/, "")
-        .startsWith("APPROVE"),
+    (r) => r.author.login === userLogin && isCleanApproveBody(r.body),
   );
 }
 

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -78,6 +78,35 @@ export function parseAllowSelfReview(content: string): boolean {
   return match?.[1] !== "false"; // default true if missing
 }
 
+// ─── Self-review body matching ────────────────────────────────────────────────
+
+/**
+ * Matches a "Verdict: APPROVE" label anywhere in a review body (case-
+ * insensitive, optional markdown bold markers around either word). Not
+ * anchored to end-of-line — narrative self-reviews trail reasoning after the
+ * verdict on the same line. The trailing `\b` requires "approve" to end as a
+ * whole word, so "Verdict: CHANGES_REQUESTED" or "Verdict: DISAPPROVE" never
+ * matches.
+ */
+export const VERDICT_APPROVE_LABEL = /verdict\**\s*:\s*\**approve\b/i;
+
+/**
+ * True when a review body is a clean APPROVE verdict, matched either by:
+ * - a leading `APPROVE` (after stripping leading markdown bold markers), or
+ * - a "Verdict: APPROVE" label anywhere in the body (the narrative
+ *   self-review convention, which ends a summary with the verdict rather
+ *   than leading with it).
+ *
+ * Shared by check-deploy.ts's hasSelfApproveReview and check-patch.ts's
+ * isSelfCleanApprove so the two self-review consumers can't diverge again.
+ */
+export function isCleanApproveBody(body: string): boolean {
+  return (
+    body.trimStart().replace(/^\*+/, "").startsWith("APPROVE") ||
+    VERDICT_APPROVE_LABEL.test(body)
+  );
+}
+
 export function readAllowSelfReview(workspacePath: string): boolean {
   try {
     const content = readFileSync(

--- a/plugins/shipwright/scripts/check-helpers.unit.test.ts
+++ b/plugins/shipwright/scripts/check-helpers.unit.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import {
   createTaskStoreClient,
   getCurrentUser,
+  isCleanApproveBody,
   resolveAllRepos,
   resolveRepos,
 } from "./check-helpers.ts";
@@ -431,5 +432,41 @@ describe("removed exports", () => {
     expect(
       (checkHelpers as Record<string, unknown>).readReviews,
     ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCleanApproveBody
+// ---------------------------------------------------------------------------
+
+describe("isCleanApproveBody", () => {
+  test("matches a leading APPROVE", () => {
+    expect(isCleanApproveBody("APPROVE")).toBe(true);
+    expect(isCleanApproveBody("APPROVE — looks good")).toBe(true);
+  });
+
+  test("matches a leading APPROVE with markdown bold markers stripped", () => {
+    expect(isCleanApproveBody("**APPROVE** — all criteria met")).toBe(true);
+  });
+
+  test("matches a narrative 'Verdict: APPROVE' label anywhere in the body", () => {
+    expect(
+      isCleanApproveBody(
+        "All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows self-approval via the API).",
+      ),
+    ).toBe(true);
+  });
+
+  test("matches 'Verdict: APPROVE' case-insensitively with bold markers", () => {
+    expect(isCleanApproveBody("verdict: **approve** — ship it")).toBe(true);
+  });
+
+  test("does not match free-form approval prose without APPROVE or the Verdict label", () => {
+    expect(isCleanApproveBody("Looks good, no blocking issues.")).toBe(false);
+  });
+
+  test("does not match a non-APPROVE verdict", () => {
+    expect(isCleanApproveBody("Verdict: CHANGES_REQUESTED")).toBe(false);
+    expect(isCleanApproveBody("Verdict: DISAPPROVE")).toBe(false);
   });
 });

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -22,6 +22,7 @@ import {
   getCurrentUser,
   ghGraphql,
   ghJson,
+  isCleanApproveBody,
   isMergeOnlyUpdate,
   resolveAllRepos,
   resolveWorkspacePath,
@@ -123,36 +124,17 @@ export function hasFailingCi(
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
 
 /**
- * Matches a "Verdict: APPROVE" label anywhere in a review body (case-
- * insensitive, optional markdown bold markers around either word). Deliberately
- * NOT anchored to end-of-line — the agent's real narrative self-reviews trail
- * reasoning after the verdict on the same line, e.g. "...All 5 acceptance
- * criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows
- * self-approval via the API)." (verbatim from shipwright PR #1272, the case
- * that motivated this). The trailing `\b` requires "approve" to end as a whole
- * word, so a genuine "Verdict: CHANGES_REQUESTED" or "Verdict: DISAPPROVE" of
- * X never matches.
- */
-const VERDICT_APPROVE_LABEL = /verdict\**\s*:\s*\**approve\b/i;
-
-/**
- * True when a review is self-authored and is a clean APPROVE verdict, matched
- * either by:
- * - a leading `APPROVE` (`body.trimStart().startsWith("APPROVE")`, matching
- *   deploy.md's Step 3a convention), or
- * - a "Verdict: APPROVE" label anywhere in the body (the agent's narrative
- *   self-review convention, which ends a summary with the verdict rather than
- *   leading with it — CPF-2.1).
+ * True when a review is self-authored and is a clean APPROVE verdict (see
+ * check-helpers.ts's isCleanApproveBody — leading `APPROVE` or a "Verdict:
+ * APPROVE" label anywhere in the body, the agent's narrative self-review
+ * convention, which ends a summary with the verdict rather than leading with
+ * it — CPF-2.1).
  *
  * GitHub blocks self-APPROVE via the API, so the agent's own clean approvals
  * are always posted as COMMENTED — treating those as findings would create a
  * permanent false positive. A self-review with a real (non-APPROVE) verdict
  * (e.g. "Verdict: CHANGES_REQUESTED") is not matched here, so it still counts
  * as a finding.
- *
- * Leading markdown bold markers (`**`) are stripped before the leading-prefix
- * check, mirroring check-deploy.ts's `hasSelfApproveReview` — the review
- * skill posts `**APPROVE**` but the body must still be treated as APPROVE.
  */
 function isSelfCleanApprove(
   review: Pick<PrReviewData["reviews"]["nodes"][number], "author" | "body">,
@@ -160,10 +142,7 @@ function isSelfCleanApprove(
 ): boolean {
   if (review.author.login !== currentUser) return false;
 
-  return (
-    review.body.trimStart().replace(/^\*+/, "").startsWith("APPROVE") ||
-    VERDICT_APPROVE_LABEL.test(review.body)
-  );
+  return isCleanApproveBody(review.body);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `check-deploy.ts`'s `hasSelfApproveReview` (and `deploy.md`'s Step 1a scan-mode / Step 3a pre-flight mirrors) only matched review bodies with a literal leading `APPROVE`. The review skill's narrative self-review convention posts `"Verdict: APPROVE — ..."`, which never matched — silently excluding every narrative self-reviewed PR from the deploy candidate list, forever.
- `check-patch.ts` already fixed this on its side via `isSelfCleanApprove`'s `VERDICT_APPROVE_LABEL` regex, but `check-deploy.ts` never got the equivalent fix — two scripts checking the same review-body convention had drifted apart.
- Extracted the shared matching logic into `check-helpers.ts`'s `isCleanApproveBody`, now used by both `check-deploy.ts` and `check-patch.ts`, so they can't diverge again. Updated `deploy.md`'s two inline bash/jq checks (Step 1a, Step 3a) to match the same convention.

Currently blocking 9 open self-reviewed PRs across shipwright and vitals-os that have clean "Verdict: APPROVE" self-reviews sitting idle.

## Test plan
- [x] `bun test plugins/shipwright/` — 738 pass, 0 fail
- [x] Added unit tests for `isCleanApproveBody` (leading APPROVE, bold markers, narrative Verdict label, non-APPROVE verdicts)
- [x] Added `check-deploy.test.ts` cases for narrative Verdict: APPROVE and non-APPROVE verdict labels
- [x] `bun run typecheck`, `task lint`, `task check-strings`, `task check-config-docs`, `task check-version-sync` all clean
- [x] Verified the updated jq expressions in `deploy.md` manually against sample review bodies (leading APPROVE, bold APPROVE, narrative Verdict: APPROVE, non-matching prose)