### PR TITLE
feat: add sort query param to task-store GET /tasks

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -79,7 +79,7 @@ List tasks
 - **Method:** GET
 - **Path:** `/tasks`
 - **Has body:** No
-- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query)
+- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query)
 
 ## `tasks_update`
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -52,6 +52,7 @@ Query params:
 | `branch` | string | Filter by branch name |
 | `limit` | number | Page size |
 | `offset` | number | Page offset |
+| `sort` | string | `asc` (default) or `desc` — orders results by `createdAt`. Default preserves existing ascending order for all callers. |
 
 Returns `{ tasks: Task[], total: number }`.
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -43,7 +43,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `session` | string | Filter by planning session slug |
 | `repo` | string | Filter by repo (`org/repo` format) |
 | `assignee` | string | Filter by assignee (admin tokens only; agent tokens see only their own tasks) |

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -84,6 +84,11 @@ export const generatedTools: GeneratedTool[] = [
           enum: ["true", "false"],
           example: "true",
         },
+        sort: {
+          type: "string",
+          enum: ["asc", "desc"],
+          example: "asc",
+        },
       },
       required: [],
       additionalProperties: false,
@@ -102,6 +107,7 @@ export const generatedTools: GeneratedTool[] = [
       "limit",
       "offset",
       "ready",
+      "sort",
     ],
     pathParams: [],
     hasBody: false,
@@ -587,6 +593,19 @@ export const generatedTools: GeneratedTool[] = [
           description: "Associated task ID",
           example: "clx1234567890",
         },
+        phase: {
+          type: "string",
+          enum: ["review", "patch", "deploy"],
+          description:
+            "Pipeline phase this claim is for (defaults to 'review' when omitted)",
+          example: "patch",
+        },
+        prCreatedAt: {
+          type: "string",
+          description:
+            "ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.",
+          example: "2026-01-01T00:00:00.000Z",
+        },
       },
       required: ["repo", "prNumber", "commitSha"],
       additionalProperties: false,
