### PR TITLE
feat: drop identity gating from clean-approve detection

### DIFF
--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -54,16 +54,15 @@ gh pr list --state open --repo {org}/{repo} --author "$AGENT_LOGIN" \
 For each PR, check in order:
 
 1. **Approval** — if `reviewDecision == "APPROVED"`: approved. Otherwise, if
-   `allow_self_review` is true: fetch the PR's reviews and check if any review authored
-   by `AGENT_LOGIN` has a clean APPROVE body — either a leading `APPROVE` (stripping
-   leading markdown bold markers (`**`) first, since the review skill posts
-   `"**APPROVE**"`) or a `Verdict: APPROVE` label anywhere in the body (the narrative
-   self-review convention, case-insensitive, optional `**` around either word — mirrors
-   `check-helpers.ts`'s `isCleanApproveBody`, shared by `check-deploy.ts`'s
-   `hasSelfApproveReview` and `check-patch.ts`'s `isSelfCleanApprove`):
+   `allow_self_review` is true: fetch the PR's reviews and check if any review has a clean
+   APPROVE body — either a leading `APPROVE` (stripping leading markdown bold markers (`**`)
+   first, since the review skill posts `"**APPROVE**"`) or a `Verdict: APPROVE` label
+   anywhere in the body (the narrative self-review convention, case-insensitive, optional
+   `**` around either word — mirrors `check-helpers.ts`'s `isCleanApproveBody`, shared by
+   `check-deploy.ts`'s `hasSelfApproveReview` and `check-patch.ts`'s `isSelfCleanApprove`):
    ```bash
    gh pr view {pr} --repo {org}/{repo} --json reviews \
-     --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | .body] | any(
+     --jq '[.reviews[] | .body] | any(
        (sub("^\\s*";"") | sub("^\\*+";"") | startswith("APPROVE"))
        or test("verdict\\**\\s*:\\s*\\**approve\\b"; "i")
      )'
@@ -167,18 +166,17 @@ gh pr view {pr} --repo {org}/{repo} --json reviewDecision,reviews \
 **If `reviewDecision` is `"APPROVED"`**: Record `approval_source = "github"` and `approvers = [list]`. Proceed to Step 3b.
 
 **If `reviewDecision` is not `"APPROVED"`**: Read `allow_self_review` from
-`state/agent-policy.md` (default: true). If `allow_self_review` is true AND the PR is
-authored by the current agent (`PR_AUTHOR == AGENT_LOGIN` from Step 2a), fetch the PR's
-reviews from GitHub and check if any review from `AGENT_LOGIN` has a clean APPROVE body —
-either a leading `APPROVE` (strip any leading markdown bold markers (`**`) first, since
-the review skill posts `"**APPROVE**"`) or a `Verdict: APPROVE` label anywhere in the body
-(the narrative self-review convention, case-insensitive, optional `**` around either word
-— mirrors `check-helpers.ts`'s `isCleanApproveBody`, shared by `check-deploy.ts`'s
+`state/agent-policy.md` (default: true). If `allow_self_review` is true, fetch the PR's
+reviews from GitHub and check if any review has a clean APPROVE body — either a leading
+`APPROVE` (strip any leading markdown bold markers (`**`) first, since the review skill
+posts `"**APPROVE**"`) or a `Verdict: APPROVE` label anywhere in the body (the narrative
+self-review convention, case-insensitive, optional `**` around either word — mirrors
+`check-helpers.ts`'s `isCleanApproveBody`, shared by `check-deploy.ts`'s
 `hasSelfApproveReview` and `check-patch.ts`'s `isSelfCleanApprove`):
 
 ```bash
 gh pr view {pr} --repo {org}/{repo} --json reviews \
-  --jq '[.reviews[] | select(.author.login == "'$AGENT_LOGIN'") | .body] | any(
+  --jq '[.reviews[] | .body] | any(
     (sub("^\\s*";"") | sub("^\\*+";"") | startswith("APPROVE"))
     or test("verdict\\**\\s*:\\s*\\**approve\\b"; "i")
   )'
@@ -189,7 +187,7 @@ A matching review is one whose stripped body `startsWith("APPROVE")` or that con
 "self_review"` and proceed to Step 3b.
 Print:
 ```
