### PR TITLE
feat: narrow TaskService.list()'s blockedBy dependency lookup to referenced IDs only

### DIFF
--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -153,8 +153,16 @@ export class TaskService implements TaskServiceLike {
     const limit = filters.limit ?? 50;
     const offset = filters.offset ?? 0;
 
-    // Load all tasks for dependency resolution (computeBlockedBy needs the full graph).
-    const [pageTasks, total, allTasks] = await this.prisma.$transaction([
+    // pageTasks + total are the only two queries that share the `where`
+    // filter, so batching them in a transaction is what actually mattered
+    // here — the old third whole-table findMany() depended on nothing else
+    // in the array and gained no consistency guarantee from sharing a
+    // transaction with it (Postgres already gives each individual query its
+    // own consistent snapshot). Splitting it out lets us compute depIds from
+    // the real pageTasks result first, then scope the dependency lookup by
+    // id — mirroring get()'s `where: { id: { in: task.dependencies } }`
+    // pattern — instead of always pulling every row in the table.
+    const [pageTasks, total] = await this.prisma.$transaction([
       this.prisma.task.findMany({
         where,
         orderBy: { createdAt: filters.sort ?? "asc" },
@@ -162,8 +170,14 @@ export class TaskService implements TaskServiceLike {
         skip: offset,
       }),
       this.prisma.task.count({ where }),
-      this.prisma.task.findMany(),
     ]);
+
+    const depIds = [
+      ...new Set(pageTasks.flatMap((t: Task) => t.dependencies ?? [])),
+    ];
+    const allTasks = depIds.length
+      ? await this.prisma.task.findMany({ where: { id: { in: depIds } } })
+      : [];
 
     const tasks: TaskWithBlockedBy[] = pageTasks.map((t: Task) => ({
       ...t,

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { computeBlockedBy } from "./blocked-by.ts";
 import { BadRequestError } from "./errors.ts";
-import type { PrismaClient } from "./index.ts";
+import type { PrismaClient, Task } from "./index.ts";
 import type { ReadyTaskLike } from "./ready.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
 import { type TaskListFilters, TaskService } from "./task-service.ts";
@@ -414,5 +414,168 @@ describe("TaskService.list() updatedSince/repo where clause", () => {
     await expect(service.list({ updatedSince: "not-a-date" })).rejects.toThrow(
       BadRequestError,
     );
+  });
+});
+
+// ─── TaskService.list() blockedBy dependency lookup scoping ────────────────
+
+describe("TaskService.list() blockedBy dependency lookup scoping", () => {
+  /**
+   * Prisma double that serves a fixed page of tasks plus a dependency task
+   * that is NOT part of the returned page — proving the dependency lookup
+   * is scoped by dependency IDs (mirroring get()'s pattern), not by
+   * page-membership and not an unconditional whole-table scan.
+   */
+  function makePagedPrismaDouble(pageTasks: Task[], depTask: Task) {
+    const findManyCalls: Array<{ where?: { id?: { in: string[] } } }> = [];
+
+    const prisma = {
+      task: {
+        findMany(args: { where?: { id?: { in: string[] } } } = {}) {
+          findManyCalls.push(args);
+          // The paginated page-query call has no id-based where clause.
+          if (!args.where?.id) {
+            return Promise.resolve(pageTasks);
+          }
+          // Scoped dependency lookup: only return tasks whose id is requested.
+          const ids = new Set(args.where.id.in);
+          return Promise.resolve(
+            [...pageTasks, depTask].filter((t) => ids.has(t.id)),
+          );
+        },
+        count() {
+          return Promise.resolve(pageTasks.length);
+        },
+      },
+      $transaction(ops: Array<Promise<unknown> | unknown>) {
+        // Support both the legacy array-of-promises shape and a
+        // fn-based transaction, since the implementation may split the
+        // dependency lookup out of the transaction entirely.
+        return Promise.all(
+          ops.map((op) => (typeof op === "function" ? op(prisma) : op)),
+        );
+      },
+      _findManyCalls: findManyCalls,
+    };
+
+    return prisma as unknown as PrismaClient & {
+      _findManyCalls: Array<{ where?: { id?: { in: string[] } } }>;
+    };
+  }
+
+  function makeFullTask(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "task-1",
+      title: "A task",
+      status: "pending",
+      source: null,
+      session: null,
+      repo: null,
+      description: null,
+      acceptanceCriteria: [],
+      layer: null,
+      branch: null,
+      dependencies: [],
+      pr: null,
+      hours: null,
+      addedAt: null,
+      startedAt: null,
+      prCreatedAt: null,
+      mergedAt: null,
+      blockedAt: null,
+      blockedReason: null,
+      note: null,
+      type: null,
+      priority: null,
+      cancelledAt: null,
+      completedAt: null,
+      deployingAt: null,
+      ciFixAttempts: null,
+      mergeCommit: null,
+      prUrl: null,
+      assignee: null,
+      issue: null,
+      model: null,
+      complexity: null,
+      hitl: null,
+      hitlNotifiedAt: null,
+      claimedBy: null,
+      agentHint: null,
+      claimedAt: null,
+      heartbeatAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    } as Task;
+  }
+
+  it("resolves a dependency referenced by a page task even though the dependency itself is not part of the page", async () => {
+    // dep-1 is intentionally NOT included in pageTasks — a naive query that
+    // filtered/matched dependency resolution against the returned page (as
+    // opposed to a real `where: { id: { in: depIds } }` lookup) would fail
+    // to resolve it, leaving the dependency block "unknown" instead of the
+    // real (satisfied) status.
+    const depTask = makeFullTask({ id: "dep-1", status: "done" });
+    const pageTask = makeFullTask({
+      id: "t1",
+      status: "pending",
+      dependencies: ["dep-1"],
+    });
+
+    const prisma = makePagedPrismaDouble([pageTask], depTask);
+    const service = new TaskService(prisma);
+
+    const result = await service.list({});
+
+    expect(result.tasks).toHaveLength(1);
+    // dep-1 is "done" (terminal) so it should be resolved as satisfied —
+    // not "unknown", which is what would happen if the lookup were scoped
+    // incorrectly (e.g. to the page only) and never found dep-1.
+    expect(result.tasks[0].blockedBy).toEqual([]);
+  });
+
+  it("scopes the dependency findMany call to id IN (deduped depIds) — no unconditional whole-table findMany remains", async () => {
+    const depTask = makeFullTask({ id: "dep-1", status: "in_progress" });
+    const pageTaskA = makeFullTask({
+      id: "t1",
+      dependencies: ["dep-1"],
+    });
+    const pageTaskB = makeFullTask({
+      id: "t2",
+      dependencies: ["dep-1"], // shared dep — must be deduped
+    });
+
+    const prisma = makePagedPrismaDouble([pageTaskA, pageTaskB], depTask);
+    const service = new TaskService(prisma);
+
+    await service.list({});
+
+    // Every findMany call beyond the initial page query must carry a scoped
+    // `where: { id: { in: [...] } }` clause — no bare findMany() (which
+    // would show up as a call with no `where.id`) beyond the page query.
+    const nonPageCalls = prisma._findManyCalls.filter(
+      (call) => call.where?.id === undefined,
+    );
+    // Exactly one unconditioned findMany call is allowed: the page query
+    // itself (`where` may be `{}` from empty filters, but never targets
+    // dependency resolution without an id filter).
+    expect(nonPageCalls.length).toBeLessThanOrEqual(1);
+
+    const depCall = prisma._findManyCalls.find((call) => call.where?.id);
+    expect(depCall?.where?.id?.in).toEqual(["dep-1"]);
+  });
+
+  it("does not call findMany for dependency resolution when no page task has dependencies", async () => {
+    const pageTask = makeFullTask({ id: "t1", dependencies: [] });
+    const prisma = makePagedPrismaDouble(
+      [pageTask],
+      makeFullTask({ id: "unused" }),
+    );
+    const service = new TaskService(prisma);
+
+    await service.list({});
+
+    const depCalls = prisma._findManyCalls.filter((call) => call.where?.id);
+    expect(depCalls).toHaveLength(0);
   });
 });

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -849,4 +849,65 @@ describeOrSkip("Task store schema (integration)", () => {
       taskService.list({ updatedSince: "not-a-date" }),
     ).rejects.toThrow();
   });
+
+  // ─── TaskService.list() blockedBy dependency lookup scoping ────────────────
+
+  it("resolves blockedBy for a dependency outside the current page/pagination window", async () => {
+    const taskService = new TaskService(prisma);
+
+    // dep created first (earliest createdAt) so, combined with limit:1, it
+    // falls on a different page than the task that depends on it — proving
+    // the dependency lookup is scoped by dependency ID, not by page.
+    const dep = await prisma.task.create({
+      data: {
+        title: "Dependency task",
+        status: "in_progress",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+    const dependent = await prisma.task.create({
+      data: {
+        title: "Dependent task",
+        status: "pending",
+        dependencies: [dep.id],
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    });
+
+    // limit:1, offset:1 selects only "Dependent task" — "Dependency task"
+    // (offset:0) is excluded from the returned page entirely.
+    const result = await taskService.list({ limit: 1, offset: 1, sort: "asc" });
+
+    expect(result.tasks.map((t) => t.id)).toEqual([dependent.id]);
+    expect(result.tasks[0].blockedBy).toEqual([
+      { type: "dependency", id: dep.id, status: "in_progress" },
+    ]);
+  });
+
+  it("resolves a same-page dependency between two tasks on the same page", async () => {
+    const taskService = new TaskService(prisma);
+
+    const dep = await prisma.task.create({
+      data: {
+        title: "Same-page dependency",
+        status: "done",
+        createdAt: new Date("2026-02-01T00:00:00Z"),
+      },
+    });
+    const dependent = await prisma.task.create({
+      data: {
+        title: "Same-page dependent",
+        status: "pending",
+        dependencies: [dep.id],
+        createdAt: new Date("2026-02-02T00:00:00Z"),
+      },
+    });
+
+    const result = await taskService.list({ sort: "asc" });
+
+    const dependentResult = result.tasks.find((t) => t.id === dependent.id);
+    expect(dependentResult).toBeDefined();
+    // dep is "done" (terminal) → satisfied, blockedBy empty.
+    expect(dependentResult?.blockedBy).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- `TaskService.list()` now scopes its `blockedBy` dependency lookup to `task.findMany({ where: { id: { in: depIds } } })` (deduped union of `pageTasks[*].dependencies`), replacing an unconditional whole-table `task.findMany()`.
- Mirrors the existing scoped-lookup pattern already used in `TaskService.get()`.
- `listReady()` and `listBlocked()` are unchanged — they intentionally remain whole-table since they need the full dependency graph.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GET /tasks` still returns identical `blockedBy` results for every existing case (HITL gate, terminal-status dependency, same-branch bundled dependency, missing/unknown dependency) | MET |
| 2 | The dependency lookup query is scoped to `id IN (...)` — no unconditional `task.findMany()` remains in `list()` | MET |
| 3 | `listReady()`/`listBlocked()` untouched | MET |
| 4 | Test decision: unit test asserting narrowed query resolves a same-page dependency correctly; real-DB integration test covering a dependency outside the current page | MET |

## Test Plan
- `task-store/src/task-service.unit.test.ts` — new suite asserting the scoped dependency lookup resolves out-of-page dependencies, dedupes shared dependency IDs into a single `id IN (...)` call, and short-circuits (no query) when no page task has dependencies.
- `task-store/src/tasks.integration.test.ts` — new real-DB cases: a dependency that falls outside the current pagination window (still resolves via ID-based lookup) and a same-page dependency sanity check.
- [x] `task lint` — clean
- [x] `task typecheck` (task-store) — clean
- [x] `bun test task-store/` — 316 pass, 0 fail, 99 skip (skips are pre-existing DB-gated integration tests; the two new integration cases are included in that DB-gated set and will run in CI against the provisioned test DB)

Generated with [Claude Code](https://claude.com/claude-code)
