### PR TITLE
fix: gate test-roadmap Milestone 3 canary generation on deploy_model

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -1265,6 +1265,24 @@ no prior `test-t-*-{repo}` tasks still starts at `T-001`.
 **Steps:** (a) Run `/test-inventory` against a repo with no `## Deploy model` declaration in CLAUDE.md. (b) Run `/test-inventory` against a repo whose CLAUDE.md declares `## Deploy model: staged`.
 **Expected:** (a) Generated inventory artifact's Notes section contains the message "deploy_model undeclared — canary eligibility skipped; declare ## Deploy model in CLAUDE.md to enable." and zero items are tagged as canary-eligible, regardless of layer/criticality. (b) Generated inventory artifact follows the existing canary-eligibility logic (tags smoke/E2E critical/high items as canary-eligible per the `canary-execution` contract).
 
+### TR-26 — Deploy model gates Milestone 3 canary generation in test-roadmap
+**Steps:** No automated test covers this — Milestone 3 gating is prompt-only generation
+logic (the `deploy_model` read-with-fallback and the Process step 5 conditional are
+followed by the LLM at run time, not code). Verify via two dry runs: (a) run
+`/test-roadmap` against a repo whose CLAUDE.md declares `## Deploy model: direct` (e.g.
+shipwright itself) — or has no `## Deploy model` declaration at all. (b) run
+`/test-roadmap` against a repo whose CLAUDE.md declares `## Deploy model: staged` (e.g.
+vitals-os).
+**Expected:** (a) `test-readiness-plan.md`'s section 4 Milestone 3 content is replaced
+with a single note line — `canary not applicable -- deploy_model=direct` (or
+`deploy_model=undeclared` when the section is absent) — no DOD text; section 5's task
+list contains **zero** Milestone 3 tasks. (b) Behavior is unchanged from before this
+gate was added: section 4 Milestone 3 keeps its normal DOD text, and section 5 emits
+canary-plumbing tasks for all canary-eligible items as before — no regression to
+vitals-os's active canary track. This is the fix for the 2026-07-14 incident where
+shipwright's own repo (`deploy_model: direct`) had 8 Milestone-3 canary-plumbing tasks
+generated and had to have them manually cancelled.
+
 ---
 
 ## Versioning Checklist (for every PR to this repo)

--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -1269,19 +1269,18 @@ no prior `test-t-*-{repo}` tasks still starts at `T-001`.
 **Steps:** No automated test covers this — Milestone 3 gating is prompt-only generation
 logic (the `deploy_model` read-with-fallback and the Process step 5 conditional are
 followed by the LLM at run time, not code). Verify via two dry runs: (a) run
-`/test-roadmap` against a repo whose CLAUDE.md declares `## Deploy model: direct` (e.g.
-shipwright itself) — or has no `## Deploy model` declaration at all. (b) run
-`/test-roadmap` against a repo whose CLAUDE.md declares `## Deploy model: staged` (e.g.
-vitals-os).
+`/test-roadmap` against a repo whose CLAUDE.md declares `## Deploy model: direct` — or
+has no `## Deploy model` declaration at all. (b) run `/test-roadmap` against a repo
+whose CLAUDE.md declares `## Deploy model: staged`.
 **Expected:** (a) `test-readiness-plan.md`'s section 4 Milestone 3 content is replaced
 with a single note line — `canary not applicable -- deploy_model=direct` (or
 `deploy_model=undeclared` when the section is absent) — no DOD text; section 5's task
 list contains **zero** Milestone 3 tasks. (b) Behavior is unchanged from before this
 gate was added: section 4 Milestone 3 keeps its normal DOD text, and section 5 emits
-canary-plumbing tasks for all canary-eligible items as before — no regression to
-vitals-os's active canary track. This is the fix for the 2026-07-14 incident where
-shipwright's own repo (`deploy_model: direct`) had 8 Milestone-3 canary-plumbing tasks
-generated and had to have them manually cancelled.
+canary-plumbing tasks for all canary-eligible items as before — no regression to a
+repo's active canary track. This is the fix for the 2026-07-14 incident where a repo
+declaring `deploy_model: direct` had 8 Milestone-3 canary-plumbing tasks generated and
+had to have them manually cancelled.
 
 ---
 

--- a/plugins/shipwright/assets/templates/test-readiness-plan.md.tmpl
+++ b/plugins/shipwright/assets/templates/test-readiness-plan.md.tmpl
@@ -76,8 +76,7 @@
 
 {{M2_TASKS_SUMMARY}}
 
