### PR TITLE
test: delete dead cost-efficiency unit placeholder (T-030)

### DIFF
--- a/metrics/src/providers/cost-efficiency.unit.test.ts
+++ b/metrics/src/providers/cost-efficiency.unit.test.ts
@@ -1,8 +1,0 @@
-/**
- * metrics/src/providers/cost-efficiency.unit.test.ts
- * RETIRED — PCE-1.5 replaced the stub implementation with run-level data.
- *
- * The integration tests in cost-efficiency.integration.test.ts cover the new
- * costEfficiency() implementation via RecordedAdminMetricsClient cassettes.
- * This file is kept as a placeholder to avoid breaking the test runner.
- */


### PR DESCRIPTION
## Summary
- Delete `metrics/src/providers/cost-efficiency.unit.test.ts`, a zero-assertion placeholder retired by PCE-1.5
- Canonical `costEfficiency()` coverage lives in `cost-efficiency.integration.test.ts`, which is unaffected

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Dead zero-assertion placeholder file removed | MET | `git rm metrics/src/providers/cost-efficiency.unit.test.ts` |
| 2 | Verification command confirms file absent and integration sibling passes | MET | `test ! -f ...` passes; `bun test cost-efficiency.integration.test.ts` — 9 pass, 0 fail |

## Test Plan
- [x] `test ! -f metrics/src/providers/cost-efficiency.unit.test.ts` — file absent
- [x] `bun test metrics/src/providers/cost-efficiency.integration.test.ts` — 9 pass, 0 fail
- [x] `metrics` package `tsc --noEmit` — clean
- [x] `bunx biome lint metrics/src/providers/` — clean
- [x] Full `metrics` package test suite — 312 pass, 0 fail
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
