### PR TITLE
feat: rewrite deploy.md Step 5b to use chained in-Bash polling instead of per-check ScheduleWakeup

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -127,7 +127,7 @@ describe("deploy.md — self-approve bold-markdown strip (PCK-1.4)", () => {
     expect(step3aSection.toLowerCase()).toContain("strip");
   });
 
-  it("Step 3a's prose describes stripping leading bold markers before startsWith(\"APPROVE\")", () => {
+  it('Step 3a\'s prose describes stripping leading bold markers before startsWith("APPROVE")', () => {
     const step3aMatch = content.match(
       /### 3a\. Verify PR Approval[\s\S]*?(?=### 3b)/,
     );
@@ -182,9 +182,14 @@ describe("deploy.md — pre-merge PR claim lock (CLM-2.2)", () => {
   it("post-merge upsert reuses PR_RECORD_ID from the pre-merge claim (plain PATCH, no redundant claim)", () => {
     // The post-merge section should PATCH the already-claimed record rather than
     // issuing a second POST /prs/claim call.
-    const postMergeSectionIdx = content.indexOf("Update PullRequest Record (post-merge)");
+    const postMergeSectionIdx = content.indexOf(
+      "Update PullRequest Record (post-merge)",
+    );
     expect(postMergeSectionIdx).toBeGreaterThan(-1);
-    const postMergeSection = content.slice(postMergeSectionIdx, postMergeSectionIdx + 1500);
+    const postMergeSection = content.slice(
+      postMergeSectionIdx,
+      postMergeSectionIdx + 1500,
+    );
     expect(postMergeSection.includes("/prs/claim")).toBe(false);
     expect(postMergeSection.includes("/prs/$PR_RECORD_ID")).toBe(true);
   });
@@ -205,7 +210,9 @@ describe("deploy.md — pre-merge PR claim lock (CLM-2.2)", () => {
 
 describe("deploy.md — chained in-Bash polling for Step 5b (AEW-1.1)", () => {
   function extractStep5bSection(md: string): string {
-    const match = md.match(/### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/);
+    const match = md.match(
+      /### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/,
+    );
     expect(match).not.toBeNull();
     return match?.[0] ?? "";
   }

--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -202,3 +202,59 @@ describe("deploy.md — pre-merge PR claim lock (CLM-2.2)", () => {
     expect(releaseIdx).toBeGreaterThan(claimIdx);
   });
 });
+
+describe("deploy.md — chained in-Bash polling for Step 5b (AEW-1.1)", () => {
+  function extractStep5bSection(md: string): string {
+    const match = md.match(/### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("Step 5b's polling implementation uses a chained in-Bash sleep loop (shell for-loop + sleep 60)", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).toContain("sleep 60");
+    const hasForLoop =
+      /for\s+\w+\s+in\s+\$\(seq/.test(step5bSection) ||
+      step5bSection.includes("for i in");
+    expect(hasForLoop).toBe(true);
+  });
+
+  it("Step 5b instructs chaining multiple Bash tool calls back-to-back to cover the 30-minute budget", () => {
+    const step5bSection = extractStep5bSection(content);
+    const mentionsChaining =
+      step5bSection.toLowerCase().includes("chain") &&
+      step5bSection.toLowerCase().includes("bash");
+    expect(mentionsChaining).toBe(true);
+  });
+
+  it("Step 5b's polling section does NOT instruct a per-60s ScheduleWakeup call", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).not.toContain("ScheduleWakeup");
+  });
+
+  it("preserves the midpoint claim-heartbeat renewal (elapsed ~15 minutes) inside Step 5b", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).toContain("/prs/$PR_RECORD_ID/heartbeat");
+    expect(step5bSection.toLowerCase()).toContain("midpoint");
+  });
+
+  it("preserves the 60-second poll interval and 30-minute budget wording in Step 5b", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).toContain("60 seconds");
+    expect(step5bSection).toContain("30 minutes");
+  });
+
+  it("preserves the progress print format for Deploy/Canary/Promote stages", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).toContain(
+      "[{elapsed}m] Deploy: {status}/{conclusion} | Canary: {status}/{conclusion} | Promote: {status}/{conclusion}",
+    );
+  });
+
+  it("does not affect the ARC desync section, which still re-surfaces every 5 minutes", () => {
+    // ARC desync detection lives just after Step 5b in the same file; it must be
+    // untouched by the polling-mechanism rewrite.
+    expect(content).toContain("ARC desync suspected");
+    expect(content).toContain("Re-surface this message every 5 minutes");
+  });
+});

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -381,13 +381,30 @@ truth — only watch runs whose `head_sha` matches this value.
 
 **Budget: 30 minutes from merge. Poll interval: 60 seconds.**
 
-Each poll fetches all runs matching the squash SHA:
+**Implementation: chained in-Bash sleep loops.** Do not wait between polls via a
+scheduled wakeup mechanism that resumes the session later (each resumption is a
+brand-new process invocation — costly and unnecessary here). Instead, run the
+60-second-interval checks as a shell-level loop inside a single Bash tool call, and
+chain several such Bash calls back-to-back within the same turn:
 
 ```bash
-REPO="{org}/{repo}"
-gh api "repos/$REPO/actions/runs?per_page=50" \
-  --jq "[.workflow_runs[] | select(.head_sha == \"$SQUASH_SHA\") | {id, name, status, conclusion, created_at}]"
+for i in $(seq 1 8); do
+  REPO="{org}/{repo}"
+  gh api "repos/$REPO/actions/runs?per_page=50" \
+    --jq "[.workflow_runs[] | select(.head_sha == \"$SQUASH_SHA\") | {id, name, status, conclusion, created_at}]"
+  # print progress, evaluate terminal conditions (see below) — break out of the
+  # loop immediately if any terminal condition is met
+  sleep 60
+done
 ```
+
+Each iteration of this loop is one poll (~8 iterations ≈ 8 minutes per Bash call, safely
+under Bash's practical ~10-minute ceiling). Chain 3-4 of these Bash calls back-to-back
+in the same turn to cover the full 30-minute budget — e.g. call 1 covers minutes 0-8,
+call 2 covers minutes 8-16, call 3 covers minutes 16-24, call 4 covers minutes 24-30 (last
+call may run fewer than 8 iterations to land on the 30-minute mark). Break out of the loop
+(and stop chaining further Bash calls) as soon as any terminal condition below is met —
+do not keep polling once Deploy has failed, Canary has resolved, or Promote has resolved.
 
 Track three stages by workflow name (`.name`):
 
@@ -397,7 +414,7 @@ Track three stages by workflow name (`.name`):
 | `"Canary"`       | Canary  |
 | `"Promote to Prod"` | Promote |
 
-Print progress on each poll:
+Print progress on each poll (each loop iteration):
 ```
 [{elapsed}m] Deploy: {status}/{conclusion} | Canary: {status}/{conclusion} | Promote: {status}/{conclusion}
 ```
@@ -407,7 +424,9 @@ Use `-` for stages not yet seen (no run exists yet).
 **Renew the claim heartbeat at the midpoint** (elapsed ≈ 15 minutes, the midpoint of the
 30-minute budget): the `PullRequest` record claimed in Step 4 has a TTL shorter than this
 poll's full budget, so a pipeline that runs the full 30 minutes would otherwise let the
-claim go stale before Promote resolves. Renew once, best-effort:
+claim go stale before Promote resolves. Renew once, best-effort — fire this at the start
+of whichever chained Bash call lands closest to elapsed ≈ 15 minutes (the 2nd or 3rd call
+in the chain above):
 
 ```bash
 if [ -n "$PR_RECORD_ID" ]; then


### PR DESCRIPTION
## Summary
- Rewrite `deploy.md` Step 5b's polling implementation to use chained in-Bash `sleep 60` loops instead of a per-60s `ScheduleWakeup` instruction — each `ScheduleWakeup` resumption is a full new process invocation, costlier than a continuous shell-level wait.
- Chain 3-4 such Bash calls (~8 min each, under Bash's ~10-min practical ceiling) back-to-back within the same turn to cover the full 30-minute monitoring budget.
- Preserve every existing exit condition and observable behavior unchanged: canary pass/fail/skip, 30-min timeout, ARC-desync re-surface-every-5-min messaging, and the midpoint claim-heartbeat renewal.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5b's polling implementation uses chained in-Bash sleep loops, not per-60s ScheduleWakeup | MET |
| 2 | All existing exit conditions preserved unchanged (canary pass/fail/skip, timeout, ARC-desync, midpoint heartbeat) | MET |
| 3 | No change to deploy.md's external contract (invocation shape, arguments, output format) | MET |
| 4 | New content-test coverage in deploy.content.test.ts asserting the chained-Bash-loop pattern and absence of ScheduleWakeup; no existing tests removed | MET |

## Test Plan
- [x] `bun test plugins/shipwright/commands/deploy.content.test.ts` — 30/30 pass (7 new tests for AEW-1.1)
- [x] Full plugin suite (`bun test` in `plugins/shipwright/`) — 838/838 pass
- [x] `tsc --noEmit` typecheck passes
- [x] `task check-strings` and `task check-version-sync` pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
