### PR TITLE
docs: test naming-convention + runner-exclusion doc (T-001)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,5 +173,6 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/helm-repo.md** — installing the published `shipwright` Helm chart, how chart publishing and version bumps are automated
 - **docs/quickstart.md** — local onboarding: metrics-only quickstart and the full dev stack (`task stack`)
 - **docs/test-readiness/test-system.md** — the authoritative test blueprint: layer matrix, boundary rules, per-component budgets, CI pipeline shape, and the full isolation contract
+- **docs/test-readiness/naming.md** — file-suffix → layer naming convention and the `bunfig.toml` runner-exclusion config (e2e + reserved canary suffix), gating M1 rename tasks
 - **docs/migration.md** — breaking changes and migration steps across versions (e.g. `AgentProvisioner.reconcile()` interface change)
 - **docs/observability.md** — Sentry error/log reporting: what's collected, what's scrubbed, how to disable, and self-hosted Sentry support

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,8 +6,15 @@
 # them with the Bun runner. Exclude site/ from the root `bun test` scan so the
 # Astro site stays fully isolated from the monorepo test suite.
 #
-# metrics/e2e/ contains Playwright *.e2e.ts tests that must be run via
-# `bunx playwright test` — not via bun test. Exclude them so Bun does not
-# try to execute Playwright test files with the Bun runner.
+# metrics/e2e/ and admin/e2e/ contain Playwright *.e2e.ts tests that must be
+# run via `bunx playwright test` — not via bun test. Exclude them so Bun does
+# not try to execute Playwright test files with the Bun runner.
+#
+# *.canary.test.ts is a reserved suffix (no files use it yet) for the future
+# canary suite defined by the canary-execution skill contract
+# (plugins/shipwright/skills/canary-execution/SKILL.md). Canary tests run via
+# a dedicated entry point, never via default `bun test` — same rationale as
+# the e2e exclusions above, added proactively to prevent a future collision.
+# See docs/test-readiness/naming.md for the full naming + exclusion reference.
 [test]
-pathIgnorePatterns = ["**/site/**", "**/metrics/e2e/**", "**/admin/e2e/**"]
+pathIgnorePatterns = ["**/site/**", "**/metrics/e2e/**", "**/admin/e2e/**", "**/*.canary.test.ts"]

