### PR TITLE
feat: admin task and PR list views request sort=desc

### DIFF
--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -3795,6 +3795,23 @@ describe("admin UI — tasks page", () => {
     expect(capturedParams[0].has("status")).toBe(false);
   });
 
+  it("GET /admin/tasks requests sort=desc from the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].get("sort")).toBe("desc");
+  });
+
   it("GET /admin/tasks renders tasks table with mock data", async () => {
     const mockTasks = [
       {
@@ -4376,6 +4393,24 @@ describe("admin UI — session detail page", () => {
     expect(html.toLowerCase()).toContain("no tasks");
   });
 
+  it("GET /admin/sessions/:id requests sort=desc from the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 500, offset: 0 };
+        },
+      }),
+    );
+    const res = await app.request("/admin/sessions/session-abc", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].get("sort")).toBe("desc");
+  });
+
   it("GET /admin/sessions/:id unauthenticated redirects to /admin/login", async () => {
     const app = createAdminUIApp(makeMockDeps());
     const res = await app.request("/admin/sessions/session-abc");
@@ -4593,6 +4628,24 @@ describe("admin UI — PRs page", () => {
     expect(html).toContain("#42");
   });
 
+  it("GET /admin/prs requests sort=desc from the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStorePrs: async (params) => {
+          capturedParams.push(params);
+          return { prs: [MOCK_PR], total: 1, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    const res = await app.request("/admin/prs", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].get("sort")).toBe("desc");
+  });
+
   it("GET /admin/prs returns 200 with degraded warning banner when fetchTaskStorePrs is absent", async () => {
     const app = createAdminUIApp(
       makeMockDeps({
@@ -4700,6 +4753,22 @@ describe("admin UI — public task board", () => {
     await app.request("/public/tasks");
     expect(capturedParams.length).toBe(1);
     expect(capturedParams[0].get("repo")).toBe(PUBLIC_REPO);
+  });
+
+  it("GET /public/tasks requests sort=desc from the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        publicRepo: PUBLIC_REPO,
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/public/tasks");
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].get("sort")).toBe("desc");
   });
 
   it("GET /public/tasks renders task rows but NO create/edit/release controls", async () => {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1955,6 +1955,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       // when an agent filter is active to avoid under-counting across pages.
       params.set("limit", agentFilterIds !== null ? "500" : String(limit));
       params.set("offset", agentFilterIds !== null ? "0" : String(offset));
+      params.set("sort", "desc");
       try {
         const [result, distinct] = await Promise.all([
           fetchTaskStoreTasks(params),
@@ -2108,6 +2109,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       // a handful of tasks, well under this ceiling.
       params.set("limit", "500");
       params.set("offset", "0");
+      params.set("sort", "desc");
       try {
         const result = await fetchTaskStoreTasks(params);
         tasks = result.tasks;
@@ -2149,6 +2151,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       if (taskId) params.set("taskId", taskId);
       params.set("limit", String(limit));
       params.set("offset", String(offset));
+      params.set("sort", "desc");
       try {
         const result = await fetchTaskStorePrs(params);
         prs = result.prs;
@@ -2743,6 +2746,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       params.set("repo", publicRepo);
       params.set("limit", "50");
       params.set("offset", "0");
+      params.set("sort", "desc");
       try {
         const result = await fetchTaskStoreTasks(params);
         tasks = result.tasks;


### PR DESCRIPTION
## Summary
- Add `params.set("sort", "desc")` to all four admin list-view handlers that call `fetchTaskStoreTasks`/`fetchTaskStorePrs`: `/admin/tasks`, `/admin/sessions/:id`, `/admin/prs`, and the public repo view — so lists render newest-first.
- Single-item fetch handlers (PR detail page, embedded PR card on task detail) are untouched, since there's nothing to sort in a one-item view.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /admin/tasks, GET /admin/sessions/:id, public repo view, and GET /admin/prs render newest-first | MET | `params.set("sort", "desc")` added at all 4 call sites |
| 2 | PR detail page and embedded PR card unchanged | MET | `fetchTaskStorePr`/`fetchTaskStorePrById` (single-item) untouched |
| 3 | Existing tests extended to assert sort=desc on all 4 routes, no tests removed | MET | 4 new tests added in admin-ui.smoke.test.ts; diff is purely additive |

## Test Plan
- 4 new smoke tests assert `sort=desc` is present in the outgoing params for each list-view route
- Full admin-ui.smoke.test.ts suite: 146 pass, 0 fail
- Full admin package suite: 1203 pass, 0 fail, 167 skip
- `tsc --noEmit` clean, `biome lint` clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
