### PR TITLE
feat: drop the addedAt column from task-store schema

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -53,7 +53,6 @@ export interface Task {
   dependencies?: string[];
   pr?: number;
   hours?: number;
-  addedAt?: string;
   createdAt?: string;
   startedAt?: string;
   prCreatedAt?: string;

--- a/lib/task-store-types.ts
+++ b/lib/task-store-types.ts
@@ -4,1792 +4,1780 @@
  */
 
 export interface paths {
-  "/tasks": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List tasks */
+        get: {
+            parameters: {
+                query?: {
+                    status?: string;
+                    state?: "open" | "closed" | "in_progress" | "ready" | "blocked";
+                    session?: string;
+                    repo?: string;
+                    assignee?: string;
+                    claimedBy?: string;
+                    branch?: string;
+                    pr?: string;
+                    limit?: string;
+                    offset?: string;
+                    ready?: "true" | "false";
+                    sort?: "asc" | "desc";
+                    updatedSince?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of tasks with total count */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskListResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a task */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CreateTaskBody"];
+                };
+            };
+            responses: {
+                /** @description Created task */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List tasks */
-    get: {
-      parameters: {
-        query?: {
-          status?: string;
-          state?: "open" | "closed" | "in_progress" | "ready" | "blocked";
-          session?: string;
-          repo?: string;
-          assignee?: string;
-          claimedBy?: string;
-          branch?: string;
-          pr?: string;
-          limit?: string;
-          offset?: string;
-          ready?: "true" | "false";
-          sort?: "asc" | "desc";
-          updatedSince?: string;
+    "/tasks/bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description List of tasks with total count */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["TaskListResponse"];
-          };
+        get?: never;
+        put?: never;
+        /** Bulk insert tasks */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["BulkInsertBody"];
+                };
+            };
+            responses: {
+                /** @description Bulk insert result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkInsertResponse"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    /** Create a task */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["CreateTaskBody"];
+    "/tasks/distinct": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Created task */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
+        /** Get distinct session and repo values */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Distinct values */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DistinctResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/bulk": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tasks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a task by ID */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete a task */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update a task */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdateTaskBody"];
+                };
+            };
+            responses: {
+                /** @description Updated task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Bulk insert tasks */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["BulkInsertBody"];
+    "/tasks/{id}/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Bulk insert result */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["BulkInsertResponse"];
-          };
+        get?: never;
+        put?: never;
+        /** Atomically claim a task */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ClaimBody"];
+                };
+            };
+            responses: {
+                /** @description Claimed task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Conflict — already claimed */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/distinct": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tasks/{id}/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Touch heartbeatAt on a claimed task */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Updated task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get distinct session and repo values */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Distinct values */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["DistinctResponse"];
-          };
+    "/tasks/{id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
+        get?: never;
+        put?: never;
+        /** Mark a task as done */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Updated task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tasks/{id}/fail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark a task as blocked */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FailBody"];
+                };
+            };
+            responses: {
+                /** @description Updated task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a task by ID */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/tasks/{id}/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
+        get?: never;
+        put?: never;
+        /** Release a task back to pending */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Updated task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    /** Delete a task */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        /** List all tokens */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Array of token metadata */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskToken"][];
+                    };
+                };
+                /** @description Forbidden — admin token required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
+        put?: never;
+        /** Create a new token — raw value returned exactly once */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["TokenBody"];
+                };
+            };
+            responses: {
+                /** @description Created token including the one-time raw value */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskTokenWithRaw"];
+                    };
+                };
+                /** @description Forbidden — admin token required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    options?: never;
-    head?: never;
-    /** Update a task */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/tokens/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["UpdateTaskBody"];
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke a token */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Revoked token metadata */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskToken"];
+                    };
+                };
+                /** @description Forbidden — admin token required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Token not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Updated task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
+        options?: never;
+        head?: never;
+        /** Update token label and/or agentId */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["TokenBody"];
+                };
+            };
+            responses: {
+                /** @description Updated token metadata */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskToken"];
+                    };
+                };
+                /** @description Bad request — token is revoked */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden — admin token required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Token not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        trace?: never;
     };
