### PR TITLE
docs: stop writing addedAt in every task-creation template/doc

### DIFF
--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -377,7 +377,6 @@ Write the tasks to `/tmp/new-tasks-{session}.json`. Set `source` to `"planning/{
     "status": "pending",
     "hitl": false,
     "pr": null,
-    "addedAt": "{ISO timestamp}",
     "hours": 2,
     "complexity": {complexity},
     "model": "{model}"

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -193,7 +193,6 @@ detected in 6q.1 — do not re-derive them:
   "layer": "Shared",
   "status": "pending",
   "hitl": <true | false — computed per Step 6q.4>,
-  "addedAt": "<current ISO timestamp>",
   "description": "<findings summary — see below>"
 }
 ```

--- a/plugins/shipwright/skills/error-fix/SKILL.md
+++ b/plugins/shipwright/skills/error-fix/SKILL.md
@@ -257,7 +257,6 @@ For each issue with a primary fix task to queue:
   "layer": "Background",
   "status": "pending",
   "hitl": <true | false — computed per Step 6>,
-  "addedAt": "<current ISO timestamp>",
   "description": "<see below>"
 }
 ```
@@ -275,7 +274,6 @@ For each companion observability-fix task to queue:
   "status": "pending",
   "hitl": <true | false — computed per Step 7>,
   "dependencies": [],
-  "addedAt": "<current ISO timestamp>",
   "description": "<see below>"
 }
 ```

--- a/plugins/shipwright/skills/task-store/references/task-schema.md
+++ b/plugins/shipwright/skills/task-store/references/task-schema.md
@@ -36,7 +36,6 @@ contract: the same shape whether the backend is GitHub Issues, Jira, or the loca
 ### Lifecycle timestamps & PR linkage
 | field | type | set when |
 |---|---|---|
-| `addedAt` | ISO string | task created |
 | `startedAt` | ISO string | → `in_progress` |
 | `pr` | number | → `pr_open` (PR number) |
 | `prUrl` | string | → `pr_open` (alternative to `pr`) |

--- a/plugins/shipwright/skills/test-fix/SKILL.md
+++ b/plugins/shipwright/skills/test-fix/SKILL.md
@@ -140,7 +140,6 @@ and `repo-slug` values detected in Step 3 — do not re-derive them:
   "status": "pending",
   "hitl": <true | false — computed per 5.2>,
   "dependencies": ["test-{predecessor-t-nnn}-{repo-slug}", "..."],
-  "addedAt": "<current ISO timestamp>",
   "acceptanceCriteria": ["...", "Verification command `{verify}` passes"],
   "description": "<see 5.3>"
 }

--- a/plugins/shipwright/skills/test-fix/references/backfill-from-github.md
+++ b/plugins/shipwright/skills/test-fix/references/backfill-from-github.md
@@ -76,7 +76,6 @@ plan row:
   "status": "pending",
   "hitl": <true | false — same classification rules as 5.2, applied to the issue's content>,
   "dependencies": ["test-{predecessor-t-nnn}-{repo-slug}", "..."],
-  "addedAt": "<current ISO timestamp>",
   "acceptanceCriteria": ["<parsed from the issue's Acceptance criteria checklist>", "Verification command `{verify}` passes"],
   "description": "<same shape as 5.3, sourced from the issue body's Expected outcome / Files to touch / Audit decisions / Context sections>"
 }


### PR DESCRIPTION
## Summary
- Removed the `addedAt` field/instruction from every task-creation JSON template in `plugins/shipwright/` (plan-session, entropy-fix, error-fix, test-fix, and its backfill-from-github reference)
- Removed the `addedAt` row from `task-schema.md`'s Lifecycle timestamps table, since it documented the same "task created" semantics as `createdAt`
- Prepares for LPF-4.6 (dropping the `addedAt` column) — stale templates still sending `addedAt` against a schema without the column would 500 on task-store's create/bulk endpoints

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | No task-creation JSON template across the listed files includes an addedAt field or instruction to set one | MET | 7 addedAt lines removed across plan-session.md, entropy-fix/SKILL.md, error-fix/SKILL.md (×2), test-fix/SKILL.md, test-fix/references/backfill-from-github.md |
| 2 | task-schema.md no longer lists addedAt as a Task field | MET | Lifecycle timestamps table row for addedAt removed |
| 3 | No addedAt reference remains in plugins/shipwright/ task-creation templates or task-schema.md (grep-verified) | MET | grep confirms zero hits in scope; check-helpers.ts's `addedAt?: string` type field is correctly out of scope (DB column, dropped separately in LPF-4.6) |

## Test Plan
- Markdown/reference-doc-only change — no code or test layer applies
- Verified via `grep -rn "addedAt" plugins/shipwright/` that no reference remains outside the expected LPF-4.6-scoped `check-helpers.ts` type definition
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
