### PR TITLE
docs(test-readiness): confirm naming/bunfig sync + cross-runner isolation (T-048)

### DIFF
--- a/docs/test-readiness/naming.md
+++ b/docs/test-readiness/naming.md
@@ -72,6 +72,27 @@ entry point (canary):
 Unit, integration, smoke, and content suffixes have **no** `pathIgnorePatterns` entry —
 they are exactly the suffixes the root `bun test` scan is meant to discover and run.
 
+## One-time cross-runner isolation check (T-048)
+
+Confirmed once, ahead of the M1 rename tasks, that each runner discovers only its own
+layer's files — the doc/config sync above only covers the `bun test` side; this closes
+the loop on the Playwright side too:
+
+- `bun test`'s default file listing (respecting `pathIgnorePatterns`) contains zero
+  `*.spec.ts`, `*.e2e.ts`, or `*.canary.test.ts` files, despite 15 such files existing on
+  disk (`site/tests/*.spec.ts`, `metrics/e2e/*.e2e.ts`, `admin/e2e/*.e2e.ts`).
+- `metrics/playwright.config.ts` and `admin/playwright.config.ts` scope `testDir: "./e2e"`
+  with `testMatch: "**/*.e2e.ts"` — each `e2e/` directory contains only its own
+  `*.e2e.ts` files (plus non-test helpers), so Playwright cannot pick up a
+  unit/integration/smoke/content file.
+- `site/playwright.config.ts` scopes `testDir: "./tests"`, which contains only
+  `*.spec.ts` files (plus a `helpers.ts` non-test file) — no bare `*.test.ts` file to
+  collide with Bun's default runner.
+
+No cross-runner discovery gaps found. This is a point-in-time confirmation, not an
+enforced regression test — the automated guard against doc/config drift is
+`plugins/shipwright/test/test-naming-convention.content.test.ts`, described above.
+
 ## Collision rules
 
 1. **One suffix per file.** A test file must match exactly one row in the suffix table.


### PR DESCRIPTION
## Summary
- Verification task (T-048): confirmed `docs/test-readiness/naming.md` and `bunfig.toml`'s `pathIgnorePatterns` are already in sync — enforced by the existing `test-naming-convention.content.test.ts` (11/11 passing).
- Closed the loop with a one-time cross-runner isolation check: `bun test`'s default file listing discovers zero `.spec.ts`/`.e2e.ts`/`.canary.test.ts` files despite 15 such files existing on disk, and each Playwright config (`metrics`, `admin`, `site`) is scoped via `testDir`/`testMatch` to only its own directory.
- No production/config code changes — the target state was already correct. Documented the isolation-check findings in a new section of `naming.md`.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | naming.md and bunfig.toml pathIgnorePatterns confirmed in sync | MET | `test-naming-convention.content.test.ts` mismatch assertion (11/11 pass) |
| 2 | Each runner discovers only its own layer's files (one-time isolation check) | MET | Manual audit documented in `naming.md`'s new "One-time cross-runner isolation check" section |
| 3 | Verification command passes | MET | Ran verbatim, exit code 0 |

## Test Plan
- [x] `bun test plugins/shipwright/test/test-naming-convention.content.test.ts` — 11/11 pass
- [x] Full verification command (`... && bun test --filter integration ... | grep -qv ...`) — exit 0
- [x] `bunx biome lint .` — clean
- [x] `bun run --filter='*' --sequential typecheck` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