-    trace?: never;
-  };
-  "/tasks/{id}/claim": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/prs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List pull requests */
+        get: {
+            parameters: {
+                query?: {
+                    repo?: string;
+                    prNumber?: string;
+                    taskId?: string;
+                    state?: "open" | "merged" | "closed";
+                    reviewState?: "pending" | "in_progress" | "posted" | "approved";
+                    staged?: "true" | "false";
+                    limit?: string;
+                    offset?: string;
+                    ready?: "true" | "false";
+                    sort?: "asc" | "desc";
+                    updatedSince?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of pull requests */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PrListResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Atomically claim a task */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/prs/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ClaimBody"];
+        get?: never;
+        put?: never;
+        /** Claim a pull request (atomic) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ClaimPrBody"];
+                };
+            };
+            responses: {
+                /** @description Updated existing claim */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description New claim created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Conflict — already claimed with same commitSha */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Claimed task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
-        };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Conflict — already claimed */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/{id}/heartbeat": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/prs/claim-next": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Atomic find-and-claim of oldest eligible PR */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ClaimNextBody"];
+                };
+            };
+            responses: {
+                /** @description PR claimed — returns {pr, phase} */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ClaimNextResponse"];
+                    };
+                };
+                /** @description No eligible PR found */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Touch heartbeatAt on a claimed task */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/prs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Updated task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
+        /** Fetch a single pull request */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Pull request record */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update pull request fields */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdatePrBody"];
+                };
+            };
+            responses: {
+                /** @description Updated pull request */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/{id}/complete": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/prs/{id}/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Touch heartbeatAt for a claimed PR */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description PR with updated heartbeatAt */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Mark a task as done */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/prs/{id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Updated task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
+        get?: never;
+        put?: never;
+        /** Mark PR review as complete (reviewState=posted) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Completed PR */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/{id}/fail": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/prs/{id}/patch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Increment patchCycles and conditionally reset reviewState=pending */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["PatchPrBody"];
+                };
+            };
+            responses: {
+                /** @description Patched PR */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Mark a task as blocked */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/prs/{id}/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FailBody"];
+        get?: never;
+        put?: never;
+        /** Release a claim (reviewState=pending, claimedBy cleared) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Released PR */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PullRequest"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Updated task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tasks/{id}/release": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Release a task back to pending */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Updated task */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Task"];
-          };
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tokens": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List all tokens */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Array of token metadata */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["TaskToken"][];
-          };
-        };
-        /** @description Forbidden — admin token required */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    put?: never;
-    /** Create a new token — raw value returned exactly once */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["TokenBody"];
-        };
-      };
-      responses: {
-        /** @description Created token including the one-time raw value */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["TaskTokenWithRaw"];
-          };
-        };
-        /** @description Forbidden — admin token required */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/tokens/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Revoke a token */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Revoked token metadata */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["TaskToken"];
-          };
-        };
-        /** @description Forbidden — admin token required */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Token not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /** Update token label and/or agentId */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["TokenBody"];
-        };
-      };
-      responses: {
-        /** @description Updated token metadata */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["TaskToken"];
-          };
-        };
-        /** @description Bad request — token is revoked */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Forbidden — admin token required */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Token not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    trace?: never;
-  };
-  "/prs": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List pull requests */
-    get: {
-      parameters: {
-        query?: {
-          repo?: string;
-          prNumber?: string;
-          taskId?: string;
-          state?: "open" | "merged" | "closed";
-          reviewState?: "pending" | "in_progress" | "posted" | "approved";
-          staged?: "true" | "false";
-          limit?: string;
-          offset?: string;
-          ready?: "true" | "false";
-          sort?: "asc" | "desc";
-          updatedSince?: string;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description List of pull requests */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PrListResponse"];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/prs/claim": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Claim a pull request (atomic) */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          "application/json": components["schemas"]["ClaimPrBody"];
-        };
-      };
-      responses: {
-        /** @description Updated existing claim */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description New claim created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Conflict — already claimed with same commitSha */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/prs/claim-next": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Atomic find-and-claim of oldest eligible PR */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ClaimNextBody"];
-        };
-      };
-      responses: {
-        /** @description PR claimed — returns {pr, phase} */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["ClaimNextResponse"];
-          };
-        };
-        /** @description No eligible PR found */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/prs/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Fetch a single pull request */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Pull request record */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Update pull request fields */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          "application/json": components["schemas"]["UpdatePrBody"];
-        };
-      };
-      responses: {
-        /** @description Updated pull request */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description Bad request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    trace?: never;
-  };
-  "/prs/{id}/heartbeat": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Touch heartbeatAt for a claimed PR */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description PR with updated heartbeatAt */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/prs/{id}/complete": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Mark PR review as complete (reviewState=posted) */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Completed PR */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/prs/{id}/patch": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Increment patchCycles and conditionally reset reviewState=pending */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["PatchPrBody"];
-        };
-      };
-      responses: {
-        /** @description Patched PR */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/prs/{id}/release": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Release a claim (reviewState=pending, claimedBy cleared) */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Released PR */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PullRequest"];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Error"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Task: {
-      /** @example clx1234567890 */
-      id: string;
-      /** @example Implement feature X */
-      title: string;
-      /**
-       * @example pending
-       * @enum {string}
-       */
-      status:
-        | "pending"
-        | "in_progress"
-        | "pr_open"
-        | "approved"
-        | "merged"
-        | "done"
-        | "deploying"
-        | "deployed"
-        | "blocked"
-        | "cancelled";
-      /** @example manual */
-      source?: string | null;
-      /** @example session-123 */
-      session?: string | null;
-      /** @example org/repo */
-      repo?: string | null;
-      /** @example Task description */
-      description?: string | null;
-      /**
-       * @example [
-       *       "Criterion 1",
-       *       "Criterion 2"
-       *     ]
-       */
-      acceptanceCriteria?: string[];
-      /** @example feature */
-      layer?: string | null;
-      /** @example feat/feature-x */
-      branch?: string | null;
-      /**
-       * @example [
-       *       "task-1",
-       *       "task-2"
-       *     ]
-       */
-      dependencies?: string[];
-      /** @example 42 */
-      pr?: number | null;
-      /** @example 5.5 */
-      hours?: number | null;
-      /** @example 2026-01-01T00:00:00.000Z */
-      addedAt?: string | null;
-      /** @example 2026-01-02T00:00:00.000Z */
-      startedAt?: string | null;
-      /** @example 2026-01-03T00:00:00.000Z */
-      prCreatedAt?: string | null;
-      /** @example 2026-01-04T00:00:00.000Z */
-      mergedAt?: string | null;
-      /** @example null */
-      blockedAt?: string | null;
-      /** @example Waiting on dependency */
-      blockedReason?: string | null;
-      /** @example Some notes */
-      note?: string | null;
-      /** @example feature */
-      type?: string | null;
-      /** @example high */
-      priority?: string | null;
-      /** @example null */
-      cancelledAt?: string | null;
-      /** @example 2026-01-05T00:00:00.000Z */
-      completedAt?: string | null;
-      /** @example null */
-      deployingAt?: string | null;
-      /** @example 2026-01-06T00:00:00.000Z */
-      deployedAt?: string | null;
-      /** @example 2 */
-      ciFixAttempts?: number | null;
-      /** @example abc123def456 */
-      mergeCommit?: string | null;
-      /** @example https://github.com/org/repo/pull/42 */
-      prUrl?: string | null;
-      /** @example user@example.com */
-      assignee?: string | null;
-      /** @example GH-123 */
-      issue?: string | null;
-      /** @example sonnet */
-      model?: string | null;
-      /** @example 7 */
-      complexity?: number | null;
-      /** @example true */
-      hitl?: boolean | null;
-      /** @example 2026-01-02T00:00:00.000Z */
-      hitlNotifiedAt?: string | null;
-      /** @example agent-id-123 */
-      claimedBy?: string | null;
-      /** @example prefer-sonnet */
-      agentHint?: string | null;
-      /** @example 2026-01-02T00:00:00.000Z */
-      claimedAt?: string | null;
-      /** @example 2026-01-06T12:00:00.000Z */
-      heartbeatAt?: string | null;
-      /** @example 10 */
-      simplifyTotal?: number | null;
-      /** @example 2 */
-      simplifyDry?: number | null;
-      /** @example 3 */
-      simplifyDeadCode?: number | null;
-      /** @example 1 */
-      simplifyNaming?: number | null;
-      /** @example 2 */
-      simplifyComplexity?: number | null;
-      /** @example 2 */
-      simplifyConsistency?: number | null;
-      /** @example 5.5 */
-      coverageDelta?: number | null;
-      /** @example medium */
-      effortLevel?: string | null;
-      /** @example 1000 */
-      inputTokens?: number | null;
-      /** @example 500 */
-      outputTokens?: number | null;
-      /** @example 100 */
-      cacheReadTokens?: number | null;
-      /** @example 50 */
-      cacheCreationTokens?: number | null;
-      /** @example 0.02 */
-      costUsd?: number | null;
-      /**
-       * @example {
-       *       "customKey": "customValue"
-       *     }
-       */
-      metadata?: {
-        [key: string]: unknown;
-      } | null;
-      /**
-       * Format: date-time
-       * @example 2026-01-01T00:00:00.000Z
-       */
-      createdAt: string;
-      /**
-       * Format: date-time
-       * @example 2026-01-06T12:00:00.000Z
-       */
-      updatedAt: string;
+    schemas: {
+        Task: {
+            /** @example clx1234567890 */
+            id: string;
+            /** @example Implement feature X */
+            title: string;
+            /**
+             * @example pending
+             * @enum {string}
+             */
+            status: "pending" | "in_progress" | "pr_open" | "approved" | "merged" | "done" | "deploying" | "deployed" | "blocked" | "cancelled";
+            /** @example manual */
+            source?: string | null;
+            /** @example session-123 */
+            session?: string | null;
+            /** @example org/repo */
+            repo?: string | null;
+            /** @example Task description */
+            description?: string | null;
+            /**
+             * @example [
+             *       "Criterion 1",
+             *       "Criterion 2"
+             *     ]
+             */
+            acceptanceCriteria?: string[];
+            /** @example feature */
+            layer?: string | null;
+            /** @example feat/feature-x */
+            branch?: string | null;
+            /**
+             * @example [
+             *       "task-1",
+             *       "task-2"
+             *     ]
+             */
+            dependencies?: string[];
+            /** @example 42 */
+            pr?: number | null;
+            /** @example 5.5 */
+            hours?: number | null;
+            /** @example 2026-01-02T00:00:00.000Z */
+            startedAt?: string | null;
+            /** @example 2026-01-03T00:00:00.000Z */
+            prCreatedAt?: string | null;
+            /** @example 2026-01-04T00:00:00.000Z */
+            mergedAt?: string | null;
+            /** @example null */
+            blockedAt?: string | null;
+            /** @example Waiting on dependency */
+            blockedReason?: string | null;
+            /** @example Some notes */
+            note?: string | null;
+            /** @example feature */
+            type?: string | null;
+            /** @example high */
+            priority?: string | null;
+            /** @example null */
+            cancelledAt?: string | null;
+            /** @example 2026-01-05T00:00:00.000Z */
+            completedAt?: string | null;
+            /** @example null */
+            deployingAt?: string | null;
+            /** @example 2026-01-06T00:00:00.000Z */
+            deployedAt?: string | null;
+            /** @example 2 */
+            ciFixAttempts?: number | null;
+            /** @example abc123def456 */
+            mergeCommit?: string | null;
+            /** @example https://github.com/org/repo/pull/42 */
+            prUrl?: string | null;
+            /** @example user@example.com */
+            assignee?: string | null;
+            /** @example GH-123 */
+            issue?: string | null;
+            /** @example sonnet */
+            model?: string | null;
+            /** @example 7 */
+            complexity?: number | null;
+            /** @example true */
+            hitl?: boolean | null;
+            /** @example 2026-01-02T00:00:00.000Z */
+            hitlNotifiedAt?: string | null;
+            /** @example agent-id-123 */
+            claimedBy?: string | null;
+            /** @example prefer-sonnet */
+            agentHint?: string | null;
+            /** @example 2026-01-02T00:00:00.000Z */
+            claimedAt?: string | null;
+            /** @example 2026-01-06T12:00:00.000Z */
+            heartbeatAt?: string | null;
+            /** @example 10 */
+            simplifyTotal?: number | null;
+            /** @example 2 */
+            simplifyDry?: number | null;
+            /** @example 3 */
+            simplifyDeadCode?: number | null;
+            /** @example 1 */
+            simplifyNaming?: number | null;
+            /** @example 2 */
+            simplifyComplexity?: number | null;
+            /** @example 2 */
+            simplifyConsistency?: number | null;
+            /** @example 5.5 */
+            coverageDelta?: number | null;
+            /** @example medium */
+            effortLevel?: string | null;
+            /** @example 1000 */
+            inputTokens?: number | null;
+            /** @example 500 */
+            outputTokens?: number | null;
+            /** @example 100 */
+            cacheReadTokens?: number | null;
+            /** @example 50 */
+            cacheCreationTokens?: number | null;
+            /** @example 0.02 */
+            costUsd?: number | null;
+            /**
+             * @example {
+             *       "customKey": "customValue"
+             *     }
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Format: date-time
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            createdAt: string;
+            /**
+             * Format: date-time
+             * @example 2026-01-06T12:00:00.000Z
+             */
+            updatedAt: string;
+        };
+        TaskListResponse: {
+            tasks: components["schemas"]["Task"][];
+            /** @example 10 */
+            total: number;
+        };
+        Error: {
+            /** @example not found */
+            error: string;
+        };
+        CreateTaskBody: {
+            /** @example Implement feature X */
+            title?: string;
+            /** @example pending */
+            status?: string;
+            /** @example org/repo */
+            repo?: string | null;
+            /** @example session-123 */
+            session?: string;
+            /** @example Task description */
+            description?: string;
+            /** @example service */
+            layer?: string;
+            /** @example feat/feature-x */
+            branch?: string;
+            /** @example [] */
+            dependencies?: string[];
+            /** @example [] */
+            acceptanceCriteria?: string[];
+            /** @example user@example.com */
+            assignee?: string;
+            /** @example high */
+            priority?: string;
+            /** @example feature */
+            type?: string;
+            /** @example manual */
+            source?: string;
+        };
+        BulkInsertResponse: {
+            /** @example 3 */
+            inserted: number;
+            /** @example 1 */
+            updated: number;
+            /**
+             * @description IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).
+             * @example [
+             *       "entropy-dead_exports-other-repo-2026-W29"
+             *     ]
+             */
+            skipped: string[];
+        };
+        BulkInsertBody: {
+            /** @example Implement feature X */
+            title?: string;
+            /** @example pending */
+            status?: string;
+            /** @example org/repo */
+            repo?: string | null;
+        }[];
+        DistinctResponse: {
+            /**
+             * @example [
+             *       "session-1"
+             *     ]
+             */
+            sessions: string[];
+            /**
+             * @example [
+             *       "org/repo"
+             *     ]
+             */
+            repos: string[];
+        };
+        UpdateTaskBody: {
+            [key: string]: unknown;
+        };
+        ClaimBody: {
+            /** @example agent-id-123 */
+            claimedBy?: string;
+        };
+        FailBody: {
+            /** @example build failed */
+            reason?: string;
+        };
+        TaskToken: {
+            /** @example clxtoken123456 */
+            id: string;
+            /** @example ci-runner */
+            label?: string | null;
+            /** @example agent-id-123 */
+            agentId?: string | null;
+            /**
+             * Format: date-time
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            createdAt: string;
+            /**
+             * Format: date-time
+             * @example null
+             */
+            revokedAt?: string | null;
+        };
+        TaskTokenWithRaw: components["schemas"]["TaskToken"] & {
+            /** @example raw-token-value-shown-once */
+            rawToken: string;
+        };
+        TokenBody: {
+            /** @example ci-runner */
+            label?: string;
+            /** @example agent-id-123 */
+            agentId?: string;
+        };
+        PullRequest: {
+            /** @example clx0987654321 */
+            id: string;
+            /** @example org/repo */
+            repo: string;
+            /** @example 42 */
+            prNumber: number;
+            /** @example clx1234567890 */
+            taskId?: string | null;
+            /**
+             * @default false
+             * @example false
+             */
+            staged: boolean;
+            /**
+             * @default open
+             * @example open
+             * @enum {string}
+             */
+            state: "open" | "merged" | "closed";
+            /**
+             * @default pending
+             * @example pending
+             * @enum {string}
+             */
+            reviewState: "pending" | "in_progress" | "posted" | "approved";
+            /** @example abc123def456 */
+            commitSha?: string | null;
+            /**
+             * @default 0
+             * @example 1
+             */
+            patchCycles: number;
+            /**
+             * @default 0
+             * @example 0
+             */
+            reviewCycles: number;
+            /** @example agent-id-123 */
+            agentId?: string | null;
+            /** @example 2026-01-03T00:00:00.000Z */
+            reviewedAt?: string | null;
+            /** @example null */
+            patchedAt?: string | null;
+            /** @example null */
+            mergedAt?: string | null;
+            /**
+             * @description ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            prCreatedAt?: string | null;
+            /** @example agent-id-123 */
+            claimedBy?: string | null;
+            /** @example 2026-01-02T00:00:00.000Z */
+            claimedAt?: string | null;
+            /** @example 2026-01-06T12:00:00.000Z */
+            heartbeatAt?: string | null;
+            /**
+             * @example review
+             * @enum {string|null}
+             */
+            phase?: "review" | "patch" | "deploy" | null;
+            /** @example 2026-01-02T00:00:00.000Z */
+            readyForReviewAt?: string | null;
+            /** @example null */
+            readyForPatchAt?: string | null;
+            /** @example null */
+            readyForDeployAt?: string | null;
+            /**
+             * Format: date-time
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            createdAt: string;
+            /**
+             * Format: date-time
+             * @example 2026-01-06T12:00:00.000Z
+             */
+            updatedAt: string;
+        };
+        PrListResponse: {
+            /** @description Array of pull requests */
+            prs: components["schemas"]["PullRequest"][];
+            /** @example 1 */
+            total: number;
+            /** @example 50 */
+            limit: number;
+            /** @example 0 */
+            offset: number;
+        };
+        ClaimPrBody: {
+            /**
+             * @description Repository in org/repo format
+             * @example org/repo
+             */
+            repo: string;
+            /**
+             * @description Pull request number
+             * @example 42
+             */
+            prNumber: number;
+            /**
+             * @description Commit SHA to associate
+             * @example abc123def456
+             */
+            commitSha: string;
+            /**
+             * @description Agent claiming this PR (admin tokens only)
+             * @example agent-id-123
+             */
+            claimedBy?: string;
+            /**
+             * @description Associated task ID
+             * @example clx1234567890
+             */
+            taskId?: string;
+            /**
+             * @description Pipeline phase this claim is for (defaults to 'review' when omitted)
+             * @example patch
+             * @enum {string}
+             */
+            phase?: "review" | "patch" | "deploy";
+            /**
+             * @description ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.
+             * @example 2026-01-01T00:00:00.000Z
+             */
+            prCreatedAt?: string;
+        };
+        ClaimNextResponse: {
+            pr: components["schemas"]["PullRequest"];
+            /**
+             * @example review
+             * @enum {string}
+             */
+            phase: "review" | "patch" | "deploy";
+        };
+        ClaimNextBody: {
+            /**
+             * @description Agent ID (admin tokens only; agent tokens use token identity)
+             * @example agent-id-123
+             */
+            agentId?: string;
+            /**
+             * @description Maximum concurrent PRs to claim
+             * @example 1
+             */
+            maxConcurrent?: number;
+        };
+        UpdatePrBody: {
+            [key: string]: unknown;
+        };
+        PatchPrBody: {
+            /**
+             * @description Current head commit SHA. When provided and it differs from the record's stored commitSha, reviewState resets to pending and commitSha is updated. When it matches, reviewState is left untouched (no-op patch cycle). When omitted, reviewState unconditionally resets to pending (legacy behavior).
+             * @example abc123def456
+             */
+            commitSha?: string;
+        };
     };
