### PR TITLE
ci: restructure ci.yml into 8/6/6 per-layer matrix pipeline (T-012)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,52 +63,17 @@ jobs:
             echo "Only automated chart/plugin-version-bump files changed — skipping app-level CI jobs."
           fi
 
-  ci:
-    name: lint / typecheck / test
+  # Non-test CI gates: lint, banned-strings scan, typecheck, config-docs and
+  # version-sync checks. No database, no test execution — those are handled
+  # by the unit/integration/smoke matrix jobs below plus the coverage-gate
+  # safety net.
+  checks:
+    name: lint / typecheck / config checks
     runs-on: ubuntu-latest
     needs: changes
     # always() so this still runs (fail-open) if the changes job itself
     # errored rather than auto-skipping every job in the suite.
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: shipwright
-          POSTGRES_PASSWORD: shipwright
-          POSTGRES_DB: shipwright_admin_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      # Admin and task-store integration tests (admin/src/*.integration.test.ts,
-      # task-store/src/*.integration.test.ts) gate on the *_TEST vars below and
-      # skip silently when absent.
-      #
-      # Every integration test's beforeEach spins up a brand-new PrismaClient
-      # (its own pooled connection) and each afterEach disconnects it, so
-      # connections don't accumulate across the suite. connection_limit still
-      # bounds each client's own pool as a safety margin — Postgres's default
-      # max_connections=100 comfortably covers that.
-      #
-      # Note: raising max_connections on the service container itself isn't
-      # possible here — GitHub Actions' service `options:` are inserted into
-      # `docker create` *before* the image name, so they can't carry postgres's
-      # own `-c max_connections=...` server flag (and `-c` collides with
-      # docker's `--cpu-shares` shorthand there anyway).
-      DATABASE_URL_ADMIN_TEST: postgres://shipwright:shipwright@localhost:5432/shipwright_admin_test?connection_limit=5&pool_timeout=20
-      DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test?connection_limit=5&pool_timeout=20
-      # The schema.prisma files read the non-_TEST var names below (per their
-      # own `datasource db { url = env(...) }` declarations), so `prisma migrate
-      # deploy` needs these set to the same connection strings as the _TEST vars
-      # above to sync schema against the right databases. Nothing else in this
-      # job reads these two vars at runtime.
-      DATABASE_URL_SHIPWRIGHT_ADMIN: postgres://shipwright:shipwright@localhost:5432/shipwright_admin_test
-      DATABASE_URL_SHIPWRIGHT_TASK_STORE: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test
     steps:
       - uses: actions/checkout@v4
 
@@ -136,6 +101,211 @@ jobs:
       - name: Check config docs
         run: task check-config-docs
 
