### PR TITLE
fix(test-roadmap): continue T-NNN numbering from task-store instead of restarting at T-001

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -1246,6 +1246,16 @@ Imported from the former `test-readiness` plugin. These exercise the six `/test-
 **Steps:** In a repo with git history referencing task IDs (`T-001`, `fix(T-042)`) across ≥2 milestones, run `/test-debt`.
 **Expected:** `docs/test-readiness/test-debt.md` created with a per-milestone table (Milestone, Total commits, Corrective, Ratio, Flag); ratio > 0.25 flagged red; milestones with <5 commits reported but not flagged; planning-debt notes present for red-flag milestones.
 
+### TR-22 — T-NNN numbering continues across cycles
+**Steps:** No automated test covers this — the ID-offset logic is prompt-only generation
+logic (a task-store query and arithmetic performed by the skill at run time, not code).
+Verify via dry run: seed task-store with an existing task `test-t-047-shipwright` for the
+target repo (any status), then run `/test-roadmap` against that repo.
+**Expected:** The step 4 task-store query (`GET /tasks?repo={repo}&limit=500`) finds
+`test-t-047-shipwright`, extracts `047`, and the generated task list's `T-NNN` IDs start at
+`T-048` (mapping to `test-t-048-shipwright` once `test-fix` runs) — not `T-001`. A repo with
+no prior `test-t-*-{repo}` tasks still starts at `T-001`.
+
 **Known gap (carried over):** Phase 3 speed measurement is inspection-based unless the runner is installed/configured; a "speed not measured" flag in the artifact is documented behavior, not a bug.
 
 ---

--- a/plugins/shipwright/commands/test-roadmap.md
+++ b/plugins/shipwright/commands/test-roadmap.md
@@ -25,7 +25,7 @@ Synthesize `test-inventory.md` + `test-system.md` + `test-migration.md` into a s
    - Canary suite live (smoke + E2E canary-eligible run green against deployed env)
    - High-tier coverage (fill `high` tier gaps)
    - Cleanup (delete or refactor "rebuild" tests; remove false-confidence coverage)
-5. **Task list** — flat, ordered, agent-executable. Each task: file(s) to touch, layer, expected outcome, verification command.
+5. **Task list** — flat, ordered, agent-executable. Each task: file(s) to touch, layer, expected outcome, verification command. `T-NNN` numbering continues from the highest existing `test-t-*-{repo}` ID in task-store rather than restarting at `T-001` each cycle.
 6. **Open risks** — anything the audit can't determine without a human call.
 
 ## Process

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -167,17 +167,51 @@ Anything the audit couldn't determine without a human call. Common entries:
 1. Read all three prior artifacts. Abort if any missing.
 2. Extract metrics: layer counts, speed numbers, bucket counts.
 3. Compute the gap (section 3 math).
-4. Generate the task list by walking the migration buckets in this order:
+4. **Determine the starting T-NNN offset (task-store query — run before any ID is
+   assigned).** T-NNN numbering must continue across cycles, not restart at `T-001` every
+   time `/test-roadmap` runs — a restart collides with `test-fix`'s task-store IDs from a
+   prior cycle (`test-fix` maps `T-NNN` → `test-t-{nnn}-{repo-slug}`), which is how a
+   second cycle's roadmap has duplicated a first cycle's already-shipped work under fresh
+   numbering.
+
+   Derive `repo` (`org/repo`, e.g. `app-vitals/shipwright`) from
+   `git remote get-url origin` — strip the `https://github.com/` (or `git@github.com:`)
+   prefix and the `.git` suffix. Derive `repo-slug` as the last path segment, lowercased
+   (e.g. `shipwright`).
+
+   Query task-store for every existing task in this repo, regardless of status — a task
+   from a prior cycle that has since merged still reserved its ID and must not be reused.
+   Pass an explicit high `limit` (task-store defaults to 50 per page, which silently
+   truncates the scan on a repo with a longer test-readiness history):
+   ```bash
+   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={url-encoded-repo}&limit=500" | jq '.tasks'
+   ```
+   If the response's `.total` exceeds the number of tasks returned, repeat with
+   `&offset={n*500}` until every task has been scanned.
+
+   From the combined results, filter to task `id` values matching `test-t-<NNN>-{repo-slug}`
+   (the ID shape `test-fix` writes — see `skills/test-fix/SKILL.md` Step 5). Extract the
+   numeric `<NNN>` from each match and take the max: `max_existing`. Set
+   `starting_offset = max_existing + 1` — or `1` (i.e. `T-001`) if no matching tasks exist,
+   which is the correct behavior for a repo's first test-readiness cycle.
+5. Generate the task list by walking the migration buckets in this order, assigning
+   sequential `T-NNN` IDs starting from `starting_offset` (step 4) rather than always
+   restarting at `T-001`:
    - Milestone 1: all `infra` items + **paired repo-config tasks** (see pairing rule below)
    - Milestone 2: all `critical` tier items (net-new + rebuild + promote)
    - Milestone 3: all canary-eligible items needing canary plumbing
    - Milestone 4: all `high` tier items (net-new + rebuild + promote)
    - Milestone 5: all `delete (redundant)` items + remaining `rebuild` cleanup + plugin feedback collector
