### PR TITLE
fix: add orderBy to listReady() for deterministic task ordering

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -43,7 +43,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. |
 | `session` | string | Filter by planning session slug |
 | `repo` | string | Filter by repo (`org/repo` format) |
 | `assignee` | string | Filter by assignee (admin tokens only; agent tokens see only their own tasks) |

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -41,7 +41,7 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.tasks'
 ```
 
-The command returns `pending` shipwright tasks whose dependencies are all satisfied, sorted by `addedAt`. Pick the first result from `.tasks`.
+The command returns `pending` shipwright tasks whose dependencies are all satisfied, sorted by `createdAt` ascending (oldest first). Pick the first result from `.tasks`.
 
 If the output is an empty JSON array (`[]`), respond `[silent]` and stop.
 

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -153,11 +153,16 @@ export class TaskService implements TaskServiceLike {
    *
    * When `repos` is provided (repo-scoped agent token), unassigned pool tasks
    * whose repo is in the repos list are also included.
+   *
+   * Tasks are returned in ascending createdAt order (oldest first) to ensure
+   * deterministic selection regardless of insertion order.
    */
   async listReady(agentId?: string, repos?: string[]): Promise<Task[]> {
     // Load all tasks so dependency resolution sees the full graph, then filter
     // the result set to the caller's agent if one is specified.
-    const tasks = await this.prisma.task.findMany();
+    const tasks = await this.prisma.task.findMany({
+      orderBy: { createdAt: "asc" },
+    });
     const ready = await resolveReadyTasks(tasks, async () => false);
     if (agentId) {
       return ready.filter(

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -502,6 +502,55 @@ describeOrSkip("Task store schema (integration)", () => {
     expect(titles).not.toContain("Warchild pending in scope");
   });
 
+  it("listReady() returns multiple ready tasks in ascending createdAt order regardless of insertion order", async () => {
+    const taskService = new TaskService(prisma);
+
+    // Insert tasks in scrambled order (not ascending by timestamp)
+    // Task 3: middle timestamp
+    const task3 = await prisma.task.create({
+      data: {
+        title: "Task 3 - middle",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "acme-inc/backend-api",
+      },
+    });
+
+    // Task 1: earliest timestamp
+    const task1 = await prisma.task.create({
+      data: {
+        title: "Task 1 - earliest",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "acme-inc/backend-api",
+      },
+    });
+
+    // Task 2: latest timestamp
+    const task2 = await prisma.task.create({
+      data: {
+        title: "Task 2 - latest",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "acme-inc/backend-api",
+      },
+    });
+
+    const result = await taskService.listReady("agent-1", [
+      "acme-inc/backend-api",
+    ]);
+
+    // Verify all three tasks are included
+    expect(result).toHaveLength(3);
+
+    // Verify they are returned in ascending createdAt order
+    // (not in insertion order, which was: task3, task1, task2)
+    const resultIds = result.map((t) => t.id);
+    const expectedOrder = [task1.id, task3.id, task2.id]; // Sorted by createdAt asc
+
+    expect(resultIds).toEqual(expectedOrder);
+  });
+
   it("list() with agentScope AND repo filter applies repo as additional AND condition", async () => {
     const taskService = new TaskService(prisma);
 

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -505,34 +505,34 @@ describeOrSkip("Task store schema (integration)", () => {
   it("listReady() returns multiple ready tasks in ascending createdAt order regardless of insertion order", async () => {
     const taskService = new TaskService(prisma);
 
-    // Insert tasks in scrambled order (not ascending by timestamp)
-    // Task 3: middle timestamp
+    // Explicitly set createdAt so timestamp order is scrambled relative to
+    // insertion order — proves the result is sorted by createdAt, not by
+    // insertion/default DB order.
     const task3 = await prisma.task.create({
       data: {
         title: "Task 3 - middle",
         status: "pending",
         assignee: "agent-1",
         repo: "acme-inc/backend-api",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
       },
     });
-
-    // Task 1: earliest timestamp
     const task1 = await prisma.task.create({
       data: {
         title: "Task 1 - earliest",
         status: "pending",
         assignee: "agent-1",
         repo: "acme-inc/backend-api",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
       },
     });
-
-    // Task 2: latest timestamp
     const task2 = await prisma.task.create({
       data: {
         title: "Task 2 - latest",
         status: "pending",
         assignee: "agent-1",
         repo: "acme-inc/backend-api",
+        createdAt: new Date("2026-01-03T00:00:00Z"),
       },
     });
 
@@ -544,7 +544,7 @@ describeOrSkip("Task store schema (integration)", () => {
     expect(result).toHaveLength(3);
 
     // Verify they are returned in ascending createdAt order
-    // (not in insertion order, which was: task3, task1, task2)
+    // (insertion order was task3, task1, task2 — a different sequence)
     const resultIds = result.map((t) => t.id);
     const expectedOrder = [task1.id, task3.id, task2.id]; // Sorted by createdAt asc
 


### PR DESCRIPTION
## Summary
- Add `orderBy: { createdAt: "asc" }` to the `findMany()` call in `TaskService.listReady()` so `GET /tasks?ready=true` deterministically returns ready tasks oldest-first, instead of unspecified DB order
- Correct `dev-task.md`'s claim that ready tasks are sorted by `addedAt` (they're sorted by `createdAt`) — this doc/behavior mismatch was the root cause of the loop and a self-searching command picking different tasks
- Refresh `docs/task-store.md`'s `ready` query param description to note the new deterministic ordering

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /tasks?ready=true returns tasks in ascending createdAt order | MET | `orderBy: { createdAt: "asc" }` added to `findMany()` in `listReady()` |
| 2 | No change to which tasks are included — only ordering changes | MET | Filtering logic (`resolveReadyTasks`, agent/repo predicate) untouched |
| 3 | New test asserting ascending createdAt order regardless of insertion order, no existing tests retired | MET | New integration test inserts tasks with explicit out-of-order `createdAt` timestamps and asserts result order matches sorted order |

## Test Plan
- New integration test in `task-store/src/tasks.integration.test.ts`: creates 3 ready tasks with explicit, scrambled-relative-to-insertion-order `createdAt` timestamps, asserts `listReady()` returns them in ascending `createdAt` order
- `task typecheck` — passes
- `task lint` — passes
- `task-store` full test suite — 294 pass, 0 fail (81 skip — DB-gated integration tests skip without `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST` in this sandbox; CI has a live test DB)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
