### PR TITLE
test: rename cron-handler test to smoke, evaluate socket conversion (T-009)

### DIFF
--- a/agent/src/cron-handler.smoke.test.ts
+++ b/agent/src/cron-handler.smoke.test.ts
@@ -1,12 +1,17 @@
 /**
- * Integration tests for cron-handler.ts and POST /cron endpoint in health.ts.
+ * Smoke tests for cron-handler.ts and the POST /cron endpoint in health.ts.
  *
  * Strategy: inject all deps. No real Slack or Claude calls.
  *
  * - runner: mock function
  * - slack: mock WebClient with chat.postMessage and conversations.open
  * - formatter: identity function (no markdown conversion)
- * - HTTP tests: real Bun.serve via startHealthServer
+ * - CronRunReporter tests spin up their own local Bun.serve() reporter mock
+ * - HTTP tests: real Bun.serve() via startHealthServer, hit with fetch() —
+ *   createHealthApp() only owns GET /health today, not /cron or /stats, so
+ *   there's no in-process app.request() seam for this route yet. This is the
+ *   real-socket exception documented for smoke tests; once createHealthApp()
+ *   is expanded to own /cron, these HTTP assertions can move to app.request().
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";

--- a/agent/src/cron-handler.smoke.test.ts
+++ b/agent/src/cron-handler.smoke.test.ts
@@ -9,9 +9,10 @@
  * - CronRunReporter tests spin up their own local Bun.serve() reporter mock
  * - HTTP tests: real Bun.serve() via startHealthServer, hit with fetch() —
  *   createHealthApp() only owns GET /health today, not /cron or /stats, so
- *   there's no in-process app.request() seam for this route yet. This is the
- *   real-socket exception documented for smoke tests; once createHealthApp()
- *   is expanded to own /cron, these HTTP assertions can move to app.request().
+ *   there's no in-process app.request() seam for this route yet. This is a
+ *   known boundary violation, tracked as a follow-on task to expand
+ *   createHealthApp() to own /cron so these HTTP assertions can move to
+ *   app.request().
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";


### PR DESCRIPTION
## Summary
- Renamed `agent/src/cron-handler.integration.test.ts` → `agent/src/cron-handler.smoke.test.ts` (T-009): the file's defining characteristic is real-socket HTTP route-contract testing (`POST /cron` via `startHealthServer()` + `fetch()`), which is smoke-layer behavior per `docs/testing.md`, not integration.
- Updated the file's header comment to describe its three test sections (direct `handleCronRequest()` calls via injected mocks, `CronRunReporter`'s own local `Bun.serve()` mock, and the `POST /cron` HTTP endpoint tests) and to document the real-socket exception.
- Evaluated whether the `POST /cron` HTTP assertions can move to `createHealthApp()`'s in-process `app.request()` pattern (already proven in `health.unit.test.ts`): **not yet possible** — `createHealthApp()` currently only owns `GET /health`, not `/cron` or `/stats`. Those routes still live only in the raw `Bun.serve()` handler inside `startHealthServer()`. Expanding `createHealthApp()` to own `/cron`/`/stats` is a follow-on task, intentionally not pre-committed here to keep this task single-concern.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | File renamed to reflect its true layer | MET | `git mv agent/src/cron-handler.integration.test.ts agent/src/cron-handler.smoke.test.ts` |
| 2 | Verification command `bun test agent/src/cron-handler.smoke.test.ts` passes | MET | 69 pass, 0 fail, 168 expect() calls |

## Test Plan
- `NODE_ENV=test bun test agent/src/cron-handler.smoke.test.ts` — 69/69 passing
- `bunx biome lint agent/src/cron-handler.smoke.test.ts` — clean
- `cd agent && bun run typecheck` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
