### PR TITLE
feat(agent): plugin-declared per-command pre-run hooks (command hooks)

### DIFF
--- a/agent/src/hooks.smoke.test.ts
+++ b/agent/src/hooks.smoke.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Smoke tests for agent/src/hooks.ts — real process spawning.
+ *
+ * Strategy: this file houses the one command-hook test that deliberately omits
+ * the injected spawner to exercise real SIGTERM→SIGKILL signal behavior via
+ * `Bun.spawn`. Per `docs/test-readiness/test-system.md`, a test that spawns a
+ * real process cannot live in `*.unit.test.ts` ("no process spawning"); the
+ * precedent for real-process hook/precheck testing is the smoke layer (see
+ * `cron-handler.smoke.test.ts`'s preCheck suite). All other, fixture-based
+ * `withCommandHooks` tests remain in `hooks.unit.test.ts` behind an injected
+ * spawner double.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ClaudeRunResult } from "./claude.ts";
+import { HookError, withCommandHooks } from "./hooks.ts";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+function writeExec(path: string, body = "#!/usr/bin/env bash\nexit 0\n"): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+const tmp = () => mkdtempSync(join(tmpdir(), "hooks-smoke-test-"));
+
+const okResult: ClaudeRunResult = { result: "ran", sessionId: "s1" };
+
+// ─── withCommandHooks — real spawn ───────────────────────────────────────────
+
+describe("withCommandHooks — real spawn", () => {
+  test("real spawn: a SIGTERM-ignoring hook is SIGKILLed after the grace period", async () => {
+    const cacheDir = tmp();
+    const dir = join(cacheDir, "custom", "hooks", "shipwright:dev-task.pre");
+    mkdirSync(dir, { recursive: true });
+    writeExec(
+      join(dir, "10-stubborn.sh"),
+      "#!/usr/bin/env bash\ntrap '' TERM\nwhile true; do sleep 0.05; done\n",
+    );
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    // No injected spawner — real Bun.spawn, real signals.
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      timeoutMs: 100,
+      killGraceMs: 200,
+    });
+
+    const started = Date.now();
+    const err = await wrapped("/shipwright:dev-task acme/x#1").catch((e) => e);
+
+    expect(err).toBeInstanceOf(HookError);
+    expect((err as HookError).timedOut).toBe(true);
+    // SIGTERM alone would hang forever — SIGKILL must bound the wait.
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(runner).not.toHaveBeenCalled();
+  });
+});

--- a/agent/src/hooks.ts
+++ b/agent/src/hooks.ts
@@ -162,6 +162,10 @@ function listPluginRoots(config: CommandHooksConfig, fs: HookFs): PluginRoot[] {
     config.pluginManifestPath ??
     join(homedir(), ".claude", "plugins", "installed_plugins.json");
 
+  // An absent manifest means no plugins are installed — the no-hooks
+  // passthrough case, not an error.
+  if (!fs.existsSync(manifestPath)) return roots;
+
   try {
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
       version: number;
@@ -175,9 +179,9 @@ function listPluginRoots(config: CommandHooksConfig, fs: HookFs): PluginRoot[] {
       }
     }
   } catch (err) {
-    console.warn(
-      `[agent:hooks] failed to read installed_plugins.json: ${String(err)}`,
-    );
+    // Fail closed: a manifest that exists but cannot be read/parsed makes
+    // hook resolution unknowable — the session must not run ungated.
+    throw new HookError(manifestPath, undefined, String(err));
   }
   return roots;
 }

