### PR TITLE
fix: replace broken Cal.com discovery-call link

### DIFF
--- a/.claude/skills/shipwright-brand/SKILL.md
+++ b/.claude/skills/shipwright-brand/SKILL.md
@@ -51,7 +51,7 @@ brand system — never by hand-picking colors, fonts, or copy. The system lives 
 
 - **No client / customer / partner names.** Anonymize by role or industry.
 - **No pricing, rates, or tiers.** The tool is free/MIT; services are discussed in conversation, never published.
-- **No email-capture forms.** The only off-page CTA is the discovery call: `https://cal.com/app-vitals/discovery`.
+- **No email-capture forms.** The only off-page CTA is the discovery call: `https://cal.com/team/app-vitals/discovery-call`.
 - **No secrets, internal infra identifiers, or local file paths** — this repo is public.
 - **Naming:** brand = **Shipwright Harness**; package/install = **`shipwright`** (`/plugin install shipwright@app-vitals/shipwright`). Never headline "shipwright" lowercase; never write the brand name as a command.
 - **Voice:** honest, direct, engineer-to-engineer, metric-first. No hype, no emoji-laden superlatives.

--- a/brand/BRAND.md
+++ b/brand/BRAND.md
@@ -169,7 +169,7 @@ Honest, direct, engineer-to-engineer, metric-first. No hype, no client names, no
 - **No client / customer / partner names.** Anonymize by role or industry if a story is needed.
 - **No competitor names** — position generically as the free, open-source, own-it alternative to closed, hosted agents; never name a competing product. **Exception: Claude Code** is the *platform* Shipwright is built on and for, **not** a competitor — feature it prominently and proudly (it's also a major discovery/SEO driver).
 - **No pricing, rates, or tiers.** The tool is free/MIT; services are discussed in conversation, not published.
-- **No email-capture forms.** The only CTA off the page is the discovery call: `https://cal.com/app-vitals/discovery`.
+- **No email-capture forms.** The only CTA off the page is the discovery call: `https://cal.com/team/app-vitals/discovery-call`.
 - **No secrets, internal infra identifiers, or local file paths** in anything committed (the repo is public).
 - Co-founders, when named: **Dan McAulay** and **Dave O'Dell**.
 - The COSS posture is the quiet bridge: give the tool away; "work with the people who built it" is a soft, no-pressure path — never a hard upsell.

--- a/brand/tokens.json
+++ b/brand/tokens.json
@@ -142,7 +142,7 @@
     "gutter": "1.5rem"
   },
   "links": {
-    "discoveryCall": "https://cal.com/app-vitals/discovery",
+    "discoveryCall": "https://cal.com/team/app-vitals/discovery-call",
     "repo": "https://github.com/app-vitals/shipwright",
     "site": "https://shipwrightharness.com"
   }

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -9,7 +9,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const repoUrl = "https://github.com/app-vitals/shipwright";
-const discoveryUrl = "https://cal.com/app-vitals/discovery";
+const discoveryUrl = "https://cal.com/team/app-vitals/discovery-call";
 const installCmd = "/plugin install shipwright@app-vitals/shipwright";
 
 // Market structure: 3-pole framing of the AI coding agent space.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,7 +9,7 @@ const taglineGradient = "in your own environment";
 const tagline = `${taglinePrefix}${taglineGradient}.`;
 const install = "/plugin install shipwright@app-vitals/shipwright";
 const githubUrl = "https://github.com/app-vitals/shipwright";
-const discoveryUrl = "https://cal.com/app-vitals/discovery";
+const discoveryUrl = "https://cal.com/team/app-vitals/discovery-call";
 const proofUrl = "https://proof.shipwrightharness.com/public/dashboard";
 const proofTasksUrl = "https://proof.shipwrightharness.com/public/tasks";
 

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -175,7 +175,7 @@ test("CTA repeats the install command and links GitHub + discovery call", async 
   ).toHaveAttribute("href", /github\.com\/app-vitals\/shipwright/);
   await expect(
     page.getByRole("link", { name: /discovery call/i }),
-  ).toHaveAttribute("href", "https://cal.com/app-vitals/discovery");
+  ).toHaveAttribute("href", "https://cal.com/team/app-vitals/discovery-call");
 });
 
 test("compare page markets no pricing", async ({ page }) => {

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -401,7 +401,7 @@ test("services bridge links to the discovery call", async ({ page }) => {
   await expect(section).toBeVisible();
   await expect(
     section.getByRole("link", { name: /discovery call/i }),
-  ).toHaveAttribute("href", "https://cal.com/app-vitals/discovery");
+  ).toHaveAttribute("href", "https://cal.com/team/app-vitals/discovery-call");
 });
 
 test("services bridge stays soft — no email-capture form", async ({ page }) => {


### PR DESCRIPTION
## Summary
- The site-wide "Book a discovery call" CTA pointed to `https://cal.com/app-vitals/discovery`, which 404s (the handle doesn't exist on Cal.com)
- Replaced every occurrence with the working link `https://cal.com/team/app-vitals/discovery-call` across brand docs, site pages, brand tokens, and tests
- Literal find-and-replace, no logic change

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All occurrences updated; `grep -r "cal.com/app-vitals/discovery"` (excl. node_modules/worktrees) returns nothing | MET |
| 2 | Both `discoveryUrl` consts and both doc references (BRAND.md, shipwright-brand SKILL.md) use the identical corrected string, no drift | MET |
| 3 | Test decision: no new tests — updated the two existing e2e assertions' expected href value in place | MET |

## Test Plan
- Verified new link returns HTTP 200 (`curl -I https://cal.com/team/app-vitals/discovery-call`)
- `astro build` succeeds; confirmed built HTML (`dist/index.html`, `dist/compare/index.html`) contains the corrected URL
- `bun run brand-lint` passes on the built site
- `bunx biome lint .` passes repo-wide
- Playwright e2e (`site/tests/home.spec.ts`, `site/tests/compare.spec.ts`) could not be run locally — sandbox is missing a system library for headless Chromium (no sudo access to fix); relying on CI to run the actual e2e suite
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
