### PR TITLE
chore(chart): bump chart version to 1.6.372

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.372] - 2026-07-15
+
+### Changed
+
+- auto-bump to chart v1.6.372 triggered by release tag(s): `agent-v0.181.0`, `task-store-v0.92.0`
+
 ## [1.6.371] - 2026-07-15
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.371
+version: 1.6.372
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,7 +29,9 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.371 triggered by release tag admin-v0.194.1"
+      description: "auto-bump to chart v1.6.372 triggered by release tag agent-v0.181.0"
+    - kind: changed
+      description: "auto-bump to chart v1.6.372 triggered by release tag task-store-v0.92.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -298,7 +298,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v0.180.2
+    tag: agent-v0.181.0
     pullPolicy: ""
   service:
     port: 3000
@@ -321,7 +321,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v0.180.2
+      tag: agent-v0.181.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).
@@ -520,7 +520,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v0.91.0
+    tag: task-store-v0.92.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.6.371 → 1.6.372

**Triggering tags:**
- `agent-v0.181.0`
- `task-store-v0.92.0`

**New chart version:** `1.6.372`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v0.181.0`
- `agent.provisioning.image.tag`: `agent-v0.181.0`
- `taskStore.image.tag`: `task-store-v0.92.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.372 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._