### PR TITLE
feat: add live branch/PR reality check before worktree creation in dev-task.md

### DIFF
--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -40,8 +40,12 @@ describe("dev-task.md — explicit-target-only argument contract", () => {
     expect(content).not.toContain("Resuming interrupted task");
   });
 
-  it("routes an explicit task-id's in_progress status through the Step 2 orphan check", () => {
-    expect(content).toMatch(/orphan check/i);
+  it("in_progress status skips straight to Step 3 — recovery now happens unconditionally in Step 4's reality check, not a status-gated orphan check", () => {
+    // The old status-gated "Step 2 Orphan Check" mechanism is retired (DOH-1.1) — superseded
+    // by the unconditional Branch/PR Reality Check in Step 4.
+    expect(content).not.toMatch(/proceed\s+straight\s+to\s+Step 2's Orphan Check/i);
+    expect(content).not.toContain("### Orphan Check (prior session recovery)");
+    expect(content).toMatch(/skip\s+Step 2's claim and proceed directly to Step 3/i);
   });
 });
 
@@ -151,5 +155,83 @@ describe("Step 4 — stale bundle branch detection", () => {
     // The check must derive the repo slug from git remote get-url and pass it as --repo.
     expect(content).toContain('--repo "$GH_REPO"');
     expect(content).toContain("remote get-url origin");
+  });
+});
+
+describe("Step 4 — unconditional branch/PR reality check (DOH-1.1)", () => {
+  it("runs the reality check before any `git worktree add -b {branch}` invocation, regardless of task-store status", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+
+    // Every worktree-add-with-new-branch invocation in Step 4 must come after the
+    // reality check header, not before it.
+    const worktreeAddIdx = content.indexOf("worktree add");
+    expect(worktreeAddIdx).toBeGreaterThan(-1);
+    expect(realityCheckIdx).toBeLessThan(worktreeAddIdx);
+  });
+
+  it("is not gated on task-store status — checks live git/GitHub state unconditionally", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 2500);
+    expect(section).toMatch(/regardless of what task-store status says/i);
+  });
+
+  it("checks the local branch, remote branch (git ls-remote --heads origin), and open PR (gh pr list --head, --state open)", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 3000);
+
+    // Local branch check
+    expect(section).toMatch(/git -C .*branch --list \{branch\}/);
+    // Remote branch check
+    expect(section).toContain("git ls-remote --heads origin {branch}");
+    // Open PR check with mergeability/CI-relevant fields
+    expect(section).toContain("--state open");
+    expect(section).toMatch(/gh pr list --head \{branch\}.*--state open.*json number,state,mergeable,mergeStateStatus/);
+  });
+
+  it("derives --repo from git remote using the same pattern as the Step 4 stale-bundle-branch check", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 3000);
+    expect(section).toContain("remote get-url origin");
+    expect(section).toContain('--repo "$GH_REPO"');
+  });
+
+  it("complete-and-correct path skips destructive delete and PATCHes the task store to reflect reality", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 5000);
+    expect(section).toMatch(/complete and correct/i);
+    expect(section).toMatch(/skip(s|ping)? (the )?destructive/i);
+    expect(section).toContain(`"$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}"`);
+    expect(section).toMatch(/-X PATCH/);
+  });
+
+  it("incomplete/stale path closes the PR (if any) and deletes the branch (remote + local) before falling through to fresh worktree creation", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 5000);
+    expect(section).toMatch(/incomplete|stale/i);
+    expect(section).toContain("gh pr close");
+    expect(section).toContain("git push origin --delete {branch}");
+    expect(section).toMatch(/git -C .*branch -D \{branch\}/);
+  });
+
+  it("resume-from-PR path checks CI status before treating an existing PR as complete", () => {
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 5000);
+    expect(section).toMatch(/CI/);
+  });
+
+  it("no longer routes an in_progress task's stale branch/PR cleanup through a status-gated Step 2 Orphan Check", () => {
+    expect(content).not.toContain("### Orphan Check (prior session recovery)");
+    expect(content).not.toMatch(/If the task's current status is already `in_progress`:/);
+  });
+
+  it("Step 1 no longer special-cases in_progress status as a distinct branch routing to Step 2's Orphan Check", () => {
+    expect(content).not.toMatch(/proceed\s+straight\s+to\s+Step 2's Orphan Check/i);
   });
 });