+      - name: Check version sync
+        run: task check-version-sync
+
+  # 8-way unit-layer matrix — one leg per workspace. Pure logic, no I/O, no
+  # database. GH Actions' default fail-fast strategy means a single failing
+  # leg fails the whole `unit` job, which skips `integration` (and
+  # transitively `smoke`) via `needs:` below.
+  unit:
+    name: "unit (${{ matrix.workspace }})"
+    runs-on: ubuntu-latest
+    needs: checks
+    strategy:
+      matrix:
+        workspace:
+          - lib
+          - plugins/shipwright
+          - metrics
+          - agent
+          - admin
+          - task-store
+          - chat
+          - mcp-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.x"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run unit tests
+        run: |
+          FILES=$(find "${{ matrix.workspace }}" -name '*.unit.test.ts')
+          if [ -z "$FILES" ]; then
+            echo "No *.unit.test.ts files in ${{ matrix.workspace }} — skipping."
+            exit 0
+          fi
+          NODE_ENV=test bun test $FILES
+
+  # 6-way integration-layer matrix — workspaces with *.integration.test.ts
+  # files today (chat and mcp-server have none, so they're excluded). Most
+  # legs use recorded-fixture doubles and never touch the database; only
+  # admin and task-store integration suites read DATABASE_URL_* and hit the
+  # real Postgres service container below. Declaring `services:` on the job
+  # gives every matrix leg its own fresh container — harmless for the four
+  # legs that don't use it.
+  integration:
+    name: "integration (${{ matrix.workspace }})"
+    runs-on: ubuntu-latest
+    needs: [checks, unit]
+    strategy:
+      matrix:
+        workspace:
+          - lib
+          - plugins/shipwright
+          - metrics
+          - agent
+          - admin
+          - task-store
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: shipwright
+          POSTGRES_PASSWORD: shipwright
+          POSTGRES_DB: shipwright_admin_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      # Admin and task-store integration tests (admin/src/*.integration.test.ts,
+      # task-store/src/*.integration.test.ts) gate on the *_TEST vars below and
+      # skip silently when absent. Every other matrix leg ignores these.
+      #
+      # Every integration test's beforeEach spins up a brand-new PrismaClient
+      # (its own pooled connection) and each afterEach disconnects it, so
+      # connections don't accumulate across the suite. connection_limit still
+      # bounds each client's own pool as a safety margin — Postgres's default
+      # max_connections=100 comfortably covers that.
+      DATABASE_URL_ADMIN_TEST: postgres://shipwright:shipwright@localhost:5432/shipwright_admin_test?connection_limit=5&pool_timeout=20
+      DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test?connection_limit=5&pool_timeout=20
+      # The schema.prisma files read the non-_TEST var names below (per their
+      # own `datasource db { url = env(...) }` declarations), so `prisma migrate
+      # deploy` needs these set to the same connection strings as the _TEST vars
+      # above to sync schema against the right databases.
+      DATABASE_URL_SHIPWRIGHT_ADMIN: postgres://shipwright:shipwright@localhost:5432/shipwright_admin_test
+      DATABASE_URL_SHIPWRIGHT_TASK_STORE: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.x"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Create task-store test database
+        if: matrix.workspace == 'task-store'
+        run: PGPASSWORD=shipwright psql -h localhost -U shipwright -d shipwright_admin_test -c "CREATE DATABASE shipwright_task_store_test;"
+
+      - name: Sync admin test DB schema
+        if: matrix.workspace == 'admin'
+        run: bunx prisma migrate deploy --schema=admin/prisma/schema.prisma
+
+      - name: Sync task-store test DB schema
+        if: matrix.workspace == 'task-store'
+        run: bunx prisma migrate deploy --schema=task-store/prisma/schema.prisma
+
+      - name: Run integration tests
+        run: |
+          FILES=$(find "${{ matrix.workspace }}" -name '*.integration.test.ts')
+          if [ -z "$FILES" ]; then
+            echo "No *.integration.test.ts files in ${{ matrix.workspace }} — skipping."
+            exit 0
+          fi
+          NODE_ENV=test bun test $FILES
+
+  # 6-way smoke-layer matrix — workspaces with (or about to have) HTTP route
+  # contract tests driven via Hono's in-process app.request(). `agent` has no
+  # *.smoke.test.ts files yet (pending an unmerged rename of an existing
+  # integration test) but is included per the target matrix shape; its leg
+  # no-ops cleanly via the zero-files guard below until that lands.
+  smoke:
+    name: "smoke (${{ matrix.workspace }})"
+    runs-on: ubuntu-latest
+    needs: [checks, integration]
+    strategy:
+      matrix:
+        workspace:
+          - metrics
+          - admin
+          - task-store
+          - chat
+          - mcp-server
+          - agent
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.x"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run smoke tests
+        run: |
+          FILES=$(find "${{ matrix.workspace }}" -name '*.smoke.test.ts')
+          if [ -z "$FILES" ]; then
+            echo "No *.smoke.test.ts files in ${{ matrix.workspace }} — skipping."
+            exit 0
+          fi
+          NODE_ENV=test bun test $FILES
+
+  # Final safety net: reruns the existing, unchanged full-suite coverage gate
+  # (task test:coverage = bun test --coverage + scripts/check-coverage.ts) so
+  # the aggregate 80/80 lines/functions gate is never silently dropped by the
+  # per-layer matrix split above. Deliberately duplicates test execution
+  # (full suite runs in ~24s per docs/test-readiness/test-system.md) rather
+  # than merging per-leg lcov artifacts, which is out of scope here.
+  coverage-gate:
+    name: coverage gate / secret scan
+    runs-on: ubuntu-latest
+    needs: [checks, unit, integration, smoke]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: shipwright
+          POSTGRES_PASSWORD: shipwright
+          POSTGRES_DB: shipwright_admin_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL_ADMIN_TEST: postgres://shipwright:shipwright@localhost:5432/shipwright_admin_test?connection_limit=5&pool_timeout=20
+      DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test?connection_limit=5&pool_timeout=20
+      DATABASE_URL_SHIPWRIGHT_ADMIN: postgres://shipwright:shipwright@localhost:5432/shipwright_admin_test
+      DATABASE_URL_SHIPWRIGHT_TASK_STORE: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.x"
+
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.51.1
+
+      - name: Install dependencies
+        run: task setup
+
       - name: Create task-store test database
         run: PGPASSWORD=shipwright psql -h localhost -U shipwright -d shipwright_admin_test -c "CREATE DATABASE shipwright_task_store_test;"
 
