### PR TITLE
test: isOrgRepo has direct unit coverage (T-063)

### DIFF
--- a/lib/org-repo.unit.test.ts
+++ b/lib/org-repo.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { isOrgRepo } from "./org-repo.ts";
+
+describe("isOrgRepo — valid strings", () => {
+  test("returns true for a simple org/repo string", () => {
+    expect(isOrgRepo("app-vitals/shipwright")).toBe(true);
+  });
+
+  test("returns true when org and repo contain hyphens and numbers", () => {
+    expect(isOrgRepo("my-org-1/my-repo-2")).toBe(true);
+  });
+});
+
+describe("isOrgRepo — invalid strings", () => {
+  test("returns false for a string with no slash", () => {
+    expect(isOrgRepo("shipwright")).toBe(false);
+  });
+
+  test("returns false for a string with more than one slash", () => {
+    expect(isOrgRepo("app-vitals/shipwright/extra")).toBe(false);
+  });
+
+  test("returns false when the org part is empty", () => {
+    expect(isOrgRepo("/shipwright")).toBe(false);
+  });
+
+  test("returns false when the repo part is empty", () => {
+    expect(isOrgRepo("app-vitals/")).toBe(false);
+  });
+
+  test("returns false when the org part is only whitespace", () => {
+    expect(isOrgRepo("   /shipwright")).toBe(false);
+  });
+
+  test("returns false when the repo part is only whitespace", () => {
+    expect(isOrgRepo("app-vitals/   ")).toBe(false);
+  });
+
+  test("returns false for an empty string", () => {
+    expect(isOrgRepo("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/org-repo.unit.test.ts` with direct unit coverage for `isOrgRepo`
- Covers valid `org/repo` strings and invalid cases: no slash, extra slash, empty/whitespace-only org or repo parts, and empty string

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | lib/org-repo.unit.test.ts added with direct coverage of isOrgRepo (valid/invalid-string cases) | MET | 9 tests covering valid and invalid cases; 100% line/function coverage on lib/org-repo.ts |
| 2 | Verification command `bun test lib/org-repo.unit.test.ts` passes | MET | 9 pass, 0 fail |

## Test Plan
- `bun test lib/org-repo.unit.test.ts` — 9 pass, 0 fail
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
