### PR TITLE
feat: remove agent-released dispatch from build-agent.yml

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -98,22 +98,10 @@ jobs:
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
         # no image behind it silently breaks any downstream consumer that trusts
-        # the tag without verifying the image exists — including the dispatch
-        # below, which downstream repos use to pick up "the latest agent tag".
+        # the tag without verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
             -f sha="${{ github.event.workflow_run.head_sha }}"
-
-      - name: Dispatch agent-released to downstream
-        env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
-          DISPATCH_REPO: ${{ vars.CHART_DISPATCH_REPO }}
-        run: |
-          [ -z "$DISPATCH_REPO" ] && echo "CHART_DISPATCH_REPO not configured, skipping" && exit 0
-          printf '{"event_type":"shipwright-agent-released","client_payload":{"base_tag":"%s"}}' "$NEW_TAG" \
-            | gh api "repos/$DISPATCH_REPO/dispatches" --method POST --input -
-          echo "Dispatched shipwright-agent-released with base_tag: ${NEW_TAG}"


### PR DESCRIPTION
## Summary
- Removes the "Dispatch agent-released to downstream" step from `.github/workflows/build-agent.yml`
- vitals-os's new node-cron poller (DCC-12.1) watches shipwright's `agent-v*` tags directly via the public tags/releases API, making this cross-repo `repository_dispatch` redundant
- `CHART_DISPATCH_REPO` is no longer referenced anywhere in this file; tag computation and git-tag creation (`agent-vX`) are unchanged

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | The 'Dispatch agent-released to downstream' step is removed | MET |
| 2 | Tag computation and git-tag creation continue to work unchanged | MET |
| 3 | CHART_DISPATCH_REPO is no longer referenced in this file | MET |
| 4 | Test decision: verified via CI workflow run, no unit test | MET |

## Test Plan
- YAML syntax validated locally (js-yaml parse)
- Confirmed no other reference to `CHART_DISPATCH_REPO`/`DISPATCH_REPO` remains in the file
- No unit/integration test applies to a CI workflow YAML deletion — verified by a successful `build-agent.yml` run in CI
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
