### PR TITLE
test: add direct unit coverage for resolveReadyTasks dependency-satisfaction logic (T-052)

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -156,6 +156,18 @@ pending → in_progress → pr_open → approved → merged → deploying → de
 Terminal statuses (closed): `merged`, `done`, `deploying`, `deployed`, `cancelled`.
 Paused status: `blocked` (returned to `pending` on retry).
 
+### Dependency satisfaction rules
+
+When `GET /tasks?ready=true` evaluates whether a task is eligible to run, it checks whether all of the task's dependencies are "satisfied." A task's dependencies are specified in its `dependencies` array (a list of task IDs). A single dependency is satisfied when its task meets one of these conditions:
+
+1. **Terminal status** — the dependency's `status` is `merged`, `done`, `deploying`, `deployed`, or `cancelled`. These statuses indicate the dependency is complete and no longer blocking.
+
+2. **Same-branch bundled** — the dependency has `status = pr_open` or `status = approved` AND its `branch` field equals the requesting task's `branch`. This indicates both tasks are part of the same feature branch and their PRs are bundled together in the queue (reviewed/approved as a unit).
+
+3. **Cross-branch merged PR** — the dependency has `status = pr_open` AND its `pr` field is set (not null) AND the referenced GitHub PR number is merged in the repository. This indicates a dependency from another branch whose work has landed.
+
+4. **Any other status is not satisfied.** If a dependency does not match one of the three rules above (e.g., it has `status = pending`, `status = blocked`, or is `pr_open` on a different branch with no PR link), the task cannot run — the dependency is unsatisfied and the task is excluded from `?ready=true` results.
+
 ### PR tracking
 
 The `/prs` surface tracks GitHub PRs through the review → patch → deploy pipeline. One record per `(repo, prNumber)`.
@@ -330,7 +342,7 @@ If `GET /tasks?ready=true` returns `{ tasks: [], total: 0 }` even though tasks e
 
 2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. Clear the flag once the human action is complete.
 
-3. **Dependencies not satisfied** — query `?status=pending` to find pending tasks, then check each task's `dependencies` array against the satisfaction rules above (terminal status, same-branch `pr_open`/`approved`, or a merged cross-branch PR).
+3. **Dependencies not satisfied** — query `?status=pending` to find pending tasks, then check each task's `dependencies` array against the [dependency satisfaction rules](#dependency-satisfaction-rules) (terminal status, same-branch `pr_open`/`approved`, or a merged cross-branch PR).
 
 4. **Queue empty** — no pending tasks exist at all. Confirm with `?status=pending`.
 