--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -212,11 +212,27 @@ describe("Step 4 — unconditional branch/PR reality check (DOH-1.1)", () => {
   it("incomplete/stale path closes the PR (if any) and deletes the branch (remote + local) before falling through to fresh worktree creation", () => {
     const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
     expect(realityCheckIdx).toBeGreaterThan(-1);
-    const section = content.slice(realityCheckIdx, realityCheckIdx + 5000);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 5500);
     expect(section).toMatch(/incomplete|stale/i);
     expect(section).toContain("gh pr close");
     expect(section).toContain("git push origin --delete {branch}");
     expect(section).toMatch(/git -C .*branch -D \{branch\}/);
+  });
+
+  it("incomplete/stale path removes any existing worktree for {branch} before force-deleting the local branch (DOH-1.1 follow-up)", () => {
+    // git refuses to force-delete a branch checked out in any worktree — a crashed session
+    // can leave `{branch}` checked out in a worktree, so the worktree must be removed first.
+    const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
+    expect(realityCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 5500);
+    const staleSectionIdx = section.search(/\*\*Incomplete, stale/i);
+    expect(staleSectionIdx).toBeGreaterThan(-1);
+    const staleSection = section.slice(staleSectionIdx);
+    const worktreeRemoveIdx = staleSection.search(/worktree remove/);
+    const branchDeleteIdx = staleSection.search(/git -C .*branch -D \{branch\}/);
+    expect(worktreeRemoveIdx).toBeGreaterThan(-1);
+    expect(branchDeleteIdx).toBeGreaterThan(-1);
+    expect(worktreeRemoveIdx).toBeLessThan(branchDeleteIdx);
   });
 
   it("resume-from-PR path checks CI status before treating an existing PR as complete", () => {

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -277,12 +277,19 @@ diff unrelated to the task, or CI red with no clear fix path): treat exactly lik
 from a crashed session — clean up before starting fresh.
 1. If an open PR exists, close it: `gh pr close {number} --repo "$GH_REPO" --comment "Shipwright cleanup — prior attempt incomplete/stale, restarting"`
 2. If a remote branch exists, delete it: `git push origin --delete {branch}`
-3. If a local branch exists, delete it: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch -D {branch}`
-4. Print:
+3. If a worktree for `{branch}` already exists (a crashed session — exactly the scenario this
+   reality check recovers from — can leave one checked out on disk), remove it first: git
+   refuses to force-delete a branch checked out in any worktree, so this must happen before
+   step 4's `branch -D`.
+   ```bash
+   git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} --force
+   ```
+4. If a local branch exists, delete it: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch -D {branch}`
+5. Print:
    ```
    ⚠ {branch} had incomplete/stale prior work — cleaned up (PR closed, branch deleted). Starting fresh.
    ```
-5. Fall through to the standard fresh-start flow below (branch now absent on remote).
+6. Fall through to the standard fresh-start flow below (branch now absent on remote).
 
 ---
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -248,25 +248,26 @@ against the task's acceptance criteria before deciding how to proceed:
    correct" — treat it the same as the incomplete/stale case below.
 
 **Complete and correct** (diff satisfies every acceptance criterion, and CI is green if a PR
-exists): skip destructive recovery — do not close the PR or delete the branch.
-- **Local-only case** (branch exists, no PR yet): rebase is enough — no PATCH of `branch` or
-  `pr` is needed since neither changed; still refresh `heartbeatAt` (Step 5b already does
-  this before dispatch). Continue to the standard "branch DOES exist on remote" flow below
-  (or, if the branch is local-only and never pushed, treat it as already checked out and
-  skip straight to Step 5 — no worktree recreation needed against a fresh `origin/main`
-  base).
-- **PR case**: resume from the existing PR rather than rebuilding it. PATCH the task store to
-  match reality so downstream steps (Step 9, Step 9b, Step 10a) see the correct state:
+exists): skip destructive recovery — do not close the PR or delete the branch. Both shortcuts
+below bypass Step 4's `worktree add` block, so each must bind `{worktree-path}` itself
+(reuse an on-disk worktree if the prior session left one, else create it) before handing off.
+- **Local-only** (branch exists, no PR, remote branch present): rebase is enough — no PATCH
+  needed; still refresh `heartbeatAt` (Step 5b). Continue to the "branch DOES exist on
+  remote" flow below, which binds `{worktree-path}` via the tracking-branch `worktree add`.
+  - **Never pushed** (no remote branch): reuse the on-disk worktree, or
+    `worktree add {worktree-path} {branch}` (no `-b`/`origin/main` — branch exists locally).
+    Bind `{worktree-path}`, go straight to Step 5.
+- **PR case**: resume from the existing PR. PATCH the task store to match reality:
   ```bash
   curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
     -H "Content-Type: application/json" \
     "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
     -d "{\"status\": \"pr_open\", \"pr\": {existing-pr-number}}" | jq .
   ```
