### PR TITLE
fix(task-store): release PR claim in the same write that posts or approves a review

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -252,6 +252,8 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 
 **Side effect:** When `state` is set to `merged` or `closed`, the claim fields (`claimedBy`, `claimedAt`, `heartbeatAt`, `phase`) are automatically cleared. This ensures that merged or closed PRs are no longer held by an agent claim.
 
+**Side effect:** When `reviewState` is set to `posted` or `approved`, the claim fields (`claimedBy`, `claimedAt`, `heartbeatAt`, `phase`) are cleared in the same write. This releases the review claim as soon as the review is done, so a PR awaiting patch/deploy is not held by a stale claim that the reaper would otherwise reap (which would regress `reviewState` and re-dispatch a duplicate review).
+
 #### PR lifecycle endpoints
 
 | Endpoint | Effect |

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -181,6 +181,20 @@ export class PullRequestService implements PullRequestServiceLike {
         }
       }
 
+      // When a review session transitions reviewState to 'posted' or
+      // 'approved' it is done with the record, so release its claim in the same
+      // write — mirroring the state:'merged' block below. Review skills
+      // historically left claimedBy/claimedAt/heartbeatAt/phase set and relied
+      // on a follow-up release call that agents often skipped; a claim left
+      // dangling past the reaper TTL then got reaped and its reviewState
+      // regressed, re-dispatching a duplicate review (app-vitals/shipwright#1016).
+      if (data.reviewState === "posted" || data.reviewState === "approved") {
+        updateData.claimedBy = null;
+        updateData.claimedAt = null;
+        updateData.heartbeatAt = null;
+        updateData.phase = null;
+      }
+
       // deploy.md's merge-completion PATCH transitions state to 'merged' —
       // explicitly release the claim in the same call, mirroring patch()'s
       // always-release behavior. Defense-in-depth: claimNext()'s WHERE clause
@@ -352,7 +366,7 @@ export class PullRequestService implements PullRequestServiceLike {
     }
   }
 
-  /** Mark a PR review as posted. Increments reviewCycles, sets reviewState=posted, reviewedAt, and readyForPatchAt. */
+  /** Mark a PR review as posted. Increments reviewCycles, sets reviewState=posted, reviewedAt, and readyForPatchAt, and releases the claim. */
   async complete(id: string): Promise<PullRequest> {
     const now = this.clock.now().toISOString();
     try {
@@ -363,6 +377,16 @@ export class PullRequestService implements PullRequestServiceLike {
           reviewState: "posted",
           reviewedAt: now,
           readyForPatchAt: now,
+          // The review session is done with the record, so release its claim in
+          // the same write — mirroring update()'s posted/approved release. This
+          // is the path the review flow actually uses (POST /prs/:id/complete),
+          // so without the clear the claim lingers until the reaper TTL and the
+          // stale-claim reap re-dispatches a duplicate review
+          // (app-vitals/shipwright#1016).
+          claimedBy: null,
+          claimedAt: null,
+          heartbeatAt: null,
+          phase: null,
         },
       });
     } catch (err: unknown) {

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -359,3 +359,152 @@ describe("PullRequestService.update() merge completion", () => {
     expect("phase" in data).toBe(false);
   });
 });