@@ -153,7 +323,6 @@ jobs:
           echo "141c3b2dede46d8b3a53b47116da756bd223decc0374797559a6b50ecba5590c  gitleaks.tar.gz" | sha256sum -c
           tar -xz -f gitleaks.tar.gz gitleaks
           ./gitleaks detect --source . --no-git --redact
-
 
   site:
     name: site build / brand-lint / smoke
@@ -218,7 +387,7 @@ jobs:
   e2e:
     name: e2e (metrics dashboard)
     runs-on: ubuntu-latest
-    needs: ci
+    needs: coverage-gate
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -88,49 +88,85 @@ The agent is a thin runner with a Prisma-backed PostgreSQL database and a Hono H
 |---|---|---|
 | All layers, all packages | `bun test` | <2 min |
 | Single package | `bun test --filter <package-name>` | see per-component above |
-| CI gates (lint → check-strings → typecheck → check-config-docs → check-version-sync → test → secret-scan) | `task ci` | <5 min |
+| CI gates (lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan) | `task ci` | <5 min |
 
 ## CI pipeline shape
 
 ```
-┌─────────┐
-│  Lint   │  bunx biome lint .
-└────┬────┘
-     │
-┌────▼──────┐
-│ Typecheck │  bun run --filter="*" --sequential typecheck
-└────┬──────┘
-     │
-     ├──────────────┬──────────────┐
-     │              │              │
-┌────▼──────┐ ┌─────▼─────┐ ┌─────▼─────┐   ← parallel, per-package
-│ plugin    │ │ metrics   │ │ agent     │
-│ unit+intg │ │ unit+intg │ │ unit+intg │
-└────┬──────┘ └─────┬─────┘ └─────┬─────┘
-     │              │              │
-     └──────────────┼──────────────┘
-                    │
-         ┌──────────┴──────────┐
-         │                     │
-   ┌─────▼─────┐         ┌─────▼─────┐   ← parallel, per-package
-   │  Smoke    │         │  Smoke    │
-   │ (metrics) │         │  (agent)  │   Phase C+
-   │ app.req() │         │ app.req() │
-   └─────┬─────┘         └─────┬─────┘
-         │                     │
-         └──────────┬──────────┘
-                    │
-              ┌─────▼─────┐
-              │   E2E     │  Playwright; Phase B+ only
-              │(dashboard)│  <5 min
-              └─────┬─────┘
-                    │
-              merge → main
+┌─────────────────────────────────────────────────────────────────┐
+│  changes: detect app-level changes (skip auto-bump-only runs)  │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+┌──────────────────────────▼──────────────────────────────────────┐
+│  checks: lint → check-strings → typecheck → check-config-docs  │
+│           → check-version-sync                                 │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │  (8 parallel legs)
+   ┌────▼─────┐   ┌────────▼────────┐   ┌────▼──────────────┐
+   │ unit: lib │   │ unit: plugins/* │   │ unit: metrics...  │
+   └────┬─────┘   └────────┬────────┘   └────┬──────────────┘
+        │                  │                  │
+        │                  ├──────────────────┤  (8 parallel: lib, plugins/shipwright,
+        │                  │                  │   metrics, agent, admin, task-store,
+        │  (all 8 legs)    │  (all 8 legs)    │   chat, mcp-server)
+        └──────────────────┼──────────────────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │  (6 parallel legs)
+   ┌────▼──────────┐   ┌───▼────────┐   ┌─────▼────────────┐
+   │ integration:  │   │ integration:│   │ integration:     │
+   │ lib           │   │ plugins/*   │   │ metrics, agent...│
+   └────┬──────────┘   └───┬────────┘   └─────┬────────────┘
+        │                  │                  │
+        │                  │  (6 parallel: lib, plugins/shipwright,
+        │                  │   metrics, agent, admin, task-store;
+        │                  │   postgres:16 service for each leg)
+        └──────────────────┼──────────────────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │  (6 parallel legs)
+   ┌────▼────────┐   ┌─────▼────────┐   ┌────▼──────────────┐
+   │ smoke: lib  │   │ smoke: admin │   │ smoke: metrics... │
+   └────┬────────┘   └─────┬────────┘   └────┬──────────────┘
+        │                  │                  │
+        │                  │  (6 parallel: metrics, admin, task-store,
+        │                  │   chat, mcp-server, agent)
+        │                  │
+        └──────────────────┼──────────────────┘
+                           │
+              ┌────────────▼─────────────┐
+              │ coverage-gate: reruns    │
+              │ full test suite with     │
+              │ --coverage; gates on     │
+              │ 80/80 lines/functions    │
+              │ (+ secret-scan)          │
+              └────────────┬─────────────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │  (3 parallel)
+   ┌────▼──────┐   ┌──────▼────────┐   ┌────▼──────────────┐
+   │  site     │   │ docker-builds │   │     e2e          │
+   │ build /   │   │ (agent image) │   │   (metrics       │
+   │ brand-lint│   │               │   │    dashboard)    │
+   └────┬──────┘   └──────┬────────┘   └────┬──────────────┘
+        │                 │                  │
+        │                 │  (all in parallel, skip if not needed)
+        │                 │
+        └─────────────────┼──────────────────┘
+                          │
+                    ✓ merge → main
 ```
 
