### PR TITLE
fix(admin): explicit 5s timeoutSeconds on agent liveness/readiness probes

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -388,12 +388,17 @@ export function buildAgentDeploymentManifest(
                 httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
                 initialDelaySeconds: 15,
                 periodSeconds: 30,
+                // Explicit, not the 1s k8s default — the health server shares
+                // its process with claude -p child spawns and GitHub API
+                // calls, which can transiently delay a response past 1s.
+                timeoutSeconds: 5,
                 failureThreshold: 3,
               },
               readinessProbe: {
                 httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
                 initialDelaySeconds: 10,
                 periodSeconds: 10,
+                timeoutSeconds: 5,
                 failureThreshold: 3,
               },
               securityContext: {

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -160,8 +160,10 @@ describe("buildAgentDeploymentManifest", () => {
     expect(AGENT_HEALTH_PORT).toBe(3459);
     expect(c.livenessProbe?.httpGet?.port).toBe(3459);
     expect(c.livenessProbe?.failureThreshold).toBe(3);
+    expect(c.livenessProbe?.timeoutSeconds).toBe(5);
     expect(c.readinessProbe?.httpGet?.port).toBe(3459);
     expect(c.readinessProbe?.failureThreshold).toBe(3);
+    expect(c.readinessProbe?.timeoutSeconds).toBe(5);
   });
 
   it("gates liveness/readiness with a startupProbe granting ~180s for a slow mise startup", () => {


### PR DESCRIPTION
## Summary
- Both the agent's `livenessProbe` and `readinessProbe` (`admin/src/agent-manifest.ts`) omitted `timeoutSeconds`, silently defaulting to Kubernetes' 1s.
- The health server (port 3459) shares its process with `claude -p` child spawns, GitHub API calls, and the loop orchestrator's candidate-qualification checks — under load a `/health` response can transiently take longer than 1s, tripping the probe.
- Confirmed live: `doc`, `warchild`, and `the dude` agents were crash-looping (25-30 restarts over ~7.5h) with kubelet events reading `Readiness probe failed: ... context deadline exceeded (Client.Timeout exceeded while awaiting headers)`, followed by `failed liveness probe, will be restarted`.
- This raises `timeoutSeconds` to 5s on both probes — enough slack for a momentarily-busy process to still answer, without masking a truly wedged one (3 consecutive misses still triggers a restart).

## Test plan
- [x] `bun test admin/src/agent-manifest.unit.test.ts` — 48 pass, added assertions for `timeoutSeconds: 5` on both probes
- [x] `node_modules/.bin/biome check` on changed files — clean
- [x] Confirmed pre-existing `bun run typecheck` failures (missing `phase` field on `AgentCronRun`, likely stale local Prisma client) are unrelated — reproduced identically on `main` before this change
- [ ] Once deployed, confirm `doc`/`warchild`/`the dude` restart counts stop climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SewZ6gtBYtyHeKTa81UeVd