-    TaskListResponse: {
-      tasks: components["schemas"]["Task"][];
-      /** @example 10 */
-      total: number;
-    };
-    Error: {
-      /** @example not found */
-      error: string;
-    };
-    CreateTaskBody: {
-      /** @example Implement feature X */
-      title?: string;
-      /** @example pending */
-      status?: string;
-      /** @example org/repo */
-      repo?: string | null;
-      /** @example session-123 */
-      session?: string;
-      /** @example Task description */
-      description?: string;
-      /** @example service */
-      layer?: string;
-      /** @example feat/feature-x */
-      branch?: string;
-      /** @example [] */
-      dependencies?: string[];
-      /** @example [] */
-      acceptanceCriteria?: string[];
-      /** @example user@example.com */
-      assignee?: string;
-      /** @example high */
-      priority?: string;
-      /** @example feature */
-      type?: string;
-      /** @example manual */
-      source?: string;
-    };
-    BulkInsertResponse: {
-      /** @example 3 */
-      inserted: number;
-      /** @example 1 */
-      updated: number;
-      /**
-       * @description IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).
-       * @example [
-       *       "entropy-dead_exports-other-repo-2026-W29"
-       *     ]
-       */
-      skipped: string[];
-    };
-    BulkInsertBody: {
-      /** @example Implement feature X */
-      title?: string;
-      /** @example pending */
-      status?: string;
-      /** @example org/repo */
-      repo?: string | null;
-    }[];
-    DistinctResponse: {
-      /**
-       * @example [
-       *       "session-1"
-       *     ]
-       */
-      sessions: string[];
-      /**
-       * @example [
-       *       "org/repo"
-       *     ]
-       */
-      repos: string[];
-    };
-    UpdateTaskBody: {
-      [key: string]: unknown;
-    };
-    ClaimBody: {
-      /** @example agent-id-123 */
-      claimedBy?: string;
-    };
-    FailBody: {
-      /** @example build failed */
-      reason?: string;
-    };
-    TaskToken: {
-      /** @example clxtoken123456 */
-      id: string;
-      /** @example ci-runner */
-      label?: string | null;
-      /** @example agent-id-123 */
-      agentId?: string | null;
-      /**
-       * Format: date-time
-       * @example 2026-01-01T00:00:00.000Z
-       */
-      createdAt: string;
-      /**
-       * Format: date-time
-       * @example null
-       */
-      revokedAt?: string | null;
-    };
-    TaskTokenWithRaw: components["schemas"]["TaskToken"] & {
-      /** @example raw-token-value-shown-once */
-      rawToken: string;
-    };
-    TokenBody: {
-      /** @example ci-runner */
-      label?: string;
-      /** @example agent-id-123 */
-      agentId?: string;
-    };
-    PullRequest: {
-      /** @example clx0987654321 */
-      id: string;
-      /** @example org/repo */
-      repo: string;
-      /** @example 42 */
-      prNumber: number;
-      /** @example clx1234567890 */
-      taskId?: string | null;
-      /**
-       * @default false
-       * @example false
-       */
-      staged: boolean;
-      /**
-       * @default open
-       * @example open
-       * @enum {string}
-       */
-      state: "open" | "merged" | "closed";
-      /**
-       * @default pending
-       * @example pending
-       * @enum {string}
-       */
-      reviewState: "pending" | "in_progress" | "posted" | "approved";
-      /** @example abc123def456 */
-      commitSha?: string | null;
-      /**
-       * @default 0
-       * @example 1
-       */
-      patchCycles: number;
-      /**
-       * @default 0
-       * @example 0
-       */
-      reviewCycles: number;
-      /** @example agent-id-123 */
-      agentId?: string | null;
-      /** @example 2026-01-03T00:00:00.000Z */
-      reviewedAt?: string | null;
-      /** @example null */
-      patchedAt?: string | null;
-      /** @example null */
-      mergedAt?: string | null;
-      /**
-       * @description ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.
-       * @example 2026-01-01T00:00:00.000Z
-       */
-      prCreatedAt?: string | null;
-      /** @example agent-id-123 */
-      claimedBy?: string | null;
-      /** @example 2026-01-02T00:00:00.000Z */
-      claimedAt?: string | null;
-      /** @example 2026-01-06T12:00:00.000Z */
-      heartbeatAt?: string | null;
-      /**
-       * @example review
-       * @enum {string|null}
-       */
-      phase?: "review" | "patch" | "deploy" | null;
-      /** @example 2026-01-02T00:00:00.000Z */
-      readyForReviewAt?: string | null;
-      /** @example null */
-      readyForPatchAt?: string | null;
-      /** @example null */
-      readyForDeployAt?: string | null;
-      /**
-       * Format: date-time
-       * @example 2026-01-01T00:00:00.000Z
-       */
-      createdAt: string;
-      /**
-       * Format: date-time
-       * @example 2026-01-06T12:00:00.000Z
-       */
-      updatedAt: string;
-    };
-    PrListResponse: {
-      /** @description Array of pull requests */
-      prs: components["schemas"]["PullRequest"][];
-      /** @example 1 */
-      total: number;
-      /** @example 50 */
-      limit: number;
-      /** @example 0 */
-      offset: number;
-    };
-    ClaimPrBody: {
-      /**
-       * @description Repository in org/repo format
-       * @example org/repo
-       */
-      repo: string;
-      /**
-       * @description Pull request number
-       * @example 42
-       */
-      prNumber: number;
-      /**
-       * @description Commit SHA to associate
-       * @example abc123def456
-       */
-      commitSha: string;
-      /**
-       * @description Agent claiming this PR (admin tokens only)
-       * @example agent-id-123
-       */
-      claimedBy?: string;
-      /**
-       * @description Associated task ID
-       * @example clx1234567890
-       */
-      taskId?: string;
-      /**
-       * @description Pipeline phase this claim is for (defaults to 'review' when omitted)
-       * @example patch
-       * @enum {string}
-       */
-      phase?: "review" | "patch" | "deploy";
-      /**
-       * @description ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.
-       * @example 2026-01-01T00:00:00.000Z
-       */
-      prCreatedAt?: string;
-    };
-    ClaimNextResponse: {
-      pr: components["schemas"]["PullRequest"];
-      /**
-       * @example review
-       * @enum {string}
-       */
-      phase: "review" | "patch" | "deploy";
-    };
-    ClaimNextBody: {
-      /**
-       * @description Agent ID (admin tokens only; agent tokens use token identity)
-       * @example agent-id-123
-       */
-      agentId?: string;
-      /**
-       * @description Maximum concurrent PRs to claim
-       * @example 1
-       */
-      maxConcurrent?: number;
-    };
-    UpdatePrBody: {
-      [key: string]: unknown;
-    };
-    PatchPrBody: {
-      /**
-       * @description Current head commit SHA. When provided and it differs from the record's stored commitSha, reviewState resets to pending and commitSha is updated. When it matches, reviewState is left untouched (no-op patch cycle). When omitted, reviewState unconditionally resets to pending (legacy behavior).
-       * @example abc123def456
-       */
-      commitSha?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/lib/task-store-types.ts
+++ b/lib/task-store-types.ts
@@ -4,1780 +4,1790 @@
  */
 
 export interface paths {
-    "/tasks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List tasks */
-        get: {
-            parameters: {
-                query?: {
-                    status?: string;
-                    state?: "open" | "closed" | "in_progress" | "ready" | "blocked";
-                    session?: string;
-                    repo?: string;
-                    assignee?: string;
-                    claimedBy?: string;
-                    branch?: string;
-                    pr?: string;
-                    limit?: string;
-                    offset?: string;
-                    ready?: "true" | "false";
-                    sort?: "asc" | "desc";
-                    updatedSince?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description List of tasks with total count */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TaskListResponse"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create a task */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["CreateTaskBody"];
-                };
-            };
-            responses: {
-                /** @description Created task */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/tasks": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/tasks/bulk": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /** List tasks */
+    get: {
+      parameters: {
+        query?: {
+          status?: string;
+          state?: "open" | "closed" | "in_progress" | "ready" | "blocked";
+          session?: string;
+          repo?: string;
+          assignee?: string;
+          claimedBy?: string;
+          branch?: string;
+          pr?: string;
+          limit?: string;
+          offset?: string;
+          ready?: "true" | "false";
+          sort?: "asc" | "desc";
+          updatedSince?: string;
         };
-        get?: never;
-        put?: never;
-        /** Bulk insert tasks */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["BulkInsertBody"];
-                };
-            };
-            responses: {
-                /** @description Bulk insert result */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["BulkInsertResponse"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description List of tasks with total count */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["TaskListResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/tasks/distinct": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    put?: never;
+    /** Create a task */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["CreateTaskBody"];
         };
-        /** Get distinct session and repo values */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Distinct values */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DistinctResponse"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Created task */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/tasks/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a task by ID */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete a task */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Deleted */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update a task */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["UpdateTaskBody"];
-                };
-            };
-            responses: {
-                /** @description Updated task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/bulk": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/tasks/{id}/claim": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    /** Bulk insert tasks */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["BulkInsertBody"];
         };
-        get?: never;
-        put?: never;
-        /** Atomically claim a task */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ClaimBody"];
-                };
-            };
-            responses: {
-                /** @description Claimed task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Conflict — already claimed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Bulk insert result */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BulkInsertResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/tasks/{id}/heartbeat": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Touch heartbeatAt on a claimed task */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Updated task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/distinct": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/tasks/{id}/complete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /** Get distinct session and repo values */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Distinct values */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["DistinctResponse"];
+          };
         };
-        get?: never;
-        put?: never;
-        /** Mark a task as done */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Updated task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/tasks/{id}/fail": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Mark a task as blocked */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FailBody"];
-                };
-            };
-            responses: {
-                /** @description Updated task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/tasks/{id}/release": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /** Get a task by ID */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        get?: never;
-        put?: never;
-        /** Release a task back to pending */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Updated task */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Task"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/tokens": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    put?: never;
+    post?: never;
+    /** Delete a task */
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        /** List all tokens */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Array of token metadata */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TaskToken"][];
-                    };
-                };
-                /** @description Forbidden — admin token required */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Deleted */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
         };
-        put?: never;
-        /** Create a new token — raw value returned exactly once */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["TokenBody"];
-                };
-            };
-            responses: {
-                /** @description Created token including the one-time raw value */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TaskTokenWithRaw"];
-                    };
-                };
-                /** @description Forbidden — admin token required */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/tokens/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    options?: never;
+    head?: never;
+    /** Update a task */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Revoke a token */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Revoked token metadata */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TaskToken"];
-                    };
-                };
-                /** @description Forbidden — admin token required */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Token not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["UpdateTaskBody"];
         };
-        options?: never;
-        head?: never;
-        /** Update token label and/or agentId */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["TokenBody"];
-                };
-            };
-            responses: {
-                /** @description Updated token metadata */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TaskToken"];
-                    };
-                };
-                /** @description Bad request — token is revoked */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden — admin token required */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Token not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Updated task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
         };
-        trace?: never;
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/prs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List pull requests */
-        get: {
-            parameters: {
-                query?: {
-                    repo?: string;
-                    prNumber?: string;
-                    taskId?: string;
-                    state?: "open" | "merged" | "closed";
-                    reviewState?: "pending" | "in_progress" | "posted" | "approved";
-                    staged?: "true" | "false";
-                    limit?: string;
-                    offset?: string;
-                    ready?: "true" | "false";
-                    sort?: "asc" | "desc";
-                    updatedSince?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description List of pull requests */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PrListResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    trace?: never;
+  };
+  "/tasks/{id}/claim": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/prs/claim": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    /** Atomically claim a task */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        get?: never;
-        put?: never;
-        /** Claim a pull request (atomic) */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["ClaimPrBody"];
-                };
-            };
-            responses: {
-                /** @description Updated existing claim */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description New claim created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Conflict — already claimed with same commitSha */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ClaimBody"];
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
+      responses: {
+        /** @description Claimed task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
+        };
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Conflict — already claimed */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/prs/claim-next": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Atomic find-and-claim of oldest eligible PR */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ClaimNextBody"];
-                };
-            };
-            responses: {
-                /** @description PR claimed — returns {pr, phase} */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ClaimNextResponse"];
-                    };
-                };
-                /** @description No eligible PR found */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/{id}/heartbeat": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/prs/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    /** Touch heartbeatAt on a claimed task */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        /** Fetch a single pull request */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Pull request record */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Updated task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update pull request fields */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdatePrBody"];
-                };
-            };
-            responses: {
-                /** @description Updated pull request */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
         };
-        trace?: never;
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/prs/{id}/heartbeat": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Touch heartbeatAt for a claimed PR */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description PR with updated heartbeatAt */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/{id}/complete": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/prs/{id}/complete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    /** Mark a task as done */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        get?: never;
-        put?: never;
-        /** Mark PR review as complete (reviewState=posted) */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Completed PR */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Updated task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
-    "/prs/{id}/patch": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Increment patchCycles and conditionally reset reviewState=pending */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["PatchPrBody"];
-                };
-            };
-            responses: {
-                /** @description Patched PR */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/{id}/fail": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/prs/{id}/release": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    /** Mark a task as blocked */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
         };
