### PR TITLE
docs: declare Deploy model as direct in shipwright's CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,10 @@ Driven by Shipwright's own commands: `/shipwright:dev-task` → `/shipwright:rev
 
 **Task-store connection** is env-var-only: both `SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN` must be set for task operations to function. There is no GitHub fallback and no file-based config — the provisioner injects these two vars into managed GKE agents, and local installs must set them explicitly. If task operations seem to no-op, check `SHIPWRIGHT_TASK_STORE_URL` first.
 
+## Deploy model
+
+`direct` — ships via Helm chart + GHCR-pinned image tags, with no staging/production GitHub Environments and no deploy-staging→canary→promote-to-production pipeline.
+
 ## Test conventions
 
 Tests land **with** the code, at the correct layer — same PR, no "add tests later" tasks. Layer is encoded in the filename:


### PR DESCRIPTION
## Summary
- Add a `## Deploy model` section to shipwright's own root `CLAUDE.md`, declared as `direct`
- Reflects the 2026-07-14 finding: shipwright ships via a Helm chart + GHCR-pinned image tags with no staging/production GitHub Environments and no deploy-staging→canary→promote-to-production pipeline (confirmed via `gh api repos/app-vitals/shipwright/environments` — only `github-pages` exists)

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Root CLAUDE.md contains a new '## Deploy model' section with value `direct` and a one-line rationale | MET | `CLAUDE.md` new section: "`direct` — ships via Helm chart + GHCR-pinned image tags, with no staging/production GitHub Environments and no deploy-staging→canary→promote-to-production pipeline." |
| 2 | No other content in CLAUDE.md is modified | MET | Diff is a pure 4-line insertion, no other lines touched |
| 3 | Test decision: none | MET | Static documentation declaration with no executable behavior |

## Test Plan
- N/A — static documentation declaration, no executable behavior (TRH-3.1/3.4's dry-run acceptance criteria exercise this value)
- [x] `task check-strings` passing

Generated with [Claude Code](https://claude.com/claude-code)
