### PR TITLE
feat(chart): pin exact GHCR image tags in values.yaml defaults

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -425,21 +425,32 @@ jobs:
           TAGS_CSV="${{ steps.batch.outputs.tags }}"
           PINNED=$(select_pinned_tags "$TAGS_CSV")
 
+          # Rendered alongside the values.yaml writes below (same
+          # service/path loop) as "- `admin.image.tag`: `admin-v0.156.2`"
+          # markdown lines, so the "Open bump PR" step can drop them
+          # straight into the PR body without re-deriving the
+          # service→path mapping itself.
+          PINNED_LINES=""
           while IFS='=' read -r service tag; do
             [ -z "$service" ] && continue
             while IFS= read -r path; do
               update_values_tag charts/shipwright/values.yaml "$path" "$tag"
               echo "Pinned ${path} = ${tag}"
+              PINNED_LINES="${PINNED_LINES}- \`${path}\`: \`${tag}\`
+          "
             done < <(values_paths_for_service "$service")
           done <<< "$PINNED"
 
-          # Thread the pinned "service=tag" list into the PR body via a
-          # multi-line GITHUB_OUTPUT (heredoc form, EOF delimiter is safe —
-          # tag values never contain newlines).
+          # Thread the pinned tags into later steps via multi-line
+          # GITHUB_OUTPUT (heredoc form, EOF delimiter is safe — tag values
+          # never contain newlines).
           {
             echo "pinned<<PINEOF"
             echo "$PINNED"
             echo "PINEOF"
+            echo "pinned_lines<<PINLINESEOF"
+            echo "$PINNED_LINES"
+            echo "PINLINESEOF"
           } >> "$GITHUB_OUTPUT"
           echo "Pinned tags for this bump:"
           echo "$PINNED"
@@ -488,25 +499,10 @@ jobs:
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/- `/; s/$/`/')
           BRANCH="${{ steps.new.outputs.branch }}"
 
