### PR TITLE
feat(agent): make claude session timeout configurable via SHIPWRIGHT_CLAUDE_TIMEOUT_MS

### DIFF
--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -1,7 +1,24 @@
 import { join } from "node:path";
 
+// Default hard timeout for a single `claude -p` session — mirrors the default
+// in createRunClaude (agent/src/claude.ts). Kept in sync so behavior is
+// unchanged when SHIPWRIGHT_CLAUDE_TIMEOUT_MS is unset.
+const DEFAULT_CLAUDE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
 function optional(key: string): string | undefined {
   return process.env[key];
+}
+
+/**
+ * Reads a positive-integer millisecond env var, falling back to `fallback`
+ * when the value is unset, non-numeric, non-integer, zero, or negative — so a
+ * malformed override never silently disables or shortens the timeout.
+ */
+function positiveIntMs(key: string, fallback: number): number {
+  const raw = optional(key);
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function buildConfig(agentHome: string) {
@@ -10,6 +27,10 @@ function buildConfig(agentHome: string) {
       model: optional("ANTHROPIC_MODEL") ?? "claude-sonnet-4-6",
       fallbackModel: optional("ANTHROPIC_FALLBACK_MODEL"),
       effortLevel: optional("ANTHROPIC_EFFORT_LEVEL"),
+      timeoutMs: positiveIntMs(
+        "SHIPWRIGHT_CLAUDE_TIMEOUT_MS",
+        DEFAULT_CLAUDE_TIMEOUT_MS,
+      ),
       anthropicApiKey: optional("ANTHROPIC_API_KEY"),
       oauthToken: optional("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/agent/src/config.unit.test.ts
+++ b/agent/src/config.unit.test.ts
@@ -83,6 +83,43 @@ describe("config.claude", () => {
     expect(cfg.claude.model).toBe("claude-sonnet-4-6");
     process.env.ANTHROPIC_MODEL = saved;
   });
+
+  test("timeoutMs defaults to 30m when SHIPWRIGHT_CLAUDE_TIMEOUT_MS not set", () => {
+    expect(config.claude.timeoutMs).toBe(30 * 60 * 1000);
+  });
+
+  test("timeoutMs from SHIPWRIGHT_CLAUDE_TIMEOUT_MS env var", () => {
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = "5400000";
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.timeoutMs).toBe(5_400_000);
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = undefined;
+  });
+
+  test("timeoutMs falls back to default when non-numeric", () => {
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = "not-a-number";
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.timeoutMs).toBe(30 * 60 * 1000);
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = undefined;
+  });
+
+  test("timeoutMs falls back to default when zero or negative", () => {
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = "0";
+    expect(createConfig(AGENT_HOME).config.claude.timeoutMs).toBe(
+      30 * 60 * 1000,
+    );
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = "-1000";
+    expect(createConfig(AGENT_HOME).config.claude.timeoutMs).toBe(
+      30 * 60 * 1000,
+    );
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = undefined;
+  });
+
+  test("timeoutMs falls back to default when non-integer", () => {
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = "1500.5";
+    const { config: cfg } = createConfig(AGENT_HOME);
+    expect(cfg.claude.timeoutMs).toBe(30 * 60 * 1000);
+    process.env.SHIPWRIGHT_CLAUDE_TIMEOUT_MS = undefined;
+  });
 });
 
 // ─── config.shipwright ────────────────────────────────────────────────────────

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -102,6 +102,10 @@ const runner = createRunClaude(
   undefined,
   config.paths.workspace,
   analytics.track,
+  undefined,
+  undefined,
+  undefined,
+  config.claude.timeoutMs,
 );
 
 const cronRunReporter =
