### PR TITLE
chore(chart): bump chart version to 1.6.419

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.419] - 2026-07-16
+
+### Changed
+
+- auto-bump to chart v1.6.419 triggered by release tag(s): `metrics-v0.168.0`
+
 ## [1.6.418] - 2026-07-16
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.418
+version: 1.6.419
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,15 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.418 triggered by release tag admin-v0.212.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.418 triggered by release tag agent-v0.208.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.418 triggered by release tag chat-v0.53.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.418 triggered by release tag metrics-v0.167.0"
-    - kind: changed
-      description: "auto-bump to chart v1.6.418 triggered by release tag task-store-v0.109.0"
+      description: "auto-bump to chart v1.6.419 triggered by release tag metrics-v0.168.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -182,7 +182,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v0.167.0
+    tag: metrics-v0.168.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.6.418 → 1.6.419

**Triggering tags:**
- `metrics-v0.168.0`

**New chart version:** `1.6.419`

**Pinned in values.yaml:**
- `metrics.image.tag`: `metrics-v0.168.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.6.419 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._