### PR TITLE
fix(admin): widen agent probe timeoutSeconds 5s -> 15s as a bridge to SIO-1.2

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -389,16 +389,20 @@ export function buildAgentDeploymentManifest(
                 initialDelaySeconds: 15,
                 periodSeconds: 30,
                 // Explicit, not the 1s k8s default — the health server shares
-                // its process with claude -p child spawns and GitHub API
-                // calls, which can transiently delay a response past 1s.
-                timeoutSeconds: 5,
+                // its process with claude -p child spawns and check-helpers.ts's
+                // spawnSync("gh", ...) calls, which block the whole process for
+                // the duration of the gh CLI call (network round-trip to GitHub,
+                // not just local CPU work). 15s is a bridge until SIO-1.2 converts
+                // those to async spawn; no fixed timeout is truly safe against a
+                // slow gh response, so this isn't a permanent fix.
+                timeoutSeconds: 15,
                 failureThreshold: 3,
               },
               readinessProbe: {
                 httpGet: { path: "/health", port: AGENT_HEALTH_PORT },
                 initialDelaySeconds: 10,
                 periodSeconds: 10,
-                timeoutSeconds: 5,
+                timeoutSeconds: 15,
                 failureThreshold: 3,
               },
               securityContext: {

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -160,10 +160,10 @@ describe("buildAgentDeploymentManifest", () => {
     expect(AGENT_HEALTH_PORT).toBe(3459);
     expect(c.livenessProbe?.httpGet?.port).toBe(3459);
     expect(c.livenessProbe?.failureThreshold).toBe(3);
-    expect(c.livenessProbe?.timeoutSeconds).toBe(5);
+    expect(c.livenessProbe?.timeoutSeconds).toBe(15);
     expect(c.readinessProbe?.httpGet?.port).toBe(3459);
     expect(c.readinessProbe?.failureThreshold).toBe(3);
-    expect(c.readinessProbe?.timeoutSeconds).toBe(5);
+    expect(c.readinessProbe?.timeoutSeconds).toBe(15);
   });
 
   it("gates liveness/readiness with a startupProbe granting ~180s for a slow mise startup", () => {


### PR DESCRIPTION
## Summary
- #1567's 5s timeout wasn't enough — doc, warchild, and the-dude kept tripping liveness/readiness restarts even with 5s of slack.
- Root cause traced further: `check-helpers.ts`'s `gh` CLI wrappers (`ghGraphql`/`ghJson`, used by the loop-orchestrator's candidate qualification) use `spawnSync`, which blocks the **entire agent process** — health server included — for the duration of the `gh` CLI call. That's a network round-trip to GitHub's API, not local CPU work, and can legitimately exceed 5s under normal latency, more so for an agent with a large active-task/PR backlog making more `gh` calls per loop tick.
- This is a stopgap while `SIO-1.2` (convert `check-helpers.ts` to async spawn) lands — no fixed timeout is truly safe against a slow enough `gh` response, but 15s absorbs the common case without approaching `periodSeconds` (30s liveness / 10s readiness).

## Test plan
- [x] `bun test admin/src/agent-manifest.unit.test.ts` — 48 pass, updated assertions for `timeoutSeconds: 15`
- [x] `node_modules/.bin/biome check` on changed files — clean
- [ ] Once deployed and live-patched onto doc/warchild/the-dude, confirm restart counts stabilize while SIO-1.1–1.4 land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SewZ6gtBYtyHeKTa81UeVd