@@ -366,6 +370,11 @@ if (config.chat.serviceUrl && config.chat.serviceToken) {
     chatSessions,
     undefined,
     config.paths.workspace,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    config.claude.timeoutMs,
   );
   const chatClient = new HttpChatServiceClient({
     baseUrl: config.chat.serviceUrl,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ Configuration for the Shipwright agent runtime (`agent/` and `admin/`). All opti
 | `ANTHROPIC_MODEL` | `string` | `claude-sonnet-4-6` | Claude model used for each agent invocation. |
 | `ANTHROPIC_FALLBACK_MODEL` | `string` | — | Fallback model if the primary is unavailable. |
 | `ANTHROPIC_EFFORT_LEVEL` | `string` | — | Effort/thinking level passed to Claude (e.g. `extended`, `auto`, `none`). |
+| `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` | `number` | `1800000` | Hard timeout in milliseconds for a single `claude -p` session spawned by the agent runner (`agent/src/claude.ts`). When a session exceeds it the process is killed and a `ClaudeTimeoutError` is raised. Defaults to 1 800 000 ms (30 min) — the `claude -p` hard-timeout figure that `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` (35 min = 30 min + 5 min buffer) is derived from. Falls back to the default when unset or not a positive integer. Raise it for long sessions that keep polling CI after implementing so the worker can mark its task complete instead of being SIGKILLed mid-poll. **When raising this, raise `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` in step** (keep the ~5 min buffer above this value); otherwise the stale-claim reaper abandons the claim and re-dispatches a duplicate run before the longer session finishes. |
 | `ANTHROPIC_API_KEY` | `string` | — | Anthropic API key. Env-var-only (secret). |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `string` | — | Claude Code OAuth token (alternative to `ANTHROPIC_API_KEY`). Env-var-only (secret). |
 

--- a/site/src/data/config-vars.ts
+++ b/site/src/data/config-vars.ts
@@ -17,6 +17,7 @@ export const agentClaudeVars: ConfigVar[] = [
   { name: "ANTHROPIC_MODEL", type: "string", def: "claude-sonnet-4-6", desc: "Claude model used for each agent invocation." },
   { name: "ANTHROPIC_FALLBACK_MODEL", type: "string", def: "—", desc: "Fallback model if the primary is unavailable." },
   { name: "ANTHROPIC_EFFORT_LEVEL", type: "string", def: "—", desc: "Effort/thinking level passed to Claude (e.g. extended, auto, none)." },
+  { name: "SHIPWRIGHT_CLAUDE_TIMEOUT_MS", type: "number", def: "1800000", desc: "Hard timeout in milliseconds for a single claude -p session spawned by the agent runner. When a session exceeds it the process is killed and a ClaudeTimeoutError is raised. Falls back to the default when unset or not a positive integer. When raising this, raise SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS in step (keep the ~5 min buffer) or the stale-claim reaper re-dispatches a duplicate run." },
   { name: "ANTHROPIC_API_KEY", type: "string", def: "—", desc: "Anthropic API key. Env-var-only (secret)." },
   { name: "CLAUDE_CODE_OAUTH_TOKEN", type: "string", def: "—", desc: "Claude Code OAuth token (alternative to ANTHROPIC_API_KEY). Env-var-only (secret)." },
 ];

--- a/state/dev-agent.env.example
+++ b/state/dev-agent.env.example
@@ -34,5 +34,9 @@ ANTHROPIC_API_KEY=
 # Thinking effort level (extended | auto | none)
 # ANTHROPIC_EFFORT_LEVEL=
 
+# Hard timeout in ms for a single `claude -p` session (default: 1800000 = 30m).
+# Raise for long sessions that poll CI; also raise SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS in step.
+# SHIPWRIGHT_CLAUDE_TIMEOUT_MS=1800000
+
 # Startup timeout in ms (default: 60000 for prod). Override to fail fast in dev.
 SHIPWRIGHT_STARTUP_TIMEOUT_MS=10000


### PR DESCRIPTION
## Problem

The `claude -p` session hard timeout is hardcoded to 30 minutes (`agent/src/claude.ts`, `timeoutMs: number = 30 * 60 * 1000`) with no override — no caller passes the parameter and no env var reads it.

I hit it when a dev-task worker finished its implementation, opened its PR, then polled CI — and was SIGKILLed at exactly 1800s mid-poll, before it could mark its task complete. The task stayed `in_progress`, the stale-claim reaper reset it to `pending` after the claim TTL, and the loop dispatched a full duplicate run of an already-complete task (repeating every ~45 min until an operator intervened with `POST /tasks/:id/complete`). A tunable timeout lets operators size sessions to their tasks.

## Changes

Makes the `claude -p` session hard timeout configurable via a new `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` env var. The value is parsed and validated in the central `agent/src/config.ts` via a new `positiveIntMs` helper (positive-integer only; unset, non-numeric, non-integer, zero, or negative all fall back to the existing `1_800_000` default, so **default behavior is unchanged**) and threaded into both `createRunClaude` call sites in `index.ts` — the task worker and the chat runner — so it uniformly governs every Claude session. Documented in `docs/configuration.md`, the rendered site config reference (`site/src/data/config-vars.ts`), and `state/dev-agent.env.example`, including the operational caveat to raise `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` in step (preserving the ~5-min buffer above the timeout, matching the invariant documented in `stale-claim-reaper.ts`) to keep the stale-claim reaper from re-dispatching duplicates. Adds 5 config unit tests covering default, valid override, and each rejection path.

## Verification

Beyond unit tests (full agent suite: 919 pass with the var unset — behavior identical to main), we verified empirically against the real code with a stub `claude` binary on PATH:

- `SHIPWRIGHT_CLAUDE_TIMEOUT_MS=3000` + a 60s-sleeping stub → `ClaudeTimeoutError` at 3004ms.
- `=20000` + a stub exiting at 5s → returns normally at 5017ms (no early fire).
- Config resolution matrix (fresh process per case): unset/"abc"/"-5"/"0"/"1.5" → 1800000; "600000" → 600000.
- Same kill test driven with the chat-runner call shape → 2006ms kill (both call sites thread the value).
- Inside a container built from the agent Dockerfile: env var read from container env, kill at 4021ms with `=4000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)