-ℹ No GitHub approval (solo-authored PR). Proceeding on self-posted APPROVE review.
+ℹ No GitHub approval. Proceeding on clean APPROVE review.
 ```
 
 If no matching review is found (or `allow_self_review` is false), print and stop:

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -144,16 +144,15 @@ A PR has **unaddressed findings** when ANY of the following are true:
 - At least one inline thread has `isResolved == false`
 - At least one review with `state == "COMMENTED"` or `state == "CHANGES_REQUESTED"` has a
   non-empty `body` (a review body without matching inline threads is itself a finding),
-  excluding self-authored clean-APPROVE reviews (see below)
+  excluding clean-APPROVE reviews (see below)
 
 A PR has **no findings** (skip it) when ALL of the following are true:
 - All inline threads are resolved (`isResolved == true` for every thread)
-- No COMMENTED or CHANGES_REQUESTED review has a non-empty body, other than self-authored
-  clean-APPROVE reviews (see below)
+- No COMMENTED or CHANGES_REQUESTED review has a non-empty body, other than clean-APPROVE
+  reviews (see below)
 
-**Self-authored clean-APPROVE exclusion**: A review is excluded from the body check above
-when `author.login == CURRENT_USER` (resolved in Step 1) AND its body is a clean APPROVE
-verdict, matched either by:
+**Clean-APPROVE exclusion**: A review is excluded from the body check above when its body is
+a clean APPROVE verdict, matched either by:
 - leading markdown bold markers (`**`) stripped, the body starts with `APPROVE`, or
 - a `Verdict: APPROVE` label appears anywhere in the body (case-insensitive, optional bold
   markers around either word) — **not** anchored to end-of-line, since the agent's narrative
@@ -162,18 +161,21 @@ verdict, matched either by:
   self-approval via the API)."` (verbatim from shipwright PR #1272, the case that motivated
   this).
 
-Per review.md's Step 10 note ("Self-review event override"), GitHub rejects self-APPROVE via
-the API, so the agent's own clean approval of its own PR is always posted as `COMMENTED`
-with a body like `"APPROVE — looks good, no changes needed."` or a narrative containing
-`"Verdict: APPROVE"` instead of an `APPROVED` review. Without this exclusion, that clean
-self-approval would look identical to a real finding and loop the patch cron forever on an
-already-approved PR. The exclusion is scoped to clean APPROVE verdicts only — a self-authored
-review whose body neither starts with `APPROVE` nor contains a `Verdict: APPROVE` label (e.g.
-it contains `Verdict: CHANGES_REQUESTED`, meaning the agent found a real issue in its own PR)
-still counts as a finding, same as any other reviewer's.
+Not restricted to self-authored reviews (SRV-1.1): multiple distinct Shipwright agents
+operate under different GitHub identities in the same repo, so WHO posted a clean APPROVE
+verdict is not meaningful — the verdict text itself is the ground truth. Per review.md's
+Step 10 note ("Self-review event override"), GitHub rejects self-APPROVE via the API, so an
+agent's own clean approval of its own PR is always posted as `COMMENTED` with a body like
+`"APPROVE — looks good, no changes needed."` or a narrative containing `"Verdict: APPROVE"`
+instead of an `APPROVED` review. Without this exclusion, that clean approval would look
+identical to a real finding and loop the patch cron forever on an already-approved PR. The
+exclusion is scoped to clean APPROVE verdicts only — a review whose body neither starts with
+`APPROVE` nor contains a `Verdict: APPROVE` label (e.g. it contains `Verdict:
+CHANGES_REQUESTED`, meaning the reviewer found a real issue) still counts as a finding,
+regardless of who posted it.
 
 If neither condition applies (e.g., no reviews at all, only approved reviews, or only an
-excluded self-authored clean-APPROVE review), skip the PR — it does not belong in List A.
+excluded clean-APPROVE review), skip the PR — it does not belong in List A.
 
 If a PR has unaddressed findings, add it to **List A**. Store the unresolved threads (with their
 `id` — needed for the `resolveReviewThread` mutation in Step 5) and review bodies for use in

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -69,12 +69,12 @@ Don't enumerate findings in the body -- the author sees both body and inline com
 
 **This literal phrase is load-bearing, not stylistic.** `check-patch.ts`'s
 `isSelfCleanApprove` matches `Verdict: APPROVE` (case-insensitive, optional `**` markdown
-bold) anywhere in a self-authored review body to recognize a clean self-approve -- this
-matters because GitHub blocks self-APPROVE via the API, so a self-review's clean approval
-is always posted as `event: COMMENT`. Free-form approval prose without the literal phrase
-(e.g. "Clean conversion, no blocking issues.") never matches, and the patch cron then
-treats the review as an unaddressed finding forever. Always lead with the `Verdict: ...`
-label -- don't paraphrase it away.
+bold) anywhere in a review body to recognize a clean APPROVE -- this matters because
+GitHub blocks self-APPROVE via the API, so a self-review's clean approval is always
+posted as `event: COMMENT`. Free-form approval prose without the literal phrase (e.g.
+"Clean conversion, no blocking issues.") never matches, and the patch cron then treats
+the review as an unaddressed finding forever. Always lead with the `Verdict: ...` label
+-- don't paraphrase it away.
 
 ### Tone
 