-          # "service=tag" pairs from the "Pin released tags into values.yaml"
-          # step, rendered as "- \`admin.image.tag\`: \`admin-v0.156.2\`" lines
-          # so the PR body lists exactly which tag(s) were pinned and where.
-          PINNED="${{ steps.pin.outputs.pinned }}"
-          PINNED_LINES=$(echo "$PINNED" | while IFS='=' read -r service tag; do
-            [ -z "$service" ] && continue
-            values_paths_for_service() {
-              case "$1" in
-                admin) printf '%s\n' "admin.image.tag" ;;
-                metrics) printf '%s\n' "metrics.image.tag" ;;
-                agent) printf '%s\n' "agent.image.tag" "agent.provisioning.image.tag" ;;
-                task-store) printf '%s\n' "taskStore.image.tag" ;;
-                chat) printf '%s\n' "chat.image.tag" ;;
-              esac
-            }
-            while IFS= read -r path; do
-              echo "- \`${path}\`: \`${tag}\`"
-            done < <(values_paths_for_service "$service")
-          done)
+          # Pre-rendered "- `admin.image.tag`: `admin-v0.156.2`" lines from
+          # the "Pin released tags into values.yaml" step, so the PR body
+          # lists exactly which tag(s) were pinned and where.
+          PINNED_LINES="${{ steps.pin.outputs.pinned_lines }}"
 
           PR_URL=$(gh pr create \
             --base main \

--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -4,8 +4,10 @@ name: Auto-Bump Chart Version
 # services. Each build workflow (build-agent.yml, build-admin.yml,
 # build-metrics.yml, build-task-store.yml, build-chat.yml) creates a tag like
 # agent-v*, admin-v*, metrics-v*, task-store-v*, or chat-v* on main after a
-# successful image push. This workflow detects those tags and
-# opens a chart-version bump PR so no manual bump-chart.sh invocation is needed.
+# successful image push. This workflow detects those tags, pins each
+# released tag into the matching charts/shipwright/values.yaml image
+# default(s), and opens a chart-version bump PR so no manual bump-chart.sh
+# invocation is needed.
 #
 # Debounce: services release independently, so it's common for two or three
 # tags to land within seconds/minutes of each other (e.g. admin-v0.156.0
@@ -34,7 +36,10 @@ name: Auto-Bump Chart Version
 #     → bump-chart job
 #       → collect every release tag pushed since the last chart-bump commit
 #       → bump patch version in Chart.yaml once for the whole batch
-#       → open PR (chore/chart-v{new_version}) crediting all batched tags
+#       → pin each batched tag's highest semver into its values.yaml
+#         image.tag path(s) (admin/metrics/agent+provisioning/taskStore/chat)
+#       → open PR (chore/chart-v{new_version}) crediting all batched tags and
+#         listing exactly which values.yaml path(s) were pinned
 #       → wait for required checks, then merge (squash)
 #     → PR merges to main
 #       → chart-release.yml triggers (paths: charts/shipwright/**)
@@ -278,7 +283,169 @@ jobs:
               f.write(content)
           PYEOF
 
-      # Create a dedicated branch, commit the Chart.yaml + CHANGELOG.md changes, and push.
+      # Pin every batched release tag into its values.yaml default(s) — the
+      # chart's GHCR image defaults (values.yaml's admin/metrics/agent/
+      # taskStore/chat blocks, added by DCC-2.1) must track the same releases
+      # this bump is crediting, not silently lag behind Chart.yaml/CHANGELOG.
+      # Same logic as .github/workflows/test-auto-bump-chart.sh's
+      # service_for_tag / values_paths_for_service / highest_semver_tag /
+      # select_pinned_tags / update_values_tag — keep both copies in sync.
+      - name: Pin released tags into values.yaml
+        id: pin
+        if: steps.idempotency.outputs.skip != 'true'
+        run: |
+          # Maps a release tag prefix to its service key.
+          service_for_tag() {
+            local tag="$1"
+            case "$tag" in
+              admin-v*) echo "admin" ;;
+              metrics-v*) echo "metrics" ;;
+              agent-v*) echo "agent" ;;
+              task-store-v*) echo "task-store" ;;
+              chat-v*) echo "chat" ;;
+              *) echo "" ;;
+            esac
+          }
+
+          # Maps a service key to the values.yaml dot-paths that must be
+          # pinned to its released tag. agent pins two paths from the same
+          # tag: the top-level agent image and the admin-provisioned agent
+          # image nested under agent.provisioning.
+          values_paths_for_service() {
+            local service="$1"
+            case "$service" in
+              admin) printf '%s\n' "admin.image.tag" ;;
+              metrics) printf '%s\n' "metrics.image.tag" ;;
+              agent) printf '%s\n' "agent.image.tag" "agent.provisioning.image.tag" ;;
+              task-store) printf '%s\n' "taskStore.image.tag" ;;
+              chat) printf '%s\n' "chat.image.tag" ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # Highest-semver tag among the given tags (space-separated, same
+          # prefix). Strips the non-numeric prefix so `sort -V` compares the
+          # bare X.Y.Z portion, then re-attaches the winning original tag.
+          highest_semver_tag() {
+            local tag
+            for tag in "$@"; do
+              printf '%s %s\n' "${tag##*-v}" "$tag"
+            done | sort -V | tail -n1 | cut -d' ' -f2-
+          }
+
+          # Groups a comma-separated tag batch by service and picks the
+          # highest-semver tag per service. Emits "service=tag" pairs, one
+          # per line, sorted by service name for deterministic output.
+          select_pinned_tags() {
+            local tags_csv="$1"
+            local tag service
+            declare -A best
+
+            IFS=',' read -ra all_tags <<< "$tags_csv"
+            for tag in "${all_tags[@]}"; do
+              [ -z "$tag" ] && continue
+              service=$(service_for_tag "$tag")
+              [ -z "$service" ] && continue
+              if [ -z "${best[$service]:-}" ]; then
+                best[$service]="$tag"
+              else
+                best[$service]=$(highest_semver_tag "${best[$service]}" "$tag")
+              fi
+            done
+
+            for service in "${!best[@]}"; do
+              printf '%s=%s\n' "$service" "${best[$service]}"
+            done | sort
+          }
+
+          # Writes `tag` into the value at `dot_path` (e.g.
+          # "agent.provisioning.image.tag") inside values.yaml, matching only
+          # the `tag:` line nested under the exact chain of parent keys
+          # (indentation-scoped) — never a blind global regex, so
+          # agent.image.tag and agent.provisioning.image.tag can be updated
+          # independently even though both lines read "tag: agent-v...".
+          update_values_tag() {
+            local values_yaml="$1"
+            local dot_path="$2"
+            local new_tag="$3"
+            python3 - "$values_yaml" "$dot_path" "$new_tag" <<'PYEOF'
+          import sys
+
+          path, dot_path, new_tag = sys.argv[1], sys.argv[2], sys.argv[3]
+          keys = dot_path.split('.')
+
+          with open(path, 'r') as f:
+              lines = f.readlines()
+
+          # Walk the key chain top-down. Each key must be found at exactly
+          # one indentation level deeper than the previous key, searching
+          # only within the span of lines belonging to the previous key's
+          # block (up to the next line at the same-or-shallower indentation).
+          search_start, search_end = 0, len(lines)
+          indent = -1
+          for depth, key in enumerate(keys):
+              is_last = depth == len(keys) - 1
+              target_indent = indent + 2 if indent >= 0 else 0
+              found_at = None
+              for i in range(search_start, search_end):
+                  line = lines[i]
+                  stripped = line.lstrip(' ')
+                  this_indent = len(line) - len(stripped)
+                  if this_indent < target_indent:
+                      break
+                  if this_indent != target_indent:
+                      continue
+                  key_match = stripped.rstrip('\n') == f'{key}:' or stripped.startswith(f'{key}:')
+                  if key_match:
+                      found_at = i
+                      break
+              if found_at is None:
+                  raise SystemExit(f'path segment {key!r} not found for dot_path {dot_path!r}')
+              if is_last:
+                  lines[found_at] = f'{" " * target_indent}{key}: {new_tag}\n'
+              else:
+                  block_start = found_at + 1
+                  block_end = search_end
+                  for j in range(block_start, search_end):
+                      j_stripped = lines[j].lstrip(' ')
+                      if j_stripped.strip() == '':
+                          continue
+                      j_indent = len(lines[j]) - len(j_stripped)
+                      if j_indent <= target_indent:
+                          block_end = j
+                          break
+                  search_start, search_end = block_start, block_end
+                  indent = target_indent
+
+          with open(path, 'w') as f:
+              f.writelines(lines)
+          PYEOF
+          }
+
+          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          PINNED=$(select_pinned_tags "$TAGS_CSV")
+
+          while IFS='=' read -r service tag; do
+            [ -z "$service" ] && continue
+            while IFS= read -r path; do
+              update_values_tag charts/shipwright/values.yaml "$path" "$tag"
+              echo "Pinned ${path} = ${tag}"
+            done < <(values_paths_for_service "$service")
+          done <<< "$PINNED"
+
+          # Thread the pinned "service=tag" list into the PR body via a
+          # multi-line GITHUB_OUTPUT (heredoc form, EOF delimiter is safe —
+          # tag values never contain newlines).
+          {
+            echo "pinned<<PINEOF"
+            echo "$PINNED"
+            echo "PINEOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Pinned tags for this bump:"
+          echo "$PINNED"
+
+      # Create a dedicated branch, commit the Chart.yaml + CHANGELOG.md +
+      # values.yaml changes, and push.
       - name: Commit and push bump branch
         id: commit-push
         if: steps.idempotency.outputs.skip != 'true'
@@ -289,7 +456,7 @@ jobs:
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/  - /')
 
           git checkout -b "$BRANCH"
-          git add charts/shipwright/Chart.yaml charts/shipwright/CHANGELOG.md
+          git add charts/shipwright/Chart.yaml charts/shipwright/CHANGELOG.md charts/shipwright/values.yaml
           git commit -m "chore(chart): bump chart version to ${NEW_VERSION}
 
           Auto-bump triggered by release tag(s):
@@ -321,6 +488,26 @@ jobs:
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/- `/; s/$/`/')
           BRANCH="${{ steps.new.outputs.branch }}"
 
+          # "service=tag" pairs from the "Pin released tags into values.yaml"
+          # step, rendered as "- \`admin.image.tag\`: \`admin-v0.156.2\`" lines
+          # so the PR body lists exactly which tag(s) were pinned and where.
+          PINNED="${{ steps.pin.outputs.pinned }}"
+          PINNED_LINES=$(echo "$PINNED" | while IFS='=' read -r service tag; do
+            [ -z "$service" ] && continue
+            values_paths_for_service() {
+              case "$1" in
+                admin) printf '%s\n' "admin.image.tag" ;;
+                metrics) printf '%s\n' "metrics.image.tag" ;;
+                agent) printf '%s\n' "agent.image.tag" "agent.provisioning.image.tag" ;;
+                task-store) printf '%s\n' "taskStore.image.tag" ;;
+                chat) printf '%s\n' "chat.image.tag" ;;
+              esac
+            }
+            while IFS= read -r path; do
+              echo "- \`${path}\`: \`${tag}\`"
+            done < <(values_paths_for_service "$service")
+          done)
+
           PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