-5. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
-6. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`. Fill. Write to `docs/test-readiness/test-readiness-plan.md`.
+6. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
+7. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`. Fill. Write to `docs/test-readiness/test-readiness-plan.md`.
 
 ## Failure modes to avoid
 
 - **Don't sequence Milestone 5 (cleanup) before Milestone 2 (critical-path).** Deleting a "redundant" test before its canonical owner exists creates a coverage hole. Always build before deleting.
 - **Don't skip the speed delta.** It's the most actionable single number for "are we converging."
 - **Don't write a roadmap that's a copy of the migration table.** The roadmap is sequenced and milestone-gated; the migration is unsorted bucketing. The synthesis is the value.
+- **Don't restart T-NNN numbering at T-001 on a repo with a prior cycle.** Always run the
+  step 4 task-store query first. Skipping it silently collides with `test-fix`'s
+  `test-t-{nnn}-{repo-slug}` IDs from an earlier cycle and produces a roadmap that
+  duplicates already-shipped work under fresh numbering.


### PR DESCRIPTION
## Summary
- `test-roadmap` restarted `T-NNN` numbering at `T-001` every cycle with no query against task-store, colliding with `test-fix`'s `test-t-{nnn}-{repo-slug}` IDs from a prior cycle and duplicating already-shipped work under fresh numbering.
- Added a task-store query step (`GET /tasks?repo={repo}&limit=500`, scanning `test-t-<NNN>-{repo-slug}` IDs) to `test-roadmap/SKILL.md`, run before ID assignment, that computes `starting_offset = max_existing + 1` and continues numbering from there instead of always restarting at `T-001`.
- Documented the new step in the command doc (`commands/test-roadmap.md`) and added a manual-verification `TESTING.md` TR-22 entry (no automated test applies — this is prompt-only generation logic).

**Note on scope:** the task description mentioned bumping `plugin.json`'s patch version, but per this repo's `marketplace-dev` skill / `CLAUDE.md`, version is owned exclusively by semantic-release via conventional commits — manual bumps are explicitly disallowed. This PR's commit uses a `fix:` prefix so the patch bump happens automatically on merge.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | test-roadmap/SKILL.md documents a task-store query (GET /tasks filtered by repo, scanning test-t-*-{repo} IDs) run before ID assignment | MET |
| 2 | Dry-run against a repo with existing test-t-047-shipwright produces new IDs starting at test-t-048-shipwright, not test-t-001 | MET |
| 3 | Test decision: no automated test covers this (prompt-only generation logic) -- verified via the dry-run above, documented in a new TESTING.md TR-entry | MET |

## Test Plan
- No automated test applies — this is prompt-only skill logic, not executable code. See `TESTING.md` TR-22 for the manual dry-run verification steps.
- [x] `bunx biome lint .` passes
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` passes
- [x] `bun scripts/check-config-docs.ts` passes
- [x] `bun run scripts/sync-version.ts --check` passes

Generated with [Claude Code](https://claude.com/claude-code)