-        get?: never;
-        put?: never;
-        /** Release a claim (reviewState=pending, claimedBy cleared) */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Released PR */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PullRequest"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FailBody"];
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
+      responses: {
+        /** @description Updated task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
     };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tasks/{id}/release": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Release a task back to pending */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Updated task */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Task"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tokens": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List all tokens */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Array of token metadata */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["TaskToken"][];
+          };
+        };
+        /** @description Forbidden — admin token required */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    put?: never;
+    /** Create a new token — raw value returned exactly once */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["TokenBody"];
+        };
+      };
+      responses: {
+        /** @description Created token including the one-time raw value */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["TaskTokenWithRaw"];
+          };
+        };
+        /** @description Forbidden — admin token required */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tokens/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Revoke a token */
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Revoked token metadata */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["TaskToken"];
+          };
+        };
+        /** @description Forbidden — admin token required */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Token not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    /** Update token label and/or agentId */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["TokenBody"];
+        };
+      };
+      responses: {
+        /** @description Updated token metadata */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["TaskToken"];
+          };
+        };
+        /** @description Bad request — token is revoked */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden — admin token required */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Token not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    trace?: never;
+  };
+  "/prs": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List pull requests */
+    get: {
+      parameters: {
+        query?: {
+          repo?: string;
+          prNumber?: string;
+          taskId?: string;
+          state?: "open" | "merged" | "closed";
+          reviewState?: "pending" | "in_progress" | "posted" | "approved";
+          staged?: "true" | "false";
+          limit?: string;
+          offset?: string;
+          ready?: "true" | "false";
+          sort?: "asc" | "desc";
+          updatedSince?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description List of pull requests */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PrListResponse"];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/prs/claim": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Claim a pull request (atomic) */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["ClaimPrBody"];
+        };
+      };
+      responses: {
+        /** @description Updated existing claim */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description New claim created */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Conflict — already claimed with same commitSha */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/prs/claim-next": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Atomic find-and-claim of oldest eligible PR */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ClaimNextBody"];
+        };
+      };
+      responses: {
+        /** @description PR claimed — returns {pr, phase} */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["ClaimNextResponse"];
+          };
+        };
+        /** @description No eligible PR found */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/prs/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Fetch a single pull request */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Pull request record */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Update pull request fields */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["UpdatePrBody"];
+        };
+      };
+      responses: {
+        /** @description Updated pull request */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    trace?: never;
+  };
+  "/prs/{id}/heartbeat": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Touch heartbeatAt for a claimed PR */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description PR with updated heartbeatAt */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/prs/{id}/complete": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Mark PR review as complete (reviewState=posted) */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Completed PR */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/prs/{id}/patch": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Increment patchCycles and conditionally reset reviewState=pending */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["PatchPrBody"];
+        };
+      };
+      responses: {
+        /** @description Patched PR */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/prs/{id}/release": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Release a claim (reviewState=pending, claimedBy cleared) */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Released PR */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PullRequest"];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        Task: {
-            /** @example clx1234567890 */
-            id: string;
-            /** @example Implement feature X */
-            title: string;
-            /**
-             * @example pending
-             * @enum {string}
-             */
-            status: "pending" | "in_progress" | "pr_open" | "approved" | "merged" | "done" | "deploying" | "deployed" | "blocked" | "cancelled";
-            /** @example manual */
-            source?: string | null;
-            /** @example session-123 */
-            session?: string | null;
-            /** @example org/repo */
-            repo?: string | null;
-            /** @example Task description */
-            description?: string | null;
-            /**
-             * @example [
-             *       "Criterion 1",
-             *       "Criterion 2"
-             *     ]
-             */
-            acceptanceCriteria?: string[];
-            /** @example feature */
-            layer?: string | null;
-            /** @example feat/feature-x */
-            branch?: string | null;
-            /**
-             * @example [
-             *       "task-1",
-             *       "task-2"
-             *     ]
-             */
-            dependencies?: string[];
-            /** @example 42 */
-            pr?: number | null;
-            /** @example 5.5 */
-            hours?: number | null;
-            /** @example 2026-01-02T00:00:00.000Z */
-            startedAt?: string | null;
-            /** @example 2026-01-03T00:00:00.000Z */
-            prCreatedAt?: string | null;
-            /** @example 2026-01-04T00:00:00.000Z */
-            mergedAt?: string | null;
-            /** @example null */
-            blockedAt?: string | null;
-            /** @example Waiting on dependency */
-            blockedReason?: string | null;
-            /** @example Some notes */
-            note?: string | null;
-            /** @example feature */
-            type?: string | null;
-            /** @example high */
-            priority?: string | null;
-            /** @example null */
-            cancelledAt?: string | null;
-            /** @example 2026-01-05T00:00:00.000Z */
-            completedAt?: string | null;
-            /** @example null */
-            deployingAt?: string | null;
-            /** @example 2026-01-06T00:00:00.000Z */
-            deployedAt?: string | null;
-            /** @example 2 */
-            ciFixAttempts?: number | null;
-            /** @example abc123def456 */
-            mergeCommit?: string | null;
-            /** @example https://github.com/org/repo/pull/42 */
-            prUrl?: string | null;
-            /** @example user@example.com */
-            assignee?: string | null;
-            /** @example GH-123 */
-            issue?: string | null;
-            /** @example sonnet */
-            model?: string | null;
-            /** @example 7 */
-            complexity?: number | null;
-            /** @example true */
-            hitl?: boolean | null;
-            /** @example 2026-01-02T00:00:00.000Z */
-            hitlNotifiedAt?: string | null;
-            /** @example agent-id-123 */
-            claimedBy?: string | null;
-            /** @example prefer-sonnet */
-            agentHint?: string | null;
-            /** @example 2026-01-02T00:00:00.000Z */
-            claimedAt?: string | null;
-            /** @example 2026-01-06T12:00:00.000Z */
-            heartbeatAt?: string | null;
-            /** @example 10 */
-            simplifyTotal?: number | null;
-            /** @example 2 */
-            simplifyDry?: number | null;
-            /** @example 3 */
-            simplifyDeadCode?: number | null;
-            /** @example 1 */
-            simplifyNaming?: number | null;
-            /** @example 2 */
-            simplifyComplexity?: number | null;
-            /** @example 2 */
-            simplifyConsistency?: number | null;
-            /** @example 5.5 */
-            coverageDelta?: number | null;
-            /** @example medium */
-            effortLevel?: string | null;
-            /** @example 1000 */
-            inputTokens?: number | null;
-            /** @example 500 */
-            outputTokens?: number | null;
-            /** @example 100 */
-            cacheReadTokens?: number | null;
-            /** @example 50 */
-            cacheCreationTokens?: number | null;
-            /** @example 0.02 */
-            costUsd?: number | null;
-            /**
-             * @example {
-             *       "customKey": "customValue"
-             *     }
-             */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Format: date-time
-             * @example 2026-01-01T00:00:00.000Z
-             */
-            createdAt: string;
-            /**
-             * Format: date-time
-             * @example 2026-01-06T12:00:00.000Z
-             */
-            updatedAt: string;
-        };
-        TaskListResponse: {
-            tasks: components["schemas"]["Task"][];
-            /** @example 10 */
-            total: number;
-        };
-        Error: {
-            /** @example not found */
-            error: string;
-        };
-        CreateTaskBody: {
-            /** @example Implement feature X */
-            title?: string;
-            /** @example pending */
-            status?: string;
-            /** @example org/repo */
-            repo?: string | null;
-            /** @example session-123 */
-            session?: string;
-            /** @example Task description */
-            description?: string;
-            /** @example service */
-            layer?: string;
-            /** @example feat/feature-x */
-            branch?: string;
-            /** @example [] */
-            dependencies?: string[];
-            /** @example [] */
-            acceptanceCriteria?: string[];
-            /** @example user@example.com */
-            assignee?: string;
-            /** @example high */
-            priority?: string;
-            /** @example feature */
-            type?: string;
-            /** @example manual */
-            source?: string;
-        };
-        BulkInsertResponse: {
-            /** @example 3 */
-            inserted: number;
-            /** @example 1 */
-            updated: number;
-            /**
-             * @description IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).
-             * @example [
-             *       "entropy-dead_exports-other-repo-2026-W29"
-             *     ]
-             */
-            skipped: string[];
-        };
-        BulkInsertBody: {
-            /** @example Implement feature X */
-            title?: string;
-            /** @example pending */
-            status?: string;
-            /** @example org/repo */
-            repo?: string | null;
-        }[];
-        DistinctResponse: {
-            /**
-             * @example [
-             *       "session-1"
-             *     ]
-             */
-            sessions: string[];
-            /**
-             * @example [
-             *       "org/repo"
-             *     ]
-             */
-            repos: string[];
-        };
-        UpdateTaskBody: {
-            [key: string]: unknown;
-        };
-        ClaimBody: {
-            /** @example agent-id-123 */
-            claimedBy?: string;
-        };
-        FailBody: {
-            /** @example build failed */
-            reason?: string;
-        };
-        TaskToken: {
-            /** @example clxtoken123456 */
-            id: string;
-            /** @example ci-runner */
-            label?: string | null;
-            /** @example agent-id-123 */
-            agentId?: string | null;
-            /**
-             * Format: date-time
-             * @example 2026-01-01T00:00:00.000Z
-             */
-            createdAt: string;
-            /**
-             * Format: date-time
-             * @example null
-             */
-            revokedAt?: string | null;
-        };
-        TaskTokenWithRaw: components["schemas"]["TaskToken"] & {
-            /** @example raw-token-value-shown-once */
-            rawToken: string;
-        };
-        TokenBody: {
-            /** @example ci-runner */
-            label?: string;
-            /** @example agent-id-123 */
-            agentId?: string;
-        };
-        PullRequest: {
-            /** @example clx0987654321 */
-            id: string;
-            /** @example org/repo */
-            repo: string;
-            /** @example 42 */
-            prNumber: number;
-            /** @example clx1234567890 */
-            taskId?: string | null;
-            /**
-             * @default false
-             * @example false
-             */
-            staged: boolean;
-            /**
-             * @default open
-             * @example open
-             * @enum {string}
-             */
-            state: "open" | "merged" | "closed";
-            /**
-             * @default pending
-             * @example pending
-             * @enum {string}
-             */
-            reviewState: "pending" | "in_progress" | "posted" | "approved";
-            /** @example abc123def456 */
-            commitSha?: string | null;
-            /**
-             * @default 0
-             * @example 1
-             */
-            patchCycles: number;
-            /**
-             * @default 0
-             * @example 0
-             */
-            reviewCycles: number;
-            /** @example agent-id-123 */
-            agentId?: string | null;
-            /** @example 2026-01-03T00:00:00.000Z */
-            reviewedAt?: string | null;
-            /** @example null */
-            patchedAt?: string | null;
-            /** @example null */
-            mergedAt?: string | null;
-            /**
-             * @description ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.
-             * @example 2026-01-01T00:00:00.000Z
-             */
-            prCreatedAt?: string | null;
-            /** @example agent-id-123 */
-            claimedBy?: string | null;
-            /** @example 2026-01-02T00:00:00.000Z */
-            claimedAt?: string | null;
-            /** @example 2026-01-06T12:00:00.000Z */
-            heartbeatAt?: string | null;
-            /**
-             * @example review
-             * @enum {string|null}
-             */
-            phase?: "review" | "patch" | "deploy" | null;
-            /** @example 2026-01-02T00:00:00.000Z */
-            readyForReviewAt?: string | null;
-            /** @example null */
-            readyForPatchAt?: string | null;
-            /** @example null */
-            readyForDeployAt?: string | null;
-            /**
-             * Format: date-time
-             * @example 2026-01-01T00:00:00.000Z
-             */
-            createdAt: string;
-            /**
-             * Format: date-time
-             * @example 2026-01-06T12:00:00.000Z
-             */
-            updatedAt: string;
-        };
-        PrListResponse: {
-            /** @description Array of pull requests */
-            prs: components["schemas"]["PullRequest"][];
-            /** @example 1 */
-            total: number;
-            /** @example 50 */
-            limit: number;
-            /** @example 0 */
-            offset: number;
-        };
-        ClaimPrBody: {
-            /**
-             * @description Repository in org/repo format
-             * @example org/repo
-             */
-            repo: string;
-            /**
-             * @description Pull request number
-             * @example 42
-             */
-            prNumber: number;
-            /**
-             * @description Commit SHA to associate
-             * @example abc123def456
-             */
-            commitSha: string;
-            /**
-             * @description Agent claiming this PR (admin tokens only)
-             * @example agent-id-123
-             */
-            claimedBy?: string;
-            /**
-             * @description Associated task ID
-             * @example clx1234567890
-             */
-            taskId?: string;
-            /**
-             * @description Pipeline phase this claim is for (defaults to 'review' when omitted)
-             * @example patch
-             * @enum {string}
-             */
-            phase?: "review" | "patch" | "deploy";
-            /**
-             * @description ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.
-             * @example 2026-01-01T00:00:00.000Z
-             */
-            prCreatedAt?: string;
-        };
-        ClaimNextResponse: {
-            pr: components["schemas"]["PullRequest"];
-            /**
-             * @example review
-             * @enum {string}
-             */
-            phase: "review" | "patch" | "deploy";
-        };
-        ClaimNextBody: {
-            /**
-             * @description Agent ID (admin tokens only; agent tokens use token identity)
-             * @example agent-id-123
-             */
-            agentId?: string;
-            /**
-             * @description Maximum concurrent PRs to claim
-             * @example 1
-             */
-            maxConcurrent?: number;
-        };
-        UpdatePrBody: {
-            [key: string]: unknown;
-        };
-        PatchPrBody: {
-            /**
-             * @description Current head commit SHA. When provided and it differs from the record's stored commitSha, reviewState resets to pending and commitSha is updated. When it matches, reviewState is left untouched (no-op patch cycle). When omitted, reviewState unconditionally resets to pending (legacy behavior).
-             * @example abc123def456
-             */
-            commitSha?: string;
-        };
+  schemas: {
+    Task: {
+      /** @example clx1234567890 */
+      id: string;
+      /** @example Implement feature X */
+      title: string;
+      /**
+       * @example pending
+       * @enum {string}
+       */
+      status:
+        | "pending"
+        | "in_progress"
+        | "pr_open"
+        | "approved"
+        | "merged"
+        | "done"
+        | "deploying"
+        | "deployed"
+        | "blocked"
+        | "cancelled";
+      /** @example manual */
+      source?: string | null;
+      /** @example session-123 */
+      session?: string | null;
+      /** @example org/repo */
+      repo?: string | null;
+      /** @example Task description */
+      description?: string | null;
+      /**
+       * @example [
+       *       "Criterion 1",
+       *       "Criterion 2"
+       *     ]
+       */
+      acceptanceCriteria?: string[];
+      /** @example feature */
+      layer?: string | null;
+      /** @example feat/feature-x */
+      branch?: string | null;
+      /**
+       * @example [
+       *       "task-1",
+       *       "task-2"
+       *     ]
+       */
+      dependencies?: string[];
+      /** @example 42 */
+      pr?: number | null;
+      /** @example 5.5 */
+      hours?: number | null;
+      /** @example 2026-01-02T00:00:00.000Z */
+      startedAt?: string | null;
+      /** @example 2026-01-03T00:00:00.000Z */
+      prCreatedAt?: string | null;
+      /** @example 2026-01-04T00:00:00.000Z */
+      mergedAt?: string | null;
+      /** @example null */
+      blockedAt?: string | null;
+      /** @example Waiting on dependency */
+      blockedReason?: string | null;
+      /** @example Some notes */
+      note?: string | null;
+      /** @example feature */
+      type?: string | null;
+      /** @example high */
+      priority?: string | null;
+      /** @example null */
+      cancelledAt?: string | null;
+      /** @example 2026-01-05T00:00:00.000Z */
+      completedAt?: string | null;
+      /** @example null */
+      deployingAt?: string | null;
+      /** @example 2026-01-06T00:00:00.000Z */
+      deployedAt?: string | null;
+      /** @example 2 */
+      ciFixAttempts?: number | null;
+      /** @example abc123def456 */
+      mergeCommit?: string | null;
+      /** @example https://github.com/org/repo/pull/42 */
+      prUrl?: string | null;
+      /** @example user@example.com */
+      assignee?: string | null;
+      /** @example GH-123 */
+      issue?: string | null;
+      /** @example sonnet */
+      model?: string | null;
+      /** @example 7 */
+      complexity?: number | null;
+      /** @example true */
+      hitl?: boolean | null;
+      /** @example 2026-01-02T00:00:00.000Z */
+      hitlNotifiedAt?: string | null;
+      /** @example agent-id-123 */
+      claimedBy?: string | null;
+      /** @example prefer-sonnet */
+      agentHint?: string | null;
+      /** @example 2026-01-02T00:00:00.000Z */
+      claimedAt?: string | null;
+      /** @example 2026-01-06T12:00:00.000Z */
+      heartbeatAt?: string | null;
+      /** @example 10 */
+      simplifyTotal?: number | null;
+      /** @example 2 */
+      simplifyDry?: number | null;
+      /** @example 3 */
+      simplifyDeadCode?: number | null;
+      /** @example 1 */
+      simplifyNaming?: number | null;
+      /** @example 2 */
+      simplifyComplexity?: number | null;
+      /** @example 2 */
+      simplifyConsistency?: number | null;
+      /** @example 5.5 */
+      coverageDelta?: number | null;
+      /** @example medium */
+      effortLevel?: string | null;
+      /** @example 1000 */
+      inputTokens?: number | null;
+      /** @example 500 */
+      outputTokens?: number | null;
+      /** @example 100 */
+      cacheReadTokens?: number | null;
+      /** @example 50 */
+      cacheCreationTokens?: number | null;
+      /** @example 0.02 */
+      costUsd?: number | null;
+      /**
+       * @example {
+       *       "customKey": "customValue"
+       *     }
+       */
+      metadata?: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * Format: date-time
+       * @example 2026-01-01T00:00:00.000Z
+       */
+      createdAt: string;
+      /**
+       * Format: date-time
+       * @example 2026-01-06T12:00:00.000Z
+       */
+      updatedAt: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    TaskListResponse: {
+      tasks: components["schemas"]["Task"][];
+      /** @example 10 */
+      total: number;
+    };
+    Error: {
+      /** @example not found */
+      error: string;
+    };
+    CreateTaskBody: {
+      /** @example Implement feature X */
+      title?: string;
+      /** @example pending */
+      status?: string;
+      /** @example org/repo */
+      repo?: string | null;
+      /** @example session-123 */
+      session?: string;
+      /** @example Task description */
+      description?: string;
+      /** @example service */
+      layer?: string;
+      /** @example feat/feature-x */
+      branch?: string;
+      /** @example [] */
+      dependencies?: string[];
+      /** @example [] */
+      acceptanceCriteria?: string[];
+      /** @example user@example.com */
+      assignee?: string;
+      /** @example high */
+      priority?: string;
+      /** @example feature */
+      type?: string;
+      /** @example manual */
+      source?: string;
+    };
+    BulkInsertResponse: {
+      /** @example 3 */
+      inserted: number;
+      /** @example 1 */
+      updated: number;
+      /**
+       * @description IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).
+       * @example [
+       *       "entropy-dead_exports-other-repo-2026-W29"
+       *     ]
+       */
+      skipped: string[];
+    };
+    BulkInsertBody: {
+      /** @example Implement feature X */
+      title?: string;
+      /** @example pending */
+      status?: string;
+      /** @example org/repo */
+      repo?: string | null;
+    }[];
+    DistinctResponse: {
+      /**
+       * @example [
+       *       "session-1"
+       *     ]
+       */
+      sessions: string[];
+      /**
+       * @example [
+       *       "org/repo"
+       *     ]
+       */
+      repos: string[];
+    };
+    UpdateTaskBody: {
+      [key: string]: unknown;
+    };
+    ClaimBody: {
+      /** @example agent-id-123 */
+      claimedBy?: string;
+    };
+    FailBody: {
+      /** @example build failed */
+      reason?: string;
+    };
+    TaskToken: {
+      /** @example clxtoken123456 */
+      id: string;
+      /** @example ci-runner */
+      label?: string | null;
+      /** @example agent-id-123 */
+      agentId?: string | null;
+      /**
+       * Format: date-time
+       * @example 2026-01-01T00:00:00.000Z
+       */
+      createdAt: string;
+      /**
+       * Format: date-time
+       * @example null
+       */
+      revokedAt?: string | null;
+    };
+    TaskTokenWithRaw: components["schemas"]["TaskToken"] & {
+      /** @example raw-token-value-shown-once */
+      rawToken: string;
+    };
+    TokenBody: {
+      /** @example ci-runner */
+      label?: string;
+      /** @example agent-id-123 */
+      agentId?: string;
+    };
+    PullRequest: {
+      /** @example clx0987654321 */
+      id: string;
+      /** @example org/repo */
+      repo: string;
+      /** @example 42 */
+      prNumber: number;
+      /** @example clx1234567890 */
+      taskId?: string | null;
+      /**
+       * @default false
+       * @example false
+       */
+      staged: boolean;
+      /**
+       * @default open
+       * @example open
+       * @enum {string}
+       */
+      state: "open" | "merged" | "closed";
+      /**
+       * @default pending
+       * @example pending
+       * @enum {string}
+       */
+      reviewState: "pending" | "in_progress" | "posted" | "approved";
+      /** @example abc123def456 */
+      commitSha?: string | null;
+      /**
+       * @default 0
+       * @example 1
+       */
+      patchCycles: number;
+      /**
+       * @default 0
+       * @example 0
+       */
+      reviewCycles: number;
+      /** @example agent-id-123 */
+      agentId?: string | null;
+      /** @example 2026-01-03T00:00:00.000Z */
+      reviewedAt?: string | null;
+      /** @example null */
+      patchedAt?: string | null;
+      /** @example null */
+      mergedAt?: string | null;
+      /**
+       * @description ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.
+       * @example 2026-01-01T00:00:00.000Z
+       */
+      prCreatedAt?: string | null;
+      /** @example agent-id-123 */
+      claimedBy?: string | null;
+      /** @example 2026-01-02T00:00:00.000Z */
+      claimedAt?: string | null;
+      /** @example 2026-01-06T12:00:00.000Z */
+      heartbeatAt?: string | null;
+      /**
+       * @example review
+       * @enum {string|null}
+       */
+      phase?: "review" | "patch" | "deploy" | null;
+      /** @example 2026-01-02T00:00:00.000Z */
+      readyForReviewAt?: string | null;
+      /** @example null */
+      readyForPatchAt?: string | null;
+      /** @example null */
+      readyForDeployAt?: string | null;
+      /**
+       * Format: date-time
+       * @example 2026-01-01T00:00:00.000Z
+       */
+      createdAt: string;
+      /**
+       * Format: date-time
+       * @example 2026-01-06T12:00:00.000Z
+       */
+      updatedAt: string;
+    };
+    PrListResponse: {
+      /** @description Array of pull requests */
+      prs: components["schemas"]["PullRequest"][];
+      /** @example 1 */
+      total: number;
+      /** @example 50 */
+      limit: number;
+      /** @example 0 */
+      offset: number;
+    };
+    ClaimPrBody: {
+      /**
+       * @description Repository in org/repo format
+       * @example org/repo
+       */
+      repo: string;
+      /**
+       * @description Pull request number
+       * @example 42
+       */
+      prNumber: number;
+      /**
+       * @description Commit SHA to associate
+       * @example abc123def456
+       */
+      commitSha: string;
+      /**
+       * @description Agent claiming this PR (admin tokens only)
+       * @example agent-id-123
+       */
+      claimedBy?: string;
+      /**
+       * @description Associated task ID
+       * @example clx1234567890
+       */
+      taskId?: string;
+      /**
+       * @description Pipeline phase this claim is for (defaults to 'review' when omitted)
+       * @example patch
+       * @enum {string}
+       */
+      phase?: "review" | "patch" | "deploy";
+      /**
+       * @description ISO timestamp of the GitHub PR's actual creation time. Only applied on first claim (record creation); ignored on subsequent claims since the field is immutable once set.
+       * @example 2026-01-01T00:00:00.000Z
+       */
+      prCreatedAt?: string;
+    };
+    ClaimNextResponse: {
+      pr: components["schemas"]["PullRequest"];
+      /**
+       * @example review
+       * @enum {string}
+       */
+      phase: "review" | "patch" | "deploy";
+    };
+    ClaimNextBody: {
+      /**
+       * @description Agent ID (admin tokens only; agent tokens use token identity)
+       * @example agent-id-123
+       */
+      agentId?: string;
+      /**
+       * @description Maximum concurrent PRs to claim
+       * @example 1
+       */
+      maxConcurrent?: number;
+    };
+    UpdatePrBody: {
+      [key: string]: unknown;
+    };
+    PatchPrBody: {
+      /**
+       * @description Current head commit SHA. When provided and it differs from the record's stored commitSha, reviewState resets to pending and commitSha is updated. When it matches, reviewState is left untouched (no-op patch cycle). When omitted, reviewState unconditionally resets to pending (legacy behavior).
+       * @example abc123def456
+       */
+      commitSha?: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/plugins/shipwright/scripts/check-dev-task.ts
+++ b/plugins/shipwright/scripts/check-dev-task.ts
@@ -9,7 +9,7 @@
  * (WLS-3.1), so the prompt must supply an id; a bare `/shipwright:dev-task`
  * with no argument now silently no-ops. Selection mirrors the FIFO ordering
  * agent/src/work-selector.ts's selectNextWorkItem() uses for the
- * loop-orchestrator path: oldest `addedAt` first.
+ * loop-orchestrator path: oldest `createdAt` first.
  * Before checking ready tasks, guards against stale in_progress tasks:
  *   - Tasks with startedAt older than 45 minutes are reset to pending.
  *   - Tasks with no startedAt are stamped with the current time so they age
@@ -82,12 +82,12 @@ export async function run(deps: Deps): Promise<RunResult> {
   if (readyTasks.length > 0) {
     // dev-task.md is explicit-target-only (WLS-3.1) — a bare `/shipwright:dev-task`
     // with no task id now silently no-ops. Select the oldest ready task by
-    // `addedAt` (same FIFO ordering as work-selector.ts's selectNextWorkItem,
+    // `createdAt` (same FIFO ordering as work-selector.ts's selectNextWorkItem,
     // the loop-orchestrator's equivalent selection) and pass its id explicitly,
     // mirroring how agent/src/loop-orchestrator.ts dispatches
     // `/shipwright:dev-task {itemId}`.
     const nextTask = readyTasks.reduce((oldest, task) =>
-      (task.addedAt ?? "") < (oldest.addedAt ?? "") ? task : oldest,
+      (task.createdAt ?? "") < (oldest.createdAt ?? "") ? task : oldest,
     );
     return {
       exit: 0,

--- a/plugins/shipwright/scripts/check-dev-task.unit.test.ts
+++ b/plugins/shipwright/scripts/check-dev-task.unit.test.ts
@@ -120,14 +120,14 @@ describe("check-dev-task", () => {
     expect(result.output).toContain("/shipwright:dev-task SWC-9.1");
   });
 
-  test("prompt selects the oldest ready task by addedAt when multiple exist", async () => {
+  test("prompt selects the oldest ready task by createdAt when multiple exist", async () => {
     const newer = makeTask({
       id: "SWC-9.2",
-      addedAt: "2026-06-01T00:00:00Z",
+      createdAt: "2026-06-01T00:00:00Z",
     });
     const older = makeTask({
       id: "SWC-9.3",
-      addedAt: "2026-05-01T00:00:00Z",
+      createdAt: "2026-05-01T00:00:00Z",
     });
 
     const result = await run(makeDeps([newer, older]));

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -41,7 +41,7 @@ export interface Task {
   dependencies?: string[];
   pr?: number;
   hours?: number;
-  addedAt?: string;
+  createdAt?: string;
   startedAt?: string;
   prCreatedAt?: string;
   mergedAt?: string;

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -14,7 +14,9 @@
   "paths": {
     "/tasks": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "List tasks",
         "parameters": [
           {
@@ -29,7 +31,13 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["open", "closed", "in_progress", "ready", "blocked"],
+              "enum": [
+                "open",
+                "closed",
+                "in_progress",
+                "ready",
+                "blocked"
+              ],
               "example": "open"
             },
             "required": false,
@@ -111,7 +119,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["true", "false"],
+              "enum": [
+                "true",
+                "false"
+              ],
               "example": "true"
             },
             "required": false,
@@ -121,7 +132,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "example": "asc"
             },
             "required": false,
@@ -163,7 +177,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Create a task",
         "requestBody": {
           "content": {
@@ -210,7 +226,9 @@
     },
     "/tasks/bulk": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Bulk insert tasks",
         "requestBody": {
           "content": {
@@ -257,7 +275,9 @@
     },
     "/tasks/distinct": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Get distinct session and repo values",
         "responses": {
           "200": {
@@ -285,7 +305,9 @@
     },
     "/tasks/{id}": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Get a task by ID",
         "parameters": [
           {
@@ -342,7 +364,9 @@
         }
       },
       "patch": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Update a task",
         "parameters": [
           {
@@ -418,7 +442,9 @@
         }
       },
       "delete": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Delete a task",
         "parameters": [
           {
@@ -470,7 +496,9 @@
     },
     "/tasks/{id}/claim": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Atomically claim a task",
         "parameters": [
           {
@@ -559,7 +587,9 @@
     },
     "/tasks/{id}/heartbeat": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Touch heartbeatAt on a claimed task",
         "parameters": [
           {
@@ -618,7 +648,9 @@
     },
     "/tasks/{id}/complete": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Mark a task as done",
         "parameters": [
           {
@@ -677,7 +709,9 @@
     },
     "/tasks/{id}/fail": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Mark a task as blocked",
         "parameters": [
           {
@@ -746,7 +780,9 @@
     },
     "/tasks/{id}/release": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Release a task back to pending",
         "parameters": [
           {
@@ -805,7 +841,9 @@
     },
     "/tokens": {
       "get": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "List all tokens",
         "security": [
           {
@@ -839,7 +877,9 @@
         }
       },
       "post": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Create a new token — raw value returned exactly once",
         "security": [
           {
@@ -882,7 +922,9 @@
     },
     "/tokens/{id}": {
       "patch": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Update token label and/or agentId",
         "security": [
           {
@@ -954,7 +996,9 @@
         }
       },
       "delete": {
-        "tags": ["tokens"],
+        "tags": [
+          "tokens"
+        ],
         "summary": "Revoke a token",
         "security": [
           {
@@ -1008,7 +1052,9 @@
     },
     "/prs": {
       "get": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "List pull requests",
         "parameters": [
           {
@@ -1042,7 +1088,11 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["open", "merged", "closed"],
+              "enum": [
+                "open",
+                "merged",
+                "closed"
+              ],
               "example": "open"
             },
             "required": false,
@@ -1052,7 +1102,12 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["pending", "in_progress", "posted", "approved"],
+              "enum": [
+                "pending",
+                "in_progress",
+                "posted",
+                "approved"
+              ],
               "example": "pending"
             },
             "required": false,
@@ -1062,7 +1117,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["true", "false"],
+              "enum": [
+                "true",
+                "false"
+              ],
               "description": "Filter by staged flag",
               "example": "false"
             },
@@ -1093,7 +1151,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["true", "false"],
+              "enum": [
+                "true",
+                "false"
+              ],
               "description": "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
               "example": "true"
             },
@@ -1104,7 +1165,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "description": "Order results by createdAt. Default is ascending (asc), preserving current behavior for existing callers. Unrelated to claim-next's own deterministic ordering.",
               "example": "asc"
             },
@@ -1139,7 +1203,9 @@
     },
     "/prs/claim": {
       "post": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Claim a pull request (atomic)",
         "requestBody": {
           "required": true,
@@ -1197,7 +1263,9 @@
     },
     "/prs/claim-next": {
       "post": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Atomic find-and-claim of oldest eligible PR",
         "requestBody": {
           "required": false,
@@ -1238,7 +1306,9 @@
     },
     "/prs/{id}": {
       "get": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Fetch a single pull request",
         "parameters": [
           {
@@ -1275,7 +1345,9 @@
         }
       },
       "patch": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Update pull request fields",
         "parameters": [
           {
@@ -1334,7 +1406,9 @@
     },
     "/prs/{id}/heartbeat": {
       "post": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Touch heartbeatAt for a claimed PR",
         "parameters": [
           {
@@ -1363,7 +1437,9 @@
     },
     "/prs/{id}/complete": {
       "post": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Mark PR review as complete (reviewState=posted)",
         "parameters": [
           {
@@ -1402,7 +1478,9 @@
     },
     "/prs/{id}/patch": {
       "post": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Increment patchCycles and conditionally reset reviewState=pending",
         "parameters": [
           {
@@ -1451,7 +1529,9 @@
     },
     "/prs/{id}/release": {
       "post": {
-        "tags": ["PRs"],
+        "tags": [
+          "PRs"
+        ],
         "summary": "Release a claim (reviewState=pending, claimedBy cleared)",
         "parameters": [
           {
@@ -1519,19 +1599,31 @@
             "example": "pending"
           },
           "source": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "manual"
           },
           "session": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "session-123"
           },
           "repo": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "org/repo"
           },
           "description": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "Task description"
           },
           "acceptanceCriteria": {
@@ -1539,14 +1631,23 @@
             "items": {
               "type": "string"
             },
-            "example": ["Criterion 1", "Criterion 2"]
+            "example": [
+              "Criterion 1",
+              "Criterion 2"
+            ]
           },
           "layer": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "feature"
           },
           "branch": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "feat/feature-x"
           },
           "dependencies": {
@@ -1554,174 +1655,296 @@
             "items": {
               "type": "string"
             },
-            "example": ["task-1", "task-2"]
+            "example": [
+              "task-1",
+              "task-2"
+            ]
           },
           "pr": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 42
           },
           "hours": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "example": 5.5
           },
-          "addedAt": {
-            "type": ["string", "null"],
-            "example": "2026-01-01T00:00:00.000Z"
-          },
           "startedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "prCreatedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-03T00:00:00.000Z"
           },
           "mergedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-04T00:00:00.000Z"
           },
           "blockedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "blockedReason": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "Waiting on dependency"
           },
           "note": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "Some notes"
           },
           "type": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "feature"
           },
           "priority": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "high"
           },
           "cancelledAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "completedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-05T00:00:00.000Z"
           },
           "deployingAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "deployedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-06T00:00:00.000Z"
           },
           "ciFixAttempts": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 2
           },
           "mergeCommit": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "abc123def456"
           },
           "prUrl": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "https://github.com/org/repo/pull/42"
           },
           "assignee": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "user@example.com"
           },
           "issue": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "GH-123"
           },
           "model": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "sonnet"
           },
           "complexity": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 7
           },
           "hitl": {
-            "type": ["boolean", "null"],
+            "type": [
+              "boolean",
+              "null"
+            ],
             "example": true
           },
           "hitlNotifiedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "claimedBy": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "agent-id-123"
           },
           "agentHint": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "prefer-sonnet"
           },
           "claimedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "heartbeatAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-06T12:00:00.000Z"
           },
           "simplifyTotal": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 10
           },
           "simplifyDry": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 2
           },
           "simplifyDeadCode": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 3
           },
           "simplifyNaming": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 1
           },
           "simplifyComplexity": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 2
           },
           "simplifyConsistency": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 2
           },
           "coverageDelta": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "example": 5.5
           },
           "effortLevel": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "medium"
           },
           "inputTokens": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 1000
           },
           "outputTokens": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 500
           },
           "cacheReadTokens": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 100
           },
           "cacheCreationTokens": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "example": 50
           },
           "costUsd": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "example": 0.02
           },
           "metadata": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "additionalProperties": {},
             "example": {
               "customKey": "customValue"
@@ -1738,7 +1961,13 @@
             "example": "2026-01-06T12:00:00.000Z"
           }
         },
