### PR TITLE
feat: remove scan mode from deploy.md

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -57,7 +57,6 @@ Manual test scenarios for each command across different project types.
 | 40 | `/dev-task` Step 8.5 | Any | Unparseable agent result is recorded, not silent | Agent returns no/garbled `AUTO_DOCS_METRICS` block; `⚠ ... agent_error` printed; metrics record has `skipped_reason:"agent_error"`, `updated:false`; pipeline continues |
 | 41 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (admin app base URL configured) | Plan viz link after markdown write | `PLAN.md`/`PRODUCT-SPEC.md` written unchanged, then a `${SHIPWRIGHT_ADMIN_APP_BASE_URL}/admin/sessions/{session}` link is constructed and a `Plan viz: {url}` line is surfaced in the confirmation block |
 | 42 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (admin app base URL unset) | Plan viz graceful skip | `⏭ Plan viz skipped — SHIPWRIGHT_ADMIN_APP_BASE_URL unset.` printed; markdown still written; no `Plan viz:` line; command never blocks |
-| 43 | `/deploy` | Any | Scan mode — bundle-blocked candidate falls back to next ready PR | Bundle-incomplete PR excluded from `CANDIDATE_LIST` in Step 1a; if a candidate is bundle-blocked at Step 2b, scan mode logs the skip and retries the next candidate instead of stopping; explicit-target mode still stops on bundle-block |
 
 ---
 

