### PR TITLE
fix: skip GA4 on localhost to prevent dev traffic in production analytics

### DIFF
--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -3,13 +3,13 @@
 // so every page is tracked. The Measurement ID is public by design — it ships
 // in the client-side tag — so committing it here is expected, not a secret leak.
 //
-// This is the site’s ONLY first-party runtime JS; the marketing pages are
+// This is the site's ONLY first-party runtime JS; the marketing pages are
 // otherwise zero-JS. The home e2e suite asserts no <script> exists beyond this
 // analytics tag (see site/tests/home.spec.ts).
-const GA_MEASUREMENT_ID = "G-QW5TVSWS5TVR713J";
+const GA_MEASUREMENT_ID = "G-WS5TVR713J";
 ---
 
-<!-- Google tag (gtag.js) -- GA4 -->
+<!-- Google tag (gtag.js) — GA4 -->
 <script
   is:inline
   async

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -3,22 +3,30 @@
 // so every page is tracked. The Measurement ID is public by design — it ships
 // in the client-side tag — so committing it here is expected, not a secret leak.
 //
-// This is the site's ONLY first-party runtime JS; the marketing pages are
+// This is the site’s ONLY first-party runtime JS; the marketing pages are
 // otherwise zero-JS. The home e2e suite asserts no <script> exists beyond this
 // analytics tag (see site/tests/home.spec.ts).
-const GA_MEASUREMENT_ID = "G-WS5TVR713J";
+const GA_MEASUREMENT_ID = "G-QW5TVSWS5TVR713J";
 ---
 
-<!-- Google tag (gtag.js) — GA4 -->
+<!-- Google tag (gtag.js) -- GA4 -->
 <script
   is:inline
   async
   src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
 <script define:vars={{ GA_MEASUREMENT_ID }}>
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-    dataLayer.push(arguments);
+  // Skip analytics on localhost / dev to avoid polluting production data.
+  if (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  ) {
+    // no-op: do not initialize GA4
+  } else {
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
+    gtag("config", GA_MEASUREMENT_ID);
   }
-  gtag("js", new Date());
-  gtag("config", GA_MEASUREMENT_ID);
 </script>


### PR DESCRIPTION
## What

Adds a hostname guard to `Analytics.astro` so GA4 does not initialize when the site is served from `localhost` or `127.0.0.1`.

## Why

Discovered that `shipwrightharness.com`'s GA4 property was receiving ~2,974 events/week tagged with `hostname=localhost` — causing a false 17,835% spike in the GA4 dashboard. Real human traffic is only ~19 users/week. The dev environment (or a headless test runner) was loading the site locally with the production GA4 measurement ID and firing events on every page load.

## Change

```astro
if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
  // no-op: do not initialize GA4
} else {
  // initialize GA4 as before
}
```

No behavior change in production. Zero GA4 calls in local dev.

Co-Authored-By: Sully <sully@app-vitals.com>