### PR TITLE
fix: force NODE_ENV=test in workspace test invocations

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,12 +24,12 @@ tasks:
   test:
     desc: Run all tests
     cmds:
-      - bun test
+      - NODE_ENV=test bun test
 
   test:coverage:
     desc: Run all tests with coverage, then gate on aggregate 80/80 lines/functions (scripts/check-coverage.ts)
     cmds:
-      - bun test --coverage --coverage-reporter=lcov
+      - NODE_ENV=test bun test --coverage --coverage-reporter=lcov
       - bun run scripts/check-coverage.ts
 
   check-strings:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,7 +6,7 @@ Everything below this line through [Configuration reference](#configuration-refe
 
 ## Overview
 
-Every Shipwright service (`admin`, `metrics`, `task-store`, `agent`) can report to Sentry when `SENTRY_DSN` is set in its own environment. Each service reads its own `SENTRY_DSN` — there is no shared/global toggle. When `SENTRY_DSN` is unset (the default), or when `NODE_ENV` is `"test"` (auto-set by `bun test`), Sentry is fully inert: no init call, zero telemetry, zero overhead. The test guard prevents test error-path assertions from leaking to production Sentry as real events.
+Every Shipwright service (`admin`, `metrics`, `task-store`, `agent`) can report to Sentry when `SENTRY_DSN` is set in its own environment. Each service reads its own `SENTRY_DSN` — there is no shared/global toggle. When `SENTRY_DSN` is unset (the default), or when `NODE_ENV` is `"test"` (explicitly set via `NODE_ENV=test` prefix in test commands), Sentry is fully inert: no init call, zero telemetry, zero overhead. The test guard prevents test error-path assertions from leaking to production Sentry as real events.
 
 All services share the same init options and scrub hooks via `buildSentryInitOptions()` / `initSentry()` in `lib/sentry.ts`, so behavior is identical regardless of which service reports.
 
@@ -27,7 +27,7 @@ When `SENTRY_DSN` is set, a service reports:
 
 ## Disabling Sentry
 
-Unset `SENTRY_DSN` (or never set it) for the service in question. This is the default — no other configuration is required to keep a service fully offline from Sentry's perspective. Alternatively, `Sentry` is automatically disabled during test runs (when `NODE_ENV` is `"test"`, auto-set by `bun test`) even if `SENTRY_DSN` is present in the environment, preventing test assertions from polluting production Sentry with unintended error events.
+Unset `SENTRY_DSN` (or never set it) for the service in question. This is the default — no other configuration is required to keep a service fully offline from Sentry's perspective. Alternatively, `Sentry` is automatically disabled during test runs (when `NODE_ENV` is `"test"`, explicitly set via `NODE_ENV=test` prefix in test commands like `NODE_ENV=test bun test`) even if `SENTRY_DSN` is present in the environment, preventing test assertions from polluting production Sentry with unintended error events.
 
 ## Self-hosted Sentry
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "mcp-server"
   ],
   "scripts": {
-    "test": "bun test",
+    "test": "NODE_ENV=test bun test",
     "lint": "bunx biome lint .",
     "format": "bunx biome format --write .",
     "typecheck": "bun run --filter='*' --sequential typecheck",

--- a/scripts/test-env-guard.unit.test.ts
+++ b/scripts/test-env-guard.unit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * scripts/test-env-guard.unit.test.ts
+ *
+ * Config-drift regression guard for SEN-3.1: `buildSentryInitOptions()` in
+ * `lib/sentry.ts` only skips Sentry init when `process.env.NODE_ENV === "test"`.
+ * Bun auto-sets NODE_ENV=test for `bun test` runs, but only when NODE_ENV is
+ * unset in the invoking shell — if a parent process already exports
+ * NODE_ENV (e.g. NODE_ENV=production), Bun leaves it unchanged and the guard
+ * silently never fires.
+ *
+ * This test asserts that every full-workspace `bun test` invocation in
+ * Taskfile.yml and package.json is explicitly prefixed with `NODE_ENV=test`,
+ * so the guard holds regardless of what's already exported by the invoking
+ * environment. It reads the two config files directly off disk (not
+ * network/DB I/O) rather than exercising `buildSentryInitOptions()` itself —
+ * that behavior is already covered by lib/sentry.unit.test.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Resolve relative to the repo root (cwd when tests run)
+const TASKFILE_PATH = resolve(process.cwd(), "Taskfile.yml");
+const PACKAGE_JSON_PATH = resolve(process.cwd(), "package.json");
+
+function readTaskfile(): string {
+  return readFileSync(TASKFILE_PATH, "utf8");
+}
+
+function readPackageJson(): string {
+  return readFileSync(PACKAGE_JSON_PATH, "utf8");
+}
+
+/**
+ * Naive YAML task-block extractor — pulls out the block under `tasks:\n  <key>:`
+ * Returns the indented block text for the given top-level task key.
+ * Mirrors the extractor in scripts/dev.taskfile.integration.test.ts.
+ */
+function getTaskBlock(content: string, taskKey: string): string | null {
+  const escapedKey = taskKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^  ${escapedKey}:\\s*$`, "m");
+  const match = re.exec(content);
+  if (!match) return null;
+
+  const start = match.index + match[0].length;
+  const rest = content.slice(start);
+  const end = rest.search(/^ {2}\S/m);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("Taskfile.yml — full-workspace `bun test` invocations are NODE_ENV=test guarded", () => {
+  test("task test runs `NODE_ENV=test bun test`", () => {
+    const content = readTaskfile();
+    const block = getTaskBlock(content, "test");
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/^\s*-\s*NODE_ENV=test bun test\s*$/m);
+  });
+
+  test("task test:coverage runs `NODE_ENV=test bun test --coverage --coverage-reporter=lcov`", () => {
+    const content = readTaskfile();
+    const block = getTaskBlock(content, "test:coverage");
+    expect(block).not.toBeNull();
+    expect(block).toMatch(
+      /^\s*-\s*NODE_ENV=test bun test --coverage --coverage-reporter=lcov\s*$/m,
+    );
+  });
+
+  test("no full-workspace `bun test` cmd line in Taskfile.yml is missing the NODE_ENV=test prefix", () => {
+    const content = readTaskfile();
+    for (const key of ["test", "test:coverage"]) {
+      const block = getTaskBlock(content, key);
+      expect(block).not.toBeNull();
+      const cmdLines = (block ?? "")
+        .split("\n")
+        .filter((line) => /^\s*-\s*bun test\b|^\s*-\s*NODE_ENV=test bun test\b/.test(line));
+      expect(cmdLines.length).toBeGreaterThan(0);
+      for (const line of cmdLines) {
+        expect(line).toMatch(/NODE_ENV=test bun test\b/);
+      }
+    }
+  });
+});
+
+describe("package.json — root `test` script is NODE_ENV=test guarded", () => {
+  test('root "test" script is exactly "NODE_ENV=test bun test"', () => {
+    const pkg = JSON.parse(readPackageJson()) as { scripts?: Record<string, string> };
+    expect(pkg.scripts?.test).toBe("NODE_ENV=test bun test");
+  });
+});


### PR DESCRIPTION
## Summary
- Prefix `NODE_ENV=test` on the two full-workspace `bun test` invocation sites (Taskfile.yml's `test`/`test:coverage` tasks and package.json's root `test` script) so `buildSentryInitOptions()`'s test guard in `lib/sentry.ts` holds even when a parent process already exports `NODE_ENV` (e.g. `NODE_ENV=production`), instead of relying on Bun's env-inheritance-dependent auto-set behavior.
- Add `scripts/test-env-guard.unit.test.ts` as net-new config-drift regression coverage, asserting every full-workspace `bun test` invocation in both files carries the prefix.
- Refresh `docs/observability.md`'s two references to the guard being "auto-set by `bun test`" to reflect the explicit prefix.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Taskfile.yml's `test` task runs `NODE_ENV=test bun test` | MET | Taskfile.yml:27 |
| 2 | Taskfile.yml's `test:coverage` task runs `NODE_ENV=test bun test --coverage --coverage-reporter=lcov` | MET | Taskfile.yml:32 |
| 3 | package.json's root `test` script is `NODE_ENV=test bun test` | MET | package.json:16 |
| 4 | New unit test asserts every `bun test` invocation in Taskfile.yml/package.json is NODE_ENV=test-prefixed; no existing tests retired | MET | scripts/test-env-guard.unit.test.ts (new, 90 lines) |

## Test Plan
- TDD red-green-refactor: wrote `scripts/test-env-guard.unit.test.ts` first, confirmed it failed against the unfixed Taskfile.yml/package.json, then applied the two-file fix and confirmed green.
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all 7 workspaces
- `bun test` — 3860 pass / 15 fail; the 15 failures are pre-existing (metrics/admin full-suite flakes), reproduce identically on unmodified `main`, unrelated to this diff
- Coverage gate (`task test:coverage` + `scripts/check-coverage.ts`): aggregate 78.99% lines, below the 80% threshold — pre-existing sandbox limitation (task-store integration tests require a live Postgres DB unavailable in this environment), not attributable to this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
