### PR TITLE
fix: review.md staging path releases claim and fixes stuck reviewState

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -568,7 +568,10 @@ should be held; the inline comments convey the specific feedback to the author.
 ### If `auto_post_reviews` is false (default):
 
 1. Mark the PR record staged, persisting the verdict so the APPROVE-first sort in
-   `/shipwright:review-staged` works correctly:
+   `/shipwright:review-staged` works correctly. Both branches also release the claim
+   (`claimedBy`/`claimedAt`/`heartbeatAt`/`phase` all cleared to `null`, mirroring
+   `pull-request-service.ts`'s `patch()` claim-clearing) — the review-writing work is
+   done regardless of posting status, so nothing should keep holding the claim:
 
    If `{verdict}` is `APPROVE`:
    ```bash
@@ -576,7 +579,7 @@ should be held; the inline comments convey the specific feedback to the author.
      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      -H "Content-Type: application/json" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
-     -d '{"staged": true, "reviewState": "approved"}' >/dev/null
+     -d '{"staged": true, "reviewState": "approved", "claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null}' >/dev/null
    ```
 
    If `{verdict}` is `COMMENT`:
@@ -585,7 +588,7 @@ should be held; the inline comments convey the specific feedback to the author.
      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      -H "Content-Type: application/json" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
-     -d '{"staged": true}' >/dev/null
+     -d '{"staged": true, "reviewState": "posted", "claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null}' >/dev/null
    ```
 
    (`PR_RECORD_ID` is the claim response `.id` from Step 4.)

--- a/plugins/shipwright/references/reviews-schema.md
+++ b/plugins/shipwright/references/reviews-schema.md
@@ -75,7 +75,7 @@ curl -X POST -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 |-------|--------|---------|
 | `pending` | review.md Step 3 | PR discovered, not yet reviewed |
 | `in_progress` | review.md Step 4 (claim) | Review in progress — claim acquired |
-| `posted` | review.md Step 11b | Review posted to GitHub |
+| `posted` | review.md Step 11 (staged COMMENT) or Step 11b (posted) | Review written (staged) or posted to GitHub — see `staged` to distinguish |
 | `approved` | review.md Step 11b (APPROVE verdict) | Review posted with APPROVE verdict |
 
 ## Field Reference


### PR DESCRIPTION
## Summary
- Step 11's staged-APPROVE and staged-COMMENT PATCH bodies now both clear `claimedBy`/`claimedAt`/`heartbeatAt`/`phase` — the review-writing work is done regardless of posting status, so nothing should keep holding the claim.
- The staged-COMMENT branch now sets `reviewState:"posted"` instead of leaving it at `"in_progress"` forever, mirroring how the APPROVE branch already sets its terminal value (`approved`). This also matches what `review-staged.md` already expects (it treats `reviewState:"posted"` as the COMMENT verdict).
- Updated `reviews-schema.md`'s field-reference table to reflect that `posted` is now set from two places (staged COMMENT in Step 11, and actual posting in Step 11b).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 11's staged-APPROVE and staged-COMMENT PATCH bodies both clear the four claim fields | MET | Both PATCH bodies include `"claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null` |
| 2 | Staged-COMMENT PATCH body sets reviewState:"posted" instead of omitting the field | MET | COMMENT branch PATCH body now includes `"reviewState": "posted"` |
| 3 | Test decision: no automated test harness for .md command files; verify manually; none added or retired | MET | Doc-only diff; no test files touched |

## Test Plan
- No automated test harness exists for `.md` command files in this repo (matches the task's own test decision).
- Verified by inspection that `review-staged.md` already treats `reviewState:"posted"` as the COMMENT verdict (lines ~34-36), so this change aligns the producer (`review.md`) with the existing consumer behavior rather than introducing a new state.
- Confirmed the claim-field-clearing shape (`claimedBy`/`claimedAt`/`heartbeatAt`/`phase` all `null`) mirrors the existing pattern in `task-store/src/pull-request-service.ts`'s `patch()` method.
- [x] Pre-commit checks passing (biome lint on changed files, banned-strings scan)

Generated with [Claude Code](https://claude.com/claude-code)