-        "required": ["id", "title", "status", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "title",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "TaskListResponse": {
         "type": "object",
@@ -1754,7 +1983,10 @@
             "example": 10
           }
         },
-        "required": ["tasks", "total"]
+        "required": [
+          "tasks",
+          "total"
+        ]
       },
       "Error": {
         "type": "object",
@@ -1764,7 +1996,9 @@
             "example": "not found"
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "CreateTaskBody": {
         "type": "object",
@@ -1780,7 +2014,10 @@
             "example": "pending"
           },
           "repo": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "org/repo"
           },
           "session": {
@@ -1848,10 +2085,16 @@
               "type": "string"
             },
             "description": "IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).",
-            "example": ["entropy-dead_exports-other-repo-2026-W29"]
+            "example": [
+              "entropy-dead_exports-other-repo-2026-W29"
+            ]
           }
         },
-        "required": ["inserted", "updated", "skipped"]
+        "required": [
+          "inserted",
+          "updated",
+          "skipped"
+        ]
       },
       "BulkInsertBody": {
         "type": "array",
@@ -1869,7 +2112,10 @@
               "example": "pending"
             },
             "repo": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "example": "org/repo"
             }
           }
@@ -1883,17 +2129,24 @@
             "items": {
               "type": "string"
             },
-            "example": ["session-1"]
+            "example": [
+              "session-1"
+            ]
           },
           "repos": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "example": ["org/repo"]
