### PR TITLE
fix: remove dead loadInClusterConfig export and unexport KubernetesCassette

### DIFF
--- a/admin/src/kubernetes-client.ts
+++ b/admin/src/kubernetes-client.ts
@@ -325,39 +325,7 @@ export function pvcBody(namespace: string, spec: PvcSpec): KubernetesPvc {
   return body;
 }
 
-// ─── In-cluster config loading ────────────────────────────────────────────────
-
 const SA_DIR = "/var/run/secrets/kubernetes.io/serviceaccount";
-
-export interface InClusterConfig {
-  apiServer: string;
-  token: string;
-  caCert?: string;
-}
-
-/**
- * Read in-cluster config from the mounted ServiceAccount. Paths are overridable
- * so tests can point at temp files (or skip this entirely and inject directly).
- */
-export function loadInClusterConfig(opts?: {
-  tokenPath?: string;
-  caPath?: string;
-  apiServer?: string;
-}): InClusterConfig {
-  const tokenPath = opts?.tokenPath ?? `${SA_DIR}/token`;
-  const caPath = opts?.caPath ?? `${SA_DIR}/ca.crt`;
-  const apiServer = opts?.apiServer ?? defaultApiServer();
-
-  const token = readFileSync(tokenPath, "utf-8").trim();
-  let caCert: string | undefined;
-  try {
-    caCert = readFileSync(caPath, "utf-8");
-  } catch {
-    caCert = undefined;
-  }
-
-  return { apiServer, token, caCert };
-}
 
 /**
  * Read the in-cluster CA cert (PEM). When the caller passed an EXPLICIT
@@ -640,7 +608,7 @@ export class HttpKubernetesClient implements KubernetesClient {
 
 // ─── RecordedKubernetesClient (in-memory double) ──────────────────────────────
 
-export interface KubernetesCassette {
+interface KubernetesCassette {
   /** Pre-seeded deployments keyed by `${namespace}/${name}`. */
   deployments: Record<string, KubernetesDeployment>;
   /** Pre-seeded secrets keyed by `${namespace}/${name}`. */


### PR DESCRIPTION
## Summary
- Removed `loadInClusterConfig` and its return type `InClusterConfig` from `admin/src/kubernetes-client.ts` — both had zero call sites anywhere in the repo (including the file itself). `HttpKubernetesClient` reads the token/CA independently via `readFileSync`/`readCa()`, so this function was fully superseded and dead.
- Removed the `export` keyword from `KubernetesCassette` — it's used internally as the `RecordedKubernetesClient` constructor parameter type, but no other file imports it (tests construct it via object literals, relying on structural typing).

Entropy patrol finding: `dead_exports` (medium severity), 2 findings in `admin/src/kubernetes-client.ts`.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `loadInClusterConfig` (and `InClusterConfig`) removed — zero call sites anywhere | MET | Function, JSDoc, and interface deleted; grep confirms zero references repo-wide |
| 2 | `KubernetesCassette` unexported but still usable internally | MET | `export` keyword removed; `RecordedKubernetesClient` constructor still uses it in-file |
| 3 | Diff is minimal and surgical, no unrelated changes | MET | 1 file changed, 1 insertion(+), 33 deletions(-) |
| 4 | Existing tests still pass (behavior-preserving) | MET | `kubernetes-client.unit.test.ts`: 31/31 pass. `kubernetes-client.integration.test.ts`: 41/42 pass (1 pre-existing environmental flake, reproduces identically on clean main via `git stash`, unrelated to this diff) |

## Test Plan
- [x] `bun test admin/src/kubernetes-client.unit.test.ts admin/src/kubernetes-client.integration.test.ts` — passes (minus a known pre-existing CA-fallback environmental flake unrelated to this change)
- [x] `bun test admin/` — no ripple effects
- [x] `bun run typecheck` — all 7 workspaces pass
- [x] `bun run lint` — passes
- [x] Confirmed via `git stash` that the CA-fallback flake and the `metrics/` full-suite flake both reproduce identically on unmodified `main` — pre-existing, not introduced by this change

Generated with [Claude Code](https://claude.com/claude-code)
