### PR TITLE
docs: sweep architecture.md, agent.md, migration.md for loop-only pipeline commands (WLS-6.1)

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -122,14 +122,27 @@ All child models cascade-delete with their `Agent` (including `AgentCronRun` via
 
 ## Default system crons
 
-Every new agent is seeded with eleven system crons (the canonical definitions live in [`admin/src/system-crons.ts`](../admin/src/system-crons.ts) and are reconciled onto each agent at startup via `POST /agents/:id/crons/reconcile`). Three are **enabled by default** (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`); the rest are opt-in (toggle in the admin UI or via `PATCH /agents/:id/crons/:cronId`). All run `silent` (they post to Slack only on a result worth surfacing, or on error). Some carry a `preCheck` script whose stdout becomes the actual prompt, so a cron only spends a Claude turn when there is real work ready — the four pipeline crons (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`, `shipwright-deploy`) instead rely on the `shipwright-loop` cron's in-process candidate providers (`agent/src/check-dev-task.ts`, `check-review.ts`, `check-patch.ts`, `check-deploy.ts`) for qualification when driven via the loop, or run unconditionally on their own schedule when driven as standalone crons.
+Every new agent is seeded with eleven system crons (the canonical definitions live in [`admin/src/system-crons.ts`](../admin/src/system-crons.ts) and are reconciled onto each agent at startup via `POST /agents/:id/crons/reconcile`). Three are **enabled by default** (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`); the rest are opt-in (toggle in the admin UI or via `PATCH /agents/:id/crons/:cronId`). All run `silent` (they post to Slack only on a result worth surfacing, or on error). Some carry a `preCheck` script whose stdout becomes the actual prompt, so a cron only spends a Claude turn when there is real work ready.
+
+The four pipeline crons (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`,
+`shipwright-deploy`) are **loop-driven, item-addressed executors, not self-discovering
+standalone crons.** `shipwright-loop` is the sole supported driver for these four phases: its
+in-process candidate providers (`agent/src/check-dev-task.ts`, `check-review.ts`,
+`check-patch.ts`, `check-deploy.ts`) select a winning candidate each tick and
+`loop-orchestrator.ts` dispatches the matching command with an explicit task id or
+`org/repo#number` embedded in the prompt. None of the four commands scans for its own work
+— each responds `[silent]` and exits immediately if invoked with no target. This means a
+standalone pipeline cron (`shipwright-loop` disabled) is **silently inert**: its stored
+prompt (e.g. `/shipwright:dev-task`) carries no target, so every tick dispatches, goes
+`[silent]`, and does nothing. See [migration.md](./migration.md) for the breaking-change
+note and the fix (enable `shipwright-loop`).
 
 | Cron | Schedule (cron expr) | Default | What it does |
 |---|---|---|---|
-| `shipwright-dev-task` | `0,30 * * * *` (min 0, 30) | **on** | Picks the next ready task, builds it with tests, opens a PR. |
-| `shipwright-review` | `15,45 * * * *` (min 15, 45) | **on** | Review-only pass over open PRs (excluding drafts and Dependabot PRs). |
-| `shipwright-patch` | `5,35 * * * *` (min 5, 35) | **on** | Patch-only pass over open PRs with failing CI or unresolved review findings. Has no `preCheck` of its own — when driven via the `shipwright-loop` cron, `agent/src/check-patch.ts`'s `getPatchCandidates()` qualifies candidate PRs in-process and `loop-orchestrator.ts` dispatches the winning candidate directly as `/shipwright:patch {org}/{repo}#{number}`; run as a standalone cron (loop disabled), it dispatches its stored prompt (`/shipwright:patch`) unconditionally on schedule. |
-| `shipwright-deploy` | `20,50 * * * *` (min 20, 50) | off | Merges approved PRs and deploys them. |
+| `shipwright-dev-task` | `0,30 * * * *` (min 0, 30) | **on** | Builds and ships a PR for the task `shipwright-loop` selects (dispatched with an explicit task id). Standalone (loop disabled): inert — see above. |
+| `shipwright-review` | `15,45 * * * *` (min 15, 45) | **on** | Reviews the PR `shipwright-loop` selects (dispatched with an explicit `org/repo#number`). Standalone (loop disabled): inert — see above. |
+| `shipwright-patch` | `5,35 * * * *` (min 5, 35) | **on** | Patches the PR `shipwright-loop` selects (dispatched with an explicit `org/repo#number`). Standalone (loop disabled): inert — see above. |
+| `shipwright-deploy` | `20,50 * * * *` (min 20, 50) | off | Merges and deploys the PR `shipwright-loop` selects (dispatched with an explicit `org/repo#number`). Standalone (loop disabled): inert — see above. |
 | `shipwright-loop` | `* * * * *` (every minute) | off | Internal: dispatches enabled pipeline phases (dev-task, review, patch, deploy) in a single multi-step drain-until-dry run. Orchestrates phase toggling and claim/retry logic; requires explicit enablement alongside per-phase cron toggling. Implemented by the `loop-orchestrator.ts` module — drain-until-dry through all phases on every tick, strict age-based FIFO work selection, per-dispatch run reporting, and spin detection (warns via `console.warn` when the same item is dispatched 3+ times consecutively, signaling a potential infinite loop for Sentry alerting). |
 | `shipwright-test-readiness` | `0 6 * * *` (daily, 06:00) | off | Iterates repos in `repos/` with a `docs/test-readiness/` directory and runs the full test-readiness audit (`--full --publish`) once per qualifying repo, each in its own worktree + branch. Via the `check-test-readiness.ts` preCheck, only repos with stale or missing phase artifacts are invoked. |
 | `shipwright-docs-freshness` | `0 7 * * *` (daily, 07:00) | off | Scans all repos in `repos/` for source changes and refreshes docs that drifted from the code via the docs-freshness agent (`research-docs --auto`). Iterates per-repo, checking each against its `state/docs-last-synced.json` anchor — skips repos without `docs/` directories. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,15 @@ Key surfaces (see `plugins/shipwright/README.md` and `plugins/shipwright/CLAUDE.
 - **Scripts** (`scripts/`) — the task-store adapters, precheck scripts for each cron (`check-docs-freshness.ts`, `check-learn-dream.ts`, etc.), and supporting tooling.
 - **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, …).
 
+`dev-task`, `review`, `patch`, and `deploy` are item-addressed executors, not self-discovering
+standalone crons: each requires an explicit target (a task id for `dev-task`; an
+`org/repo#number` PR for the other three) and does no candidate scanning of its own.
+Candidate selection happens once, upstream, in the Shipwright agent's `shipwright-loop`
+cron (artifact **C** — see [agent.md](./agent.md)), which is the sole supported driver for
+these four phases; it merges candidates from `agent/src`'s per-phase qualification
+functions and dispatches the winning item's command with its id/PR embedded directly in the
+prompt. A human can still invoke any of the four directly with an explicit target.
+
 The plugin is pure TypeScript with **no server, no database, and no external HTTP in production code** — only `unit` and `integration` test layers apply.
 
 ## B — Metrics dashboard

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,33 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
+## Breaking: `dev-task`/`review`/`patch`/`deploy` require `shipwright-loop` (or an explicit target)
+
+**Version**: next (WLS-6.1)
+
+`dev-task`, `review`, `patch`, and `deploy` no longer self-discover work. Each is now an
+explicit-target-only executor: `dev-task` requires a task id, and `review`/`patch`/`deploy`
+require an `org/repo#number` PR. Candidate selection — deciding *what* to work on — now
+happens exclusively upstream, in the `shipwright-loop` cron's in-process candidate
+providers (`agent/src/check-dev-task.ts`, `check-review.ts`, `check-patch.ts`,
+`check-deploy.ts`), which merge candidates and dispatch the winning item's command with its
+id/PR embedded directly in the prompt. No self-search fallback remains inside any of the
+four commands.
+
+**Impact**: any agent running `shipwright-dev-task`, `shipwright-review`, or
+`shipwright-patch` as **standalone crons** (i.e. without `shipwright-loop` enabled) will see
+those crons go silently inert. Their stored prompt (e.g. `/shipwright:dev-task`) carries no
+target, so the command responds `[silent]` and exits immediately on every tick — no error,
+no Slack message, no work done.
+
+**What to update**: enable the `shipwright-loop` system cron (`PATCH
+/agents/:id/crons/:cronId` with `{"enabled": true}`, or via the admin UI). `dev-task`,
+`review`, and `patch` are enabled by default, so once the loop is on, they resume working
+automatically. `shipwright-deploy` remains an explicit opt-in — its per-phase cron ships
+`enabled: false`, so toggle it on separately if you also want deploys driven by the loop.
+
+---
+
 ## Upgrading to chart 1.6.132
 
 Remove `metrics.provider.posthog.*` from your `values.yaml` before running `helm upgrade`. The `posthog` key is no longer accepted by the values schema — with `additionalProperties: false` still in place, Helm will reject the upgrade with a schema validation error if any `metrics.provider.posthog.*` keys remain.


### PR DESCRIPTION
## Summary
- Update `docs/architecture.md` and `docs/agent.md` to describe `dev-task`/`review`/`patch`/`deploy` as loop-driven, item-addressed executors — `shipwright-loop` is now the sole supported driver for these four phases, and none of the four commands self-discovers work.
- Rewrite the `docs/agent.md` default-cron table rows so they no longer imply standalone crons still self-select work; a standalone pipeline cron (loop disabled) is now documented as silently inert.
- Add a new breaking-change entry to `docs/migration.md` documenting the standalone-cron inertness and the fix (enable `shipwright-loop`; `dev-task`/`review`/`patch` resume automatically since they're on by default, `deploy` remains an explicit opt-in).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | docs/architecture.md and docs/agent.md describe dev-task/review/patch/deploy as loop-driven, item-addressed executors, not self-discovering standalone crons | MET | New paragraphs in both files + rewritten cron table rows in agent.md |
| 2 | docs/migration.md gains a new breaking-change entry describing the standalone-cron inertness and the shipwright-loop migration path | MET | New "Breaking: dev-task/review/patch/deploy require shipwright-loop" section |
| 3 | No automated test — confirm check-config-docs CI gate still passes via `task ci` locally | MET | `bun scripts/check-config-docs.ts` passes standalone; `task lint`, `check-strings`, `typecheck`, `check-version-sync` all pass. The aggregate `task ci` coverage gate fails at 79.94%/80% in-sandbox only (no `DATABASE_URL_*` set locally → integration tests skip), a known sandbox artifact unrelated to this docs-only change — real CI runs against a live test DB. |

## Test Plan
- Prose documentation only — no automated tests apply per the task's own test decision.
- [x] `bun scripts/check-config-docs.ts` — passes
- [x] `task lint` / `task check-strings` / `task typecheck` / `task check-version-sync` — all pass

Generated with [Claude Code](https://claude.com/claude-code)