-- **Layer order:** unit → integration → smoke → e2e. A lower-layer failure skips higher layers (fail-fast).
-- **Parallelism:** unit and integration run in parallel across packages. Smoke layers (metrics + agent) run in parallel with each other, sequentially after all integration jobs pass.
-- **Test-DB service container:** CI provisions a real `postgres:16` service container (see `.github/workflows/ci.yml`) for any DB-backed integration/smoke test (e.g., the agent's DB integration suite) — never a mocked or in-memory Postgres substitute.
+- **Layer order & fail-fast:** unit → integration → smoke → coverage-gate → (parallel site/e2e/docker-builds). A failure in any serial stage skips all later stages.
+- **Parallelism:**
+  - **Unit:** 8-way matrix (one leg per workspace: lib, plugins/shipwright, metrics, agent, admin, task-store, chat, mcp-server). Pure logic, no I/O, no database.
+  - **Integration:** 6-way matrix (workspaces with `*.integration.test.ts` files: lib, plugins/shipwright, metrics, agent, admin, task-store). Postgres service container provided to each leg; only admin and task-store read `DATABASE_URL_*`, others skip silently.
+  - **Smoke:** 6-way matrix (metrics, admin, task-store, chat, mcp-server, agent). Driven via Hono `app.request()` — no real socket.
+  - **Coverage-gate:** single job that reruns the full suite with `--coverage` as a final safety net, gates on 80% lines + 80% functions aggregate, and also runs secret-scan.
+  - **Site / E2E / Docker:** 3 jobs in parallel after coverage-gate, independent of each other.
+- **Test-DB service container:** Postgres `postgres:16` is provisioned as a `services:` entry for the integration job (shared across all 6 matrix legs, each gets its own fresh connection pool). The coverage-gate job also provisions Postgres for the full suite re-run. See `.github/workflows/ci.yml` for the exact service container config and connection-limit tuning.
 
 ## Speed budgets (consolidated)
 

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -128,7 +128,7 @@ The agent is a thin runner with a Prisma-backed PostgreSQL database and a Hono H
         ┌──────────────────┼──────────────────┐
         │                  │                  │  (6 parallel legs)
    ┌────▼────────┐   ┌─────▼────────┐   ┌────▼──────────────┐
-   │ smoke: lib  │   │ smoke: admin │   │ smoke: metrics... │
+   │ smoke: chat │   │ smoke: admin │   │ smoke: metrics... │
    └────┬────────┘   └─────┬────────┘   └────┬──────────────┘
         │                  │                  │
         │                  │  (6 parallel: metrics, admin, task-store,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,7 +74,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 
 ## CI gates
 
-CI runs the exact `task ci` chain: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan**, layer order unit → integration → smoke → e2e (a lower-layer failure fails fast and skips higher layers). Unit and integration run in parallel across packages; smoke (metrics + agent) runs after all integration jobs pass; e2e (Playwright — metrics dashboard + admin UI) runs last and only in Phase B+. The coverage gate (80% lines + 80% functions on an aggregate basis) is enforced by `scripts/check-coverage.ts` on the LCOV report produced by `task test:coverage`.
+Locally, `task ci` runs: **lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan**. In GitHub Actions, this expands into a matrix pipeline: **checks** (the above, as a single job) → **unit** (8-way per-workspace matrix) → **integration** (6-way per-workspace matrix) → **smoke** (6-way per-workspace matrix) → **coverage-gate** (full suite with `--coverage`, gates on 80/80 lines/functions aggregate, plus secret-scan) → **site/e2e/docker-builds** (in parallel, optional per configuration). Layer order is enforced: a failure in any stage skips all downstream stages (unit fails → integration/smoke/coverage skipped; integration fails → smoke/coverage skipped; etc.). The 80% lines + 80% functions aggregate gate is the final safety net before merge and is enforced by `scripts/check-coverage.ts` on the LCOV report.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Restructure `.github/workflows/ci.yml` from a single unfiltered `task test:coverage` job into a per-layer matrix pipeline: `changes` → `checks` (lint/typecheck/config gates) → 8-way `unit` matrix → 6-way `integration` matrix (Postgres service per workspace) → 6-way `smoke` matrix → `coverage-gate` (full-suite aggregate 80/80 safety net + secret-scan) → `site`/`e2e`/docker-builds.
- Fail-fast ordering via `needs:` chain: a unit-matrix failure skips integration+smoke; an integration-matrix failure skips smoke.
- Refresh `docs/test-readiness/test-system.md` and `docs/testing.md` to describe the new matrix pipeline shape (was describing the old single-job shape).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | ci.yml restructured into 8-way unit → 6-way integration (Postgres per workspace) → 6-way smoke matrix, fail-fast ordering | MET | `unit`/`integration`/`smoke` jobs with matrix strategies and a `needs:` chain enforcing fail-fast |
| 2 | Verification command shows 8 distinct unit, 6 distinct integration, 6 distinct smoke job entries | MET | Job `name:` fields templated as `"unit (${{ matrix.workspace }})"` etc., rendering 20 distinct job entries matching the exact per-layer workspace lists |

## Test Plan
- [x] `task lint` passes
- [x] YAML structure manually verified: job names render correctly, `needs:` graph correct (unit→checks, integration→[checks,unit], smoke→[checks,integration], coverage-gate→[checks,unit,integration,smoke], e2e→coverage-gate)
- [x] Spot-checked `find`-based file enumeration + `bun test <files>` invocation against real repo (lib unit: 65 tests pass; admin smoke: 349 tests pass)
- [ ] Full CI run against this PR (verifies the 20 job entries live in the Actions UI)

Generated with [Claude Code](https://claude.com/claude-code)
