### PR TITLE
refactor: wire stale-claim-reaper to shared claim-TTL constant

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.212.0",
+      "version": "0.217.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -98,7 +98,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.212.0",
+      "version": "0.217.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -116,7 +116,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.212.0",
+      "version": "0.217.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "0.217.0",
+      "version": "0.212.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -98,7 +98,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "0.217.0",
+      "version": "0.212.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -116,7 +116,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "0.217.0",
+      "version": "0.212.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/task-store/src/stale-claim-reaper.ts
+++ b/task-store/src/stale-claim-reaper.ts
@@ -32,7 +32,9 @@ export class StaleClaimReaper {
   ) {
     this.ttlMs =
       ttlMs ??
-      Number(process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS ?? DEFAULT_CLAIM_TTL_MS);
+      Number(
+        process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS ?? DEFAULT_CLAIM_TTL_MS,
+      );
   }
 
   /**

--- a/task-store/src/stale-claim-reaper.ts
+++ b/task-store/src/stale-claim-reaper.ts
@@ -10,17 +10,17 @@
  *   2. heartbeatAt IS NULL and claimedAt < cutoff (agent claimed but never beat)
  *
  * The cutoff is: clock.now() - ttlMs. Both Task and PullRequest claims use a
- * single unified TTL, defaulting to 2 100 000 ms (35 min) — the 30-minute
- * `claude -p` hard timeout plus a 5-minute buffer — overridable via
+ * single unified TTL, derived from the shared DEFAULT_CLAIM_TTL_MS constant
+ * in @shipwright/lib/claim-ttl (which combines the 30-minute `claude -p` hard
+ * timeout plus a 5-minute buffer) — overridable via
  * SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS.
  *
  * Usage: register via setInterval(() => reaper.reap(), 60_000) in main.ts.
  */
 
+import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import { type Clock, SystemClock } from "./clock.ts";
 import type { PrismaClient } from "./index.ts";
-
-const DEFAULT_TTL_MS = 2_100_000;
 
 export class StaleClaimReaper {
   private readonly ttlMs: number;
@@ -32,7 +32,7 @@ export class StaleClaimReaper {
   ) {
     this.ttlMs =
       ttlMs ??
-      Number(process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS ?? DEFAULT_TTL_MS);
+      Number(process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS ?? DEFAULT_CLAIM_TTL_MS);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace `task-store/src/stale-claim-reaper.ts`'s locally-defined `DEFAULT_TTL_MS = 2_100_000` with an import of `DEFAULT_CLAIM_TTL_MS` from `@shipwright/lib/claim-ttl` (added in RTC-1.1/CTB-1.1)
- Update the module doc comment to reference the shared constant as the source of truth instead of restating the literal computation
- No behavior change — the TTL value (2,100,000ms / 35min) is identical, only its source moved

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Imports `DEFAULT_CLAIM_TTL_MS` from `@shipwright/lib/claim-ttl`, no local `DEFAULT_TTL_MS` | MET | Import added, local const removed |
| 2 | Module doc comment references shared constant as source of truth | MET | Doc comment reworded to cite `DEFAULT_CLAIM_TTL_MS` |
| 3 | Existing unit tests pass unchanged | MET | 21/21 pass, test file untouched |
| 4 | No new test needed | MET | No new test added, per spec |

## Test Plan
- `NODE_ENV=test bun test task-store/src/stale-claim-reaper.unit.test.ts` — 21 pass, 0 fail
- `bunx biome lint` / `bunx biome format` — clean
- `bun run typecheck` (task-store package) — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