--- a/task-store/src/ready.unit.test.ts
+++ b/task-store/src/ready.unit.test.ts
@@ -1,0 +1,196 @@
+/**
+ * task-store/src/ready.unit.test.ts
+ *
+ * Direct unit tests for the resolveReadyTasks() dependency-satisfaction logic.
+ * No I/O — pure logic only. isPrMerged is injected as a plain async function
+ * (dependency injection, not a global/module mock).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { type ReadyTaskLike, resolveReadyTasks } from "./ready.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<ReadyTaskLike> = {}): ReadyTaskLike {
+  return {
+    id: "task-1",
+    status: "pending",
+    branch: null,
+    dependencies: [],
+    pr: null,
+    hitl: null,
+    hitlNotifiedAt: null,
+    ...overrides,
+  };
+}
+
+/** isPrMerged stub that always throws — use when the test asserts it must
+ * never be called (e.g. dep.pr is null so the check should short-circuit). */
+const isPrMergedShouldNotBeCalled = async (): Promise<boolean> => {
+  throw new Error("isPrMerged should not have been called");
+};
+
+const isPrMergedAlwaysFalse = async (): Promise<boolean> => false;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("resolveReadyTasks", () => {
+  it("excludes a task whose status is not pending", async () => {
+    const task = makeTask({ id: "t1", status: "in_progress" });
+    const result = await resolveReadyTasks([task], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a task with hitl === true even if otherwise ready", async () => {
+    const task = makeTask({ id: "t1", hitl: true });
+    const result = await resolveReadyTasks([task], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([]);
+  });
+
+  it("includes a pending task with no dependencies", async () => {
+    const task = makeTask({ id: "t1" });
+    const result = await resolveReadyTasks([task], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("excludes a task when a dependency ID does not resolve to a known task", async () => {
+    const task = makeTask({ id: "t1", dependencies: ["missing-dep"] });
+    const result = await resolveReadyTasks([task], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([]);
+  });
+
+  it("includes a task when dependency status is merged (terminal)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "merged" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("includes a task when dependency status is done (terminal)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "done" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("includes a task when dependency status is deploying (terminal)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "deploying" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("includes a task when dependency status is deployed (terminal)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "deployed" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("includes a task when dependency status is cancelled (terminal)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "cancelled" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("includes a task when same-branch dependency has pr_open status (bundled)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/shared" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/shared" });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("includes a task when same-branch dependency has approved status (bundled)", async () => {
+    const dep = makeTask({ id: "dep-1", status: "approved", branch: "feat/shared" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/shared" });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([task]);
+  });
+
+  it("excludes a task when same-branch dependency has a non-satisfying status (pending)", async () => {
+    // dep-1 is itself "pending" with no deps of its own, so it resolves as
+    // ready independently — assert on t1's exclusion specifically, not on
+    // the full result set being empty.
+    const dep = makeTask({ id: "dep-1", status: "pending", branch: "feat/shared" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/shared" });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result.map((t) => t.id)).not.toContain("t1");
+  });
+
+  it("includes a task when cross-branch pr_open dependency's PR is merged", async () => {
+    const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/other", pr: 42 });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/main" });
+    const isPrMerged = async (prNumber: number) => {
+      expect(prNumber).toBe(42);
+      return true;
+    };
+    const result = await resolveReadyTasks([task, dep], isPrMerged);
+    expect(result).toEqual([task]);
+  });
+
+  it("excludes a task when cross-branch pr_open dependency's PR is not merged", async () => {
+    const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/other", pr: 42 });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/main" });
+    const result = await resolveReadyTasks([task, dep], isPrMergedAlwaysFalse);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a task when pr_open dependency has no pr set, without calling isPrMerged", async () => {
+    const dep = makeTask({ id: "dep-1", status: "pr_open", branch: "feat/other", pr: null });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"], branch: "feat/main" });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a task when dependency has an arbitrary non-satisfying status", async () => {
+    const dep = makeTask({ id: "dep-1", status: "blocked" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+    const result = await resolveReadyTasks([task, dep], isPrMergedShouldNotBeCalled);
+    expect(result).toEqual([]);
+  });
+
+  it("returns only the ready tasks from a mixed input array, preserving original order", async () => {
+    const readyTask1 = makeTask({ id: "ready-1" });
+    const notPending = makeTask({ id: "not-pending", status: "in_progress" });
+    const hitlBlocked = makeTask({ id: "hitl-blocked", hitl: true });
+    const readyTask2 = makeTask({ id: "ready-2" });
+    const unsatisfiedDep = makeTask({
+      id: "unsatisfied",
+      dependencies: ["missing"],
+    });
+
+    const tasks = [readyTask1, notPending, hitlBlocked, readyTask2, unsatisfiedDep];
+    const result = await resolveReadyTasks(tasks, isPrMergedShouldNotBeCalled);
+
+    expect(result).toEqual([readyTask1, readyTask2]);
+  });
+
+  it("excludes a task when it has multiple dependencies and only one is unsatisfied", async () => {
+    // dep-pending is itself "pending" with no deps of its own, so it resolves
+    // as ready independently — assert on t1's exclusion specifically, not on
+    // the full result set being empty.
+    const satisfiedDep = makeTask({ id: "dep-done", status: "done" });
+    const unsatisfiedDep = makeTask({ id: "dep-pending", status: "pending" });
+    const task = makeTask({
+      id: "t1",
+      dependencies: ["dep-done", "dep-pending"],
+    });
+    const result = await resolveReadyTasks(
+      [task, satisfiedDep, unsatisfiedDep],
+      isPrMergedShouldNotBeCalled,
+    );
+    expect(result.map((t) => t.id)).not.toContain("t1");
+  });
+
+  it("includes a task when it has multiple dependencies and all are satisfied", async () => {
+    const dep1 = makeTask({ id: "dep-1", status: "done" });
+    const dep2 = makeTask({ id: "dep-2", status: "merged" });
+    const task = makeTask({ id: "t1", dependencies: ["dep-1", "dep-2"] });
+    const result = await resolveReadyTasks(
+      [task, dep1, dep2],
+      isPrMergedShouldNotBeCalled,
+    );
+    expect(result).toEqual([task]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `task-store/src/ready.unit.test.ts` with 19 direct unit tests covering `resolveReadyTasks`'s dependency-satisfaction logic (previously only exercised indirectly via imports in sibling test files)
- Covers all four documented dependency-satisfaction rules: terminal statuses (merged/done/deploying/deployed/cancelled), same-branch bundling (pr_open/approved), cross-branch PR-merged check via injected `isPrMerged`, and the not-satisfied fallback — plus HITL blocking, missing-dependency exclusion, and multi-dependency scenarios
- Refreshes `docs/task-store.md` with a new "Dependency satisfaction rules" section documenting the ready-task logic

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | task-store/src/ready.unit.test.ts added with direct coverage of resolveReadyTasks's dependency-satisfaction logic | MET | New file, 196 lines, 19 tests |
| 2 | Verification command `bun test task-store/src/ready.unit.test.ts` passes | MET | 19 pass, 0 fail |

## Test Plan
- `NODE_ENV=test bun test task-store/src/ready.unit.test.ts` → 19 pass, 0 fail
- `bun test --coverage` on `ready.ts` → 100% lines/funcs
- `task lint` → clean
- `task typecheck` → clean across all packages
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
