### PR TITLE
fix(task-store): accept "completed" status alias and return 400 on invalid status

### DIFF
--- a/task-store/src/api.integration.test.ts
+++ b/task-store/src/api.integration.test.ts
@@ -188,6 +188,55 @@ describeOrSkip("task-store API (integration)", () => {
     expect(released.heartbeatAt).toBeNull();
   });
 
+  // ─── PATCH status normalization (completed → done) ─────────────────────────
+
+  it("PATCH /tasks/:id with status 'completed' persists 'done' (200)", async () => {
+    const id = await createPendingTask();
+
+    const res = await app.request(`/tasks/${id}`, {
+      method: "PATCH",
+      headers: auth(),
+      body: JSON.stringify({ status: "completed" }),
+    });
+    expect(res.status).toBe(200);
+    const updated = (await res.json()) as { status: string };
+    expect(updated.status).toBe("done");
+
+    // The stored row reflects the normalized status.
+    const read = await app.request(`/tasks/${id}`, { headers: auth() });
+    const stored = (await read.json()) as { status: string };
+    expect(stored.status).toBe("done");
+  });
+
+  it("PATCH /tasks/:id with an unknown status returns 400, not 500", async () => {
+    const id = await createPendingTask();
+
+    const res = await app.request(`/tasks/${id}`, {
+      method: "PATCH",
+      headers: auth(),
+      body: JSON.stringify({ status: "totally-bogus" }),
+    });
+    expect(res.status).toBe(400);
+
+    // The task is untouched — still pending.
+    const read = await app.request(`/tasks/${id}`, { headers: auth() });
+    const stored = (await read.json()) as { status: string };
+    expect(stored.status).toBe("pending");
+  });
+
+  it("PATCH /tasks/:id with an existing status is unaffected (200)", async () => {
+    const id = await createPendingTask();
+
+    const res = await app.request(`/tasks/${id}`, {
+      method: "PATCH",
+      headers: auth(),
+      body: JSON.stringify({ status: "in_progress" }),
+    });
+    expect(res.status).toBe(200);
+    const updated = (await res.json()) as { status: string };
+    expect(updated.status).toBe("in_progress");
+  });
+
   // ─── Concurrent claim ──────────────────────────────────────────────────────
 
   it("allows exactly one of two concurrent claims (one 200, one 409)", async () => {

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -616,6 +616,27 @@ describe("task-store API (smoke)", () => {
     expect(capturedUpdates[0]?.status).toBe("done");
   });
 
+  it("PATCH /tasks/:id normalizes a case variant ('Completed') to 'done' (200)", async () => {
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: makeTask({ id: "task-1" }) }),
+      async update(id, data) {
+        capturedUpdates.push(data as Record<string, unknown>);
+        return makeTask({ ...(data as Partial<Task>), id });
+      },
+    };
+    const app = makeApp({ taskService: spyTaskService });
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ status: "Completed" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task;
+    expect(body.status).toBe("done");
+    expect(capturedUpdates[0]?.status).toBe("done");
+  });
+
   it("PATCH /tasks/:id rejects an unknown status with 400, not 500", async () => {
     const app = makeApp({
       taskService: fakeTaskService({ getResult: makeTask({ id: "task-1" }) }),

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -592,6 +592,95 @@ describe("task-store API (smoke)", () => {
     expect(capturedUpdates[0]?.assignee).toBeUndefined();
   });
 
+  // ─── Status normalization (completed → done) ────────────────────────────────
+
+  it("PATCH /tasks/:id normalizes the 'completed' alias to 'done' (200)", async () => {
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: makeTask({ id: "task-1" }) }),
+      async update(id, data) {
+        capturedUpdates.push(data as Record<string, unknown>);
+        return makeTask({ ...(data as Partial<Task>), id });
+      },
+    };
+    const app = makeApp({ taskService: spyTaskService });
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ status: "completed" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Task;
+    expect(body.status).toBe("done");
+    // The value persisted must be the normalized "done", never "completed".
+    expect(capturedUpdates[0]?.status).toBe("done");
+  });
+
+  it("PATCH /tasks/:id rejects an unknown status with 400, not 500", async () => {
+    const app = makeApp({
+      taskService: fakeTaskService({ getResult: makeTask({ id: "task-1" }) }),
+    });
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ status: "totally-bogus" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /tasks/:id leaves a canonical status unchanged (200)", async () => {
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService({ getResult: makeTask({ id: "task-1" }) }),
+      async update(id, data) {
+        capturedUpdates.push(data as Record<string, unknown>);
+        return makeTask({ ...(data as Partial<Task>), id });
+      },
+    };
+    const app = makeApp({ taskService: spyTaskService });
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    });
+    expect(res.status).toBe(200);
+    expect(capturedUpdates[0]?.status).toBe("done");
+  });
+
+  it("PATCH /tasks/:id without a status field is unaffected (200)", async () => {
+    const app = makeApp({
+      taskService: fakeTaskService({ getResult: makeTask({ id: "task-1" }) }),
+    });
+    const res = await app.request("/tasks/task-1", {
+      method: "PATCH",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ note: "just a note" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /tasks normalizes the 'completed' alias to 'done' (201)", async () => {
+    const app = makeApp();
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ title: "New", status: "completed", repo: null }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Task;
+    expect(body.status).toBe("done");
+  });
+
+  it("POST /tasks rejects an unknown status with 400, not 500", async () => {
+    const app = makeApp();
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: { ...auth(), "content-type": "application/json" },
+      body: JSON.stringify({ title: "New", status: "nonsense", repo: null }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("GET /tasks?ready=true with agent token forwards agentId to listReady", async () => {
     const capturedArgs: Array<string | undefined> = [];
 

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -46,6 +46,7 @@ import {
   TaskSchema,
   UpdateTaskBodySchema,
 } from "../openapi-schemas.ts";
+import { ALL_STATUSES, isValidStatus, normalizeStatus } from "../statuses.ts";
 import type { TaskServiceLike } from "../task-service.ts";
 import { isOrgRepo } from "../validate.ts";
 
@@ -72,6 +73,28 @@ function validateRepo(repo: unknown, repos: string[] | null): void {
   if (repos !== null && !repos.includes(repo)) {
     throw new BadRequestError(`repo '${repo}' is not in this agent's scope`);
   }
+}
+
+/**
+ * Normalize and validate the `status` field on a request body, mutating it in
+ * place. Accepts the canonical TaskStatus values plus documented aliases
+ * (e.g. "completed" → "done"; see STATUS_ALIASES). An unknown status raises a
+ * clean 400 listing the valid values, rather than falling through to Prisma
+ * where an out-of-enum value surfaces as an opaque 500. A body without a
+ * `status` key is left untouched (PATCH bodies need not include one).
+ */
+function normalizeStatusField(body: Record<string, unknown>): void {
+  if (!("status" in body)) return;
+  if (typeof body.status !== "string" || !body.status) {
+    throw new BadRequestError("status must be a non-empty string");
+  }
+  const normalized = normalizeStatus(body.status);
+  if (!isValidStatus(normalized)) {
+    throw new BadRequestError(
+      `invalid status '${body.status}' (valid: ${ALL_STATUSES.join(", ")})`,
+    );
+  }
+  body.status = normalized;
 }
 
 /** Fetch a task and enforce agent ownership. Throws 404 or 403 as appropriate.
@@ -532,6 +555,7 @@ export function createTasksRoutes(
     if (typeof body.status !== "string" || !body.status) {
       throw new BadRequestError("status is required");
     }
+    normalizeStatusField(body);
     if (!("repo" in body)) {
       throw new BadRequestError(
         "repo key is required (null is valid for unscoped tasks)",
@@ -568,6 +592,7 @@ export function createTasksRoutes(
         );
       }
       validateRepo(task.repo, agentId !== null ? repos : null);
+      normalizeStatusField(task);
     }
     const tasks =
       agentId !== null
@@ -622,6 +647,7 @@ export function createTasksRoutes(
     );
     const body = await readJson(c);
     validateRepo(body.repo, agentId !== null ? repos : null);
+    normalizeStatusField(body);
     // Prevent agent tokens from reassigning tasks outside their ownership scope.
     // Only force-assign when the acting agent is the explicit assignee or claimedBy.
     // Skip force-assign when access is purely via repo scope — the task may belong

--- a/task-store/src/statuses.ts
+++ b/task-store/src/statuses.ts
@@ -47,9 +47,16 @@ export const STATUS_ALIASES: Record<string, TaskStatusValue> = {
   completed: "done",
 };
 
-/** Resolve a status alias to its canonical value; pass non-aliases through. */
+/**
+ * Resolve a status to its canonical value: trim, lowercase, then apply the
+ * alias table, so case/whitespace variants like "Completed" or " Done "
+ * normalize the same way as their lowercase forms (improvised statuses come
+ * with improvised casing). Unknown values pass through trimmed/lowercased for
+ * the caller to reject via isValidStatus.
+ */
 export function normalizeStatus(status: string): string {
-  return STATUS_ALIASES[status] ?? status;
+  const canonical = status.trim().toLowerCase();
+  return STATUS_ALIASES[canonical] ?? canonical;
 }
 
 /** True when `status` is a canonical (post-normalization) TaskStatus value. */

--- a/task-store/src/statuses.ts
+++ b/task-store/src/statuses.ts
@@ -23,3 +23,36 @@ export const OPEN_STATUSES = [
   "approved",
   "blocked",
 ] as const;
+
+/**
+ * Every valid task status — the union of open and closed. Mirrors the
+ * `TaskStatus` enum in prisma/schema.prisma; keep the two in sync.
+ */
+export const ALL_STATUSES = [...OPEN_STATUSES, ...CLOSED_STATUSES] as const;
+
+export type TaskStatusValue = (typeof ALL_STATUSES)[number];
+
+/**
+ * Aliases accepted at the API write boundary and normalized to a canonical
+ * status before persistence.
+ *
+ * "completed" is the terminal status LLM-based workers most often improvise
+ * when finishing a task — it is not in the enum, so a raw `status:"completed"`
+ * write reaches Prisma and 500s, which cheap workers exit on before any
+ * fallback, leaving the task stuck `in_progress` for the stale-claim reaper to
+ * re-dispatch. Mapping it to "done" lets the worker's first completion write
+ * terminalize the task. No schema migration — the alias resolves before Prisma.
+ */
+export const STATUS_ALIASES: Record<string, TaskStatusValue> = {
+  completed: "done",
+};
+
+/** Resolve a status alias to its canonical value; pass non-aliases through. */
+export function normalizeStatus(status: string): string {
+  return STATUS_ALIASES[status] ?? status;
+}
+
+/** True when `status` is a canonical (post-normalization) TaskStatus value. */
+export function isValidStatus(status: string): boolean {
+  return (ALL_STATUSES as readonly string[]).includes(status);
+}

--- a/task-store/src/statuses.unit.test.ts
+++ b/task-store/src/statuses.unit.test.ts
@@ -1,0 +1,76 @@
+/**
+ * task-store/src/statuses.unit.test.ts
+ *
+ * Unit tests for the status constants, alias table, and normalize/validate
+ * helpers shared across the task-store write paths.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  ALL_STATUSES,
+  CLOSED_STATUSES,
+  OPEN_STATUSES,
+  isValidStatus,
+  normalizeStatus,
+} from "./statuses.ts";
+
+// The canonical enum in prisma/schema.prisma — the source of truth ALL_STATUSES
+// must mirror. Kept as a literal here so the test fails loudly if the two drift.
+const PRISMA_TASK_STATUS = [
+  "pending",
+  "in_progress",
+  "pr_open",
+  "approved",
+  "merged",
+  "done",
+  "deploying",
+  "deployed",
+  "blocked",
+  "cancelled",
+];
+
+describe("ALL_STATUSES (unit)", () => {
+  it("is the union of OPEN_STATUSES and CLOSED_STATUSES", () => {
+    expect(ALL_STATUSES).toEqual([...OPEN_STATUSES, ...CLOSED_STATUSES]);
+  });
+
+  it("matches the TaskStatus enum in prisma/schema.prisma", () => {
+    expect(([...ALL_STATUSES] as string[]).sort()).toEqual(
+      [...PRISMA_TASK_STATUS].sort(),
+    );
+  });
+});
+
+describe("normalizeStatus (unit)", () => {
+  it("maps the 'completed' alias to 'done'", () => {
+    expect(normalizeStatus("completed")).toBe("done");
+  });
+
+  it("passes every canonical status through unchanged", () => {
+    for (const status of ALL_STATUSES) {
+      expect(normalizeStatus(status)).toBe(status);
+    }
+  });
+
+  it("passes unknown values through unchanged (validity is checked separately)", () => {
+    expect(normalizeStatus("bogus")).toBe("bogus");
+  });
+});
+
+describe("isValidStatus (unit)", () => {
+  it("accepts every canonical status", () => {
+    for (const status of ALL_STATUSES) {
+      expect(isValidStatus(status)).toBe(true);
+    }
+  });
+
+  it("rejects unknown and empty values", () => {
+    expect(isValidStatus("bogus")).toBe(false);
+    expect(isValidStatus("")).toBe(false);
+  });
+
+  it("rejects the raw 'completed' alias — it must be normalized first", () => {
+    expect(isValidStatus("completed")).toBe(false);
+    expect(isValidStatus(normalizeStatus("completed"))).toBe(true);
+  });
+});

--- a/task-store/src/statuses.unit.test.ts
+++ b/task-store/src/statuses.unit.test.ts
@@ -52,8 +52,21 @@ describe("normalizeStatus (unit)", () => {
     }
   });
 
-  it("passes unknown values through unchanged (validity is checked separately)", () => {
+  it("maps case and whitespace variants of the alias to 'done'", () => {
+    expect(normalizeStatus("Completed")).toBe("done");
+    expect(normalizeStatus("COMPLETED")).toBe("done");
+    expect(normalizeStatus(" completed ")).toBe("done");
+  });
+
+  it("canonicalizes case and whitespace variants of canonical statuses", () => {
+    expect(normalizeStatus("Done")).toBe("done");
+    expect(normalizeStatus("IN_PROGRESS")).toBe("in_progress");
+    expect(normalizeStatus(" pending ")).toBe("pending");
+  });
+
+  it("passes unknown values through trimmed/lowercased (validity is checked separately)", () => {
     expect(normalizeStatus("bogus")).toBe("bogus");
+    expect(normalizeStatus(" BoGuS ")).toBe("bogus");
   });
 });
 
@@ -67,6 +80,10 @@ describe("isValidStatus (unit)", () => {
   it("rejects unknown and empty values", () => {
     expect(isValidStatus("bogus")).toBe(false);
     expect(isValidStatus("")).toBe(false);
+  });
+
+  it("rejects genuinely-unknown values even after normalization", () => {
+    expect(isValidStatus(normalizeStatus("Totally-Bogus"))).toBe(false);
   });
 
   it("rejects the raw 'completed' alias — it must be normalized first", () => {


### PR DESCRIPTION
## Problem

The task-store's `TaskStatus` Prisma enum has no `completed` value, and status validation is open (`CreateTaskBodySchema.status` is `z.string()`, `UpdateTaskBodySchema` is `z.record`), so an out-of-enum status reaches `prisma.task.update()` and surfaces as an opaque **500**:

```
PATCH /tasks/:id {"status":"completed"}
→ 500  Invalid `this.prisma.task.update()` invocation ... Invalid value for argument `status`. Expected TaskStatus.
```

(Reproduced against a live task-store at current main `5511c2f2` with Postgres 16.)

This matters in practice because Claude-based workers improvise `status:"completed"` when finishing a task — "completed" is the natural English word for the terminal state. In our production deployment, a worker hit the 500s and exited before any fallback, leaving the task `in_progress` forever; the stale-claim reaper then reset it and the loop re-dispatched full duplicate paid runs of already-finished work. (Related: #1565 addresses the timeout-flavored path into the same stall.)

## Changes

Adds a `"completed" → "done"` status alias and clean 400-on-invalid-status handling at the task-store write boundary. `task-store/src/statuses.ts` gains `ALL_STATUSES` (kept in sync with the Prisma enum, asserted by a unit test), a `STATUS_ALIASES` table, and `normalizeStatus()`/`isValidStatus()` helpers; normalization canonicalizes with `trim().toLowerCase()` first, so case/whitespace variants (`"Completed"`, `" COMPLETED "`) resolve too. A shared `normalizeStatusField()` helper in `routes/tasks.ts` is wired into the create, bulk, and PATCH handlers: aliases resolve to their canonical value and any unknown status is rejected with a `400 BadRequestError` listing the valid values, instead of reaching Prisma as a 500. Normalization is route-level (matching the existing `validateRepo` precedent) and requires **no schema migration**.

One deliberate scope decision, disclosed: a task terminalized via the alias goes through the same `update()` path as a plain `PATCH {"status":"done"}` and therefore does not set `completedAt` (unlike `POST /tasks/:id/complete`). The alias behaves exactly like its canonical value; changing `completedAt` semantics for PATCH-to-terminal writes felt like a separate discussion.

## Verification

- Unit/smoke/integration tests added (full task-store suite: 396 tests, 0 fail; integration suite run against real Postgres 16).
- Live-service verification (real `task-store` + Postgres 16 in docker, HTTP): baseline 500 reproduced on main; on the branch — `completed`/`Completed`/`" COMPLETED "` → 200 with stored `done` on PATCH, create, and bulk; `totally-bogus` → 400 listing valid values, task unchanged; all 10 canonical statuses regression-clean; create→claim→complete lifecycle intact.
- Adversarial sweep — nothing produces a 500: status as number/array/null/object, duplicate JSON keys, whitespace-only, cyrillic-с `"сompleted"` lookalike, bulk items with bogus statuses → all clean 400s with the DB untouched.
- Drop-in: zero `prisma/` changes; the branch service boots against a database migrated by main (`No pending migrations to apply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)