### PR TITLE
docs: remove stale PostHog mentions from quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The Shipwright agent runs as a Slack app — DMs, `@mentions`, and cron notifica
 
 ## Quickstart
 
-Run the **metrics dashboard locally today** — **offline by default**: no PostHog key, no accounts, no database. One copy-paste prompt covers both steps (terminal + an in-session slash command) and opens the dashboard.
+Run the **metrics dashboard locally today** — **offline by default**: fixtures-backed, no accounts, no database. One copy-paste prompt covers both steps (terminal + an in-session slash command) and opens the dashboard.
 
 Paste this into a **Claude Code** session:
 

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -10,8 +10,8 @@
 # What it does (deterministic, idempotent):
 #   1. Verifies prerequisites: git, bun, and the `task` (go-task) binary.
 #   2. Runs `task setup` (idempotent `bun install` across all workspaces).
-#   3. Starts the metrics dashboard via `task dev` (offline by default — no
-#      PostHog key, no accounts, no database needed) → http://localhost:3460/dashboard
+#   3. Starts the metrics dashboard via `task dev` (offline by default —
+#      fixtures-backed, no accounts, no database needed) → http://localhost:3460/dashboard
 #
 # Offline by default: `task dev` bakes in METRICS_OFFLINE=true, so the dashboard
 # serves from fixtures with no external accounts or secrets.
@@ -57,8 +57,8 @@ task setup
 
 echo ""
 echo "[quickstart] setup complete."
-echo "[quickstart] The metrics dashboard runs offline by default — no PostHog"
-echo "[quickstart] key, no accounts, and no database are required."
+echo "[quickstart] The metrics dashboard runs offline by default — fixtures-"
+echo "[quickstart] backed, with no accounts and no database required."
 echo ""
 echo "[quickstart] Open the dashboard at: ${DASHBOARD_URL}"
 echo "[quickstart] Starting the dev supervisor (task dev) — press Ctrl-C to stop."


### PR DESCRIPTION
## Summary
- Reworded the offline-quickstart description in README.md and scripts/quickstart.sh to drop stale PostHog mentions
- The metrics service no longer supports a PostHog mode at all (only fixtures/offline and taskstore/live) — copy now describes the actual offline behavior (fixtures-backed, no accounts/database needed)

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | README.md Quickstart section no longer mentions PostHog | MET | Line 49 reworded to "fixtures-backed, no accounts, no database" |
| 2 | scripts/quickstart.sh comment header and echo output no longer mention PostHog | MET | Lines 13-14 and 60-61 reworded, no PostHog references remain |
| 3 | Test decision: no test change needed | MET | Only prose/comment edits, no logic changed |

## Test Plan
- [x] `bunx biome lint` on changed files — passing
- [x] `bash -n scripts/quickstart.sh` — shell syntax OK
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — no banned strings found
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
