### PR TITLE
feat: link homepage to /vs/devin and /self-hosted (DVN-4.1)

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -383,6 +383,11 @@ const differentiators = [
       infrastructure, fork it if you want to — the wedge is price,
       ownership, and control.
     </p>
+    <p class="mt-4">
+      <a href="/vs/devin">See the full Shipwright vs Devin comparison →</a>
+      <span class="mx-2" style="color: var(--sw-color-text-muted);">·</span>
+      <a href="/self-hosted">What "self-hosted" actually means →</a>
+    </p>
   </section>
 
   <!-- Showcase: four tabbed panels (Two ways · Crons · Metrics · Demo).

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -124,6 +124,21 @@ test("hero features the intro video as its centerpiece", async ({ page }) => {
   ).toBeVisible();
 });
 
+// DVN-4.1: the "Own it" section links prominently to the two comparison
+// pages once they exist (avoids a dead-link window in production).
+test("'Own it' section links to /vs/devin and /self-hosted", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const section = page.locator("#own-it");
+  await expect(
+    section.getByRole("link", { name: /Shipwright vs Devin comparison/i }),
+  ).toHaveAttribute("href", "/vs/devin");
+  await expect(
+    section.getByRole("link", { name: /self-hosted.*actually means/i }),
+  ).toHaveAttribute("href", "/self-hosted");
+});
+
 test("page does NOT contain the string 'Autonomous programming, installed'", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Adds two links from the homepage "Own it" section to `/vs/devin` and `/self-hosted`, now that both pages exist (deferred in DVN-1.4 to avoid a dead-link window).
- Extends `home.spec.ts` with an assertion that both links are present and resolve correctly.

## Test plan
- [x] `npm run build` — succeeds
- [x] `npx playwright test` — 155/155 pass
- [x] `npm run brand-lint` — on-brand
- [x] `task check-strings` — no banned strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBSuGGLNGdei3gbEDzFvaC