### PR TITLE
feat: fold Phase-2 coverage-estimate caveat into test-design SKILL.md (T-066)

### DIFF
--- a/plugins/shipwright/skills/test-design/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-design/SKILL.content.test.ts
@@ -120,8 +120,15 @@ describe("SKILL.md — Step 6 subsection placement", () => {
 });
 
 describe("SKILL.md — Failure modes: Phase 2 recommendations are estimates, not verified coverage facts", () => {
+  let failureModesIdx: number;
+  let section: string;
+
+  beforeAll(() => {
+    failureModesIdx = content.indexOf("## Failure modes to avoid");
+    section = content.slice(failureModesIdx);
+  });
+
   it("has a failure-mode bullet placed right after the 'Don't look at existing tests' bullet", () => {
-    const failureModesIdx = content.indexOf("## Failure modes to avoid");
     expect(failureModesIdx).toBeGreaterThan(-1);
     const dontLookIdx = content.indexOf(
       "Don't look at existing tests.",
@@ -135,8 +142,6 @@ describe("SKILL.md — Failure modes: Phase 2 recommendations are estimates, not
   });
 
   it("warns that recommendations describe target state, not verified existing coverage, since this phase never reads existing tests", () => {
-    const failureModesIdx = content.indexOf("## Failure modes to avoid");
-    const section = content.slice(failureModesIdx);
     const hasEstimateFramingLanguage =
       /\brecommend(ation)?s?\b/i.test(section) &&
       (/\bestimate\b/i.test(section) || /\btarget state\b/i.test(section)) &&
@@ -145,16 +150,12 @@ describe("SKILL.md — Failure modes: Phase 2 recommendations are estimates, not
   });
 
   it("instructs downstream consumers to verify actual coverage against the working tree before trusting it", () => {
-    const failureModesIdx = content.indexOf("## Failure modes to avoid");
-    const section = content.slice(failureModesIdx);
     const hasVerifyAgainstWorkingTree =
       /\bverify\b/i.test(section) && /\bworking tree\b/i.test(section);
     expect(hasVerifyAgainstWorkingTree).toBe(true);
   });
 
   it("names at least one downstream consumer phase/actor (Phase 3, Phase 4, or a task implementer) that must do the verification", () => {
-    const failureModesIdx = content.indexOf("## Failure modes to avoid");
-    const section = content.slice(failureModesIdx);
     const namesDownstreamConsumer =
       /Phase 3/.test(section) ||
       /Phase 4/.test(section) ||
@@ -163,8 +164,6 @@ describe("SKILL.md — Failure modes: Phase 2 recommendations are estimates, not
   });
 
   it("does not name a specific repo or use dated/cycle-specific framing", () => {
-    const failureModesIdx = content.indexOf("## Failure modes to avoid");
-    const section = content.slice(failureModesIdx);
     expect(/this cycle/i.test(section)).toBe(false);
   });
 });

--- a/plugins/shipwright/skills/test-design/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-design/SKILL.content.test.ts
@@ -119,6 +119,56 @@ describe("SKILL.md — Step 6 subsection placement", () => {
   });
 });
 
+describe("SKILL.md — Failure modes: Phase 2 recommendations are estimates, not verified coverage facts", () => {
+  it("has a failure-mode bullet placed right after the 'Don't look at existing tests' bullet", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    expect(failureModesIdx).toBeGreaterThan(-1);
+    const dontLookIdx = content.indexOf(
+      "Don't look at existing tests.",
+      failureModesIdx,
+    );
+    expect(dontLookIdx).toBeGreaterThan(-1);
+    const nextBulletIdx = content.indexOf("\n- **", dontLookIdx);
+    expect(nextBulletIdx).toBeGreaterThan(-1);
+    const bulletSection = content.slice(dontLookIdx, nextBulletIdx);
+    expect(bulletSection.length).toBeGreaterThan(0);
+  });
+
+  it("warns that recommendations describe target state, not verified existing coverage, since this phase never reads existing tests", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    const section = content.slice(failureModesIdx);
+    const hasEstimateFramingLanguage =
+      /\brecommend(ation)?s?\b/i.test(section) &&
+      (/\bestimate\b/i.test(section) || /\btarget state\b/i.test(section)) &&
+      /\bnot\b.*\b(a )?(verified|confirmed) fact\b/i.test(section);
+    expect(hasEstimateFramingLanguage).toBe(true);
+  });
+
+  it("instructs downstream consumers to verify actual coverage against the working tree before trusting it", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    const section = content.slice(failureModesIdx);
+    const hasVerifyAgainstWorkingTree =
+      /\bverify\b/i.test(section) && /\bworking tree\b/i.test(section);
+    expect(hasVerifyAgainstWorkingTree).toBe(true);
+  });
+
+  it("names at least one downstream consumer phase/actor (Phase 3, Phase 4, or a task implementer) that must do the verification", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    const section = content.slice(failureModesIdx);
+    const namesDownstreamConsumer =
+      /Phase 3/.test(section) ||
+      /Phase 4/.test(section) ||
+      /implement(ing|er)?/i.test(section);
+    expect(namesDownstreamConsumer).toBe(true);
+  });
+
+  it("does not name a specific repo or use dated/cycle-specific framing", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    const section = content.slice(failureModesIdx);
+    expect(/this cycle/i.test(section)).toBe(false);
+  });
+});
+
 describe("speed-budgets/SKILL.md — cross-references test-design Step 6 rule instead of duplicating it", () => {
   it("references test-design/SKILL.md", () => {
     expect(speedBudgetsContent).toContain("test-design");

--- a/plugins/shipwright/skills/test-design/SKILL.md
+++ b/plugins/shipwright/skills/test-design/SKILL.md
@@ -153,6 +153,7 @@ Load template at `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-system.md.tmpl`. F
 ## Failure modes to avoid
 
 - **Don't look at existing tests.** That's Phase 3's job. Anchoring here makes Phase 3 cosmetic.
+- **A recommendation in this artifact is a target state, not a verified fact about current coverage.** Because this phase never reads existing tests, statements like "prefer mocking the client interface" for an internal HTTP service describe what *should* exist, not confirmation that it *does*. Downstream consumers — Phase 3 reconciliation, Phase 4 task generation, or an agent implementing a generated task — must verify actual coverage (e.g., does a recorded-client abstraction actually exist in the codebase) against the working tree before trusting this document's implied existing-coverage claims as a basis for effort estimation or task scoping.
 - **Don't recommend mocks for boundaries the inventory marked as integration-canonical.** A mocked DB is not an integration test.
 - **Don't skip the parallelization plan.** "Suite finishes in 8 minutes" is meaningless without "with N workers running in parallel."
 - **Don't recommend a stack the team can't actually run locally.** If the inventory names a dependency you can't suggest a local substitute for, flag it as a *blocker* in the artifact rather than hand-waving.


### PR DESCRIPTION
## Summary
- Adds a new "Failure modes to avoid" bullet to `plugins/shipwright/skills/test-design/SKILL.md` (Phase 2 of the test-readiness pipeline) warning that its recommendations describe target state, not verified fact — since Phase 2 never reads existing tests, downstream consumers (Phase 3 reconciliation, Phase 4 task generation, or a `dev-task` implementer) must verify actual coverage against the working tree before trusting an implied existing-coverage claim.
- This folds a generalized, repo-agnostic learning from a prior test-readiness cycle directly into the existing skill doc, per `learning-capture`'s routing and `test-roadmap/SKILL.md`'s existing anti-pattern guardrail against creating a new per-repo narrative file under the plugin's own `references/`.
- Adds a matching content-test `describe` block to `SKILL.content.test.ts` asserting the new bullet's placement and required language.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Generalized, repo-agnostic learning folded into relevant existing skill doc | MET | New failure-mode bullet in `test-design/SKILL.md`, no repo names or dated framing |
| 2 | No new per-repo narrative file created under plugin's `references/` | MET | Diff touches only existing files |
| 3 | Verification command `git diff --stat plugins/shipwright/skills/` shows a change to an existing skill doc, not a new file | MET | Confirmed — 2 existing files modified, 0 new files |

## Test Plan
- [x] `bun test plugins/shipwright/skills/test-design/` — 20 pass, 0 fail
- [x] `bunx biome lint` — clean
- [x] `tsc --noEmit` (plugins/shipwright workspace) — clean
- [x] `task check-strings`, `task check-config-docs`, `task check-version-sync` — all pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
