### PR TITLE
feat(site): note competitor customization findings on /compare

### DIFF
--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -455,6 +455,17 @@ helm install shipwright shipwright/shipwright</code></pre>
         </p>
       </div>
     </div>
+    <p class="mt-8 max-w-3xl sw-editorial">
+      Every tool in the landscape above has converged on some form of this —
+      Devin has Playbooks and CLI-beta Skills, Cursor has rules and hooks,
+      Copilot Agent has custom .agent.md agents, Augment Code has Rules and
+      CLI-only Subagents, and OpenHands has Skills and hooks in the open. The
+      difference is where it lives: for the commercial tools, the deeper
+      extensibility (subagents, hooks, plugins) sits in a separate CLI
+      product, often beta, sometimes pulled without notice (Cursor removed
+      Custom Modes in v2.1). Shipwright's skills, gates, and cron controls are
+      first-class in the one product you actually run.
+    </p>
     <div class="sw-callout sw-callout-info mt-8 max-w-3xl">
       <p>
         <strong>Honest note:</strong> Shipwright is not as easy to customize as


### PR DESCRIPTION
## Summary
- Adds a short paragraph to the Customizability section on `/compare` summarizing competitive research: Devin, Cursor, Copilot Agent, Augment Code, and OpenHands have all converged on skill/subagent/hook-like customization, but for the commercial tools it typically lives in a separate, often-beta CLI product — while Shipwright's is first-class in the harness itself.
- No changes to the landscape table or existing head-to-head sections — kept intentionally brief per feedback not to bloat the page.

## Test plan
- [x] `npm run build` (astro build) succeeds
- [x] `npm run build:check` (build + brand-lint) — on-brand
- [ ] Playwright e2e (`npm test`) — blocked in this sandbox: browser deps (`libglib-2.0.so.0`) aren't installable without root; existing `compare.spec.ts` assertions don't target the new paragraph and manual inspection of the built HTML confirms correct rendering