### PR TITLE
fix: prevent global.imageRegistry double-prefix on fully-qualified images

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,16 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.340] - 2026-07-11
+
+### Fixed
+
+- `global.imageRegistry` no longer double-prefixes the fully-qualified
+  `ghcr.io/app-vitals` service image repositories (admin, metrics, taskStore,
+  chat). A shared `shipwright.imageRef` helper detects a fully-qualified
+  repository (a registry host in the first `/`-delimited segment) and only
+  applies the `global.imageRegistry` prefix to bare repository names.
+
 ## [1.6.339] - 2026-07-11
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.339
+version: 1.6.340
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -28,10 +28,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Default image values are now fully-qualified, pinned GHCR references (ghcr.io/app-vitals/<service>:<tag>) instead of a bare repository name with an appVersion-fallback tag"
-    - kind: changed
-      description: "auto-bump-chart.yml now pins each batch's released tag(s) directly into the matching values.yaml image.tag path(s), keeping chart defaults in sync with the services they package"
+    - kind: fixed
+      description: "global.imageRegistry no longer double-prefixes the fully-qualified ghcr.io/app-vitals service image repositories (admin, metrics, taskStore, chat); a shared shipwright.imageRef helper detects fully-qualified repositories and only prefixes bare repository names"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -63,6 +63,37 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
+Assemble a container image reference, applying global.imageRegistry only when it
+is safe to do so.
+
+Args: a dict with keys
+  - context:    the root "." context (to reach .Values.global.imageRegistry)
+  - repository: the image repository (may be bare or fully-qualified)
+  - tag:        the image tag
+
+DCC-3.1: the shipwright service repositories default to fully-qualified GHCR
+paths (e.g. ghcr.io/app-vitals/shipwright-admin). Blindly prefixing
+global.imageRegistry onto those would DOUBLE-prefix them
+(registry/ghcr.io/app-vitals/...). Following the standard Helm/OCI community
+convention, a repository is treated as already naming a registry host when its
+first "/"-delimited segment contains a "." or ":" (e.g. "ghcr.io",
+"docker.io", "localhost:5000"). Such fully-qualified repositories are rendered
+verbatim; only BARE repository names (e.g. a user-overridden "shipwright-admin")
+receive the global.imageRegistry prefix.
+*/}}
+{{- define "shipwright.imageRef" -}}
+{{- $registry := .context.Values.global.imageRegistry -}}
+{{- $repository := .repository -}}
+{{- $tag := .tag -}}
+{{- $firstSegment := $repository | splitList "/" | first -}}
+{{- if and $registry (not (or (contains "." $firstSegment) (contains ":" $firstSegment))) -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Admin component fullname: "<fullname>-admin".
 */}}
 {{- define "shipwright.admin.fullname" -}}

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: admin
-          image: "{{ with .Values.global.imageRegistry }}{{ . }}/{{ end }}{{ .Values.admin.image.repository }}:{{ .Values.admin.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "shipwright.imageRef" (dict "context" $ "repository" .Values.admin.image.repository "tag" (.Values.admin.image.tag | default .Chart.AppVersion)) | quote }}
           imagePullPolicy: {{ .Values.admin.image.pullPolicy | default .Values.imagePullPolicy }}
           ports:
             - name: http

--- a/charts/shipwright/templates/chat-deployment.yaml
+++ b/charts/shipwright/templates/chat-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: chat
-          image: "{{ with .Values.global.imageRegistry }}{{ . }}/{{ end }}{{ .Values.chat.image.repository }}:{{ .Values.chat.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "shipwright.imageRef" (dict "context" $ "repository" .Values.chat.image.repository "tag" (.Values.chat.image.tag | default .Chart.AppVersion)) | quote }}
           imagePullPolicy: {{ .Values.chat.image.pullPolicy | default .Values.imagePullPolicy }}
           ports:
             - name: http

