### PR TITLE
feat: preserve list filters/pagination in task detail back link

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1401,6 +1401,35 @@ export function renderTasksPage(
       .join("");
   };
 
+  // Pagination (hoisted above the row loop so row links can carry the current
+  // list view as a `from` back-link param — see makePageUrl usage below).
+  const totalPages = Math.max(
+    1,
+    Math.ceil(pagination.total / pagination.limit),
+  );
+  const page = pagination.page;
+  const makePageUrl = (p: number) => {
+    const params = new URLSearchParams();
+    if (filters.status) params.set("status", filters.status);
+    else if (filters.state) params.set("state", filters.state);
+    if (filters.session) params.set("session", filters.session);
+    if (filters.repo) params.set("repo", filters.repo);
+    if (filters.agent) params.set("agent", filters.agent);
+    if (p > 1) params.set("page", String(p));
+    const qs = params.toString();
+    return `/admin/tasks${qs ? `?${qs}` : ""}`;
+  };
+
+  // The URL the user is currently viewing. When it differs from the bare
+  // /admin/tasks default (any filter, state, or page > 1 active), row links
+  // into the detail page carry it as `?from=` so the "← Tasks" back link on
+  // the detail page can return here instead of the cleared default view.
+  const currentListUrl = makePageUrl(page);
+  const detailHrefSuffix =
+    currentListUrl === "/admin/tasks"
+      ? ""
+      : `?from=${encodeURIComponent(currentListUrl)}`;
+
   const rows =
     tasks.length === 0
       ? `<tr><td colspan="8" class="empty-state">No tasks found.</td></tr>`