-### Milestone 3 — Canary suite live
-**DOD:** Smoke + E2E canary-eligible tests run green against the deployed env in <60s wall time.
+{{M3_HEADING_AND_DOD}}
 
 {{M3_TASKS_SUMMARY}}
 

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -79,7 +79,14 @@ Write or rebuild every `critical` tier test across all layers.
 
 #### Milestone 3: Canary suite live
 Smoke + E2E canary-eligible tests run green against a freshly deployed environment.
-- DOD: CI job runs the canary suite against a staging URL post-deploy. Suite completes in <60s. All canary tests pass.
+Gated on `deploy_model` (determined in Process step 1): this milestone only applies
+when `deploy_model == 'staged'`.
+- DOD (when `deploy_model == 'staged'`): CI job runs the canary suite against a staging URL post-deploy. Suite completes in <60s. All canary tests pass.
+- When `deploy_model != 'staged'` (i.e. declared `direct`, declared `none`, or
+  undeclared): there is no staging/canary pipeline to gate on. Replace this milestone's
+  entire content with a single note line — `canary not applicable -- deploy_model={value}`,
+  where `{value}` is `direct`, `none`, or `undeclared` — and skip the milestone entirely:
+  no DOD, no tasks. Do not fabricate canary-plumbing work for a pipeline that doesn't exist.
 
 #### Milestone 4: High-tier coverage
 Fill `high` tier gaps.
@@ -175,7 +182,12 @@ Anything the audit couldn't determine without a human call. Common entries:
 
 ## Process
 
