### PR TITLE
feat: add error-patrol-maintenance system cron (disabled) + precheck

### DIFF
--- a/admin/src/system-crons.ts
+++ b/admin/src/system-crons.ts
@@ -103,4 +103,13 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
     silent: true,
     enabled: false,
   },
+  {
+    name: "error-patrol-maintenance",
+    schedule: "0 4 * * *",
+    prompt:
+      '/shipwright:error-scan\n/shipwright:error-fix\n/shipwright:error-resolve\nAfter the chain completes, write state/error-patrol-ledger.json\'s lastRun field: "<ISO timestamp>". Use [silent] if no new or regressed issues are found.',
+    silent: true,
+    preCheck: "shipwright:check-error-patrol.ts",
+    enabled: false,
+  },
 ] as const;

--- a/admin/src/system-crons.unit.test.ts
+++ b/admin/src/system-crons.unit.test.ts
@@ -88,6 +88,7 @@ describe("SYSTEM_CRONS pipeline schedule staggering", () => {
       "learn-dream": "0 3 * * *",
       "dependabot-triage": "0 8 * * *",
       "entropy-patrol-maintenance": "0 4 * * 1",
+      "error-patrol-maintenance": "0 4 * * *",
     };
     for (const [name, schedule] of Object.entries(expected)) {
       const cron = SYSTEM_CRONS.find((c) => c.name === name);
@@ -97,11 +98,11 @@ describe("SYSTEM_CRONS pipeline schedule staggering", () => {
 });
 
 describe("SYSTEM_CRONS", () => {
-  test("exports exactly eleven crons", () => {
-    expect(SYSTEM_CRONS).toHaveLength(11);
+  test("exports exactly twelve crons", () => {
+    expect(SYSTEM_CRONS).toHaveLength(12);
   });
 
-  test("cron names are the eleven expected crons", () => {
+  test("cron names are the twelve expected crons", () => {
     const names = SYSTEM_CRONS.map((c) => c.name);
     expect(names).toContain("shipwright-dev-task");
     expect(names).toContain("shipwright-patch");
@@ -113,6 +114,7 @@ describe("SYSTEM_CRONS", () => {
     expect(names).toContain("learn-dream");
     expect(names).toContain("dependabot-triage");
     expect(names).toContain("entropy-patrol-maintenance");
+    expect(names).toContain("error-patrol-maintenance");
     expect(names).toContain("shipwright-loop");
   });
 
@@ -267,6 +269,7 @@ describe("SYSTEM_CRONS", () => {
         c.name !== "learn-dream" &&
         c.name !== "dependabot-triage" &&
         c.name !== "entropy-patrol-maintenance" &&
+        c.name !== "error-patrol-maintenance" &&
         c.name !== "shipwright-loop",
     );
     for (const cron of pollingCrons) {
@@ -342,6 +345,52 @@ describe("SYSTEM_CRONS", () => {
     expect(cron?.prompt).toContain("/shipwright:entropy-fix");
     expect(cron?.prompt).not.toContain("entropy-patrol:");
     expect(cron?.prompt).toContain("entropy-patrol-last-run.json");
+  });
+
+  test("error-patrol-maintenance cron has schedule 0 4 * * *", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(cron?.schedule).toBe("0 4 * * *");
+  });
+
+  test("error-patrol-maintenance cron has enabled: false", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(cron?.enabled).toBe(false);
+  });
+
+  test("error-patrol-maintenance cron has correct preCheck", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(cron?.preCheck).toBe("shipwright:check-error-patrol.ts");
+  });
+
+  test("error-patrol-maintenance prompt chains /shipwright:error-scan, /shipwright:error-fix, and /shipwright:error-resolve", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(cron?.prompt).toContain("/shipwright:error-scan");
+    expect(cron?.prompt).toContain("/shipwright:error-fix");
+    expect(cron?.prompt).toContain("/shipwright:error-resolve");
+  });
+
+  test("error-patrol-maintenance prompt writes error-patrol-ledger.json's lastRun field, not a separate last-run file", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(cron?.prompt).toContain("error-patrol-ledger.json");
+    expect(cron?.prompt).toContain("lastRun");
+    expect(cron?.prompt).not.toContain("error-patrol-last-run.json");
+  });
+
+  test("error-patrol-maintenance prompt uses [silent] when nothing new was found", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(cron?.prompt).toContain("[silent]");
   });
 
   // ── No old plugin-prefix refs anywhere in prompts ──────────────────────────

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -122,7 +122,7 @@ All child models cascade-delete with their `Agent` (including `AgentCronRun` via
 
 ## Default system crons
 
-Every new agent is seeded with eleven system crons (the canonical definitions live in [`admin/src/system-crons.ts`](../admin/src/system-crons.ts) and are reconciled onto each agent at startup via `POST /agents/:id/crons/reconcile`). Two are **enabled by default**; the rest are opt-in (toggle in the admin UI or via `PATCH /agents/:id/crons/:cronId`). All run `silent` (they post to Slack only on a result worth surfacing, or on error), and most carry a `preCheck` script whose stdout becomes the actual prompt — so a cron only spends a Claude turn when there is real work ready.
+Every new agent is seeded with twelve system crons (the canonical definitions live in [`admin/src/system-crons.ts`](../admin/src/system-crons.ts) and are reconciled onto each agent at startup via `POST /agents/:id/crons/reconcile`). Two are **enabled by default**; the rest are opt-in (toggle in the admin UI or via `PATCH /agents/:id/crons/:cronId`). All run `silent` (they post to Slack only on a result worth surfacing, or on error), and most carry a `preCheck` script whose stdout becomes the actual prompt — so a cron only spends a Claude turn when there is real work ready.
 
 | Cron | Schedule (cron expr) | Default | What it does |
 |---|---|---|---|
@@ -137,6 +137,7 @@ Every new agent is seeded with eleven system crons (the canonical definitions li
 | `learn-dream` | `0 3 * * *` (daily, 03:00) | off | Mines the last day of merged PRs for durable learnings. |
 | `dependabot-triage` | `0 8 * * *` (daily, 08:00) | off | Reviews and triages open Dependabot PRs. |
 | `entropy-patrol-maintenance` | `0 4 * * 1` (weekly, Mon 04:00) | off | Scans for code entropy and fixes what's PR-worthy. |
+| `error-patrol-maintenance` | `0 4 * * *` (daily, 04:00) | off | Scans for unresolved Sentry errors and fixes what's PR-worthy. |
 
 ## Environment
 

--- a/plugins/shipwright/scripts/check-error-patrol.ts
+++ b/plugins/shipwright/scripts/check-error-patrol.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bun
+/**
+ * plugins/shipwright/scripts/check-error-patrol.ts
+ *
+ * Pre-check for the error-patrol-maintenance cron.
+ *
+ * Reads state/error-patrol-ledger.json for the previously-seen issue set,
+ * fetches currently-unresolved Sentry issues, and diffs them against the
+ * ledger using the same new/regressed classification error-scan's SKILL.md
+ * documents (Step 5):
+ *   - New: no ledger entry exists for the issue id.
+ *   - Regressed: an entry exists and either (a) its recorded status was
+ *     resolved/ignored (now unresolved again), or (b) its recorded count
+ *     is lower than the current count (kept firing since last run).
+ *
+ * - If the Sentry fetch fails/creds are missing → exit 0 (permissive; can't
+ *   rule out work exists).
+ * - If zero unresolved issues are new/regressed (including zero unresolved
+ *   issues at all) → exit 1 (nothing to do).
+ * - Otherwise → exit 0 with a short summary as stdout.
+ *
+ * Never logs or persists SENTRY_AUTH_TOKEN.
+ *
+ * Usage:
+ *   bun plugins/shipwright/scripts/check-error-patrol.ts
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface LedgerIssue {
+  status: string;
+  count: number;
+  lastSeen: string;
+}
+
+interface Ledger {
+  lastRun: string | null;
+  issues: Record<string, LedgerIssue>;
+}
+
+interface SentryIssue {
+  id: string;
+  count: number;
+  status: string;
+}
+
+interface Deps {
+  readLedger: () => Ledger | null;
+  fetchUnresolvedIssues: () => Promise<SentryIssue[] | null>;
+}
+
+interface RunResult {
+  exit: 0 | 1;
+  output: string;
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * True if a currently-unresolved Sentry issue is new or regressed relative
+ * to the ledger's last-recorded state for that issue id. Mirrors error-scan
+ * SKILL.md's Step 5 classification.
+ */
+function isNewOrRegressed(
+  issue: SentryIssue,
+  ledgerIssues: Record<string, LedgerIssue>,
+): boolean {
+  const ledgerEntry = ledgerIssues[issue.id];
+  if (!ledgerEntry) return true; // New
+  if (ledgerEntry.status === "resolved" || ledgerEntry.status === "ignored")
+    return true; // Regressed — status flip
+  if (issue.count > ledgerEntry.count) return true; // Regressed — count growth
+  return false; // Unchanged
+}
+
+export async function run(deps: Deps): Promise<RunResult> {
+  const ledger = deps.readLedger();
+  const ledgerIssues = ledger?.issues ?? {};
+
+  const unresolvedIssues = await deps.fetchUnresolvedIssues();
+
+  // Fetch failure (network error, missing creds, non-2xx) — unknown state,
+  // exit permissively per the precheck contract's "err permissive" rule.
+  if (unresolvedIssues === null) {
+    return {
+      exit: 0,
+      output:
+        "Sentry fetch failed or credentials missing — running permissively.",
+    };
+  }
+
+  const newOrRegressedCount = unresolvedIssues.filter((issue) =>
+    isNewOrRegressed(issue, ledgerIssues),
+  ).length;
+
+  if (newOrRegressedCount === 0) {
+    return { exit: 1, output: "" };
+  }
+
+  return {
+    exit: 0,
+    output: `${newOrRegressedCount} new/regressed Sentry issue(s) since last run — running error-patrol check.`,
+  };
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+function buildProductionDeps(): Deps {
+  const cwd = process.cwd();
+
+  return {
+    readLedger: (): Ledger | null => {
+      const ledgerPath = join(cwd, "state", "error-patrol-ledger.json");
+      if (!existsSync(ledgerPath)) return null;
+      try {
+        return JSON.parse(readFileSync(ledgerPath, "utf-8")) as Ledger;
+      } catch {
+        return null;
+      }
+    },
+
+    fetchUnresolvedIssues: async (): Promise<SentryIssue[] | null> => {
+      const sentryOrg = (process.env.SENTRY_ORG ?? "").trim();
+      const sentryAuthToken = (process.env.SENTRY_AUTH_TOKEN ?? "").trim();
+      if (!sentryOrg || !sentryAuthToken) return null;
+
+      try {
+        const res = await fetch(
+          `https://sentry.io/api/0/organizations/${sentryOrg}/issues/?query=is:unresolved`,
+          { headers: { Authorization: `Bearer ${sentryAuthToken}` } },
+        );
+        if (!res.ok) return null;
+        const data = (await res.json()) as unknown;
+        if (!Array.isArray(data)) return null;
+        return data.map((item) => {
+          const record = item as Record<string, unknown>;
+          return {
+            id: String(record.id ?? ""),
+            count: Number(record.count ?? 0),
+            status: String(record.status ?? ""),
+          };
+        });
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const deps = buildProductionDeps();
+  const result = await run(deps);
+  if (result.exit === 0) {
+    process.stdout.write(`${result.output}\n`);
+  }
+  process.exit(result.exit);
+}
+
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/plugins/shipwright/scripts/check-error-patrol.unit.test.ts
+++ b/plugins/shipwright/scripts/check-error-patrol.unit.test.ts
@@ -1,0 +1,256 @@
+/**
+ * plugins/shipwright/scripts/check-error-patrol.unit.test.ts
+ *
+ * Unit tests for check-error-patrol.ts
+ *
+ * Design: the script exports a `run(deps)` function that accepts injected
+ * dependencies. Tests inject stub implementations — no file I/O or network
+ * calls are executed. No mock.module()/global.fetch overrides per the
+ * repo's test isolation rule.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { run } from "./check-error-patrol.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface LedgerIssue {
+  status: string;
+  count: number;
+  lastSeen: string;
+}
+
+interface Ledger {
+  lastRun: string | null;
+  issues: Record<string, LedgerIssue>;
+}
+
+interface SentryIssue {
+  id: string;
+  count: number;
+  status: string;
+}
+
+function makeDeps(overrides: {
+  readLedger?: () => Ledger | null;
+  fetchUnresolvedIssues?: () => Promise<SentryIssue[] | null>;
+}) {
+  return {
+    readLedger: overrides.readLedger ?? (() => ({ lastRun: null, issues: {} })),
+    fetchUnresolvedIssues: overrides.fetchUnresolvedIssues ?? (async () => []),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("check-error-patrol", () => {
+  test("exits 1 when Sentry returns zero unresolved issues (empty ledger)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({ lastRun: null, issues: {} }),
+      fetchUnresolvedIssues: async () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when Sentry returns zero unresolved issues (non-empty ledger)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "unresolved",
+            count: 5,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when all unresolved issues are unchanged from the ledger", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "unresolved",
+            count: 5,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+          "issue-2": {
+            status: "unresolved",
+            count: 10,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 5, status: "unresolved" },
+        { id: "issue-2", count: 10, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when unresolved issue count is lower than ledger's recorded count", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "unresolved",
+            count: 20,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 5, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when an unresolved issue has no ledger entry at all (new)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {},
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-new", count: 3, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+    expect(result.output).toContain("1");
+  });
+
+  test("exits 0 when a ledger entry's status was resolved but the issue is unresolved now (regressed by status flip)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "resolved",
+            count: 5,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 5, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 when a ledger entry's status was ignored but the issue is unresolved now (regressed by status flip)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "ignored",
+            count: 5,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 5, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 when a ledger entry's count grew (regressed by count growth)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "unresolved",
+            count: 5,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 12, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 with a summary mentioning the count of new/regressed issues", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        issues: {
+          "issue-1": {
+            status: "unresolved",
+            count: 5,
+            lastSeen: "2026-07-01T00:00:00.000Z",
+          },
+        },
+      }),
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 12, status: "unresolved" }, // regressed
+        { id: "issue-2", count: 1, status: "unresolved" }, // new
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("2");
+  });
+
+  test("exits 0 permissively when fetchUnresolvedIssues returns null (Sentry unreachable / creds missing)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({ lastRun: null, issues: {} }),
+      fetchUnresolvedIssues: async () => null,
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 permissively when the ledger is missing/unreadable and there are unresolved issues (all new)", async () => {
+    const deps = makeDeps({
+      readLedger: () => null,
+      fetchUnresolvedIssues: async () => [
+        { id: "issue-1", count: 5, status: "unresolved" },
+      ],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 1 when the ledger is missing/unreadable and there are zero unresolved issues", async () => {
+    const deps = makeDeps({
+      readLedger: () => null,
+      fetchUnresolvedIssues: async () => [],
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the `error-patrol-maintenance` system cron (disabled per the plugin constitution), chaining `/shipwright:error-scan → /shipwright:error-fix → /shipwright:error-resolve` on a daily schedule
- Adds `check-error-patrol.ts`, a precheck script mirroring `check-learn-dream.ts`'s shape: a cheap Sentry API call that exits 1 fast when no issue is new/regressed since the ledger's `lastRun`, exits 0 otherwise
- Refreshes `docs/agent.md`'s system-cron table/count (11 → 12) to document the new cron

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New SYSTEM_CRONS entry added with enabled: false | MET |
| 2 | check-error-patrol.ts exits 1 fast when Sentry has no new/regressed issues since the ledger's lastRun, exits 0 otherwise | MET |
| 3 | check-error-patrol.unit.test.ts covers exit-0 and exit-1 paths via an injected fetch double, mirroring check-learn-dream.test.ts's structure; no mock.module()/global.fetch override | MET |

## Test Plan
- `bun test admin/src/system-crons.unit.test.ts plugins/shipwright/scripts/check-error-patrol.unit.test.ts` — 67 pass, 0 fail
- Typecheck clean for `@shipwright/admin` and `@shipwright/plugin`
- Lint clean (`bunx biome lint .`)
- `task check-strings` — no banned strings found
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
