### PR TITLE
chore(chart): bump chart version to 1.6.343

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.343] - 2026-07-13
+
+### Changed
+
+- auto-bump to chart v1.6.343 triggered by release tag(s): `admin-v0.190.0`
+
 ## [1.6.342] - 2026-07-13
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.342
+version: 1.6.343
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,15 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.342 triggered by release tag admin-v0.189.3"
-    - kind: changed
-      description: "auto-bump to chart v1.6.342 triggered by release tag agent-v0.173.3"
-    - kind: changed
-      description: "auto-bump to chart v1.6.342 triggered by release tag chat-v0.39.1"
-    - kind: changed
-      description: "auto-bump to chart v1.6.342 triggered by release tag metrics-v0.151.1"
-    - kind: changed
-      description: "auto-bump to chart v1.6.342 triggered by release tag task-store-v0.87.2"
+      description: "auto-bump to chart v1.6.343 triggered by release tag admin-v0.190.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -114,7 +114,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v0.189.3
+    tag: admin-v0.190.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.6.342 → 1.6.343

**Triggering tags:**
- `admin-v0.190.0`

**New chart version:** `1.6.343`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v0.190.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.343 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._