### PR TITLE
docs: remove stale PostHog claims from plugin README

### DIFF
--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -177,7 +177,7 @@ Key metrics:
 - **CI first-pass rate** and common failure patterns
 - **Estimation accuracy** by complexity tier (1–2 / 3 / 4–5)
 
-PostHog events are fired automatically by `/dev-task` at each checkpoint — `/metrics` is pure local analysis.
+`/metrics` reads task-store timestamps directly — no event-firing pipeline required.
 
 ### 7. Research
 
@@ -232,7 +232,6 @@ Shipwright is self-contained. It uses Claude Code's built-in `general-purpose` a
 | Plugin | Source | Used By | What It Enables |
 |--------|--------|---------|-----------------|
 | `frontend-design` | [Claude Code plugins](https://github.com/anthropics/claude-code/tree/main/plugins/frontend-design) | `/dev-task` | When a task is tagged with `Design Skill: frontend-design` in the planning doc, produces distinctive, high-quality UI instead of generic AI-generated interfaces |
-| `posthog` (optional) | [PostHog plugin](https://github.com/PostHog/posthog-mcp) | `/metrics` | Enables querying PostHog pipeline data via MCP. Optional — the MCP server is only needed for ad-hoc querying |
 
 ### What Happens Without Them
 


### PR DESCRIPTION
## Summary
- Removed the false claim that `/dev-task` fires PostHog events at each checkpoint; replaced with an accurate description that `/metrics` reads task-store timestamps directly
- Removed the dead `posthog` (optional) row from the Recommended Plugins table — no PostHog MCP integration exists in the codebase

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Line 180's PostHog-events claim is removed or replaced with an accurate description of how `/metrics` sources its data | MET | Replaced with "`/metrics` reads task-store timestamps directly — no event-firing pipeline required." |
| 2 | The posthog row is removed from the Recommended Plugins table (and its "What Happens Without Them" row, if present) | MET | Row deleted from Recommended Plugins table; no corresponding row existed in "What Happens Without Them" |
| 3 | Test decision: no test change — README prose only | MET | Only `plugins/shipwright/README.md` touched |

## Test Plan
- Confirmed no remaining `posthog`/`PostHog` references anywhere in `plugins/shipwright/README.md`
- `bunx biome lint` on the changed file passes clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
