### PR TITLE
chore(chart): bump chart version to 1.6.341

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.341] - 2026-07-12
+
+### Changed
+
+- auto-bump to chart v1.6.341 triggered by release tag(s): `admin-v0.189.0`, `agent-v0.173.0`
+
 ## [1.6.340] - 2026-07-11
 
 ### Fixed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.340
+version: 1.6.341
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -28,8 +28,10 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "global.imageRegistry no longer double-prefixes the fully-qualified ghcr.io/app-vitals service image repositories (admin, metrics, taskStore, chat); a shared shipwright.imageRef helper detects fully-qualified repositories and only prefixes bare repository names"
+    - kind: changed
+      description: "auto-bump to chart v1.6.341 triggered by release tag admin-v0.189.0"
+    - kind: changed
+      description: "auto-bump to chart v1.6.341 triggered by release tag agent-v0.173.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -114,7 +114,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v0.188.0
+    tag: admin-v0.189.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -298,7 +298,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v0.172.0
+    tag: agent-v0.173.0
     pullPolicy: ""
   service:
     port: 3000
@@ -321,7 +321,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v0.172.0
+      tag: agent-v0.173.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.6.340 → 1.6.341

**Triggering tags:**
- `admin-v0.189.0`
- `agent-v0.173.0`

**New chart version:** `1.6.341`

Manually landed — the original `auto-bump-chart.yml` run pushed this branch but crashed in "Open bump PR" before opening a PR (backtick command-substitution bug in `PINNED_LINES`, fixed separately in DCC-11.1). This PR carries the same commit, rebased onto current main.

---
_Manually opened to unblock the stuck bump; see DCC-11.1 for the underlying workflow fix._