-1. Read all three prior artifacts. Abort if any missing.
+1. Read all three prior artifacts. Abort if any missing. Also determine `deploy_model`
+   using the same read-with-fallback mechanism `skills/test-inventory/SKILL.md` Step 1
+   uses ("CLAUDE.md deploy-model declaration"): check the target repo's root `CLAUDE.md`
+   for a `## Deploy model` section with value `staged`, `direct`, or `none`; if the
+   section is absent, treat it as **undeclared** and default to NOT staged. Store this
+   value — Step 5 gates Milestone 3 canary-task generation on it.
 2. Extract metrics: layer counts, speed numbers, bucket counts.
 3. Compute the gap (section 3 math).
 4. **Determine the starting T-NNN offset (task-store query — run before any ID is
@@ -211,7 +223,12 @@ Anything the audit couldn't determine without a human call. Common entries:
    restarting at `T-001`:
    - Milestone 1: all `infra` items + **paired repo-config tasks** (see pairing rule below)
    - Milestone 2: all `critical` tier items (net-new + rebuild + promote)
-   - Milestone 3: all canary-eligible items needing canary plumbing
+   - Milestone 3: **only when `deploy_model == 'staged'`** (Process step 1) — all
+     canary-eligible items needing canary plumbing. When `deploy_model != 'staged'`
+     (declared `direct`, declared `none`, or undeclared), emit **zero** Milestone 3 tasks
+     here — the section 4 note (`canary not applicable -- deploy_model={value}`) is the
+     only artifact of this milestone; do not generate canary-plumbing tasks for a
+     pipeline that doesn't exist.
    - Milestone 4: all `high` tier items (net-new + rebuild + promote)
    - Milestone 5: all `delete (redundant)` items + remaining `rebuild` cleanup + plugin feedback collector
 6. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
@@ -228,3 +245,10 @@ Anything the audit couldn't determine without a human call. Common entries:
   step 4 task-store query first. Skipping it silently collides with `test-fix`'s
   `test-t-{nnn}-{repo-slug}` IDs from an earlier cycle and produces a roadmap that
   duplicates already-shipped work under fresh numbering.
+- **Don't generate Milestone 3 canary-plumbing tasks when `deploy_model != 'staged'`.**
+  Check the value determined in Process step 1 before emitting any Milestone 3 task.
+  Getting this wrong is not hypothetical: on 2026-07-14 this happened to shipwright's own
+  repo (`deploy_model: direct` — no staging environment) and produced a pile of
+  canary-plumbing tasks for a pipeline that doesn't exist, requiring 8 tasks to be
+  manually cancelled. When not staged, emit the `canary not applicable -- deploy_model={value}`
+  note in section 4 and skip the milestone — zero tasks, not a smaller pile of tasks.

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -233,7 +233,18 @@ Anything the audit couldn't determine without a human call. Common entries:
    - Milestone 5: all `delete (redundant)` items + remaining `rebuild` cleanup + plugin feedback collector
 6. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
 7. **Apply the E2E classification guardrail** (non-negotiable): Before emitting any task with `layer: e2e`, verify against test-system.md's "Classifying a new test" step that the proposed test journey actually exercises a real browser (step 4: "Does it test a multi-step browser flow? → e2e (Playwright)"). If the journey is a backend orchestration flow, an API contract test, or any other non-browser interaction, downgrade the task to `layer: integration` or `layer: smoke` with a one-line note explaining why (e.g., "backend orchestration flow — moved to smoke"). This guardrail prevents shipping e2e tasks that violate the test classification rules, ensuring the e2e layer contains only true multi-step browser-driven flows.
-8. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`. Fill. Write to `docs/test-readiness/test-readiness-plan.md`.
+8. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`. Fill.
+   Write to `docs/test-readiness/test-readiness-plan.md`.
+   - **`{{M3_HEADING_AND_DOD}}` is gated on `deploy_model`** (Process step 1) — the
+     template has no static text for this milestone precisely because it must reflect
+     the gate:
+     - When `deploy_model == 'staged'`: fill with
+       `### Milestone 3 — Canary suite live\n**DOD:** Smoke + E2E canary-eligible tests run green against the deployed env in <60s wall time.`
+     - When `deploy_model != 'staged'` (declared `direct`, declared `none`, or
+       undeclared): fill with the single note line —
+       `### Milestone 3 — Canary suite live\n**DOD:** canary not applicable -- deploy_model={value}`
+       (no task list, no DOD beyond the note) — where `{value}` is `direct`, `none`, or
+       `undeclared`.
 
 ## Failure modes to avoid
 


### PR DESCRIPTION
## Summary
- Gates `test-roadmap`'s Milestone 3 (canary suite live) on the `deploy_model` value read from the target repo's CLAUDE.md — reusing the exact read-with-fallback mechanism `test-inventory` (TRH-3.1) established (`staged`/`direct`/`none`, undeclared defaults to not-staged).
- When `deploy_model != 'staged'`, the generated roadmap replaces Milestone 3's content with a single note (`canary not applicable -- deploy_model={value}`) and emits zero canary-plumbing tasks, instead of the prior unconditional generation that required manually cancelling 8 tasks on 2026-07-14 for a canary pipeline that doesn't exist.
- Adds a new `TR-26` entry to `TESTING.md` documenting the two dry-run verification scenarios (direct/undeclared → skip-note + zero tasks; staged → unchanged behavior), per this task's explicit test decision that no automated test covers this prompt-only generation logic.
- No manual version bump — this repo's plugin versioning is fully automated (tag-driven CI); the commit uses a `fix:` conventional prefix per `.claude/skills/marketplace-dev/references/version-sync-checklist.md`, which explicitly warns against hand-editing version fields (cites PR #1296 as precedent).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Dry-run of test-roadmap against a `deploy_model: direct` repo produces the skip-note and zero Milestone 3 canary tasks | MET | SKILL.md §4 Milestone 3 + Process step 5 both gate on `deploy_model == 'staged'`, otherwise emit the note and zero tasks |
| 2 | Dry-run of test-roadmap against a `deploy_model: staged` repo still produces Milestone 3 canary tasks as before — no regression | MET | Milestone 3 DOD and Process step 5's task generation are unchanged for the staged case |
| 3 | Test decision: no automated test covers this (prompt-only generation logic) — verified via the two dry-runs above, documented in a new TESTING.md TR-entry | MET | New `TR-26` entry added, following TR-23/24/25's "no automated test" framing |

## Test Plan
- [x] `bun test plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts` — 10 pass, 0 fail (no existing assertions broken)
- [x] `bunx biome lint .` — clean
- [x] `bun run scripts/sync-version.ts --check` — version sync passed (no manual bump)
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean (fixed a repo-name leak caught during review — TR-26 initially named a private repo, genericized to match TR-25's phrasing)
- [x] `bun scripts/check-config-docs.ts` — all env vars documented
- [x] Reasoning dry-run walkthrough of the edited Process step 1 + Milestone 3 (§4) + step 5, confirming both the direct/undeclared skip path and the staged unchanged path

Generated with [Claude Code](https://claude.com/claude-code)