@@ -1417,9 +1446,10 @@ export function renderTasksPage(
                 : t.prUrl
                   ? `<a href="${escapeHtml(t.prUrl)}" style="color:#6366f1;text-decoration:none" title="View PR">#${t.pr ?? "PR"}</a>`
                   : '<span style="color:#9ca3af">—</span>';
-            return `<tr${readOnly ? "" : ` data-href="/admin/tasks/${escapeHtml(t.id)}" style="cursor:pointer"`}>
-    <td class="mono" style="font-size:11px">${readOnly ? escapeHtml(t.id) : `<a href="/admin/tasks/${escapeHtml(t.id)}" style="color:#6366f1;text-decoration:none" title="View details">${escapeHtml(t.id)}</a>`}</td>
-    <td>${readOnly ? escapeHtml(t.title) : `<a href="/admin/tasks/${escapeHtml(t.id)}" style="color:inherit;text-decoration:none">${escapeHtml(t.title)}</a>`}${blockerBadges}</td>
+            const detailHref = `/admin/tasks/${escapeHtml(t.id)}${detailHrefSuffix}`;
+            return `<tr${readOnly ? "" : ` data-href="${detailHref}" style="cursor:pointer"`}>
+    <td class="mono" style="font-size:11px">${readOnly ? escapeHtml(t.id) : `<a href="${detailHref}" style="color:#6366f1;text-decoration:none" title="View details">${escapeHtml(t.id)}</a>`}</td>
+    <td>${readOnly ? escapeHtml(t.title) : `<a href="${detailHref}" style="color:inherit;text-decoration:none">${escapeHtml(t.title)}</a>`}${blockerBadges}</td>
     <td><span class="badge ${statusBadgeClass(t.status)}">${escapeHtml(t.status)}</span></td>
     <td style="font-size:12px">${agentCell}</td>
     <td class="col-session mono" style="font-size:11px">${t.session ? escapeHtml(t.session) : '<span style="color:#9ca3af">—</span>'}</td>
@@ -1486,24 +1516,6 @@ export function renderTasksPage(
         `<option value="${escapeHtml(s)}" ${filters.status === s ? "selected" : ""}>${s === "" ? "Any status" : escapeHtml(s)}</option>`,
     )
     .join("");
-
-  // Pagination
-  const totalPages = Math.max(
-    1,
-    Math.ceil(pagination.total / pagination.limit),
-  );
-  const page = pagination.page;
-  const makePageUrl = (p: number) => {
-    const params = new URLSearchParams();
-    if (filters.status) params.set("status", filters.status);
-    else if (filters.state) params.set("state", filters.state);
-    if (filters.session) params.set("session", filters.session);
-    if (filters.repo) params.set("repo", filters.repo);
-    if (filters.agent) params.set("agent", filters.agent);
-    if (p > 1) params.set("page", String(p));
-    const qs = params.toString();
-    return `/admin/tasks${qs ? `?${qs}` : ""}`;
-  };
 
   const from = pagination.total === 0 ? 0 : (page - 1) * pagination.limit + 1;
   const to = Math.min(page * pagination.limit, pagination.total);
@@ -1627,6 +1639,7 @@ export function renderTaskDetailPage(
   agentNames: Record<string, string> = {},
   timezone = "America/Los_Angeles",
   pullRequest?: PullRequestItem,
+  backHref = "/admin/tasks",
 ): string {
   const statusClass =
     task.status === "in_progress"
@@ -1876,7 +1889,7 @@ export function renderTaskDetailPage(
   ${renderAdminToolbar(userName, "/admin/tasks")}
   <div class="vos-page">
     <div class="page-header" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
-      <a href="/admin/tasks" style="color:#6b7280;font-size:13px;text-decoration:none">← Tasks</a>
+      <a href="${escapeHtml(backHref)}" style="color:#6b7280;font-size:13px;text-decoration:none">← Tasks</a>
       <h1 class="page-title" style="margin:0;flex:1">${escapeHtml(task.title)}</h1>
       <span class="badge ${statusClass}">${escapeHtml(task.status)}</span>
       ${releaseButton}

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1477,6 +1477,102 @@ describe("renderTasksPage — row click navigation", () => {
   });
 });
 
+// ─── renderTasksPage — back-link context (TBL-1.1) ───────────────────────────
+
+describe("renderTasksPage — back-link context (TBL-1.1)", () => {
+  // AC1: default list view (no filters, page 1) keeps emitting bare links —
+  // this guards the exact-match assertions in the describe block above.
+  test("default list view (no filters, page 1) omits ?from= from row links", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain(`data-href="/admin/tasks/${TASK_ITEM.id}"`);
+    expect(html).not.toContain("from=");
+  });
+
+  // AC1: a non-default filter (status) causes row links to carry ?from=<current list URL>
+  test("row links carry ?from=<current list URL> when a status filter is active", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { status: "in_progress" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    const expectedFrom = encodeURIComponent("/admin/tasks?status=in_progress");
+    expect(html).toContain(
+      `data-href="/admin/tasks/${TASK_ITEM.id}?from=${expectedFrom}"`,
+    );
+    expect(html).toContain(
+      `<a href="/admin/tasks/${TASK_ITEM.id}?from=${expectedFrom}"`,
+    );
+  });
+
+  // AC1: state filter also triggers ?from=
+  test("row links carry ?from= when a state filter is active", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { state: "blocked" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    const expectedFrom = encodeURIComponent("/admin/tasks?state=blocked");
+    expect(html).toContain(
+      `data-href="/admin/tasks/${TASK_ITEM.id}?from=${expectedFrom}"`,
+    );
+  });
+
+  // AC1: page > 1 also triggers ?from=
+  test("row links carry ?from= when page is greater than 1", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: 100, limit: 50, page: 2 },
+      undefined,
+      undefined,
+    );
+    const expectedFrom = encodeURIComponent("/admin/tasks?page=2");
+    expect(html).toContain(
+      `data-href="/admin/tasks/${TASK_ITEM.id}?from=${expectedFrom}"`,
+    );
+  });
+
+  // AC1: the title link (second <td>) also carries ?from=
+  test("title link also carries ?from= when filters are active", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { repo: "org/repo" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    const expectedFrom = encodeURIComponent("/admin/tasks?repo=org%2Frepo");
+    expect(html).toContain(
+      `<a href="/admin/tasks/${TASK_ITEM.id}?from=${expectedFrom}" style="color:inherit;text-decoration:none">${TASK_ITEM.title}</a>`,
+    );
+  });
+});
+
 // ─── renderAgentDetailPage — repos section ───────────────────────────────────
 
 describe("renderAgentDetailPage — repos", () => {
@@ -2285,6 +2381,53 @@ describe("renderTaskDetailPage — markdown", () => {
     // The interior lines must NOT produce orphaned <li> tags — there is no actual
     // list in this input, so no <li> should appear anywhere in the rendered page.
     expect(html).not.toContain("<li>");
+  });
+});
+
+// ─── renderTaskDetailPage — back link (TBL-1.1) ──────────────────────────────
+
+describe("renderTaskDetailPage — back link (TBL-1.1)", () => {
+  // AC3: default back link is the bare /admin/tasks URL when backHref is omitted
+  test("defaults to bare /admin/tasks when backHref is not provided", () => {
+    const html = renderTaskDetailPage(
+      TASK_DETAIL,
+      "user@example.com",
+      {},
+      "UTC",
+    );
+    expect(html).toContain(
+      `<a href="/admin/tasks" style="color:#6b7280;font-size:13px;text-decoration:none">← Tasks</a>`,
+    );
+  });
+
+  // AC3: a provided backHref is rendered (HTML-escaped) for the ← Tasks anchor
+  test("renders the given backHref for the ← Tasks anchor", () => {
+    const backHref = "/admin/tasks?status=in_progress&page=2";
+    const html = renderTaskDetailPage(
+      TASK_DETAIL,
+      "user@example.com",
+      {},
+      "UTC",
+      undefined,
+      backHref,
+    );
+    expect(html).toContain(
+      `<a href="${backHref.replace(/&/g, "&amp;")}" style="color:#6b7280;font-size:13px;text-decoration:none">← Tasks</a>`,
+    );
+  });
+
+  // AC3: backHref is HTML-escaped to prevent attribute-breakout XSS
+  test("HTML-escapes a malicious backHref", () => {
+    const html = renderTaskDetailPage(
+      TASK_DETAIL,
+      "user@example.com",
+      {},
+      "UTC",
+      undefined,
+      '/admin/tasks"><script>xss()</script>',
+    );
+    expect(html).not.toContain('"><script>xss()</script>');
+    expect(html).toContain("&lt;script&gt;");
   });
 });
 

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -3653,6 +3653,66 @@ describe("admin UI — tasks page", () => {
     expect(html).toContain(AGENT_ID);
   });
 
