### PR TITLE
fix: remove createdAt-ordering flake in PR sort integration test

### DIFF
--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -987,14 +987,29 @@ describeOrSkip("PullRequestService.list() and get() (integration)", () => {
   });
 
   it("list({ sort: 'desc' }) orders by createdAt descending; default/asc preserves current order", async () => {
+    // Explicit, well-separated createdAt values so ordering is deterministic
+    // even when rows are created within the same DB timestamp tick.
+    const base = new Date("2026-01-01T00:00:00.000Z").getTime();
     const first = await prisma.pullRequest.create({
-      data: { repo: "app-vitals/shipwright", prNumber: 1060 },
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1060,
+        createdAt: new Date(base),
+      },
     });
     const second = await prisma.pullRequest.create({
-      data: { repo: "app-vitals/shipwright", prNumber: 1061 },
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1061,
+        createdAt: new Date(base + 1000),
+      },
     });
     const third = await prisma.pullRequest.create({
-      data: { repo: "app-vitals/shipwright", prNumber: 1062 },
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 1062,
+        createdAt: new Date(base + 2000),
+      },
     });
 
     const ascDefault = await service.list();


### PR DESCRIPTION
## Summary
- `list({ sort: 'desc' }) orders by createdAt descending...` intermittently failed in CI (saw it flake on #1658). Root cause: the test creates three PR rows back-to-back with implicit `createdAt: now()`, and `PullRequestService.list()`'s `orderBy: { createdAt }` has no tiebreaker — when two rows land in the same DB timestamp tick, order is nondeterministic.
- Fix: give each row an explicit, well-separated `createdAt` instead of relying on wall-clock gaps between inserts.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `bunx biome lint` passes on the changed file
- [ ] CI integration suite (no local Postgres in this sandbox to run it directly)