-  Then skip Step 5 (implementation) entirely and continue from Step 6 (Simplify) using the
-  existing PR's branch, or — if Step 6 onward were already fully done too (CI green, nothing
-  left to verify) — skip straight to Step 10 (Handoff) since the task is effectively already
-  shipped. Print:
+  Reuse the on-disk worktree, or fetch + tracking-add one for the PR branch (same pair as
+  "branch DOES exist on remote" below). Bind `{worktree-path}` — Step 6's diff/Edit work
+  runs from it. Skip Step 5, continue from Step 6 on the PR's branch — or go straight to
+  Step 10 if Step 6+ was already done (CI green). Print:
   ```
   ↩ {branch} already has complete, correct work ({If PR: "PR #{number}, CI green" | "local branch, no PR yet"}).
   Resuming from existing state — skipping destructive recovery.
@@ -297,10 +298,25 @@ The reality check above already ran `git pull` and `git ls-remote --heads origin
 for the local/remote signals — reuse that same remote-branch result here (indicates a
 bundled task joining an existing PR) rather than re-querying:
 
-**If the branch does NOT exist on remote** (new task, standard flow):
-```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
-```
+**If the branch does NOT exist on remote** (new task, standard flow) — but first check
+whether a local branch `{branch}` already exists (from the reality check's `branch --list`
+result above). This happens when the branch was pushed then deleted externally between
+sessions (a remote-absent edge case, distinct from the never-pushed local-only case already
+handled above under "Complete and correct"):
+- **Local branch exists, remote does not** (pushed-then-deleted): do not run `origin/main -b
+  {branch}` — it fails because the local branch already exists. Treat this as a fresh start
+  from the local branch's current state: delete the stale local branch first, then create
+  fresh from `origin/main`:
+  ```bash
+  git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch -D {branch}
+  git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
+  ```
+  (If a worktree for `{branch}` already exists on disk, remove it first per the same
+  worktree-before-branch-delete ordering used in the incomplete/stale cleanup above.)
+- **Local branch does not exist either** (genuinely new): standard flow.
+  ```bash
+  git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
+  ```
 
 **If the branch DOES exist on remote** (bundled task — joining an existing branch/PR):
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -298,25 +298,14 @@ The reality check above already ran `git pull` and `git ls-remote --heads origin
 for the local/remote signals — reuse that same remote-branch result here (indicates a
 bundled task joining an existing PR) rather than re-querying:
 
-**If the branch does NOT exist on remote** (new task, standard flow) — but first check
-whether a local branch `{branch}` already exists (from the reality check's `branch --list`
-result above). This happens when the branch was pushed then deleted externally between
-sessions (a remote-absent edge case, distinct from the never-pushed local-only case already
-handled above under "Complete and correct"):
-- **Local branch exists, remote does not** (pushed-then-deleted): do not run `origin/main -b
-  {branch}` — it fails because the local branch already exists. Treat this as a fresh start
-  from the local branch's current state: delete the stale local branch first, then create
-  fresh from `origin/main`:
-  ```bash
-  git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch -D {branch}
-  git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
-  ```
-  (If a worktree for `{branch}` already exists on disk, remove it first per the same
-  worktree-before-branch-delete ordering used in the incomplete/stale cleanup above.)
-- **Local branch does not exist either** (genuinely new): standard flow.
-  ```bash
-  git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
-  ```
+**If the branch does NOT exist on remote** (new task, standard flow): by this point the
+reality check above has already resolved any local branch named `{branch}` — either it
+never existed, it was routed through the "complete and correct" local-only shortcut, or it
+was deleted during the incomplete/stale cleanup — so a local branch is guaranteed absent
+here. Standard flow:
+```bash
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
+```
 
 **If the branch DOES exist on remote** (bundled task — joining an existing branch/PR):
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -43,9 +43,13 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 ```
 
 - **404**: the task doesn't exist. Print `⚠ Task {task-id} not found.` and stop.