+            "example": [
+              "org/repo"
+            ]
           }
         },
-        "required": ["sessions", "repos"]
+        "required": [
+          "sessions",
+          "repos"
+        ]
       },
       "UpdateTaskBody": {
         "type": "object",
@@ -1925,11 +2178,17 @@
             "example": "clxtoken123456"
           },
           "label": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "ci-runner"
           },
           "agentId": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "agent-id-123"
           },
           "createdAt": {
@@ -1938,12 +2197,18 @@
             "example": "2026-01-01T00:00:00.000Z"
           },
           "revokedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "example": null
           }
         },
-        "required": ["id", "createdAt"]
+        "required": [
+          "id",
+          "createdAt"
+        ]
       },
       "TaskTokenWithRaw": {
         "allOf": [
@@ -1958,7 +2223,9 @@
                 "example": "raw-token-value-shown-once"
               }
             },
-            "required": ["rawToken"]
+            "required": [
+              "rawToken"
+            ]
           }
         ]
       },
@@ -1991,7 +2258,10 @@
             "example": 42
           },
           "taskId": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "clx1234567890"
           },
           "staged": {
@@ -2001,18 +2271,30 @@
           },
           "state": {
             "type": "string",
-            "enum": ["open", "merged", "closed"],
+            "enum": [
+              "open",
+              "merged",
+              "closed"
+            ],
             "default": "open",
             "example": "open"
           },
           "reviewState": {
             "type": "string",
-            "enum": ["pending", "in_progress", "posted", "approved"],
+            "enum": [
+              "pending",
+              "in_progress",
+              "posted",
+              "approved"
+            ],
             "default": "pending",
             "example": "pending"
           },
           "commitSha": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "abc123def456"
           },
           "patchCycles": {
@@ -2026,53 +2308,93 @@
             "example": 0
           },
           "agentId": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "agent-id-123"
           },
           "reviewedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-03T00:00:00.000Z"
           },
           "patchedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "mergedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "prCreatedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.",
             "example": "2026-01-01T00:00:00.000Z"
           },
           "claimedBy": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "agent-id-123"
           },
           "claimedAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "heartbeatAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-06T12:00:00.000Z"
           },
           "phase": {
-            "type": ["string", "null"],
-            "enum": ["review", "patch", "deploy"],
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "review",
+              "patch",
+              "deploy"
+            ],
             "example": "review"
           },
           "readyForReviewAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "readyForPatchAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "readyForDeployAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "example": null
           },
           "createdAt": {
@@ -2086,7 +2408,13 @@
             "example": "2026-01-06T12:00:00.000Z"
           }
         },
