### PR TITLE
feat: repoint admin task-detail Added field from addedAt to createdAt

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -222,7 +222,6 @@ export interface TaskItem {
   complexity?: number | null;
   hitl?: boolean | null;
   hours?: number | null;
-  addedAt?: string | null;
   startedAt?: string | null;
   completedAt?: string | null;
   blockedAt?: string | null;
@@ -1881,7 +1880,7 @@ export function renderTaskDetailPage(
     .join("\n");
 
   const datesRows = [
-    dateField("Added", task.addedAt),
+    dateField("Added", task.createdAt),
     dateField("Started", task.startedAt),
     dateField("Claimed", task.claimedAt),
     dateField("Last Heartbeat", task.heartbeatAt),

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2444,7 +2444,7 @@ describe("renderTaskDetailPage — timezone formatting", () => {
         id: "TZ-1",
         title: "Timezone test",
         status: "pending",
-        addedAt: "2025-01-16T05:00:00Z", // Jan 16 UTC, Jan 15 Pacific
+        createdAt: "2025-01-16T05:00:00Z", // Jan 16 UTC, Jan 15 Pacific
       },
       "user@example.com",
       {},
@@ -2463,7 +2463,7 @@ describe("renderTaskDetailPage — timezone formatting", () => {
         id: "TZ-2",
         title: "Timezone test UTC",
         status: "pending",
-        addedAt: "2025-01-16T05:00:00Z",
+        createdAt: "2025-01-16T05:00:00Z",
       },
       "user@example.com",
       {},


### PR DESCRIPTION
## Summary
- Repoints the admin task-detail "Added" date field from `task.addedAt` to `task.createdAt` — same displayed concept, now sourced from the DB-guaranteed field
- Removes `addedAt` from the `TaskItem` interface in `admin-ui-pages.ts` since it's no longer referenced in this file (`createdAt` was already present, used by an existing separate "Created" field)
- Part of Group 4 (LPF-4.x) removing the `addedAt` field entirely in favor of `createdAt`, per `planning/loop-fixes/PLAN.md`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Interface types createdAt instead of/in addition to addedAt | MET |
| 2 | 'Added' date field renders task.createdAt | MET |
| 3 | addedAt removed from file if unreferenced | MET |
| 4 | Test fixtures/assertions updated addedAt→createdAt (unit-layer) | MET |

## Test Plan
- Updated `admin-ui-pages.unit.test.ts` timezone-formatting fixtures (TZ-1, TZ-2) to use `createdAt` instead of `addedAt`
- `bun test admin/src/admin-ui-pages.unit.test.ts` — 349 pass, 0 fail
- `tsc --noEmit` in `admin/` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
