### PR TITLE
feat: group session dependencies by ready/in_progress/blocked/closed state

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1986,10 +1986,171 @@ const SESSION_CLOSED_STATUSES = new Set([
 ]);
 
 /**
+ * A node in the session's dependency graph. `title`/`status`/`branch` are
+ * null for a dependency id that isn't one of this session's own tasks (an
+ * "external" prerequisite from another session) — we only know its id.
+ */
+interface DependencyNode {
+  id: string;
+  title: string | null;
+  status: string | null;
+  branch: string | null;
+  dependsOn: string[];
+}
+
+/**
+ * Groups a session's tasks into topological "waves": wave N contains every
+ * node whose dependencies are all satisfied by nodes in waves < N. Only
+ * tasks that participate in a dependency edge are included (either they
+ * declare a dependency, or another task in the session declares them as
+ * one) — tasks with no relationships are noise here and stay in the plain
+ * task table above.
+ *
+ * Layering uses round-based Kahn's algorithm: each round admits every node
+ * whose deps already have an assigned wave, so a node's wave number equals
+ * 1 + max(dep wave) without an explicit longest-path pass. A dependency
+ * cycle (shouldn't happen, but the field is free-text) would stall the
+ * algorithm forever, so any nodes still unresolved after all rounds are
+ * dumped into one final wave rather than looping.
+ */
+function computeDependencyWaves(tasks: TaskItem[]): DependencyNode[][] {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+
+  const relevant = new Set<string>();
+  const stack = tasks
+    .filter((t) => (t.dependencies?.length ?? 0) > 0)
+    .map((t) => t.id);
+  for (const id of stack) relevant.add(id);
+  while (stack.length > 0) {
+    const id = stack.pop();
+    if (id === undefined) continue;
+    for (const dep of byId.get(id)?.dependencies ?? []) {
+      if (!relevant.has(dep)) {
+        relevant.add(dep);
+        stack.push(dep);
+      }
+    }
+  }
+
+  const nodes = new Map<string, DependencyNode>();
+  for (const id of relevant) {
+    const t = byId.get(id);
+    nodes.set(id, {
+      id,
+      title: t?.title ?? null,
+      status: t?.status ?? null,
+      branch: t?.branch ?? null,
+      dependsOn: (t?.dependencies ?? []).filter((d) => relevant.has(d)),
+    });
+  }
+
+  const waveOf = new Map<string, number>();
+  const remaining = new Set(nodes.keys());
+  let wave = 0;
+  while (remaining.size > 0) {
+    const ready = [...remaining].filter((id) =>
+      nodes.get(id)?.dependsOn.every((d) => waveOf.has(d)),
+    );
+    if (ready.length === 0) {
+      for (const id of remaining) waveOf.set(id, wave);
+      break;
+    }
+    for (const id of ready) {
+      waveOf.set(id, wave);
+      remaining.delete(id);
+    }
+    wave++;
+  }
+
+  const waves: DependencyNode[][] = [];
+  for (const [id, w] of waveOf) {
+    const node = nodes.get(id);
+    if (!node) continue;
+    if (!waves[w]) waves[w] = [];
+    waves[w].push(node);
+  }
+  for (const w of waves) w.sort((a, b) => a.id.localeCompare(b.id));
+  return waves;
+}
+
+// Fixed palette for branch chips — a stable hash picks a color per branch
+// name so tasks bundled onto the same branch/PR are visually correlated
+// even when they land in different waves (a task and its dependent are
+// often shipped together on one branch, e.g. AGY-1.1 + AGY-1.2).
+const BRANCH_COLORS = [
+  "#6366f1",
+  "#059669",
+  "#d97706",
+  "#db2777",
+  "#0891b2",
+  "#7c3aed",
+];
+
+function branchColor(branch: string): string {
+  let hash = 0;
+  for (let i = 0; i < branch.length; i++) {
+    hash = (hash * 31 + branch.charCodeAt(i)) >>> 0;
+  }
+  return BRANCH_COLORS[hash % BRANCH_COLORS.length];
+}
+
+/**
+ * Renders the topological waves as stacked rows of cards. Each card gets a
+ * color-coded left border/chip when its task has a branch, so tasks bundled
+ * onto the same branch (shipped in one PR) are visually correlated across
+ * waves without needing to co-locate them spatially.
+ */
+function renderDependencyGraph(waves: DependencyNode[][]): string {
+  const nodeCard = (n: DependencyNode): string => {
+    const idHtml =
+      n.title === null
+        ? `<span class="mono" style="font-size:12px;color:#6b7280">${escapeHtml(n.id)}</span>`
+        : `<a href="/admin/tasks/${escapeHtml(n.id)}" class="mono" style="font-size:12px;color:#6366f1;text-decoration:none;font-weight:600">${escapeHtml(n.id)}</a>`;
+    const statusHtml =
+      n.status !== null
+        ? `<span class="badge ${statusBadgeClass(n.status)}" style="margin-left:6px;font-size:10px">${escapeHtml(n.status)}</span>`
+        : `<span style="margin-left:6px;font-size:10px;color:#9ca3af">outside session</span>`;
+    const titleHtml =
+      n.title !== null
+        ? `<div style="font-size:12px;color:#374151;margin-top:2px">${escapeHtml(n.title)}</div>`
+        : "";
+    const dependsOnHtml =
+      n.dependsOn.length > 0
+        ? `<div style="font-size:11px;color:#9ca3af;margin-top:4px">needs ${n.dependsOn.map((d) => escapeHtml(d)).join(", ")}</div>`
+        : "";
+    const branchHtml =
+      n.branch !== null
+        ? `<div style="font-size:10px;margin-top:4px" class="mono"><span style="color:${branchColor(n.branch)}">⎇ ${escapeHtml(n.branch)}</span></div>`
+        : "";
+    const borderLeft =
+      n.branch !== null
+        ? `border-left:3px solid ${branchColor(n.branch)};`
+        : "";
+    return `<div style="border:1px solid #e5e7eb;${borderLeft}border-radius:6px;padding:8px 10px;min-width:150px;background:#fff">
+        <div>${idHtml}${statusHtml}</div>
+        ${titleHtml}
+        ${dependsOnHtml}
+        ${branchHtml}
+      </div>`;
+  };
+
+  const waveHtml = waves.map(
+    (nodesInWave, i) => `<div>
+      <div style="font-size:10px;color:#9ca3af;text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Wave ${i + 1}</div>
+      <div style="display:flex;gap:10px;flex-wrap:wrap">${nodesInWave.map(nodeCard).join("")}</div>
+    </div>`,
+  );
+
+  return waveHtml.join(
+    `<div style="text-align:center;color:#d1d5db;font-size:16px;margin:2px 0">↓</div>`,
+  );
+}
+
+/**
  * Renders the session detail page: stat cards (total tasks, est. hours,
  * distinct layers), an open/closed summary, a task table with a Status
- * column, and a distinct dependency list — sourced from a live
- * `/tasks?session=` fetch (no plan-time snapshot).
+ * column, and a dependency graph — sourced from a live `/tasks?session=`
+ * fetch (no plan-time snapshot).
  */
 export function renderSessionDetailPage(
   sessionId: string,
@@ -2012,9 +2173,7 @@ export function renderSessionDetailPage(
     SESSION_CLOSED_STATUSES.has(t.status),
   );
 
-  const dependencyIds = [
-    ...new Set(tasks.flatMap((t) => t.dependencies ?? [])),
-  ];
+  const dependencyWaves = computeDependencyWaves(tasks);
 
   function taskRow(t: TaskItem): string {
     return `<tr>
@@ -2042,12 +2201,10 @@ export function renderSessionDetailPage(
           .join("\n");
 
   const depsSection =
-    dependencyIds.length > 0
+    dependencyWaves.length > 0
       ? `<div class="card" style="margin-bottom:16px">
-      <div style="font-size:12px;font-weight:600;color:#374151;margin-bottom:8px;text-transform:uppercase;letter-spacing:.05em">Dependencies</div>
-      <ul style="margin:0;padding-left:16px">
-        ${dependencyIds.map((id) => `<li style="font-size:13px;margin-bottom:4px" class="mono">${escapeHtml(id)}</li>`).join("")}
-      </ul>
+      <div style="font-size:12px;font-weight:600;color:#374151;margin-bottom:12px;text-transform:uppercase;letter-spacing:.05em">Dependency graph</div>
+      ${renderDependencyGraph(dependencyWaves)}
     </div>`
       : "";
 
@@ -2548,7 +2705,10 @@ export function renderCronLogsPage(opts: {
   }).join("\n");
 
   // Pagination — mirrors renderPrsPage's pattern.
-  const totalPages = Math.max(1, Math.ceil(pagination.total / pagination.limit));
+  const totalPages = Math.max(
+    1,
+    Math.ceil(pagination.total / pagination.limit),
+  );
   const page = pagination.page;
   const makePageUrl = (p: number) => {
     const params = new URLSearchParams();

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1992,11 +1992,12 @@ const SESSION_CLOSED_STATUSES = new Set([
  * dependencies; ready = "pending" with none. `blockedBy` is computed
  * server-side by the task-store's computeBlockedBy and passed through as-is
  * on each TaskItem — this only classifies, it doesn't resolve dependencies
- * itself.
+ * itself. Shared by the session task table and the dependency graph card
+ * below so both use the same grouping.
  */
-type DependencyState = "ready" | "in_progress" | "blocked" | "closed";
+type TaskState = "ready" | "in_progress" | "blocked" | "closed";
 
-function classifyDependencyState(t: TaskItem): DependencyState {
+function classifyTaskState(t: TaskItem): TaskState {
   if (SESSION_CLOSED_STATUSES.has(t.status)) return "closed";
   if (
     t.status === "in_progress" ||
@@ -2009,7 +2010,7 @@ function classifyDependencyState(t: TaskItem): DependencyState {
   return (t.blockedBy?.length ?? 0) > 0 ? "blocked" : "ready";
 }
 
-const DEPENDENCY_STATE_GROUPS: { key: DependencyState; label: string }[] = [
+const TASK_STATE_GROUPS: { key: TaskState; label: string }[] = [
   { key: "ready", label: "Ready" },
   { key: "in_progress", label: "In Progress" },
   { key: "blocked", label: "Blocked" },
@@ -2022,7 +2023,7 @@ interface DependencyNode {
   status: string;
   branch: string | null;
   dependsOn: string[];
-  state: DependencyState;
+  state: TaskState;
 }
 
 /**
@@ -2039,13 +2040,13 @@ interface DependencyNode {
  */
 function computeDependencyGroups(
   tasks: TaskItem[],
-): Map<DependencyState, DependencyNode[]> {
+): Map<TaskState, DependencyNode[]> {
   const referencedIds = new Set<string>();
   for (const t of tasks) {
     for (const dep of t.dependencies ?? []) referencedIds.add(dep);
   }
 
-  const groups = new Map<DependencyState, DependencyNode[]>();
+  const groups = new Map<TaskState, DependencyNode[]>();
   for (const t of tasks) {
     if ((t.dependencies?.length ?? 0) === 0 && !referencedIds.has(t.id)) {
       continue;
@@ -2056,7 +2057,7 @@ function computeDependencyGroups(
       status: t.status,
       branch: t.branch ?? null,
       dependsOn: t.dependencies ?? [],
-      state: classifyDependencyState(t),
+      state: classifyTaskState(t),
     };
     const bucket = groups.get(node.state);
     if (bucket) bucket.push(node);
@@ -2098,7 +2099,7 @@ function branchColor(branch: string): string {
  */
 function renderDependencyGraph(
   tasks: TaskItem[],
-  groups: Map<DependencyState, DependencyNode[]>,
+  groups: Map<TaskState, DependencyNode[]>,
 ): string {
   const byId = new Map(tasks.map((t) => [t.id, t]));
 
@@ -2132,7 +2133,7 @@ function renderDependencyGraph(
       </div>`;
   };
 
-  return DEPENDENCY_STATE_GROUPS.map(({ key, label }) => {
+  return TASK_STATE_GROUPS.map(({ key, label }) => {
     const nodes = groups.get(key);
     if (!nodes || nodes.length === 0) return "";
     return `<div style="margin-bottom:14px">
@@ -2146,9 +2147,9 @@ function renderDependencyGraph(
 
 /**
  * Renders the session detail page: stat cards (total tasks, est. hours,
- * distinct layers), an open/closed summary, a task table with a Status
- * column, and a dependency graph — sourced from a live `/tasks?session=`
- * fetch (no plan-time snapshot).
+ * distinct layers), a ready/in_progress/blocked/closed summary, a task table
+ * grouped the same way, and a dependency graph — sourced from a live
+ * `/tasks?session=` fetch (no plan-time snapshot).
  */
 export function renderSessionDetailPage(
   sessionId: string,
@@ -2166,10 +2167,13 @@ export function renderSessionDetailPage(
     tasks.map((t) => t.layer).filter((l): l is string => !!l),
   ).size;
 
-  const openTasks = tasks.filter((t) => !SESSION_CLOSED_STATUSES.has(t.status));
-  const closedTasks = tasks.filter((t) =>
-    SESSION_CLOSED_STATUSES.has(t.status),
-  );
+  const tasksByState = new Map<TaskState, TaskItem[]>();
+  for (const t of tasks) {
+    const state = classifyTaskState(t);
+    const bucket = tasksByState.get(state);
+    if (bucket) bucket.push(t);
+    else tasksByState.set(state, [t]);
+  }
 
   const dependencyGroups = computeDependencyGroups(tasks);
 
@@ -2187,14 +2191,11 @@ export function renderSessionDetailPage(
   const tableRows =
     tasks.length === 0
       ? `<tr><td colspan="6" class="empty-state">No tasks found for this session.</td></tr>`
-      : [
-          openTasks.length > 0
-            ? `<tr><td colspan="6" style="background:#f9fafb;font-size:11px;font-weight:600;color:#374151;padding:6px 12px;text-transform:uppercase;letter-spacing:.05em">Open (${openTasks.length})</td></tr>${openTasks.map(taskRow).join("\n")}`
-            : "",
-          closedTasks.length > 0
-            ? `<tr><td colspan="6" style="background:#f9fafb;font-size:11px;font-weight:600;color:#374151;padding:6px 12px;text-transform:uppercase;letter-spacing:.05em">Closed (${closedTasks.length})</td></tr>${closedTasks.map(taskRow).join("\n")}`
-            : "",
-        ]
+      : TASK_STATE_GROUPS.map(({ key, label }) => {
+          const group = tasksByState.get(key);
+          if (!group || group.length === 0) return "";
+          return `<tr><td colspan="6" style="background:#f9fafb;font-size:11px;font-weight:600;color:#374151;padding:6px 12px;text-transform:uppercase;letter-spacing:.05em">${label} (${group.length})</td></tr>${group.map(taskRow).join("\n")}`;
+        })
           .filter(Boolean)
           .join("\n");
 
@@ -2239,7 +2240,10 @@ export function renderSessionDetailPage(
       ${statCard("Layers", String(distinctLayers))}
     </div>
     <div style="font-size:13px;color:#374151;margin-bottom:12px">
-      <strong>${openTasks.length}</strong> open / <strong>${closedTasks.length}</strong> closed
+      ${TASK_STATE_GROUPS.map(
+        ({ key, label }) =>
+          `<strong>${tasksByState.get(key)?.length ?? 0}</strong> ${escapeHtml(label.toLowerCase())}`,
+      ).join(" / ")}
     </div>
     <div class="card">
       <div class="data-table-wrapper">

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1985,98 +1985,93 @@ const SESSION_CLOSED_STATUSES = new Set([
   "cancelled",
 ]);
 
-/**
- * A node in the session's dependency graph. `title`/`status`/`branch` are
- * null for a dependency id that isn't one of this session's own tasks (an
- * "external" prerequisite from another session) — we only know its id.
+/** Mirrors the ready/in_progress/blocked/closed taxonomy used by the Tasks
+ * page's state tabs — see task-store's TaskService.listReady/listBlocked:
+ * closed = terminal status; in_progress = {in_progress, pr_open, approved};
+ * blocked = explicit status "blocked", or "pending" with unresolved
+ * dependencies; ready = "pending" with none. `blockedBy` is computed
+ * server-side by the task-store's computeBlockedBy and passed through as-is
+ * on each TaskItem — this only classifies, it doesn't resolve dependencies
+ * itself.
  */
+type DependencyState = "ready" | "in_progress" | "blocked" | "closed";
+
+function classifyDependencyState(t: TaskItem): DependencyState {
+  if (SESSION_CLOSED_STATUSES.has(t.status)) return "closed";
+  if (
+    t.status === "in_progress" ||
+    t.status === "pr_open" ||
+    t.status === "approved"
+  ) {
+    return "in_progress";
+  }
+  if (t.status === "blocked") return "blocked";
+  return (t.blockedBy?.length ?? 0) > 0 ? "blocked" : "ready";
+}
+
+const DEPENDENCY_STATE_GROUPS: { key: DependencyState; label: string }[] = [
+  { key: "ready", label: "Ready" },
+  { key: "in_progress", label: "In Progress" },
+  { key: "blocked", label: "Blocked" },
+  { key: "closed", label: "Closed" },
+];
+
 interface DependencyNode {
   id: string;
-  title: string | null;
-  status: string | null;
+  title: string;
+  status: string;
   branch: string | null;
   dependsOn: string[];
+  state: DependencyState;
 }
 
 /**
- * Groups a session's tasks into topological "waves": wave N contains every
- * node whose dependencies are all satisfied by nodes in waves < N. Only
- * tasks that participate in a dependency edge are included (either they
- * declare a dependency, or another task in the session declares them as
- * one) — tasks with no relationships are noise here and stay in the plain
- * task table above.
- *
- * Layering uses round-based Kahn's algorithm: each round admits every node
- * whose deps already have an assigned wave, so a node's wave number equals
- * 1 + max(dep wave) without an explicit longest-path pass. A dependency
- * cycle (shouldn't happen, but the field is free-text) would stall the
- * algorithm forever, so any nodes still unresolved after all rounds are
- * dumped into one final wave rather than looping.
+ * Selects the session's tasks that participate in a dependency edge —
+ * either they declare a dependency, or another task in the session declares
+ * them as one — and buckets them by the same ready/in_progress/blocked/
+ * closed states shown on the Tasks page, so the card answers "what can I
+ * work on now" rather than an abstract structural order. Tasks with no
+ * relationship are noise here and stay visible in the plain task table
+ * above. Dependency ids outside the session (unknown to this task list)
+ * aren't session tasks and have no status to classify by, so they never get
+ * their own node — they still show up in a participating task's `dependsOn`
+ * list, just unlinked (see `renderDependencyGraph`).
  */
-function computeDependencyWaves(tasks: TaskItem[]): DependencyNode[][] {
-  const byId = new Map(tasks.map((t) => [t.id, t]));
+function computeDependencyGroups(
+  tasks: TaskItem[],
+): Map<DependencyState, DependencyNode[]> {
+  const referencedIds = new Set<string>();
+  for (const t of tasks) {
+    for (const dep of t.dependencies ?? []) referencedIds.add(dep);
+  }
 
-  const relevant = new Set<string>();
-  const stack = tasks
-    .filter((t) => (t.dependencies?.length ?? 0) > 0)
-    .map((t) => t.id);
-  for (const id of stack) relevant.add(id);
-  while (stack.length > 0) {
-    const id = stack.pop();
-    if (id === undefined) continue;
-    for (const dep of byId.get(id)?.dependencies ?? []) {
-      if (!relevant.has(dep)) {
-        relevant.add(dep);
-        stack.push(dep);
-      }
+  const groups = new Map<DependencyState, DependencyNode[]>();
+  for (const t of tasks) {
+    if ((t.dependencies?.length ?? 0) === 0 && !referencedIds.has(t.id)) {
+      continue;
     }
+    const node: DependencyNode = {
+      id: t.id,
+      title: t.title,
+      status: t.status,
+      branch: t.branch ?? null,
+      dependsOn: t.dependencies ?? [],
+      state: classifyDependencyState(t),
+    };
+    const bucket = groups.get(node.state);
+    if (bucket) bucket.push(node);
+    else groups.set(node.state, [node]);
   }
-
-  const nodes = new Map<string, DependencyNode>();
-  for (const id of relevant) {
-    const t = byId.get(id);
-    nodes.set(id, {
-      id,
-      title: t?.title ?? null,
-      status: t?.status ?? null,
-      branch: t?.branch ?? null,
-      dependsOn: (t?.dependencies ?? []).filter((d) => relevant.has(d)),
-    });
+  for (const bucket of groups.values()) {
+    bucket.sort((a, b) => a.id.localeCompare(b.id));
   }
-
-  const waveOf = new Map<string, number>();
-  const remaining = new Set(nodes.keys());
-  let wave = 0;
-  while (remaining.size > 0) {
-    const ready = [...remaining].filter((id) =>
-      nodes.get(id)?.dependsOn.every((d) => waveOf.has(d)),
-    );
-    if (ready.length === 0) {
-      for (const id of remaining) waveOf.set(id, wave);
-      break;
-    }
-    for (const id of ready) {
-      waveOf.set(id, wave);
-      remaining.delete(id);
-    }
-    wave++;
-  }
-
-  const waves: DependencyNode[][] = [];
-  for (const [id, w] of waveOf) {
-    const node = nodes.get(id);
-    if (!node) continue;
-    if (!waves[w]) waves[w] = [];
-    waves[w].push(node);
-  }
-  for (const w of waves) w.sort((a, b) => a.id.localeCompare(b.id));
-  return waves;
+  return groups;
 }
 
 // Fixed palette for branch chips — a stable hash picks a color per branch
 // name so tasks bundled onto the same branch/PR are visually correlated
-// even when they land in different waves (a task and its dependent are
-// often shipped together on one branch, e.g. AGY-1.1 + AGY-1.2).
+// even when they land in different state groups (a task and its dependent
+// are often shipped together on one branch, e.g. AGY-1.1 + AGY-1.2).
 const BRANCH_COLORS = [
   "#6366f1",
   "#059669",
@@ -2095,28 +2090,31 @@ function branchColor(branch: string): string {
 }
 
 /**
- * Renders the topological waves as stacked rows of cards. Each card gets a
- * color-coded left border/chip when its task has a branch, so tasks bundled
- * onto the same branch (shipped in one PR) are visually correlated across
- * waves without needing to co-locate them spatially.
+ * Renders the Ready/In Progress/Blocked/Closed groups as stacked rows of
+ * cards, skipping empty groups. Each card gets a color-coded left
+ * border/chip when its task has a branch (bundle), and its `dependsOn`
+ * list links to sibling session tasks while leaving ids outside the
+ * session as plain unlinked text.
  */
-function renderDependencyGraph(waves: DependencyNode[][]): string {
+function renderDependencyGraph(
+  tasks: TaskItem[],
+  groups: Map<DependencyState, DependencyNode[]>,
+): string {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+
   const nodeCard = (n: DependencyNode): string => {
-    const idHtml =
-      n.title === null
-        ? `<span class="mono" style="font-size:12px;color:#6b7280">${escapeHtml(n.id)}</span>`
-        : `<a href="/admin/tasks/${escapeHtml(n.id)}" class="mono" style="font-size:12px;color:#6366f1;text-decoration:none;font-weight:600">${escapeHtml(n.id)}</a>`;
-    const statusHtml =
-      n.status !== null
-        ? `<span class="badge ${statusBadgeClass(n.status)}" style="margin-left:6px;font-size:10px">${escapeHtml(n.status)}</span>`
-        : `<span style="margin-left:6px;font-size:10px;color:#9ca3af">outside session</span>`;
-    const titleHtml =
-      n.title !== null
-        ? `<div style="font-size:12px;color:#374151;margin-top:2px">${escapeHtml(n.title)}</div>`
-        : "";
+    const idHtml = `<a href="/admin/tasks/${escapeHtml(n.id)}" class="mono" style="font-size:12px;color:#6366f1;text-decoration:none;font-weight:600">${escapeHtml(n.id)}</a>`;
+    const statusHtml = `<span class="badge ${statusBadgeClass(n.status)}" style="margin-left:6px;font-size:10px">${escapeHtml(n.status)}</span>`;
+    const titleHtml = `<div style="font-size:12px;color:#374151;margin-top:2px">${escapeHtml(n.title)}</div>`;
     const dependsOnHtml =
       n.dependsOn.length > 0
-        ? `<div style="font-size:11px;color:#9ca3af;margin-top:4px">needs ${n.dependsOn.map((d) => escapeHtml(d)).join(", ")}</div>`
+        ? `<div style="font-size:11px;color:#9ca3af;margin-top:4px">needs ${n.dependsOn
+            .map((d) =>
+              byId.has(d)
+                ? `<a href="/admin/tasks/${escapeHtml(d)}" style="color:inherit;text-decoration:underline">${escapeHtml(d)}</a>`
+                : escapeHtml(d),
+            )
+            .join(", ")}</div>`
         : "";
     const branchHtml =
       n.branch !== null
@@ -2134,16 +2132,16 @@ function renderDependencyGraph(waves: DependencyNode[][]): string {
       </div>`;
   };
 
-  const waveHtml = waves.map(
-    (nodesInWave, i) => `<div>
-      <div style="font-size:10px;color:#9ca3af;text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Wave ${i + 1}</div>
-      <div style="display:flex;gap:10px;flex-wrap:wrap">${nodesInWave.map(nodeCard).join("")}</div>
-    </div>`,
-  );
-
-  return waveHtml.join(
-    `<div style="text-align:center;color:#d1d5db;font-size:16px;margin:2px 0">↓</div>`,
-  );
+  return DEPENDENCY_STATE_GROUPS.map(({ key, label }) => {
+    const nodes = groups.get(key);
+    if (!nodes || nodes.length === 0) return "";
+    return `<div style="margin-bottom:14px">
+      <div style="font-size:10px;color:#9ca3af;text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">${label} (${nodes.length})</div>
+      <div style="display:flex;gap:10px;flex-wrap:wrap">${nodes.map(nodeCard).join("")}</div>
+    </div>`;
+  })
+    .filter(Boolean)
+    .join("");
 }
 
 /**
@@ -2173,7 +2171,7 @@ export function renderSessionDetailPage(
     SESSION_CLOSED_STATUSES.has(t.status),
   );
 
-  const dependencyWaves = computeDependencyWaves(tasks);
+  const dependencyGroups = computeDependencyGroups(tasks);
 
   function taskRow(t: TaskItem): string {
     return `<tr>
@@ -2201,10 +2199,10 @@ export function renderSessionDetailPage(
           .join("\n");
 
   const depsSection =
-    dependencyWaves.length > 0
+    dependencyGroups.size > 0
       ? `<div class="card" style="margin-bottom:16px">
       <div style="font-size:12px;font-weight:600;color:#374151;margin-bottom:12px;text-transform:uppercase;letter-spacing:.05em">Dependency graph</div>
-      ${renderDependencyGraph(dependencyWaves)}
+      ${renderDependencyGraph(tasks, dependencyGroups)}
     </div>`
       : "";
 

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -4043,12 +4043,13 @@ describe("renderSessionDetailPage dependency graph", () => {
     return html.slice(idx);
   }
 
-  test("chains tasks into topological waves and annotates what each needs", () => {
+  test("a pending task with no unresolved blockers lands in Ready, and annotates what it needs", () => {
     const a: TaskItem = {
       id: "TASK-A",
       title: "Root",
       status: "pending",
       session: SESSION_ID,
+      blockedBy: [],
     };
     const b: TaskItem = {
       id: "TASK-B",
@@ -4056,28 +4057,110 @@ describe("renderSessionDetailPage dependency graph", () => {
       status: "pending",
       session: SESSION_ID,
       dependencies: ["TASK-A"],
+      blockedBy: [{ type: "dependency", id: "TASK-A", status: "pending" }],
     };
     const html = renderSessionDetailPage(SESSION_ID, [a, b], USER_NAME);
     const section = graphSection(html);
-    expect(section).toContain("Wave 1");
-    expect(section).toContain("Wave 2");
+    expect(section).toContain("Ready (1)");
+    expect(section).toContain("Blocked (1)");
     expect(section).toContain("TASK-A");
-    expect(section).toContain("needs TASK-A");
+    expect(section).toContain("needs");
+    expect(section).toContain('href="/admin/tasks/TASK-A"');
   });
 
-  test("a task outside the session (unknown id) renders without a link or status, marked outside session", () => {
+  test("groups tasks by the ready/in_progress/blocked/closed taxonomy, matching the Tasks page", () => {
+    const ready: TaskItem = {
+      id: "TASK-READY",
+      title: "Ready root",
+      status: "pending",
+      session: SESSION_ID,
+      blockedBy: [],
+    };
+    const inProgress: TaskItem = {
+      id: "TASK-INPROG",
+      title: "Being worked",
+      status: "pr_open",
+      session: SESSION_ID,
+      dependencies: ["TASK-READY"],
+      blockedBy: [],
+    };
+    const explicitlyBlocked: TaskItem = {
+      id: "TASK-BLOCKED",
+      title: "Explicitly blocked",
+      status: "blocked",
+      session: SESSION_ID,
+      dependencies: ["TASK-READY"],
+    };
+    const depBlocked: TaskItem = {
+      id: "TASK-DEPBLOCKED",
+      title: "Pending with unresolved dep",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-INPROG"],
+      blockedBy: [{ type: "dependency", id: "TASK-INPROG", status: "pr_open" }],
+    };
+    const closed: TaskItem = {
+      id: "TASK-CLOSED",
+      title: "Done",
+      status: "done",
+      session: SESSION_ID,
+      dependencies: ["TASK-READY"],
+    };
+    const html = renderSessionDetailPage(
+      SESSION_ID,
+      [ready, inProgress, explicitlyBlocked, depBlocked, closed],
+      USER_NAME,
+    );
+    const section = graphSection(html);
+    // Groups render in this fixed order regardless of input order.
+    const readyIdx = section.indexOf("Ready (1)");
+    const inProgressIdx = section.indexOf("In Progress (1)");
+    const blockedIdx = section.indexOf("Blocked (2)");
+    const closedIdx = section.indexOf("Closed (1)");
+    expect(readyIdx).toBeGreaterThan(-1);
+    expect(inProgressIdx).toBeGreaterThan(readyIdx);
+    expect(blockedIdx).toBeGreaterThan(inProgressIdx);
+    expect(closedIdx).toBeGreaterThan(blockedIdx);
+  });
+
+  test("a dependency id outside the session renders as plain unlinked text in the needs line", () => {
     const c: TaskItem = {
       id: "TASK-C",
       title: "Needs an external dep",
       status: "pending",
       session: SESSION_ID,
       dependencies: ["EXTERNAL-1"],
+      blockedBy: [{ type: "dependency", id: "EXTERNAL-1", status: "unknown" }],
     };
     const html = renderSessionDetailPage(SESSION_ID, [c], USER_NAME);
     const section = graphSection(html);
     expect(section).toContain("EXTERNAL-1");
     expect(section).not.toContain('href="/admin/tasks/EXTERNAL-1"');
-    expect(section).toContain("outside session");
+  });
+
+  test("a dependency id inside the session links to that task's detail page", () => {
+    const root: TaskItem = {
+      id: "TASK-ROOT",
+      title: "Root",
+      status: "pending",
+      session: SESSION_ID,
+      blockedBy: [],
+    };
+    const dependent: TaskItem = {
+      id: "TASK-DEP",
+      title: "Depends on root",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-ROOT"],
+      blockedBy: [{ type: "dependency", id: "TASK-ROOT", status: "pending" }],
+    };
+    const html = renderSessionDetailPage(
+      SESSION_ID,
+      [root, dependent],
+      USER_NAME,
+    );
+    const section = graphSection(html);
+    expect(section).toContain('href="/admin/tasks/TASK-ROOT"');
   });
 
   test("tasks with no dependency relationship at all are excluded from the graph", () => {
@@ -4086,6 +4169,7 @@ describe("renderSessionDetailPage dependency graph", () => {
       title: "No relationships",
       status: "pending",
       session: SESSION_ID,
+      blockedBy: [],
     };
     const dependent: TaskItem = {
       id: "TASK-DEP",
@@ -4093,12 +4177,14 @@ describe("renderSessionDetailPage dependency graph", () => {
       status: "pending",
       session: SESSION_ID,
       dependencies: ["TASK-ROOT"],
+      blockedBy: [{ type: "dependency", id: "TASK-ROOT", status: "pending" }],
     };
     const root: TaskItem = {
       id: "TASK-ROOT",
       title: "Root",
       status: "pending",
       session: SESSION_ID,
+      blockedBy: [],
     };
     const html = renderSessionDetailPage(
       SESSION_ID,
@@ -4111,18 +4197,19 @@ describe("renderSessionDetailPage dependency graph", () => {
     expect(section).not.toContain("TASK-LONER");
   });
 
-  test("same-branch tasks get a matching branch color even across different waves (bundle)", () => {
+  test("same-branch tasks get a matching branch color even across different state groups (bundle)", () => {
     const first: TaskItem = {
       id: "TASK-1",
       title: "models + migration",
       status: "pending",
       session: SESSION_ID,
       branch: "feat/bundle",
+      blockedBy: [],
     };
     const second: TaskItem = {
       id: "TASK-2",
       title: "admin endpoint",
-      status: "pending",
+      status: "in_progress",
       session: SESSION_ID,
       branch: "feat/bundle",
       dependencies: ["TASK-1"],
@@ -4146,18 +4233,42 @@ describe("renderSessionDetailPage dependency graph", () => {
       title: "Independent",
       status: "pending",
       session: SESSION_ID,
+      blockedBy: [],
     };
     const html = renderSessionDetailPage(SESSION_ID, [solo], USER_NAME);
     expect(html).not.toContain("Dependency graph");
   });
 
-  test("a dependency cycle doesn't hang rendering — remaining nodes dump into a final wave", () => {
+  test("empty state groups (e.g. no in-progress or closed tasks) are omitted", () => {
+    const a: TaskItem = {
+      id: "TASK-A",
+      title: "Root",
+      status: "pending",
+      session: SESSION_ID,
+      blockedBy: [],
+    };
+    const b: TaskItem = {
+      id: "TASK-B",
+      title: "Depends on A",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-A"],
+      blockedBy: [{ type: "dependency", id: "TASK-A", status: "pending" }],
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [a, b], USER_NAME);
+    const section = graphSection(html);
+    expect(section).not.toContain("In Progress (");
+    expect(section).not.toContain("Closed (");
+  });
+
+  test("a mutual dependency cycle doesn't hang rendering — each task is classified independently", () => {
     const x: TaskItem = {
       id: "TASK-X",
       title: "X",
       status: "pending",
       session: SESSION_ID,
       dependencies: ["TASK-Y"],
+      blockedBy: [{ type: "dependency", id: "TASK-Y", status: "pending" }],
     };
     const y: TaskItem = {
       id: "TASK-Y",
@@ -4165,11 +4276,13 @@ describe("renderSessionDetailPage dependency graph", () => {
       status: "pending",
       session: SESSION_ID,
       dependencies: ["TASK-X"],
+      blockedBy: [{ type: "dependency", id: "TASK-X", status: "pending" }],
     };
     const html = renderSessionDetailPage(SESSION_ID, [x, y], USER_NAME);
     const section = graphSection(html);
     expect(section).toContain("TASK-X");
     expect(section).toContain("TASK-Y");
+    expect(section).toContain("Blocked (2)");
   });
 
   test("escapes task ids, titles, and branch names in the graph to avoid XSS", () => {
@@ -4180,6 +4293,7 @@ describe("renderSessionDetailPage dependency graph", () => {
       session: SESSION_ID,
       branch: "<script>evil()</script>",
       dependencies: ["<b>dep</b>"],
+      blockedBy: [{ type: "dependency", id: "<b>dep</b>", status: "unknown" }],
     };
     const html = renderSessionDetailPage(SESSION_ID, [xss], USER_NAME);
     const section = graphSection(html);

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -4029,3 +4029,162 @@ describe("renderSessionDetailPage", () => {
     expect(html).toContain(">1<"); // 1 total task
   });
 });
+
+// ─── renderSessionDetailPage — dependency graph ──────────────────────────────
+
+describe("renderSessionDetailPage dependency graph", () => {
+  const SESSION_ID = "session-graph";
+
+  // Isolates the graph card from the task table above it — both can contain
+  // the same task ids, so plain html.toContain() can't tell them apart.
+  function graphSection(html: string): string {
+    const idx = html.indexOf("Dependency graph");
+    expect(idx).toBeGreaterThan(-1);
+    return html.slice(idx);
+  }
+
+  test("chains tasks into topological waves and annotates what each needs", () => {
+    const a: TaskItem = {
+      id: "TASK-A",
+      title: "Root",
+      status: "pending",
+      session: SESSION_ID,
+    };
+    const b: TaskItem = {
+      id: "TASK-B",
+      title: "Depends on A",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-A"],
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [a, b], USER_NAME);
+    const section = graphSection(html);
+    expect(section).toContain("Wave 1");
+    expect(section).toContain("Wave 2");
+    expect(section).toContain("TASK-A");
+    expect(section).toContain("needs TASK-A");
+  });
+
+  test("a task outside the session (unknown id) renders without a link or status, marked outside session", () => {
+    const c: TaskItem = {
+      id: "TASK-C",
+      title: "Needs an external dep",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["EXTERNAL-1"],
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [c], USER_NAME);
+    const section = graphSection(html);
+    expect(section).toContain("EXTERNAL-1");
+    expect(section).not.toContain('href="/admin/tasks/EXTERNAL-1"');
+    expect(section).toContain("outside session");
+  });
+
+  test("tasks with no dependency relationship at all are excluded from the graph", () => {
+    const unrelated: TaskItem = {
+      id: "TASK-LONER",
+      title: "No relationships",
+      status: "pending",
+      session: SESSION_ID,
+    };
+    const dependent: TaskItem = {
+      id: "TASK-DEP",
+      title: "Depends on root",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-ROOT"],
+    };
+    const root: TaskItem = {
+      id: "TASK-ROOT",
+      title: "Root",
+      status: "pending",
+      session: SESSION_ID,
+    };
+    const html = renderSessionDetailPage(
+      SESSION_ID,
+      [unrelated, dependent, root],
+      USER_NAME,
+    );
+    const section = graphSection(html);
+    expect(section).toContain("TASK-DEP");
+    expect(section).toContain("TASK-ROOT");
+    expect(section).not.toContain("TASK-LONER");
+  });
+
+  test("same-branch tasks get a matching branch color even across different waves (bundle)", () => {
+    const first: TaskItem = {
+      id: "TASK-1",
+      title: "models + migration",
+      status: "pending",
+      session: SESSION_ID,
+      branch: "feat/bundle",
+    };
+    const second: TaskItem = {
+      id: "TASK-2",
+      title: "admin endpoint",
+      status: "pending",
+      session: SESSION_ID,
+      branch: "feat/bundle",
+      dependencies: ["TASK-1"],
+    };
+    const html = renderSessionDetailPage(
+      SESSION_ID,
+      [first, second],
+      USER_NAME,
+    );
+    const section = graphSection(html);
+    const colors = [
+      ...section.matchAll(/border-left:3px solid (#[0-9a-f]{6})/g),
+    ].map((m) => m[1]);
+    expect(colors.length).toBe(2);
+    expect(colors[0]).toBe(colors[1]);
+  });
+
+  test("session with zero dependency edges omits the dependency graph card entirely", () => {
+    const solo: TaskItem = {
+      id: "TASK-SOLO",
+      title: "Independent",
+      status: "pending",
+      session: SESSION_ID,
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [solo], USER_NAME);
+    expect(html).not.toContain("Dependency graph");
+  });
+
+  test("a dependency cycle doesn't hang rendering — remaining nodes dump into a final wave", () => {
+    const x: TaskItem = {
+      id: "TASK-X",
+      title: "X",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-Y"],
+    };
+    const y: TaskItem = {
+      id: "TASK-Y",
+      title: "Y",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-X"],
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [x, y], USER_NAME);
+    const section = graphSection(html);
+    expect(section).toContain("TASK-X");
+    expect(section).toContain("TASK-Y");
+  });
+
+  test("escapes task ids, titles, and branch names in the graph to avoid XSS", () => {
+    const xss: TaskItem = {
+      id: "TASK-XSS",
+      title: "<img src=x onerror=alert(1)>",
+      status: "pending",
+      session: SESSION_ID,
+      branch: "<script>evil()</script>",
+      dependencies: ["<b>dep</b>"],
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [xss], USER_NAME);
+    const section = graphSection(html);
+    expect(section).not.toContain("<img src=x onerror=alert(1)>");
+    expect(section).not.toContain("<script>evil()</script>");
+    expect(section).not.toContain("<b>dep</b>");
+  });
+});

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -3901,7 +3901,7 @@ describe("renderChatThreadPage", () => {
 describe("renderSessionDetailPage", () => {
   const SESSION_ID = "session-abc";
 
-  const OPEN_TASK_1: TaskItem = {
+  const READY_TASK: TaskItem = {
     id: "TASK-1",
     title: "Build the thing",
     status: "pending",
@@ -3912,7 +3912,7 @@ describe("renderSessionDetailPage", () => {
     dependencies: ["TASK-0"],
   };
 
-  const OPEN_TASK_2: TaskItem = {
+  const IN_PROGRESS_TASK: TaskItem = {
     id: "TASK-2",
     title: "Wire up the UI",
     status: "in_progress",
@@ -3942,7 +3942,12 @@ describe("renderSessionDetailPage", () => {
     hours: 0.5,
   };
 
-  const MIXED_TASKS = [OPEN_TASK_1, OPEN_TASK_2, CLOSED_TASK_1, CLOSED_TASK_2];
+  const MIXED_TASKS = [
+    READY_TASK,
+    IN_PROGRESS_TASK,
+    CLOSED_TASK_1,
+    CLOSED_TASK_2,
+  ];
 
   test("stat cards: total tasks, est. hours sum, distinct layers", () => {
     const html = renderSessionDetailPage(SESSION_ID, MIXED_TASKS, USER_NAME);
@@ -3967,31 +3972,53 @@ describe("renderSessionDetailPage", () => {
     expect(html).toContain("merged");
   });
 
-  test("distinguishes open vs. closed tasks — 'X open / Y closed' summary", () => {
+  test("summarizes and groups the task table by ready/in_progress/blocked/closed — matching the Tasks page taxonomy", () => {
     const html = renderSessionDetailPage(SESSION_ID, MIXED_TASKS, USER_NAME);
-    // 2 open (pending, in_progress), 2 closed (done, merged)
-    expect(html).toMatch(/2[^0-9]*open/i);
+    // READY_TASK (pending, no blockedBy) -> ready; IN_PROGRESS_TASK (in_progress) -> in_progress;
+    // CLOSED_TASK_1/2 (done, merged) -> closed; none blocked.
+    expect(html).toMatch(/1[^0-9]*ready/i);
+    expect(html).toMatch(/1[^0-9]*in progress/i);
+    expect(html).toMatch(/0[^0-9]*blocked/i);
     expect(html).toMatch(/2[^0-9]*closed/i);
+    expect(html).toContain("Ready (1)");
+    expect(html).toContain("In Progress (1)");
+    expect(html).toContain("Closed (2)");
+    expect(html).not.toContain("Blocked (");
   });
 
-  test("all-open session: 4 open / 0 closed", () => {
+  test("all-ready-or-in-progress session: no Closed group rendered", () => {
     const html = renderSessionDetailPage(
       SESSION_ID,
-      [OPEN_TASK_1, OPEN_TASK_2],
+      [READY_TASK, IN_PROGRESS_TASK],
       USER_NAME,
     );
-    expect(html).toMatch(/2[^0-9]*open/i);
-    expect(html).toMatch(/0[^0-9]*closed/i);
+    expect(html).toContain("Ready (1)");
+    expect(html).toContain("In Progress (1)");
+    expect(html).not.toContain("Closed (");
   });
 
-  test("all-closed session: 0 open / 2 closed", () => {
+  test("all-closed session: single Closed group, no Ready/In Progress/Blocked", () => {
     const html = renderSessionDetailPage(
       SESSION_ID,
       [CLOSED_TASK_1, CLOSED_TASK_2],
       USER_NAME,
     );
-    expect(html).toMatch(/0[^0-9]*open/i);
-    expect(html).toMatch(/2[^0-9]*closed/i);
+    expect(html).toContain("Closed (2)");
+    expect(html).not.toContain("Ready (");
+    expect(html).not.toContain("In Progress (");
+    expect(html).not.toContain("Blocked (");
+  });
+
+  test("a pending task with unresolved blockers groups under Blocked in the task table", () => {
+    const blocked: TaskItem = {
+      id: "TASK-5",
+      title: "Blocked on something",
+      status: "pending",
+      session: SESSION_ID,
+      blockedBy: [{ type: "dependency", id: "TASK-1", status: "pending" }],
+    };
+    const html = renderSessionDetailPage(SESSION_ID, [blocked], USER_NAME);
+    expect(html).toContain("Blocked (1)");
   });
 
   test("dependency list rendering: distinct dependency ids collected across tasks", () => {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -4302,7 +4302,7 @@ describe("admin UI — session detail page", () => {
     cookie = await makeSessionCookie();
   });
 
-  it("GET /admin/sessions/:id renders stat cards + task table with a mix of open/closed tasks", async () => {
+  it("GET /admin/sessions/:id renders stat cards + task table grouped by ready/in_progress/blocked/closed", async () => {
     const mockTasks = [
       {
         id: "task-1",
@@ -4347,9 +4347,12 @@ describe("admin UI — session detail page", () => {
     const html = await res.text();
     expect(html).toContain("Build auth module");
     expect(html).toContain("Ship the feature");
-    // Open/closed grouping present
-    expect(html).toMatch(/1[^0-9]*open/i);
+    // Ready/in_progress/blocked/closed grouping present — task-1 is pending
+    // with no blockedBy entries (ready), task-2 is done (closed).
+    expect(html).toMatch(/1[^0-9]*ready/i);
     expect(html).toMatch(/1[^0-9]*closed/i);
+    expect(html).toContain("Ready (1)");
+    expect(html).toContain("Closed (1)");
     // Status column
     expect(html).toContain("Status");
   });


### PR DESCRIPTION
## Summary
- The session detail page's Dependencies card flattened all tasks' dependencies into a single deduped bullet list — no way to see which task needed which dependency, or what's actually actionable right now.
- Added a **Dependency graph** card grouped by **Ready / In Progress / Blocked / Closed** — the same taxonomy already used by the Tasks page's state tabs (task-store's `listReady`/`listBlocked` semantics). Each card shows what it needs, and same-branch tasks (bundled into one PR) get a matching color-coded chip/border even across groups. Only tasks that participate in a dependency edge are shown here; unrelated tasks stay in the plain task table.
- The **task table above it** (previously split into just "Open"/"Closed") now uses the same Ready/In Progress/Blocked/Closed grouping and summary line, so both views speak the same language.
- Dependency ids outside the session render as plain unlinked text inline in a participating task's "needs" list; in-session dependency ids link to that task's detail page.

## Test plan
- [x] `bun test admin/src/admin-ui-pages.unit.test.ts` — 368 pass, covering state-group classification/ordering for both the task table and the dependency graph, in-session vs external dependency linking, unrelated-task exclusion, branch-bundle color matching across groups, empty-group omission, cycle safety, and XSS escaping
- [x] `task typecheck` — all workspaces pass
- [x] `bunx biome check` on both changed files — clean (pre-existing formatting drift elsewhere in the test file left untouched)