-        "required": ["id", "repo", "prNumber", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "repo",
+          "prNumber",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "PrListResponse": {
         "type": "object",
@@ -2111,7 +2439,12 @@
             "example": 0
           }
         },
-        "required": ["prs", "total", "limit", "offset"]
+        "required": [
+          "prs",
+          "total",
+          "limit",
+          "offset"
+        ]
       },
       "ClaimPrBody": {
         "type": "object",
@@ -2143,7 +2476,11 @@
           },
           "phase": {
             "type": "string",
-            "enum": ["review", "patch", "deploy"],
+            "enum": [
+              "review",
+              "patch",
+              "deploy"
+            ],
             "description": "Pipeline phase this claim is for (defaults to 'review' when omitted)",
             "example": "patch"
           },
@@ -2153,7 +2490,11 @@
             "example": "2026-01-01T00:00:00.000Z"
           }
         },
-        "required": ["repo", "prNumber", "commitSha"]
+        "required": [
+          "repo",
+          "prNumber",
+          "commitSha"
+        ]
       },
       "ClaimNextResponse": {
         "type": "object",
@@ -2163,11 +2504,18 @@
           },
           "phase": {
             "type": "string",
-            "enum": ["review", "patch", "deploy"],
+            "enum": [
+              "review",
+              "patch",
+              "deploy"
+            ],
             "example": "review"
           }
         },
-        "required": ["pr", "phase"]
+        "required": [
+          "pr",
+          "phase"
+        ]
       },
       "ClaimNextBody": {
         "type": "object",

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -14,9 +14,7 @@
   "paths": {
     "/tasks": {
       "get": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "List tasks",
         "parameters": [
           {
@@ -31,13 +29,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "open",
-                "closed",
-                "in_progress",
-                "ready",
-                "blocked"
-              ],
+              "enum": ["open", "closed", "in_progress", "ready", "blocked"],
               "example": "open"
             },
             "required": false,
@@ -119,10 +111,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ],
+              "enum": ["true", "false"],
               "example": "true"
             },
             "required": false,
@@ -132,10 +121,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "example": "asc"
             },
             "required": false,
@@ -177,9 +163,7 @@
         }
       },
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Create a task",
         "requestBody": {
           "content": {
@@ -226,9 +210,7 @@
     },
     "/tasks/bulk": {
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Bulk insert tasks",
         "requestBody": {
           "content": {
@@ -275,9 +257,7 @@
     },
     "/tasks/distinct": {
       "get": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Get distinct session and repo values",
         "responses": {
           "200": {
@@ -305,9 +285,7 @@
     },
     "/tasks/{id}": {
       "get": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Get a task by ID",
         "parameters": [
           {
@@ -364,9 +342,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Update a task",
         "parameters": [
           {
@@ -442,9 +418,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Delete a task",
         "parameters": [
           {
@@ -496,9 +470,7 @@
     },
     "/tasks/{id}/claim": {
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Atomically claim a task",
         "parameters": [
           {
@@ -587,9 +559,7 @@
     },
     "/tasks/{id}/heartbeat": {
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Touch heartbeatAt on a claimed task",
         "parameters": [
           {
@@ -648,9 +618,7 @@
     },
     "/tasks/{id}/complete": {
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Mark a task as done",
         "parameters": [
           {
@@ -709,9 +677,7 @@
     },
     "/tasks/{id}/fail": {
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Mark a task as blocked",
         "parameters": [
           {
@@ -780,9 +746,7 @@
     },
     "/tasks/{id}/release": {
       "post": {
-        "tags": [
-          "tasks"
-        ],
+        "tags": ["tasks"],
         "summary": "Release a task back to pending",
         "parameters": [
           {
@@ -841,9 +805,7 @@
     },
     "/tokens": {
       "get": {
-        "tags": [
-          "tokens"
-        ],
+        "tags": ["tokens"],
         "summary": "List all tokens",
         "security": [
           {
@@ -877,9 +839,7 @@
         }
       },
       "post": {
-        "tags": [
-          "tokens"
-        ],
+        "tags": ["tokens"],
         "summary": "Create a new token — raw value returned exactly once",
         "security": [
           {
@@ -922,9 +882,7 @@
     },
     "/tokens/{id}": {
       "patch": {
-        "tags": [
-          "tokens"
-        ],
+        "tags": ["tokens"],
         "summary": "Update token label and/or agentId",
         "security": [
           {
@@ -996,9 +954,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "tokens"
-        ],
+        "tags": ["tokens"],
         "summary": "Revoke a token",
         "security": [
           {
@@ -1052,9 +1008,7 @@
     },
     "/prs": {
       "get": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "List pull requests",
         "parameters": [
           {
@@ -1088,11 +1042,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "open",
-                "merged",
-                "closed"
-              ],
+              "enum": ["open", "merged", "closed"],
               "example": "open"
             },
             "required": false,
@@ -1102,12 +1052,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "pending",
-                "in_progress",
-                "posted",
-                "approved"
-              ],
+              "enum": ["pending", "in_progress", "posted", "approved"],
               "example": "pending"
             },
             "required": false,
@@ -1117,10 +1062,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ],
+              "enum": ["true", "false"],
               "description": "Filter by staged flag",
               "example": "false"
             },
@@ -1151,10 +1093,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ],
+              "enum": ["true", "false"],
               "description": "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
               "example": "true"
             },
@@ -1165,10 +1104,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "description": "Order results by createdAt. Default is ascending (asc), preserving current behavior for existing callers. Unrelated to claim-next's own deterministic ordering.",
               "example": "asc"
             },
@@ -1203,9 +1139,7 @@
     },
     "/prs/claim": {
       "post": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Claim a pull request (atomic)",
         "requestBody": {
           "required": true,
@@ -1263,9 +1197,7 @@
     },
     "/prs/claim-next": {
       "post": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Atomic find-and-claim of oldest eligible PR",
         "requestBody": {
           "required": false,
@@ -1306,9 +1238,7 @@
     },
     "/prs/{id}": {
       "get": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Fetch a single pull request",
         "parameters": [
           {
@@ -1345,9 +1275,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Update pull request fields",
         "parameters": [
           {
@@ -1406,9 +1334,7 @@
     },
     "/prs/{id}/heartbeat": {
       "post": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Touch heartbeatAt for a claimed PR",
         "parameters": [
           {
@@ -1437,9 +1363,7 @@
     },
     "/prs/{id}/complete": {
       "post": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Mark PR review as complete (reviewState=posted)",
         "parameters": [
           {
@@ -1478,9 +1402,7 @@
     },
     "/prs/{id}/patch": {
       "post": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Increment patchCycles and conditionally reset reviewState=pending",
         "parameters": [
           {
@@ -1529,9 +1451,7 @@
     },
     "/prs/{id}/release": {
       "post": {
-        "tags": [
-          "PRs"
-        ],
+        "tags": ["PRs"],
         "summary": "Release a claim (reviewState=pending, claimedBy cleared)",
         "parameters": [
           {
@@ -1599,31 +1519,19 @@
             "example": "pending"
           },
           "source": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "manual"
           },
           "session": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "session-123"
           },
           "repo": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "org/repo"
           },
           "description": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "Task description"
           },
           "acceptanceCriteria": {
@@ -1631,23 +1539,14 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "Criterion 1",
-              "Criterion 2"
-            ]
+            "example": ["Criterion 1", "Criterion 2"]
           },
           "layer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "feature"
           },
           "branch": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "feat/feature-x"
           },
           "dependencies": {
@@ -1655,296 +1554,170 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "task-1",
-              "task-2"
-            ]
+            "example": ["task-1", "task-2"]
           },
           "pr": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 42
           },
           "hours": {
-            "type": [
-              "number",
-              "null"
-            ],
+            "type": ["number", "null"],
             "example": 5.5
           },
           "startedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "prCreatedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-03T00:00:00.000Z"
           },
           "mergedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-04T00:00:00.000Z"
           },
           "blockedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "blockedReason": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "Waiting on dependency"
           },
           "note": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "Some notes"
           },
           "type": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "feature"
           },
           "priority": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "high"
           },
           "cancelledAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "completedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-05T00:00:00.000Z"
           },
           "deployingAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "deployedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-06T00:00:00.000Z"
           },
           "ciFixAttempts": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 2
           },
           "mergeCommit": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "abc123def456"
           },
           "prUrl": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "https://github.com/org/repo/pull/42"
           },
           "assignee": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "user@example.com"
           },
           "issue": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "GH-123"
           },
           "model": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "sonnet"
           },
           "complexity": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 7
           },
           "hitl": {
-            "type": [
-              "boolean",
-              "null"
-            ],
+            "type": ["boolean", "null"],
             "example": true
           },
           "hitlNotifiedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "claimedBy": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "agent-id-123"
           },
           "agentHint": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "prefer-sonnet"
           },
           "claimedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "heartbeatAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-06T12:00:00.000Z"
           },
           "simplifyTotal": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 10
           },
           "simplifyDry": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 2
           },
           "simplifyDeadCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 3
           },
           "simplifyNaming": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 1
           },
           "simplifyComplexity": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 2
           },
           "simplifyConsistency": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 2
           },
           "coverageDelta": {
-            "type": [
-              "number",
-              "null"
-            ],
+            "type": ["number", "null"],
             "example": 5.5
           },
           "effortLevel": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "medium"
           },
           "inputTokens": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 1000
           },
           "outputTokens": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 500
           },
           "cacheReadTokens": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 100
           },
           "cacheCreationTokens": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "example": 50
           },
           "costUsd": {
-            "type": [
-              "number",
-              "null"
-            ],
+            "type": ["number", "null"],
             "example": 0.02
           },
           "metadata": {
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": ["object", "null"],
             "additionalProperties": {},
             "example": {
               "customKey": "customValue"
@@ -1961,13 +1734,7 @@
             "example": "2026-01-06T12:00:00.000Z"
           }
         },
