### PR TITLE
feat: add CI-shape proportionality threshold to test-design/speed-budgets

### DIFF
--- a/plugins/shipwright/skills/speed-budgets/SKILL.md
+++ b/plugins/shipwright/skills/speed-budgets/SKILL.md
@@ -57,6 +57,8 @@ A suite that hits its target only with 16-way parallelism but fails serially is 
 
 Phase 2 must output the parallelization plan (worker count, sharding strategy). Per-test budgets stay tight so the suite hits its target without requiring heroic parallelism.
 
+See `test-design/SKILL.md` Step 6 for the explicit threshold on when per-workspace matrix sharding (vs. one combined job per layer) is justified — the same proportionality question applies here: parallelism only pays off once its fixed overhead is outweighed by the wall-clock it saves.
+
 ## How other skills reference this
 
 - **`test-inventory`** does not measure speed (no tests exist for some items). It only assigns layer.

--- a/plugins/shipwright/skills/test-design/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-design/SKILL.content.test.ts
@@ -1,0 +1,152 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+const SPEED_BUDGETS_SKILL_MD_PATH = join(
+  import.meta.dir,
+  "..",
+  "speed-budgets",
+  "SKILL.md",
+);
+
+let content: string;
+let speedBudgetsContent: string;
+
+beforeAll(() => {
+  content = existsSync(SKILL_MD_PATH)
+    ? readFileSync(SKILL_MD_PATH, "utf-8")
+    : "";
+  speedBudgetsContent = existsSync(SPEED_BUDGETS_SKILL_MD_PATH)
+    ? readFileSync(SPEED_BUDGETS_SKILL_MD_PATH, "utf-8")
+    : "";
+});
+
+describe("SKILL.md — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(content.length).toBeGreaterThan(200);
+  });
+});
+
+describe("SKILL.md — frontmatter", () => {
+  it("has frontmatter with name: test-design", () => {
+    expect(content).toContain("name: test-design");
+  });
+
+  it("has frontmatter with a description field", () => {
+    expect(content).toMatch(/^description:/m);
+  });
+});
+
+describe("SKILL.md — Step 6: default CI shape is one job per layer", () => {
+  it("states the default shape is one job per layer, not per workspace", () => {
+    const hasOneJobPerLayer =
+      content.includes("one job per layer") ||
+      content.includes("one job per layer, not one job per workspace") ||
+      (content.includes("job per layer") && content.includes("job per workspace"));
+    expect(hasOneJobPerLayer).toBe(true);
+  });
+
+  it("names the default layer jobs (unit-all, integration-all, smoke-all)", () => {
+    const hasLayerJobNames =
+      content.includes("unit-all") &&
+      content.includes("integration-all") &&
+      content.includes("smoke-all");
+    expect(hasLayerJobNames).toBe(true);
+  });
+
+  it("frames per-workspace matrix sharding as an explicit override, not the default", () => {
+    const hasOverrideLanguage =
+      /override/i.test(content) &&
+      (content.includes("per-workspace") || content.includes("per workspace"));
+    expect(hasOverrideLanguage).toBe(true);
+  });
+});
+
+describe("SKILL.md — Step 6: threshold conditions for per-workspace sharding", () => {
+  it("condition (a): combined layer suite can't hit its speed budget in one job", () => {
+    const hasBudgetCondition =
+      /speed budget/i.test(content) &&
+      (content.includes("can't hit") ||
+        content.includes("cannot hit") ||
+        content.includes("can't meet") ||
+        content.includes("cannot meet") ||
+        content.includes("in one job"));
+    expect(hasBudgetCondition).toBe(true);
+  });
+
+  it("condition (b): a specific workspace has documented flake/slowness history worth isolating", () => {
+    const hasFlakeCondition =
+      /flak(e|y|iness)/i.test(content) &&
+      /slow(ness)?/i.test(content) &&
+      (content.includes("isolat") || content.includes("history"));
+    expect(hasFlakeCondition).toBe(true);
+  });
+
+  it("condition (c): projected wall-clock savings exceed roughly 2x the added fixed per-job overhead", () => {
+    const hasOverheadCondition =
+      (content.includes("2x") || content.includes("2×") || content.includes("twice")) &&
+      /overhead/i.test(content) &&
+      (content.includes("wall-clock") || content.includes("wall clock") || content.includes("wall time"));
+    expect(hasOverheadCondition).toBe(true);
+  });
+
+  it("mentions checkout+setup+install and container init as sources of fixed per-job overhead", () => {
+    const hasOverheadSources =
+      content.includes("checkout") &&
+      content.includes("setup") &&
+      content.includes("install") &&
+      /container init/i.test(content);
+    expect(hasOverheadSources).toBe(true);
+  });
+});
+
+describe("SKILL.md — Step 6 subsection placement", () => {
+  it("has a subsection heading for per-workspace matrix sharding near Step 6", () => {
+    const step6Idx = content.indexOf("### Step 6");
+    const step7Idx = content.indexOf("### Step 7");
+    expect(step6Idx).toBeGreaterThan(-1);
+    expect(step7Idx).toBeGreaterThan(step6Idx);
+    const step6Section = content.slice(step6Idx, step7Idx);
+    const hasSubsection =
+      /per-workspace matrix sharding/i.test(step6Section) &&
+      /override/i.test(step6Section);
+    expect(hasSubsection).toBe(true);
+  });
+});
+
+describe("speed-budgets/SKILL.md — cross-references test-design Step 6 rule instead of duplicating it", () => {
+  it("references test-design/SKILL.md", () => {
+    expect(speedBudgetsContent).toContain("test-design");
+  });
+
+  it("points to Step 6 or the threshold rule specifically, not just the file name", () => {
+    const hasSpecificPointer =
+      speedBudgetsContent.includes("Step 6") ||
+      /threshold/i.test(speedBudgetsContent);
+    expect(hasSpecificPointer).toBe(true);
+  });
+
+  it("does not duplicate the three threshold conditions' prose (no '2x' overhead language here)", () => {
+    const parallelSectionIdx = speedBudgetsContent.indexOf(
+      "Why parallelization is prescribed, not assumed",
+    );
+    expect(parallelSectionIdx).toBeGreaterThan(-1);
+    const nextSectionIdx = speedBudgetsContent.indexOf(
+      "\n## ",
+      parallelSectionIdx,
+    );
+    const section = speedBudgetsContent.slice(
+      parallelSectionIdx,
+      nextSectionIdx === -1 ? undefined : nextSectionIdx,
+    );
+    const hasDuplicatedOverheadProse =
+      (section.includes("2x") || section.includes("2×")) &&
+      /overhead/i.test(section);
+    expect(hasDuplicatedOverheadProse).toBe(false);
+  });
+});