--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -117,19 +117,6 @@ describe("deploy.md — PR upsert on merge (PRI-2.4)", () => {
 });
 
 describe("deploy.md — self-approve bold-markdown strip (PCK-1.4)", () => {
-  it("Step 1a's jq check strips leading ** before startswith(\"APPROVE\")", () => {
-    // Must apply a jq sub() (or equivalent) that strips leading markdown bold
-    // markers from the review body before the startswith("APPROVE") check —
-    // mirroring check-deploy.ts's hasSelfApproveReview strip.
-    const step1aMatch = content.match(
-      /1a\. Find Qualifying PRs[\s\S]*?(?=###|## Step 2)/,
-    );
-    expect(step1aMatch).not.toBeNull();
-    const step1aSection = step1aMatch?.[0] ?? "";
-    expect(step1aSection).toContain('sub("^\\\\*+";"")');
-    expect(step1aSection).toContain('startswith("APPROVE")');
-  });
-
   it("Step 3a's AGENT_LOGIN self-approval check strips leading ** before the comparison", () => {
     const step3aMatch = content.match(
       /### 3a\. Verify PR Approval[\s\S]*?(?=### 3b)/,
@@ -146,6 +133,26 @@ describe("deploy.md — self-approve bold-markdown strip (PCK-1.4)", () => {
     );
     const step3aSection = step3aMatch?.[0] ?? "";
     expect(step3aSection).toContain('startsWith("APPROVE")');
+  });
+});
+
+describe("deploy.md — scan mode removed (WLS-3.4)", () => {
+  it("does not contain a Step 1 Scan Mode section", () => {
+    expect(content).not.toContain("Scan Mode");
+    expect(content).not.toContain("## Step 1");
+  });
+
+  it("does not reference CANDIDATE_LIST or scan-mode candidate fallback", () => {
+    expect(content).not.toContain("CANDIDATE_LIST");
+    expect(content.toLowerCase()).not.toContain("scan mode");
+  });
+
+  it("states $ARGUMENTS is required and no-argument invocation responds [silent]", () => {
+    const argsMatch = content.match(/## Arguments[\s\S]*?(?=---)/);
+    expect(argsMatch).not.toBeNull();
+    const argsSection = argsMatch?.[0] ?? "";
+    expect(argsSection).toContain("required");
+    expect(argsSection).toContain("[silent]");
   });
 });
 
@@ -170,11 +177,6 @@ describe("deploy.md — pre-merge PR claim lock (CLM-2.2)", () => {
       content.includes("do NOT merge") || content.includes("skipping");
     expect(hasConflictHandling).toBe(true);
     expect(hasSkipLanguage).toBe(true);
-  });
-
-  it("on 409 in scan mode, moves to the next candidate; ends the run if none remain", () => {
-    expect(content).toContain("CANDIDATE_LIST");
-    expect(content).toContain("next candidate");
   });
 
   it("post-merge upsert reuses PR_RECORD_ID from the pre-merge claim (plain PATCH, no redundant claim)", () => {

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -17,91 +17,20 @@ metrics on success.
 
 ## Arguments
 
-Parse `$ARGUMENTS` to extract `org`, `repo`, and `pr` number:
+Parse `$ARGUMENTS` to extract `org`, `repo`, and `pr` number. `$ARGUMENTS` is required —
+this command always targets an explicit PR:
 - `org/repo#number` (e.g. `app-vitals/shipwright#123`): explicit
 - `number` or `#number`: infer org/repo from the agent config (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[0] // empty'`),
   defaulting to `app-vitals/shipwright`.
   **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
-- _(no arguments)_: scan mode — find the next ready PR to deploy (see Step 1)
-
----
-
-## Step 1: Scan Mode (no arguments)
-
-When invoked with no arguments, find the next PR ready to deploy autonomously.
-
-### 1a. Find Qualifying PRs
-
-Get the current agent's own GH login and read `allow_self_review` from
-`state/agent-policy.md` (default: true):
-
-```bash
-AGENT_LOGIN=$(gh api user --jq '.login')
-```
-
-Resolve the configured repos:
-```bash
-REPOS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[]')
-```
-
-For each configured repo, fetch all open PRs authored by `AGENT_LOGIN`:
-```bash
-gh pr list --state open --repo {org}/{repo} --author "$AGENT_LOGIN" \
-  --json number,headRefOid,headRefName,author,reviewDecision
-```
-
-For each PR, check in order:
-
-1. **Approval** — if `reviewDecision == "APPROVED"`: approved. Otherwise, if
-   `allow_self_review` is true: fetch the PR's reviews and check if any review has a clean
-   APPROVE body — either a leading `APPROVE` (stripping leading markdown bold markers (`**`)
-   first, since the review skill posts `"**APPROVE**"`) or a `Verdict: APPROVE` label
-   anywhere in the body (the narrative self-review convention, case-insensitive, optional
-   `**` around either word — mirrors `check-helpers.ts`'s `isCleanApproveBody`, shared by
-   `check-deploy.ts`'s `hasSelfApproveReview` and `check-patch.ts`'s `isSelfCleanApprove`):
-   ```bash
-   gh pr view {pr} --repo {org}/{repo} --json reviews \
-     --jq '[.reviews[] | .body] | any(
-       (sub("^\\s*";"") | sub("^\\*+";"") | startswith("APPROVE"))
-       or test("verdict\\**\\s*:\\s*\\**approve\\b"; "i")
-     )'
-   ```
-   Skip if neither source shows approval.
-
-2. **CI green** — fetch CI runs for the PR's head commit:
-   ```bash
-   gh api "repos/{org}/{repo}/actions/runs?head_sha={headRefOid}&per_page=20" \
-     --jq '[.workflow_runs[] | select(.name == "CI") | {status, conclusion}]'
-   ```
-   Skip if no CI run has `status == "completed"` and `conclusion == "success"`.
-
-3. **Bundle completeness** — a PR's branch may have sibling tasks (bundle-mates) still in
-   flight. Skip PRs whose bundle isn't complete yet rather than picking a doomed candidate.
-   Mirrors `check-deploy.ts`'s `isBundleComplete` gate exactly:
-   ```bash
-   BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={headRefName}" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
-   INCOMPLETE=$(echo "$BRANCH_TASKS" | jq '[.tasks[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked")] | length')
-   ```
-   Skip if `INCOMPLETE > 0`.
-
-Keep the ordered list of qualifying PRs as `CANDIDATE_LIST`. Pick the **first** entry
-as the primary candidate. If none qualify, respond `[silent]` and stop — no output.
-
-Once a qualifying PR is found, proceed to Step 2 with that PR number and repo as the target.
-If Step 2b's bundle re-check or Step 4a's pre-merge claim later finds the candidate blocked
-(a bundle-mate went in flight, or another deploy run already claimed it), control returns
-here to retry with the next untried entry in `CANDIDATE_LIST`.
+- _(no arguments)_: respond `[silent]` and stop — no GitHub scan across own open PRs.
 
 ---
 
 ## Step 2: Resolve Target PR
 
-If arriving from scan mode (Step 1a): use the `org`, `repo`, and `pr` already resolved
-there — skip argument parsing entirely.
-
-If invoked with explicit arguments: parse `$ARGUMENTS` using the rules in the Arguments
-section above to extract `org`, `repo`, and `pr`.
+Parse `$ARGUMENTS` using the rules in the Arguments section above to extract `org`, `repo`,
+and `pr`.
 
 Look up the task via the task store:
 
@@ -142,12 +71,6 @@ Before running pre-flight checks, verify that all tasks on this branch are `pr_o
 beyond (i.e., no bundle-mates are still in flight). This prevents deploying a PR while
 sibling tasks on the same branch are still being developed or are blocked.
 
-Scan mode already excluded bundle-incomplete PRs from `CANDIDATE_LIST` in Step 1a. This
-re-check is defense-in-depth for the case where a bundle-mate task transitioned to
-pending/in_progress/blocked in the time between Step 1a's scan and Step 2's arrival at this
-specific candidate — it also covers explicit-target mode, which skips Step 1a entirely and
-arrives here directly.
-
 ```bash
 HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
 BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch=$HEAD_BRANCH" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
@@ -161,13 +84,7 @@ INCOMPLETE=$(echo "$INCOMPLETE_TASKS" | jq 'length')
   {for each item in INCOMPLETE_TASKS: "  - {id} ({status})"}
   Waiting for bundle-mates to reach pr_open before deploying.
 ```
-- **Scan mode**: log which candidate was skipped and why:
-  ```
-  ⏭ Skipping PR #{pr} — bundle-blocked on branch {HEAD_BRANCH}, trying next candidate.
-  ```
-  Then return to Step 1a's `CANDIDATE_LIST` and retry Steps 2 through 4a with the next
-  candidate PR. If no candidates remain, respond `[silent]` and stop.
-- **Explicit-target mode**: there is no other candidate to fall back to. Stop here `[silent]`.
+Stop here `[silent]` — there is no other candidate to fall back to.
 
 **Otherwise** (`INCOMPLETE == 0` — no tasks tracked, or all tasks are `pr_open` or beyond):
 proceed to Step 3.
@@ -280,9 +197,7 @@ do NOT merge. Print:
 ```
 ⏸ PR #{pr} is already claimed by another deploy run — skipping.
 ```
-- **Scan mode**: return to Step 1a's `CANDIDATE_LIST` and retry Steps 2 through 4a with the
-  next candidate PR. If no candidates remain, respond `[silent]` and stop.
-- **Explicit-target mode**: there is no other candidate to fall back to. Stop here.
+There is no other candidate to fall back to. Stop here.
 
 **Otherwise** (`200` or `201`): the claim succeeded. `PR_RECORD_ID` is reused by the
 post-merge update in Step 4c — no second claim call is needed. Proceed to Step 4b.

--- a/plugins/shipwright/scripts/check-deploy.ts
+++ b/plugins/shipwright/scripts/check-deploy.ts
@@ -213,7 +213,12 @@ export async function run(deps: Deps): Promise<RunResult> {
 
         return {
           exit: 0,
-          output: "Deploy ready PRs via /shipwright:deploy",
+          // Embed the resolved candidate directly: cron-handler.ts uses this
+          // string verbatim as the dispatched prompt (prompt = output), and
+          // deploy.md's Scan Mode was removed — $ARGUMENTS is now required,
+          // so the prompt must already contain a resolvable org/repo#pr or a
+          // no-argument invocation would hit deploy.md's `[silent]` stop.
+          output: `/shipwright:deploy ${org}/${repoName}#${pr.number}`,
           candidate: { pr: pr.number, org, repo: repoName },
         };
       } catch (err) {

--- a/plugins/shipwright/scripts/check-deploy.unit.test.ts
+++ b/plugins/shipwright/scripts/check-deploy.unit.test.ts
@@ -666,20 +666,22 @@ describe("check-deploy — candidate field (--json mode)", () => {
 });
 
 describe("check-deploy — non-json mode backwards compat", () => {
-  test("output string contains 'deploy' when candidate found", async () => {
+  test("output string embeds the resolved org/repo#pr candidate", async () => {
     const pr = makeGhPr({
+      number: 42,
       author: { login: "bodhi-agent" },
       reviewDecision: "APPROVED",
     });
     const result = await run(
       makeDeps({
         currentUser: "bodhi-agent",
+        repos: ["acme/example-repo"],
         prs: { "acme/example-repo": [pr] },
         ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
       }),
     );
     expect(result.exit).toBe(0);
-    expect(result.output).toBe("Deploy ready PRs via /shipwright:deploy");
+    expect(result.output).toBe("/shipwright:deploy acme/example-repo#42");
     expect(result.output.toLowerCase()).toContain("deploy");
   });
 


### PR DESCRIPTION
## Summary
- Removed Step 1 (Scan Mode) from `deploy.md` entirely — `$ARGUMENTS` is now required, and no-argument invocation responds `[silent]` and stops with no GitHub scan across own open PRs
- Removed all `CANDIDATE_LIST` fallback branches from Step 2b and Step 4a (bundle-block and claim-409), keeping only the explicit-target "stop here" behavior
- Updated `deploy.content.test.ts` and `TESTING.md` to drop scan-mode/`CANDIDATE_LIST` fixtures while keeping all explicit-target-mode fixtures (bundle gate, approval, CI-green, claim-409-exit-clean) unchanged

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 1 Scan Mode + "no arguments" branch removed; $ARGUMENTS required | MET | `## Step 1: Scan Mode` section fully deleted; Arguments section now reads "$ARGUMENTS is required — this command always targets an explicit PR" |
| 2 | No-argument invocation responds [silent] and stops, no GitHub scan | MET | Arguments section: "_(no arguments)_: respond `[silent]` and stop — no GitHub scan across own open PRs." |
| 3 | Step 2 onward unchanged, incl. claim-409 exit-clean | MET | Bundle gate, pre-flight, claim, merge/canary/promote logic unchanged aside from removing dead scan-mode fallback branches; claim-409 "Stop here" behavior preserved |
| 4 | Tests updated: scan-mode/CANDIDATE_LIST fixtures removed, explicit-target fixtures kept | MET | Removed 2 scan-mode tests + TESTING.md row 43; added new WLS-3.4 assertion suite; explicit-target fixtures untouched |

## Test Plan
- `bun test plugins/shipwright/commands/deploy.content.test.ts` — 23/23 pass
- `bun test` (full plugins/shipwright suite) — 724/724 pass
- `bun run typecheck` — clean
- `bunx biome lint` on changed files — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
