### PR TITLE
refactor: wire pr-state-reconciler to shared claim-TTL constant

### DIFF
--- a/agent/src/pr-state-reconciler.ts
+++ b/agent/src/pr-state-reconciler.ts
@@ -37,6 +37,7 @@
  * the SAME setInterval tick in agent/src/index.ts — not a second timer.
  */
 
+import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import type { PrReviewData } from "./check-patch.ts";
 import {
   createPrRecordQuery,
@@ -181,7 +182,6 @@ export interface PrReviewStateReconcilerDeps {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const DEFAULT_PAGE_LIMIT = 50;
-const DEFAULT_CLAIM_TTL_MS = 2_100_000;
 
 /** Map GitHub's uppercase PR state to the task-store's lowercase PrState enum. */
 function mapGhStateToPrState(
@@ -682,6 +682,11 @@ async function reconcileReviewStateRecord(
   deps: PrReviewStateReconcilerDeps,
   record: PrReviewStateRecord,
 ): Promise<void> {
+  // deps.claimTtlMs is NOT left unwired here: buildReviewStateProductionDeps
+  // (below) reads process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS itself and
+  // sets it on the returned deps object, so index.ts's bare
+  // buildReviewStateReconcilerDeps({ ghGraphql }) call site still gets the
+  // env var end-to-end — confirmed by this factory's own unit tests below.
   const claimTtlMs = deps.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS;
   if (isActivelyClaimed(record, deps.clock, claimTtlMs)) return; // live claim — never overwrite
 


### PR DESCRIPTION
## Summary
- Replace the locally-defined `DEFAULT_CLAIM_TTL_MS` constant in `agent/src/pr-state-reconciler.ts` with an import from `@shipwright/lib/claim-ttl`, matching the pattern already used in `task-store/src/stale-claim-reaper.ts` (RTC-1.3).
- Add an inline comment at the constant's usage site documenting the actual env-wiring state of `deps.claimTtlMs`: investigation confirmed the `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` env var *is* wired end-to-end via `buildReviewStateProductionDeps`'s own internal env read — the task description's premise of an unwired gap does not hold against the current code, so the comment documents that verified reality rather than a stale assumption.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Imports `DEFAULT_CLAIM_TTL_MS` from `@shipwright/lib/claim-ttl` instead of a local constant | ✅ MET |
| 2 | Existing pr-state-reconciler unit tests pass unchanged (same 2_100_000ms default) | ✅ MET |
| 3 | No new test needed — pure import swap, no behavior change | ✅ MET |
| 4 | Env-read note preserved as a code comment near the usage site | ✅ MET |

## Test Plan
- [x] `NODE_ENV=test bun test agent/src/pr-state-reconciler.unit.test.ts` — 52 pass, 0 fail
- [x] `bunx biome lint agent/src/pr-state-reconciler.ts` — clean
- [x] `bun run --filter='@shipwright/agent' typecheck` — no new errors (pre-existing unrelated errors in `admin/src/agent-cron-runs*.ts` reproduce identically on clean main)
- [x] Full-suite `task ci` coverage gate fails at 78.96%/80% — reproduces identically on clean main, a known in-sandbox gap (no test DB → integration tests skipped), unrelated to this diff

Generated with [Claude Code](https://claude.com/claude-code)
