### PR TITLE
fix: stamp readyForReviewAt on claim() create for review phase

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -184,7 +184,7 @@ Body:
 | `commitSha` | yes | Current head commit SHA |
 | `claimedBy` | admin only | Agent ID (agent tokens pin to their own ID) |
 | `taskId` | no | Associated task ID |
-| `phase` | no | Pipeline phase (`review`, `patch`, or `deploy`; default: `review`). When set, the phase is updated and reviewState is preserved. |
+| `phase` | no | Pipeline phase (`review`, `patch`, or `deploy`; default: `review`). When set, the phase is updated and reviewState is preserved. Phase-specific behavior on record creation: `review` sets `readyForReviewAt=now`; `deploy` sets `readyForDeployAt=now`; `patch` does not set a ready timestamp. |
 | `prCreatedAt` | no | ISO timestamp of the GitHub PR's actual creation time. Only applied when the claim creates a new record (`201`); ignored on subsequent claims (`200`) of an existing record since the field is immutable once set. |
 
 Claim semantics:
@@ -258,6 +258,9 @@ The following timestamp fields are managed by the task store:
 | `prCreatedAt` | `POST /prs/claim` | ISO timestamp of the GitHub PR's actual creation time (distinct from `createdAt`, which records when the task-store record itself was created). Set once via the optional `prCreatedAt` field on the first `POST /prs/claim` call that creates the record (`201`); read-only thereafter — later claims cannot modify it. Not currently populated by any Shipwright command; callers must supply GitHub's PR `createdAt` explicitly to use this field. |
 | `createdAt` | Auto | ISO timestamp when the task-store PR record was created. |
 | `updatedAt` | Auto | ISO timestamp when the task-store PR record was last modified. |
+| `readyForReviewAt` | `POST /prs/claim` (phase=review) | Set to `now` when `POST /prs/claim` creates a new record with `phase=review`. Records when the PR became eligible for review. |
+| `readyForPatchAt` | (internal use) | Records when the PR transitioned to the patch phase; not currently populated by any Shipwright command but available via `PATCH /prs/:id`. |
+| `readyForDeployAt` | `POST /prs/claim` (phase=deploy) | Set to `now` when `POST /prs/claim` creates a new record with `phase=deploy`. Records when the PR became eligible for deployment. |
 | `reviewedAt` | `POST /prs/:id/complete` | Set when the review cycle completes. |
 | `patchedAt` | `POST /prs/:id/patch` | Set when the patch cycle completes. |
 | `mergedAt` | Writable via `PATCH /prs/:id` | Manually set or updated when marking the PR as merged. |

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -139,7 +139,9 @@ export class PullRequestService implements PullRequestServiceLike {
    * Atomically claim a PR using a Prisma transaction.
    *
    * phase defaults to 'review'. Phase-specific behaviour:
-   *   - review (default): sets reviewState='in_progress', phase='review'
+   *   - review (default): sets reviewState='in_progress', phase='review';
+   *     on first creation of the record, also stamps readyForReviewAt=now
+   *     (mirrors claimNext()'s behaviour for pre-existing records)
    *   - patch: sets phase='patch', claim fields; does NOT touch reviewState
    *   - deploy: sets phase='deploy', claim fields, sets readyForDeployAt=now if null
    *
@@ -237,6 +239,7 @@ export class PullRequestService implements PullRequestServiceLike {
 
         if (phase === "review") {
           createData.reviewState = "in_progress";
+          createData.readyForReviewAt = now;
         } else if (phase === "deploy") {
           createData.readyForDeployAt = now;
         }

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -388,6 +388,30 @@ describeOrSkip("PullRequestService.claim() phase support (integration)", () => {
     expect(result.record.reviewState).toBe("in_progress");
   });
 
+  it("claim(phase=review) stamps readyForReviewAt=now on record creation", async () => {
+    const now = new Date("2026-07-01T12:00:00.000Z");
+    const clock = FixedClock(now);
+    const svc = new PullRequestService(prisma, clock);
+
+    const repo = "app-vitals/shipwright";
+    const prNumber = 704;
+    const commitSha = "sha-review-created";
+
+    const result = await svc.claim(repo, prNumber, commitSha, "agent-a", undefined, "review");
+    expect(result.status).toBe(201);
+    expect(result.record.readyForReviewAt).toBe(now.toISOString());
+  });
+
+  it("claim(phase=patch) does not stamp readyForReviewAt on record creation", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 705;
+    const commitSha = "sha-patch-created";
+
+    const result = await service.claim(repo, prNumber, commitSha, "agent-a", undefined, "patch");
+    expect(result.status).toBe(201);
+    expect(result.record.readyForReviewAt).toBeNull();
+  });
+
   it("claim(phase=patch) conflict: 409 if same commitSha and phase=patch and already claimed", async () => {
     const repo = "app-vitals/shipwright";
     const prNumber = 703;


### PR DESCRIPTION
## Summary
- Fixed `PullRequestService.claim()`'s create-new-record branch to stamp `readyForReviewAt = now` when `phase === 'review'`, matching `claimNext()`'s existing behavior for this field
- `prCreatedAt` accept/store/immutability (landed in the WL-1.1 dependency) verified as already correct on this branch — no changes needed there
- Added two integration tests confirming `readyForReviewAt` is stamped on a fresh review-phase claim and left `null` on a patch-phase claim
- Refreshed `docs/task-store.md` to document the phase-specific timestamp behavior on record creation

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `claim()` and `POST /prs/claim` accept optional `prCreatedAt`; stored on create only, immutable on reclaim | MET | Landed via WL-1.1; verified present and tested on this branch |
| 2 | `claim()`'s create-new-record branch stamps `readyForReviewAt=now` for `phase='review'` | MET | `task-store/src/pull-request-service.ts` — mirrors `claimNext()`'s existing pattern |
| 3 | Tests cover (a) `prCreatedAt` stored+preserved, (b) `readyForReviewAt` stamped via `claim()` review-phase, (c) omitted `prCreatedAt` → null; no existing tests retired | MET | (a)/(c) pre-existing; (b) added as 2 new tests |

## Test Plan
- `cd task-store && bun test` — 305 pass / 80 skip / 0 fail (integration tests skip due to no test DB in this sandbox; new tests follow the same `describeOrSkip` pattern as all sibling claim()/claimNext() tests in the file)
- `cd task-store && bun run typecheck` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