-- **Found, `status == "in_progress"`**: a prior session left this task in progress — proceed
-  straight to Step 2's Orphan Check with this task (which cleans up any stale branch/PR
-  before restarting). Record `task_started_at` (current ISO timestamp) for metrics.
+- **Found, `status == "in_progress"`**: a prior session left this task in progress (or a
+  human is manually re-running dev-task against it) — the task is already claimed, so skip
+  Step 2's claim and proceed directly to Step 3. Step 4's Branch/PR Reality Check (below)
+  runs unconditionally before worktree creation regardless of this status, so any stale
+  branch/PR left behind by the prior session is discovered and handled there — no separate
+  orphan-recovery path is needed here. Record `task_started_at` (current ISO timestamp) for
+  metrics.
 - **Found, `status == "pending"`**: check dependency satisfaction before claiming (see
   "Dependency Check" below). If satisfied, proceed to Step 2's Mark In-Progress with this
   task.
@@ -134,30 +138,15 @@ Refer to `references/toolchain-patterns.md` for the full detection lookup table.
 
 ## Step 2: Mark In-Progress
 
-### Orphan Check (prior session recovery)
-
-If the task's current status is already `in_progress`:
-
-1. Check for an orphaned branch: `git ls-remote --heads origin {branch}`
-2. Check for an orphaned PR: `gh pr list --head {branch} --state open --json number,title`
-3. If an orphaned PR exists, close it: `gh pr close {number} --comment "Shipwright cleanup — resuming task from prior session"`
-4. If a remote branch exists, delete it: `git push origin --delete {branch}`
-5. Print:
-   ```
-   ↩ Recovered orphaned session for {id}
-   {If PR closed: "Closed PR #{number}"}
-   {If branch deleted: "Deleted branch {branch}"}
-   Starting fresh.
-   ```
-
 ### Mark In-Progress
 
