### PR TITLE
docs: refresh stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/metrics.md** — metrics service (B): JSON endpoints, server-rendered dashboard, dual auth (Bearer / session), and environment
 - **docs/agent.md** — Shipwright agent (C): runtime + admin CRUD APIs, the ten-model Prisma store, and encryption/env notes
 - **docs/agent-api.md** — the admin CRUD API (D): agents, envs, crons, cron runs, tools, tokens, plugins, and chat-token-usage endpoints, plus auth paths
-- **docs/task-store.md** — task store service (D): the sole HTTP-service backend — tasks, PR tracking, tokens, ephemeral docs — and troubleshooting
+- **docs/task-store.md** — task store service (D): the sole HTTP-service backend — tasks, PR tracking, tokens — and troubleshooting
 - **docs/mcp-tools.md** — generated MCP server tool reference (name, description, HTTP method/path, parameters, body) derived from task-store/openapi.json + the tool allowlist; regenerate with `bun run generate:mcp-docs`
 - **docs/chat.md** — chat service (D): auth model (admin vs. agent tokens, scope resolver), thread/message/token endpoints (incl. attachment streaming and the claim/reply queue), data model, and environment
 - **docs/deploy-kubernetes.md** — Kubernetes deployment guide: Minikube / GKE (Gateway API + cert-manager) / EKS (ALB), the agent runtime-provisioning RBAC model, and auth modes

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -408,16 +408,20 @@ Setting `agent.provisioning.enabled=true` switches the admin service to the
 
 ### What the chart renders when provisioning is enabled
 
-- A **`ClusterRole`** (not a namespace-scoped `Role`) named
-  `<admin>-agent-provisioner` granting `create`, `get`, and `delete` on
-  `PersistentVolumeClaims` (core), `Deployments` (`apps`), and `Secrets` (core)
-  — exactly the verbs the provisioner exercises. The ClusterRole enables the
-  admin service to provision agents in any target namespace, not just its own
-  release namespace (e.g. provisioning agents with PVCs pinned to a dedicated
-  target namespace).
-- A **`ClusterRoleBinding`** binding that ClusterRole to the **admin ServiceAccount**.
-  The subject's namespace scopes which ServiceAccount is granted the
-  cluster-wide permissions.
+- RBAC scope depends on `agent.provisioning.namespace`:
+  - **Empty (default, same-namespace provisioning):** a namespace-scoped
+    **`Role`** + **`RoleBinding`** named `<admin>-agent-provisioner`, granting
+    `create`, `get`, `list`, `patch`, `update`, and `delete` on `Deployments`
+    (`apps`) and `create`, `get`, `delete` on `Secrets` and
+    `PersistentVolumeClaims` (core) — exactly the verbs the provisioner
+    exercises, scoped to the release namespace (least privilege).
+  - **Non-empty (cross-namespace provisioning):** a **`ClusterRole`** +
+    **`ClusterRoleBinding`** with the same name and verb set, so the admin
+    service can provision agents into a namespace other than its own release
+    namespace.
+  - Either way the binding's subject is the **admin ServiceAccount**; the
+    subject's namespace scopes which ServiceAccount is granted the
+    permissions.
 - A separate **agent ServiceAccount** that provisioned agent pods run as
   (distinct from the admin SA).
 - The provisioner env contract injected into the admin Deployment, matching
@@ -450,25 +454,9 @@ These map to the admin service's provisioning env vars
 
 ### Chat service provisioning (opt-in)
 
-By default the admin service **does not** mint chat-service tokens — provisioned agents carry no chat-service credentials. To enable per-agent chat-service token provisioning on `POST /agents`, set both `SHIPWRIGHT_CHAT_SERVICE_URL` and `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` on the admin Deployment:
+By default the admin service **does not** mint chat-service tokens — provisioned agents carry no chat-service credentials. Per-agent chat-service token provisioning on `POST /agents` is enabled the same way the admin console's Chat tab is: via the top-level `chat.enabled` + `chat.adminToken.existingSecret` chart values described in [Chat service (opt-in)](#chat-service-opt-in) above — there is no separate `agent.provisioning.chatService.*` value block.
 
-- `SHIPWRIGHT_CHAT_SERVICE_URL` — in-cluster base URL of the chat service (e.g. `http://chat:3000`). Injected into the agent Deployment as `SHIPWRIGHT_CHAT_SERVICE_URL` (plain env value).
-- `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` — bearer token for the admin service to mint/revoke chat-service tokens via the chat-service REST API. Env-var-only (secret).
-
-When both are set, the provisioner mints a scoped per-agent token during `POST /agents`, stores it in the agent Secret (key `chat-service-token`), and injects it into the Deployment as `SHIPWRIGHT_CHAT_SERVICE_TOKEN` (via `secretKeyRef`). On agent deletion the token is revoked via `DELETE /tokens/:id`. When either var is unset, chat-service token provisioning is disabled and agents carry no chat-service credentials.
-
-**Chart values:**
-
-```yaml
-agent:
-  provisioning:
-    enabled: true
-    # ... other values
-  chatService:
-    enabled: false                   # set to true to enable chat-service token provisioning
-    url: http://chat:3000            # in-cluster chat service URL; required when enabled=true
-    adminToken: ""                   # secret bearer token; required when enabled=true
-```
+When `chat.enabled=true` and `chat.adminToken.existingSecret` is set, the chart injects `SHIPWRIGHT_CHAT_SERVICE_URL` and `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` into the admin Deployment. With those present, the provisioner mints a scoped per-agent token during `POST /agents`, stores it in the agent Secret (key `chat-service-token`), and injects it into the agent Deployment as `SHIPWRIGHT_CHAT_SERVICE_TOKEN` (via `secretKeyRef`). On agent deletion the token is revoked via `DELETE /tokens/:id`. When the admin token wiring is absent, chat-service token provisioning is disabled and agents carry no chat-service credentials.
 
 ---
 


### PR DESCRIPTION
## Summary
- `docs/deploy-kubernetes.md`: fixes the RBAC section (namespace-scoped `Role`/`RoleBinding` by default, `ClusterRole`/`ClusterRoleBinding` only when `agent.provisioning.namespace` is set — was previously described as unconditionally cluster-wide) and the chat-service provisioning section (there's no `agent.provisioning.chatService.*` values block; wiring is actually `chat.enabled` + `chat.adminToken.existingSecret`)
- `CLAUDE.md`: drops a stale "ephemeral docs" mention from the `docs/task-store.md` Reference bullet (that feature was removed)

Generated by the automated docs-freshness cron.

## Test plan
- [x] Verified RBAC claims against `charts/shipwright/templates/agent-provisioning-rbac.yaml`
- [x] Verified chat-service wiring against `charts/shipwright/templates/admin-deployment.yaml` and `values.yaml`
- Docs-only change, no code/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)