### PR TITLE
feat: add sort query param to task-store GET /prs

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -25,7 +25,7 @@ List pull requests
 - **Method:** GET
 - **Path:** `/prs`
 - **Has body:** No
-- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query), `ready` (query)
+- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query)
 
 ## `prs_update`
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -165,9 +165,11 @@ The `/prs` surface tracks GitHub PRs through the review → patch → deploy pip
 GET /prs
 ```
 
-Query params: `repo`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`, `ready`.
+Query params: `repo`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`, `ready`, `sort`.
 
 `ready=true` returns only unclaimed PRs (`claimedBy IS NULL`) — mirrors `/tasks?ready=true`'s semantics for tasks. It composes with the other filters (e.g. `?ready=true&repo=org/repo`) rather than hardcoding `claim-next`'s `state=open AND reviewState IN (pending, posted, approved)` eligibility rules; claim staleness itself is handled entirely by the `StaleClaimReaper` background job, not by this filter.
+
+`sort` orders results by `createdAt`: `asc` (default, oldest first — current behavior for every existing caller) or `desc` (newest first). Unrelated to `claim-next`'s own deterministic ordering, which is a separate, non-configurable `ORDER BY` used for phase-ready claiming.
 
 Returns `{ prs: PullRequest[], total: number, limit: number, offset: number }`.
 

--- a/lib/task-store-types.ts
+++ b/lib/task-store-types.ts
@@ -937,6 +937,8 @@ export interface paths {
                     staged?: "true" | "false";
                     limit?: string;
                     offset?: string;
+                    ready?: "true" | "false";
+                    sort?: "asc" | "desc";
                 };
                 header?: never;
                 path?: never;
@@ -1543,6 +1545,13 @@ export interface components {
             inserted: number;
             /** @example 1 */
             updated: number;
+            /**
+             * @description IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).
+             * @example [
+             *       "entropy-dead_exports-other-repo-2026-W29"
+             *     ]
+             */
+            skipped: string[];
         };
         BulkInsertBody: {
             /** @example Implement feature X */

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -544,6 +544,13 @@ export const generatedTools: GeneratedTool[] = [
             "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
           example: "true",
         },
+        sort: {
+          type: "string",
+          enum: ["asc", "desc"],
+          description:
+            "Order results by createdAt. Default is ascending (asc), preserving current behavior for existing callers. Unrelated to claim-next's own deterministic ordering.",
+          example: "asc",
+        },
       },
       required: [],
       additionalProperties: false,
@@ -560,6 +567,7 @@ export const generatedTools: GeneratedTool[] = [
       "limit",
       "offset",
       "ready",
+      "sort",
     ],
     pathParams: [],
     hasBody: false,

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -1138,6 +1138,20 @@
             "required": false,
             "name": "ready",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Order results by createdAt. Default is ascending (asc), preserving current behavior for existing callers. Unrelated to claim-next's own deterministic ordering.",
+              "example": "asc"
+            },
+            "required": false,
+            "name": "sort",
+            "in": "query"
           }
         ],
         "responses": {

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -531,6 +531,11 @@ export const PrListQuerySchema = z
       description:
         "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
     }),
+    sort: z.enum(["asc", "desc"]).optional().openapi({
+      example: "asc",
+      description:
+        "Order results by createdAt. Default is ascending (asc), preserving current behavior for existing callers. Unrelated to claim-next's own deterministic ordering.",
+    }),
   })
   .openapi("PrListQuery");
 

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -770,6 +770,83 @@ describe("/prs routes (smoke)", () => {
     expect(capturedFilters?.ready).toBeUndefined();
   });
 
+  it("GET /prs?sort=desc wires the sort filter through to the service", async () => {
+    let capturedFilters: PullRequestListFilters | undefined;
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const baseFake = fakePrService({ store });
+    const prServiceWithCapture: PullRequestServiceLike = {
+      ...baseFake,
+      async list(filters?: PullRequestListFilters): Promise<PullRequestListResult> {
+        capturedFilters = filters;
+        return baseFake.list(filters);
+      },
+    };
+    const app = makeApp({ prService: prServiceWithCapture });
+
+    const res = await app.request("/prs?sort=desc", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    expect(capturedFilters?.sort).toBe("desc");
+  });
+
+  it("GET /prs without sort leaves the sort filter undefined (default asc)", async () => {
+    let capturedFilters: PullRequestListFilters | undefined;
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const baseFake = fakePrService({ store });
+    const prServiceWithCapture: PullRequestServiceLike = {
+      ...baseFake,
+      async list(filters?: PullRequestListFilters): Promise<PullRequestListResult> {
+        capturedFilters = filters;
+        return baseFake.list(filters);
+      },
+    };
+    const app = makeApp({ prService: prServiceWithCapture });
+
+    const res = await app.request("/prs", { headers: adminAuth() });
+    expect(res.status).toBe(200);
+    expect(capturedFilters?.sort).toBeUndefined();
+  });
+
+  it("GET /prs?sort=desc round-trips descending order through the route", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set(
+      "pr-1",
+      makePr({ id: "pr-1", prNumber: 1, createdAt: new Date("2026-01-01T00:00:00.000Z") }),
+    );
+    store.set(
+      "pr-2",
+      makePr({ id: "pr-2", prNumber: 2, createdAt: new Date("2026-01-03T00:00:00.000Z") }),
+    );
+    store.set(
+      "pr-3",
+      makePr({ id: "pr-3", prNumber: 3, createdAt: new Date("2026-01-02T00:00:00.000Z") }),
+    );
+    // fakePrService's list() doesn't itself sort — apply the route's sort
+    // filter here to model what the real Prisma-backed service does, so this
+    // test exercises the query-param → filter → response round trip.
+    const baseFake = fakePrService({ store });
+    const prServiceWithSort: PullRequestServiceLike = {
+      ...baseFake,
+      async list(filters?: PullRequestListFilters): Promise<PullRequestListResult> {
+        const result = await baseFake.list(filters);
+        const sorted = [...result.prs].sort((a, b) => {
+          const diff = a.createdAt.getTime() - b.createdAt.getTime();
+          return filters?.sort === "desc" ? -diff : diff;
+        });
+        return { ...result, prs: sorted };
+      },
+    };
+    const app = makeApp({ prService: prServiceWithSort });
+
+    const res = await app.request("/prs?sort=desc", { headers: adminAuth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs.map((p) => p.prNumber)).toEqual([2, 3, 1]);
+  });
+
   it("GET /prs?staged=false returns unstaged records only", async () => {
     const store = new Map<string, PullRequest>();
     store.set("pr-1", makePr({ id: "pr-1", staged: true }));

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -40,6 +40,14 @@ export interface PullRequestListFilters {
    * duplicate that logic, it just reads the current claimedBy column.
    */
   ready?: boolean;
+  /**
+   * Order results by createdAt. Defaults to "asc", preserving current
+   * behavior for every existing caller. Unrelated to claimNext()'s own
+   * deterministic SQL ORDER BY (COALESCE(readyForReviewAt, ...) ASC) used
+   * for phase-ready claiming — claimNext() does not call list() and does not
+   * accept this filter.
+   */
+  sort?: "asc" | "desc";
 }
 
 /** Paginated list result from PullRequestService.list. */
@@ -102,7 +110,7 @@ export class PullRequestService implements PullRequestServiceLike {
     const [prs, total] = await this.prisma.$transaction([
       this.prisma.pullRequest.findMany({
         where,
-        orderBy: { createdAt: "asc" },
+        orderBy: { createdAt: filters.sort ?? "asc" },
         take: limit,
         skip: offset,
       }),

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -135,6 +135,75 @@ describe("PullRequestService.patch()", () => {
   });
 });
 
+describe("PullRequestService.list() sort", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  /**
+   * Prisma double for list(): captures the findMany args (in particular
+   * orderBy) passed by the service, mirroring the $transaction([findMany,
+   * count]) shape list() actually issues.
+   */
+  function makeListPrismaDouble() {
+    const findManyCalls: Array<{ orderBy?: unknown }> = [];
+
+    const prisma = {
+      pullRequest: {
+        findMany(args: { orderBy?: unknown }) {
+          findManyCalls.push(args);
+          return Promise.resolve([]);
+        },
+        count() {
+          return Promise.resolve(0);
+        },
+      },
+      $transaction(ops: Promise<unknown>[]) {
+        return Promise.all(ops);
+      },
+      _findManyCalls: findManyCalls,
+    };
+
+    return prisma as unknown as {
+      pullRequest: {
+        findMany: (args: { orderBy?: unknown }) => Promise<unknown[]>;
+        count: () => Promise<number>;
+      };
+      $transaction: (ops: Promise<unknown>[]) => Promise<unknown[]>;
+      _findManyCalls: Array<{ orderBy?: unknown }>;
+    };
+  }
+
+  test("list({ sort: 'desc' }) orders by createdAt descending", async () => {
+    const prisma = makeListPrismaDouble();
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.list({ sort: "desc" });
+
+    expect(prisma._findManyCalls).toHaveLength(1);
+    expect(prisma._findManyCalls[0].orderBy).toEqual({ createdAt: "desc" });
+  });
+
+  test("list({}) orders by createdAt ascending (current/default behavior)", async () => {
+    const prisma = makeListPrismaDouble();
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.list({});
+
+    expect(prisma._findManyCalls).toHaveLength(1);
+    expect(prisma._findManyCalls[0].orderBy).toEqual({ createdAt: "asc" });
+  });
+
+  test("list({ sort: 'asc' }) orders by createdAt ascending (explicit)", async () => {
+    const prisma = makeListPrismaDouble();
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.list({ sort: "asc" });
+
+    expect(prisma._findManyCalls).toHaveLength(1);
+    expect(prisma._findManyCalls[0].orderBy).toEqual({ createdAt: "asc" });
+  });
+});
+
 describe("PullRequestService.update() merge completion", () => {
   const NOW = new Date("2026-07-10T12:00:00.000Z");
   const clock = FixedClock(NOW);

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -986,6 +986,35 @@ describeOrSkip("PullRequestService.list() and get() (integration)", () => {
     expect(readyResult.prs.some((p) => p.id === claimed.id)).toBe(false);
   });
 
+  it("list({ sort: 'desc' }) orders by createdAt descending; default/asc preserves current order", async () => {
+    const first = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 1060 },
+    });
+    const second = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 1061 },
+    });
+    const third = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 1062 },
+    });
+
+    const ascDefault = await service.list();
+    expect(ascDefault.prs.map((p) => p.id)).toEqual([
+      first.id,
+      second.id,
+      third.id,
+    ]);
+
+    const ascExplicit = await service.list({ sort: "asc" });
+    expect(ascExplicit.prs.map((p) => p.id)).toEqual([
+      first.id,
+      second.id,
+      third.id,
+    ]);
+
+    const desc = await service.list({ sort: "desc" });
+    expect(desc.prs.map((p) => p.id)).toEqual([third.id, second.id, first.id]);
+  });
+
   it("list() without ready returns both claimed and unclaimed PRs (backward compatible)", async () => {
     await prisma.pullRequest.create({
       data: {

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -10,7 +10,7 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState, ?staged, ?ready)
+ *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState, ?staged, ?ready, ?sort)
  *   POST   /prs/claim         atomic claim (201 new, 200 update, 409 conflict)
  *   POST   /prs/claim-next    atomic find-and-claim oldest eligible PR (200+{pr,phase} or 204)
  *   GET    /prs/:id           fetch one (404 when missing)
@@ -290,6 +290,7 @@ export function createPrsRoutes(
     const staged =
       stagedRaw === "true" ? true : stagedRaw === "false" ? false : undefined;
     const ready = c.req.query("ready") === "true" ? true : undefined;
+    const sort = c.req.query("sort") === "desc" ? "desc" : undefined;
 
     const result = await prService.list({
       repo: c.req.query("repo"),
@@ -302,6 +303,7 @@ export function createPrsRoutes(
       reviewState: c.req.query("reviewState"),
       staged,
       ready,
+      sort,
       limit:
         limitRaw !== undefined
           ? Number.parseInt(limitRaw, 10) || undefined


### PR DESCRIPTION
## Summary
- Adds an explicit `sort` query param (`asc`|`desc`, default `asc`) to `GET /prs` in task-store, ordering by `createdAt`
- Default preserves current behavior for every existing caller; `claimNext()` remains untouched — it's a separate method with its own deterministic SQL ordering used for phase-ready claiming
- Regenerated derived OpenAPI/MCP artifacts (`task-store/openapi.json`, `mcp-server/src/generated-tools.ts`, `docs/mcp-tools.md`, `lib/task-store-types.ts`) so the new param is visible end-to-end, including via the MCP tool surface

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GET /prs?sort=desc` returns PRs ordered by `createdAt` descending; no param / `sort=asc` returns ascending (unchanged) | MET |
| 2 | `claimNext()` unchanged — still uses its own deterministic SQL `ORDER BY`, no new param accepted | MET |
| 3 | `docs/task-store.md` documents the new `sort` param on `GET /prs` | MET |
| 4 | Test coverage: unit tests for `list()` ordering (asc/desc/default), integration test round-tripping through real Postgres, smoke tests covering the route's query-param wiring and response ordering — no existing tests removed | MET |

## Test Plan
- `bun test` (task-store): 303 pass / 0 fail / 84 skip (skips are pre-existing DB-gated integration tests, unaffected by this change)
- `bunx biome lint .`: clean
- `bunx tsc --noEmit` (task-store): clean
- Verified via `git diff` that `claimNext()` has zero changes
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