-This path is for the fresh-pending-task fetched in Step 1 (the resume/orphan path above
-already owns an `in_progress` task and does not need to claim it). Claim the task
-atomically instead of a plain PATCH — a plain read-modify-write PATCH here would race
-against any other concurrent run targeting the same task id. The claim is a single
-conditional `UPDATE ... WHERE status='pending'`; it also sets `claimedAt`, `heartbeatAt`,
-and `startedAt` atomically, so no separate PATCH of `startedAt` is needed afterward:
+This path is for the fresh-pending-task fetched in Step 1 (an already-`in_progress` task
+fetched in Step 1 already owns its claim and does not need to claim it again — skip
+straight to Step 3). Claim the task atomically instead of a plain PATCH — a plain
+read-modify-write PATCH here would race against any other concurrent run targeting the same
+task id. The claim is a single conditional `UPDATE ... WHERE status='pending'`; it also sets
+`claimedAt`, `heartbeatAt`, and `startedAt` atomically, so no separate PATCH of `startedAt`
+is needed afterward:
 
 ```bash
 CLAIM_CODE=$(curl -s -o /tmp/task_claim.json -w '%{http_code}' -X POST \
@@ -208,12 +197,98 @@ architecture to implementation. Auto-fix all quality issues.
 
 All work happens in a worktree — see workspace `CLAUDE.md` for the convention. Branch slug = branch name with `/` replaced by `-`.
 
-First, pull and check whether the branch already exists on the remote (indicates a bundled task joining an existing PR):
+### Branch/PR Reality Check (prior-session recovery)
+
+Before creating (or reusing) a worktree, check live git/GitHub state for the task's own
+`{branch}` directly — **regardless of what task-store status says**. This replaces the old
+status-gated Step 1/Step 2 orphan-recovery logic: per the plugin's Design Constitution
+(§4, "manual human actions do not break automation"), a task's recorded status is not
+trustworthy — a crashed session can leave a complete, unpushed local branch, or a complete,
+CI-green open PR, with the task still showing `in_progress` (or even reset back to
+`pending`). Checking live state unconditionally means both the cron-driven path (which only
+ever sees `pending`) and a manual re-run against an `in_progress` task get the same
+correctness guarantee.
+
+Reuse the exact `--repo` derivation already used later in this step for the stale-bundle-
+branch check, since CWD is the workspace, not the target repo:
 
 ```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} pull
