### PR TITLE
docs: fix metrics Dockerfile run example to taskstore mode

### DIFF
--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -3,10 +3,10 @@
 # Build from repo root:
 #   docker build -f metrics/Dockerfile -t shipwright-metrics .
 #
-# Run (PostHog mode):
+# Run (taskstore mode):
 #   docker run \
-#     -e POSTHOG_PERSONAL_API_KEY=phx_... \
-#     -e POSTHOG_PROJECT_ID=<project-id> \
+#     -e METRICS_TASK_STORE_URL=http://task-store:3002 \
+#     -e METRICS_ADMIN_URL=http://admin:3001 \
 #     -e SHIPWRIGHT_SESSION_SECRET=... \
 #     -p 3460:3460 \
 #     shipwright-metrics


### PR DESCRIPTION
## Summary
- Replaces the dead PostHog-mode run example in `metrics/Dockerfile`'s header comment with a working taskstore-mode example (`METRICS_TASK_STORE_URL`, `METRICS_ADMIN_URL`), matching what `metrics/src/select-provider.ts` actually reads.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Dockerfile header comment shows a working taskstore-mode docker run example instead of the dead PostHog-mode one | MET |
| 2 | Env vars named in the comment match what metrics/src/select-provider.ts actually reads | MET |
| 3 | Test decision: no test change — Dockerfile comments aren't executable and have no test coverage | MET |

## Test Plan
- Docs-only change; no executable surface to test.
- Verified no leftover PostHog references remain in the file.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