-        "required": [
-          "id",
-          "title",
-          "status",
-          "createdAt",
-          "updatedAt"
-        ]
+        "required": ["id", "title", "status", "createdAt", "updatedAt"]
       },
       "TaskListResponse": {
         "type": "object",
@@ -1983,10 +1750,7 @@
             "example": 10
           }
         },
-        "required": [
-          "tasks",
-          "total"
-        ]
+        "required": ["tasks", "total"]
       },
       "Error": {
         "type": "object",
@@ -1996,9 +1760,7 @@
             "example": "not found"
           }
         },
-        "required": [
-          "error"
-        ]
+        "required": ["error"]
       },
       "CreateTaskBody": {
         "type": "object",
@@ -2014,10 +1776,7 @@
             "example": "pending"
           },
           "repo": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "org/repo"
           },
           "session": {
@@ -2085,16 +1844,10 @@
               "type": "string"
             },
             "description": "IDs of tasks skipped because they already exist (Prisma P2002 unique constraint collision).",
-            "example": [
-              "entropy-dead_exports-other-repo-2026-W29"
-            ]
+            "example": ["entropy-dead_exports-other-repo-2026-W29"]
           }
         },
-        "required": [
-          "inserted",
-          "updated",
-          "skipped"
-        ]
+        "required": ["inserted", "updated", "skipped"]
       },
       "BulkInsertBody": {
         "type": "array",
@@ -2112,10 +1865,7 @@
               "example": "pending"
             },
             "repo": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "example": "org/repo"
             }
           }
@@ -2129,24 +1879,17 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "session-1"
-            ]
+            "example": ["session-1"]
           },
           "repos": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "example": [
-              "org/repo"
-            ]
+            "example": ["org/repo"]
           }
         },
-        "required": [
-          "sessions",
-          "repos"
-        ]
+        "required": ["sessions", "repos"]
       },
       "UpdateTaskBody": {
         "type": "object",
@@ -2178,17 +1921,11 @@
             "example": "clxtoken123456"
           },
           "label": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "ci-runner"
           },
           "agentId": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "agent-id-123"
           },
           "createdAt": {
@@ -2197,18 +1934,12 @@
             "example": "2026-01-01T00:00:00.000Z"
           },
           "revokedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time",
             "example": null
           }
         },
-        "required": [
-          "id",
-          "createdAt"
-        ]
+        "required": ["id", "createdAt"]
       },
       "TaskTokenWithRaw": {
         "allOf": [
@@ -2223,9 +1954,7 @@
                 "example": "raw-token-value-shown-once"
               }
             },
-            "required": [
-              "rawToken"
-            ]
+            "required": ["rawToken"]
           }
         ]
       },
@@ -2258,10 +1987,7 @@
             "example": 42
           },
           "taskId": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "clx1234567890"
           },
           "staged": {
@@ -2271,30 +1997,18 @@
           },
           "state": {
             "type": "string",
-            "enum": [
-              "open",
-              "merged",
-              "closed"
-            ],
+            "enum": ["open", "merged", "closed"],
             "default": "open",
             "example": "open"
           },
           "reviewState": {
             "type": "string",
-            "enum": [
-              "pending",
-              "in_progress",
-              "posted",
-              "approved"
-            ],
+            "enum": ["pending", "in_progress", "posted", "approved"],
             "default": "pending",
             "example": "pending"
           },
           "commitSha": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "abc123def456"
           },
           "patchCycles": {
@@ -2308,93 +2022,53 @@
             "example": 0
           },
           "agentId": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "agent-id-123"
           },
           "reviewedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-03T00:00:00.000Z"
           },
           "patchedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "mergedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "prCreatedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "ISO timestamp of the GitHub PR's actual creation time. Set once via POST /prs/claim (first claim only); read-only thereafter.",
             "example": "2026-01-01T00:00:00.000Z"
           },
           "claimedBy": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "agent-id-123"
           },
           "claimedAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "heartbeatAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-06T12:00:00.000Z"
           },
           "phase": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "enum": [
-              "review",
-              "patch",
-              "deploy"
-            ],
+            "type": ["string", "null"],
+            "enum": ["review", "patch", "deploy"],
             "example": "review"
           },
           "readyForReviewAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": "2026-01-02T00:00:00.000Z"
           },
           "readyForPatchAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "readyForDeployAt": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "example": null
           },
           "createdAt": {
@@ -2408,13 +2082,7 @@
             "example": "2026-01-06T12:00:00.000Z"
           }
         },
-        "required": [
-          "id",
-          "repo",
-          "prNumber",
-          "createdAt",
-          "updatedAt"
-        ]
+        "required": ["id", "repo", "prNumber", "createdAt", "updatedAt"]
       },
       "PrListResponse": {
         "type": "object",
@@ -2439,12 +2107,7 @@
             "example": 0
           }
         },
-        "required": [
-          "prs",
-          "total",
-          "limit",
-          "offset"
-        ]
+        "required": ["prs", "total", "limit", "offset"]
       },
       "ClaimPrBody": {
         "type": "object",
@@ -2476,11 +2139,7 @@
           },
           "phase": {
             "type": "string",
-            "enum": [
-              "review",
-              "patch",
-              "deploy"
-            ],
+            "enum": ["review", "patch", "deploy"],
             "description": "Pipeline phase this claim is for (defaults to 'review' when omitted)",
             "example": "patch"
           },
@@ -2490,11 +2149,7 @@
             "example": "2026-01-01T00:00:00.000Z"
           }
         },
-        "required": [
-          "repo",
-          "prNumber",
-          "commitSha"
-        ]
+        "required": ["repo", "prNumber", "commitSha"]
       },
       "ClaimNextResponse": {
         "type": "object",
@@ -2504,18 +2159,11 @@
           },
           "phase": {
             "type": "string",
-            "enum": [
-              "review",
-              "patch",
-              "deploy"
-            ],
+            "enum": ["review", "patch", "deploy"],
             "example": "review"
           }
         },
-        "required": [
-          "pr",
-          "phase"
-        ]
+        "required": ["pr", "phase"]
       },
       "ClaimNextBody": {
         "type": "object",

--- a/task-store/prisma/migrations/20260716150000_drop_task_added_at/migration.sql
+++ b/task-store/prisma/migrations/20260716150000_drop_task_added_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Task" DROP COLUMN "addedAt";

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -55,7 +55,6 @@ model Task {
   dependencies       String[]
   pr                 Int?
   hours              Float?
-  addedAt            String?
   startedAt          String?
   prCreatedAt        String?
   mergedAt           String?

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -112,7 +112,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     dependencies: [],
     pr: null,
     hours: null,
-    addedAt: null,
     startedAt: null,
     prCreatedAt: null,
     mergedAt: null,

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -68,7 +68,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     dependencies: [],
     pr: null,
     hours: null,
-    addedAt: null,
     startedAt: null,
     prCreatedAt: null,
     mergedAt: null,

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -74,11 +74,6 @@ export const TaskSchema = z
       .openapi({ example: ["task-1", "task-2"] }),
     pr: z.number().int().nullable().optional().openapi({ example: 42 }),
     hours: z.number().nullable().optional().openapi({ example: 5.5 }),
-    addedAt: z
-      .string()
-      .nullable()
-      .optional()
-      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
     startedAt: z
       .string()
       .nullable()

--- a/task-store/src/openapi-schemas.unit.test.ts
+++ b/task-store/src/openapi-schemas.unit.test.ts
@@ -35,7 +35,6 @@ const validTask = {
   dependencies: ["task-1", "task-2"],
   pr: 42,
   hours: 5.5,
-  addedAt: yesterday,
   startedAt: yesterday,
   prCreatedAt: yesterday,
   mergedAt: null,

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -30,7 +30,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     dependencies: [],
     pr: null,
     hours: null,
-    addedAt: null,
     startedAt: null,
     prCreatedAt: null,
     mergedAt: null,

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -62,7 +62,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     dependencies: [],
     pr: null,
     hours: null,
-    addedAt: null,
     startedAt: null,
     prCreatedAt: null,
     mergedAt: null,

--- a/task-store/src/tasks.execution-fields.smoke.test.ts
+++ b/task-store/src/tasks.execution-fields.smoke.test.ts
@@ -62,7 +62,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     dependencies: [],
     pr: null,
     hours: null,
-    addedAt: null,
     startedAt: null,
     prCreatedAt: null,
     mergedAt: null,

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -52,7 +52,6 @@ describeOrSkip("Task store schema (integration)", () => {
         dependencies: ["TSS-0", "TSS-0b"],
         pr: 42,
         hours: 3.5,
-        addedAt: "2026-06-22T10:00:00.000Z",
         startedAt: "2026-06-22T11:00:00.000Z",
         prCreatedAt: "2026-06-22T12:00:00.000Z",
         mergedAt: "2026-06-22T13:00:00.000Z",
@@ -112,7 +111,6 @@ describeOrSkip("Task store schema (integration)", () => {
     expect(read.dependencies).toEqual(["TSS-0", "TSS-0b"]);
     expect(read.pr).toBe(42);
     expect(read.hours).toBe(3.5);
-    expect(read.addedAt).toBe("2026-06-22T10:00:00.000Z");
     expect(read.startedAt).toBe("2026-06-22T11:00:00.000Z");
     expect(read.prCreatedAt).toBe("2026-06-22T12:00:00.000Z");
     expect(read.mergedAt).toBe("2026-06-22T13:00:00.000Z");

--- a/task-store/src/validate.smoke.test.ts
+++ b/task-store/src/validate.smoke.test.ts
@@ -95,7 +95,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     dependencies: [],
     pr: null,
     hours: null,
-    addedAt: null,
     startedAt: null,
     prCreatedAt: null,
     mergedAt: null,


### PR DESCRIPTION
## Summary
- Drops the `addedAt` column from the task-store `Task` model — the final "remove" step of the add→migrate→remove `addedAt` → `createdAt` rollout (Group 4 of the loop-fixes session). Removes the field from `schema.prisma`, `openapi-schemas.ts`, regenerates `lib/task-store-types.ts` and `task-store/openapi.json`, and adds a hand-written Prisma migration (`DROP COLUMN`, no live DB available in-sandbox to generate against).
- **Discovered gap (in scope):** `plugins/shipwright/scripts/check-dev-task.ts` was still actively sorting ready tasks by `task.addedAt` for FIFO selection — this reader was never migrated by the prior LPF-4.1/3.2/4.3/4.4/4.5 tasks. Dropping the column without fixing it would have silently broken FIFO ordering (the `"" < ""` degenerate case), reintroducing the exact null-poisons-FIFO bug this whole initiative exists to fix. Fixed to sort by `createdAt`, matching the already-migrated pattern in `agent/src/work-selector.ts`. Removed the now-vestigial `addedAt` type fields from both `check-helpers.ts` files.
- Updated all 8 affected test fixtures/assertions (7 listed in the task + `validate.smoke.test.ts`, found via grep) at their existing test layers — no new layer needed since this is field removal, not new behavior.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `schema.prisma` drops `addedAt`; migration exists | ✅ MET |
| 2 | `openapi-schemas.ts` `TaskSchema` drops `addedAt` | ✅ MET |
| 3 | `lib/task-store-types.ts` regenerated (not hand-edited) | ✅ MET |
| 4 | `docs/mcp-tools.md` regenerated if referenced | ✅ MET (no diff — never referenced `addedAt`) |
| 5 | 7 listed test files updated; typecheck/coverage gate passes with field gone | ✅ MET |
| 6 | `check-dev-task.ts` FIFO reader migrated to `createdAt` (discovered gap, in scope) | ✅ MET |

## Test Plan
- [x] TDD: `check-dev-task.unit.test.ts` FIFO test confirmed RED against pre-fix code (wrong task selected), GREEN after the fix
- [x] Full `bun test`: 4021 pass / 0 fail
- [x] Full `bun run --filter='*' --sequential typecheck`: clean across all 7 workspaces (no stale `addedAt` references against regenerated Prisma/openapi types)
- [x] `bunx biome lint .`: clean
- [x] `task check-strings`, `check-config-docs`, `check-version-sync`: pass
- [x] Coverage gate (`task test:coverage`): 79.26% lines vs 80% threshold — pre-existing sandbox gap (no test DB skips integration tests), confirmed identical on clean `main` (79.27%); not a regression from this change
- [ ] **Migration not applied against a live Postgres** — no DB available in this sandbox. SQL is standard `ALTER TABLE ... DROP COLUMN` matching the exact column name/casing from `schema.prisma`; applies automatically via `prisma migrate deploy` on the existing Helm hook at deploy time. **Please review the migration file before merge** — this drops a column from a live production table with existing data.

Generated with [Claude Code](https://claude.com/claude-code)
