### PR TITLE
fix: namespace entropy-fix task IDs by repo to prevent cross-repo collisions

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -71,7 +71,7 @@ Body (JSON): task fields. `title`, `status`, and `repo` are required. The `repo`
 POST /tasks/bulk
 ```
 
-Body: JSON array of task objects. Each task must have `title`, `status`, and `repo` fields. The `repo` key must be present on every task; `null` is accepted as a valid value for tasks that are not scoped to a specific repository. Skips conflicts (existing ID) rather than failing. Returns `{ inserted: number, updated: number }`.
+Body: JSON array of task objects. Each task must have `title`, `status`, and `repo` fields. The `repo` key must be present on every task; `null` is accepted as a valid value for tasks that are not scoped to a specific repository. Skips conflicts (existing ID) rather than failing. Returns `{ inserted: number, updated: number, skipped: string[] }`, where `skipped` lists the IDs of tasks that collided with an existing task.
 
 #### Distinct values
 

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -86,7 +86,7 @@ ENTROPY FIX — DRY RUN
 
 Would queue {N} tasks:
 
-  1. entropy-{rule-id}-{YYYY-Www}
+  1. entropy-{rule-id}-{repo-slug}-{YYYY-Www}
      Rule: {rule.description} ({severity})
      Findings: {count} instances
      Files: {list of unique file paths}
@@ -122,19 +122,34 @@ Queueing is the only mode. Run this workflow for every run.
 
 ### 6q.1 Dedup Check
 
-Run:
+First, detect the current repo from git: run `git remote get-url origin` and strip the
+`https://github.com/` (or `git@github.com:`, stripping the `.git` suffix) prefix to get the
+`org/repo` value — e.g. `app-vitals/shipwright`. This is the `repo` value used both to scope
+the dedup queries below and, unchanged, as the task JSON's `repo` field in 6q.3 — compute it
+once here and reuse it there.
+
+Derive `repo-slug` from it too: the last path segment, lowercased — e.g. `app-vitals/shipwright`
+→ `shipwright`. This slug is used in task IDs throughout this skill (6q.3, 6q.6) to keep IDs
+unique per repo.
+
+Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`):
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}" | jq '.tasks'
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}" | jq '.tasks'
 ```
+
+The `&repo=` filter scopes dedup to tasks for the repo currently being scanned — without it, a
+rule active for one repo would incorrectly block or interfere with dedup for a different repo.
 
 Parse both `.tasks` arrays. From the combined results, collect tasks where:
 - `source == "shipwright"`, OR
 - `title` starts with `"Entropy fix:"`
 
-Extract the rule IDs from existing tasks by parsing the `id` field (format: `entropy-{rule-id}-{YYYY-Www}`) or from the `branch` field (format: `fix/entropy-{rule-id}-...`). Build a set of "already active" rule IDs.
+Extract the rule IDs from existing tasks by parsing the `id` field (format:
+`entropy-{rule-id}-{repo-slug}-{YYYY-Www}`) or from the `branch` field (format:
+`fix/entropy-{rule-id}-...`). Build a set of "already active" rule IDs.
 
 For each rule group: if its `rule_id` is in the "already active" set, skip it. Print: `Skipping {rule_id} — task already active`.
 
@@ -165,14 +180,15 @@ deletion rules are not cross-checked — they pass through unchanged.
 
 ### 6q.3 Build Task JSON
 
-For each remaining rule group, build a task object:
+For each remaining rule group, build a task object. Reuse the `repo` and `repo-slug` values
+detected in 6q.1 — do not re-derive them:
 
 ```json
 {
-  "id": "entropy-{rule-id}-{YYYY-Www}",
+  "id": "entropy-{rule-id}-{repo-slug}-{YYYY-Www}",
   "title": "Entropy fix: {rule.description}",
   "source": "shipwright",
-  "repo": "<detected from git remote get-url origin — strip https://github.com/ prefix>",
+  "repo": "<repo, as detected in 6q.1>",
   "branch": "fix/entropy-{rule-id}-{short-description}",
   "layer": "Shared",
   "status": "pending",
@@ -195,11 +211,15 @@ Fix guidance: {entry's **Detection:** field, or remediation guidance from the pr
 Rule: {rule.id} | Severity: {rule.severity} | Domain: {rule.domain} | HITL: {hitl}
 ```
 
+The `{repo-slug}` segment is the last path segment of the detected `repo` value (from 6q.1),
+lowercased — e.g. `app-vitals/shipwright` → `shipwright`. It namespaces the task ID per repo so
+the same rule scanned in two different repos in the same week never collides.
+
 The `{YYYY-Www}` suffix in the task ID uses ISO week format. Compute from the current date:
 - Year: 4-digit year
 - `W`: literal `W`
 - Week number: 2-digit zero-padded ISO week number (01–53)