+
+describe("PullRequestService.update() claim release on review post", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  test("reviewState:posted clears claimedBy/claimedAt/heartbeatAt/phase in the same write", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.update("pr-1", { reviewState: "posted" });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("posted");
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+    expect(data.phase).toBeNull();
+  });
+
+  test("reviewState:approved clears claim fields AND stamps readyForDeployAt", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      claimedBy: "agent-a",
+      readyForDeployAt: null,
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.update("pr-1", { reviewState: "approved" });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("approved");
+    expect(data.readyForDeployAt).toBe(NOW.toISOString());
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+    expect(data.phase).toBeNull();
+  });
+
+  test("auto-release wins over claim fields set in the same posted PATCH body", async () => {
+    // The release is unconditional, mirroring the state:'merged' block, so any
+    // claim field supplied in the same posted/approved PATCH is overwritten with
+    // null. (In practice the route allowlist already drops claimedBy/claimedAt/
+    // heartbeatAt; only phase is writable and it too gets nulled here.)
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.update("pr-1", {
+      reviewState: "posted",
+      claimedBy: "agent-b",
+      phase: "patch",
+    });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("posted");
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+    expect(data.phase).toBeNull();
+  });
+
+  test("update that does not touch reviewState leaves claim fields alone", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.update("pr-1", { staged: true });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect("claimedBy" in data).toBe(false);
+    expect("claimedAt" in data).toBe(false);
+    expect("heartbeatAt" in data).toBe(false);
+    expect("phase" in data).toBe(false);
+  });
+
+  test("re-asserting an already-posted reviewState still (idempotently) clears claim fields", async () => {
+    // Behavior choice: the release keys off the incoming reviewState value, not
+    // a state transition, so a redundant PATCH to 'posted' also clears the claim
+    // fields. This is harmless — an already-released claim is written null→null —
+    // and keeps the rule simple: "posted/approved ⇒ no claim".
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      reviewState: "posted",
+      claimedBy: null,
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.update("pr-1", { reviewState: "posted" });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("posted");
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+    expect(data.phase).toBeNull();
+  });
+});
+
+describe("PullRequestService.complete() claim release", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  test("complete() clears claimedBy/claimedAt/heartbeatAt/phase in the same write", async () => {
+    // complete() is the path the review flow actually uses
+    // (POST /prs/:id/complete); it must release the claim in the same write, not
+    // leave it for the reaper.
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      claimedBy: "agent-a",
+      phase: "review",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.complete("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+    expect(data.phase).toBeNull();
+  });
+
+  test("complete() preserves existing posted-review behavior (reviewCycles/reviewState/reviewedAt/readyForPatchAt)", async () => {
+    const prisma = makePrismaDouble({ id: "pr-1" } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.complete("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewCycles).toEqual({ increment: 1 });
+    expect(data.reviewState).toBe("posted");
+    expect(data.reviewedAt).toBe(NOW.toISOString());
+    expect(data.readyForPatchAt).toBe(NOW.toISOString());
+  });
+});

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -9,9 +9,12 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { PrismaClient } from "../prisma/client/index.js";
+import { createTaskStoreApp } from "./app.ts";
 import { FixedClock } from "./clock.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import { PullRequestService } from "./pull-request-service.ts";
+import { TaskService } from "./task-service.ts";
+import { TaskTokenService } from "./token-service.ts";
 
 const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
 
@@ -1326,6 +1329,125 @@ describeOrSkip(
         caught = err;
       }
       expect(caught).toBeInstanceOf(NotFoundError);
+    });
+  },
+);
+
+// ─── review-completion claim release via the HTTP route layer ─────────────────
+// Drives the exact endpoints a review session uses — POST /prs/:id/complete
+// (the posted path, verified in production as the real review flow) and
+// PATCH /prs/:id (the approved path) — through the Hono app with a real
+// PullRequestService, and reads the row back to prove the claim was released in
+// the same write rather than left for the reaper.
+
+describeOrSkip(
+  "PR review-completion claim release (integration, route layer)",
+  () => {
+    let prisma: PrismaClient;
+    let app: ReturnType<typeof createTaskStoreApp>;
+    let rawToken: string;
+
+    beforeEach(async () => {
+      prisma = makePrisma();
+      await prisma.taskToken.deleteMany();
+      await prisma.pullRequest.deleteMany();
+
+      const tokenService = new TaskTokenService(prisma);
+      rawToken = (await tokenService.create("integration")).rawToken;
+
+      app = createTaskStoreApp({
+        taskService: new TaskService(prisma),
+        tokenService,
+        pullRequestService: new PullRequestService(prisma),
+      });
+    });
+
+    afterEach(async () => {
+      await prisma.$disconnect();
+    });
+
+    function auth(): Record<string, string> {
+      return {
+        Authorization: `Bearer ${rawToken}`,
+        "content-type": "application/json",
+      };
+    }
+
+    async function seedClaimedReviewPr(prNumber: number): Promise<string> {
+      const now = new Date().toISOString();
+      const pr = await prisma.pullRequest.create({
+        data: {
+          repo: "app-vitals/shipwright",
+          prNumber,
+          commitSha: "sha-review",
+          reviewState: "in_progress",
+          phase: "review",
+          claimedBy: "agent-reviewer",
+          claimedAt: now,
+          heartbeatAt: now,
+        },
+      });
+      return pr.id;
+    }
+
+    it("POST /prs/:id/complete posts the review and releases the claim in the same write", async () => {
+      const id = await seedClaimedReviewPr(3100);
+
+      const res = await app.request(`/prs/${id}/complete`, {
+        method: "POST",
+        headers: auth(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as {
+        reviewState: string;
+        reviewCycles: number;
+        reviewedAt: string | null;
+        readyForPatchAt: string | null;
+        claimedBy: string | null;
+        claimedAt: string | null;
+        heartbeatAt: string | null;
+        phase: string | null;
+      };
+      expect(body.reviewState).toBe("posted");
+      expect(body.reviewCycles).toBe(1);
+      expect(body.reviewedAt).not.toBeNull();
+      expect(body.readyForPatchAt).not.toBeNull();
+      expect(body.claimedBy).toBeNull();
+      expect(body.claimedAt).toBeNull();
+      expect(body.heartbeatAt).toBeNull();
+      expect(body.phase).toBeNull();
+
+      // Read the row back to confirm the release is persisted, not just serialized.
+      const row = await prisma.pullRequest.findUnique({ where: { id } });
+      expect(row).not.toBeNull();
+      if (!row) return;
+      expect(row.reviewState).toBe("posted");
+      expect(row.claimedBy).toBeNull();
+      expect(row.claimedAt).toBeNull();
+      expect(row.heartbeatAt).toBeNull();
+      expect(row.phase).toBeNull();
+    });
+
+    it("PATCH /prs/:id to approved releases the claim and stamps readyForDeployAt", async () => {
+      const id = await seedClaimedReviewPr(3101);
+
+      const res = await app.request(`/prs/${id}`, {
+        method: "PATCH",
+        headers: auth(),
+        body: JSON.stringify({ reviewState: "approved" }),
+      });
+      expect(res.status).toBe(200);
+
+      const row = await prisma.pullRequest.findUnique({ where: { id } });
+      expect(row).not.toBeNull();
+      if (!row) return;
+      expect(row.reviewState).toBe("approved");
+      expect(row.readyForDeployAt).not.toBeNull();
+      expect(row.claimedBy).toBeNull();
+      expect(row.claimedAt).toBeNull();
+      expect(row.heartbeatAt).toBeNull();
+      expect(row.phase).toBeNull();
     });
   },
 );

--- a/task-store/src/stale-claim-reaper.integration.test.ts
+++ b/task-store/src/stale-claim-reaper.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * task-store/src/stale-claim-reaper.integration.test.ts
+ *
+ * Integration tests for StaleClaimReaper against a real Postgres DB. Verifies
+ * the phase/reviewState-aware reap semantics end to end (raw SQL CASE + WHERE
+ * behaviour that the unit tests can only assert on as SQL text).
+ *
+ * Requires DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST to be set; skips otherwise.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { FixedClock } from "./clock.ts";
+import { StaleClaimReaper } from "./stale-claim-reaper.ts";
+
+const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+const DEFAULT_TTL_MS = 2_100_000;
+
+describeOrSkip("StaleClaimReaper PR reaping (integration)", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  // Well past the TTL window → stale; comfortably within it → fresh.
+  const STALE = new Date(
+    NOW.getTime() - DEFAULT_TTL_MS - 5 * 60_000,
+  ).toISOString();
+  const FRESH = new Date(NOW.getTime() - 60_000).toISOString();
+
+  let prisma: PrismaClient;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    await prisma.pullRequest.deleteMany();
+  });
+
+  it("releases stale claims, regressing only pending/in_progress reviewState and preserving posted/approved", async () => {
+    // Four stale-claimed rows, one per reviewState, plus a fresh-claimed control.
+    await prisma.pullRequest.createMany({
+      data: [
+        {
+          repo: "app-vitals/shipwright",
+          prNumber: 2001,
+          reviewState: "pending",
+          phase: "review",
+          claimedBy: "agent-stale",
+          claimedAt: STALE,
+          heartbeatAt: STALE,
+        },
+        {
+          repo: "app-vitals/shipwright",
+          prNumber: 2002,
+          reviewState: "in_progress",
+          phase: "review",
+          claimedBy: "agent-stale",
+          claimedAt: STALE,
+          heartbeatAt: STALE,
+        },
+        {
+          repo: "app-vitals/shipwright",
+          prNumber: 2003,
+          reviewState: "posted",
+          phase: "review",
+          claimedBy: "agent-stale",
+          claimedAt: STALE,
+          heartbeatAt: STALE,
+        },
+        {
+          repo: "app-vitals/shipwright",
+          prNumber: 2004,
+          reviewState: "approved",
+          phase: "review",
+          claimedBy: "agent-stale",
+          claimedAt: STALE,
+          heartbeatAt: STALE,
+        },
+        {
+          repo: "app-vitals/shipwright",
+          prNumber: 2005,
+          reviewState: "in_progress",
+          phase: "review",
+          claimedBy: "agent-fresh",
+          claimedAt: FRESH,
+          heartbeatAt: FRESH,
+        },
+      ],
+    });
+
+    const reaper = new StaleClaimReaper(prisma, FixedClock(NOW));
+    const reaped = await reaper.reap();
+
+    // Four stale PRs reaped; the fresh control is not.
+    expect(reaped).toBe(4);
+
+    const byNumber = async (prNumber: number) => {
+      const row = await prisma.pullRequest.findUnique({
+        where: { repo_prNumber: { repo: "app-vitals/shipwright", prNumber } },
+      });
+      if (!row) throw new Error(`expected PR ${prNumber} to exist`);
+      return row;
+    };
+
+    // pending + in_progress → regressed to pending, claim released.
+    for (const prNumber of [2001, 2002]) {
+      const row = await byNumber(prNumber);
+      expect(row.reviewState).toBe("pending");
+      expect(row.claimedBy).toBeNull();
+      expect(row.claimedAt).toBeNull();
+      expect(row.heartbeatAt).toBeNull();
+      expect(row.phase).toBeNull();
+    }
+
+    // posted → reviewState preserved, claim released.
+    const posted = await byNumber(2003);
+    expect(posted.reviewState).toBe("posted");
+    expect(posted.claimedBy).toBeNull();
+    expect(posted.claimedAt).toBeNull();
+    expect(posted.heartbeatAt).toBeNull();
+    expect(posted.phase).toBeNull();
+
+    // approved → reviewState preserved, claim released.
+    const approved = await byNumber(2004);
+    expect(approved.reviewState).toBe("approved");
+    expect(approved.claimedBy).toBeNull();
+    expect(approved.claimedAt).toBeNull();
+    expect(approved.heartbeatAt).toBeNull();
+    expect(approved.phase).toBeNull();
+
+    // Fresh control → completely untouched.
+    const fresh = await byNumber(2005);
+    expect(fresh.reviewState).toBe("in_progress");
+    expect(fresh.claimedBy).toBe("agent-fresh");
+    expect(fresh.claimedAt).toBe(FRESH);
+    expect(fresh.heartbeatAt).toBe(FRESH);
+    expect(fresh.phase).toBe("review");
+  });
+});

