### PR TITLE
feat: tag Sentry initialScope with agent_id so events are filterable per-agent fleet-wide

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -87,7 +87,7 @@ for (const level of ["log", "warn", "error"] as const) {
 // wraps on top of it — this captures clean log args in Sentry while local
 // output keeps its timestamp prefix.
 
-initSentry({ service: "agent" });
+initSentry({ service: "agent", agentId });
 
 // ─── Step 1: Agent home ───────────────────────────────────────────────────────
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,6 +18,7 @@ When `SENTRY_DSN` is set, a service reports:
 - **`console.log` / `console.warn` / `console.error` calls**, forwarded as structured Sentry Logs via `consoleLoggingIntegration`.
 - **Request path and method** for errors that occur inside an HTTP handler (via `@sentry/hono`'s `sentry()` middleware, or the app's own `onError` hook).
 - **Caller identity** (admin or agent token) in error logs from admin, metrics, and task-store, for tracing which token triggered an unhandled error.
+- **Tags** — structured key-value metadata attached to every event: `service` (the reporting service name, always present), and `agent_id` (when initializing Sentry for an agent runner with an `agentId`).
 
 ## What is never collected
 

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -16,6 +16,7 @@ type SentryLog = NonNullable<BunOptions["beforeSendLog"]> extends (
 
 export interface InitSentryOptions {
   service: string;
+  agentId?: string;
 }
 
 /** Narrowed to the one method initSentry calls, so tests can inject a fake without mock.module(). */
@@ -138,6 +139,11 @@ export function buildSentryInitOptions(
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return undefined;
 
+  const tags: Record<string, string> = { service: opts.service };
+  if (opts.agentId) {
+    tags.agent_id = opts.agentId;
+  }
+
   return {
     dsn,
     enableLogs: true,
@@ -146,7 +152,7 @@ export function buildSentryInitOptions(
     ],
     environment:
       process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? "production",
-    initialScope: { tags: { service: opts.service } },
+    initialScope: { tags },
     beforeSend: scrubEvent,
     beforeSendLog: scrubLog,
   };

--- a/lib/sentry.unit.test.ts
+++ b/lib/sentry.unit.test.ts
@@ -120,6 +120,32 @@ describe("initSentry — SENTRY_DSN set", () => {
     expect(Array.isArray(options.integrations)).toBe(true);
     expect(options.integrations.length).toBeGreaterThan(0);
   });
+
+  test("agent_id tag is included in initialScope.tags when agentId is passed", () => {
+    process.env.SENTRY_DSN = "https://example@o0.ingest.sentry.io/0";
+    const fakeClient = createFakeSentryClient();
+
+    initSentry({ service: "agent", agentId: "test-agent-123" }, fakeClient);
+
+    expect(fakeClient.calls.length).toBe(1);
+    const options = fakeClient.calls[0] as {
+      initialScope: { tags: Record<string, string> };
+    };
+    expect(options.initialScope.tags.agent_id).toBe("test-agent-123");
+  });
+
+  test("agent_id tag is absent when agentId is not passed", () => {
+    process.env.SENTRY_DSN = "https://example@o0.ingest.sentry.io/0";
+    const fakeClient = createFakeSentryClient();
+
+    initSentry({ service: "metrics" }, fakeClient);
+
+    expect(fakeClient.calls.length).toBe(1);
+    const options = fakeClient.calls[0] as {
+      initialScope: { tags: Record<string, unknown> };
+    };
+    expect(options.initialScope.tags).not.toHaveProperty("agent_id");
+  });
 });
 
 describe("scrubEvent — header stripping", () => {


### PR DESCRIPTION
## Summary
- Add optional `agentId` field to `InitSentryOptions` in `lib/sentry.ts`
- `buildSentryInitOptions` now includes an `agent_id` tag in `initialScope.tags` when `agentId` is passed, and omits it (unchanged behavior) when not — other `initSentry` callers (task-store, metrics, admin, `@sentry/hono` middleware) are unaffected
- `agent/src/index.ts`'s `initSentry` call now passes the already-in-scope `agentId`, making Sentry events for a given agent exact-filterable and stable across pod restarts (previously only inferable via the hash-suffixed `server.address` hostname tag)
- Refreshed `docs/observability.md` to document the new `agent_id` tag

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | InitSentryOptions gains optional agentId field | MET | `lib/sentry.ts`: `agentId?: string;` added to interface |
| 2 | agent_id included when passed, omitted when not; other callers unaffected | MET | Conditional `tags.agent_id = opts.agentId` only when truthy; task-store/metrics/admin call sites unchanged |
| 3 | agent/src/index.ts passes already-in-scope agentId | MET | `initSentry({ service: "agent", agentId });` |
| 4 | Test extends sentry.unit.test.ts with presence/absence cases, no removals | MET | Two new tests added in "SENTRY_DSN set" block; existing 13 tests untouched |

## Test Plan
- `NODE_ENV=test bun test lib/sentry.unit.test.ts` — 15/15 pass, 100% line/function coverage on `lib/sentry.ts`
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