-- Example: `entropy-dead_exports-2026-W23`
+- Example: `entropy-dead_exports-shipwright-2026-W23`
 
 `short-description`: lowercase, hyphens, max 5 words from rule.description.
 
@@ -258,7 +278,7 @@ ENTROPY FIX — QUEUED
   DEFERRED  {N} findings (referenced by pending/in-progress tasks)
 
 Tasks queued:
-  entropy-{rule-id}-{YYYY-Www} — {rule.description}  [hitl: {true|false}]
+  entropy-{rule-id}-{repo-slug}-{YYYY-Www} — {rule.description}  [hitl: {true|false}]
   ...
 
 {If any skipped:}

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -204,7 +204,7 @@ function fakeTaskService(
       return makeTask({ id, status: "pending" });
     },
     async bulk(_tasks) {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct(_agentId?) {
       return { sessions: [], repos: [] };

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -167,7 +167,7 @@ function fakeTaskService(
       return makeTask({ id, status: "pending" });
     },
     async bulk(_tasks) {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct(_agentId?) {
       return { sessions: [], repos: [] };

--- a/task-store/src/generate-spec.ts
+++ b/task-store/src/generate-spec.ts
@@ -42,7 +42,7 @@ const stubTaskService: TaskServiceLike = {
     return {} as never;
   },
   async bulk() {
-    return { inserted: 0, updated: 0 };
+    return { inserted: 0, updated: 0, skipped: [] };
   },
   async update() {
     return {} as never;

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -460,6 +460,11 @@ export const BulkInsertResponseSchema = z
   .object({
     inserted: z.number().int().openapi({ example: 3 }),
     updated: z.number().int().openapi({ example: 1 }),
+    skipped: z.array(z.string()).openapi({
+      example: ["entropy-dead_exports-vitals-os-2026-W29"],
+      description:
+        "IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).",
+    }),
   })
   .openapi("BulkInsertResponse");
 

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -461,7 +461,7 @@ export const BulkInsertResponseSchema = z
     inserted: z.number().int().openapi({ example: 3 }),
     updated: z.number().int().openapi({ example: 1 }),
     skipped: z.array(z.string()).openapi({
-      example: ["entropy-dead_exports-vitals-os-2026-W29"],
+      example: ["entropy-dead_exports-other-repo-2026-W29"],
       description:
         "IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).",
     }),

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -343,7 +343,7 @@ function fakeTaskService(): TaskServiceLike {
       return {} as never;
     },
     async bulk() {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
       return { sessions: [], repos: [] };

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -126,7 +126,7 @@ function fakeTaskService(opts: { tasks?: Task[] } = {}): TaskServiceLike {
       return makeTask({ id, status: "pending" });
     },
     async bulk() {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
       return { sessions: [], repos: [] };

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -16,7 +16,8 @@
  *   GET    /tasks               list (?status, ?state=open|closed, ?session, ?assignee, ?pr, ?branch, ?limit, ?offset, ?ready=true)
  *                              returns { tasks, total }
  *   POST   /tasks               create one (409 if id exists)
- *   POST   /tasks/bulk          insert array, skip 409s → { inserted, updated }
+ *   POST   /tasks/bulk          insert array, skip 409s → { inserted, updated, skipped }
+ *                              (skipped lists the IDs that collided with an existing task)
  *   GET    /tasks/:id           fetch one (404 when missing)
  *   PATCH  /tasks/:id           update
  *   DELETE /tasks/:id           delete

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -160,7 +160,7 @@ function fakeTaskService(opts: {
       return makeTask({ id, status: "pending" });
     },
     async bulk(_tasks) {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
       return { sessions: [], repos: [] };

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -70,7 +70,7 @@ export interface TaskServiceLike {
   create(data: Prisma.TaskCreateInput): Promise<Task>;
   bulk(
     tasks: Prisma.TaskCreateInput[],
-  ): Promise<{ inserted: number; updated: number }>;
+  ): Promise<{ inserted: number; updated: number; skipped: string[] }>;
   update(id: string, data: Prisma.TaskUpdateInput): Promise<Task>;
   remove(id: string): Promise<void>;
   claim(id: string, claimedBy: string): Promise<Task>;
@@ -258,26 +258,30 @@ export class TaskService implements TaskServiceLike {
 
   async bulk(
     tasks: Prisma.TaskCreateInput[],
-  ): Promise<{ inserted: number; updated: number }> {
+  ): Promise<{ inserted: number; updated: number; skipped: string[] }> {
     let inserted = 0;
+    const skipped: string[] = [];
     for (const task of tasks) {
       try {
         await this.prisma.task.create({ data: task });
         inserted++;
       } catch (err: unknown) {
-        // P2002 = unique constraint violation (id already exists) — skip silently
+        // P2002 = unique constraint violation (id already exists) — skip, but
+        // record the id so callers can see which tasks collided instead of
+        // this being silently swallowed.
         if (
           typeof err === "object" &&
           err !== null &&
           "code" in err &&
           (err as { code: string }).code === "P2002"
         ) {
+          if (typeof task.id === "string") skipped.push(task.id);
           continue;
         }
         throw err;
       }
     }
-    return { inserted, updated: 0 };
+    return { inserted, updated: 0, skipped };
   }
 
   async update(id: string, data: Prisma.TaskUpdateInput): Promise<Task> {

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { computeBlockedBy } from "./blocked-by.ts";
+import type { PrismaClient } from "./index.ts";
 import type { ReadyTaskLike } from "./ready.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
-import type { TaskListFilters } from "./task-service.ts";
+import { type TaskListFilters, TaskService } from "./task-service.ts";
 
 // ─── Minimal in-memory stub matching only the logic under test ────────────────
 
@@ -296,5 +297,38 @@ describe("listBlocked logic (unit)", () => {
     expect(result[0].blockedBy).toEqual([
       { type: "dependency", id: "dep-1", status: "in_progress" },
     ]);
+  });
+});
+
+// ─── TaskService.bulk() ─────────────────────────────────────────────────────
+
+describe("TaskService.bulk (unit)", () => {
+  it("collects skipped IDs for tasks that collide with a P2002 unique constraint error", async () => {
+    const created: string[] = [];
+    const fakePrisma = {
+      task: {
+        create: async ({
+          data,
+        }: {
+          data: { id?: string };
+        }) => {
+          if (data.id === "dup-task") {
+            throw { code: "P2002" };
+          }
+          created.push(data.id as string);
+          return { ...data };
+        },
+      },
+    } as unknown as PrismaClient;
+
+    const service = new TaskService(fakePrisma);
+    const result = await service.bulk([
+      { id: "dup-task", title: "Duplicate", status: "pending" } as never,
+      { id: "new-task", title: "New task", status: "pending" } as never,
+    ]);
+
+    expect(result.inserted).toBe(1);
+    expect(result.skipped).toEqual(["dup-task"]);
+    expect(created).toEqual(["new-task"]);
   });
 });

--- a/task-store/src/tasks.execution-fields.smoke.test.ts
+++ b/task-store/src/tasks.execution-fields.smoke.test.ts
@@ -180,7 +180,7 @@ function fakeTaskService(storedTasks: Map<string, Task> = new Map()): TaskServic
       return updated;
     },
     async bulk(_tasks) {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct(): Promise<{ sessions: string[]; repos: string[] }> {
       return Promise.resolve({ sessions: [], repos: [] });

--- a/task-store/src/tokens.smoke.test.ts
+++ b/task-store/src/tokens.smoke.test.ts
@@ -160,7 +160,7 @@ function fakeTaskService(): TaskServiceLike {
       return data as never;
     },
     async bulk() {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async update(_id, data) {
       return data as never;

--- a/task-store/src/validate.smoke.test.ts
+++ b/task-store/src/validate.smoke.test.ts
@@ -175,7 +175,7 @@ function fakeTaskService(
       return makeTask({ id, status: "pending" });
     },
     async bulk(_tasks) {
-      return { inserted: 0, updated: 0 };
+      return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct(
       _agentId?: string,


### PR DESCRIPTION
## Summary
- Namespace entropy-fix task IDs by repo (`entropy-{rule-id}-{repo-slug}-{YYYY-Www}`) so the same rule scanned in two different repos in the same ISO week never collides in the task store.
- Scope entropy-fix's dedup check (Step 6q.1) to the repo currently being scanned via `&repo=` on both task-store queries, so an active task in one repo no longer incorrectly blocks dedup for a different repo.
- Surface `skipped: string[]` from `POST /tasks/bulk` (task-store) so ID collisions are visible in the response instead of being silently swallowed — backward compatible, still 200 on partial success.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Task ID template includes repo-slug | MET | `entropy-{rule-id}-{repo-slug}-{YYYY-Www}` used consistently in SKILL.md |
| 2 | All SKILL.md ID-format mentions updated consistently | MET | dry-run preview, Build Task JSON, summary print all match |
| 3 | 6q.1 dedup parsing description matches new format | MET | id/branch parsing note updated |
| 4 | 6q.1 dedup queries scoped to current repo | MET | `&repo={url-encoded-repo}` added to both dedup curl calls |
| 5 | `bulk()` returns `skipped: string[]`, schema+JSDoc updated, 200 status unchanged | MET | task-service.ts, openapi-schemas.ts, routes/tasks.ts |
| 6 | Unit test covers `skipped` behavior | MET | task-service.unit.test.ts, P2002-rigged fake Prisma |
| 7 | No new non-2xx path for collisions | MET | route still returns `c.json(result, 200)` |

## Test Plan
- `bun test task-store/src/task-service.unit.test.ts` — new TDD test for `bulk()`'s `skipped` array (red → green)
- Full `task-store` suite: 312 pass / 0 fail / 80 skip (DB-gated, pre-existing)
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
