### PR TITLE
feat: add hitl filter to admin task list view

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1407,6 +1407,7 @@ export function renderTasksPage(
     session?: string;
     repo?: string;
     agent?: string;
+    hitl?: "true" | "false";
   },
   degraded: boolean,
   userName: string,
@@ -1460,6 +1461,7 @@ export function renderTasksPage(
     if (filters.session) params.set("session", filters.session);
     if (filters.repo) params.set("repo", filters.repo);
     if (filters.agent) params.set("agent", filters.agent);
+    if (filters.hitl) params.set("hitl", filters.hitl);
     if (p > 1) params.set("page", String(p));
     const qs = params.toString();
     return `/admin/tasks${qs ? `?${qs}` : ""}`;
@@ -1528,6 +1530,7 @@ export function renderTasksPage(
     if (filters.session) p.set("session", filters.session);
     if (filters.repo) p.set("repo", filters.repo);
     if (filters.agent) p.set("agent", filters.agent);
+    if (filters.hitl) p.set("hitl", filters.hitl);
     const qs = p.toString();
     return qs ? `?${qs}` : "";
   };
@@ -1565,6 +1568,17 @@ export function renderTasksPage(
     .map(
       (s) =>
         `<option value="${escapeHtml(s)}" ${filters.status === s ? "selected" : ""}>${s === "" ? "Any status" : escapeHtml(s)}</option>`,
+    )
+    .join("");
+
+  const hitlOptions = [
+    { value: "", label: "Any" },
+    { value: "true", label: "Yes" },
+    { value: "false", label: "No" },
+  ]
+    .map(
+      (o) =>
+        `<option value="${o.value}" ${filters.hitl === o.value ? "selected" : ""}>${o.label}</option>`,
     )
     .join("");
 
@@ -1618,6 +1632,10 @@ export function renderTasksPage(
         <div class="form-group" style="margin-bottom:0">
           <label class="form-label" style="font-size:11px">Status</label>
           <select name="status" class="form-input" style="font-size:12px;padding:4px 8px">${statusOptions}</select>
+        </div>
+        <div class="form-group" style="margin-bottom:0">
+          <label class="form-label" style="font-size:11px">HITL</label>
+          <select name="hitl" class="form-input" style="font-size:12px;padding:4px 8px">${hitlOptions}</select>
         </div>
         <div class="form-group" style="margin-bottom:0">
           <label class="form-label" style="font-size:11px">Session</label>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1574,6 +1574,119 @@ describe("renderTasksPage — back-link context (TBL-1.1)", () => {
   });
 });
 
+// ─── renderTasksPage — hitl filter ───────────────────────────────────────────
+
+describe("renderTasksPage — hitl filter", () => {
+  test("renders a hitl select with Any/Yes/No options next to Status", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain('<select name="hitl"');
+    expect(html).toMatch(/<option value=""[^>]*>Any<\/option>/);
+    expect(html).toMatch(/<option value="true"[^>]*>Yes<\/option>/);
+    expect(html).toMatch(/<option value="false"[^>]*>No<\/option>/);
+  });
+
+  test("selects 'Yes' option when filters.hitl is 'true'", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { hitl: "true" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain('<option value="true" selected>Yes</option>');
+  });
+
+  test("selects 'No' option when filters.hitl is 'false'", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { hitl: "false" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain('<option value="false" selected>No</option>');
+  });
+
+  test("defaults to 'Any' with no explicit hitl option selected when filters.hitl is undefined", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toMatch(/<option value=""[^>]*>Any<\/option>/);
+    expect(html).not.toMatch(/<option value="true"[^>]*selected[^>]*>Yes<\/option>/);
+    expect(html).not.toMatch(/<option value="false"[^>]*selected[^>]*>No<\/option>/);
+  });
+
+  test("makePageUrl preserves hitl filter across pagination links", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { hitl: "true" },
+      false,
+      USER_NAME,
+      {},
+      { total: 100, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain('href="/admin/tasks?hitl=true&page=2"');
+  });
+
+  test("makeStateParams preserves hitl filter in state-tab links", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { hitl: "true" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain('href="/admin/tasks?state=ready&hitl=true"');
+    expect(html).toContain('href="/admin/tasks?state=in_progress&hitl=true"');
+    expect(html).toContain('href="/admin/tasks?state=blocked&hitl=true"');
+    expect(html).toContain('href="/admin/tasks?state=closed&hitl=true"');
+  });
+
+  test("row links carry ?from= including hitl when a hitl filter is active", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { hitl: "true" },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    const expectedFrom = encodeURIComponent("/admin/tasks?hitl=true");
+    expect(html).toContain(
+      `data-href="/admin/tasks/${TASK_ITEM.id}?from=${expectedFrom}"`,
+    );
+  });
+});
+
 // ─── renderAgentDetailPage — repos section ───────────────────────────────────
 
 describe("renderAgentDetailPage — repos", () => {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -3797,6 +3797,74 @@ describe("admin UI — tasks page", () => {
     expect(capturedParams[0].has("status")).toBe(false);
   });
 
+  it("GET /admin/tasks?hitl=true forwards hitl=true to the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks?hitl=true", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].get("hitl")).toBe("true");
+  });
+
+  it("GET /admin/tasks?hitl=false forwards hitl=false to the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks?hitl=false", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].get("hitl")).toBe("false");
+  });
+
+  it("GET /admin/tasks with no hitl param forwards no hitl to the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].has("hitl")).toBe(false);
+  });
+
+  it("GET /admin/tasks?hitl=garbage forwards no hitl to the task store (invalid values treated as no filter)", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks?hitl=garbage", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].has("hitl")).toBe(false);
+  });
+
   it("GET /admin/tasks requests sort=desc from the task store", async () => {
     const capturedParams: URLSearchParams[] = [];
     const app = createAdminUIApp(

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1922,6 +1922,9 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     const session = c.req.query("session") ?? undefined;
     const repo = c.req.query("repo") ?? undefined;
     const agent = c.req.query("agent") ?? undefined;
+    const hitlRaw = c.req.query("hitl");
+    const hitl: "true" | "false" | undefined =
+      hitlRaw === "true" || hitlRaw === "false" ? hitlRaw : undefined;
     const error = c.req.query("error") ?? undefined;
     const pageRaw = c.req.query("page");
     const page = pageRaw ? Math.max(1, Number.parseInt(pageRaw, 10) || 1) : 1;
@@ -1951,6 +1954,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       if (state) params.set("state", state);
       if (session) params.set("session", session);
       if (repo) params.set("repo", repo);
+      if (hitl) params.set("hitl", hitl);
       // Agent-name filtering is done client-side, so we fetch a larger slice
       // when an agent filter is active to avoid under-counting across pages.
       params.set("limit", agentFilterIds !== null ? "500" : String(limit));
@@ -2013,7 +2017,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     return html(
       renderTasksPage(
         tasks,
-        { status, state, session, repo, agent },
+        { status, state, session, repo, agent, hitl },
         degraded,
         c.var.userEmail,
         agentNames,

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -79,7 +79,7 @@ List tasks
 - **Method:** GET
 - **Path:** `/tasks`
 - **Has body:** No
-- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query), `updatedSince` (query)
+- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `hitl` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query), `updatedSince` (query)
 
 ## `tasks_update`
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -50,6 +50,7 @@ Query params:
 | `claimedBy` | string | Filter by claiming agent |
 | `pr` | number | Filter by PR number |
 | `branch` | string | Filter by branch name |
+| `hitl` | `true` or `false` | Filter by HITL (human-in-the-loop) flag: return tasks with or without the flag set |
 | `limit` | number | Page size |
 | `offset` | number | Page offset |
 | `sort` | string | `asc` (default) or `desc` — orders results by `createdAt`. Default preserves existing ascending order for all callers. |

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -386,6 +386,7 @@ export const TaskListQuerySchema = z.object({
   limit: z.string().optional().openapi({ example: "50" }),
   offset: z.string().optional().openapi({ example: "0" }),
   ready: z.enum(["true", "false"]).optional().openapi({ example: "true" }),
+  hitl: z.enum(["true", "false"]).optional().openapi({ example: "true" }),
   sort: z.enum(["asc", "desc"]).optional().openapi({ example: "asc" }),
   updatedSince: z.string().optional().openapi({
     example: "2026-01-01T00:00:00.000Z",

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -302,6 +302,68 @@ describe("createTasksRoutes — OpenAPIHono migration (TSM-1.2)", () => {
     expect(res.status).toBe(400);
   });
 
+  it("GET /?hitl=true passes hitl: true through to taskService.list()", async () => {
+    const task = makeTask({ id: "t-1", hitl: true });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?hitl=true");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { hitl?: boolean }).hitl).toBe(true);
+  });
+
+  it("GET /?hitl=false passes hitl: false through to taskService.list()", async () => {
+    const task = makeTask({ id: "t-1", hitl: false });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?hitl=false");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { hitl?: boolean }).hitl).toBe(false);
+  });
+
+  it("GET / with no hitl param passes hitl: undefined through to taskService.list() (existing behavior)", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { hitl?: boolean }).hitl).toBeUndefined();
+  });
+
+  it("GET /?hitl=garbage rejects with a 400 (invalid enum value, mirrors ?ready= behavior)", async () => {
+    const app = createTasksRoutes(fakeTaskService());
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?hitl=garbage");
+    expect(res.status).toBe(400);
+  });
+
   it("GET /distinct returns 200 with { sessions, repos } shape", async () => {
     const app = createTasksRoutes(fakeTaskService());
     const parent = makeAdminParent(app);

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -13,7 +13,7 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /tasks               list (?status, ?state=open|closed, ?session, ?assignee, ?pr, ?branch, ?limit, ?offset, ?ready=true)
+ *   GET    /tasks               list (?status, ?state=open|closed, ?session, ?assignee, ?pr, ?branch, ?hitl=true|false, ?limit, ?offset, ?ready=true)
  *                              returns { tasks, total }
  *   POST   /tasks               create one (409 if id exists)
  *   POST   /tasks/bulk          insert array, skip 409s → { inserted, updated, skipped }
@@ -498,6 +498,12 @@ export function createTasksRoutes(
       claimedBy: c.req.query("claimedBy"),
       pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
       branch: c.req.query("branch"),
+      hitl:
+        c.req.query("hitl") === "true"
+          ? true
+          : c.req.query("hitl") === "false"
+            ? false
+            : undefined,
       limit:
         limitRaw !== undefined
           ? Number.parseInt(limitRaw, 10) || undefined

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -54,6 +54,7 @@ export interface TaskListFilters {
   claimedBy?: string;
   pr?: number;
   branch?: string;
+  hitl?: boolean;
   limit?: number;
   offset?: number;
   /** Order results by createdAt. Defaults to "asc" (existing behavior). */
@@ -130,6 +131,7 @@ export class TaskService implements TaskServiceLike {
     if (filters.claimedBy) where.claimedBy = filters.claimedBy;
     if (filters.pr !== undefined) where.pr = filters.pr;
     if (filters.branch !== undefined) where.branch = filters.branch;
+    if (filters.hitl !== undefined) where.hitl = filters.hitl;
     if (filters.updatedSince) {
       where.updatedAt = { gte: parseUpdatedSince(filters.updatedSince) };
     }

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -415,6 +415,42 @@ describe("TaskService.list() updatedSince/repo where clause", () => {
       BadRequestError,
     );
   });
+
+  it("list({ hitl: true }) sets where.hitl = true", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({ hitl: true });
+
+    const where = prisma._findManyCalls[0].where as
+      | { hitl?: boolean }
+      | undefined;
+    expect(where?.hitl).toBe(true);
+  });
+
+  it("list({ hitl: false }) sets where.hitl = false", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({ hitl: false });
+
+    const where = prisma._findManyCalls[0].where as
+      | { hitl?: boolean }
+      | undefined;
+    expect(where?.hitl).toBe(false);
+  });
+
+  it("list({}) omits where.hitl entirely (preserves current unfiltered behavior)", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({});
+
+    const where = prisma._findManyCalls[0].where as
+      | { hitl?: boolean }
+      | undefined;
+    expect(where?.hitl).toBeUndefined();
+  });
 });
 
 // ─── TaskService.list() blockedBy dependency lookup scoping ────────────────


### PR DESCRIPTION
## Summary
- Add a `hitl` (true/false) query param filter to the task-store `GET /tasks` API, threaded through `TaskService.list()`'s Prisma where-clause.
- Forward the `hitl` param from the admin app's `/admin/tasks` route to the task-store API call.
- Add a Yes/No/Any `hitl` select control to the rendered task list page, next to the existing Status filter, wired through `makePageUrl`/`makeStateParams` so it round-trips across pagination and state-tab links.
- Refresh `docs/task-store.md` and `docs/mcp-tools.md` to document the new query param.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `GET /tasks` accepts `hitl=true`/`hitl=false` and filters by the `hitl` column; omitting it is unchanged behavior | MET |
| 2 | `GET /admin/tasks` accepts and passes through `hitl` to the task-store call | MET |
| 3 | Rendered `/admin/tasks` page includes a Yes/No/Any select for `hitl` alongside Status | MET |
| 4 | `hitl` filter round-trips through pagination and state-tab links | MET |
| 5 | Existing filters (status, repo, etc.) continue to work unmodified | MET |

## Test Plan
- `task-store/src/task-service.unit.test.ts` — `list({hitl:true|false|omitted})` where-clause assertions
- `task-store/src/routes/tasks.openapi.smoke.test.ts` — `GET /?hitl=true|false|<none>|garbage` (garbage → 400, mirrors `?ready=`/`?sort=`)
- `admin/src/admin-ui.smoke.test.ts` — `/admin/tasks?hitl=...` forwarding
- `admin/src/admin-ui-pages.unit.test.ts` — select rendering + pagination/state-tab round-tripping
- [x] `bunx biome lint .` clean
- [x] `bun run --filter='*' --sequential typecheck` clean across all workspaces
- [x] Scoped `bun test task-store/ admin/` — 1612 pass, 0 fail

Generated with [Claude Code](https://claude.com/claude-code)
