### PR TITLE
docs: document error-patrol Sentry read-side integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,6 +186,8 @@ Each of `admin`, `metrics`, `task-store`, and `agent` reads its own `SENTRY_DSN`
 
 `SENTRY_DSN` / `SENTRY_ENVIRONMENT` are documented per-service rather than repeated here: see the `SENTRY_DSN` row under [Agent Config → Server](#server) for the agent — including the pod-startup timing constraint, since `initSentry` runs once at module load, before the config-sync loop — and the `SENTRY_DSN` row under [Agent Config → Metrics & Admin & Chat & Task-Store services](#metrics--admin--chat--task-store-services) for `task-store`, `metrics`, and `admin`.
 
+This is the write side (services reporting into Sentry). For the read side — the `SENTRY_ORG` / `SENTRY_AUTH_TOKEN` credentials (documented above under [Plugin Config](#plugin-config)) and how the `error-scan`, `error-fix`, and `error-resolve` skills query the Sentry Issues API — see [Read side](./observability.md#read-side) in `docs/observability.md`.
+
 ---
 
 ## Policy Config

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,6 +2,8 @@
 
 > Optional Sentry error/log reporting, wired identically across the admin, metrics, task-store, and agent services via the shared `lib/sentry.ts` helper.
 
+Everything below this line through [Configuration reference](#configuration-reference) covers the **write side**: services reporting their own errors/logs into Sentry via the SDK. See [Read side](#read-side) for the error-patrol skills, which query the Sentry Issues API in the opposite direction — pulling issues *out* of Sentry to drive automated fixes.
+
 ## Overview
 
 Every Shipwright service (`admin`, `metrics`, `task-store`, `agent`) can report to Sentry when `SENTRY_DSN` is set in its own environment. Each service reads its own `SENTRY_DSN` — there is no shared/global toggle. When `SENTRY_DSN` is unset (the default), or when `NODE_ENV` is `"test"` (auto-set by `bun test`), Sentry is fully inert: no init call, zero telemetry, zero overhead. The test guard prevents test error-path assertions from leaking to production Sentry as real events.
@@ -31,11 +33,36 @@ Unset `SENTRY_DSN` (or never set it) for the service in question. This is the de
 
 `SENTRY_DSN` works with a self-hosted Sentry instance the same way it works with Sentry's SaaS offering — point it at your own instance/project's DSN instead of a sentry.io one. No other configuration changes are needed.
 
+## Read side
+
+Where the sections above cover services *reporting* their own errors into Sentry (the write side), the **error-patrol** subsystem reads *out* of Sentry's Issues API to drive automated triage, fixing, and resolution. It's a separate credential pair — `SENTRY_ORG` / `SENTRY_AUTH_TOKEN` — from the write-side `SENTRY_DSN`, and the two are independent: a service can report to Sentry without error-patrol configured, and vice versa.
+
+### Credentials
+
+| Var | Purpose |
+|---|---|
+| `SENTRY_ORG` | Sentry organization slug (e.g. `acme-corp`), used to build every Issues API URL (`/api/0/organizations/{org}/...`). |
+| `SENTRY_AUTH_TOKEN` | Bearer token sent as `Authorization: Bearer $SENTRY_AUTH_TOKEN` on every read-side request. Needs `event:read` scope for the GET endpoints below, and `event:write` scope for error-resolve's mutating PUT. |
+
+Both are env-var-only secrets — see the [Plugin Config](./configuration.md#plugin-config) table in `docs/configuration.md` for the full reference row. Unlike the write-side `SENTRY_DSN` (per-service, optional, silently inert when unset), these two gate whether the read-side skills run at all: each skill checks for both at its first step and exits early (without writing files or mutating the ledger) if either is missing.
+
+### Skills and scripts
+
+Four surfaces read from Sentry, each with a distinct role in the error-patrol pipeline:
+
+- **`error-scan`** (`plugins/shipwright/skills/error-scan/SKILL.md`) — enumerates Sentry projects (`GET /organizations/{org}/projects/`) and unresolved issues (`GET /organizations/{org}/issues/?query=is:unresolved`), tags each issue with its owning service (`GET /organizations/{org}/{project_slug}/tags/service/values/`, falling back to the per-issue tag endpoint), diffs against the local ledger to find new/regressed issues, and writes a report. Makes no code changes.
+- **`error-fix`** (`plugins/shipwright/skills/error-fix/SKILL.md`) — for each issue surfaced by error-scan, fetches full issue detail (`GET /organizations/{org}/issues/{issue_id}/`) and the latest event's stack trace (`GET /organizations/{org}/issues/{issue_id}/events/latest/`) to drive root-cause analysis, then queues task-store tasks. Opens no PRs itself.
+- **`error-resolve`** (`plugins/shipwright/skills/error-resolve/SKILL.md`) — polls the task store for each gating task's status and, only once a task reaches `deployed` or `done`, marks the corresponding Sentry issue resolved (`PUT /organizations/{org}/issues/{issue_id}/` with `{"status": "resolved"}`). This is the only read-side surface that mutates Sentry state.
+- **`check-error-patrol.ts`** (`plugins/shipwright/scripts/check-error-patrol.ts`) — the precheck for the `error-patrol-maintenance` cron. Fetches unresolved issues (`GET /organizations/{org}/issues/?query=is:unresolved`) and compares against the ledger to decide whether the cron has new/regressed work to do. Unlike the three skills above, a missing credential or failed fetch here exits permissively (runs the cron anyway) rather than skipping — an unknown state favors running the check over silently going quiet.
+
+All four share the same ledger at `state/error-patrol-ledger.json` and the same Bearer-token auth pattern; none of them ever log `$SENTRY_AUTH_TOKEN`.
+
 ## Configuration reference
 
-See the `SENTRY_DSN` / `SENTRY_ENVIRONMENT` rows under [Observability](./configuration.md#observability) in `docs/configuration.md` for the full per-service env var reference.
+See the `SENTRY_DSN` / `SENTRY_ENVIRONMENT` rows under [Observability](./configuration.md#observability) in `docs/configuration.md` for the full per-service env var reference, and the `SENTRY_ORG` / `SENTRY_AUTH_TOKEN` rows under [Plugin Config](./configuration.md#plugin-config) for the read-side credentials.
 
 ## See also
 
 - [`docs/configuration.md`](./configuration.md) — full env var reference
 - [`lib/sentry.ts`](../lib/sentry.ts) — shared init options, scrub hooks, and secret allowlist
+- [`plugins/shipwright/skills/error-scan/SKILL.md`](../plugins/shipwright/skills/error-scan/SKILL.md), [`error-fix/SKILL.md`](../plugins/shipwright/skills/error-fix/SKILL.md), [`error-resolve/SKILL.md`](../plugins/shipwright/skills/error-resolve/SKILL.md) — the read-side skills


### PR DESCRIPTION
## Summary
- Adds a "Read side" section to `docs/observability.md` documenting `SENTRY_AUTH_TOKEN`/`SENTRY_ORG` and how the `error-scan`, `error-fix`, and `error-resolve` skills (plus the `check-error-patrol.ts` cron precheck) use the Sentry Issues API — alongside the existing write-side (SDK error reporting) docs.
- Cross-references the new section from `docs/configuration.md`'s Observability section.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New section in docs/observability.md covers SENTRY_AUTH_TOKEN/SENTRY_ORG and each of the three skills' read/write Sentry API usage | MET |
| 2 | docs/configuration.md's Observability section cross-references the new section | MET |
| 3 | Test decision: docs-only change, no tests needed -- no logic introduced | MET |

## Test Plan
- `bun scripts/check-config-docs.ts` — passes (31/31 env vars documented)
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — passes
- Docs-only change; no logic introduced, no tests required per task's own test decision.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