--- a/plugins/shipwright/scripts/check-deploy.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.test.ts
@@ -236,6 +236,31 @@ describe("check-deploy", () => {
     expect(result.output).toBeTruthy();
   });
 
+  test("exits 0 when clean 'Verdict: APPROVE' review is from a different author than currentUser (identity-agnostic clean-approve fallback)", async () => {
+    const pr = makeGhPr({
+      author: { login: "bodhi-agent" },
+      reviewDecision: null,
+    });
+    const reviews: GhReview[] = [
+      {
+        author: { login: "some-other-agent" },
+        body: "All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows self-approval via the API).",
+        state: "COMMENTED",
+      },
+    ];
+    const result = await run(
+      makeDeps({
+        currentUser: "bodhi-agent",
+        isSelfReviewAllowed: true,
+        prs: { "acme/example-repo": [pr] },
+        reviews: { 50: reviews },
+        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+      }),
+    );
+    expect(result.exit).toBe(0);
+    expect(result.output).toBeTruthy();
+  });
+
   test("exits 1 when self-review has a non-APPROVE verdict label", async () => {
     const pr = makeGhPr({
       author: { login: "bodhi-agent" },

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -100,10 +100,18 @@ function isActiveRun(run: WorkflowRun, now: string): boolean {
   return false;
 }
 
-function hasSelfApproveReview(reviews: GhReview[], userLogin: string): boolean {
-  return reviews.some(
-    (r) => r.author.login === userLogin && isCleanApproveBody(r.body),
-  );
+/**
+ * True when any review on the PR is a clean APPROVE verdict (see
+ * check-helpers.ts's isCleanApproveBody). Not restricted to a specific
+ * author (SRV-1.1): multiple distinct Shipwright agents operate under
+ * different GitHub identities in the same repo, so WHO posted a clean
+ * APPROVE verdict is not meaningful — the verdict text itself is the ground
+ * truth. The separate hard authorship filter in run() independently
+ * guarantees only the current user's own PRs reach the deploy candidate
+ * stage, regardless of who reviewed them.
+ */
+function hasSelfApproveReview(reviews: GhReview[]): boolean {
+  return reviews.some((r) => isCleanApproveBody(r.body));
 }
 
 // ─── Core logic ───────────────────────────────────────────────────────────────
@@ -181,12 +189,9 @@ export async function run(deps: Deps): Promise<RunResult> {
 
         if (pr.reviewDecision === "APPROVED") {
           approved = true;
-        } else if (
-          deps.isSelfReviewAllowed &&
-          pr.author.login === currentUser
-        ) {
+        } else if (deps.isSelfReviewAllowed) {
           const reviews = await deps.fetchPrReviews(org, repoName, pr.number);
-          if (hasSelfApproveReview(reviews, currentUser)) {
+          if (hasSelfApproveReview(reviews)) {
             approved = true;
           }
         }

--- a/plugins/shipwright/scripts/check-patch.test.ts
+++ b/plugins/shipwright/scripts/check-patch.test.ts
@@ -687,6 +687,37 @@ describe("check-patch", () => {
     expect(result.output).toBe("");
   });
 
+  test("exits 1 when only review is a clean 'Verdict: APPROVE' from a different author than currentUser (identity-agnostic clean-approve)", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "some-other-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Reviewed the diff for correctness and style. Everything checks out, no issues found.\n\nVerdict: APPROVE",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await run(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: () => "the-agent",
+      }),
+    );
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
   test("exits 0 when self-authored review coexists with a different reviewer's CHANGES_REQUESTED finding", async () => {
     const pr = makeOwnPr();
     const reviewData = makePrReviewData({

--- a/plugins/shipwright/scripts/check-patch.ts
+++ b/plugins/shipwright/scripts/check-patch.ts
@@ -124,24 +124,23 @@ export function hasFailingCi(
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
 
 /**
- * True when a review is self-authored and is a clean APPROVE verdict (see
- * check-helpers.ts's isCleanApproveBody — leading `APPROVE` or a "Verdict:
- * APPROVE" label anywhere in the body, the agent's narrative self-review
- * convention, which ends a summary with the verdict rather than leading with
- * it — CPF-2.1).
+ * True when a review is a clean APPROVE verdict (see check-helpers.ts's
+ * isCleanApproveBody — leading `APPROVE` or a "Verdict: APPROVE" label
+ * anywhere in the body, the agent's narrative self-review convention, which
+ * ends a summary with the verdict rather than leading with it — CPF-2.1).
  *
- * GitHub blocks self-APPROVE via the API, so the agent's own clean approvals
- * are always posted as COMMENTED — treating those as findings would create a
- * permanent false positive. A self-review with a real (non-APPROVE) verdict
- * (e.g. "Verdict: CHANGES_REQUESTED") is not matched here, so it still counts
- * as a finding.
+ * Not restricted to self-authored reviews (SRV-1.1): multiple distinct
+ * Shipwright agents operate under different GitHub identities in the same
+ * repo, so WHO posted a clean APPROVE verdict is not meaningful — the
+ * verdict text itself is the ground truth. GitHub blocks self-APPROVE via
+ * the API, so an agent's own clean approvals are always posted as COMMENTED
+ * — treating those as findings would create a permanent false positive. A
+ * review with a real (non-APPROVE) verdict (e.g. "Verdict: CHANGES_REQUESTED")
+ * is not matched here, so it still counts as a finding.
  */
 function isSelfCleanApprove(
-  review: Pick<PrReviewData["reviews"]["nodes"][number], "author" | "body">,
-  currentUser: string,
+  review: Pick<PrReviewData["reviews"]["nodes"][number], "body">,
 ): boolean {
-  if (review.author.login !== currentUser) return false;
-
   return isCleanApproveBody(review.body);
 }
 
@@ -150,23 +149,20 @@ function isSelfCleanApprove(
  * - At least one COMMENTED or CHANGES_REQUESTED review posted at the current HEAD
  * - AND (has a non-empty review body OR has at least one unresolved inline thread)
  *
- * A self-authored review is excluded only when it is a clean APPROVE verdict
- * (see isSelfCleanApprove) — a self-review with a real (non-APPROVE) verdict
- * still counts as an unaddressed finding, same as any other reviewer's.
+ * A review is excluded only when it is a clean APPROVE verdict (see
+ * isSelfCleanApprove) — a review with a real (non-APPROVE) verdict still
+ * counts as an unaddressed finding, regardless of who posted it.
  */
-function hasUnaddressedFindings(
-  data: PrReviewData,
-  currentUser: string,
-): boolean {
+function hasUnaddressedFindings(data: PrReviewData): boolean {
   const { headRefOid, reviews, reviewThreads } = data;
 
   // Find qualifying reviews: state COMMENTED or CHANGES_REQUESTED at current HEAD,
-  // excluding self-authored clean-APPROVE reviews.
+  // excluding clean-APPROVE reviews.
   const qualifyingReviews = reviews.nodes.filter(
     (r) =>
       (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
       r.commit.oid === headRefOid &&
-      !isSelfCleanApprove(r, currentUser),
+      !isSelfCleanApprove(r),
   );
 
   if (qualifyingReviews.length === 0) return false;
@@ -188,16 +184,15 @@ function hasUnaddressedFindings(
  * merge-only skip: a branch updated only via merge-from-main hasn't had real
  * author activity, so findings from the pre-merge review are still valid.
  *
- * A self-authored review is excluded only when it is a clean APPROVE verdict
- * (see isSelfCleanApprove) — a self-review with a real (non-APPROVE) verdict
- * still counts as a stale finding.
+ * A review is excluded only when it is a clean APPROVE verdict (see
+ * isSelfCleanApprove) — a review with a real (non-APPROVE) verdict still
+ * counts as a stale finding, regardless of who posted it.
  */
 async function hasMergeOnlyStaleFindings(
   prNumber: number,
   data: PrReviewData,
   deps: Pick<Deps, "listPrCommits">,
   repo: string | undefined,
-  currentUser: string,
 ): Promise<boolean> {
   const { headRefOid, reviews, reviewThreads } = data;
 
@@ -205,7 +200,7 @@ async function hasMergeOnlyStaleFindings(
     (r) =>
       (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
       r.commit.oid !== headRefOid &&
-      !isSelfCleanApprove(r, currentUser),
+      !isSelfCleanApprove(r),
   );
 
   if (staleReviews.length === 0) return false;
@@ -234,8 +229,6 @@ interface RunResult {
 }
 
 export async function run(deps: Deps): Promise<RunResult> {
-  const currentUser = await deps.getCurrentUser();
-
   const prs = await deps.listOwnOpenPrs("default");
   if (prs.length === 0) return { exit: 1, output: "" };
 
@@ -256,7 +249,7 @@ export async function run(deps: Deps): Promise<RunResult> {
     }
 
     const reviewData = await deps.fetchPrReviews(org, repo, pr.number);
-    if (hasUnaddressedFindings(reviewData, currentUser)) {
+    if (hasUnaddressedFindings(reviewData)) {
       return {
         exit: 0,
         output:
@@ -267,13 +260,7 @@ export async function run(deps: Deps): Promise<RunResult> {
     // If findings exist at a stale commit but all new commits are merges, the
     // findings are still valid — only a merge-from-main landed, not real author work.
     if (
-      await hasMergeOnlyStaleFindings(
-        pr.number,
-        reviewData,
-        deps,
-        pr.repo,
-        currentUser,
-      )
+      await hasMergeOnlyStaleFindings(pr.number, reviewData, deps, pr.repo)
     ) {
       return {
         exit: 0,


### PR DESCRIPTION
## Summary
- Drops the author-identity check from clean-APPROVE detection in `check-patch.ts` (`isSelfCleanApprove`) and `check-deploy.ts` (`hasSelfApproveReview`) — any review with a clean `Verdict: APPROVE` body now counts, regardless of who posted it, since multiple distinct Shipwright agents operate in this repo under different GitHub identities and the verdict text itself is the ground truth.
- Removes the now-redundant `pr.author.login === currentUser` gate in `check-deploy.ts`'s self-review fallback branch — the separate hard authorship filter a few lines below already independently guarantees only the agent's own PRs reach the deploy candidate stage.
- Refreshes `deploy.md` and `post-review-guide.md` to match (removes the `select(.author.login == ...)` jq filter from the two clean-APPROVE checks; leaves the Own-PRs-Only Check / hard authorship filter untouched).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | check-patch.ts: isSelfCleanApprove drops currentUser param, call sites updated | MET | `isSelfCleanApprove(review)` now checks only `isCleanApproveBody(review.body)`; both call sites updated; dead `deps.getCurrentUser()` local removed from `run()` |
| 2 | check-deploy.ts: hasSelfApproveReview drops userLogin param + redundant author gate removed | MET | `hasSelfApproveReview(reviews)` now `reviews.some(r => isCleanApproveBody(r.body))`; redundant PR-author gate dropped from the self-review fallback branch |
| 3 | review.md + hard authorship filter untouched | MET | Diff touches only check-patch/check-deploy (+tests) and docs; the hard authorship filter (`if (pr.author.login !== currentUser) continue;`) is unchanged |
| 4 | Test decision: flip/add cross-author clean-approve cases in both test files | MET | New test in each file covers a clean APPROVE from a different author than currentUser; no existing tests deleted |

## Test Plan
- `bun test` (plugin-scoped): 748 pass, 0 fail
- New unit tests: cross-author clean-APPROVE now non-blocking (check-patch) / valid deploy-approval fallback (check-deploy)
- `bunx biome lint .` — clean
- `bunx tsc --noEmit` (all workspaces) — clean
- Full monorepo `bun test`: 15 pre-existing failures unrelated to this diff (agent Kubernetes-client/plugin-install + chat-token-reporter tests) — confirmed pre-existing
- Aggregate coverage gate (80/80): fails at 79.28% lines, dragged down by task-store integration tests skipped in-sandbox (no test DB) — pre-existing sandbox gap, unrelated to this diff
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