-git ls-remote --heads origin {branch}
+GH_REPO=$(git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
 ```
+
+Check all three signals:
+
+```bash
+# Local branch (pull first so remote-tracking state is current)
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} pull
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch --list {branch}
+
+# Remote branch
+git ls-remote --heads origin {branch}
+
+# Open PR (mergeable/mergeStateStatus feed the completeness assessment below;
+# CI status is checked separately once a PR number is known)
+gh pr list --head {branch} --state open --json number,state,mergeable,mergeStateStatus --repo "$GH_REPO"
+```
+
+**If none of the three exist** (no local branch, no remote branch, no open PR): nothing to
+recover — proceed to the standard branch-existence check below.
+
+**If any of the three exist**, assess whether the existing work is complete and correct
+against the task's acceptance criteria before deciding how to proceed:
+
+1. Inspect the existing work: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} log {branch} --oneline -20`
+   and `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} diff main...{branch}` (fetch first if
+   the branch is remote-only: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} fetch origin {branch}`).
+2. Compare the diff/log against the task's `acceptanceCriteria` (same MET/PARTIAL/NOT MET
+   evaluation used in Step 7) — every criterion should show clear evidence in the diff.
+3. **If a PR exists**, additionally check its CI status before treating it as complete —
+   reuse the Step 9b Actions-API pattern (`gh api "repos/$GH_REPO/actions/runs?head_sha=..."`)
+   against the PR's head SHA. A PR with failing or still-running CI is not "complete and
+   correct" — treat it the same as the incomplete/stale case below.
+
+**Complete and correct** (diff satisfies every acceptance criterion, and CI is green if a PR
+exists): skip destructive recovery — do not close the PR or delete the branch.
+- **Local-only case** (branch exists, no PR yet): rebase is enough — no PATCH of `branch` or
+  `pr` is needed since neither changed; still refresh `heartbeatAt` (Step 5b already does
+  this before dispatch). Continue to the standard "branch DOES exist on remote" flow below
+  (or, if the branch is local-only and never pushed, treat it as already checked out and
+  skip straight to Step 5 — no worktree recreation needed against a fresh `origin/main`
+  base).
+- **PR case**: resume from the existing PR rather than rebuilding it. PATCH the task store to
+  match reality so downstream steps (Step 9, Step 9b, Step 10a) see the correct state:
+  ```bash
+  curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
+    -d "{\"status\": \"pr_open\", \"pr\": {existing-pr-number}}" | jq .
+  ```
+  Then skip Step 5 (implementation) entirely and continue from Step 6 (Simplify) using the
+  existing PR's branch, or — if Step 6 onward were already fully done too (CI green, nothing
+  left to verify) — skip straight to Step 10 (Handoff) since the task is effectively already
+  shipped. Print:
+  ```
+  ↩ {branch} already has complete, correct work ({If PR: "PR #{number}, CI green" | "local branch, no PR yet"}).
+  Resuming from existing state — skipping destructive recovery.
+  ```
+
+**Incomplete, stale, or the diff doesn't match the brief** (missing acceptance criteria,
+diff unrelated to the task, or CI red with no clear fix path): treat exactly like an orphan
+from a crashed session — clean up before starting fresh.
+1. If an open PR exists, close it: `gh pr close {number} --repo "$GH_REPO" --comment "Shipwright cleanup — prior attempt incomplete/stale, restarting"`
+2. If a remote branch exists, delete it: `git push origin --delete {branch}`
+3. If a local branch exists, delete it: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch -D {branch}`
+4. Print:
+   ```
+   ⚠ {branch} had incomplete/stale prior work — cleaned up (PR closed, branch deleted). Starting fresh.
+   ```
+5. Fall through to the standard fresh-start flow below (branch now absent on remote).
+
+---
+
+The reality check above already ran `git pull` and `git ls-remote --heads origin {branch}`
+for the local/remote signals — reuse that same remote-branch result here (indicates a
+bundled task joining an existing PR) rather than re-querying:
 
 **If the branch does NOT exist on remote** (new task, standard flow):
 ```bash


### PR DESCRIPTION
## Summary
- Replace the status-gated Step 1/Step 2 "in_progress → Orphan Check" logic in `dev-task.md` — now unreachable in the normal cron-driven path since WLS-3.1 landed (work-selector.ts only ever hands out `pending` tasks) — with an unconditional Branch/PR Reality Check that runs right before worktree creation in Step 4, regardless of task-store status.
- The new check inspects local branch, remote branch (`git ls-remote --heads origin`), and open PR (`gh pr list --head ... --state open`) state directly. Complete-and-correct prior work (diff satisfies acceptance criteria, CI green if a PR exists) skips destructive recovery and PATCHes the task store to match reality; incomplete/stale work closes the PR and deletes the branch (remote + local) before falling through to the existing fresh-worktree flow.
- Reuses the exact `--repo` derivation pattern from the existing Step 4 stale-bundle-branch check (`git remote get-url origin | sed ...`) rather than inventing a new idiom.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Check local branch / remote branch / open PR before `git worktree add -b {branch}`, regardless of task-store status | MET |
| 2 | Complete-and-correct: skip destructive recovery, rebase or resume-from-PR, PATCH task-store to match reality | MET |
| 3 | Incomplete/stale: close PR + delete branch (remote+local), proceed to fresh worktree creation | MET |
| 4 | Reuses existing Step 4 `--repo` derivation pattern | MET |
| 5 | Test decision: retire stale in_progress/409 tests (already retired by WLS-3.1), add new coverage for reality-check ordering, complete/incomplete paths, `--repo` derivation | MET |

## Test Plan
- `bun test plugins/shipwright/commands/` — 223 pass, 0 fail
- `bun test` (full suite) — 4036 pass, 0 fail
- `bun run lint` — clean
- `bun run typecheck` — clean (all 7 packages)
- `task check-strings`, `check-config-docs`, `sync-version --check` — all pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
