### PR TITLE
feat: surface design ambiguity explicitly in plan-session Step 4

### DIFF
--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -152,6 +152,7 @@ Also include:
 - **Per-layer test reasoning** — if the spec has a Testing Strategy section, adopt it directly rather than re-deriving: confirm the layer assignments make sense given the codebase findings in Step 2, note any disagreements, and proceed with the spec's strategy unless a concrete technical reason overrides it. If Testing Strategy is absent, derive it from scratch using the layer definitions loaded in Step 2.
 
 Keep it simple. If two approaches exist, recommend one and explain why.
+If the spec is ambiguous or silent on a decision that affects the design, state the assumption you're making and flag it explicitly for confirmation during this feedback loop — don't pick an interpretation silently.
 
 Iterate on feedback. Do not move to task breakdown until the design is approved.
 


### PR DESCRIPTION
## Summary
- Adds a bullet to Step 4 ("Propose a Design") of `plan-session.md` instructing the planner to state assumptions explicitly and flag them for human confirmation when the spec is silent on a design-relevant decision, rather than silently picking an interpretation.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New bullet positioned right after "If two approaches exist, recommend one and explain why." | MET | Diff adds the line immediately after that sentence |
| 2 | Exact bullet text as specified | MET | Added text matches verbatim |
| 3 | No other prose changed; no edits to dev-task.md, principles.md, prd.md | MET | Only plan-session.md touched, 1 insertion |
| 4 | No test layer applies (prose-only file) | MET | No companion test file exists; none added |

## Test Plan
- N/A — prose-only markdown instruction change, no executable logic
- [x] `bunx biome lint` clean
- [x] `check-banned-strings.ts` clean

Generated with [Claude Code](https://claude.com/claude-code)
