### PR TITLE
feat: metrics client sends updatedSince/repo server-side instead of full-fetch-then-filter

### DIFF
--- a/metrics/src/lib/task-store-client.ts
+++ b/metrics/src/lib/task-store-client.ts
@@ -104,11 +104,12 @@ export interface TaskStoreClient {
 
 // ─── Window filtering ─────────────────────────────────────────────────────────
 //
-// The live task store ignores `from`/`to` query params (the `/tasks` and `/prs`
-// routes read only `limit`/`offset`), so the client must window-filter the rows
-// it fetches. These helpers are the single source of truth for that filtering —
-// the recorded test double imports them so the cassette path and the live HTTP
-// path apply byte-identical windowing.
+// The live task store accepts `updatedSince` (mapped from `from`) as a coarse,
+// inclusive-only pre-filter — it has no window-end (`to`) equivalent and is not
+// a precise sync anchor. The client must still window-filter the rows it
+// fetches to apply the exact [from, to] boundary. These helpers are the single
+// source of truth for that filtering — the recorded test double imports them
+// so the cassette path and the live HTTP path apply byte-identical windowing.
 
 /** Pick the timestamp a task is "anchored" to for window filtering. */
 export function taskAnchor(t: TaskRecord): string | null {
@@ -271,10 +272,15 @@ export class HttpTaskStoreClient implements TaskStoreClient {
     status?: string;
     repo?: string;
   }): Promise<TaskRecord[]> {
-    // `from`/`to`/`repo` are ignored by the live route — only `status` narrows
-    // server side; the date window and repo scope are applied client-side below.
+    // `updatedSince`/`repo` narrow server-side to cut down what's fetched over
+    // the wire, but `updatedSince` is a conservative pre-filter (inclusive-only,
+    // no window-end) rather than a precise sync anchor — the client-side
+    // taskAnchor/inWindow/matchesRepo filtering below still runs as the precise
+    // final filter, since `to` has no server-side equivalent.
     const tasks = await this.fetchAllPages<TaskRecord>("/tasks", "tasks", {
       status: params.status,
+      updatedSince: params.from,
+      repo: params.repo,
     });
     return tasks.filter(
       (t) =>
@@ -288,8 +294,12 @@ export class HttpTaskStoreClient implements TaskStoreClient {
     reviewState?: string;
     repo?: string;
   }): Promise<PrRecord[]> {
+    // Same server-side pre-filter / client-side precise-filter split as
+    // listTasks() above.
     const prs = await this.fetchAllPages<PrRecord>("/prs", "prs", {
       reviewState: params.reviewState,
+      updatedSince: params.from,
+      repo: params.repo,
     });
     return prs.filter(
       (p) => matchesRepo(p.repo, params.repo) && inWindow(prAnchor(p), params),

--- a/metrics/src/lib/task-store-client.unit.test.ts
+++ b/metrics/src/lib/task-store-client.unit.test.ts
@@ -140,6 +140,60 @@ describe("HttpTaskStoreClient client-side window filtering", () => {
   });
 });
 
+describe("HttpTaskStoreClient server-side query params", () => {
+  test("listTasks sends updatedSince and repo in the query string", async () => {
+    const { fetch, calls } = pagingFetch<TaskRecord>("tasks", []);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    await client.listTasks({ from: "2026-06-01", repo: "org/alpha" });
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const url = new URL(call);
+      expect(url.searchParams.get("updatedSince")).toBe("2026-06-01");
+      expect(url.searchParams.get("repo")).toBe("org/alpha");
+    }
+  });
+
+  test("listPrs sends updatedSince and repo in the query string", async () => {
+    const { fetch, calls } = pagingFetch<PrRecord>("prs", []);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    await client.listPrs({ from: "2026-06-01", repo: "org/beta" });
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const url = new URL(call);
+      expect(url.searchParams.get("updatedSince")).toBe("2026-06-01");
+      expect(url.searchParams.get("repo")).toBe("org/beta");
+    }
+  });
+
+  test("listTasks omits updatedSince/repo from the query string when not provided", async () => {
+    const { fetch, calls } = pagingFetch<TaskRecord>("tasks", []);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    await client.listTasks({});
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const url = new URL(call);
+      expect(url.searchParams.has("updatedSince")).toBe(false);
+      expect(url.searchParams.has("repo")).toBe(false);
+    }
+  });
+
+  test("listPrs omits updatedSince/repo from the query string when not provided", async () => {
+    const { fetch, calls } = pagingFetch<PrRecord>("prs", []);
+    const client = new HttpTaskStoreClient("http://store", "tok", fetch);
+
+    await client.listPrs({});
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const url = new URL(call);
+      expect(url.searchParams.has("updatedSince")).toBe(false);
+      expect(url.searchParams.has("repo")).toBe(false);
+    }
+  });
+});
+
 describe("HttpTaskStoreClient repo filtering", () => {
   test("listTasks returns only tasks matching params.repo", async () => {
     const tasks: TaskRecord[] = [


### PR DESCRIPTION
## Summary
- `HttpTaskStoreClient.listTasks()`/`listPrs()` now pass `updatedSince` (mapped from `params.from`) and `repo` (from `params.repo`) into the server-side query string via `fetchAllPages()`'s `baseParams`, instead of relying purely on client-side filtering after fetching every row.
- The server already supports both params (TSF-1.1, merged/deployed) — this wires the metrics client to actually send them, cutting down the amount of data fetched over the wire and paginated round-trips.
- `taskAnchor()`/`prAnchor()`/`inWindow()`/`matchesRepo()` are unchanged and still run as the precise final filter — `updatedSince` is a conservative, inclusive-only pre-filter with no window-end equivalent, so client-side filtering remains necessary for correctness. Updated the stale comments that claimed these params were fully ignored server-side.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | listTasks/listPrs requests include updatedSince/repo in the query string | MET |
| 2 | Dashboard /metrics/summary, /trends, /features, /queue return identical results to before, just over fewer paginated round-trips | MET |
| 3 | No changes to taskAnchor()/prAnchor()/inWindow()/matchesRepo() or to the offline/recorded-fixture provider path | MET |
| 4 | Extend metrics/src/lib/task-store-client.unit.test.ts to assert the built request URL includes updatedSince/repo; no changes to task-store-provider.integration.test.ts; no existing tests retired | MET |

## Test Plan
- Added 4 unit tests in `task-store-client.unit.test.ts` asserting `updatedSince`/`repo` are present in every paginated request URL when passed, and absent when omitted, for both `listTasks()` and `listPrs()`.
- All pre-existing pagination/window-filtering/repo-filtering tests remain green (byte-identical filtering behavior).
- [x] `bunx biome lint .` clean
- [x] `bun run --filter='*' --sequential typecheck` clean across all workspaces
- [x] `NODE_ENV=test bun test --coverage` — 4024 pass, 0 fail
- [x] `task-store-client.ts` coverage: 95.4% (repo-wide aggregate coverage gate is at 79.27%, a pre-existing gap unrelated to this 2-file change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