--- a/charts/shipwright/templates/metrics-deployment.yaml
+++ b/charts/shipwright/templates/metrics-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: metrics
-          image: "{{ with .Values.global.imageRegistry }}{{ . }}/{{ end }}{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "shipwright.imageRef" (dict "context" $ "repository" .Values.metrics.image.repository "tag" (.Values.metrics.image.tag | default .Chart.AppVersion)) | quote }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | default .Values.imagePullPolicy }}
           ports:
             - name: http

--- a/charts/shipwright/templates/task-store-deployment.yaml
+++ b/charts/shipwright/templates/task-store-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: task-store
-          image: "{{ with .Values.global.imageRegistry }}{{ . }}/{{ end }}{{ .Values.taskStore.image.repository }}:{{ .Values.taskStore.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "shipwright.imageRef" (dict "context" $ "repository" .Values.taskStore.image.repository "tag" (.Values.taskStore.image.tag | default .Chart.AppVersion)) | quote }}
           imagePullPolicy: {{ .Values.taskStore.image.pullPolicy | default .Values.imagePullPolicy }}
           ports:
             - name: http

--- a/charts/shipwright/tests/image_defaults_test.yaml
+++ b/charts/shipwright/tests/image_defaults_test.yaml
@@ -2,15 +2,24 @@ suite: default image repositories and pull policy
 # HD-2.1 set the PostgreSQL image coordinates (docker.io/bitnami/postgresql,
 # concrete tag — never `latest`) and the IfNotPresent default pull policy.
 # The shipwright service image repositories (shipwright-admin / -metrics /
-# -agent) live in values.yaml but have no consuming workload template until
-# HD-3.x, so they are guarded by values.schema.json `required: [repository]`
-# (see values_schema_test.yaml) rather than asserted on a rendered Deployment.
-# Here we assert the image facts that actually render today: the PostgreSQL
-# subchart's concrete image and pull policy.
+# -task-store / -chat) now DO have consuming workload templates (admin/metrics/
+# task-store/chat Deployments), so their image + registry-prefix behavior is
+# asserted on the rendered Deployments below (in addition to the schema guard in
+# values_schema_test.yaml). Per DCC-3.1, service images default to fully-qualified
+# ghcr.io/app-vitals repositories and are therefore NOT re-prefixed by
+# global.imageRegistry (which would otherwise double-prefix); only bare
+# repository names (e.g. the whisper image) get the registry prefix.
+# The PostgreSQL subchart assertions below cover the concrete image + pull policy.
 templates:
   - charts/postgresql/templates/primary/statefulset.yaml
+  - templates/admin-deployment.yaml
+  - templates/metrics-deployment.yaml
+  - templates/task-store-deployment.yaml
+  - templates/chat-deployment.yaml
+  - templates/whisper-deployment.yaml
 tests:
   - it: renders the bitnami/postgresql image from the docker.io registry
+    template: charts/postgresql/templates/primary/statefulset.yaml
     set:
       postgresql.enabled: true
     asserts:
@@ -19,6 +28,7 @@ tests:
           pattern: "^docker\\.io/bitnami/postgresql:"
 
   - it: pins a concrete PostgreSQL image tag (never `latest`)
+    template: charts/postgresql/templates/primary/statefulset.yaml
     set:
       postgresql.enabled: true
     asserts:
@@ -27,6 +37,7 @@ tests:
           pattern: ":latest$"
 
   - it: defaults the PostgreSQL pull policy to IfNotPresent
+    template: charts/postgresql/templates/primary/statefulset.yaml
     set:
       postgresql.enabled: true
     asserts:
@@ -35,6 +46,7 @@ tests:
           value: IfNotPresent
 
   - it: repoints the image when global.imageRegistry overrides the registry
+    template: charts/postgresql/templates/primary/statefulset.yaml
     set:
       postgresql.enabled: true
       global.imageRegistry: my-mirror.example.com
