### PR TITLE
feat: add ready/unclaimed filter to task-store /prs endpoint

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -25,7 +25,7 @@ List pull requests
 - **Method:** GET
 - **Path:** `/prs`
 - **Has body:** No
-- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query)
+- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query), `ready` (query)
 
 ## `prs_update`
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -165,7 +165,9 @@ The `/prs` surface tracks GitHub PRs through the review → patch → deploy pip
 GET /prs
 ```
 
-Query params: `repo`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`.
+Query params: `repo`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`, `ready`.
+
+`ready=true` returns only unclaimed PRs (`claimedBy IS NULL`) — mirrors `/tasks?ready=true`'s semantics for tasks. It composes with the other filters (e.g. `?ready=true&repo=org/repo`) rather than hardcoding `claim-next`'s `state=open AND reviewState IN (pending, posted, approved)` eligibility rules; claim staleness itself is handled entirely by the `StaleClaimReaper` background job, not by this filter.
 
 Returns `{ prs: PullRequest[], total: number, limit: number, offset: number }`.
 

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -537,6 +537,13 @@ export const generatedTools: GeneratedTool[] = [
           description: "Pagination offset",
           example: "0",
         },
+        ready: {
+          type: "string",
+          enum: ["true", "false"],
+          description:
+            "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
+          example: "true",
+        },
       },
       required: [],
       additionalProperties: false,
@@ -552,6 +559,7 @@ export const generatedTools: GeneratedTool[] = [
       "staged",
       "limit",
       "offset",
+      "ready",
     ],
     pathParams: [],
     hasBody: false,
@@ -586,6 +594,19 @@ export const generatedTools: GeneratedTool[] = [
           type: "string",
           description: "Associated task ID",
           example: "clx1234567890",
+        },
+        phase: {
+          type: "string",
+          enum: ["review", "patch", "deploy"],
+          description:
+            "Pipeline phase this claim is for (defaults to 'review' when omitted)",
+          example: "patch",
+        },
+        prCreatedAt: {
+          type: "string",
+          description:
+            "ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.",
+          example: "2026-01-01T00:00:00.000Z",
         },
       },
       required: ["repo", "prNumber", "commitSha"],
@@ -706,13 +727,20 @@ export const generatedTools: GeneratedTool[] = [
   },
   {
     name: "prs_patch",
-    description: "Increment patchCycles and reset reviewState=pending",
+    description:
+      "Increment patchCycles and conditionally reset reviewState=pending",
     inputSchema: {
       type: "object",
       properties: {
         id: {
           type: "string",
           example: "clx0987654321",
+        },
+        commitSha: {
+          type: "string",
+          description:
+            "Current head commit SHA. When provided and it differs from the record's stored commitSha, reviewState resets to pending and commitSha is updated. When it matches, reviewState is left untouched (no-op patch cycle). When omitted, reviewState unconditionally resets to pending (legacy behavior).",
+          example: "abc123def456",
         },
       },
       required: ["id"],
@@ -722,7 +750,7 @@ export const generatedTools: GeneratedTool[] = [
     pathTemplate: "/prs/{id}/patch",
     queryParams: [],
     pathParams: ["id"],
-    hasBody: false,
+    hasBody: true,
   },
   {
     name: "prs_release",

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -1124,6 +1124,20 @@
             "required": false,
             "name": "offset",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
+              "example": "true"
+            },
+            "required": false,
+            "name": "ready",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2024,11 +2038,22 @@
           "updated": {
             "type": "integer",
             "example": 1
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).",
+            "example": [
+              "entropy-dead_exports-other-repo-2026-W29"
+            ]
           }
         },
         "required": [
           "inserted",
-          "updated"
+          "updated",
+          "skipped"
         ]
       },
       "BulkInsertBody": {

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -526,6 +526,11 @@ export const PrListQuerySchema = z
       .string()
       .optional()
       .openapi({ example: "0", description: "Pagination offset" }),
+    ready: z.enum(["true", "false"]).optional().openapi({
+      example: "true",
+      description:
+        "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
+    }),
   })
   .openapi("PrListQuery");
 

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -730,6 +730,46 @@ describe("/prs routes (smoke)", () => {
     expect(body.prs.every((p: PullRequest) => p.staged === true)).toBe(true);
   });
 
+  it("GET /prs?ready=true wires the ready filter through to the service", async () => {
+    let capturedFilters: PullRequestListFilters | undefined;
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", claimedBy: null }));
+    const baseFake = fakePrService({ store });
+    const prServiceWithCapture: PullRequestServiceLike = {
+      ...baseFake,
+      async list(filters?: PullRequestListFilters): Promise<PullRequestListResult> {
+        capturedFilters = filters;
+        return baseFake.list(filters);
+      },
+    };
+    const app = makeApp({ prService: prServiceWithCapture });
+
+    const res = await app.request("/prs?ready=true", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    expect(capturedFilters?.ready).toBe(true);
+  });
+
+  it("GET /prs without ready leaves the ready filter undefined", async () => {
+    let capturedFilters: PullRequestListFilters | undefined;
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const baseFake = fakePrService({ store });
+    const prServiceWithCapture: PullRequestServiceLike = {
+      ...baseFake,
+      async list(filters?: PullRequestListFilters): Promise<PullRequestListResult> {
+        capturedFilters = filters;
+        return baseFake.list(filters);
+      },
+    };
+    const app = makeApp({ prService: prServiceWithCapture });
+
+    const res = await app.request("/prs", { headers: adminAuth() });
+    expect(res.status).toBe(200);
+    expect(capturedFilters?.ready).toBeUndefined();
+  });
+
   it("GET /prs?staged=false returns unstaged records only", async () => {
     const store = new Map<string, PullRequest>();
     store.set("pr-1", makePr({ id: "pr-1", staged: true }));

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -27,6 +27,19 @@ export interface PullRequestListFilters {
   staged?: boolean;
   limit?: number;
   offset?: number;
+  /**
+   * When true, only return unclaimed PRs (claimedBy IS NULL) — mirrors
+   * /tasks?ready=true's semantics for tasks. Deliberately kept to the literal
+   * "unclaimed" interpretation from the acceptance criteria rather than also
+   * hardcoding claimNext()'s state='open' AND reviewState IN
+   * ('pending','posted','approved') eligibility rules: GET /prs is a general
+   * list endpoint used by multiple callers (not just the claim-next code
+   * path), and those additional rules are already composable via the
+   * existing `state`/`reviewState` filters when a caller needs them. Claim
+   * staleness is handled entirely by StaleClaimReaper — this filter does not
+   * duplicate that logic, it just reads the current claimedBy column.
+   */
+  ready?: boolean;
 }
 
 /** Paginated list result from PullRequestService.list. */
@@ -81,6 +94,7 @@ export class PullRequestService implements PullRequestServiceLike {
     if (filters.reviewState)
       where.reviewState = filters.reviewState as PullRequest["reviewState"];
     if (filters.staged !== undefined) where.staged = filters.staged;
+    if (filters.ready) where.claimedBy = null;
 
     const limit = filters.limit ?? 50;
     const offset = filters.offset ?? 0;

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -960,6 +960,54 @@ describeOrSkip("PullRequestService.list() and get() (integration)", () => {
     const found = await service.get("00000000-0000-0000-0000-000000000000");
     expect(found).toBeNull();
   });
+
+  it("list({ ready: true }) returns only unclaimed PRs, excluding claimed ones", async () => {
+    const claimed = await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1040,
+        claimedBy: "agent-a",
+        claimedAt: new Date().toISOString(),
+        heartbeatAt: new Date().toISOString(),
+      },
+    });
+    const unclaimed = await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1041,
+        claimedBy: null,
+      },
+    });
+
+    const readyResult = await service.list({ ready: true });
+    expect(readyResult.total).toBe(1);
+    expect(readyResult.prs).toHaveLength(1);
+    expect(readyResult.prs[0].id).toBe(unclaimed.id);
+    expect(readyResult.prs.some((p) => p.id === claimed.id)).toBe(false);
+  });
+
+  it("list() without ready returns both claimed and unclaimed PRs (backward compatible)", async () => {
+    await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1050,
+        claimedBy: "agent-a",
+        claimedAt: new Date().toISOString(),
+        heartbeatAt: new Date().toISOString(),
+      },
+    });
+    await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1051,
+        claimedBy: null,
+      },
+    });
+
+    const result = await service.list();
+    expect(result.total).toBe(2);
+    expect(result.prs).toHaveLength(2);
+  });
 });
 
 // ─── heartbeat() / release() / patch() (liveness + lifecycle) ────────────────

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -10,7 +10,7 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState, ?staged)
+ *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState, ?staged, ?ready)
  *   POST   /prs/claim         atomic claim (201 new, 200 update, 409 conflict)
  *   POST   /prs/claim-next    atomic find-and-claim oldest eligible PR (200+{pr,phase} or 204)
  *   GET    /prs/:id           fetch one (404 when missing)
@@ -289,6 +289,7 @@ export function createPrsRoutes(
     const stagedRaw = c.req.query("staged");
     const staged =
       stagedRaw === "true" ? true : stagedRaw === "false" ? false : undefined;
+    const ready = c.req.query("ready") === "true" ? true : undefined;
 
     const result = await prService.list({
       repo: c.req.query("repo"),
@@ -300,6 +301,7 @@ export function createPrsRoutes(
       state: c.req.query("state"),
       reviewState: c.req.query("reviewState"),
       staged,
+      ready,
       limit:
         limitRaw !== undefined
           ? Number.parseInt(limitRaw, 10) || undefined


### PR DESCRIPTION
## Summary
- Add a `ready=true` filter to `GET /prs` in the task-store service, mirroring the existing `/tasks?ready=true` semantics for tasks
- Filter is scoped to a literal "unclaimed" interpretation (`claimedBy IS NULL`), composable with the endpoint's existing `repo`/`state`/`reviewState` filters, and relies on `StaleClaimReaper` to keep `claimedBy` accurate rather than duplicating staleness logic
- Regenerated `task-store/openapi.json` and `mcp-server/src/generated-tools.ts` from the updated schema, and refreshed `docs/task-store.md` / `docs/mcp-tools.md` to document the new parameter

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /prs supports a new filter param returning only unclaimed PR records, consistent with existing claim/heartbeat/reaper semantics | MET | `ready` param added to `PrListQuerySchema`, wired through `routes/prs.ts` → `PullRequestService.list()` → `where.claimedBy = null` |
| 2 | admin/openapi.json and/or task-store/openapi.json updated to reflect the new parameter | MET | `task-store/openapi.json` regenerated; `admin/openapi.json` doesn't document `/prs` so no change needed there |
| 3 | Integration test (Postgres-backed) covering claimed vs. unclaimed PRs correctly included/excluded | MET | New tests in `pull-request.integration.test.ts`: `ready:true` excludes claimed PRs; omitting `ready` stays backward compatible |

## Test Plan
- `task-store` test suite: 296 pass, 0 fail (Postgres-gated integration tests skip in sandbox, will run in CI)
- `bun run lint`, `bun run typecheck` (all workspaces), `task check-strings` — all pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
