### PR TITLE
chore(chart): bump chart version to 1.6.398

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.398] - 2026-07-16
+
+### Changed
+
+- auto-bump to chart v1.6.398 triggered by release tag(s): `agent-v0.189.0`, `agent-v0.193.0`
+
 ## [1.6.397] - 2026-07-16
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.397
+version: 1.6.398
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,9 +29,9 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.397 triggered by release tag agent-v0.189.0"
+      description: "auto-bump to chart v1.6.398 triggered by release tag agent-v0.189.0"
     - kind: changed
-      description: "auto-bump to chart v1.6.397 triggered by release tag agent-v0.192.0"
+      description: "auto-bump to chart v1.6.398 triggered by release tag agent-v0.193.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -298,7 +298,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v0.192.0
+    tag: agent-v0.193.0
     pullPolicy: ""
   service:
     port: 3000
@@ -321,7 +321,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v0.192.0
+      tag: agent-v0.193.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.6.397 → 1.6.398

**Triggering tags:**
- `agent-v0.189.0`
- `agent-v0.193.0`

**New chart version:** `1.6.398`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v0.193.0`
- `agent.provisioning.image.tag`: `agent-v0.193.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.398 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._