### PR TITLE
docs: document opt-in TTL-buffer var + N:1 fleet requirement (CTB-3.1)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.6.448] - 2026-07-17
+
+### Changed
+
+- docs: document opt-in claim TTL buffer var (`taskStore.extraEnv` example) and N:1 agents-to-task-store TTL requirement (CTB-3.1)
+
 ## [1.6.447] - 2026-07-17
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.6.447
+version: 1.6.448
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,7 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.6.447 triggered by release tag task-store-v1.0.0"
+      description: "docs: document opt-in claim TTL buffer var (taskStore.extraEnv example) and N:1 agents-to-task-store TTL requirement"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -558,6 +558,9 @@ taskStore:
   # wiring (e.g. SHIPWRIGHT_TASK_STORE_AGENTS_URL + AGENTS_API_KEY for the
   # scope resolver) without baking those into the chart template.
   extraEnv: []
+  # Example: opt-in claim TTL buffer check (see docs/deploy-kubernetes.md):
+  # - name: SHIPWRIGHT_CLAUDE_TIMEOUT_MS
+  #   value: "1800000"  # set to the MAX SHIPWRIGHT_CLAUDE_TIMEOUT_MS across all provisioned agents
   # -- Optional Sentry error reporting for the task-store service. Leave
   # dsn.existingSecret empty to disable (no Sentry init, no middleware mounted).
   sentry:

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -458,6 +458,12 @@ By default the admin service **does not** mint chat-service tokens — provision
 
 When `chat.enabled=true` and `chat.adminToken.existingSecret` is set, the chart injects `SHIPWRIGHT_CHAT_SERVICE_URL` and `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` into the admin Deployment. With those present, the provisioner mints a scoped per-agent token during `POST /agents`, stores it in the agent Secret (key `chat-service-token`), and injects it into the agent Deployment as `SHIPWRIGHT_CHAT_SERVICE_TOKEN` (via `secretKeyRef`). On agent deletion the token is revoked via `DELETE /tokens/:id`. When the admin token wiring is absent, chat-service token provisioning is disabled and agents carry no chat-service credentials.
 
+### Task-store claim TTL and the agent fleet (opt-in)
+
+Task-store and the agent are separate deployables with independent env surfaces. When provisioning a **fleet of N agents sharing one task-store**, each agent can have its own `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` (the hard session timeout, defaulting to 30 minutes), configured per-agent via the admin service's `POST`/`PATCH /agents/:id/envs` endpoints. Task-store itself has a single `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` (the claim reaping timeout, defaulting to 35 minutes) that gates how long a claim remains valid without a heartbeat.
+
+To prevent claims from being reaped mid-session when long-running agents approach their session timeout, `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` must exceed the **maximum** `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` across all provisioned agents, plus the standard 5-minute buffer. Task-store has an opt-in startup check (`checkClaimTtlBuffer` in `task-store/src/claim-ttl-buffer-check.ts`) that validates this constraint: set `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` in task-store's own env (via `taskStore.extraEnv` in the chart) to the **maximum** across your fleet, and if the resolved claim TTL is insufficient, task-store will `console.warn` at startup with both values and a suggested minimum TTL. The check is purely a warning — it does not block startup — so you can deploy and adjust the TTL upward to resolve it. When `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` is unset in task-store's env, the check is a no-op (today's default behavior). See [`configuration.md`](./configuration.md#server) for the full `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS` and `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` variable descriptions and defaults.
+
 ---
 
 ## Agent voice (STT/TTS)


### PR DESCRIPTION
## Summary
- Add a commented example under `taskStore.extraEnv` in `charts/shipwright/values.yaml` showing how to opt in to the `SHIPWRIGHT_CLAUDE_TIMEOUT_MS` cross-check var (comment only — no functional chart change)
- Add a new "Task-store claim TTL and the agent fleet (opt-in)" section to `docs/deploy-kubernetes.md` explaining the N:1 agents-to-task-store TTL requirement and cross-referencing the `checkClaimTtlBuffer` opt-in startup check

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Commented example under taskStore.extraEnv, helm template byte-identical | MET | Comment-only lines added (charts/shipwright/values.yaml:561-563) |
| 2 | New N:1 section in deploy-kubernetes.md cross-referencing opt-in warning | MET | New "### Task-store claim TTL and the agent fleet (opt-in)" section added |
| 3 | check-config-docs and check-strings gates pass | MET | Both re-confirmed passing |
| 4 | No test change | MET | No test files touched — docs/comment-only task |

## Test Plan
- [x] `task check-strings` passes
- [x] `task check-config-docs` passes
- [x] `task lint` passes
- [x] Verified `charts/shipwright/values.yaml` diff is comment-only (no functional chart change)
- N/A: no test layer applies to this docs/comment-only change

Generated with [Claude Code](https://claude.com/claude-code)
