### PR TITLE
feat: add phase field to WorkPrCandidate in work-selector.ts

### DIFF
--- a/agent/src/work-selector.ts
+++ b/agent/src/work-selector.ts
@@ -36,6 +36,7 @@ export interface WorkPrCandidate {
   id: string;
   age: string;
   claimedBy?: string | null;
+  phase?: "review" | "patch" | "deploy";
 }
 
 export type WorkItem =

--- a/agent/src/work-selector.unit.test.ts
+++ b/agent/src/work-selector.unit.test.ts
@@ -25,7 +25,9 @@ function makeTask(overrides: Partial<WorkTaskCandidate> = {}): WorkTaskCandidate
   };
 }
 
-function makePr(overrides: Partial<WorkPrCandidate> = {}): WorkPrCandidate {
+function makePr(
+  overrides: Partial<WorkPrCandidate> = {},
+): WorkPrCandidate {
   return {
     id: "pr-1",
     age: "2026-01-01T00:00:00.000Z",
@@ -148,5 +150,27 @@ describe("selectNextWorkItem", () => {
     const pr2 = makePr({ id: "pr2", age: "2026-01-10T00:00:00.000Z", claimedBy: "agent-y" });
     const result = selectNextWorkItem([t1, t2], [pr1, pr2]);
     expect(result).toEqual({ type: "task", task: t2 });
+  });
+
+  it("carries the phase field through unchanged to the winning PR", () => {
+    const pr = makePr({ id: "pr1", age: "2026-01-01T00:00:00.000Z", phase: "review" });
+    const result = selectNextWorkItem([], [pr]);
+    expect(result).toEqual({ type: "pr", pr: expect.objectContaining({ phase: "review" }) });
+  });
+
+  it("ranks by age regardless of phase — older review-phase beats newer deploy-phase", () => {
+    const olderReview = makePr({ id: "pr-older", age: "2026-01-01T00:00:00.000Z", phase: "review" });
+    const newerDeploy = makePr({ id: "pr-newer", age: "2026-01-02T00:00:00.000Z", phase: "deploy" });
+    const result = selectNextWorkItem([], [newerDeploy, olderReview]);
+    expect(result).toEqual({ type: "pr", pr: olderReview });
+    expect(result?.type === "pr" && result.pr.phase).toBe("review");
+  });
+
+  it("handles PR without phase set (undefined) in ranking correctly", () => {
+    const older = makePr({ id: "pr-older", age: "2026-01-01T00:00:00.000Z" });
+    const newer = makePr({ id: "pr-newer", age: "2026-01-02T00:00:00.000Z", phase: "patch" });
+    const result = selectNextWorkItem([], [newer, older]);
+    expect(result).toEqual({ type: "pr", pr: older });
+    expect(result?.type === "pr" && result.pr.phase).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Adds an optional `phase: 'review' | 'patch' | 'deploy'` field to `WorkPrCandidate` in `agent/src/work-selector.ts`
- Pure pass-through: `selectNextWorkItem`'s age-based FIFO ranking is unchanged — `phase` is never read or compared in the selection algorithm, only carried onto the winning `WorkItem`'s `pr` variant so the caller knows which command to dispatch

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | WorkPrCandidate gains a phase field, additive | MET | `phase?: "review" \| "patch" \| "deploy"` added to the interface, existing fields untouched |
| 2 | Winning WorkItem carries phase through unchanged | MET | WorkItem's `pr` variant holds the full `WorkPrCandidate` object by reference, so `phase` flows through automatically |
| 3 | Ranking logic unmodified — phase not read/compared | MET | `selectNextWorkItem` body has zero references to `phase`; only `createdAt`/`age` drive comparisons |
| 4 | Tests extend work-selector.unit.test.ts additively | MET | 3 new tests added, all 14 pre-existing tests retained unmodified (17 total, 0 fail) |

## Test Plan
- `bun test agent/src/work-selector.unit.test.ts` — 17 pass, 0 fail (100% line coverage on work-selector.ts)
- New fixture: older `review`-phase candidate still beats a newer `deploy`-phase candidate (proves phase isn't part of ranking)
- New fixture: phase passes through unchanged onto the winning `WorkItem`
- New fixture: candidates without `phase` set still rank correctly
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
