### PR TITLE
docs: fix marketing site metrics-backend copy

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -571,8 +571,8 @@ const differentiators = [
     <p class="mt-5 max-w-2xl text-lg">
       Every task emits telemetry — first-time-quality, estimation accuracy,
       review verdicts, cycle time, and token cost — to a dashboard you host
-      yourself. PostHog, Postgres, or a local SQLite store; no data leaves your
-      control.
+      yourself. Offline fixtures for local dev, or your own self-hosted
+      Shipwright task-store for live data; no data leaves your control.
     </p>
 
     <!-- Simulated dashboard screenshot (on-brand mock, no runtime JS). -->


### PR DESCRIPTION
## Summary
- Updates the marketing site's Metrics panel copy, which claimed the dashboard could be backed by "PostHog, Postgres, or a local SQLite store" — none of which exist anymore after the metrics migration to fixtures/task-store-only modes (`feat/mme-5-3`)
- New copy accurately describes the two real backend modes: offline fixtures for local dev, or a self-hosted Shipwright task-store for live data

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Copy in the Metrics panel accurately reflects the current two backend modes (fixtures / taskstore) | MET | `site/src/pages/index.astro` now reads "Offline fixtures for local dev, or your own self-hosted Shipwright task-store for live data" |
| 2 | No remaining PostHog/Postgres/SQLite backend claims on the page | MET | Grepped the file post-change — no matches |
| 3 | Test decision: no test change | MET | No test changes made — site Playwright specs don't assert on this prose string |

## Test Plan
- [x] `astro build` succeeds
- [x] `brand-lint` passes on the built output
- [x] `biome lint` passes on the changed file
- [x] Manually grepped for stale PostHog/Postgres/SQLite mentions — none remain

Generated with [Claude Code](https://claude.com/claude-code)
