### PR TITLE
feat(agent): convert slack/voice attachment I/O to async (SIO-1.4)

### DIFF
--- a/agent/src/slack.ts
+++ b/agent/src/slack.ts
@@ -6,7 +6,8 @@
  * createRunClaude() and your injected config values.
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { App } from "@slack/bolt";
@@ -78,7 +79,7 @@ export async function downloadFile(
 
   const buffer = Buffer.from(await resp.arrayBuffer());
   const tmpPath = join(tmpdir(), `shipwright-agent-${Date.now()}-${file.name}`);
-  writeFileSync(tmpPath, buffer);
+  await writeFile(tmpPath, buffer);
   return tmpPath;
 }
 
@@ -189,7 +190,7 @@ export async function dispatchMarkers(
           .uploadV2({
             channel_id: channel,
             thread_ts: threadTs,
-            file: readFileSync(absPath),
+            file: await readFile(absPath),
             filename: absPath.split("/").pop() ?? "file",
           })
           .catch((err: unknown) =>
@@ -219,7 +220,7 @@ export async function dispatchMarkers(
             .uploadV2({
               channel_id: channel,
               thread_ts: threadTs,
-              file: readFileSync(audioPath),
+              file: await readFile(audioPath),
               filename: audioPath.split("/").pop() ?? "response.mp3",
             })
             .catch((err: unknown) =>

--- a/agent/src/voice.ts
+++ b/agent/src/voice.ts
@@ -1,5 +1,6 @@
 import { type SpawnOptions, spawn } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -142,7 +143,7 @@ export async function transcribeAudio(
 ): Promise<string | null> {
   let fileBuffer: Buffer;
   try {
-    fileBuffer = readFileSync(audioPath);
+    fileBuffer = await readFile(audioPath);
   } catch (err) {
     console.warn("[voice] could not read audio file:", err);
     return null;
@@ -244,7 +245,7 @@ async function synthesizeElevenLabs(
   }
 
   const outPath = join(VOICE_DIR, `${Date.now()}-response.mp3`);
-  writeFileSync(outPath, Buffer.from(await resp.arrayBuffer()));
+  await writeFile(outPath, Buffer.from(await resp.arrayBuffer()));
   return outPath;
 }
 


### PR DESCRIPTION
## Summary
- Converted the four remaining sync `writeFileSync`/`readFileSync` calls on Slack attachment and voice audio buffers in `agent/src/slack.ts` and `agent/src/voice.ts` to `node:fs/promises` `writeFile`/`readFile`, awaited at each call site.
- All four call sites were already inside `async` functions already awaited by their callers, so no signature changes propagated up the stack — this is a pure sync→async I/O swap.
- `existsSync` (slack.ts) and `mkdirSync` (voice.ts) were intentionally left sync — they're existence checks / directory creation, not buffer I/O, and out of scope per the acceptance criteria.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | writeFileSync/readFileSync/unlinkSync for attachment and voice buffers replaced with node:fs/promises equivalents; call sites updated to await | MET | slack.ts + voice.ts import `readFile`/`writeFile` from `node:fs/promises`; all call sites use `await`. No `unlinkSync` call exists in either file. |
| 2 | No behavior change for files up to the existing 10MB cap | MET | 10MB cap check in `downloadFile` runs before the writeFile call, untouched. All 165 integration tests pass unchanged. |
| 3 | Integration tests stay integration-layer, updated to await async calls, no tests retired | MET | `slack.integration.test.ts`/`voice.integration.test.ts` needed no edits — every call site under test was already inside an awaited async chain. 165/165 pass. |
| 4 | Safe to deploy standalone: yes | MET | No new deps, no API/schema changes, purely internal I/O mechanism swap. |

## Test Plan
- [x] `NODE_ENV=test bun test agent/src/slack.integration.test.ts agent/src/voice.integration.test.ts` — 165/165 pass
- [x] `bunx biome lint` on changed files — clean
- [x] `bun run typecheck` (agent workspace) — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