@@ -333,6 +520,9 @@ jobs:
           ${TAGS_LINES}
 
           **New chart version:** \`${NEW_VERSION}\`
+
+          **Pinned in values.yaml:**
+          ${PINNED_LINES}
 
           ### What happens next
 

--- a/.github/workflows/test-auto-bump-chart.sh
+++ b/.github/workflows/test-auto-bump-chart.sh
@@ -109,6 +109,146 @@ format_changelog_tags() {
   echo "$tags_csv" | tr ',' '\n' | sed 's/^/`/; s/$/`/' | paste -sd, - | sed 's/,/, /g'
 }
 
+# Maps a release tag prefix to its service key, used to key both the
+# values.yaml path table below and the highest-semver grouping in
+# select_pinned_tags(). Mirrors the "Pin released tags into values.yaml"
+# step's SERVICE_FOR_PREFIX lookup — must stay in sync with the tag prefixes
+# in this workflow's `on.push.tags` list.
+service_for_tag() {
+  local tag="$1"
+  case "$tag" in
+    admin-v*) echo "admin" ;;
+    metrics-v*) echo "metrics" ;;
+    agent-v*) echo "agent" ;;
+    task-store-v*) echo "task-store" ;;
+    chat-v*) echo "chat" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Maps a service key to the values.yaml dot-paths that must be pinned to its
+# released tag, one path per line. The agent service pins two paths from the
+# same agent-v* tag: the top-level agent image and the admin-provisioned
+# agent image nested under agent.provisioning. Mirrors the "Pin released
+# tags into values.yaml" step's VALUES_PATHS_FOR_SERVICE lookup.
+values_paths_for_service() {
+  local service="$1"
+  case "$service" in
+    admin) printf '%s\n' "admin.image.tag" ;;
+    metrics) printf '%s\n' "metrics.image.tag" ;;
+    agent) printf '%s\n' "agent.image.tag" "agent.provisioning.image.tag" ;;
+    task-store) printf '%s\n' "taskStore.image.tag" ;;
+    chat) printf '%s\n' "chat.image.tag" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Returns the highest-semver tag among the given tags (space-separated, all
+# sharing the same prefix). Strips the non-numeric prefix so `sort -V`
+# compares the bare X.Y.Z portion, then re-attaches the winning original tag.
+# A single-tag input is a no-op — the sole tag always "wins". Mirrors the
+# "Pin released tags into values.yaml" step's highest_semver_tag().
+highest_semver_tag() {
+  local tag
+  for tag in "$@"; do
+    printf '%s %s\n' "${tag##*-v}" "$tag"
+  done | sort -V | tail -n1 | cut -d' ' -f2-
+}
+
+# Given a batch of tags (comma-separated, possibly mixed services and
+# possibly multiple tags per service), groups by service and picks the
+# highest-semver tag per service. Returns "service=tag" pairs, one per line,
+# sorted by service name for deterministic output. Mirrors the "Pin released
+# tags into values.yaml" step's own grouping loop.
+select_pinned_tags() {
+  local tags_csv="$1"
+  local tag service
+  declare -A best
+
+  IFS=',' read -ra all_tags <<< "$tags_csv"
+  for tag in "${all_tags[@]}"; do
+    [ -z "$tag" ] && continue
+    service=$(service_for_tag "$tag")
+    [ -z "$service" ] && continue
+    if [ -z "${best[$service]:-}" ]; then
+      best[$service]="$tag"
+    else
+      best[$service]=$(highest_semver_tag "${best[$service]}" "$tag")
+    fi
+  done
+
+  for service in "${!best[@]}"; do
+    printf '%s=%s\n' "$service" "${best[$service]}"
+  done | sort
+}
+
+# Writes `tag` into the value at `dot_path` (e.g. "agent.provisioning.image.tag")
+# inside `values_yaml`, matching only the `tag:` line nested under the exact
+# chain of parent keys (indentation-scoped) — never a blind global regex, so
+# agent.image.tag and agent.provisioning.image.tag can be updated
+# independently even though both lines read "tag: agent-v...". Mirrors the
+# "Pin released tags into values.yaml" step's update_values_tag() (uses
+# python3 — same tool the workflow already uses for Chart.yaml edits).
+update_values_tag() {
+  local values_yaml="$1"
+  local dot_path="$2"
+  local new_tag="$3"
+  python3 - "$values_yaml" "$dot_path" "$new_tag" <<'PYEOF'
+import sys
+
+path, dot_path, new_tag = sys.argv[1], sys.argv[2], sys.argv[3]
+keys = dot_path.split('.')
+
+with open(path, 'r') as f:
+    lines = f.readlines()
+
+# Walk the key chain top-down. Each key must be found at exactly one
+# indentation level deeper than the previous key, searching only within the
+# span of lines that belongs to the previous key's block (up to the next
+# line at the same-or-shallower indentation).
+search_start, search_end = 0, len(lines)
+indent = -1
+for depth, key in enumerate(keys):
+    is_last = depth == len(keys) - 1
+    target_indent = indent + 2 if indent >= 0 else 0
+    found_at = None
+    for i in range(search_start, search_end):
+        line = lines[i]
+        stripped = line.lstrip(' ')
+        this_indent = len(line) - len(stripped)
+        if this_indent < target_indent:
+            break
+        if this_indent != target_indent:
+            continue
+        key_match = stripped.rstrip('\n') == f'{key}:' or stripped.startswith(f'{key}:')
+        if key_match:
+            found_at = i
+            break
+    if found_at is None:
+        raise SystemExit(f'path segment {key!r} not found for dot_path {dot_path!r}')
+    if is_last:
+        lines[found_at] = f'{" " * target_indent}{key}: {new_tag}\n'
+    else:
+        # Narrow the search window to this key's own block: from the next
+        # line up to (not including) the next line at <= this indentation.
+        block_start = found_at + 1
+        block_end = search_end
+        for j in range(block_start, search_end):
+            j_stripped = lines[j].lstrip(' ')
+            if j_stripped.strip() == '':
+                continue
+            j_indent = len(lines[j]) - len(j_stripped)
+            if j_indent <= target_indent:
+                block_end = j
+                break
+        search_start, search_end = block_start, block_end
+        indent = target_indent
+
+with open(path, 'w') as f:
+    f.writelines(lines)
+PYEOF
+}
+
 # Collects every release tag pushed since the last chart-bump commit, falling
 # back to the triggering tag alone if no prior bump commit exists. Mirrors
 # the "Collect release tags in this batch" step — must be run inside a git
@@ -225,6 +365,57 @@ EOF
   echo "$path"
 }
 
+# Fixture mirroring the shape of charts/shipwright/values.yaml's five
+# image-tag-bearing service blocks (admin, metrics, agent + nested
+# provisioning.image, taskStore, chat) — trimmed to just the keys
+# update_values_tag() needs to walk, plus decoy sibling keys at each level to
+# catch over-broad matching (e.g. a global "tag:" regex would wrongly hit
+# every one of these).
+make_values_yaml() {
+  local path="$TMPDIR_TEST/values-$$-${RANDOM}.yaml"
+  cat > "$path" <<'EOF'
+admin:
+  enabled: true
+  image:
+    repository: ghcr.io/app-vitals/shipwright-admin
+    tag: admin-v0.188.0
+    pullPolicy: ""
+  replicas: 1
+metrics:
+  enabled: true
+  image:
+    repository: ghcr.io/app-vitals/shipwright-metrics
+    tag: metrics-v0.150.0
+    pullPolicy: ""
+agent:
+  enabled: true
+  image:
+    repository: ghcr.io/app-vitals/shipwright-agent
+    tag: agent-v0.172.0
+    pullPolicy: ""
+  provisioning:
+    enabled: false
+    namespace: ""
+    image:
+      repository: ghcr.io/app-vitals/shipwright-agent
+      tag: agent-v0.172.0
+    replicas: 1
+taskStore:
+  enabled: false
+  image:
+    repository: ghcr.io/app-vitals/shipwright-task-store
+    tag: task-store-v0.86.0
+    pullPolicy: ""
+chat:
+  enabled: false
+  image:
+    repository: ghcr.io/app-vitals/shipwright-chat
+    tag: chat-v0.38.0
+    pullPolicy: ""
+EOF
+  echo "$path"
+}
+
 # ---------------------------------------------------------------------------
 # Tests: bump_patch
 # ---------------------------------------------------------------------------
@@ -311,6 +502,128 @@ echo "=== format_changelog_tags tests ==="
 
 assert_eq "single tag" '`agent-v1.2.3`' "$(format_changelog_tags 'agent-v1.2.3')"
 assert_eq "two tags" '`admin-v0.156.0`, `agent-v0.144.0`' "$(format_changelog_tags 'admin-v0.156.0,agent-v0.144.0')"
+
+# ---------------------------------------------------------------------------
+# Tests: service_for_tag
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== service_for_tag tests ==="
+
+assert_eq "admin-v0.188.0 → admin" "admin" "$(service_for_tag 'admin-v0.188.0')"
+assert_eq "metrics-v0.150.0 → metrics" "metrics" "$(service_for_tag 'metrics-v0.150.0')"
+assert_eq "agent-v0.172.0 → agent" "agent" "$(service_for_tag 'agent-v0.172.0')"
+assert_eq "task-store-v0.86.0 → task-store" "task-store" "$(service_for_tag 'task-store-v0.86.0')"
+assert_eq "chat-v0.38.0 → chat" "chat" "$(service_for_tag 'chat-v0.38.0')"
+assert_eq "unrecognized prefix → empty" "" "$(service_for_tag 'unknown-v1.0.0')"
+
+# ---------------------------------------------------------------------------
+# Tests: values_paths_for_service
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== values_paths_for_service tests ==="
+
+assert_eq "admin → single path" "admin.image.tag" "$(values_paths_for_service 'admin' | paste -sd, -)"
+assert_eq "metrics → single path" "metrics.image.tag" "$(values_paths_for_service 'metrics' | paste -sd, -)"
+assert_eq "task-store → taskStore.image.tag" "taskStore.image.tag" "$(values_paths_for_service 'task-store' | paste -sd, -)"
+assert_eq "chat → single path" "chat.image.tag" "$(values_paths_for_service 'chat' | paste -sd, -)"
+assert_eq "agent → dual path (image.tag AND provisioning.image.tag)" \
+  "agent.image.tag,agent.provisioning.image.tag" \
+  "$(values_paths_for_service 'agent' | paste -sd, -)"
+
+# ---------------------------------------------------------------------------
+# Tests: highest_semver_tag
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== highest_semver_tag tests ==="
+
+assert_eq "single tag is a no-op" "agent-v0.144.0" "$(highest_semver_tag 'agent-v0.144.0')"
+assert_eq "picks higher patch" "admin-v0.156.1" "$(highest_semver_tag 'admin-v0.156.0' 'admin-v0.156.1')"
+assert_eq "picks higher patch regardless of arg order" "admin-v0.156.1" "$(highest_semver_tag 'admin-v0.156.1' 'admin-v0.156.0')"
+assert_eq "picks higher minor" "metrics-v0.151.0" "$(highest_semver_tag 'metrics-v0.150.9' 'metrics-v0.151.0')"
+assert_eq "picks higher major" "chat-v1.0.0" "$(highest_semver_tag 'chat-v0.99.9' 'chat-v1.0.0')"
+assert_eq "double-digit patch beats single-digit (not lexicographic)" "agent-v0.172.10" "$(highest_semver_tag 'agent-v0.172.2' 'agent-v0.172.10')"
+assert_eq "three-way batch picks the max" "task-store-v0.86.2" "$(highest_semver_tag 'task-store-v0.86.0' 'task-store-v0.86.2' 'task-store-v0.86.1')"
+
+# ---------------------------------------------------------------------------
+# Tests: select_pinned_tags
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== select_pinned_tags tests ==="
+
+assert_eq "single-service batch" "agent=agent-v0.144.0" "$(select_pinned_tags 'agent-v0.144.0')"
+
+assert_eq "multi-service batch, one tag each" \
+  "admin=admin-v0.156.0
+agent=agent-v0.144.0" \
+  "$(select_pinned_tags 'admin-v0.156.0,agent-v0.144.0')"
+
+assert_eq "same-service batch picks highest semver, not last-seen" \
+  "admin=admin-v0.156.2" \
+  "$(select_pinned_tags 'admin-v0.156.0,admin-v0.156.2,admin-v0.156.1')"
+
+assert_eq "mixed batch: multi-tag service resolved to highest, single-tag services pass through" \
+  "admin=admin-v0.156.2
+agent=agent-v0.144.0
+chat=chat-v0.38.0" \
+  "$(select_pinned_tags 'admin-v0.156.0,agent-v0.144.0,admin-v0.156.2,chat-v0.38.0')"
+
+# ---------------------------------------------------------------------------
+# Tests: update_values_tag
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== update_values_tag tests ==="
+
+v1=$(make_values_yaml)
+update_values_tag "$v1" "admin.image.tag" "admin-v9.9.9"
+ADMIN_TAG=$(sed -n '/^admin:/,/^metrics:/p' "$v1" | grep 'tag:' | sed 's/^\s*tag: //')
+assert_eq "admin.image.tag updated" "admin-v9.9.9" "$ADMIN_TAG"
+METRICS_TAG_UNCHANGED=$(sed -n '/^metrics:/,/^agent:/p' "$v1" | grep 'tag:' | sed 's/^\s*tag: //')
+assert_eq "sibling service (metrics) untouched by admin update" "metrics-v0.150.0" "$METRICS_TAG_UNCHANGED"
+
+v2=$(make_values_yaml)
+update_values_tag "$v2" "agent.image.tag" "agent-v9.9.8"
+update_values_tag "$v2" "agent.provisioning.image.tag" "agent-v9.9.8"
+AGENT_TOP_TAG=$(sed -n '/^agent:/,/^provisioning:/p' "$v2" | grep 'tag:' | head -1 | sed 's/^\s*tag: //')
+AGENT_PROV_TAG=$(sed -n '/provisioning:/,/^taskStore:/p' "$v2" | grep 'tag:' | head -1 | sed 's/^\s*tag: //')
+assert_eq "agent.image.tag updated (dual-path write, top-level)" "agent-v9.9.8" "$AGENT_TOP_TAG"
+assert_eq "agent.provisioning.image.tag updated (dual-path write, nested)" "agent-v9.9.8" "$AGENT_PROV_TAG"
+
+v3=$(make_values_yaml)
+update_values_tag "$v3" "taskStore.image.tag" "task-store-v9.0.0"
+TASKSTORE_TAG=$(sed -n '/^taskStore:/,/^chat:/p' "$v3" | grep 'tag:' | sed 's/^\s*tag: //')
+assert_eq "taskStore.image.tag updated" "task-store-v9.0.0" "$TASKSTORE_TAG"
+CHAT_TAG_UNCHANGED=$(sed -n '/^chat:/,$p' "$v3" | grep 'tag:' | sed 's/^\s*tag: //')
+assert_eq "sibling service (chat) untouched by taskStore update" "chat-v0.38.0" "$CHAT_TAG_UNCHANGED"
+
+# Full multi-service batch pin: exercises select_pinned_tags() output feeding
+# straight into update_values_tag() for every path, mirroring how the
+# workflow step chains the two.
+v4=$(make_values_yaml)
+PINNED=$(select_pinned_tags 'admin-v0.156.0,agent-v0.144.0,admin-v0.156.2,chat-v0.38.1')
+while IFS='=' read -r service tag; do
+  while IFS= read -r path; do
+    update_values_tag "$v4" "$path" "$tag"
+  done < <(values_paths_for_service "$service")
+done <<< "$PINNED"
+
+ADMIN_FINAL=$(sed -n '/^admin:/,/^metrics:/p' "$v4" | grep 'tag:' | sed 's/^\s*tag: //')
+AGENT_TOP_FINAL=$(sed -n '/^agent:/,/^  provisioning:/p' "$v4" | grep 'tag:' | head -1 | sed 's/^\s*tag: //')
+AGENT_PROV_FINAL=$(sed -n '/provisioning:/,/^taskStore:/p' "$v4" | grep 'tag:' | head -1 | sed 's/^\s*tag: //')
+CHAT_FINAL=$(sed -n '/^chat:/,$p' "$v4" | grep 'tag:' | sed 's/^\s*tag: //')
+METRICS_FINAL=$(sed -n '/^metrics:/,/^agent:/p' "$v4" | grep 'tag:' | sed 's/^\s*tag: //')
+TASKSTORE_FINAL=$(sed -n '/^taskStore:/,/^chat:/p' "$v4" | grep 'tag:' | sed 's/^\s*tag: //')
+
+assert_eq "batch pin: admin resolved to highest semver" "admin-v0.156.2" "$ADMIN_FINAL"
+assert_eq "batch pin: agent.image.tag pinned" "agent-v0.144.0" "$AGENT_TOP_FINAL"
+assert_eq "batch pin: agent.provisioning.image.tag pinned" "agent-v0.144.0" "$AGENT_PROV_FINAL"
+assert_eq "batch pin: chat pinned" "chat-v0.38.1" "$CHAT_FINAL"
+assert_eq "batch pin: metrics untouched (not in this batch)" "metrics-v0.150.0" "$METRICS_FINAL"
+assert_eq "batch pin: taskStore untouched (not in this batch)" "task-store-v0.86.0" "$TASKSTORE_FINAL"
 
 # ---------------------------------------------------------------------------
 # Tests: collect_batch_tags

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,15 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.338] - 2026-07-11
+
+### Changed
+
+- Pin exact GHCR image tags in `values.yaml` defaults for all six shipwright
+  service image blocks (admin, metrics, agent, agent provisioning, taskStore,
+  chat), replacing the bare repository name + `appVersion`-fallback `tag: ""`
+  defaults.
+
 ## [1.6.337] - 2026-07-11
 
 ### Changed

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,20 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.339] - 2026-07-11
+
+### Changed
+
+- Default image values are now fully-qualified, pinned GHCR references
+  (`ghcr.io/app-vitals/<service>:<tag>`) for all six shipwright service image
+  blocks (admin, metrics, agent, agent provisioning, taskStore, chat),
+  replacing the bare repository name + `appVersion`-fallback `tag: ""`
+  defaults.
+- `auto-bump-chart.yml` now pins each batch's released tag(s) directly into
+  the matching `values.yaml` `image.tag` path(s) on every auto-bump, keeping
+  chart defaults in sync with the services they package instead of only
+  bumping the chart version.
+
 ## [1.6.338] - 2026-07-11
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.338
+version: 1.6.339
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,17 +29,9 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "Pin exact GHCR image tags in values.yaml defaults for all six shipwright service image blocks (admin, metrics, agent, agent provisioning, taskStore, chat)"
+      description: "Default image values are now fully-qualified, pinned GHCR references (ghcr.io/app-vitals/<service>:<tag>) instead of a bare repository name with an appVersion-fallback tag"
     - kind: changed
-      description: "auto-bump to chart v1.6.337 triggered by release tag admin-v0.188.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.337 triggered by release tag agent-v0.172.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.337 triggered by release tag chat-v0.38.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.337 triggered by release tag metrics-v0.150.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.337 triggered by release tag task-store-v0.86.0"
+      description: "auto-bump-chart.yml now pins each batch's released tag(s) directly into the matching values.yaml image.tag path(s), keeping chart defaults in sync with the services they package"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.337
+version: 1.6.338
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -28,6 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Pin exact GHCR image tags in values.yaml defaults for all six shipwright service image blocks (admin, metrics, agent, agent provisioning, taskStore, chat)"
     - kind: changed
       description: "auto-bump to chart v1.6.337 triggered by release tag admin-v0.188.0"
     - kind: changed

--- a/charts/shipwright/README.md
+++ b/charts/shipwright/README.md
@@ -87,19 +87,19 @@ environment, set `postgresql.auth.existingSecret` to a pre-created Secret (or se
 | `serviceAccount.name` | `""` | ServiceAccount name (generated if empty). |
 | `serviceAccount.annotations` | `{}` | Annotations for the ServiceAccount. |
 | `admin.enabled` | `true` | Toggle the admin service (port **3001**). |
-| `admin.image.repository` | `shipwright-admin` | Admin image repo. |
-| `admin.image.tag` | `""` | Admin image tag (defaults to chart `appVersion`). |
+| `admin.image.repository` | `ghcr.io/app-vitals/shipwright-admin` | Admin image repo (fully-qualified GHCR default). |
+| `admin.image.tag` | pinned per release | Admin image tag, rewritten on every chart release. |
 | `admin.service.port` | `3001` | Admin service port. |
 | `admin.replicas` | `1` | Admin replica count. |
 | `metrics.enabled` | `true` | Toggle the metrics dashboard (port **3460**). |
-| `metrics.image.repository` | `shipwright-metrics` | Metrics image repo. |
-| `metrics.image.tag` | `""` | Metrics image tag (defaults to chart `appVersion`). |
+| `metrics.image.repository` | `ghcr.io/app-vitals/shipwright-metrics` | Metrics image repo (fully-qualified GHCR default). |
+| `metrics.image.tag` | pinned per release | Metrics image tag, rewritten on every chart release. |
 | `metrics.service.port` | `3460` | Metrics service port. |
 | `metrics.replicas` | `1` | Metrics replica count. |
 | `metrics.sessionSecret.existingSecret` | `""` | Source the metrics `SHIPWRIGHT_SESSION_SECRET` from a pre-created Secret. Point at the admin's Secret so admin-minted dashboard JWTs validate (a mismatch 401s the dashboard). Empty = chart-generated. |
 | `agent.enabled` | `true` | Toggle the agent service (port **3000**). |
-| `agent.image.repository` | `shipwright-agent` | Agent image repo. |
-| `agent.image.tag` | `""` | Agent image tag (defaults to chart `appVersion`). |
+| `agent.image.repository` | `ghcr.io/app-vitals/shipwright-agent` | Agent image repo (fully-qualified GHCR default). |
+| `agent.image.tag` | pinned per release | Agent image tag, rewritten on every chart release. |
 | `agent.service.port` | `3000` | Agent service port. |
 | `agent.replicas` | `1` | Agent replica count. |
 | `agent.provisioning.persistence.enabled` | `true` | Create a PVC for the agent home (`AGENT_HOME`). |

--- a/charts/shipwright/ci/eks-values.yaml
+++ b/charts/shipwright/ci/eks-values.yaml
@@ -13,13 +13,24 @@ auth:
   mode: open
 
 admin:
+  # Pin repository/tag to the image `helm.yml` builds and side-loads via
+  # `kind load docker-image` (tag 0.1.0 = Chart.yaml appVersion) — pullPolicy
+  # Never means kind uses ONLY this local image, so the reference here must be
+  # an exact match or the pod fails to schedule (ErrImageNeverPull). Overrides
+  # values.yaml's GHCR default (DCC-2.1), which is unpublished at PR time.
   image:
+    repository: shipwright-admin
+    tag: "0.1.0"
     pullPolicy: Never
 
 metrics:
   # pullPolicy Never so kind uses the side-loaded shipwright-metrics image and
   # never reaches a registry. Postgres mode is exercised via the bundled subchart.
+  # repository/tag pinned to match the image `helm.yml` side-loads (tag 0.1.0 =
+  # Chart.yaml appVersion) — overrides values.yaml's GHCR default (DCC-2.1).
   image:
+    repository: shipwright-metrics
+    tag: "0.1.0"
     pullPolicy: Never
   provider:
     # Run in offline (fixture) mode — no task-store or admin service available in CI.

--- a/charts/shipwright/ci/gke-values.yaml
+++ b/charts/shipwright/ci/gke-values.yaml
@@ -30,13 +30,24 @@ auth:
     allowedEmails: ci@example.com
 
 admin:
+  # Pin repository/tag to the image `helm.yml` builds and side-loads via
+  # `kind load docker-image` (tag 0.1.0 = Chart.yaml appVersion) — pullPolicy
+  # Never means kind uses ONLY this local image, so the reference here must be
+  # an exact match or the pod fails to schedule (ErrImageNeverPull). Overrides
+  # values.yaml's GHCR default (DCC-2.1), which is unpublished at PR time.
   image:
+    repository: shipwright-admin
+    tag: "0.1.0"
     pullPolicy: Never
 
 metrics:
   # pullPolicy Never so kind uses the side-loaded shipwright-metrics image and
   # never reaches a registry. Postgres mode is exercised via the bundled subchart.
+  # repository/tag pinned to match the image `helm.yml` side-loads (tag 0.1.0 =
+  # Chart.yaml appVersion) — overrides values.yaml's GHCR default (DCC-2.1).
   image:
+    repository: shipwright-metrics
+    tag: "0.1.0"
     pullPolicy: Never
   provider:
     # Run in offline (fixture) mode — no task-store or admin service available in CI.

--- a/charts/shipwright/ci/minikube-values.yaml
+++ b/charts/shipwright/ci/minikube-values.yaml
@@ -9,13 +9,24 @@ auth:
   mode: open
 
 admin:
+  # Pin repository/tag to the image `helm.yml` builds and side-loads via
+  # `kind load docker-image` (tag 0.1.0 = Chart.yaml appVersion) — pullPolicy
+  # Never means kind uses ONLY this local image, so the reference here must be
+  # an exact match or the pod fails to schedule (ErrImageNeverPull). Overrides
+  # values.yaml's GHCR default (DCC-2.1), which is unpublished at PR time.
   image:
+    repository: shipwright-admin
+    tag: "0.1.0"
     pullPolicy: Never
 
 metrics:
   # pullPolicy Never so kind uses the side-loaded shipwright-metrics image and
   # never reaches a registry. Postgres mode is exercised via the bundled subchart.
+  # repository/tag pinned to match the image `helm.yml` side-loads (tag 0.1.0 =
+  # Chart.yaml appVersion) — overrides values.yaml's GHCR default (DCC-2.1).
   image:
+    repository: shipwright-metrics
+    tag: "0.1.0"
     pullPolicy: Never
   provider:
     # Run in offline (fixture) mode — no task-store or admin service available in CI.

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -1,17 +1,17 @@
 suite: admin Deployment / Service / ServiceAccount workloads
 # HD-3.1 adds the admin workload templates. These assert the structural facts:
-# image (tag defaults to appVersion), container port 3001, /health liveness +
+# image (pinned to the GHCR default), container port 3001, /health liveness +
 # readiness probes, ServiceAccount wiring, Service shape, and the DATABASE_URL
 # wiring to the bundled PostgreSQL subchart (assembled in the admin Secret).
 tests:
-  - it: renders the admin Deployment with the appVersion-defaulted image and port 3001
+  - it: renders the admin Deployment with the GHCR-pinned image and port 3001
     template: templates/admin-deployment.yaml
     asserts:
       - isKind:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: shipwright-admin:0.1.0
+          value: ghcr.io/app-vitals/shipwright-admin:admin-v0.188.0
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3001

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -9,9 +9,9 @@ tests:
     asserts:
       - isKind:
           of: Deployment
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/app-vitals/shipwright-admin:admin-v0.188.0
+          pattern: "^ghcr\\.io/app-vitals/shipwright-admin:admin-v\\d+\\.\\d+\\.\\d+$"
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3001

--- a/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
+++ b/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
@@ -199,12 +199,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SHIPWRIGHT_AGENT_IMAGE
-            value: shipwright-agent
+            value: ghcr.io/app-vitals/shipwright-agent
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SHIPWRIGHT_AGENT_IMAGE_TAG
-            value: "0.1.0"
+            value: "agent-v0.172.0"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -271,12 +271,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SHIPWRIGHT_AGENT_IMAGE
-            value: shipwright-agent
+            value: ghcr.io/app-vitals/shipwright-agent
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: SHIPWRIGHT_AGENT_IMAGE_TAG
-            value: "0.1.0"
+            value: "agent-v0.172.0"
       - notContains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
+++ b/charts/shipwright/tests/agent_provisioning_rbac_test.yaml
@@ -200,11 +200,9 @@ tests:
           content:
             name: SHIPWRIGHT_AGENT_IMAGE
             value: ghcr.io/app-vitals/shipwright-agent
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SHIPWRIGHT_AGENT_IMAGE_TAG
-            value: "agent-v0.172.0"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "SHIPWRIGHT_AGENT_IMAGE_TAG")].value
+          pattern: "^agent-v\\d+\\.\\d+\\.\\d+$"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/shipwright/tests/chat_workload_test.yaml
+++ b/charts/shipwright/tests/chat_workload_test.yaml
@@ -12,9 +12,9 @@ tests:
     asserts:
       - isKind:
           of: Deployment
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/app-vitals/shipwright-chat:chat-v0.38.0
+          pattern: "^ghcr\\.io/app-vitals/shipwright-chat:chat-v\\d+\\.\\d+\\.\\d+$"
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3000

--- a/charts/shipwright/tests/chat_workload_test.yaml
+++ b/charts/shipwright/tests/chat_workload_test.yaml
@@ -1,11 +1,11 @@
 suite: chat Deployment / Service workloads
 # CHT-2.1 adds the chat workload templates. These assert the structural
-# facts: image (tag defaults to appVersion), container port 3000, /health
+# facts: image (pinned to the GHCR default), container port 3000, /health
 # liveness + readiness probes, DATABASE_URL_SHIPWRIGHT_CHAT secret wiring
 # (default and custom existingSecret), extraEnv appended, Service shape,
 # and that no resources render when chat.enabled=false.
 tests:
-  - it: renders the chat Deployment with the appVersion-defaulted image and port 3000
+  - it: renders the chat Deployment with the GHCR-pinned image and port 3000
     template: templates/chat-deployment.yaml
     set:
       chat.enabled: true
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: shipwright-chat:0.1.0
+          value: ghcr.io/app-vitals/shipwright-chat:chat-v0.38.0
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3000

--- a/charts/shipwright/tests/metrics_workload_test.yaml
+++ b/charts/shipwright/tests/metrics_workload_test.yaml
@@ -11,9 +11,9 @@ tests:
     asserts:
       - isKind:
           of: Deployment
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/app-vitals/shipwright-metrics:metrics-v0.150.0
+          pattern: "^ghcr\\.io/app-vitals/shipwright-metrics:metrics-v\\d+\\.\\d+\\.\\d+$"
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3460

--- a/charts/shipwright/tests/metrics_workload_test.yaml
+++ b/charts/shipwright/tests/metrics_workload_test.yaml
@@ -1,19 +1,19 @@
 suite: metrics Deployment / Service / ServiceAccount workloads
 # HD-3.2 adds the metrics workload templates (mirrors the admin pattern). These
-# assert the structural facts: image (tag defaults to appVersion), container port
+# assert the structural facts: image (pinned to the GHCR default), container port
 # 3460, /health liveness + readiness probes, ServiceAccount wiring, Service shape,
 # the postgres-mode env (METRICS_API_PORT), and the
 # METRICS_DATABASE_URL wiring to the bundled PostgreSQL subchart (assembled in the
 # metrics Secret).
 tests:
-  - it: renders the metrics Deployment with the appVersion-defaulted image and port 3460
+  - it: renders the metrics Deployment with the GHCR-pinned image and port 3460
     template: templates/metrics-deployment.yaml
     asserts:
       - isKind:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: shipwright-metrics:0.1.0
+          value: ghcr.io/app-vitals/shipwright-metrics:metrics-v0.150.0
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3460

--- a/charts/shipwright/tests/task_store_workload_test.yaml
+++ b/charts/shipwright/tests/task_store_workload_test.yaml
@@ -1,10 +1,10 @@
 suite: task-store Deployment / Service workloads
 # TSS-4.1 adds the task-store workload templates. These assert the structural
-# facts: image (tag defaults to appVersion), container port 3000, /health
+# facts: image (pinned to the GHCR default), container port 3000, /health
 # liveness + readiness probes, Service shape, and the DATABASE_URL wiring
 # from an existingSecret (shipwright-secrets by default).
 tests:
-  - it: renders the task-store Deployment with the appVersion-defaulted image and port 3000
+  - it: renders the task-store Deployment with the GHCR-pinned image and port 3000
     template: templates/task-store-deployment.yaml
     set:
       taskStore.enabled: true
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: shipwright-task-store:0.1.0
+          value: ghcr.io/app-vitals/shipwright-task-store:task-store-v0.86.0
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3000

--- a/charts/shipwright/tests/task_store_workload_test.yaml
+++ b/charts/shipwright/tests/task_store_workload_test.yaml
@@ -11,9 +11,9 @@ tests:
     asserts:
       - isKind:
           of: Deployment
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/app-vitals/shipwright-task-store:task-store-v0.86.0
+          pattern: "^ghcr\\.io/app-vitals/shipwright-task-store:task-store-v\\d+\\.\\d+\\.\\d+$"
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3000

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -9,8 +9,12 @@
 # -- Global values shared with subcharts (including Bitnami PostgreSQL).
 global:
   # -- Override the registry for ALL images (chart + subcharts) in one place.
-  # Set this to a mirror (e.g. your registry, or a `bitnamilegacy` mirror) if the
-  # default Bitnami registry tags become unavailable. See README "Bitnami registry risk".
+  # Shipwright service images (admin, metrics, agent, taskStore, chat) default to
+  # fully-qualified ghcr.io/app-vitals/shipwright-<svc> repositories, so this is
+  # mainly relevant for the Bitnami PostgreSQL subchart and the whisper/cloud-sql
+  # sidecar images. Set this to a mirror (e.g. your registry, or a `bitnamilegacy`
+  # mirror) if the default Bitnami registry tags become unavailable. See README
+  # "Bitnami registry risk".
   imageRegistry: ""
   # -- Global image pull secrets (list of secret names) applied to all pods.
   imagePullSecrets: []
@@ -101,8 +105,8 @@ serviceAccount:
 admin:
   enabled: true
   image:
-    repository: shipwright-admin
-    tag: ""           # defaults to .Chart.AppVersion when empty
+    repository: ghcr.io/app-vitals/shipwright-admin
+    tag: admin-v0.188.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -169,8 +173,8 @@ admin:
 metrics:
   enabled: true
   image:
-    repository: shipwright-metrics
-    tag: ""           # defaults to .Chart.AppVersion when empty
+    repository: ghcr.io/app-vitals/shipwright-metrics
+    tag: metrics-v0.150.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -285,8 +289,8 @@ metrics:
 agent:
   enabled: true
   image:
-    repository: shipwright-agent
-    tag: ""
+    repository: ghcr.io/app-vitals/shipwright-agent
+    tag: agent-v0.172.0
     pullPolicy: ""
   service:
     port: 3000
@@ -308,8 +312,8 @@ agent:
     namespace: ""
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
-      repository: shipwright-agent
-      tag: ""           # defaults to .Chart.AppVersion when empty
+      repository: ghcr.io/app-vitals/shipwright-agent
+      tag: agent-v0.172.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).
@@ -507,8 +511,8 @@ taskStore:
   # -- Whether to render the task-store Deployment and Service.
   enabled: false
   image:
-    repository: shipwright-task-store
-    tag: ""           # defaults to .Chart.AppVersion when empty
+    repository: ghcr.io/app-vitals/shipwright-task-store
+    tag: task-store-v0.86.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -569,8 +573,8 @@ chat:
   # -- Whether to render the chat Deployment and Service.
   enabled: false
   image:
-    repository: shipwright-chat
-    tag: ""           # defaults to .Chart.AppVersion when empty
+    repository: ghcr.io/app-vitals/shipwright-chat
+    tag: chat-v0.38.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -429,8 +429,8 @@ agent:
     enabled: true
     namespace: ""                  # target namespace for provisioned agent resources; defaults to the admin pod's release namespace
     image:
-      repository: shipwright-agent
-      tag: ""                      # defaults to the chart appVersion
+      repository: ghcr.io/app-vitals/shipwright-agent
+      tag: agent-v0.172.0
     replicas: 1                    # replicas for each provisioned agent Deployment
     serviceAccount:
       create: true

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -44,9 +44,18 @@ Chart version bumps are **automated** by the
 Whenever a release tag is pushed matching `agent-v*`, `admin-v*`, `metrics-v*`,
 `task-store-v*`, or `chat-v*` (created by the service build workflows on
 successful image push), the automation detects the tag, increments the chart
-patch version in `Chart.yaml`, opens a PR (targeting `main`), and merges it
+patch version in `Chart.yaml`, pins each released tag into the matching
+`values.yaml` image defaults, opens a PR (targeting `main`), and merges it
 once checks pass. Once the PR merges, `chart-release.yml` fires and publishes
 the new chart version. No manual version bump is required.
+
+The `values.yaml` pinning ensures the chart's GHCR image defaults (in the
+`admin`, `metrics`, `agent`, `taskStore`, and `chat` blocks) track the same
+releases the chart version is crediting — preventing a scenario where the
+bumped chart would be deployed with stale image tags. Each batched release
+tag is pinned into its corresponding `values.yaml` path(s); for example,
+`admin-v0.156.2` pins into `admin.image.tag`, and `agent-v1.5.0` pins into
+both `agent.image.tag` and `agent.provisioning.image.tag`.
 
 Services release independently, so it's common for two or three tags to land
 within seconds or minutes of each other. Rather than bumping the chart once
@@ -55,7 +64,8 @@ event), the workflow **debounces**: a 90-second quiet period absorbs bursts,
 and only the last tag in a burst triggers the actual bump. The resulting PR
 credits every release tag that landed since the previous chart-bump commit,
 so the batch stays fully traceable even though it's collapsed into a single
-version bump.
+version bump. The PR body lists exactly which `values.yaml` path(s) were
+pinned and to which tag(s).
 
 ## First-time setup (one-time)
 


### PR DESCRIPTION
## Summary
- Fully-qualify all six shipwright service image blocks in `charts/shipwright/values.yaml` (admin, metrics, agent, agent provisioning, taskStore, chat) to `ghcr.io/app-vitals/shipwright-<svc>` with exact pinned tags, replacing bare repository names + `tag: ""` (appVersion-fallback) defaults
- Update the `global.imageRegistry` comment to clarify it's now mainly relevant for the Bitnami PostgreSQL subchart and sidecar images, since service images are fully-qualified by default
- Sync `charts/shipwright/README.md` values table and `docs/deploy-kubernetes.md`'s provisioning example to the new defaults

## Bundle note
This is **DCC-2.1**, the first task in the `feat/dcc-2-chart-ghcr-defaults` bundle (DCC-2.1 → DCC-2.5), which lands in this same PR per the plan's bricking-risk callout. As expected, 5 helm-unittest suites (admin/agent-provisioning-env/chat/metrics/task-store workload tests) currently fail locally on exact-string image assertions written against the old defaults — this is intentional and explicitly out of scope for DCC-2.1 (see its acceptance criteria's "Test decision" note). **DCC-2.3** (queued, depends on DCC-2.1) fixes those assertions on this same branch before the PR is mergeable. `helm lint` and `helm template` both pass; only `helm unittest` is red pending DCC-2.3.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All six image blocks fully-qualified with exact tags, no `tag: ""` | MET |
| 2 | `global.imageRegistry` comment updated | MET |
| 3 | No automated test required this task; DCC-2.3 fixes helm-unittest | MET |

## Test Plan
- [x] `helm lint charts/shipwright` passes
- [x] `helm template shipwright charts/shipwright --namespace shipwright` renders successfully with the new GHCR image refs
- [x] `helm unittest charts/shipwright` — 5 expected failures (exact-tag assertions), scoped to DCC-2.3, not this task
- [x] Independent spec-compliance subagent review: all criteria MET

Generated with [Claude Code](https://claude.com/claude-code)
