### PR TITLE
fix: route agent prisma calls through AgentService layer

### DIFF
--- a/admin/src/admin-spec.smoke.test.ts
+++ b/admin/src/admin-spec.smoke.test.ts
@@ -32,12 +32,12 @@ function buildSpecApp() {
         return [];
       },
     },
-    prisma: {
-      agent: {
-        async findUnique() {
-          return null;
-        },
+    agentService: {
+      async getById() {
+        return null;
       },
+    },
+    prisma: {
       agentPlugin: {
         async findMany() {
           return [];
@@ -50,6 +50,30 @@ function buildSpecApp() {
   });
 
   const adminApp = createAdminApp({
+    agentService: {
+      create: async () => ({
+        id: "a1",
+        name: "",
+        slackId: null,
+        selfHosted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      delete: async () => {},
+      list: async () => [],
+      getSummary: async () => null,
+      getDetail: async () => null,
+      exists: async () => false,
+      updateSelfHosted: async () => ({
+        id: "a1",
+        name: "",
+        slackId: null,
+        selfHosted: false,
+        repos: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    },
     agentEnvService: {
       upsert: async () => {},
       patch: async () => {},

--- a/admin/src/agent-chat-tokens.smoke.test.ts
+++ b/admin/src/agent-chat-tokens.smoke.test.ts
@@ -120,6 +120,19 @@ function makeMockDeps(opts?: {
   agentChatTokenServiceThrows?: boolean;
 }): AdminDeps {
   return {
+    agentService: {
+      create: async () => {
+        throw new Error("not implemented");
+      },
+      delete: async () => {},
+      list: async () => [],
+      getSummary: async () => null,
+      getDetail: async () => null,
+      exists: async () => false,
+      updateSelfHosted: async () => {
+        throw new Error("not implemented");
+      },
+    },
     agentEnvService: {
       upsert: async () => {},
       patch: async () => {},

--- a/admin/src/agent-cron-run-stats.smoke.test.ts
+++ b/admin/src/agent-cron-run-stats.smoke.test.ts
@@ -165,6 +165,19 @@ function makeMockStatsService(): Pick<AgentCronRunStatsService, "query"> {
 
 function makeMockDeps(): AdminDeps {
   return {
+    agentService: {
+      create: async () => {
+        throw new Error("not implemented");
+      },
+      delete: async () => {},
+      list: async () => [],
+      getSummary: async () => null,
+      getDetail: async () => null,
+      exists: async () => false,
+      updateSelfHosted: async () => {
+        throw new Error("not implemented");
+      },
+    },
     agentEnvService: {
       upsert: async () => {},
       patch: async () => {},

--- a/admin/src/agents-api.integration.test.ts
+++ b/admin/src/agents-api.integration.test.ts
@@ -24,6 +24,7 @@ import { AgentTokenService } from "./agent-tokens.ts";
 import { AgentToolService } from "./agent-tools.ts";
 import { createAdminApp } from "./agents-api.ts";
 import type { AdminDeps } from "./agents-api.ts";
+import { AgentService } from "./agents.ts";
 import { NoopChatServiceProvisioningClient } from "./chat-service-provisioning-client.ts";
 import { NoopTaskStoreProvisioningClient } from "./task-store-provisioning-client.ts";
 import { makeTokenCrypto } from "./token-crypto.ts";
@@ -90,6 +91,7 @@ describeOrSkip("admin CRUD API (integration)", () => {
     process.env.SHIPWRIGHT_ENCRYPTION_KEY = savedKey;
 
     const deps: AdminDeps = {
+      agentService: new AgentService(prisma),
       agentEnvService: new AgentEnvService(prisma, crypto),
       agentCronJobService: new AgentCronJobService(prisma),
       agentCronRunService: new AgentCronRunService(prisma),

--- a/admin/src/agents-api.sentry.smoke.test.ts
+++ b/admin/src/agents-api.sentry.smoke.test.ts
@@ -104,6 +104,19 @@ function makeBaseDeps(
   agentEnvService: AdminDeps["agentEnvService"],
 ): Omit<AdminDeps, "sentryClient"> {
   return {
+    agentService: {
+      create: async () => {
+        throw new Error("not implemented");
+      },
+      delete: async () => {},
+      list: async () => [],
+      getSummary: async () => null,
+      getDetail: async () => null,
+      exists: async () => false,
+      updateSelfHosted: async () => {
+        throw new Error("not implemented");
+      },
+    },
     agentEnvService,
     agentCronJobService: {
       list: async () => [],

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -109,6 +109,54 @@ const MOCK_CRON = {
 
 function makeMockDeps(): AdminDeps {
   return {
+    agentService: {
+      create: async (input: {
+        name: string;
+        slackId?: string | null;
+        selfHosted?: boolean;
+      }) => ({
+        id: "agent-new-id",
+        name: input.name,
+        slackId: input.slackId ?? null,
+        selfHosted: input.selfHosted ?? false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+      delete: async (_id: string) => {},
+      list: async () => [
+        { id: AGENT_ID, name: "Existing Agent", selfHosted: false },
+        { id: "agent-other-id", name: "Other Agent", selfHosted: false },
+      ],
+      getSummary: async (id: string) =>
+        id === AGENT_ID
+          ? { id: AGENT_ID, name: "Existing Agent", selfHosted: false }
+          : null,
+      getDetail: async (id: string) =>
+        id === AGENT_ID
+          ? {
+              id: AGENT_ID,
+              name: "Existing Agent",
+              slackId: null,
+              selfHosted: false,
+              repos: [],
+              createdAt: new Date("2024-01-01"),
+              updatedAt: new Date("2024-01-01"),
+            }
+          : null,
+      exists: async (id: string) => id === AGENT_ID,
+      updateSelfHosted: async (
+        id: string,
+        input: { selfHosted?: boolean; repos?: string[] },
+      ) => ({
+        id,
+        name: "Existing Agent",
+        slackId: null,
+        selfHosted: input.selfHosted ?? false,
+        repos: input.repos ?? [],
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      }),
+    },
     agentEnvService: {
       upsert: async () => {},
       patch: async () => {},
@@ -1038,29 +1086,20 @@ describe("admin API — create agent", () => {
     const deps: AdminDeps = {
       ...base,
       provisioner,
-      prisma: {
-        agent: {
-          create: async (args: {
-            data: { name: string; slackId: string | null };
-          }) => ({
-            id: "agent-new-id",
-            name: args.data.name,
-            slackId: args.data.slackId,
-            createdAt: new Date("2024-01-01"),
-            updatedAt: new Date("2024-01-01"),
-          }),
-          delete: async (args: { where: { id: string } }) => {
-            deleted.push(args.where.id);
-            return {
-              id: args.where.id,
-              name: "rolled-back",
-              slackId: null,
-              createdAt: new Date("2024-01-01"),
-              updatedAt: new Date("2024-01-01"),
-            };
-          },
+      agentService: {
+        ...base.agentService,
+        create: async (input: { name: string; slackId?: string | null }) => ({
+          id: "agent-new-id",
+          name: input.name,
+          slackId: input.slackId ?? null,
+          selfHosted: false,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        }),
+        delete: async (id: string) => {
+          deleted.push(id);
         },
-      } as unknown as AdminDeps["prisma"],
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request("/agents", {
@@ -1200,6 +1239,24 @@ describe("admin API — delete agent", () => {
     const deps: AdminDeps = {
       ...base,
       provisioner,
+      // agentService.getDetail() backs the follow-up GET below.
+      agentService: {
+        ...base.agentService,
+        getDetail: async (id: string) =>
+          id === AGENT_ID
+            ? {
+                id: AGENT_ID,
+                name: "Existing Agent",
+                slackId: null,
+                selfHosted: false,
+                repos: [],
+                createdAt: new Date("2024-01-01"),
+                updatedAt: new Date("2024-01-01"),
+              }
+            : null,
+      },
+      // deleteAgentFully() (agent-deletion.ts) still reads/deletes via
+      // prisma.agent directly — out of scope for this migration.
       prisma: {
         agent: {
           findUnique: async (args: { where: { id: string } }) =>
@@ -1604,19 +1661,13 @@ describe("admin API — provision agent", () => {
     const deps: AdminDeps = {
       ...base,
       provisioner,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findUnique: async (args: { where: { id: string } }) =>
-            args.where.id === AGENT_ID
-              ? {
-                  id: AGENT_ID,
-                  name: "Self-Hosted Agent",
-                  selfHosted: true,
-                }
-              : null,
-        },
-      } as unknown as AdminDeps["prisma"],
+      agentService: {
+        ...base.agentService,
+        getSummary: async (id: string) =>
+          id === AGENT_ID
+            ? { id: AGENT_ID, name: "Self-Hosted Agent", selfHosted: true }
+            : null,
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request(`/agents/${AGENT_ID}/provision`, {
@@ -1643,21 +1694,21 @@ describe("admin API — selfHosted field", () => {
     const base = makeMockDeps();
     const deps: AdminDeps = {
       ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          create: async (args: {
-            data: { name: string; slackId: string | null; selfHosted: boolean };
-          }) => ({
-            id: "agent-new-id",
-            name: args.data.name,
-            slackId: args.data.slackId,
-            selfHosted: args.data.selfHosted,
-            createdAt: new Date("2024-01-01"),
-            updatedAt: new Date("2024-01-01"),
-          }),
-        },
-      } as unknown as AdminDeps["prisma"],
+      agentService: {
+        ...base.agentService,
+        create: async (input: {
+          name: string;
+          slackId?: string | null;
+          selfHosted?: boolean;
+        }) => ({
+          id: "agent-new-id",
+          name: input.name,
+          slackId: input.slackId ?? null,
+          selfHosted: input.selfHosted ?? false,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        }),
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request("/agents", {
@@ -1674,26 +1725,7 @@ describe("admin API — selfHosted field", () => {
   });
 
   it("POST /agents without selfHosted defaults to false (201)", async () => {
-    const base = makeMockDeps();
-    const deps: AdminDeps = {
-      ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          create: async (args: {
-            data: { name: string; slackId: string | null; selfHosted: boolean };
-          }) => ({
-            id: "agent-new-id",
-            name: args.data.name,
-            slackId: args.data.slackId,
-            selfHosted: args.data.selfHosted ?? false,
-            createdAt: new Date("2024-01-01"),
-            updatedAt: new Date("2024-01-01"),
-          }),
-        },
-      } as unknown as AdminDeps["prisma"],
-    };
-    const app = createAdminApp(deps);
+    const app = createAdminApp(makeMockDeps());
     const res = await app.request("/agents", {
       method: "POST",
       body: JSON.stringify({ name: "Regular Agent" }),
@@ -1711,15 +1743,13 @@ describe("admin API — selfHosted field", () => {
     const base = makeMockDeps();
     const deps: AdminDeps = {
       ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findMany: async () => [
-            { id: AGENT_ID, name: "Existing Agent", selfHosted: false },
-            { id: "agent-other-id", name: "Other Agent", selfHosted: true },
-          ],
-        },
-      } as unknown as AdminDeps["prisma"],
+      agentService: {
+        ...base.agentService,
+        list: async () => [
+          { id: AGENT_ID, name: "Existing Agent", selfHosted: false },
+          { id: "agent-other-id", name: "Other Agent", selfHosted: true },
+        ],
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request("/agents", {
@@ -1733,27 +1763,7 @@ describe("admin API — selfHosted field", () => {
   });
 
   it("GET /agents/:id returns full agent record with selfHosted", async () => {
-    const base = makeMockDeps();
-    const deps: AdminDeps = {
-      ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findUnique: async (args: { where: { id: string } }) =>
-            args.where.id === AGENT_ID
-              ? {
-                  id: AGENT_ID,
-                  name: "Existing Agent",
-                  slackId: null,
-                  selfHosted: false,
-                  createdAt: new Date("2024-01-01"),
-                  updatedAt: new Date("2024-01-01"),
-                }
-              : null,
-        },
-      } as unknown as AdminDeps["prisma"],
-    };
-    const app = createAdminApp(deps);
+    const app = createAdminApp(makeMockDeps());
     const res = await app.request(`/agents/${AGENT_ID}`, {
       headers: { Cookie: `admin_session=${cookie}` },
     });
@@ -1772,38 +1782,7 @@ describe("admin API — selfHosted field", () => {
   });
 
   it("PATCH /agents/:id with {selfHosted: true} updates flag and returns 200", async () => {
-    const base = makeMockDeps();
-    const deps: AdminDeps = {
-      ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findUnique: async (args: { where: { id: string } }) =>
-            args.where.id === AGENT_ID
-              ? {
-                  id: AGENT_ID,
-                  name: "Existing Agent",
-                  slackId: null,
-                  selfHosted: false,
-                  createdAt: new Date("2024-01-01"),
-                  updatedAt: new Date("2024-01-01"),
-                }
-              : null,
-          update: async (args: {
-            where: { id: string };
-            data: { selfHosted?: boolean };
-          }) => ({
-            id: args.where.id,
-            name: "Existing Agent",
-            slackId: null,
-            selfHosted: args.data.selfHosted ?? false,
-            createdAt: new Date("2024-01-01"),
-            updatedAt: new Date("2024-01-01"),
-          }),
-        },
-      } as unknown as AdminDeps["prisma"],
-    };
-    const app = createAdminApp(deps);
+    const app = createAdminApp(makeMockDeps());
     const res = await app.request(`/agents/${AGENT_ID}`, {
       method: "PATCH",
       body: JSON.stringify({ selfHosted: true }),
@@ -1858,19 +1837,17 @@ describe("admin API — selfHosted field", () => {
     const deps: AdminDeps = {
       ...base,
       provisioner: trackingProvisioner,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findMany: async () => [
-            { id: AGENT_ID, name: "Regular Agent", selfHosted: false },
-            {
-              id: "self-hosted-id",
-              name: "Self-Hosted Agent",
-              selfHosted: true,
-            },
-          ],
-        },
-      } as unknown as AdminDeps["prisma"],
+      agentService: {
+        ...base.agentService,
+        list: async () => [
+          { id: AGENT_ID, name: "Regular Agent", selfHosted: false },
+          {
+            id: "self-hosted-id",
+            name: "Self-Hosted Agent",
+            selfHosted: true,
+          },
+        ],
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request("/agents/reconcile", {
@@ -1917,35 +1894,33 @@ describe("admin API — repos field", () => {
     const base = makeMockDeps();
     const deps: AdminDeps = {
       ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findUnique: async (args: { where: { id: string } }) =>
-            args.where.id === AGENT_ID
-              ? {
-                  id: AGENT_ID,
-                  name: "Existing Agent",
-                  slackId: null,
-                  selfHosted: false,
-                  repos: [],
-                  createdAt: new Date("2024-01-01"),
-                  updatedAt: new Date("2024-01-01"),
-                }
-              : null,
-          update: async (args: {
-            where: { id: string };
-            data: { selfHosted?: boolean; repos?: string[] };
-          }) => ({
-            id: args.where.id,
-            name: "Existing Agent",
-            slackId: null,
-            selfHosted: args.data.selfHosted ?? false,
-            repos: args.data.repos ?? [],
-            createdAt: new Date("2024-01-01"),
-            updatedAt: new Date("2024-01-01"),
-          }),
-        },
-      } as unknown as AdminDeps["prisma"],
+      agentService: {
+        ...base.agentService,
+        getDetail: async (id: string) =>
+          id === AGENT_ID
+            ? {
+                id: AGENT_ID,
+                name: "Existing Agent",
+                slackId: null,
+                selfHosted: false,
+                repos: [],
+                createdAt: new Date("2024-01-01"),
+                updatedAt: new Date("2024-01-01"),
+              }
+            : null,
+        updateSelfHosted: async (
+          id: string,
+          input: { selfHosted?: boolean; repos?: string[] },
+        ) => ({
+          id,
+          name: "Existing Agent",
+          slackId: null,
+          selfHosted: input.selfHosted ?? false,
+          repos: input.repos ?? [],
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        }),
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request(`/agents/${AGENT_ID}`, {
@@ -1965,35 +1940,33 @@ describe("admin API — repos field", () => {
     const base = makeMockDeps();
     const deps: AdminDeps = {
       ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findUnique: async (args: { where: { id: string } }) =>
-            args.where.id === AGENT_ID
-              ? {
-                  id: AGENT_ID,
-                  name: "Existing Agent",
-                  slackId: null,
-                  selfHosted: false,
-                  repos: ["my-org/my-repo"],
-                  createdAt: new Date("2024-01-01"),
-                  updatedAt: new Date("2024-01-01"),
-                }
-              : null,
-          update: async (args: {
-            where: { id: string };
-            data: { selfHosted?: boolean; repos?: string[] };
-          }) => ({
-            id: args.where.id,
-            name: "Existing Agent",
-            slackId: null,
-            selfHosted: args.data.selfHosted ?? false,
-            repos: args.data.repos ?? [],
-            createdAt: new Date("2024-01-01"),
-            updatedAt: new Date("2024-01-01"),
-          }),
-        },
-      } as unknown as AdminDeps["prisma"],
+      agentService: {
+        ...base.agentService,
+        getDetail: async (id: string) =>
+          id === AGENT_ID
+            ? {
+                id: AGENT_ID,
+                name: "Existing Agent",
+                slackId: null,
+                selfHosted: false,
+                repos: ["my-org/my-repo"],
+                createdAt: new Date("2024-01-01"),
+                updatedAt: new Date("2024-01-01"),
+              }
+            : null,
+        updateSelfHosted: async (
+          id: string,
+          input: { selfHosted?: boolean; repos?: string[] },
+        ) => ({
+          id,
+          name: "Existing Agent",
+          slackId: null,
+          selfHosted: input.selfHosted ?? false,
+          repos: input.repos ?? [],
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        }),
+      },
     };
     const app = createAdminApp(deps);
     const res = await app.request(`/agents/${AGENT_ID}`, {
@@ -2010,28 +1983,7 @@ describe("admin API — repos field", () => {
   });
 
   it("GET /agents/:id returns repos field (empty array for existing agents)", async () => {
-    const base = makeMockDeps();
-    const deps: AdminDeps = {
-      ...base,
-      prisma: {
-        agent: {
-          ...base.prisma.agent,
-          findUnique: async (args: { where: { id: string } }) =>
-            args.where.id === AGENT_ID
-              ? {
-                  id: AGENT_ID,
-                  name: "Existing Agent",
-                  slackId: null,
-                  selfHosted: false,
-                  repos: [],
-                  createdAt: new Date("2024-01-01"),
-                  updatedAt: new Date("2024-01-01"),
-                }
-              : null,
-        },
-      } as unknown as AdminDeps["prisma"],
-    };
-    const app = createAdminApp(deps);
+    const app = createAdminApp(makeMockDeps());
     const res = await app.request(`/agents/${AGENT_ID}`, {
       headers: { Cookie: `admin_session=${cookie}` },
     });

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -37,6 +37,7 @@ import type { AgentPluginService } from "./agent-plugins.ts";
 import type { AgentProvisioner } from "./agent-provisioner.ts";
 import type { AgentTokenService } from "./agent-tokens.ts";
 import type { AgentToolService } from "./agent-tools.ts";
+import type { AgentService } from "./agents.ts";
 import { createAdminAuthMiddleware, parseAdminApiKeys } from "./api-auth.ts";
 import type { AdminApiKey, AdminAuthEnv } from "./api-auth.ts";
 import {
@@ -92,6 +93,16 @@ import {
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface AdminDeps {
+  agentService: Pick<
+    AgentService,
+    | "create"
+    | "delete"
+    | "list"
+    | "getSummary"
+    | "getDetail"
+    | "exists"
+    | "updateSelfHosted"
+  >;
   agentEnvService: Pick<
     AgentEnvService,
     "upsert" | "patch" | "getByAgentId" | "deleteKey"
@@ -126,6 +137,13 @@ export interface AdminDeps {
     AgentChatTokenService,
     "upsertDailyByModel" | "queryStats"
   >;
+  /**
+   * Retained solely as a pass-through to deleteAgentFully() (DELETE /agents/:id),
+   * which has its own internal prisma.agent/prisma.agentEnv access — out of
+   * scope for the AgentService migration. All other route handlers in this
+   * file go through `agentService` instead of touching `prisma.agent.*`
+   * directly.
+   */
   prisma: Pick<PrismaClient, "agent" | "agentEnv">;
   /**
    * Provisions (and tears down) the workload backing an agent. Defaults to a
@@ -804,6 +822,7 @@ const chatTokenDailyStatsRoute = createRoute({
 
 export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
   const {
+    agentService,
     agentEnvService,
     agentCronJobService,
     agentCronRunService,
@@ -883,12 +902,10 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       );
     }
     const body = c.req.valid("json");
-    const agent = await prisma.agent.create({
-      data: {
-        name: body.name,
-        slackId: body.slackId ?? null,
-        selfHosted: body.selfHosted ?? false,
-      },
+    const agent = await agentService.create({
+      name: body.name,
+      slackId: body.slackId ?? null,
+      selfHosted: body.selfHosted ?? false,
     });
 
     // Provision the backing workload AFTER the row exists (the provisioner
@@ -901,14 +918,12 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       try {
         await provisioner.provision(agent.id, { slug: agent.name });
       } catch (err) {
-        await prisma.agent
-          .delete({ where: { id: agent.id } })
-          .catch((cleanupErr) => {
-            console.error(
-              "[agents-api] failed to roll back agent after provision error:",
-              cleanupErr,
-            );
-          });
+        await agentService.delete(agent.id).catch((cleanupErr) => {
+          console.error(
+            "[agents-api] failed to roll back agent after provision error:",
+            cleanupErr,
+          );
+        });
         throw err;
       }
     }
@@ -923,9 +938,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
         "Only admin bearers and session users can reconcile agents",
       );
     }
-    const agents = await prisma.agent.findMany({
-      select: { id: true, name: true, selfHosted: true },
-    });
+    const agents = await agentService.list();
     // Self-hosted agents manage their own workloads — exclude them from K8s reconciliation.
     const managedAgents = agents.filter((a) => !a.selfHosted);
     const result = await provisioner.reconcile(
@@ -944,10 +957,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     }
     const { id: agentId } = c.req.valid("param");
 
-    const agent = await prisma.agent.findUnique({
-      where: { id: agentId },
-      select: { id: true, name: true, selfHosted: true },
-    });
+    const agent = await agentService.getSummary(agentId);
     if (!agent) {
       throw new NotFoundError(`agent ${agentId} not found`);
     }
@@ -967,18 +977,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       throw new ForbiddenError("Admin access required to get agent");
     }
     const { id: agentId } = c.req.valid("param");
-    const agent = await prisma.agent.findUnique({
-      where: { id: agentId },
-      select: {
-        id: true,
-        name: true,
-        slackId: true,
-        selfHosted: true,
-        repos: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+    const agent = await agentService.getDetail(agentId);
     if (!agent) {
       throw new NotFoundError(`agent ${agentId} not found`);
     }
@@ -993,28 +992,13 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     const { id: agentId } = c.req.valid("param");
     const body = c.req.valid("json");
 
-    const existing = await prisma.agent.findUnique({
-      where: { id: agentId },
-      select: { id: true },
-    });
+    const existing = await agentService.exists(agentId);
     if (!existing) {
       throw new NotFoundError(`agent ${agentId} not found`);
     }
-    const agent = await prisma.agent.update({
-      where: { id: agentId },
-      data: {
-        selfHosted: body.selfHosted,
-        ...(body.repos !== undefined ? { repos: body.repos } : {}),
-      },
-      select: {
-        id: true,
-        name: true,
-        slackId: true,
-        selfHosted: true,
-        repos: true,
-        createdAt: true,
-        updatedAt: true,
-      },
+    const agent = await agentService.updateSelfHosted(agentId, {
+      selfHosted: body.selfHosted,
+      ...(body.repos !== undefined ? { repos: body.repos } : {}),
     });
     return c.json(serializeAgent(agent), 200);
   });
@@ -1055,10 +1039,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     if (c.get("isAdmin") !== true) {
       throw new ForbiddenError("Admin access required to list agents");
     }
-    const agents = await prisma.agent.findMany({
-      select: { id: true, name: true, selfHosted: true },
-      orderBy: { name: "asc" },
-    });
+    const agents = await agentService.list();
     return c.json(agents, 200);
   });
 

--- a/admin/src/agents.ts
+++ b/admin/src/agents.ts
@@ -1,0 +1,169 @@
+/**
+ * agent/src/agents.ts
+ * AgentService — CRUD/read access to the Agent model.
+ *
+ * Mirrors the sibling *Service modules (AgentEnvService, AgentTokenService,
+ * etc.) so route handlers never call prisma.agent.* directly.
+ */
+
+import type { PrismaClient } from "../prisma/client/index.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CreateAgentInput {
+  name: string;
+  slackId?: string | null;
+  selfHosted?: boolean;
+}
+
+export interface AgentRecord {
+  id: string;
+  name: string;
+  slackId: string | null;
+  selfHosted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AgentSummary {
+  id: string;
+  name: string;
+  selfHosted: boolean;
+}
+
+export interface AgentDetail {
+  id: string;
+  name: string;
+  slackId: string | null;
+  selfHosted: boolean;
+  repos: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UpdateSelfHostedInput {
+  /**
+   * Optional to mirror Prisma's generated AgentUpdateInput shape (undefined
+   * means "leave unchanged"); callers such as PATCH /agents/:id currently
+   * always pass a value since selfHosted is treated as required at the route
+   * level, but the type stays permissive to match the underlying data layer.
+   */
+  selfHosted?: boolean;
+  repos?: string[];
+}
+
+export interface AgentIdAndRepos {
+  id: string;
+  repos: string[];
+}
+
+// ─── Select shapes ────────────────────────────────────────────────────────────
+
+const SUMMARY_SELECT = { id: true, name: true, selfHosted: true } as const;
+
+const DETAIL_SELECT = {
+  id: true,
+  name: true,
+  slackId: true,
+  selfHosted: true,
+  repos: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export class AgentService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Create a new agent row.
+   */
+  async create(input: CreateAgentInput): Promise<AgentRecord> {
+    return this.prisma.agent.create({
+      data: {
+        name: input.name,
+        slackId: input.slackId ?? null,
+        selfHosted: input.selfHosted ?? false,
+      },
+    });
+  }
+
+  /**
+   * Delete an agent row by id. Used as the provisioning-failure rollback path
+   * on create(), and (out of scope here) internally by deleteAgentFully().
+   */
+  async delete(id: string): Promise<void> {
+    await this.prisma.agent.delete({ where: { id } });
+  }
+
+  /**
+   * List all agents (id + name + selfHosted), ordered by name asc.
+   */
+  async list(): Promise<AgentSummary[]> {
+    return this.prisma.agent.findMany({
+      select: SUMMARY_SELECT,
+      orderBy: { name: "asc" },
+    });
+  }
+
+  /**
+   * Get {id, name, selfHosted} for a single agent. Returns null if not found.
+   */
+  async getSummary(id: string): Promise<AgentSummary | null> {
+    return this.prisma.agent.findUnique({
+      where: { id },
+      select: SUMMARY_SELECT,
+    });
+  }
+
+  /**
+   * Get the full agent record (incl. repos/timestamps). Returns null if not found.
+   */
+  async getDetail(id: string): Promise<AgentDetail | null> {
+    return this.prisma.agent.findUnique({
+      where: { id },
+      select: DETAIL_SELECT,
+    });
+  }
+
+  /**
+   * Returns whether an agent with the given id exists.
+   */
+  async exists(id: string): Promise<boolean> {
+    const agent = await this.prisma.agent.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return agent !== null;
+  }
+
+  /**
+   * Update selfHosted (and optionally repos) for an agent. Returns the full
+   * updated record.
+   */
+  async updateSelfHosted(
+    id: string,
+    input: UpdateSelfHostedInput,
+  ): Promise<AgentDetail> {
+    return this.prisma.agent.update({
+      where: { id },
+      data: {
+        selfHosted: input.selfHosted,
+        ...(input.repos !== undefined ? { repos: input.repos } : {}),
+      },
+      select: DETAIL_SELECT,
+    });
+  }
+
+  /**
+   * Get {id, repos} for a single agent — used by the runtime config/crons
+   * routes. Returns null if not found.
+   */
+  async getById(id: string): Promise<AgentIdAndRepos | null> {
+    return this.prisma.agent.findUnique({
+      where: { id },
+      select: { id: true, repos: true },
+    });
+  }
+}

--- a/admin/src/agents.unit.test.ts
+++ b/admin/src/agents.unit.test.ts
@@ -1,0 +1,340 @@
+/**
+ * agent/src/agents.unit.test.ts
+ * Unit tests for AgentService (admin/src/agents.ts) — pure logic against an
+ * injected prisma test double. No real DB — see docs/testing.md for the
+ * unit-layer contract.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AgentService } from "./agents.ts";
+
+// ─── In-memory prisma.agent test double ────────────────────────────────────
+
+interface FakeAgentRow {
+  id: string;
+  name: string;
+  slackId: string | null;
+  selfHosted: boolean;
+  repos: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Projects a row down to just the keys named in a Prisma-style `select` object. */
+function applySelect<T extends object>(
+  row: T,
+  select?: Partial<Record<keyof T, boolean>>,
+): T {
+  if (!select) return row;
+  const projected = {} as T;
+  for (const key of Object.keys(select) as (keyof T)[]) {
+    if (select[key]) projected[key] = row[key];
+  }
+  return projected;
+}
+
+function makeFakePrisma(seed: FakeAgentRow[] = []) {
+  const rows = new Map<string, FakeAgentRow>(seed.map((r) => [r.id, r]));
+  let nextId = 1;
+
+  const agent = {
+    async create({
+      data,
+    }: {
+      data: { name: string; slackId: string | null; selfHosted: boolean };
+    }): Promise<FakeAgentRow> {
+      const row: FakeAgentRow = {
+        id: `agent-${nextId++}`,
+        name: data.name,
+        slackId: data.slackId,
+        selfHosted: data.selfHosted,
+        repos: [],
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      };
+      rows.set(row.id, row);
+      return row;
+    },
+    async delete({
+      where,
+    }: {
+      where: { id: string };
+    }): Promise<FakeAgentRow> {
+      const row = rows.get(where.id);
+      if (!row) throw new Error("record not found");
+      rows.delete(where.id);
+      return row;
+    },
+    async findMany({
+      select,
+      orderBy,
+    }: {
+      select?: Partial<Record<keyof FakeAgentRow, boolean>>;
+      orderBy?: { name?: "asc" | "desc" };
+    } = {}): Promise<FakeAgentRow[]> {
+      let all = Array.from(rows.values());
+      if (orderBy?.name) {
+        all = [...all].sort((a, b) =>
+          orderBy.name === "desc"
+            ? b.name.localeCompare(a.name)
+            : a.name.localeCompare(b.name),
+        );
+      }
+      return all.map((r) => applySelect(r, select));
+    },
+    async findUnique({
+      where,
+      select,
+    }: {
+      where: { id: string };
+      select?: Partial<Record<keyof FakeAgentRow, boolean>>;
+    }): Promise<FakeAgentRow | null> {
+      const row = rows.get(where.id);
+      if (!row) return null;
+      return applySelect(row, select);
+    },
+    async update({
+      where,
+      data,
+      select,
+    }: {
+      where: { id: string };
+      data: { selfHosted?: boolean; repos?: string[] };
+      select?: Partial<Record<keyof FakeAgentRow, boolean>>;
+    }): Promise<FakeAgentRow> {
+      const row = rows.get(where.id);
+      if (!row) throw new Error("record not found");
+      const updated: FakeAgentRow = {
+        ...row,
+        ...(data.selfHosted !== undefined && { selfHosted: data.selfHosted }),
+        ...(data.repos !== undefined && { repos: data.repos }),
+        updatedAt: new Date("2024-01-02"),
+      };
+      rows.set(where.id, updated);
+      return applySelect(updated, select);
+    },
+  };
+
+  return { agent, __rows: rows };
+}
+
+type FakePrisma = ReturnType<typeof makeFakePrisma>;
+
+function seedRow(overrides: Partial<FakeAgentRow> = {}): FakeAgentRow {
+  return {
+    id: "agent-existing",
+    name: "Existing Agent",
+    slackId: null,
+    selfHosted: false,
+    repos: [],
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+// ─── create ─────────────────────────────────────────────────────────────────
+
+describe("AgentService.create", () => {
+  it("creates an agent with the given name, slackId, and selfHosted flag", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const agent = await service.create({
+      name: "New Agent",
+      slackId: "U123",
+      selfHosted: true,
+    });
+
+    expect(agent.name).toBe("New Agent");
+    expect(agent.slackId).toBe("U123");
+    expect(agent.selfHosted).toBe(true);
+    expect(agent.id).toBeDefined();
+  });
+
+  it("defaults slackId to null and selfHosted to false when omitted", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const agent = await service.create({ name: "Plain Agent" });
+
+    expect(agent.slackId).toBeNull();
+    expect(agent.selfHosted).toBe(false);
+  });
+});
+
+// ─── delete ─────────────────────────────────────────────────────────────────
+
+describe("AgentService.delete", () => {
+  it("deletes the agent row by id", async () => {
+    const row = seedRow();
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    await service.delete(row.id);
+
+    expect(await prisma.agent.findUnique({ where: { id: row.id } })).toBeNull();
+  });
+});
+
+// ─── list ───────────────────────────────────────────────────────────────────
+
+describe("AgentService.list", () => {
+  it("returns id/name/selfHosted for all agents, ordered by name asc", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "Zeta", selfHosted: false }),
+      seedRow({ id: "a2", name: "Alpha", selfHosted: true }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.list();
+
+    expect(result).toEqual([
+      { id: "a2", name: "Alpha", selfHosted: true },
+      { id: "a1", name: "Zeta", selfHosted: false },
+    ]);
+  });
+
+  it("returns an empty array when there are no agents", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.list()).toEqual([]);
+  });
+});
+
+// ─── getSummary ─────────────────────────────────────────────────────────────
+
+describe("AgentService.getSummary", () => {
+  it("returns {id, name, selfHosted} for an existing agent", async () => {
+    const row = seedRow({ id: "a1", name: "Existing", selfHosted: true });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.getSummary("a1")).toEqual({
+      id: "a1",
+      name: "Existing",
+      selfHosted: true,
+    });
+  });
+
+  it("returns null when the agent does not exist", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.getSummary("missing")).toBeNull();
+  });
+});
+
+// ─── getDetail ──────────────────────────────────────────────────────────────
+
+describe("AgentService.getDetail", () => {
+  it("returns the full record including repos and timestamps", async () => {
+    const row = seedRow({
+      id: "a1",
+      name: "Existing",
+      slackId: "U999",
+      repos: ["org/repo"],
+    });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const detail = await service.getDetail("a1");
+
+    expect(detail).toEqual({
+      id: "a1",
+      name: "Existing",
+      slackId: "U999",
+      selfHosted: false,
+      repos: ["org/repo"],
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    });
+  });
+
+  it("returns null when the agent does not exist", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.getDetail("missing")).toBeNull();
+  });
+});
+
+// ─── exists ─────────────────────────────────────────────────────────────────
+
+describe("AgentService.exists", () => {
+  it("returns true when the agent exists", async () => {
+    const row = seedRow({ id: "a1" });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.exists("a1")).toBe(true);
+  });
+
+  it("returns false when the agent does not exist", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.exists("missing")).toBe(false);
+  });
+});
+
+// ─── updateSelfHosted ───────────────────────────────────────────────────────
+
+describe("AgentService.updateSelfHosted", () => {
+  it("updates the selfHosted flag and returns the full record", async () => {
+    const row = seedRow({ id: "a1", selfHosted: false });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateSelfHosted("a1", { selfHosted: true });
+
+    expect(updated.selfHosted).toBe(true);
+    expect(updated.id).toBe("a1");
+  });
+
+  it("updates repos when provided", async () => {
+    const row = seedRow({ id: "a1", repos: [] });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateSelfHosted("a1", {
+      selfHosted: false,
+      repos: ["org/repo"],
+    });
+
+    expect(updated.repos).toEqual(["org/repo"]);
+  });
+
+  it("leaves repos untouched when not provided", async () => {
+    const row = seedRow({ id: "a1", repos: ["org/existing"] });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateSelfHosted("a1", { selfHosted: true });
+
+    expect(updated.repos).toEqual(["org/existing"]);
+  });
+});
+
+// ─── getById ────────────────────────────────────────────────────────────────
+
+describe("AgentService.getById", () => {
+  it("returns {id, repos} for an existing agent", async () => {
+    const row = seedRow({ id: "a1", repos: ["org/repo1", "org/repo2"] });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.getById("a1")).toEqual({
+      id: "a1",
+      repos: ["org/repo1", "org/repo2"],
+    });
+  });
+
+  it("returns null when the agent does not exist", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.getById("missing")).toBeNull();
+  });
+});

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -73,13 +73,20 @@ function makeMockAgentCronJobService(crons: Map<string, AgentCronJob[]>): {
   };
 }
 
-function makeMockPrisma(
-  agents: Map<string, MockAgent>,
-  plugins: Map<string, MockPlugin[]>,
-): {
-  agent: {
-    findUnique: (args: { where: { id: string } }) => Promise<MockAgent | null>;
+function makeMockAgentService(agents: Map<string, MockAgent>): {
+  getById: (agentId: string) => Promise<{ id: string; repos: string[] } | null>;
+} {
+  return {
+    async getById(
+      agentId: string,
+    ): Promise<{ id: string; repos: string[] } | null> {
+      const agent = agents.get(agentId);
+      return agent ? { id: agent.id, repos: agent.repos } : null;
+    },
   };
+}
+
+function makeMockPrisma(plugins: Map<string, MockPlugin[]>): {
   agentPlugin: {
     findMany: (args: {
       where: { agentId: string; enabled: boolean };
@@ -87,13 +94,6 @@ function makeMockPrisma(
   };
 } {
   return {
-    agent: {
-      async findUnique({
-        where,
-      }: { where: { id: string } }): Promise<MockAgent | null> {
-        return agents.get(where.id) ?? null;
-      },
-    },
     agentPlugin: {
       async findMany({
         where,
@@ -191,7 +191,8 @@ function buildApp(opts?: {
   return createAgentRuntimeApp({
     agentEnvService: makeMockAgentEnvService(bundles),
     agentCronJobService: makeMockAgentCronJobService(cronMap),
-    prisma: makeMockPrisma(agents, pluginMap) as never,
+    agentService: makeMockAgentService(agents),
+    prisma: makeMockPrisma(pluginMap) as never,
     adminApiKeys: parseAdminApiKeys(`admin:${VALID_ADMIN_KEY}:*`),
     agentTokenService: { validate: async () => null },
     sessionSecret: SESSION_SECRET,
@@ -379,12 +380,12 @@ function buildCombinedApp() {
         return [];
       },
     },
-    prisma: {
-      agent: {
-        async findUnique() {
-          return { id: COMBINED_AGENT_ID, repos: [] };
-        },
+    agentService: {
+      async getById() {
+        return { id: COMBINED_AGENT_ID, repos: [] };
       },
+    },
+    prisma: {
       agentPlugin: {
         async findMany() {
           return [];
@@ -397,6 +398,30 @@ function buildCombinedApp() {
   });
 
   const adminApp = createAdminApp({
+    agentService: {
+      create: async () => ({
+        id: "a1",
+        name: "",
+        slackId: null,
+        selfHosted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      delete: async () => {},
+      list: async () => [],
+      getSummary: async () => null,
+      getDetail: async () => null,
+      exists: async () => false,
+      updateSelfHosted: async () => ({
+        id: "a1",
+        name: "",
+        slackId: null,
+        selfHosted: false,
+        repos: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    },
     agentEnvService: {
       upsert: async () => {},
       patch: async () => {},

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -66,10 +66,11 @@ interface AgentCronJobServiceLike {
   >;
 }
 
+interface AgentServiceLike {
+  getById(agentId: string): Promise<{ id: string; repos: string[] } | null>;
+}
+
 interface PrismaLike {
-  agent: {
-    findUnique(args: { where: { id: string } }): Promise<{ id: string; repos: string[] } | null>;
-  };
   agentPlugin: {
     findMany(args: {
       where: { agentId: string; enabled: boolean };
@@ -80,6 +81,7 @@ interface PrismaLike {
 export interface AgentRuntimeDeps {
   agentEnvService: AgentEnvServiceLike;
   agentCronJobService: AgentCronJobServiceLike;
+  agentService: AgentServiceLike;
   prisma: PrismaLike;
   /** Session secret for cookie auth (SHIPWRIGHT_SESSION_SECRET). */
   sessionSecret: string;
@@ -151,7 +153,7 @@ const getCronsRoute = createRoute({
  * Inject real services for production; inject mocks for tests.
  */
 export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
-  const { agentEnvService, agentCronJobService, prisma } = deps;
+  const { agentEnvService, agentCronJobService, agentService, prisma } = deps;
 
   const app = new OpenAPIHono();
 
@@ -172,7 +174,7 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     const { id } = c.req.valid("param");
 
     // Check agent existence
-    const agent = await prisma.agent.findUnique({ where: { id } });
+    const agent = await agentService.getById(id);
     if (!agent) {
       return c.json({ error: "Not found" }, 404);
     }
@@ -212,7 +214,7 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     const { id } = c.req.valid("param");
 
     // Check agent existence
-    const agent = await prisma.agent.findUnique({ where: { id } });
+    const agent = await agentService.getById(id);
     if (!agent) {
       return c.json({ error: "Not found" }, 404);
     }

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -39,6 +39,7 @@ import {
 import { AgentTokenService } from "./agent-tokens.ts";
 import { AgentToolService } from "./agent-tools.ts";
 import { createAdminApp, parseAdminApiKeys } from "./agents-api.ts";
+import { AgentService } from "./agents.ts";
 import { createAgentRuntimeApp } from "./api.ts";
 import type { ChatServiceProvisioningClient } from "./chat-service-provisioning-client.ts";
 import {
@@ -316,6 +317,7 @@ async function startServer(): Promise<void> {
   const crypto = makeTokenCrypto();
 
   // Construct all services with injected deps
+  const agentService = new AgentService(prisma);
   const agentEnvService = new AgentEnvService(prisma, crypto);
   const agentCronJobService = new AgentCronJobService(prisma);
   const agentCronRunService = new AgentCronRunService(prisma);
@@ -381,6 +383,7 @@ async function startServer(): Promise<void> {
   const runtimeApp = createAgentRuntimeApp({
     agentEnvService,
     agentCronJobService,
+    agentService,
     prisma: prisma as never,
     sessionSecret,
     adminApiKeys,
@@ -393,6 +396,7 @@ async function startServer(): Promise<void> {
   //    Routes are now at /agents/:id/* (same prefix as runtime, different sub-paths).
   //    MUST be mounted before admin-ui (/admin/*) to avoid shadowing.
   const adminApiApp = createAdminApp({
+    agentService,
     agentEnvService,
     agentCronJobService,
     agentCronRunService,


### PR DESCRIPTION
## Summary
- Introduce `AgentService` (`admin/src/agents.ts`), mirroring the existing `AgentEnvService`/`AgentTokenService`/etc. DI shape, to own all `prisma.agent.*` access
- Route all 8 direct `prisma.agent.*` call sites in `admin/src/agents-api.ts` (create/rollback-delete/reconcile-list/getSummary/getDetail/exists/updateSelfHosted/list) through `agentService`, keeping `prisma` in `AdminDeps` only as the existing pass-through needed by `deleteAgentFully()` (out of scope here)
- Route both `prisma.agent.findUnique` call sites in `admin/src/api.ts` through a new structural `AgentServiceLike.getById()` interface, matching that file's existing hand-rolled `*Like` dependency pattern

Fixes an entropy patrol finding (`architecture_layering`, high severity): every sibling model already had a dedicated service module except `Agent`, so route handlers were reaching into the data layer directly.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `admin/src/agents.ts` exports `AgentService(prisma)` with `create`/`delete`/`list`/`getSummary`/`getDetail`/`exists`/`updateSelfHosted`/`getById`, mirroring `AgentEnvService`'s constructor shape | MET |
| 2 | `agents-api.ts` has zero remaining `prisma.agent.*` calls; `AdminDeps` gains `agentService`; `prisma` retained only for the `deleteAgentFully()` pass-through | MET |
| 3 | `api.ts` lines 175/215 route through the new `AgentServiceLike.getById()`, replacing `PrismaLike.agent.findUnique` | MET |
| 4 | No behavior change — response shapes/status codes unchanged (pure layering refactor) | MET |
| 5 | `admin/src/agents.unit.test.ts` added covering every `AgentService` method; existing smoke/integration test mocks updated to mock `agentService` instead of `prisma.agent.*` | MET |

## Test Plan
- New `admin/src/agents.unit.test.ts` — 16 unit tests covering all 8 `AgentService` methods against an injected prisma test double (TDD red→green confirmed)
- `admin/src/agents-api.smoke.test.ts`, `agents-api.integration.test.ts`, `agents-api.sentry.smoke.test.ts` updated to mock `agentService` (integration test uses a real `AgentService(prisma)` instance)
- `admin/src/main.ts` wires a single `new AgentService(prisma)` into both the admin CRUD app and the agent runtime app
- Full `admin` suite: 1145 pass / 153 skip / 1 fail — the 1 failure (`kubernetes-client.integration.test.ts` system-CA fallback test) is a pre-existing environment-dependent flake, reproduced identically on clean `main` before this change
- `bunx biome lint .` clean, `admin` `tsc --noEmit` clean
- Coverage on touched files: `agents.ts` 100% lines/functions, `agents-api.ts` 98.3%/98.9%, `api.ts` 100%/100% — well above the 80% gate
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