--- a/plugins/shipwright/skills/test-design/SKILL.md
+++ b/plugins/shipwright/skills/test-design/SKILL.md
@@ -81,6 +81,16 @@ Document:
 - **Parallelism**: per-layer worker count.
 - **Budget**: <15min total per PR (agent-readiness checklist Condition 4).
 
+**Per-workspace matrix sharding — explicit override, not the default.** The default CI shape is **one job per layer** — `unit-all`, `integration-all`, `smoke-all` — each running its layer's full suite across every workspace in a single combined job. Splitting a layer into a per-workspace matrix (one job per workspace, per layer) is an **explicit override** that must be justified against the conditions below, not a default granularity choice. Per-job overhead — checkout, dependency install, environment setup, and (for integration jobs) container init for dependencies like Postgres — is fixed cost paid by every job in the matrix regardless of how little work that job actually does; at low per-workspace test volume this overhead routinely dwarfs the real test execution time, and job-level CI queuing delays are multiplied by every extra job added to a PR.
+
+Shard a layer into a per-workspace matrix only when at least one of these holds:
+
+1. **(a) Budget miss:** the combined layer's suite wall time can't hit its speed budget (see `speed-budgets/SKILL.md`) running as a single job.
+2. **(b) Documented flake/slowness history:** a specific workspace has a documented history of flakiness or slowness that's worth isolating from the rest of the layer (e.g., to unblock the layer without quarantining unrelated workspaces).
+3. **(c) Overhead-justified parallel savings:** the projected wall-clock savings from running workspaces in parallel exceed roughly **2x** the added fixed per-job overhead (checkout+setup+install, plus container init where applicable) — i.e., the matrix must pay for itself at least twice over, not just break even.
+
+If none of these conditions hold, keep the layer as a single combined job. Default to the cheaper shape.
+
 **Naming convention and runner-exclusion config (required):** The artifact must specify both a file-naming convention and the runner-exclusion config that enforces it. These two items are inseparable — a naming convention without matching exclusion config is not enforced, and exclusion config without a naming convention is unauditable. Document:
 
 1. **File-naming convention** — one suffix rule per entry point:


### PR DESCRIPTION
## Summary
- Encodes an explicit CI-shape proportionality threshold in `test-design/SKILL.md` Step 6: the default CI shape is one job per layer (`unit-all`, `integration-all`, `smoke-all`), and per-workspace matrix sharding is an explicit override justified by one of three conditions (speed-budget miss, documented flake/slowness history, or projected parallel savings exceeding ~2x fixed per-job overhead).
- `speed-budgets/SKILL.md`'s "why parallelization is prescribed, not assumed" section now cross-references this rule instead of duplicating the prose — single source of truth.
- Adds `plugins/shipwright/skills/test-design/SKILL.content.test.ts` (new, content layer) asserting the new threshold section's key phrases are present and that `speed-budgets/SKILL.md` references it without duplication.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | test-design/SKILL.md Step 6 states default CI shape is one job per layer, not per-workspace | MET | New subsection states default shape explicitly; frames sharding as explicit override |
| 2 | Threshold conditions (a) budget miss, (b) flake/slowness history, (c) 2x overhead savings written explicitly | MET | All three conditions listed verbatim |
| 3 | speed-budgets/SKILL.md cross-references the rule instead of duplicating prose | MET | New sentence points to test-design/SKILL.md Step 6; no prose duplicated |
| 4 | New SKILL.content.test.ts asserts key phrases; no existing tests changed | MET | 152-line new test file, 15/15 passing; no existing test files touched |

## Test Plan
- `bun test plugins/shipwright/skills/test-design/SKILL.content.test.ts` — 15/15 pass
- `task lint`, `task check-strings`, `task check-config-docs`, `task check-version-sync` — all pass
- `bun run --filter='@shipwright/plugin' typecheck` — pass
- Full repo test suite (`bun test`): 3889 pass, 1 pre-existing unrelated failure (`agent/src/claude.unit.test.ts`, byte-identical to `origin/main` — not touched by this change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