--- a/docs/test-readiness/naming.md
+++ b/docs/test-readiness/naming.md
@@ -1,0 +1,103 @@
+# Test Naming Convention & Runner-Exclusion Config
+
+> **Mandatory M1 gating doc.** This is the authoritative reference for "file suffix →
+> layer" naming and for which suffixes the default `bun test` runner must **not**
+> discover. It must land before any test-readiness rename task (T-002 onward) to
+> prevent file-discovery collisions — a file that matches two suffix rules, or a
+> reserved suffix that collides with an existing one, breaks the whole
+> classify-by-filename scheme this repo relies on.
+>
+> For layer *boundary rules* (what belongs in each layer) and *speed budgets*, see
+> [`test-system.md`](./test-system.md) (the full blueprint) and
+> [`docs/testing.md`](../testing.md) (the digest). This doc does not repeat that
+> content — it is scoped to naming and runner exclusion only.
+
+## Suffix → layer table
+
+Every test file's layer is encoded entirely in its filename suffix. A file must match
+**exactly one** suffix below.
+
+| Suffix | Layer | Discovered by `bun test`? |
+|---|---|---|
+| `*.unit.test.ts` | unit | Yes |
+| `*.integration.test.ts` | integration | Yes |
+| `*.smoke.test.ts` | smoke | Yes |
+| `*.content.test.ts` | content | Yes |
+| `*.spec.ts` (in `site/`) | e2e | **No** — excluded via `bunfig.toml` |
+| `*.e2e.ts` (in `metrics/e2e/`, `admin/e2e/`) | e2e | **No** — excluded via `bunfig.toml` |
+| `*.canary.test.ts` | canary (**reserved**) | **No** — excluded via `bunfig.toml` |
+
+See `test-system.md`'s [layer definitions](./test-system.md#layer-definitions) for the
+boundary rule each layer enforces, and `testing.md`'s [speed budgets](../testing.md#speed-budgets)
+for per-layer timing targets.
+
+## The reserved `.canary.` suffix
+
+No `*.canary.test.ts` files exist in the repo yet — the suffix is **reserved**, not yet
+in use. It is defined here now, ahead of any concrete canary test, so that when the
+test-readiness pipeline's canary suite is introduced (see the `canary-execution` skill —
+[`plugins/shipwright/skills/canary-execution/SKILL.md`](../../plugins/shipwright/skills/canary-execution/SKILL.md)),
+there is no ambiguity about what filename pattern it uses and no risk of an existing
+file accidentally colliding with it.
+
+Per the canary-execution contract, canary-eligible tests are smoke or E2E tests that also
+run against a deployed environment via a **dedicated entry point** — never through
+`bun test` or the local smoke runner. They read `TEST_TARGET_URL` at process start:
+unset means local mode (boot dependencies inline), set means canary mode (hit the
+deployed URL directly, using canary-scoped auth). Eligibility is restricted to
+read-only-or-self-cleaning, critical/high-criticality, DB-free tests, with a 60-second
+suite wall-time budget. See the skill doc for the full eligibility rules, the canary
+safety lint, and the gating contract — this doc only concerns itself with the naming
+and exclusion mechanics.
+
+Because the canary suite has its own dedicated entry point (a distinct npm script or
+Playwright project) and must never reuse `test:smoke`, `*.canary.test.ts` files must
+also stay out of the default `bun test` scan — identical rationale to the existing
+`*.spec.ts` / `*.e2e.ts` exclusions.
+
+## Runner-exclusion config (`bunfig.toml`)
+
+`bunfig.toml`'s `[test]` section lists `pathIgnorePatterns` — globs the root `bun test`
+scan skips entirely. Each entry corresponds to a suffix in the table above that is
+handled by a different runner (Playwright) or reserved for a not-yet-built dedicated
+entry point (canary):
+
+| Pattern | Excludes | Why |
+|---|---|---|
+| `**/site/**` | `site/**/*.spec.ts` | Astro marketing site's Playwright suite; run via `cd site && npm test`, not `bun test`. Bun would otherwise try to execute Playwright specs and crash. |
+| `**/metrics/e2e/**` | `metrics/e2e/*.e2e.ts` | Metrics dashboard's Playwright E2E suite; run via `task e2e` / `bunx playwright test`, not `bun test`. |
+| `**/admin/e2e/**` | `admin/e2e/*.e2e.ts` | Admin UI's Playwright E2E suite; run via `cd admin && bunx playwright test`, not `bun test`. |
+| `**/*.canary.test.ts` | any `*.canary.test.ts` file, anywhere | Reserved for the future canary suite's dedicated entry point (`canary-execution` skill contract). Canary tests must never run via the default `bun test` scan — same rationale as the e2e exclusions, added proactively even though no file currently matches this glob. |
+
+Unit, integration, smoke, and content suffixes have **no** `pathIgnorePatterns` entry —
+they are exactly the suffixes the root `bun test` scan is meant to discover and run.
+
+## Collision rules
+
+1. **One suffix per file.** A test file must match exactly one row in the suffix table.
+   A filename like `foo.unit.integration.test.ts` is invalid — pick one layer.
+2. **Reserved suffixes must not collide with layer suffixes.** `.canary.` is reserved
+   specifically because it does not overlap with any existing `.unit.`/`.integration.`/
+   `.smoke.`/`.content.` infix, and `*.canary.test.ts` does not match any existing
+   `*.spec.ts`/`*.e2e.ts` glob.
+3. **Exclusion config must stay in sync with this doc.** Any new reserved or runner-owned
+   suffix added here must have a matching `pathIgnorePatterns` entry in `bunfig.toml` in
+   the same change — and vice versa. This doc and `bunfig.toml` are verified together by
+   `plugins/shipwright/test/test-naming-convention.content.test.ts`.
+4. **Bare `*.test.ts` files (no layer suffix) are a known pre-M1 gap.** A small number of
+   existing files predate this convention and have not yet been renamed to a layer
+   suffix: `brand/brand-lint.test.ts`, `brand/build-brand-css.test.ts`,
+   `scripts/sync-version.test.ts`. Renaming them is out of scope for this doc — it is a
+   later test-readiness rename task's job (T-002+). They are not currently excluded from
+   `bun test` and continue to run; they are noted here only so a future rename task has a
+   starting inventory.
+
+## References
+
+- [`test-system.md`](./test-system.md) — the authoritative blueprint: layer boundary
+  rules, per-component speed budgets, CI pipeline shape, and the full isolation contract.
+- [`docs/testing.md`](../testing.md) — the digest doc: layer table, run commands, and
+  CI gates.
+- [`plugins/shipwright/skills/canary-execution/SKILL.md`](../../plugins/shipwright/skills/canary-execution/SKILL.md) —
+  the canary-execution contract: dedicated entry point, `TEST_TARGET_URL` mode
+  selection, eligibility rules, the canary safety lint, and the 60-second suite budget.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,7 @@ The marketing site is **not** part of the root `bun test` scan — run its Playw
 cd site && npm test                  # playwright (*.spec.ts)
 ```
 
-> `bunfig.toml` excludes `site/**`, `metrics/e2e/**`, and `admin/e2e/**` from the root runner. Keep site tests as `*.spec.ts` and E2E tests as `*.e2e.ts` to stay isolated — Bun would otherwise try to execute Playwright specs and crash.
+> `bunfig.toml` excludes `site/**`, `metrics/e2e/**`, `admin/e2e/**`, and `**/*.canary.test.ts` from the root runner. Keep site tests as `*.spec.ts` and E2E tests as `*.e2e.ts` to stay isolated — Bun would otherwise try to execute Playwright specs and crash. Canary tests are reserved for the canary-execution skill and run via their own entry point.
 
 ### Per-component layers
 

--- a/plugins/shipwright/test/test-naming-convention.content.test.ts
+++ b/plugins/shipwright/test/test-naming-convention.content.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Test naming-convention + runner-exclusion doc — T-001 (M1 infra baseline)
+ *
+ * Verifies docs/test-readiness/naming.md exists and documents all five
+ * established test-suffix layers plus the new reserved `.canary.` suffix,
+ * and that bunfig.toml's [test] pathIgnorePatterns excludes the e2e globs
+ * plus the new reserved canary test glob — keeping the doc and the actual
+ * runner-exclusion config in sync.
+ *
+ * Content-assertion only: readFileSync, no I/O beyond local file reads.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/test/ → repo root
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+function repoPath(...parts: string[]): string {
+  return join(repoRoot, ...parts);
+}
+
+const NAMING_DOC_PATH = "docs/test-readiness/naming.md";
+
+const ESTABLISHED_SUFFIXES = [
+  ".unit.test.ts",
+  ".integration.test.ts",
+  ".smoke.test.ts",
+  ".content.test.ts",
+  ".spec.ts",
+  ".e2e.ts",
+] as const;
+
+const RESERVED_SUFFIX = ".canary.";
+
+const REQUIRED_IGNORE_PATTERNS = [
+  "**/site/**",
+  "**/metrics/e2e/**",
+  "**/admin/e2e/**",
+  "**/*.canary.test.ts",
+] as const;
+
+/**
+ * Extract the pathIgnorePatterns array from bunfig.toml.
+ *
+ * bunfig.toml has no TOML parser dependency in this repo (checked
+ * package.json / bun.lock), and the [test] section's array is a simple
+ * single-line array — a line-scan against the known format is acceptable
+ * per the current file structure.
+ */
+function readPathIgnorePatterns(): string[] {
+  const raw = readFileSync(repoPath("bunfig.toml"), "utf8");
+  const match = raw.match(/pathIgnorePatterns\s*=\s*\[([^\]]*)\]/);
+  if (!match) {
+    throw new Error("bunfig.toml: could not find pathIgnorePatterns array");
+  }
+  return match[1]
+    .split(",")
+    .map((entry) => entry.trim().replace(/^["']|["']$/g, ""))
+    .filter((entry) => entry.length > 0);
+}
+
+describe("test naming-convention + runner-exclusion doc (T-001)", () => {
+  it("docs/test-readiness/naming.md exists", () => {
+    expect(existsSync(repoPath(NAMING_DOC_PATH))).toBe(true);
+  });
+
+  const body = existsSync(repoPath(NAMING_DOC_PATH))
+    ? readFileSync(repoPath(NAMING_DOC_PATH), "utf8")
+    : "";
+
+  for (const suffix of ESTABLISHED_SUFFIXES) {
+    it(`naming.md mentions the established suffix '${suffix}'`, () => {
+      expect(body).toContain(suffix);
+    });
+  }
+
+  it(`naming.md mentions the reserved suffix '${RESERVED_SUFFIX}'`, () => {
+    expect(body).toContain(RESERVED_SUFFIX);
+  });
+
+  it("naming.md documents the reserved canary suffix as not yet in use", () => {
+    expect(body.toLowerCase()).toContain("reserved");
+  });
+
+  it("bunfig.toml pathIgnorePatterns contains all required exclusion globs", () => {
+    const patterns = readPathIgnorePatterns();
+    for (const required of REQUIRED_IGNORE_PATTERNS) {
+      expect(patterns).toContain(required);
+    }
+  });
+});

--- a/plugins/shipwright/test/test-naming-convention.content.test.ts
+++ b/plugins/shipwright/test/test-naming-convention.content.test.ts
@@ -10,7 +10,7 @@
  * Content-assertion only: readFileSync, no I/O beyond local file reads.
  */
 import { describe, expect, it } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 // plugins/shipwright/test/ → repo root
@@ -60,6 +60,62 @@ function readPathIgnorePatterns(): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+// Minimal glob matcher for bunfig.toml's pathIgnorePatterns entries, all of
+// which are shaped like a leading globstar segment, a literal segment, then
+// a trailing globstar segment (e.g. site, metrics/e2e, or a *.suffix glob).
+// A leading globstar segment matches zero or more leading path segments
+// (including none); a trailing one matches zero or more trailing segments;
+// a bare asterisk within a segment matches any run of non-separator
+// characters. Scoped narrowly to verifying bunfig.toml's actual exclusion
+// behavior — not a general-purpose glob engine.
+function matchesGlob(path: string, pattern: string): boolean {
+  let core = pattern;
+  const hasLeadingGlobstar = core.startsWith("**/");
+  if (hasLeadingGlobstar) core = core.slice(3);
+  const hasTrailingGlobstar = core.endsWith("/**");
+  if (hasTrailingGlobstar) core = core.slice(0, -3);
+
+  const escaped = core
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, "[^/]*");
+  const prefixRe = hasLeadingGlobstar ? "(?:.*/)?" : "";
+  const suffixRe = hasTrailingGlobstar ? "(?:/.*)?" : "";
+  return new RegExp(`^${prefixRe}${escaped}${suffixRe}$`).test(path);
+}
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "coverage",
+]);
+
+/** Recursively collect every *.test.ts / *.spec.ts / *.e2e.ts path, relative to repoRoot. */
+function collectTestFiles(dir: string, relDir = ""): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(join(dir, relDir))) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const relPath = relDir ? `${relDir}/${entry}` : entry;
+    const absPath = join(dir, relPath);
+    if (statSync(absPath).isDirectory()) {
+      results.push(...collectTestFiles(dir, relPath));
+    } else if (/\.(test\.ts|spec\.ts|e2e\.ts)$/.test(entry)) {
+      results.push(relPath);
+    }
+  }
+  return results;
+}
+
+/** Whether a relative test-file path is a reserved/runner-owned suffix that must never run under default `bun test`. */
+function isReservedOrRunnerOwned(relPath: string): boolean {
+  return (
+    relPath.endsWith(".spec.ts") ||
+    relPath.endsWith(".e2e.ts") ||
+    relPath.endsWith(".canary.test.ts")
+  );
+}
+
 describe("test naming-convention + runner-exclusion doc (T-001)", () => {
   it("docs/test-readiness/naming.md exists", () => {
     expect(existsSync(repoPath(NAMING_DOC_PATH))).toBe(true);
@@ -88,5 +144,20 @@ describe("test naming-convention + runner-exclusion doc (T-001)", () => {
     for (const required of REQUIRED_IGNORE_PATTERNS) {
       expect(patterns).toContain(required);
     }
+  });
+
+  it("bunfig.toml's pathIgnorePatterns exclude exactly the reserved/runner-owned files across the real repo tree — no unexpected file paths either way", () => {
+    const patterns = readPathIgnorePatterns();
+    const allTestFiles = collectTestFiles(repoRoot);
+
+    const mismatches = allTestFiles
+      .map((relPath) => {
+        const isExcluded = patterns.some((p) => matchesGlob(relPath, p));
+        const shouldBeExcluded = isReservedOrRunnerOwned(relPath);
+        return { relPath, isExcluded, shouldBeExcluded };
+      })
+      .filter((r) => r.isExcluded !== r.shouldBeExcluded);
+
+    expect(mismatches).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add `docs/test-readiness/naming.md`, the authoritative M1 reference for "file suffix → layer" naming and which suffixes the default `bun test` runner must not discover. Reserves a new `.canary.` suffix for the future canary suite, ahead of any concrete canary test file.
- Update `bunfig.toml`'s `pathIgnorePatterns` to add `**/*.canary.test.ts`, keeping it in sync with the doc's exclusion contract (e2e via `site/**`, `metrics/e2e/**`, `admin/e2e/**` was already excluded).
- Add `plugins/shipwright/test/test-naming-convention.content.test.ts`, which both string-checks doc/config sync and walks the real repo file tree to confirm `bunfig.toml`'s exclusion patterns match exactly the e2e/canary suffixes and nothing else.
- Refresh `docs/testing.md`'s `bunfig.toml` reference line to mention the new canary exclusion (auto-docs pass).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Naming-convention + runner-exclusion doc is written; bunfig.toml pathIgnorePatterns confirmed to match it (unit/integration/smoke via suffix, canary via new `.canary.` suffix reserved, E2E via `*.spec.ts`/`*.e2e.ts` excluded) | MET | `docs/test-readiness/naming.md` + `bunfig.toml` change + repo-wide behavioral test, all passing. |
| 2 | Verification command shows no unexpected file paths (empty diagnostic output beyond bun's own summary lines) | MET | The task's stored verification command has a pre-existing Bun CLI syntax issue (`--filter` isn't a real `bun test` flag) that reproduces identically on `main`, unrelated to this change. The underlying intent is verified directly by the new repo-wide test and by `bun test unit.test.ts`, which cleanly runs exactly the 99 existing unit test files. |

## Test Plan
- [x] `NODE_ENV=test bun test` — 3844 pass / 0 fail / 242 skip (full suite, unrelated skips are pre-existing DB-gated integration tests)
- [x] `bunx biome lint .` — clean
- [x] `bun run --filter='*' --sequential typecheck` — clean across all 7 packages
- [x] `task check-strings` / `task check-version-sync` — clean
- [x] `task test:coverage` — 79.17% lines / 81.04% functions, below the 80/80 gate but byte-identical to a clean `main` run in this sandbox (no test DB env vars configured here, so DB-backed integration tests skip) — pre-existing, not introduced by this change
- [x] New content test (`test-naming-convention.content.test.ts`, 11 assertions) passes, including a repo-wide walk confirming `bunfig.toml`'s exclusion patterns match the real file tree exactly

Generated with [Claude Code](https://claude.com/claude-code)