--- a/task-store/src/stale-claim-reaper.ts
+++ b/task-store/src/stale-claim-reaper.ts
@@ -59,10 +59,16 @@ export class StaleClaimReaper {
         )
     `;
 
+    // A stale PR claim always releases its claim fields, but reviewState only
+    // regresses to 'pending' when it is still 'pending'/'in_progress' (an
+    // unfinished review). A record already at 'posted'/'approved' keeps its
+    // reviewState — regressing it there re-dispatches a duplicate review
+    // (app-vitals/shipwright#1016).
     const prsAffected = await this.prisma.$executeRaw`
       UPDATE "PullRequest"
       SET "reviewState" = CASE
-            WHEN "phase" = 'review' THEN 'pending'::"PrReviewState"
+            WHEN "reviewState" IN ('pending', 'in_progress')
+              THEN 'pending'::"PrReviewState"
             ELSE "reviewState"
           END,
           "claimedBy" = NULL,

--- a/task-store/src/stale-claim-reaper.unit.test.ts
+++ b/task-store/src/stale-claim-reaper.unit.test.ts
@@ -275,8 +275,11 @@ describe("StaleClaimReaper", () => {
     const prSql = prisma._calls[1].strings.join("?");
     // Should filter by claimedBy IS NOT NULL, not reviewState = 'in_progress'
     expect(prSql).toContain('"claimedBy" IS NOT NULL');
-    // Should NOT use reviewState = 'in_progress' as the primary filter anymore
-    expect(prSql).not.toContain("'in_progress'");
+    // The WHERE clause must not gate on reviewState — every stale claim is
+    // released regardless of its reviewState (reviewState only governs whether
+    // the reset-to-pending happens, via the SET CASE, not whether we act).
+    const whereClause = prSql.slice(prSql.indexOf("WHERE"));
+    expect(whereClause).not.toContain('"reviewState"');
   });
 
   test("PR reap resets phase=null and clears claim fields", async () => {
@@ -292,18 +295,39 @@ describe("StaleClaimReaper", () => {
     expect(prSql).toContain('"phase" = NULL');
   });
 
-  test("PR reap does not blindly reset reviewState to pending — uses CASE based on phase", async () => {
+  test("PR reap does not blindly reset reviewState to pending — uses CASE based on reviewState", async () => {
     const prisma = makePrismaDouble([0, 1]);
     const reaper = new StaleClaimReaper(prisma as never, clock);
 
     await reaper.reap();
 
     const prSql = prisma._calls[1].strings.join("?");
-    // Should use a CASE expression that only resets to pending when phase was 'review'
-    // and preserves 'posted'/'approved' for patch/deploy items
+    // Should use a CASE expression that only resets to pending when reviewState
+    // is still 'pending'/'in_progress' and preserves 'posted'/'approved'.
     expect(prSql).toContain("CASE");
-    expect(prSql).toContain("'review'");
+    expect(prSql).toContain('"reviewState" IN');
+    expect(prSql).toContain("'in_progress'");
     expect(prSql).toContain("'pending'");
+    expect(prSql).toContain('ELSE "reviewState"');
+  });
+
+  test("PR reap preserves posted/approved reviewState but still clears claim fields", async () => {
+    const prisma = makePrismaDouble([0, 1]);
+    const reaper = new StaleClaimReaper(prisma as never, clock);
+
+    await reaper.reap();
+
+    const prSql = prisma._calls[1].strings.join("?");
+    // reviewState regresses to pending only for pending/in_progress; posted and
+    // approved fall through the ELSE branch and keep their value (no duplicate
+    // review re-dispatch).
+    expect(prSql).toContain('WHEN "reviewState" IN');
+    expect(prSql).toContain('ELSE "reviewState"');
+    // Claim fields are released for every stale claim regardless of reviewState.
+    expect(prSql).toContain('"claimedBy" = NULL');
+    expect(prSql).toContain('"claimedAt" = NULL');
+    expect(prSql).toContain('"heartbeatAt" = NULL');
+    expect(prSql).toContain('"phase" = NULL');
   });
 
   // ─── 2_100_000ms unified default TTL boundary ──────────────────────────────
@@ -350,10 +374,11 @@ describe("StaleClaimReaper", () => {
       true,
     );
 
-    // The reaper resets reviewState to 'pending' for phase='review' claims via CASE.
+    // The reaper resets reviewState to 'pending' for pending/in_progress claims via CASE.
     const prSql = prisma._calls[1].strings.join("?");
     expect(prSql).toContain("CASE");
-    expect(prSql).toContain("'review'");
+    expect(prSql).toContain('"reviewState" IN');
+    expect(prSql).toContain("'in_progress'");
     expect(prSql).toContain("'pending'");
   });
 


### PR DESCRIPTION
## Problem

A review session never releases the PR claim it holds. It transitions the PR to `posted` (via `POST /prs/:id/complete`) or `approved` (via `PATCH /prs/:id`) and then exits, leaving `claimedBy`/`claimedAt`/`heartbeatAt`/`phase` set. Once that claim ages past the `StaleClaimReaper` TTL, the reaper's sweep releases it — and, because the reap keyed the reset on `phase = 'review'`, it also regressed `reviewState` back to `pending`. A reviewed-but-unmerged PR then looks like fresh review work and gets a duplicate review dispatched against it.

This is the failure behind #1016 (5 duplicate reviews of one PR over ~9h). #1050 and #1369 lengthened the claim/reaper TTLs, which widens the window but does not fix the semantics: any PR that stays unmerged longer than one TTL still re-triggers the bug. On a self-hosted setup with a human merge gate, PRs routinely sit reviewed-but-unmerged for longer than a TTL, so the regression fires reliably.

## Evidence from my deployment

I run a self-hosted agent with a human merge gate. A concrete instance:

- 05:02 — review completed, `reviewState` set to `posted`; the claim was never released.
- ~05:47 — the TTL sweep reaped the stale claim and regressed `posted` -> `pending`.
- 05:48 — a duplicate review was dispatched on the same head SHA. It re-reviewed an already-reviewed PR and posted nothing new, at a cost of ~814K wasted input tokens.

After deploying this change I observed review completions clearing the claim in the same write (a `reviewCycles` increment with the claim fields going null under a single `updatedAt`), and a full TTL window elapsed with no duplicate review dispatched.

One note on scope: my initial version of the fix patched only `update()`. Production showed the review flow actually completes via `POST /prs/:id/complete` (`PullRequestService.complete()`), so a claim posted through that path still lingered until the reaper. The fix therefore covers both write paths, and the integration tests drive the real routes rather than the service methods directly.

## Fix

Three parts:

1. `PullRequestService.update()` — when a PATCH sets `reviewState` to `posted` or `approved`, clear `claimedBy`/`claimedAt`/`heartbeatAt`/`phase` in the same write. This mirrors the adjacent `state: 'merged'` block that already clears the claim, and sits alongside the existing `approved` -> `readyForDeployAt` auto-stamp.
2. `PullRequestService.complete()` — the `POST /prs/:id/complete` path review sessions actually use. Same clear in the same write that sets `reviewState = 'posted'`.
3. `StaleClaimReaper` — the PR bulk UPDATE still releases the claim fields for every stale claim, but now only regresses `reviewState` -> `pending` when it is currently `pending`/`in_progress`. A stale claim on a record already at `posted`/`approved` releases without regressing `reviewState`, so it no longer re-dispatches a duplicate review.

Precedent: the handler already auto-stamps `readyForDeployAt` on `approved` and clears the claim on `state = 'merged'`; this extends the same same-write pattern to review completion. The reaper narrowing is belt-and-suspenders — it keeps stale claims releasing while no longer regressing a completed review, which also covers claims that predate this change.

## Tests

- Unit (`pull-request-service.unit.test.ts`): `update()` clears the claim on `posted` and on `approved` (and still stamps `readyForDeployAt`), the release wins over claim fields supplied in the same PATCH body, a non-`reviewState` update leaves the claim untouched, re-asserting `posted` is idempotent; `complete()` clears the claim while preserving `reviewCycles`/`reviewState`/`reviewedAt`/`readyForPatchAt`.
- Unit (`stale-claim-reaper.unit.test.ts`): the reap SQL regresses `reviewState` only for `pending`/`in_progress` (CASE with `ELSE "reviewState"`) and releases claim fields for every stale claim regardless of `reviewState`.
- Integration, real Postgres (`stale-claim-reaper.integration.test.ts`): a stale claim seeded per `reviewState` plus a fresh control — `pending`/`in_progress` regress to `pending` and release; `posted`/`approved` keep their `reviewState` and release; the fresh control is untouched.
- Integration, route layer (`pull-request.integration.test.ts`): drives the actual `POST /prs/:id/complete` and `PATCH /prs/:id` (approved) endpoints through the Hono app with a real service, reading the row back to prove the claim was released in the same write.
- Docs: `docs/task-store.md` gains the side-effect sentence for the `posted`/`approved` release.

`bun test` passes with 0 failures; `tsc --noEmit` is clean for task-store; the real-DB integration tests pass against a throwaway `postgres:16-alpine` after `prisma migrate deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
