### PR TITLE
feat: normalize deploy candidate age to task addedAt / PR createdAt

### DIFF
--- a/agent/src/check-deploy.ts
+++ b/agent/src/check-deploy.ts
@@ -94,7 +94,10 @@ export interface CheckDeployDeps {
   // signal, since "unknown" must not be treated as "confirmed ready". This
   // deliberately does NOT mirror queryPrRecord's fail-open posture, which
   // only affects a non-gating ordering field.
-  queryTaskStatus?: (repo: string, prNumber: number) => Promise<TaskStatus | null>;
+  queryTaskStatus?: (
+    repo: string,
+    prNumber: number,
+  ) => Promise<{ status: TaskStatus; addedAt?: string } | null>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -203,17 +206,17 @@ export async function getDeployCandidates(
         // linked task) is not disqualifying, but a lookup FAILURE fails
         // CLOSED — deploy is consequential enough that "unknown" must not be
         // treated as "confirmed ready".
+        let linkedTask: { status: TaskStatus; addedAt?: string } | null = null;
         if (deps.queryTaskStatus) {
-          let taskStatus: TaskStatus | null;
           try {
-            taskStatus = await deps.queryTaskStatus(repo, pr.number);
+            linkedTask = await deps.queryTaskStatus(repo, pr.number);
           } catch (err) {
             process.stderr.write(
               `check-deploy: task-status lookup failed for PR ${pr.number}: ${err instanceof Error ? err.message : String(err)}\n`,
             );
             continue;
           }
-          if (taskStatus === "blocked") continue;
+          if (linkedTask?.status === "blocked") continue;
         }
 
         if (deps.isBundleComplete) {
@@ -234,7 +237,7 @@ export async function getDeployCandidates(
 
         candidates.push({
           id: candidateId(repo, pr.number),
-          age: record?.readyForDeployAt ?? pr.createdAt ?? "",
+          age: linkedTask?.addedAt ?? pr.createdAt ?? "",
           claimedBy: record?.claimedBy ?? null,
           phase: "deploy",
         });

--- a/agent/src/check-deploy.ts
+++ b/agent/src/check-deploy.ts
@@ -31,7 +31,7 @@ import {
   resolveWorkspacePath,
   splitOrgRepo,
 } from "./check-helpers.ts";
-import type { TaskStatus } from "./check-helpers.ts";
+import type { LinkedTaskInfo } from "./check-helpers.ts";
 import type { WorkPrCandidate } from "./work-selector.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ export interface CheckDeployDeps {
   queryTaskStatus?: (
     repo: string,
     prNumber: number,
-  ) => Promise<{ status: TaskStatus; addedAt?: string } | null>;
+  ) => Promise<LinkedTaskInfo | null>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -206,7 +206,7 @@ export async function getDeployCandidates(
         // linked task) is not disqualifying, but a lookup FAILURE fails
         // CLOSED — deploy is consequential enough that "unknown" must not be
         // treated as "confirmed ready".
-        let linkedTask: { status: TaskStatus; addedAt?: string } | null = null;
+        let linkedTask: LinkedTaskInfo | null = null;
         if (deps.queryTaskStatus) {
           try {
             linkedTask = await deps.queryTaskStatus(repo, pr.number);

--- a/agent/src/check-deploy.unit.test.ts
+++ b/agent/src/check-deploy.unit.test.ts
@@ -40,7 +40,7 @@ interface MakeDepsOptions {
   ciRuns?: Record<string, CiRun[]>;
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
-  taskStatus?: Record<string, TaskStatus | null>;
+  taskStatus?: Record<string, { status: TaskStatus; addedAt?: string } | null>;
 }
 
 function makeDeps({
@@ -74,6 +74,7 @@ function makeDeps({
     },
   };
 }
+
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -442,29 +443,48 @@ describe("getDeployCandidates", () => {
 
   // ─── age field sourcing ────────────────────────────────────────────────────
 
-  test("age is sourced from queryPrRecord's readyForDeployAt when available", async () => {
+  test("age is sourced from the linked task's addedAt when a task is linked", async () => {
     const pr = makeGhPr({ reviewDecision: "APPROVED", createdAt: "2026-06-01T00:00:00.000Z" });
     const deps = makeDeps({
       prs: { "acme/example-repo": [pr] },
       ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+    });
+    deps.queryTaskStatus = async () => ({
+      status: "in_progress",
+      addedAt: "2026-05-01T00:00:00.000Z",
+    });
+    const result = await getDeployCandidates(deps);
+    expect(result[0].age).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  test("age falls back to PR createdAt when no task is linked (queryTaskStatus resolves null)", async () => {
+    const pr = makeGhPr({ reviewDecision: "APPROVED", createdAt: "2026-06-01T00:00:00.000Z" });
+    const deps = makeDeps({
+      prs: { "acme/example-repo": [pr] },
+      ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+    });
+    deps.queryTaskStatus = async () => null;
+    const result = await getDeployCandidates(deps);
+    expect(result[0].age).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  test("queryPrRecord's readyForDeployAt is never used for age sourcing", async () => {
+    const pr = makeGhPr({ reviewDecision: "APPROVED", createdAt: "2026-06-01T00:00:00.000Z" });
+    const deps = makeDeps({
+      prs: { "acme/example-repo": [pr] },
+      ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+    });
+    deps.queryTaskStatus = async () => ({
+      status: "in_progress",
+      addedAt: "2026-05-01T00:00:00.000Z",
     });
     deps.queryPrRecord = async () => ({
       readyForDeployAt: "2026-05-20T00:00:00.000Z",
       claimedBy: null,
     });
     const result = await getDeployCandidates(deps);
-    expect(result[0].age).toBe("2026-05-20T00:00:00.000Z");
-  });
-
-  test("age falls back to PR createdAt when queryPrRecord is not provided", async () => {
-    const pr = makeGhPr({ reviewDecision: "APPROVED", createdAt: "2026-06-01T00:00:00.000Z" });
-    const result = await getDeployCandidates(
-      makeDeps({
-        prs: { "acme/example-repo": [pr] },
-        ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
-      }),
-    );
-    expect(result[0].age).toBe("2026-06-01T00:00:00.000Z");
+    expect(result[0].age).not.toBe("2026-05-20T00:00:00.000Z");
+    expect(result[0].age).toBe("2026-05-01T00:00:00.000Z");
   });
 
   // ─── mergeStateStatus DIRTY exclusion ──────────────────────────────────
@@ -494,7 +514,7 @@ describe("getDeployCandidates", () => {
       prs: { "acme/example-repo": [pr] },
       ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
     });
-    deps.queryTaskStatus = async () => "blocked";
+    deps.queryTaskStatus = async () => ({ status: "blocked" });
     const result = await getDeployCandidates(deps);
     expect(result).toEqual([]);
   });

--- a/agent/src/check-deploy.unit.test.ts
+++ b/agent/src/check-deploy.unit.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { TaskStatus } from "./check-helpers.ts";
+import type { LinkedTaskInfo } from "./check-helpers.ts";
 import {
   type CheckDeployDeps,
   type CiRun,
@@ -40,7 +40,7 @@ interface MakeDepsOptions {
   ciRuns?: Record<string, CiRun[]>;
   currentUser?: string;
   isSelfReviewAllowed?: boolean;
-  taskStatus?: Record<string, { status: TaskStatus; addedAt?: string } | null>;
+  taskStatus?: Record<string, LinkedTaskInfo | null>;
 }
 
 function makeDeps({
@@ -74,7 +74,6 @@ function makeDeps({
     },
   };
 }
-
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 

--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -407,25 +407,37 @@ export function createPrRecordQuery<T>(opts?: {
 }
 
 /**
- * Build a `(repo, prNumber) => status | null` query function against the
- * task-store `/tasks` endpoint's `?repo=&pr=` filters. Returns null ONLY on a
- * confirmed empty result (no linked task) — a PR simply has no task yet.
- * Throws on missing config, a non-ok response, or a malformed/unreachable
- * response, so a caller who needs a go/no-go decision (unlike
- * createPrRecordQuery's non-gating age field) can distinguish "no task" from
- * "couldn't tell" and fail closed on the latter.
+ * Build a `(repo, prNumber) => { status, addedAt } | null` query function
+ * against the task-store `/tasks` endpoint's `?repo=&pr=` filters. Returns
+ * null ONLY on a confirmed empty result (no linked task) — a PR simply has no
+ * task yet. Throws on missing config, a non-ok response, or a
+ * malformed/unreachable response, so a caller who needs a go/no-go decision
+ * (unlike createPrRecordQuery's non-gating age field) can distinguish "no
+ * task" from "couldn't tell" and fail closed on the latter.
+ *
+ * `addedAt` is included alongside `status` so callers can source a
+ * cross-phase age comparison from the SAME clock dev-task's backlog
+ * candidates already use (task.addedAt), instead of a phase-recent
+ * timestamp. It may be undefined if the matched task record doesn't carry
+ * one.
  *
  * Accepts an optional `fetchFn` for dependency injection in tests, matching
  * createPrRecordQuery's pattern.
  */
 export function createTaskStatusQuery(opts?: {
   fetchFn?: FetchFn;
-}): (repo: string, prNumber: number) => Promise<TaskStatus | null> {
+}): (
+  repo: string,
+  prNumber: number,
+) => Promise<{ status: TaskStatus; addedAt?: string } | null> {
   const taskStoreUrl = (process.env.SHIPWRIGHT_TASK_STORE_URL ?? "").trim();
   const taskStoreToken = (process.env.SHIPWRIGHT_TASK_STORE_TOKEN ?? "").trim();
   const doFetch: FetchFn = opts?.fetchFn ?? fetch;
 
-  return async (repo: string, prNumber: number): Promise<TaskStatus | null> => {
+  return async (
+    repo: string,
+    prNumber: number,
+  ): Promise<{ status: TaskStatus; addedAt?: string } | null> => {
     if (!taskStoreUrl || !taskStoreToken) {
       throw new Error(
         "SHIPWRIGHT_TASK_STORE_URL/SHIPWRIGHT_TASK_STORE_TOKEN not configured",
@@ -455,7 +467,9 @@ export function createTaskStatusQuery(opts?: {
     } else {
       throw new Error(`Unexpected task-store response format: ${JSON.stringify(data)}`);
     }
-    return tasks[0]?.status ?? null;
+    const task = tasks[0];
+    if (!task) return null;
+    return { status: task.status, addedAt: task.addedAt };
   };
 }
 

--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -407,29 +407,33 @@ export function createPrRecordQuery<T>(opts?: {
 }
 
 /**
- * Build a `(repo, prNumber) => { status, addedAt } | null` query function
- * against the task-store `/tasks` endpoint's `?repo=&pr=` filters. Returns
- * null ONLY on a confirmed empty result (no linked task) — a PR simply has no
- * task yet. Throws on missing config, a non-ok response, or a
- * malformed/unreachable response, so a caller who needs a go/no-go decision
- * (unlike createPrRecordQuery's non-gating age field) can distinguish "no
- * task" from "couldn't tell" and fail closed on the latter.
- *
- * `addedAt` is included alongside `status` so callers can source a
- * cross-phase age comparison from the SAME clock dev-task's backlog
- * candidates already use (task.addedAt), instead of a phase-recent
+ * Status + addedAt for the task linked to a PR, as returned by
+ * createTaskStatusQuery. `addedAt` is included alongside `status` so callers
+ * can source a cross-phase age comparison from the SAME clock dev-task's
+ * backlog candidates already use (task.addedAt), instead of a phase-recent
  * timestamp. It may be undefined if the matched task record doesn't carry
  * one.
+ */
+export interface LinkedTaskInfo {
+  status: TaskStatus;
+  addedAt?: string;
+}
+
+/**
+ * Build a `(repo, prNumber) => LinkedTaskInfo | null` query function against
+ * the task-store `/tasks` endpoint's `?repo=&pr=` filters. Returns null ONLY
+ * on a confirmed empty result (no linked task) — a PR simply has no task yet.
+ * Throws on missing config, a non-ok response, or a malformed/unreachable
+ * response, so a caller who needs a go/no-go decision (unlike
+ * createPrRecordQuery's non-gating age field) can distinguish "no task" from
+ * "couldn't tell" and fail closed on the latter.
  *
  * Accepts an optional `fetchFn` for dependency injection in tests, matching
  * createPrRecordQuery's pattern.
  */
 export function createTaskStatusQuery(opts?: {
   fetchFn?: FetchFn;
-}): (
-  repo: string,
-  prNumber: number,
-) => Promise<{ status: TaskStatus; addedAt?: string } | null> {
+}): (repo: string, prNumber: number) => Promise<LinkedTaskInfo | null> {
   const taskStoreUrl = (process.env.SHIPWRIGHT_TASK_STORE_URL ?? "").trim();
   const taskStoreToken = (process.env.SHIPWRIGHT_TASK_STORE_TOKEN ?? "").trim();
   const doFetch: FetchFn = opts?.fetchFn ?? fetch;
@@ -437,7 +441,7 @@ export function createTaskStatusQuery(opts?: {
   return async (
     repo: string,
     prNumber: number,
-  ): Promise<{ status: TaskStatus; addedAt?: string } | null> => {
+  ): Promise<LinkedTaskInfo | null> => {
     if (!taskStoreUrl || !taskStoreToken) {
       throw new Error(
         "SHIPWRIGHT_TASK_STORE_URL/SHIPWRIGHT_TASK_STORE_TOKEN not configured",

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -20,6 +20,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  createTaskStatusQuery,
   createTaskStoreClient,
   getCurrentUser,
   isCleanApproveBody,
@@ -677,6 +678,109 @@ describe("createTaskStoreClient query()", () => {
     await expect(
       client.update("T-1", { status: "in_progress" }),
     ).rejects.toThrow("task-store PATCH /tasks/T-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTaskStatusQuery
+// ---------------------------------------------------------------------------
+
+describe("createTaskStatusQuery", () => {
+  let savedEnv: { url?: string; token?: string };
+
+  beforeEach(() => {
+    savedEnv = {
+      url: process.env.SHIPWRIGHT_TASK_STORE_URL,
+      token: process.env.SHIPWRIGHT_TASK_STORE_TOKEN,
+    };
+    process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.com";
+    process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    if (savedEnv.url !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_URL = savedEnv.url;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_URL;
+    }
+    if (savedEnv.token !== undefined) {
+      process.env.SHIPWRIGHT_TASK_STORE_TOKEN = savedEnv.token;
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional env cleanup
+      delete process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    }
+  });
+
+  test("returns { status, addedAt } when a linked task is found with both fields present", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          tasks: [
+            { id: "T-1", title: "Do the thing", status: "in_progress", addedAt: "2026-05-01T00:00:00.000Z" },
+          ],
+        }),
+      }) as Response) as unknown as typeof fetch;
+
+    const query = createTaskStatusQuery({ fetchFn: fakeFetch });
+    const result = await query("acme/example-repo", 42);
+    expect(result).toEqual({
+      status: "in_progress",
+      addedAt: "2026-05-01T00:00:00.000Z",
+    });
+  });
+
+  test("returns { status, addedAt: undefined } when the matched task has no addedAt", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          tasks: [{ id: "T-1", title: "Do the thing", status: "pending" }],
+        }),
+      }) as Response) as unknown as typeof fetch;
+
+    const query = createTaskStatusQuery({ fetchFn: fakeFetch });
+    const result = await query("acme/example-repo", 42);
+    expect(result).toEqual({ status: "pending", addedAt: undefined });
+  });
+
+  test("returns null when no linked task is found (empty tasks array)", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ tasks: [] }),
+      }) as Response) as unknown as typeof fetch;
+
+    const query = createTaskStatusQuery({ fetchFn: fakeFetch });
+    const result = await query("acme/example-repo", 42);
+    expect(result).toBeNull();
+  });
+
+  test("throws when the lookup response is not ok (fail-closed)", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      }) as Response) as unknown as typeof fetch;
+
+    const query = createTaskStatusQuery({ fetchFn: fakeFetch });
+    await expect(query("acme/example-repo", 42)).rejects.toThrow(
+      "task-store GET /tasks",
+    );
+  });
+
+  test("throws when SHIPWRIGHT_TASK_STORE_URL/TOKEN are not configured", async () => {
+    // biome-ignore lint/performance/noDelete: intentional env cleanup
+    delete process.env.SHIPWRIGHT_TASK_STORE_URL;
+    // biome-ignore lint/performance/noDelete: intentional env cleanup
+    delete process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+
+    const query = createTaskStatusQuery();
+    await expect(query("acme/example-repo", 42)).rejects.toThrow(
+      "SHIPWRIGHT_TASK_STORE_URL/SHIPWRIGHT_TASK_STORE_TOKEN not configured",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Extends `createTaskStatusQuery` in `check-helpers.ts` to return `{ status, addedAt }` (a new `LinkedTaskInfo` type) instead of just the bare status string, so callers can source the linked task's `addedAt`.
- Normalizes `getDeployCandidates()`'s `age` field to `linkedTask.addedAt ?? pr.createdAt`, replacing the previous `record?.readyForDeployAt ?? pr.createdAt` — this puts deploy candidates on the same age clock dev-task's backlog candidates already use, fixing a starvation bug where backlog dev-task work systematically out-aged deploy candidates in the loop's cross-phase selector.
- `readyForDeployAt` / `PrRecord` / `queryPrRecord` are untouched otherwise (still sourced for `claimedBy`).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | check-helpers.ts's task-status query returns addedAt alongside status; unit test covers new field on success and lookup-failure paths | MET |
| 2 | getDeployCandidates() sets `age` from `linkedTask.addedAt ?? pr.createdAt`, never from readyForDeployAt | MET |
| 3 | readyForDeployAt remains used only for phase-eligibility/ordering-fallback (queryPrRecord path) — no behavior change there | MET |
| 4 | check-deploy.unit.test.ts updated to assert age sources from linked task's addedAt / pr.createdAt, replacing the readyForDeployAt-based assertion | MET |

## Test Plan
- `bun test agent/src/check-deploy.unit.test.ts agent/src/check-helpers.unit.test.ts` — 80/80 passing, including 5 new tests for `createTaskStatusQuery` and 3 updated/new age-sourcing tests for `getDeployCandidates()`.
- `bun run typecheck` — clean across all workspaces.
- `bunx biome lint .` — clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