--- a/agent/src/hooks.ts
+++ b/agent/src/hooks.ts
@@ -1,0 +1,330 @@
+/**
+ * agent/src/hooks.ts
+ *
+ * Command hooks — plugin-declared, per-command pre-run hooks executed as
+ * fail-closed guards around the shared Claude runner. Hook dirs named
+ * `hooks/<plugin>:<command>.pre/` are resolved across all installed plugins
+ * (same manifest/pluginCacheDir resolution preCheck uses), then the workspace
+ * escape hatch `state/hooks/<plugin>:<command>.pre/`. With no hook dirs
+ * installed the decorator is a byte-identical passthrough.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ClaudeRunResult } from "./claude.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** The claude runner signature the decorator preserves. */
+export type ClaudeRunner = (
+  message: string,
+  sessionKey?: string,
+) => Promise<ClaudeRunResult>;
+
+/** Filesystem surface used for hook resolution — injectable for tests. */
+export interface HookFs {
+  existsSync: (path: string) => boolean;
+  statSync: (path: string) => { isDirectory: () => boolean; mode: number };
+  readdirSync: (path: string) => string[];
+  readFileSync: (path: string, encoding: "utf-8") => string;
+}
+
+const nodeFs: HookFs = { existsSync, statSync, readdirSync, readFileSync };
+
+export interface CommandHooksConfig {
+  /** Workspace root — hook cwd, and the base for the `state/hooks` escape hatch. */
+  workspace?: string;
+  /** Plugin cache dir — overridable for testing, like cron-handler's preCheck. */
+  pluginCacheDir?: string;
+  /** installed_plugins.json path — the production resolution source. */
+  pluginManifestPath?: string;
+  /** Per-hook timeout. Defaults to SHIPWRIGHT_HOOK_TIMEOUT_MS (120000ms). */
+  timeoutMs?: number;
+  /** Grace period between SIGTERM and SIGKILL on timeout. Default 5000ms. */
+  killGraceMs?: number;
+  /** Process spawner — injectable for tests. Defaults to Bun.spawn. */
+  spawner?: typeof Bun.spawn;
+  /** Filesystem surface — injectable for tests. Defaults to node:fs. */
+  fs?: HookFs;
+}
+
+/** The plugin + command a slash-command message invokes. */
+export interface ParsedCommand {
+  plugin: string;
+  command: string;
+}
+
+const DEFAULT_HOOK_TIMEOUT_MS = 120_000;
+const DEFAULT_KILL_GRACE_MS = 5_000;
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a pre hook exits nonzero, times out, or cannot be resolved.
+ * Fail-closed: the session is suppressed.
+ */
+export class HookError extends Error {
+  constructor(
+    readonly hookName: string,
+    readonly exitCode: number | undefined,
+    readonly stderr: string,
+    readonly timedOut: boolean = false,
+  ) {
+    super(
+      timedOut
+        ? `pre hook "${hookName}" timed out${stderr ? `: ${stderr}` : ""}`
+        : `pre hook "${hookName}" failed (exit ${exitCode})${stderr ? `: ${stderr}` : ""}`,
+    );
+    this.name = "HookError";
+  }
+}
+
+// ─── Command parsing ────────────────────────────────────────────────────────
+
+// A fully-qualified slash command: /<plugin>:<command>, terminated by
+// whitespace or end-of-line.
+const COMMAND_RE = /^\/([A-Za-z0-9._-]+):([A-Za-z0-9._-]+)(?:\s|$)/;
+
+// Wrapper lines the dispatch paths prepend on their own line(s) before the
+// substantive message: cron-handler's `[Cron job: <id>] Current time: …` and
+// slack.ts's `[Thread message — …]` line. Skipped so the command is still
+// resolvable from the outgoing message alone.
+const WRAPPER_LINE_RE = /^\[(?:Cron job:|Thread message)/;
+
+// slack.ts's app_mention handler may prepend a `[Thread context]` …
+// `[end thread context]` block of quoted history — never the message being
+// sent, so it is skipped wholesale (a slash command inside it must NOT fire).
+const THREAD_CONTEXT_START = "[Thread context]";
+const THREAD_CONTEXT_END = "[end thread context]";
+
+// slack.ts prefixes every human message with `[<display name>]: ` and an
+// app_mention's text retains the bot's `<@U…>` mention token — both may
+// precede the slash command on the substantive line.
+const SENDER_PREFIX_RE = /^\[[^\]]+\]:\s*/;
+const MENTION_TOKEN_RE = /^(?:<@[^>\s]+>\s*)+/;
+
+/**
+ * Parse the leading fully-qualified slash command from an outgoing runner
+ * message. Returns undefined when the message does not invoke one (⇒ the
+ * decorator passes through untouched).
+ */
+export function parseCommand(message: string): ParsedCommand | undefined {
+  let inThreadContext = false;
+  for (const rawLine of message.split("\n")) {
+    const line = rawLine.trim();
+    if (inThreadContext) {
+      if (line === THREAD_CONTEXT_END) inThreadContext = false;
+      continue;
+    }
+    if (line === "") continue;
+    if (line === THREAD_CONTEXT_START) {
+      inThreadContext = true;
+      continue;
+    }
+    if (WRAPPER_LINE_RE.test(line)) continue;
+    const stripped = line
+      .replace(SENDER_PREFIX_RE, "")
+      .replace(MENTION_TOKEN_RE, "");
+    const match = COMMAND_RE.exec(stripped);
+    return match ? { plugin: match[1], command: match[2] } : undefined;
+  }
+  return undefined;
+}
+
+// ─── Hook resolution ────────────────────────────────────────────────────────
+
+interface PluginRoot {
+  name: string;
+  root: string;
+}
+
+/**
+ * Enumerate installed plugins as `{ name, root }`, using the same
+ * pluginCacheDir / installed_plugins.json sources cron-handler's preCheck
+ * resolution uses.
+ */
+function listPluginRoots(config: CommandHooksConfig, fs: HookFs): PluginRoot[] {
+  const roots: PluginRoot[] = [];
+
+  if (config.pluginCacheDir) {
+    if (!fs.existsSync(config.pluginCacheDir)) return roots;
+    for (const name of fs.readdirSync(config.pluginCacheDir)) {
+      const root = join(config.pluginCacheDir, name);
+      if (fs.existsSync(root) && fs.statSync(root).isDirectory()) {
+        roots.push({ name, root });
+      }
+    }
+    return roots;
+  }
+
+  const manifestPath =
+    config.pluginManifestPath ??
+    join(homedir(), ".claude", "plugins", "installed_plugins.json");
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
+      version: number;
+      plugins: Record<string, Array<{ installPath?: string }>>;
+    };
+    for (const [key, entries] of Object.entries(manifest.plugins)) {
+      const installPath = entries?.[0]?.installPath;
+      if (installPath) {
+        // Manifest keys are `<name>@<source>` — the plugin name is the prefix.
+        roots.push({ name: key.split("@")[0], root: installPath });
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[agent:hooks] failed to read installed_plugins.json: ${String(err)}`,
+    );
+  }
+  return roots;
+}
+
+/** Sorted list of executable files in a hook directory (empty if absent). */
+function listHookScripts(dir: string, fs: HookFs): string[] {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
+  const scripts: string[] = [];
+  for (const name of fs.readdirSync(dir).sort()) {
+    const path = join(dir, name);
+    let stat: { isDirectory: () => boolean; mode: number };
+    try {
+      stat = fs.statSync(path);
+    } catch (err) {
+      // Fail closed: an unstat-able entry (e.g. a dangling symlink) is a
+      // broken hook install, not a skippable file.
+      throw new HookError(path, undefined, String(err));
+    }
+    // Only regular executable files run — skip subdirs and non-exec files.
+    if (!stat.isDirectory() && (stat.mode & 0o111) !== 0) {
+      scripts.push(path);
+    }
+  }
+  return scripts;
+}
+
+/**
+ * Resolve the ordered list of pre-hook script paths for an invoked command:
+ * plugin hooks first (alphabetical by plugin, then filename), workspace
+ * escape-hatch hooks last.
+ */
+export function resolveHookScripts(
+  parsed: ParsedCommand,
+  config: CommandHooksConfig,
+): string[] {
+  const fs = config.fs ?? nodeFs;
+  const dirName = `${parsed.plugin}:${parsed.command}.pre`;
+  const scripts: string[] = [];
+
+  const roots = listPluginRoots(config, fs).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  for (const { root } of roots) {
+    scripts.push(...listHookScripts(join(root, "hooks", dirName), fs));
+  }
+
+  if (config.workspace) {
+    scripts.push(
+      ...listHookScripts(join(config.workspace, "state", "hooks", dirName), fs),
+    );
+  }
+
+  return scripts;
+}
+
+// ─── Execution ────────────────────────────────────────────────────────────
+
+function resolveTimeoutMs(config: CommandHooksConfig): number {
+  if (config.timeoutMs !== undefined) return config.timeoutMs;
+  const raw = process.env.SHIPWRIGHT_HOOK_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_HOOK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_HOOK_TIMEOUT_MS;
+}
+
+/** Run a single pre hook, throwing HookError on nonzero exit or timeout. */
+async function runHook(
+  scriptPath: string,
+  message: string,
+  parsed: ParsedCommand,
+  config: CommandHooksConfig,
+): Promise<void> {
+  const spawner = config.spawner ?? Bun.spawn;
+  const timeoutMs = resolveTimeoutMs(config);
+  const killGraceMs = config.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+
+  const proc = spawner([scriptPath], {
+    ...(config.workspace ? { cwd: config.workspace } : {}),
+    // Spread at spawn time so live config-sync env rotations are visible,
+    // mirroring preCheck's env: process.env passthrough.
+    env: {
+      ...process.env,
+      SHIPWRIGHT_HOOK_EVENT: "pre",
+      SHIPWRIGHT_HOOK_COMMAND: `${parsed.plugin}:${parsed.command}`,
+    },
+    stdin: new TextEncoder().encode(message),
+    stdout: "inherit",
+    stderr: "pipe",
+  });
+
+  let timedOut = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+    // Escalate: a hook that ignores SIGTERM must not hang the agent.
+    killTimer = setTimeout(() => proc.kill("SIGKILL"), killGraceMs);
+  }, timeoutMs);
+
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]).finally(() => {
+    clearTimeout(timer);
+    if (killTimer !== undefined) clearTimeout(killTimer);
+  });
+
+  if (timedOut) {
+    throw new HookError(scriptPath, exitCode, stderr.trim(), true);
+  }
+  if (exitCode !== 0) {
+    throw new HookError(scriptPath, exitCode, stderr.trim(), false);
+  }
+}
+
+// ─── Decorator ────────────────────────────────────────────────────────────
+
+/**
+ * Wrap a claude runner so every message whose leading slash command has
+ * attached pre hooks runs those hooks first. No leading command, or no hooks
+ * attached ⇒ byte-identical passthrough. A hook failure throws HookError
+ * before the runner is ever called, so the session does not run.
+ */
+export function withCommandHooks(
+  runner: ClaudeRunner,
+  config: CommandHooksConfig = {},
+): ClaudeRunner {
+  return async function runWithHooks(
+    message: string,
+    sessionKey?: string,
+  ): Promise<ClaudeRunResult> {
+    const parsed = parseCommand(message);
+    if (!parsed) return runner(message, sessionKey);
+
+    const scripts = resolveHookScripts(parsed, config);
+    if (scripts.length === 0) return runner(message, sessionKey);
+
+    const command = `${parsed.plugin}:${parsed.command}`;
+    for (const scriptPath of scripts) {
+      console.log(
+        `[agent:hooks] running pre hook for ${command}: ${scriptPath}`,
+      );
+      await runHook(scriptPath, message, parsed, config);
+    }
+
+    return runner(message, sessionKey);
+  };
+}

--- a/agent/src/hooks.unit.test.ts
+++ b/agent/src/hooks.unit.test.ts
@@ -356,6 +356,38 @@ describe("resolveHookScripts — resolution order", () => {
       ),
     ).toThrow(HookError);
   });
+
+  test("an absent plugin manifest is the no-hooks passthrough case", async () => {
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([]);
+    const wrapped = withCommandHooks(runner, {
+      pluginManifestPath: join(tmp(), "installed_plugins.json"), // never written
+      spawner,
+    });
+
+    const out = await wrapped("/shipwright:dev-task acme/x#1");
+
+    expect(out).toBe(okResult);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a corrupt plugin manifest throws HookError and blocks the session (fail closed)", async () => {
+    const manifestPath = join(tmp(), "installed_plugins.json");
+    writeFileSync(manifestPath, "not json {{");
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner } = recordingSpawner([]);
+    const wrapped = withCommandHooks(runner, {
+      pluginManifestPath: manifestPath,
+      spawner,
+    });
+
+    const err = await wrapped("/shipwright:dev-task acme/x#1").catch((e) => e);
+
+    expect(err).toBeInstanceOf(HookError);
+    expect((err as HookError).hookName).toBe(manifestPath);
+    expect(runner).not.toHaveBeenCalled();
+  });
 });
 
 // ─── withCommandHooks — passthrough ──────────────────────────────────────────

--- a/agent/src/hooks.unit.test.ts
+++ b/agent/src/hooks.unit.test.ts
@@ -571,32 +571,6 @@ describe("withCommandHooks — execution", () => {
     );
     expect(runner).toHaveBeenCalledTimes(1);
   });
-
-  test("real spawn: a SIGTERM-ignoring hook is SIGKILLed after the grace period", async () => {
-    const cacheDir = tmp();
-    const dir = join(cacheDir, "custom", "hooks", "shipwright:dev-task.pre");
-    mkdirSync(dir, { recursive: true });
-    writeExec(
-      join(dir, "10-stubborn.sh"),
-      "#!/usr/bin/env bash\ntrap '' TERM\nwhile true; do sleep 0.05; done\n",
-    );
-    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
-    // No injected spawner — real Bun.spawn, real signals.
-    const wrapped = withCommandHooks(runner, {
-      pluginCacheDir: cacheDir,
-      timeoutMs: 100,
-      killGraceMs: 200,
-    });
-
-    const started = Date.now();
-    const err = await wrapped("/shipwright:dev-task acme/x#1").catch((e) => e);
-
-    expect(err).toBeInstanceOf(HookError);
-    expect((err as HookError).timedOut).toBe(true);
-    // SIGTERM alone would hang forever — SIGKILL must bound the wait.
-    expect(Date.now() - started).toBeLessThan(2_000);
-    expect(runner).not.toHaveBeenCalled();
-  });
 });
 
 // ─── HookError through the cron-handler failed-run path ──────────────────────

--- a/agent/src/hooks.unit.test.ts
+++ b/agent/src/hooks.unit.test.ts
@@ -1,0 +1,661 @@
+/**
+ * Tests for agent/src/hooks.ts
+ *
+ * Strategy: real temp dirs for hook resolution (matching the preCheck tests'
+ * house style), an injected spawner double so no real hook process runs, and an
+ * injected CronRunReporter double for the cron-handler propagation test. No
+ * mock.module() calls.
+ */
+
+import "./test-env.ts";
+import { describe, expect, mock, test } from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createChatPoller } from "./chat-poller.ts";
+import type { ClaudeRunResult } from "./claude.ts";
+import { handleCronRequest } from "./cron-handler.ts";
+import type { CronRunReporter } from "./cron-run-reporter.ts";
+import {
+  HookError,
+  parseCommand,
+  resolveHookScripts,
+  withCommandHooks,
+} from "./hooks.ts";
+import type { ChatServiceClient } from "./http-chat-service-client.ts";
+
+// ─── Spawner double ───────────────────────────────────────────────────────────
+
+interface FakeProc {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill: () => void;
+}
+
+function stream(content: string): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(enc.encode(content));
+      c.close();
+    },
+  });
+}
+
+function fakeProc(stderr = "", exitCode = 0): FakeProc {
+  return {
+    stdout: stream(""),
+    stderr: stream(stderr),
+    exited: Promise.resolve(exitCode),
+    kill: () => {},
+  };
+}
+
+function hangingProc(): FakeProc & { killed: () => boolean } {
+  let resolveExited!: (code: number) => void;
+  let wasKilled = false;
+  const exited = new Promise<number>((r) => {
+    resolveExited = r;
+  });
+  return {
+    stdout: stream(""),
+    stderr: stream(""),
+    exited,
+    kill: () => {
+      wasKilled = true;
+      resolveExited(143);
+    },
+    killed: () => wasKilled,
+  };
+}
+
+interface SpawnCall {
+  cmd: string[];
+  opts: {
+    cwd?: string;
+    env?: Record<string, string>;
+    stdin?: Uint8Array;
+  };
+}
+
+function recordingSpawner(procs: FakeProc[]): {
+  spawner: typeof Bun.spawn;
+  calls: SpawnCall[];
+} {
+  const calls: SpawnCall[] = [];
+  let i = 0;
+  const spawner = ((cmd: string[], opts: SpawnCall["opts"]) => {
+    calls.push({ cmd, opts });
+    return procs[i++] ?? fakeProc();
+  }) as unknown as typeof Bun.spawn;
+  return { spawner, calls };
+}
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+function writeExec(path: string, body = "#!/usr/bin/env bash\nexit 0\n"): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+/** Creates `<cacheDir>/<plugin>/hooks/<plugin>:<command>.pre/<file>` (executable). */
+function seedPluginHook(
+  cacheDir: string,
+  plugin: string,
+  target: string,
+  file: string,
+): string {
+  const dir = join(cacheDir, plugin, "hooks", `${target}.pre`);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, file);
+  writeExec(path);
+  return path;
+}
+
+/** Creates `<workspace>/state/hooks/<target>.pre/<file>` (executable). */
+function seedWorkspaceHook(
+  workspace: string,
+  target: string,
+  file: string,
+): string {
+  const dir = join(workspace, "state", "hooks", `${target}.pre`);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, file);
+  writeExec(path);
+  return path;
+}
+
+const tmp = () => mkdtempSync(join(tmpdir(), "hooks-test-"));
+
+const okResult: ClaudeRunResult = { result: "ran", sessionId: "s1" };
+
+// ─── parseCommand ─────────────────────────────────────────────────────────────
+
+describe("parseCommand", () => {
+  test("parses a loop-dispatch message (command at index 0)", () => {
+    expect(parseCommand("/shipwright:dev-task acme/x#1")).toEqual({
+      plugin: "shipwright",
+      command: "dev-task",
+    });
+  });
+
+  test("parses through the cron-handler wrapper line", () => {
+    const msg =
+      "[Cron job: my-job] Current time: 1/1/2026\n\n/custom:review-foundry acme/x#2";
+    expect(parseCommand(msg)).toEqual({
+      plugin: "custom",
+      command: "review-foundry",
+    });
+  });
+
+  test("returns undefined for a non-slash-command message", () => {
+    expect(parseCommand("hello, please summarize the day")).toBeUndefined();
+  });
+
+  test("returns undefined for a cron prompt that is natural language", () => {
+    const msg = "[Cron job: daily] Current time: 1/1/2026\n\nSummarize the day";
+    expect(parseCommand(msg)).toBeUndefined();
+  });
+
+  test("requires a fully-qualified plugin:command (bare slash command ⇒ none)", () => {
+    expect(parseCommand("/dev-task acme/x#1")).toBeUndefined();
+  });
+
+  test("allows dots in plugin and command names", () => {
+    expect(parseCommand("/shipwright:dev.task acme/x#1")).toEqual({
+      plugin: "shipwright",
+      command: "dev.task",
+    });
+  });
+
+  // The Slack handlers prefix every human message before it reaches the
+  // runner — formats below are copied from slack.ts's construction.
+
+  test("parses a Slack DM invocation ('[<name>]: ' prefix)", () => {
+    expect(
+      parseCommand("[Eugene Trapeznikov]: /shipwright:dev-task acme/x#1"),
+    ).toEqual({ plugin: "shipwright", command: "dev-task" });
+  });
+
+  test("parses a Slack channel thread message ('[Thread message …]' line + name prefix)", () => {
+    const msg =
+      "[Thread message — respond normally, or use [silent] if no response is needed]\n" +
+      "[Eugene Trapeznikov]: /shipwright:patch acme/x#2";
+    expect(parseCommand(msg)).toEqual({
+      plugin: "shipwright",
+      command: "patch",
+    });
+  });
+
+  test("parses a Slack app_mention (name prefix + bot mention token)", () => {
+    expect(
+      parseCommand(
+        "[Eugene Trapeznikov]: <@U0BOTID> /shipwright:dev-task acme/x#1",
+      ),
+    ).toEqual({ plugin: "shipwright", command: "dev-task" });
+  });
+
+  test("parses an app_mention preceded by a '[Thread context]' history block", () => {
+    const msg =
+      "[Thread context]\n" +
+      "[Alice]: earlier chatter\n" +
+      "[end thread context]\n" +
+      "\n" +
+      "[Eugene]: <@U0BOTID> /custom:review-foundry acme/x#3";
+    expect(parseCommand(msg)).toEqual({
+      plugin: "custom",
+      command: "review-foundry",
+    });
+  });
+
+  test("a slash command quoted INSIDE the thread-context block does NOT fire", () => {
+    const msg =
+      "[Thread context]\n" +
+      "[Alice]: /shipwright:deploy acme/x#9\n" +
+      "[end thread context]\n" +
+      "\n" +
+      "[Eugene]: <@U0BOTID> what happened here?";
+    expect(parseCommand(msg)).toBeUndefined();
+  });
+
+  test("returns undefined for a Slack DM that is natural language", () => {
+    expect(parseCommand("[Eugene]: how is the deploy going?")).toBeUndefined();
+  });
+});
+
+// ─── resolveHookScripts ─────────────────────────────────────────────────────
+
+describe("resolveHookScripts — resolution order", () => {
+  test("own-plugin, cross-plugin, and workspace hooks in the correct order", () => {
+    const cacheDir = tmp();
+    const workspace = tmp();
+    // Cross-plugin: `custom` attaches to shipwright:dev-task (sorts before shipwright).
+    const cross = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:dev-task",
+      "20-b.sh",
+    );
+    // Own-plugin: shipwright attaches to its own dev-task.
+    const own = seedPluginHook(
+      cacheDir,
+      "shipwright",
+      "shipwright:dev-task",
+      "10-a.sh",
+    );
+    // Workspace escape hatch runs last.
+    const ws = seedWorkspaceHook(workspace, "shipwright:dev-task", "30-c.sh");
+
+    const scripts = resolveHookScripts(
+      { plugin: "shipwright", command: "dev-task" },
+      { pluginCacheDir: cacheDir, workspace },
+    );
+
+    // Plugins alphabetical (custom < shipwright), workspace last.
+    expect(scripts).toEqual([cross, own, ws]);
+  });
+
+  test("filename order within a single plugin hook dir", () => {
+    const cacheDir = tmp();
+    const b = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:patch",
+      "20-second.sh",
+    );
+    const a = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:patch",
+      "10-first.sh",
+    );
+
+    const scripts = resolveHookScripts(
+      { plugin: "shipwright", command: "patch" },
+      { pluginCacheDir: cacheDir },
+    );
+
+    expect(scripts).toEqual([a, b]);
+  });
+
+  test("non-executable files are ignored", () => {
+    const cacheDir = tmp();
+    const dir = join(cacheDir, "custom", "hooks", "shipwright:dev-task.pre");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "README.md"), "not a hook\n"); // no exec bit
+    const exec = join(dir, "10-run.sh");
+    writeExec(exec);
+
+    const scripts = resolveHookScripts(
+      { plugin: "shipwright", command: "dev-task" },
+      { pluginCacheDir: cacheDir },
+    );
+
+    expect(scripts).toEqual([exec]);
+  });
+
+  test("no hook dirs anywhere ⇒ empty list", () => {
+    const scripts = resolveHookScripts(
+      { plugin: "shipwright", command: "dev-task" },
+      { pluginCacheDir: tmp(), workspace: tmp() },
+    );
+    expect(scripts).toEqual([]);
+  });
+
+  test("resolves cross-plugin hooks via installed_plugins.json manifest", () => {
+    const installDir = tmp();
+    const customRoot = join(installDir, "custom");
+    mkdirSync(customRoot, { recursive: true });
+    const hook = seedPluginHook(
+      installDir,
+      "custom",
+      "shipwright:dev-task",
+      "10-a.sh",
+    );
+
+    const manifestDir = tmp();
+    const manifestPath = join(manifestDir, "installed_plugins.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "custom@foundryeng/custom": [{ installPath: customRoot }],
+          "shipwright@app-vitals/shipwright": [
+            { installPath: join(installDir, "shipwright") },
+          ],
+        },
+      }),
+    );
+
+    const scripts = resolveHookScripts(
+      { plugin: "shipwright", command: "dev-task" },
+      { pluginManifestPath: manifestPath },
+    );
+
+    expect(scripts).toEqual([hook]);
+  });
+
+  test("a dangling symlink in a hook dir throws HookError (fail closed)", () => {
+    const cacheDir = tmp();
+    const dir = join(cacheDir, "custom", "hooks", "shipwright:dev-task.pre");
+    mkdirSync(dir, { recursive: true });
+    symlinkSync(join(dir, "missing-target.sh"), join(dir, "10-dangling.sh"));
+
+    expect(() =>
+      resolveHookScripts(
+        { plugin: "shipwright", command: "dev-task" },
+        { pluginCacheDir: cacheDir },
+      ),
+    ).toThrow(HookError);
+  });
+});
+
+// ─── withCommandHooks — passthrough ──────────────────────────────────────────
+
+describe("withCommandHooks — passthrough (off by default)", () => {
+  test("no hooks anywhere ⇒ byte-identical passthrough, spawner never called", async () => {
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([]);
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: tmp(),
+      workspace: tmp(),
+      spawner,
+    });
+
+    const out = await wrapped("/shipwright:dev-task acme/x#1", "chan:ts");
+
+    expect(out).toBe(okResult);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner.mock.calls[0]).toEqual([
+      "/shipwright:dev-task acme/x#1",
+      "chan:ts",
+    ]);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("non-slash-command message ⇒ passthrough even when hooks exist", async () => {
+    const cacheDir = tmp();
+    seedPluginHook(cacheDir, "custom", "shipwright:dev-task", "10-a.sh");
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([]);
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      spawner,
+    });
+
+    await wrapped("just a chat message", undefined);
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ─── withCommandHooks — execution + context ──────────────────────────────────
+
+describe("withCommandHooks — execution", () => {
+  test("runs a resolved hook, then the runner (order + context passed)", async () => {
+    const cacheDir = tmp();
+    const workspace = tmp();
+    const hook = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:dev-task",
+      "10-a.sh",
+    );
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([fakeProc("", 0)]);
+
+    const message = "/shipwright:dev-task acme/x#1";
+    await withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      workspace,
+      spawner,
+    })(message, "chan:ts");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toEqual([hook]);
+    expect(calls[0].opts.cwd).toBe(workspace);
+    expect(calls[0].opts.env?.SHIPWRIGHT_HOOK_EVENT).toBe("pre");
+    expect(calls[0].opts.env?.SHIPWRIGHT_HOOK_COMMAND).toBe(
+      "shipwright:dev-task",
+    );
+    expect(new TextDecoder().decode(calls[0].opts.stdin)).toBe(message);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs multiple hooks sequentially before the runner", async () => {
+    const cacheDir = tmp();
+    const first = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:patch",
+      "10-a.sh",
+    );
+    const second = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:patch",
+      "20-b.sh",
+    );
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([
+      fakeProc("", 0),
+      fakeProc("", 0),
+    ]);
+
+    await withCommandHooks(runner, { pluginCacheDir: cacheDir, spawner })(
+      "/shipwright:patch acme/x#2",
+    );
+
+    expect(calls.map((c) => c.cmd[0])).toEqual([first, second]);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test("guard-abort: nonzero exit throws HookError and the runner never runs", async () => {
+    const cacheDir = tmp();
+    seedPluginHook(cacheDir, "custom", "shipwright:dev-task", "10-a.sh");
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner } = recordingSpawner([fakeProc("boom", 1)]);
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      spawner,
+    });
+
+    const err = await wrapped("/shipwright:dev-task acme/x#1").catch((e) => e);
+
+    expect(err).toBeInstanceOf(HookError);
+    expect((err as HookError).exitCode).toBe(1);
+    expect((err as HookError).stderr).toBe("boom");
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test("timeout: a hanging hook is killed and throws a timed-out HookError", async () => {
+    const cacheDir = tmp();
+    seedPluginHook(cacheDir, "custom", "shipwright:dev-task", "10-a.sh");
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const proc = hangingProc();
+    const { spawner } = recordingSpawner([proc]);
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      spawner,
+      timeoutMs: 10,
+    });
+
+    const err = await wrapped("/shipwright:dev-task acme/x#1").catch((e) => e);
+
+    expect(err).toBeInstanceOf(HookError);
+    expect((err as HookError).timedOut).toBe(true);
+    expect(proc.killed()).toBe(true);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test("a later hook is not spawned after an earlier one aborts", async () => {
+    const cacheDir = tmp();
+    seedPluginHook(cacheDir, "custom", "shipwright:dev-task", "10-a.sh");
+    seedPluginHook(cacheDir, "custom", "shipwright:dev-task", "20-b.sh");
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([
+      fakeProc("nope", 3),
+      fakeProc("", 0),
+    ]);
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      spawner,
+    });
+
+    await wrapped("/shipwright:dev-task acme/x#1").catch(() => {});
+
+    expect(calls).toHaveLength(1); // stopped after the first hook failed
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test("a Slack DM manual invocation fires the same hooks as a loop dispatch", async () => {
+    const cacheDir = tmp();
+    const hook = seedPluginHook(
+      cacheDir,
+      "custom",
+      "shipwright:dev-task",
+      "10-a.sh",
+    );
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    const { spawner, calls } = recordingSpawner([fakeProc("", 0)]);
+
+    await withCommandHooks(runner, { pluginCacheDir: cacheDir, spawner })(
+      "[Eugene Trapeznikov]: /shipwright:dev-task acme/x#1",
+      "C123:1.1",
+    );
+
+    expect(calls.map((c) => c.cmd[0])).toEqual([hook]);
+    expect(calls[0].opts.env?.SHIPWRIGHT_HOOK_COMMAND).toBe(
+      "shipwright:dev-task",
+    );
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test("real spawn: a SIGTERM-ignoring hook is SIGKILLed after the grace period", async () => {
+    const cacheDir = tmp();
+    const dir = join(cacheDir, "custom", "hooks", "shipwright:dev-task.pre");
+    mkdirSync(dir, { recursive: true });
+    writeExec(
+      join(dir, "10-stubborn.sh"),
+      "#!/usr/bin/env bash\ntrap '' TERM\nwhile true; do sleep 0.05; done\n",
+    );
+    const runner = mock((_m: string, _k?: string) => Promise.resolve(okResult));
+    // No injected spawner — real Bun.spawn, real signals.
+    const wrapped = withCommandHooks(runner, {
+      pluginCacheDir: cacheDir,
+      timeoutMs: 100,
+      killGraceMs: 200,
+    });
+
+    const started = Date.now();
+    const err = await wrapped("/shipwright:dev-task acme/x#1").catch((e) => e);
+
+    expect(err).toBeInstanceOf(HookError);
+    expect((err as HookError).timedOut).toBe(true);
+    // SIGTERM alone would hang forever — SIGKILL must bound the wait.
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(runner).not.toHaveBeenCalled();
+  });
+});
+
+// ─── HookError through the cron-handler failed-run path ──────────────────────
+
+describe("HookError surfaces as a failed run via cron-handler", () => {
+  const mockSlack = {
+    chat: { postMessage: mock(() => Promise.resolve({ ok: true, ts: "1.1" })) },
+    conversations: {
+      open: mock(() => Promise.resolve({ channel: { id: "D" } })),
+    },
+  } as unknown as Parameters<typeof handleCronRequest>[1]["slack"];
+
+  test("pre-hook failure ⇒ runner not called, run recorded 'failed', error rethrown", async () => {
+    const cacheDir = tmp();
+    seedPluginHook(cacheDir, "custom", "custom:review-foundry", "10-guard.sh");
+    const { spawner } = recordingSpawner([fakeProc("guard rejected", 2)]);
+
+    const innerRunner = mock((_m: string, _k?: string) =>
+      Promise.resolve(okResult),
+    );
+    const hookedRunner = withCommandHooks(innerRunner, {
+      pluginCacheDir: cacheDir,
+      spawner,
+    });
+
+    const completed: Array<{ outcome: string; error?: string }> = [];
+    const reporter: CronRunReporter = {
+      createRun: async () => "run-1",
+      completeRun: async (_c, _r, _t, outcome, opts) => {
+        completed.push({ outcome, error: opts?.error });
+      },
+      skipRun: async () => {},
+    };
+
+    await expect(
+      handleCronRequest(
+        {
+          jobId: "review-foundry",
+          prompt: "/custom:review-foundry acme/x#3",
+          silent: true,
+        },
+        { slack: mockSlack, runner: hookedRunner, cronRunReporter: reporter },
+      ),
+    ).rejects.toBeInstanceOf(HookError);
+
+    expect(innerRunner).not.toHaveBeenCalled();
+    expect(completed).toHaveLength(1);
+    expect(completed[0].outcome).toBe("failed");
+    expect(completed[0].error).toContain("review-foundry");
+  });
+});
+
+// ─── HookError through the chat-poller path ───────────────────────────────────
+
+describe("HookError suppresses a chat-poller session", () => {
+  test("pre-hook failure ⇒ runner not called, no reply posted", async () => {
+    const cacheDir = tmp();
+    seedPluginHook(cacheDir, "custom", "shipwright:dev-task", "10-guard.sh");
+    const { spawner } = recordingSpawner([fakeProc("guard rejected", 2)]);
+
+    const innerRunner = mock((_m: string, _k?: string) =>
+      Promise.resolve(okResult),
+    );
+    const hookedRunner = withCommandHooks(innerRunner, {
+      pluginCacheDir: cacheDir,
+      spawner,
+    });
+
+    const replyToMessage = mock(() => Promise.resolve(undefined));
+    const client = {
+      listThreads: async () => ({
+        threads: [{ id: "thread-1" }],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      }),
+      claimMessage: async () => ({
+        id: "msg-1",
+        threadId: "thread-1",
+        role: "user",
+        body: "/shipwright:dev-task acme/x#9",
+        attachmentFilename: null,
+      }),
+      getAttachment: async () => null,
+      replyToMessage,
+    } as unknown as ChatServiceClient;
+
+    const poller = createChatPoller({ client, runner: hookedRunner });
+    await poller.pollOnce();
+
+    expect(innerRunner).not.toHaveBeenCalled();
+    expect(replyToMessage).not.toHaveBeenCalled();
+  });
+});

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -45,6 +45,7 @@ import {
   markSlackDisconnected,
   startHealthServer,
 } from "./health.ts";
+import { withCommandHooks } from "./hooks.ts";
 import { HttpChatServiceClient } from "./http-chat-service-client.ts";
 import { buildLogPrefix } from "./log-prefix.ts";
 import { classifyCronJobsForScheduling } from "./loop-cron-classifier.ts";
@@ -101,7 +102,7 @@ const analytics = createAnalyticsStore(join(config.paths.home, "analytics"));
 analytics.track({ type: "session_start" });
 
 const slack = new WebClient(config.slack.botToken ?? "");
-const runner = createRunClaude(
+const baseRunner = createRunClaude(
   Bun.spawn,
   sessions,
   undefined,
@@ -112,6 +113,13 @@ const runner = createRunClaude(
   undefined,
   config.claude.timeoutMs,
 );
+// Wrap the shared runner once with command hooks. Off by default: with no hook
+// dirs installed anywhere, this is a byte-identical passthrough. A pre-hook
+// failure throws HookError, which the loop and cron dispatch paths already
+// catch and record as a failed run.
+const runner = withCommandHooks(baseRunner, {
+  workspace: config.paths.workspace,
+});
 
 const cronRunReporter =
   config.shipwright.apiUrl &&
@@ -403,16 +411,21 @@ if (runtimeClient && agentId) {
 
 if (config.chat.serviceUrl && config.chat.serviceToken) {
   const chatSessions = createFileSessionStore(config.paths.chatSessions);
-  const chatRunner = createRunClaude(
-    Bun.spawn,
-    chatSessions,
-    undefined,
-    config.paths.workspace,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    config.claude.timeoutMs,
+  // Command hooks wrap this runner too — the chat poll loop dispatches
+  // through its own runner, not the shared one wrapped above.
+  const chatRunner = withCommandHooks(
+    createRunClaude(
+      Bun.spawn,
+      chatSessions,
+      undefined,
+      config.paths.workspace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      config.claude.timeoutMs,
+    ),
+    { workspace: config.paths.workspace },
   );
   const chatClient = new HttpChatServiceClient({
     baseUrl: config.chat.serviceUrl,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ Configuration for the Shipwright agent runtime (`agent/` and `admin/`). All opti
 | `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` | `number` | `1800000` | Hard timeout in milliseconds for a single `claude -p` session spawned by the agent runner (`agent/src/claude.ts`). When a session exceeds it the process is killed and a `ClaudeTimeoutError` is raised. Defaults to 1 800 000 ms (30 min) — the `claude -p` hard-timeout figure that `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` (35 min = 30 min + 5 min buffer) is derived from. Falls back to the default when unset or not a positive integer. Raise it for long sessions that keep polling CI after implementing so the worker can mark its task complete instead of being SIGKILLed mid-poll. **When raising this, raise `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` in step** (keep the ~5 min buffer above this value); otherwise the stale-claim reaper abandons the claim and re-dispatches a duplicate run before the longer session finishes. |
 | `ANTHROPIC_API_KEY` | `string` | — | Anthropic API key. Env-var-only (secret). |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `string` | — | Claude Code OAuth token (alternative to `ANTHROPIC_API_KEY`). Env-var-only (secret). |
+| `SHIPWRIGHT_HOOK_TIMEOUT_MS` | `number` | `120000` | Per-hook timeout in milliseconds for command pre-run hooks (`agent/src/hooks.ts`). A hook exceeding it is sent SIGTERM (then SIGKILL after a short grace) and the session is suppressed with a `HookError`. Falls back to the default when unset or not a positive integer. |
 
 ### Slack
 

--- a/site/src/data/config-vars.ts
+++ b/site/src/data/config-vars.ts
@@ -20,6 +20,7 @@ export const agentClaudeVars: ConfigVar[] = [
   { name: "SHIPWRIGHT_CLAUDE_TIMEOUT_MS", type: "number", def: "1800000", desc: "Hard timeout in milliseconds for a single claude -p session spawned by the agent runner. When a session exceeds it the process is killed and a ClaudeTimeoutError is raised. Falls back to the default when unset or not a positive integer. When raising this, raise SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS in step (keep the ~5 min buffer) or the stale-claim reaper re-dispatches a duplicate run." },
   { name: "ANTHROPIC_API_KEY", type: "string", def: "—", desc: "Anthropic API key. Env-var-only (secret)." },
   { name: "CLAUDE_CODE_OAUTH_TOKEN", type: "string", def: "—", desc: "Claude Code OAuth token (alternative to ANTHROPIC_API_KEY). Env-var-only (secret)." },
+  { name: "SHIPWRIGHT_HOOK_TIMEOUT_MS", type: "number", def: "120000", desc: "Per-hook timeout in milliseconds for command pre-run hooks. A hook exceeding it is sent SIGTERM (then SIGKILL after a short grace) and the session is suppressed with a HookError. Falls back to the default when unset or not a positive integer." },
 ];
 
 export const agentSlackVars: ConfigVar[] = [

--- a/state/dev-agent.env.example
+++ b/state/dev-agent.env.example
@@ -40,3 +40,6 @@ ANTHROPIC_API_KEY=
 
 # Startup timeout in ms (default: 60000 for prod). Override to fail fast in dev.
 SHIPWRIGHT_STARTUP_TIMEOUT_MS=10000
+
+# Per-hook timeout in ms for command pre-run hooks (default: 120000 = 2m).
+# SHIPWRIGHT_HOOK_TIMEOUT_MS=120000


### PR DESCRIPTION
## What this adds

**Command hooks** — plugin-declared, per-command **pre-run** hooks, executed as guards around the shared Claude runner.

A hook is attached to a fully-qualified slash command by directory convention, resolved across **all installed plugins** (same `installed_plugins.json` / plugin-cache resolution `preCheck` already uses), plus a workspace escape hatch:

```
<plugin root>/hooks/<plugin>:<command>.pre/*     # executable(s), filename order
<workspace>/state/hooks/<plugin>:<command>.pre/* # operator escape hatch, runs last
```

Execution order: plugin hooks first (alphabetical by plugin, then filename), workspace hooks last. Each hook runs sequentially via a single `withCommandHooks(runner)` decorator applied where the shared runner is constructed in `index.ts` — because the attachment unit is the slash command parsed from the outgoing message itself, the same hooks fire uniformly for **loop dispatches, generic cron jobs, Slack invocations, and the chat poll loop**, with zero per-dispatch-site code. The parser understands each path's message framing (the `[Cron job: …]` tag from `formatCronMessage`, Slack's `[<name>]: ` sender prefix / thread-message line / mention token / thread-context block).

Hooks receive: the raw outgoing message on stdin, `cwd` = workspace, and `env` = live `process.env` (mirroring `preCheck`'s passthrough, so runtime config-sync rotations are visible) plus `SHIPWRIGHT_HOOK_EVENT=pre` and `SHIPWRIGHT_HOOK_COMMAND=<plugin>:<command>`.

## Off by default

No hook directories installed anywhere ⇒ the decorator is a **byte-identical passthrough**. Existing installs see zero behavior change.

## Fail-closed guard semantics

Pre hooks answer "is it safe/ready to run this command." A nonzero exit or timeout throws a typed `HookError` (hook name, exit code, stderr) and **the session does not run**. `HookError` propagates as an ordinary runner error through the **existing** error paths — `loop-orchestrator.ts`, `cron-handler.ts`, and `chat-poller.ts` already catch runner errors and record a failed run, so this PR makes **zero changes** to `loop-orchestrator.ts`, `cron-handler.ts`, `cron-run-reporter.ts`, or any schema. A failed pre hook is visible today as a failed `AgentCronRun` with the hook's name and stderr in the error payload. No modes, no config: candidacy gating ("is there work?") stays `preCheck`'s job; hooks are a readiness guard.

## Timeout

Per-hook timeout via `SHIPWRIGHT_HOOK_TIMEOUT_MS` (default 120000 ms), following the existing `SHIPWRIGHT_*_MS` convention. On expiry the hook gets SIGTERM, then SIGKILL after a short grace — a SIGTERM-ignoring hook cannot hang the agent. Documented in `docs/configuration.md`, the site config reference, and `state/dev-agent.env.example`.

## Security stance

Hooks are arbitrary executables at the **plugin/workspace trust tier** — the tier that already executes `preCheck` scripts and authors session prompts; installing a plugin already means trusting its code. Hooks are deliberately **not declarable from the remote admin config bundle**: the bundle stays a data-only surface, and no new remote-code-execution vector is introduced. (The bundle can still select which plugins install, exactly as it can for `preCheck`-carrying plugins today — unchanged boundary.)

## Motivating use-case

Attaching environment-preparation guards to stock commands **without forking their markdown**. Example: a deployment that provisions an ephemeral dev/test environment can ship a `hooks/shipwright:dev-task.pre/10-reset-env.sh` in its **own** plugin to reset that environment before every dev-task session — including manually-invoked ones — while `dev-task.md` stays byte-identical to upstream. Cross-plugin attachment is intentional: a sidecar-directory design (rather than frontmatter in the command's own file) is what makes hooking another plugin's command possible without maintaining a drifting copy of a large prompt file.

## Hook-authoring note (documentation guidance)

A hook must not leave background children attached to its stdio. The runner waits on the hook's stderr pipe as well as its exit; a hook that daemonizes a child without redirecting the child's output (`>/dev/null 2>&1` or `setsid`/`nohup` with redirection) keeps the pipe open and reads as a timeout.

## Tests

29 unit tests in `agent/src/hooks.unit.test.ts` (injected spawner/fs doubles, house style):
- resolution order: own-plugin / cross-plugin / workspace, filename order, non-executable files skipped, manifest + plugin-cache resolution
- message parsing for every dispatch framing (loop, cron tag, Slack DM / thread / mention / thread-context block — commands quoted inside history do **not** fire), fully-qualified-command requirement
- guard-abort on nonzero exit (runner never called), sequential abort, dangling-symlink fail-closed
- **real-spawn** timeout test: an actual `trap '' TERM` process is SIGKILLed within the grace window
- `HookError` surfacing as a failed run through the real `cron-handler` error path, and session suppression through the real chat-poller path
- no-hooks and non-command passthrough identity

`bun test agent/` 974 pass / 0 fail; `tsc --noEmit` clean; no new biome diagnostics vs `main`.

Scope note: `pre` event only. `post` hooks and `hooks:` frontmatter sugar for the own-command case are possible follow-ups, deliberately kept out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
