### PR TITLE
feat: switch 5 build workflows to publish to public GHCR

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  packages: write
 
 jobs:
   filter:
@@ -61,25 +61,24 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |
           docker build \
             -f admin/Dockerfile \
-            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-admin:${{ steps.tag.outputs.new_tag }} \
+            --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
+            -t ghcr.io/app-vitals/shipwright-admin:${{ steps.tag.outputs.new_tag }} \
             .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-admin:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-admin:${{ steps.tag.outputs.new_tag }}
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  packages: write
 
 jobs:
   filter:
@@ -75,26 +75,25 @@ jobs:
           TAG="${{ steps.tag.outputs.new_tag }}"
           echo "version=${TAG#agent-v}" >> "$GITHUB_OUTPUT"
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |
           docker build \
             -f agent/Dockerfile \
             --build-arg AGENT_VERSION=${{ steps.version.outputs.version }} \
-            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }} \
+            --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
+            -t ghcr.io/app-vitals/shipwright-agent:${{ steps.tag.outputs.new_tag }} \
             .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-agent:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-agent:${{ steps.tag.outputs.new_tag }}
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  packages: write
 
 jobs:
   filter:
@@ -61,25 +61,24 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |
           docker build \
             -f chat/Dockerfile \
-            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-chat:${{ steps.tag.outputs.new_tag }} \
+            --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
+            -t ghcr.io/app-vitals/shipwright-chat:${{ steps.tag.outputs.new_tag }} \
             .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-chat:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-chat:${{ steps.tag.outputs.new_tag }}
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  packages: write
 
 jobs:
   filter:
@@ -61,25 +61,24 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |
           docker build \
             -f metrics/Dockerfile \
-            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-metrics:${{ steps.tag.outputs.new_tag }} \
+            --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
+            -t ghcr.io/app-vitals/shipwright-metrics:${{ steps.tag.outputs.new_tag }} \
             .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-metrics:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-metrics:${{ steps.tag.outputs.new_tag }}
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  packages: write
 
 jobs:
   filter:
@@ -61,25 +61,24 @@ jobs:
           fetch_all_tags: true
           dry_run: true
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ secrets.ARTIFACT_REGISTRY_HOST }} --quiet
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |
           docker build \
             -f task-store/Dockerfile \
-            -t ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-task-store:${{ steps.tag.outputs.new_tag }} \
+            --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
+            -t ghcr.io/app-vitals/shipwright-task-store:${{ steps.tag.outputs.new_tag }} \
             .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.ARTIFACT_REGISTRY_REPO }}/shipwright-task-store:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-task-store:${{ steps.tag.outputs.new_tag }}
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with


### PR DESCRIPTION
## Summary
- Replace GCP Artifact Registry WIF auth with `docker/login-action` + `GITHUB_TOKEN` (`packages: write`) in build-admin.yml, build-metrics.yml, build-agent.yml, build-task-store.yml, and build-chat.yml
- Push images to `ghcr.io/app-vitals/shipwright-<svc>`, labeled `org.opencontainers.image.source=https://github.com/app-vitals/shipwright`
- Preserve the push-image-before-git-tag ordering in every workflow (an incident established this invariant)
- Leave build-agent.yml's `shipwright-agent-released` dispatch step and `DISPATCH_TOKEN`/`CHART_DISPATCH_REPO` usage untouched

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Release pushes `ghcr.io/app-vitals/shipwright-<svc>:<svc>-vX.Y.Z`, pullable anonymously | MET |
| 2 | Git tag created only after image push, in all five workflows | MET |
| 3 | No Artifact Registry secrets referenced after change | MET |
| 4 | build-agent.yml dispatch step + DISPATCH_TOKEN/CHART_DISPATCH_REPO unchanged | MET |
| 5 | Smoke-only test decision (CI YAML, no unit-testable logic) | MET |

Depends on DCC-1.1 (done — GHCR backfill, public package visibility, and `packages: write` org policy already verified).

## Test Plan
- [x] All 5 workflow YAML files validated as parseable
- [x] Confirmed no remaining `WIF_PROVIDER`/`GCP_SA_EMAIL`/`ARTIFACT_REGISTRY_*` references in changed files
- [x] Confirmed push-before-tag step ordering preserved in every workflow
- [x] Confirmed build-agent.yml's dispatch step and AGENT_VERSION build-arg untouched
- [ ] Post-merge: trigger one real build per service and verify anonymous `docker pull` from a clean machine (per task's smoke-test decision)

Generated with [Claude Code](https://claude.com/claude-code)
