### PR TITLE
fix: deploy scan mode skips bundle-blocked candidates and falls back to next ready PR

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -57,6 +57,7 @@ Manual test scenarios for each command across different project types.
 | 40 | `/dev-task` Step 8.5 | Any | Unparseable agent result is recorded, not silent | Agent returns no/garbled `AUTO_DOCS_METRICS` block; `⚠ ... agent_error` printed; metrics record has `skipped_reason:"agent_error"`, `updated:false`; pipeline continues |
 | 41 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (hosted store configured) | Plan viz render after markdown write | `PLAN.md`/`PRODUCT-SPEC.md` written unchanged, then `render-plan.ts` runs and a `Plan viz: {url}` line is surfaced in the confirmation block |
 | 42 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (hosted store unset) | Plan viz graceful skip | `⏭ Plan viz skipped — SHIPWRIGHT_TASK_STORE_URL/TOKEN unset.` printed; markdown still written; no `Plan viz:` line; command never blocks |
+| 43 | `/deploy` | Any | Scan mode — bundle-blocked candidate falls back to next ready PR | Bundle-incomplete PR excluded from `CANDIDATE_LIST` in Step 1a; if a candidate is bundle-blocked at Step 2b, scan mode logs the skip and retries the next candidate instead of stopping; explicit-target mode still stops on bundle-block |
 
 ---
 

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -48,7 +48,7 @@ REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
 For each configured repo, fetch all open PRs authored by `AGENT_LOGIN`:
 ```bash
 gh pr list --state open --repo {org}/{repo} --author "$AGENT_LOGIN" \
-  --json number,headRefOid,author,reviewDecision
+  --json number,headRefOid,headRefName,author,reviewDecision
 ```
 
 For each PR, check in order:
@@ -76,12 +76,22 @@ For each PR, check in order:
    ```
    Skip if no CI run has `status == "completed"` and `conclusion == "success"`.
 
+3. **Bundle completeness** — a PR's branch may have sibling tasks (bundle-mates) still in
+   flight. Skip PRs whose bundle isn't complete yet rather than picking a doomed candidate.
+   Mirrors `check-deploy.ts`'s `isBundleComplete` gate exactly:
+   ```bash
+   BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={headRefName}" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
+   INCOMPLETE=$(echo "$BRANCH_TASKS" | jq '[.tasks[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked")] | length')
+   ```
+   Skip if `INCOMPLETE > 0`.
+
 Keep the ordered list of qualifying PRs as `CANDIDATE_LIST`. Pick the **first** entry
 as the primary candidate. If none qualify, respond `[silent]` and stop — no output.
 
 Once a qualifying PR is found, proceed to Step 2 with that PR number and repo as the target.
-If Step 4a's pre-merge claim later hits a 409 conflict, control returns here to retry with
-the next untried entry in `CANDIDATE_LIST`.
+If Step 2b's bundle re-check or Step 4a's pre-merge claim later finds the candidate blocked
+(a bundle-mate went in flight, or another deploy run already claimed it), control returns
+here to retry with the next untried entry in `CANDIDATE_LIST`.
 
 ---
 
@@ -132,6 +142,12 @@ Before running pre-flight checks, verify that all tasks on this branch are `pr_o
 beyond (i.e., no bundle-mates are still in flight). This prevents deploying a PR while
 sibling tasks on the same branch are still being developed or are blocked.
 
+Scan mode already excluded bundle-incomplete PRs from `CANDIDATE_LIST` in Step 1a. This
+re-check is defense-in-depth for the case where a bundle-mate task transitioned to
+pending/in_progress/blocked in the time between Step 1a's scan and Step 2's arrival at this
+specific candidate — it also covers explicit-target mode, which skips Step 1a entirely and
+arrives here directly.
+
 ```bash
 HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
 BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch=$HEAD_BRANCH" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
@@ -139,14 +155,22 @@ INCOMPLETE_TASKS=$(echo "$BRANCH_TASKS" | jq '[.tasks[] | select(.status == "pen
 INCOMPLETE=$(echo "$INCOMPLETE_TASKS" | jq 'length')
 ```
 
-If `INCOMPLETE > 0`: print and stop [silent]:
+**If `INCOMPLETE > 0`**: do NOT proceed to pre-flight. Print:
 ```
 ⏸ Bundle gate: {INCOMPLETE} task(s) on branch {HEAD_BRANCH} are still in flight:
   {for each item in INCOMPLETE_TASKS: "  - {id} ({status})"}
   Waiting for bundle-mates to reach pr_open before deploying.
 ```
+- **Scan mode**: log which candidate was skipped and why:
+  ```
+  ⏭ Skipping PR #{pr} — bundle-blocked on branch {HEAD_BRANCH}, trying next candidate.
+  ```
+  Then return to Step 1a's `CANDIDATE_LIST` and retry Steps 2 through 4a with the next
+  candidate PR. If no candidates remain, respond `[silent]` and stop.
+- **Explicit-target mode**: there is no other candidate to fall back to. Stop here `[silent]`.
 
-If `INCOMPLETE == 0` (no tasks tracked, or all tasks are `pr_open` or beyond): proceed to Step 3.
+**Otherwise** (`INCOMPLETE == 0` — no tasks tracked, or all tasks are `pr_open` or beyond):
+proceed to Step 3.
 
 ---
 


### PR DESCRIPTION
## Summary
- Step 1a now excludes bundle-blocked PRs from `CANDIDATE_LIST` up front, checking `GET /tasks?branch={headRefName}` for incomplete (pending/in_progress/blocked) sibling tasks — mirrors `check-deploy.ts`'s `isBundleComplete` gate exactly.
- Step 2b's bundle re-check (defense-in-depth for the race window between Step 1a's scan and Step 2's arrival at a specific candidate, and for explicit-target mode which skips Step 1a) now bifurcates on scan mode vs explicit-target mode: scan mode logs the skip and retries the next `CANDIDATE_LIST` entry instead of hard-stopping the whole scan; explicit-target mode keeps its original stop behavior — mirrors Step 4a's existing 409-conflict fallback structure verbatim.
- Added TESTING.md test matrix row 43 documenting the bundle-gate fallback scenario.

Fixes the root cause confirmed live on 2026-07-10: app-vitals/shipwright#1369 (3 pending bundle-mates) sorted first in scan mode's candidate list, blocked at Step 2b, and stopped the whole scan silently — so app-vitals/shipwright#1351 and app-vitals/vitals-os#2512 (both otherwise ready) were never evaluated, and the deploy cron reported success but merged nothing.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 1a's CANDIDATE_LIST construction excludes PRs with any incomplete bundle-mate task | MET |
| 2 | Step 2b: scan-mode bundle block logs the skip and retries the next candidate; explicit-target mode unchanged | MET |
| 3 | TESTING.md gains a new test matrix row documenting the bundle-gate fallback scenario | MET |
| 4 | Test decision: prompt-only change, no application code touched | MET |
| 5 | Safe to deploy standalone — additive only, no renames/removals | MET |

## Test Plan
- Prompt-only change — no application code touched, no unit/integration/smoke test applies (per this task's own acceptance criteria).
- Verification is a manual dry run of `/shipwright:deploy` scan mode against a bundle-blocked + ready-candidate scenario (documented as TESTING.md row 43); no existing tests are retired.
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — no banned strings found
- [x] Re-read the full edited `deploy.md` end-to-end for coherence (Step 1a → 2 → 2b → 4a)

Generated with [Claude Code](https://claude.com/claude-code)
