### PR TITLE
docs: reconcile testing.md with M1 renames and new chat coverage (T-029)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,14 +46,15 @@ cd site && npm test                  # playwright (*.spec.ts)
 
 | Component | Layers in use | Run command |
 |---|---|---|
-| Plugin (`plugins/shipwright`) | unit, integration, content | `bun test --filter plugins/shipwright` |
+| Plugin (`plugins/shipwright`) | unit, content | `bun test --filter plugins/shipwright` |
 | Metrics (`metrics`) | unit, integration, smoke, e2e | `bun test --filter metrics` (unit/integration/smoke); `task e2e` (e2e) |
 | Agent (`agent`) | unit, integration, smoke | `bun test --filter agent` |
 | Admin (`admin`) | unit, integration, smoke, e2e | `bun test --filter admin` (unit/integration/smoke); `cd admin && bunx playwright test` (e2e) |
-| Task Store (`task-store`) | integration | `bun test --filter task-store` |
+| Chat (`chat`) | unit, integration, smoke | `bun test --filter chat` |
+| Task Store (`task-store`) | unit, integration, smoke | `bun test --filter task-store` |
 | MCP Server (`mcp-server`) | unit, integration, smoke | `bun test --filter mcp-server` |
 
-The plugin has **no smoke/e2e layer** (no HTTP surface). Task Store is a pure Prisma package (library, no HTTP surface). MCP Server is a Hono app with no database; integration tests inject a recorded fetch implementation, and smoke tests drive the Hono app via `app.request()`. E2E (Playwright) covers the marketing site (`site/tests/home.spec.ts`, `site/tests/docs-platform.spec.ts`, `site/tests/docs-search.spec.ts`), the metrics dashboard UI (`metrics/e2e/dashboard.e2e.ts`), and the admin UI (`admin/e2e/agents-page.e2e.ts`, `admin/e2e/login-page.e2e.ts`).
+The plugin has **no integration/smoke/e2e layer** (no HTTP surface, no external dependencies). Chat and Task Store are Hono apps backed by Prisma (Postgres); integration tests cover the Prisma-backed services against a real DB (`describeOrSkip`-gated on `DATABASE_URL_SHIPWRIGHT_CHAT` / `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST`), and smoke tests drive the Hono app via `app.request()`. MCP Server is a Hono app with no database; integration tests inject a recorded fetch implementation, and smoke tests drive the Hono app via `app.request()`. E2E (Playwright) covers the marketing site (`site/tests/home.spec.ts`, `site/tests/docs-platform.spec.ts`, `site/tests/docs-search.spec.ts`, and others), the metrics dashboard UI (`metrics/e2e/dashboard.e2e.ts`), and the admin UI (`admin/e2e/agents-page.e2e.ts`, `admin/e2e/login-page.e2e.ts`).
 
 ## Speed budgets
 
@@ -72,7 +73,7 @@ A unit test over 200 ms is a suspected hidden integration test (audit its import
 - **Time:** any production code path that calls `new Date()` / `Date.now()` non-trivially must accept a `Clock` interface; tests inject `FixedClock(t)`. Raw `Date.now()` in code under test is a bug.
 - **External HTTP:** service clients (`TaskStoreClient`, `GithubClient`, …) are interfaces with an `Http*Client` production impl; tests inject `Recorded*Client` recorded fixture doubles replaying fixture data from `src/fixtures/<service>/*.json` (versioned JSON committed to the repo).
 - **No global state:** **no `mock.module()`**, **no `global.fetch` / `global.*` overrides.** Bun runs test files in the same process, so module-level mocks and global mutation leak across sibling suites. Each test must be independently runnable, order-independent.
-- **Offline by default:** no live external calls. Live external service credentials must be absent for metrics unit/integration/smoke tests; `DATABASE_URL_ADMIN_TEST` must be set to a Postgres connection string for admin DB integration tests, and `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST` for task-store DB integration tests (suites skip automatically when the respective var is absent).
+- **Offline by default:** no live external calls. Live external service credentials must be absent for metrics unit/integration/smoke tests; `DATABASE_URL_ADMIN_TEST` must be set to a Postgres connection string for admin DB integration tests, `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST` for task-store DB integration tests, and `DATABASE_URL_SHIPWRIGHT_CHAT` for chat DB integration tests (suites skip automatically when the respective var is absent).
 
 ## CI gates
 


### PR DESCRIPTION
## Summary
- Adds the missing `Chat (chat)` row to `docs/testing.md`'s per-component layer table (unit/integration/smoke — previously undocumented despite having coverage from T-026/T-027).
- Corrects the `Task Store` row from "integration"-only to "unit, integration, smoke" and fixes the stale "pure Prisma package, no HTTP surface" description — it's a Hono app with an HTTP surface, same shape as MCP Server.
- Removes the stale "integration" entry from the `Plugin` row — `plugins/shipwright` has no integration test files, only unit and content.
- Documents `DATABASE_URL_SHIPWRIGHT_CHAT` in the isolation-contract bullet, alongside the existing admin/task-store DB-gating vars.

Milestone 1 rename tasks (T-003–T-011 / test-t-016 through test-t-024) were cross-checked against live file state: all renames are already reflected in the repo's file names and don't change any "Layers in use" cell (those components already listed the post-rename layer). One rename — `slack.integration.test.ts` → `.smoke.test.ts` (T-008) — was explicitly reverted on `main` (commit `076409e0`, "address review findings on #1528 — revert rename, keep slack.integration.test.ts"), so the Agent row correctly still shows `integration` untouched.

## Note on acceptance criterion 2
The verification command in the task description, `bun test plugins/shipwright/test/*.unit.test.ts`, matches zero files and fails with exit code 1 — `plugins/shipwright/test/` only contains `*.content.test.ts` files, never `*.unit.test.ts`. This predates this change (confirmed on `main` too) and appears to be a stale artifact from the task-generation pipeline; no "doc-structure-lint" cluster matching that exact glob has ever existed in this repo. The actual doc-structure-lint cluster — `plugins/shipwright/test/*.content.test.ts` (6 files, incl. `fixture-terminology.content.test.ts`, which asserts on `docs/testing.md` content) — passes 125/125 after this change.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Per-component layer table reflects M1 renames and new chat coverage | MET |
| 2 | Verification command passes (doc-structure-lint cluster) | UNVERIFIABLE via literal glob (pre-existing, unrelated to this diff) — actual content-test cluster passes 125/125 |

## Test Plan
- [x] `bun test plugins/shipwright/test/*.content.test.ts` — 125/125 pass (actual doc-lint cluster)
- [x] `bun test --filter plugins/shipwright` — 832/832 pass
- [x] `bunx biome lint .` — clean
- [x] Table contents verified against live test-file listing for every component (chat, task-store, plugin, agent, admin, metrics, mcp-server)

Generated with [Claude Code](https://claude.com/claude-code)
