### PR TITLE
fix: run monorepo typecheck sequentially to avoid OOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ task test         # bun test            (single file: bun test path/to/file.test
 task test:coverage  # bun test --coverage --coverage-reporter=lcov, then gate on aggregate 80/80 lines/functions (scripts/check-coverage.ts)
 task lint         # bunx biome lint .
 task format       # bunx biome format --write .
-task typecheck    # bun run --filter='*' typecheck
+task typecheck    # bun run --filter='*' --sequential typecheck
 task check-strings  # scan entire repo for banned/confidential identifiers (client names, internal infra IDs)
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
   typecheck:
     desc: Type-check all packages
     cmds:
-      - bun run --filter="*" typecheck
+      - bun run --filter="*" --sequential typecheck
 
   test:
     desc: Run all tests

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -98,7 +98,7 @@ The agent is a thin runner with a Prisma-backed PostgreSQL database and a Hono H
 └────┬────┘
      │
 ┌────▼──────┐
-│ Typecheck │  bun run --filter="*" typecheck
+│ Typecheck │  bun run --filter="*" --sequential typecheck
 └────┬──────┘
      │
      ├──────────────┬──────────────┐

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "bun test",
     "lint": "bunx biome lint .",
     "format": "bunx biome format --write .",
-    "typecheck": "bun run --filter='*' typecheck",
+    "typecheck": "bun run --filter='*' --sequential typecheck",
     "generate:admin-spec": "bun run scripts/generate-admin-spec.ts",
     "generate:admin-types": "bunx openapi-typescript ./admin/openapi.json --output ./lib/admin-types.ts",
     "generate:task-store-spec": "bun run scripts/generate-task-store-spec.ts",


### PR DESCRIPTION
## Summary
- `bun run --filter='*' typecheck` fans out `tsc --noEmit` across all 7 TS workspace packages concurrently. As the monorepo has grown (task-store, chat, admin, agent), that concurrent fan-out has been pushing dev-task/CI sessions past the container's 8GB memory ceiling.
- Confirmed cause of the dev-task cron's "unknown" outcome status tonight: the agent process was getting killed mid-run with no error reported (not a graceful failure — the whole session just dies), leaving `AgentCronRun.outcome` null.
- Switches `task typecheck` (both `package.json` and `Taskfile.yml`) to `bun run --filter='*' --sequential typecheck`, trading wall-clock time for a bounded, predictable memory footprint. Also updates the two docs references to the old command.

## Test plan
- [x] `bun run --filter='*' --sequential typecheck` — all 7 packages pass, ~1m23s total (vs. instant-but-OOM-risk parallel fan-out)
- [x] `bunx biome lint .` — clean, no fixes needed
- [x] Verified `--sequential` flag syntax against a real bun run (2-package subset) before applying to the full command

🤖 Generated with [Claude Code](https://claude.com/claude-code)