@@ -706,13 +725,20 @@ export const generatedTools: GeneratedTool[] = [
   },
   {
     name: "prs_patch",
-    description: "Increment patchCycles and reset reviewState=pending",
+    description:
+      "Increment patchCycles and conditionally reset reviewState=pending",
     inputSchema: {
       type: "object",
       properties: {
         id: {
           type: "string",
           example: "clx0987654321",
+        },
+        commitSha: {
+          type: "string",
+          description:
+            "Current head commit SHA. When provided and it differs from the record's stored commitSha, reviewState resets to pending and commitSha is updated. When it matches, reviewState is left untouched (no-op patch cycle). When omitted, reviewState unconditionally resets to pending (legacy behavior).",
+          example: "abc123def456",
         },
       },
       required: ["id"],
@@ -722,7 +748,7 @@ export const generatedTools: GeneratedTool[] = [
     pathTemplate: "/prs/{id}/patch",
     queryParams: [],
     pathParams: ["id"],
-    hasBody: false,
+    hasBody: true,
   },
   {
     name: "prs_release",

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -128,6 +128,19 @@
             "required": false,
             "name": "ready",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "example": "asc"
+            },
+            "required": false,
+            "name": "sort",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2024,11 +2037,22 @@
           "updated": {
             "type": "integer",
             "example": 1
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).",
+            "example": [
+              "entropy-dead_exports-other-repo-2026-W29"
+            ]
           }
         },
         "required": [
           "inserted",
-          "updated"
+          "updated",
+          "skipped"
         ]
       },
       "BulkInsertBody": {

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -395,6 +395,7 @@ export const TaskListQuerySchema = z.object({
   limit: z.string().optional().openapi({ example: "50" }),
   offset: z.string().optional().openapi({ example: "0" }),
   ready: z.enum(["true", "false"]).optional().openapi({ example: "true" }),
+  sort: z.enum(["asc", "desc"]).optional().openapi({ example: "asc" }),
 });
 
 /** Response for GET /tasks */

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -80,10 +80,13 @@ function withBlockedBy(task: Task) {
   return { ...task, blockedBy: [] };
 }
 
-function fakeTaskService(opts: { tasks?: Task[] } = {}): TaskServiceLike {
+function fakeTaskService(
+  opts: { tasks?: Task[]; onList?: (filters: unknown) => void } = {},
+): TaskServiceLike {
   const tasks = opts.tasks ?? [];
   return {
-    async list() {
+    async list(filters) {
+      opts.onList?.(filters);
       return {
         tasks: tasks.map(withBlockedBy),
         total: tasks.length,
@@ -187,6 +190,60 @@ describe("createTasksRoutes — OpenAPIHono migration (TSM-1.2)", () => {
 
     const res = await parent.request("/nonexistent");
     expect(res.status).toBe(404);
+  });
+
+  it("GET /?sort=desc passes sort: 'desc' through to taskService.list()", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?sort=desc");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { sort?: string }).sort).toBe("desc");
+  });
+
+  it("GET / with no sort param passes sort: undefined through to taskService.list() (existing behavior)", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { sort?: string }).sort).toBeUndefined();
+  });
+
+  it("GET /?sort=asc passes sort: undefined through to taskService.list() (falls through to default ascending)", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?sort=asc");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { sort?: string }).sort).toBeUndefined();
   });
 
   it("GET /distinct returns 200 with { sessions, repos } shape", async () => {

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -501,6 +501,7 @@ export function createTasksRoutes(
         offsetRaw !== undefined
           ? Number.parseInt(offsetRaw, 10) || undefined
           : undefined,
+      sort: c.req.query("sort") === "desc" ? "desc" : undefined,
       // Use agentScope for repo-scoped agent tokens; otherwise use assignee filter.
       // Under agentScope, an explicit caller-supplied ?assignee= further narrows
       // the already-visible OR set (assigned-to-me OR in-my-repo-pool) — safe,

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -39,6 +39,8 @@ export interface TaskListFilters {
   branch?: string;
   limit?: number;
   offset?: number;
+  /** Order results by createdAt. Defaults to "asc" (existing behavior). */
+  sort?: "asc" | "desc";
   /**
    * Repo-scoped visibility for agent tokens.
    * When set, replaces the simple `assignee` filter with an OR clause:
@@ -128,7 +130,7 @@ export class TaskService implements TaskServiceLike {
     const [pageTasks, total, allTasks] = await this.prisma.$transaction([
       this.prisma.task.findMany({
         where,
-        orderBy: { createdAt: "asc" },
+        orderBy: { createdAt: filters.sort ?? "asc" },
         take: limit,
         skip: offset,
       }),

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -597,6 +597,107 @@ describeOrSkip("Task store schema (integration)", () => {
     expect(result.total).toBe(2);
   });
 
+  // ─── TaskService.list() sort param ────────────────────────────────────────
+
+  it("list() with no sort param returns tasks in ascending createdAt order (existing behavior)", async () => {
+    const taskService = new TaskService(prisma);
+
+    const task3 = await prisma.task.create({
+      data: {
+        title: "Task 3 - middle",
+        status: "pending",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    });
+    const task1 = await prisma.task.create({
+      data: {
+        title: "Task 1 - earliest",
+        status: "pending",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+    const task2 = await prisma.task.create({
+      data: {
+        title: "Task 2 - latest",
+        status: "pending",
+        createdAt: new Date("2026-01-03T00:00:00Z"),
+      },
+    });
+
+    const result = await taskService.list({});
+    expect(result.tasks.map((t) => t.id)).toEqual([
+      task1.id,
+      task3.id,
+      task2.id,
+    ]);
+  });
+
+  it("list() with sort: 'asc' returns tasks in ascending createdAt order (existing behavior)", async () => {
+    const taskService = new TaskService(prisma);
+
+    const task3 = await prisma.task.create({
+      data: {
+        title: "Task 3 - middle",
+        status: "pending",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    });
+    const task1 = await prisma.task.create({
+      data: {
+        title: "Task 1 - earliest",
+        status: "pending",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+    const task2 = await prisma.task.create({
+      data: {
+        title: "Task 2 - latest",
+        status: "pending",
+        createdAt: new Date("2026-01-03T00:00:00Z"),
+      },
+    });
+
+    const result = await taskService.list({ sort: "asc" });
+    expect(result.tasks.map((t) => t.id)).toEqual([
+      task1.id,
+      task3.id,
+      task2.id,
+    ]);
+  });
+
+  it("list() with sort: 'desc' returns tasks in descending createdAt order (newest first)", async () => {
+    const taskService = new TaskService(prisma);
+
+    const task3 = await prisma.task.create({
+      data: {
+        title: "Task 3 - middle",
+        status: "pending",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    });
+    const task1 = await prisma.task.create({
+      data: {
+        title: "Task 1 - earliest",
+        status: "pending",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+    const task2 = await prisma.task.create({
+      data: {
+        title: "Task 2 - latest",
+        status: "pending",
+        createdAt: new Date("2026-01-03T00:00:00Z"),
+      },
+    });
+
+    const result = await taskService.list({ sort: "desc" });
+    expect(result.tasks.map((t) => t.id)).toEqual([
+      task2.id,
+      task3.id,
+      task1.id,
+    ]);
+  });
+
   it("list() with agentScope AND assignee filter narrows the pool to just that assignee", async () => {
     const taskService = new TaskService(prisma);
 


### PR DESCRIPTION
## Summary
- Adds an explicit `sort` query param (`asc`|`desc`, default `asc`) to `GET /tasks` in task-store, ordering results by `createdAt`
- `listReady()` and `listBlocked()` are left untouched — they stay hardcoded ascending for deterministic dev-task cron selection
- Regenerates `task-store/openapi.json`, `docs/mcp-tools.md`, and `mcp-server/src/generated-tools.ts` to reflect the new param in the MCP tool surface; clarifies in `docs/task-store.md` that `?sort` is not supported with `?ready=true`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /tasks?sort=desc returns tasks ordered by createdAt descending (newest first); no sort param or sort=asc returns ascending order exactly as today | MET | `routes/tasks.ts` passes `sort:"desc"` only when query is exactly `"desc"`; `task-service.ts` `orderBy: { createdAt: filters.sort ?? "asc" }` |
| 2 | listReady() and listBlocked() are unchanged — still ascending, no new param accepted | MET | Both methods untouched in diff |
| 3 | docs/task-store.md documents the new sort param | MET | New row added to query params table |
| 4 | Integration test (task-service) + smoke test (route) covering asc/desc, no tests removed | MET | 3 new tests in `tasks.integration.test.ts`, 3 new tests in `routes/tasks.openapi.smoke.test.ts`; diff is purely additive |

## Test Plan
- `list({sort: "desc"})` returns descending order; `list({})` / `list({sort: "asc"})` return ascending order (integration tests, DB-gated)
- `GET /?sort=desc` round-trips through the route to `taskService.list()`; no-param and `sort=asc` fall through to `sort: undefined` (smoke tests)
- [x] `task lint` — clean
- [x] `task typecheck` — clean across all workspaces
- [x] `bun test` (task-store) — 297 pass, 0 fail, 84 skip (DB-gated integration suites skip locally, run in CI)

Generated with [Claude Code](https://claude.com/claude-code)