@@ -42,3 +54,73 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "^my-mirror\\.example\\.com/bitnami/postgresql:"
+
+  # ── DCC-3.1: global.imageRegistry must NOT double-prefix fully-qualified
+  # service repositories, but SHOULD still prefix bare repository names. The
+  # shared shipwright.imageRef helper detects a registry host (a "." or ":" in
+  # the first "/"-delimited segment) and skips the prefix for those. ──────────
+
+  - it: does not double-prefix the fully-qualified admin image when global.imageRegistry is set
+    template: templates/admin-deployment.yaml
+    set:
+      global.imageRegistry: mirror.example.com
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/app-vitals/shipwright-admin:admin-v\\d+\\.\\d+\\.\\d+$"
+
+  - it: does not double-prefix the fully-qualified metrics image when global.imageRegistry is set
+    template: templates/metrics-deployment.yaml
+    set:
+      global.imageRegistry: mirror.example.com
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/app-vitals/shipwright-metrics:"
+
+  - it: does not double-prefix the fully-qualified task-store image when global.imageRegistry is set
+    template: templates/task-store-deployment.yaml
+    set:
+      taskStore.enabled: true
+      global.imageRegistry: mirror.example.com
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/app-vitals/shipwright-task-store:"
+
+  - it: does not double-prefix the fully-qualified chat image when global.imageRegistry is set
+    template: templates/chat-deployment.yaml
+    set:
+      chat.enabled: true
+      global.imageRegistry: mirror.example.com
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/app-vitals/shipwright-chat:"
+
+  - it: still prefixes a bare (user-overridden) admin repository with global.imageRegistry
+    template: templates/admin-deployment.yaml
+    set:
+      global.imageRegistry: mirror.example.com
+      admin.image.repository: shipwright-admin
+      admin.image.tag: local
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: mirror.example.com/shipwright-admin:local
+
+  # ── whisper: bare-ish repo (onerahmet — no "." or ":" before first "/"), so
+  # global.imageRegistry STILL prefixes it (unchanged existing behavior). The
+  # whisper image is a single combined string and does NOT use the helper, but
+  # its prefix behavior is asserted here as the bare-repo regression guard. ───
+
+  - it: still prefixes the bare whisper image with global.imageRegistry
+    template: templates/whisper-deployment.yaml
+    set:
+      agent.voice.enabled: true
+      agent.voice.provider: whisper
+      global.imageRegistry: mirror.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: mirror.example.com/onerahmet/openai-whisper-asr-webservice:v1.3.0

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -9,12 +9,20 @@
 # -- Global values shared with subcharts (including Bitnami PostgreSQL).
 global:
   # -- Override the registry for ALL images (chart + subcharts) in one place.
-  # Shipwright service images (admin, metrics, agent, taskStore, chat) default to
+  # Shipwright service images (admin, metrics, taskStore, chat) default to
   # fully-qualified ghcr.io/app-vitals/shipwright-<svc> repositories, so this is
   # mainly relevant for the Bitnami PostgreSQL subchart and the whisper/cloud-sql
   # sidecar images. Set this to a mirror (e.g. your registry, or a `bitnamilegacy`
   # mirror) if the default Bitnami registry tags become unavailable. See README
   # "Bitnami registry risk".
+  #
+  # Fully-qualified-repository detection (DCC-3.1): setting this does NOT
+  # re-prefix a service image whose repository already names a registry host —
+  # i.e. its first "/"-delimited segment contains a "." or ":" (e.g. "ghcr.io",
+  # "docker.io", "localhost:5000"). This avoids double-prefixing the
+  # ghcr.io/app-vitals defaults (which would render registry/ghcr.io/...). Only
+  # BARE repository names (no registry host, e.g. an override like
+  # "shipwright-admin", or the whisper "onerahmet/..." image) receive the prefix.
   imageRegistry: ""
   # -- Global image pull secrets (list of secret names) applied to all pods.
   imagePullSecrets: []

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -9,7 +9,9 @@ published to a Helm repo on every chart version bump (see
 [`helm-repo.md`](./helm-repo.md)). It packages the admin (port **3001**), metrics
 (port **3460**), agent (port **3000**), task-store (port **3000**), and optional chat
 (port **3000**) services plus an optional bundled PostgreSQL dependency,