+  it("GET /admin/tasks/:id?from=<valid list URL> round-trips into the ← Tasks back link", async () => {
+    const mockTask = {
+      id: "task-42",
+      title: "Build the thing",
+      status: "in_progress",
+      session: null,
+      repo: "org/repo",
+    };
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTask: async (id: string) =>
+          id === "task-42" ? mockTask : null,
+      }),
+    );
+    const from = "/admin/tasks?status=in_progress&page=2";
+    const res = await app.request(
+      `/admin/tasks/task-42?from=${encodeURIComponent(from)}`,
+      { headers: { Cookie: `admin_session=${cookie}` } },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      `<a href="${from.replace(/&/g, "&amp;")}" style="color:#6b7280;font-size:13px;text-decoration:none">← Tasks</a>`,
+    );
+  });
+
+  it.each([
+    ["https://evil.com", "absolute URL"],
+    ["//evil.com", "protocol-relative URL"],
+    ["javascript:alert(1)", "javascript: URI"],
+    ["/admin/other", "different admin path"],
+  ])(
+    "GET /admin/tasks/:id?from=<malicious %s (%s)> falls back to /admin/tasks",
+    async (maliciousFrom) => {
+      const mockTask = {
+        id: "task-42",
+        title: "Build the thing",
+        status: "in_progress",
+        session: null,
+        repo: "org/repo",
+      };
+      const app = createAdminUIApp(
+        makeMockDeps({
+          fetchTaskStoreTask: async (id: string) =>
+            id === "task-42" ? mockTask : null,
+        }),
+      );
+      const res = await app.request(
+        `/admin/tasks/task-42?from=${encodeURIComponent(maliciousFrom)}`,
+        { headers: { Cookie: `admin_session=${cookie}` } },
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain(
+        `<a href="/admin/tasks" style="color:#6b7280;font-size:13px;text-decoration:none">← Tasks</a>`,
+      );
+      expect(html).not.toContain(maliciousFrom);
+    },
+  );
+
   it("GET /admin/tasks/:id redirects to list when task not found", async () => {
     const app = createAdminUIApp(
       makeMockDeps({

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -381,6 +381,22 @@ function createUIAuthMiddleware(
   };
 }
 
+// ─── Task detail back-link validation ──────────────────────────────────────────
+
+// Allowlist: a same-path /admin/tasks URL, optionally followed by a query
+// string. Rejects protocol-relative (//evil.com), absolute (https://evil.com),
+// javascript:, and any other-path values — those fall back to /admin/tasks so
+// the "← Tasks" anchor on the detail page can never be used as an
+// open-redirect/phishing hop off the admin domain.
+const TASK_LIST_BACK_HREF_PATTERN = /^\/admin\/tasks(\?[^\s]*)?$/;
+
+function resolveTaskDetailBackHref(fromParam: string | undefined): string {
+  if (fromParam && TASK_LIST_BACK_HREF_PATTERN.test(fromParam)) {
+    return fromParam;
+  }
+  return "/admin/tasks";
+}
+
 // ─── App factory ──────────────────────────────────────────────────────────────
 
 export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
@@ -1960,6 +1976,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
   app.get("/admin/tasks/:id", requireAuth, async (c) => {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
     const taskId = c.req.param("id");
+    const backHref = resolveTaskDetailBackHref(c.req.query("from"));
     if (!fetchTaskStoreTask)
       return c.redirect("/admin/tasks?error=task_store_unavailable", 302);
     let task: TaskItem | null = null;
@@ -1999,6 +2016,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         agentNames,
         timezone,
         pullRequest,
+        backHref,
       ),
     );
   });


### PR DESCRIPTION
## Summary
- Row links (data-href, ID link, title link) in `renderTasksPage` now append `?from=<url-encoded current list URL>` when the list view has active filters/state/page > 1, so navigating into a task's detail page preserves that context.
- `GET /admin/tasks/:id` validates the `from` query param against a strict allowlist regex (same-path `/admin/tasks`, optionally with a query string) and falls back to `/admin/tasks` for anything else — guards against open-redirect/phishing via a crafted link.
- `renderTaskDetailPage` accepts an optional `backHref` param (default `/admin/tasks`, HTML-escaped) and uses it for the "← Tasks" anchor instead of a hardcoded string.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Row links append `?from=<url-encoded current list URL>` only when non-default | MET | Hoisted `makePageUrl`/`currentListUrl`/`detailHrefSuffix`; default view keeps emitting bare links |
| 2 | `GET /admin/tasks/:id` validates `from` via allowlist regex, falls back to `/admin/tasks` | MET | `TASK_LIST_BACK_HREF_PATTERN` + `resolveTaskDetailBackHref()`, wired into the route handler |
| 3 | `renderTaskDetailPage` accepts optional `backHref` (HTML-escaped) | MET | New trailing param, defaults to `/admin/tasks`, escaped via `escapeHtml()` |
| 4 | Unit + smoke test coverage, no existing tests retired | MET | 8 new unit tests, 2 new smoke tests (incl. parametrized malicious-input cases) |

## Test Plan
- `bun test admin/src/admin-ui-pages.unit.test.ts admin/src/admin-ui.smoke.test.ts` — 465 pass, 0 fail
- `bun test admin/src --coverage` — admin-ui-pages.ts 95.26% lines, admin-ui.ts 87.23% lines (target 80%)
- `bunx biome lint .` — clean
- `bun run --filter='*' typecheck` — all workspaces pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
