### PR TITLE
feat: wire agent config to shared claim-TTL constant

### DIFF
--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -1,9 +1,5 @@
 import { join } from "node:path";
-
-// Default hard timeout for a single `claude -p` session — mirrors the default
-// in createRunClaude (agent/src/claude.ts). Kept in sync so behavior is
-// unchanged when SHIPWRIGHT_CLAUDE_TIMEOUT_MS is unset.
-const DEFAULT_CLAUDE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+import { DEFAULT_CLAUDE_TIMEOUT_MS } from "@shipwright/lib/claim-ttl";
 
 function optional(key: string): string | undefined {
   return process.env[key];


### PR DESCRIPTION
## Summary
- Replace the locally-defined `DEFAULT_CLAUDE_TIMEOUT_MS` constant in `agent/src/config.ts` with an import from `@shipwright/lib/claim-ttl` (added in CTB-1.1)
- Removes a second independent source of truth for the `1_800_000`ms (30min) magic number — no behavior change

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | config.ts imports DEFAULT_CLAUDE_TIMEOUT_MS from '@shipwright/lib/claim-ttl' | MET | Local const removed, import added |
| 2 | claude.timeoutMs default unchanged (1_800_000ms) | MET | claim-ttl.ts defines the same numeric value |
| 3 | Existing config.unit.test.ts tests pass unchanged | MET | 40/40 pass |
| 4 | No new test added (pure import swap) | MET | No test file changes |

## Test Plan
- [x] `bun test agent/src/config.unit.test.ts` — 40 pass, 0 fail
- [x] `bun test agent/src` (full agent suite) — 1017 pass, 0 fail
- [x] `bun run --filter='@shipwright/agent' typecheck` — passes
- [x] `bunx biome lint agent/src/config.ts` — clean
- [x] `config.ts` coverage: 100% lines / 100% branches

Generated with [Claude Code](https://claude.com/claude-code)