-with Minikube-friendly defaults throughout. Task-store and chat are disabled by default.
+with Minikube-friendly defaults throughout. Task-store and chat are disabled by
+default; the agent is provisioned dynamically when `agent.provisioning.enabled=true`
+is set.
 
 This guide covers three deployment targets end-to-end, then the cross-cutting
 concerns shared by all of them:
@@ -570,7 +572,18 @@ default registry tags become unavailable you can repoint the images without
 changing the chart, or bring your own database:
 
 - **Mirror the whole stack:** set `global.imageRegistry: <your-mirror>`.
+  When set, this prefix is applied **only** to bare repository names (those not
+  already naming a registry host). Shipwright's service images default to
+  fully-qualified GHCR paths (e.g., `ghcr.io/app-vitals/shipwright-admin`),
+  which are **not** prefixed — avoiding double-prefixing
+  (e.g., `registry/ghcr.io/...`). A repository's first `/`-delimited segment is
+  checked: if it contains a `.` or `:` (e.g., `ghcr.io`, `docker.io`,
+  `localhost:5000`), it's treated as a fully-qualified registry host and left
+  alone. Only bare names (e.g., `shipwright-admin` or the whisper image
+  `onerahmet/openai-whisper-asr-webservice`) receive the prefix.
+
 - **Use the `bitnamilegacy` mirror** for PostgreSQL specifically.
+
 - **Bring your own PostgreSQL:** set `postgresql.enabled=false` and point
   `externalDatabase.existingSecret` at a pre-created Kubernetes Secret holding
   `DATABASE_URL_SHIPWRIGHT_ADMIN`. The chart injects the value into the admin


### PR DESCRIPTION
## Summary
- Add a shared `shipwright.imageRef` helper to `_helpers.tpl` that detects a fully-qualified repository (registry host — `.` or `:` in the first `/`-delimited segment) and skips the `global.imageRegistry` prefix for it, while still prefixing bare repository names.
- Migrate all four service deployment templates (admin, metrics, task-store, chat) to call the helper instead of inlining the old pattern — fixes the double-prefix bug (`registry/ghcr.io/app-vitals/...`) that would occur today if `global.imageRegistry` were set.
- Document the fully-qualified-repository detection behavior in `values.yaml` comments.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Fully-qualified unprefixed, whisper still prefixed — new helm-unittest cases | MET | New cases in `image_defaults_test.yaml` assert admin/metrics/task-store/chat render unprefixed GHCR with `global.imageRegistry` set, and whisper still renders `mirror.example.com/onerahmet/...` |
| 2 | Default rendering byte-identical to DCC-2.1 | MET | Pre-existing `admin/metrics/task-store/chat_workload_test.yaml` regex assertions (unmodified, no imageRegistry set) still pass — 243/243 tests green |
| 3 | All four deployment templates call the shared helper; no template still inlines the pattern | MET | All 4 call `include "shipwright.imageRef"`; only `whisper-deployment.yaml` (intentionally out of scope — combined image string, not repository/tag fields) still inlines the old pattern |
| 4 | values.yaml comments document fully-qualified-repository detection | MET | `global.imageRegistry` comment block extended with detection rules and rationale |
| 5 | Unit-layer helm-unittest coverage for (a) fully-qualified+registry, (b) bare+registry, (c) no-registry byte-identical; no tests retired | MET | (a)/(b) added as new cases; (c) covered by unmodified pre-existing per-component tests; no existing test deleted |

## Test Plan
- `helm unittest charts/shipwright` — 243/243 tests pass (19 suites, including all pre-existing regression guards)
- `helm lint charts/shipwright` — clean
- New helm-unittest cases: fully-qualified admin/metrics/task-store/chat images stay unprefixed with `global.imageRegistry` set; bare-override admin repo and whisper's bare `onerahmet/...` image still get prefixed
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
