### PR TITLE
chore(chart): bump chart version to 1.6.349

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.349] - 2026-07-14
+
+### Changed
+
+- auto-bump to chart v1.6.349 triggered by release tag(s): `agent-v0.174.3`
+
 ## [1.6.348] - 2026-07-14
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.348
+version: 1.6.349
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,9 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.348 triggered by release tag agent-v0.174.3"
-    - kind: changed
-      description: "auto-bump to chart v1.6.348 triggered by release tag task-store-v0.88.0"
+      description: "auto-bump to chart v1.6.349 triggered by release tag agent-v0.174.3"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer


### PR DESCRIPTION
## Chart version bump: 1.6.348 → 1.6.349

**Triggering tags:**
- `agent-v0.174.3`

**New chart version:** `1.6.349`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v0.174.3`
- `agent.provisioning.image.tag`: `agent-v0.174.3`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.349 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._