### PR TITLE
fix: reset reviewState to pending after an all-REJECT, no-diff patch cycle

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -280,11 +280,81 @@ describe("patch.md — rebuttal comment for all-REJECT findings (RPF-1.1)", () =
     expect(section).toContain("Do not post the comment here");
   });
 
-  it("Step 5c still skips Step 5c.5 (no PR record patch) on the all-REJECT no-push path", () => {
+  it("Step 5c no longer skips Step 5c.5 on the all-REJECT no-push path — it always proceeds", () => {
     const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
     const step5c5Idx = content.indexOf("### Step 5c.5:");
     const section = content.slice(step5cIdx, step5c5Idx);
 
-    expect(section).toContain("skip Step 5c.5");
+    expect(section).not.toContain("skip Step 5c.5");
+    expect(section).toMatch(/proceed(s)? to Step 5c\.5/i);
+    // Still distinguishes the all-REJECT/no-push case from the mixed/push case in prose,
+    // it just no longer skips the step for it.
+    expect(section).toContain("no-push");
+  });
+});
+
+describe("patch.md — reset reviewState to pending after all-REJECT no-diff patch cycle (RPF-1.2)", () => {
+  it("Step 5c always proceeds to Step 5c.5, carrying forward whether this was the all-REJECT/no-push/rebuttal-confirmed case", () => {
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    const step5c5Idx = content.indexOf("### Step 5c.5:");
+    const section = content.slice(step5cIdx, step5c5Idx);
+
+    expect(section).toContain("DONE_WITH_CONCERNS");
+    expect(section).toMatch(/proceed(s)? to Step 5c\.5/i);
+    // Both the mixed-push case and the all-REJECT-no-push case now reach Step 5c.5.
+    expect(section.toLowerCase()).toContain("mixed");
+    expect(section).toContain("no-push");
+  });
+
+  it("Step 5c.5 conditionally PATCHes /prs/{id} with reviewState:pending, gated on the all-REJECT/no-push/rebuttal-confirmed case", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    expect(step5c5Idx).toBeGreaterThan(-1);
+    expect(step5dIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    // Existing unconditional heartbeat + commitSha patch calls remain.
+    expect(section).toContain("/prs/$PR_RECORD_ID/heartbeat");
+    expect(section).toContain("/prs/$PR_RECORD_ID/patch");
+    expect(section).toContain("commitSha");
+
+    // New conditional reviewState reset.
+    expect(section).toContain("-X PATCH");
+    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+    expect(section).toContain("reviewState");
+    expect(section).toContain("pending");
+    // It must be gated by a condition, not unconditional — expect an if-check near the
+    // reviewState reset referencing the all-REJECT/no-push/rebuttal case.
+    const reviewStateIdx = section.indexOf("reviewState");
+    const before = section.slice(Math.max(0, reviewStateIdx - 600), reviewStateIdx);
+    expect(before).toMatch(/if\s*\[/);
+  });
+
+  it("Step 5c.5's reviewState reset is scoped to the all-REJECT/no-push case, not the ACCEPT/MODIFY push case", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    // The prose around the conditional must reference the all-REJECT/no-push/rebuttal case,
+    // not fire for every patch cycle.
+    expect(section.toLowerCase()).toMatch(/all-reject/);
+    expect(section.toLowerCase()).toContain("no-push");
+  });
+
+  it("the ACCEPT/MODIFY push path text in Step 5b [D] is unchanged — still commits, pushes, and records commitSha", () => {
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    const step5bSection = content.slice(step5bIdx, step5cIdx);
+
+    const dIdx = step5bSection.indexOf("[D] Commit");
+    const eIdx = step5bSection.indexOf("[E] Resolve addressed inline threads");
+    const dSection = step5bSection.slice(dIdx, eIdx);
+
+    expect(dSection).toContain("ACCEPTED or MODIFIED");
+    expect(dSection).toContain("git add {changed files}");
+    expect(dSection).toContain("git push origin {branch}");
+    // No reviewState reset language belongs in the subagent-dispatched commit instructions —
+    // that logic lives in Step 5c.5, driven by the orchestrator, not the subagent.
+    expect(dSection).not.toContain("reviewState");
   });
 });

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -293,20 +293,22 @@ describe("patch.md — rebuttal comment for all-REJECT findings (RPF-1.1)", () =
   });
 });
 
-describe("patch.md — reset reviewState to pending after all-REJECT no-diff patch cycle (RPF-1.2)", () => {
-  it("Step 5c always proceeds to Step 5c.5, carrying forward whether this was the all-REJECT/no-push/rebuttal-confirmed case", () => {
+describe("patch.md — reset reviewState to pending after a no-push, rebuttal-confirmed patch cycle (RPF-1.2)", () => {
+  it("Step 5c always proceeds to Step 5c.5, carrying forward whether this was the no-push/rebuttal-confirmed case", () => {
     const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
     const step5c5Idx = content.indexOf("### Step 5c.5:");
     const section = content.slice(step5cIdx, step5c5Idx);
 
     expect(section).toContain("DONE_WITH_CONCERNS");
     expect(section).toMatch(/proceed(s)? to Step 5c\.5/i);
-    // Both the mixed-push case and the all-REJECT-no-push case now reach Step 5c.5.
+    // Both the mixed-push case and the no-push case (whether every finding was REJECTed or
+    // some ACCEPTED/MODIFIED findings resolved to a zero-diff no-op) now reach Step 5c.5.
     expect(section.toLowerCase()).toContain("mixed");
     expect(section).toContain("no-push");
+    expect(section).not.toContain("ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED");
   });
 
-  it("Step 5c.5 conditionally PATCHes /prs/{id} with reviewState:pending, gated on the all-REJECT/no-push/rebuttal-confirmed case", () => {
+  it("Step 5c.5 conditionally PATCHes /prs/{id} with reviewState:pending, gated on the no-push/rebuttal-confirmed case", () => {
     const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
     const step5dIdx = content.indexOf("### Step 5d:");
     expect(step5c5Idx).toBeGreaterThan(-1);
@@ -324,21 +326,25 @@ describe("patch.md — reset reviewState to pending after all-REJECT no-diff pat
     expect(section).toContain("reviewState");
     expect(section).toContain("pending");
     // It must be gated by a condition, not unconditional — expect an if-check near the
-    // reviewState reset referencing the all-REJECT/no-push/rebuttal case.
+    // reviewState reset referencing the no-push/rebuttal case.
     const reviewStateIdx = section.indexOf("reviewState");
     const before = section.slice(Math.max(0, reviewStateIdx - 600), reviewStateIdx);
     expect(before).toMatch(/if\s*\[/);
+    expect(section).toContain("NO_PUSH_REBUTTAL_CONFIRMED");
   });
 
-  it("Step 5c.5's reviewState reset is scoped to the all-REJECT/no-push case, not the ACCEPT/MODIFY push case", () => {
+  it("Step 5c.5's reviewState reset is scoped to the no-push case, not the ACCEPT/MODIFY push case, and doesn't require every finding to be REJECTed", () => {
     const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
     const step5dIdx = content.indexOf("### Step 5d:");
     const section = content.slice(step5c5Idx, step5dIdx);
 
-    // The prose around the conditional must reference the all-REJECT/no-push/rebuttal case,
-    // not fire for every patch cycle.
-    expect(section.toLowerCase()).toMatch(/all-reject/);
+    // The prose around the conditional must reference the no-push/rebuttal case, not fire
+    // for every patch cycle, and must not require literally every finding to be REJECTed
+    // (a mixed run whose ACCEPTED/MODIFIED findings all resolve to zero-diff no-ops also
+    // qualifies, since dedup keys off the commit SHA, not the finding classification).
     expect(section.toLowerCase()).toContain("no-push");
+    const normalized = section.replace(/\s+/g, " ");
+    expect(normalized).toMatch(/does not require every finding.{0,40}REJECTed/i);
   });
 
   it("the ACCEPT/MODIFY push path text in Step 5b [D] is unchanged — still commits, pushes, and records commitSha", () => {

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -741,23 +741,27 @@ Parse the subagent's STATUS:
 - **DONE**: Record the findings addressed. Proceed to Step 5c.5 (upsert PR record).
 - **DONE_WITH_CONCERNS**: Read concerns. If any concern reports a REJECTed finding (per
   Step 5b Instructions [D], this fires whenever at least one finding was REJECTed —
-  whether that was the *only* outcome (the all-REJECT, no-diff path) or one branch of a
-  mixed ACCEPT+REJECT run where a push also happened), confirm the subagent's CONCERNS
-  text reports both that it already posted the required `gh pr comment` rebuttal AND that
-  it resolved the inline threads for the REJECTed findings. Both are needed — the rebuttal
-  activates the `isAddressedByAuthorReply` escape hatch in `check-patch.ts`, but
+  whether every finding in the run was REJECTed with no push at all, one branch of a mixed
+  ACCEPT+REJECT run where a push also happened, or a mixed run where no push happened
+  because every ACCEPTED/MODIFIED finding in that run resolved to a zero-diff no-op
+  alongside the REJECTed one(s)), confirm the subagent's CONCERNS text reports both that it
+  already posted the required `gh pr comment` rebuttal AND that it resolved the inline
+  threads for the REJECTed findings. Both are needed — the rebuttal activates the
+  `isAddressedByAuthorReply` escape hatch in `check-patch.ts`, but
   `hasUnaddressedFindings()` short-circuits to `true` on any unresolved inline thread before
   that escape hatch is even consulted, so the threads must also be resolved or the review
   stops being reflagged only for body-level findings, not inline ones (the common case).
   Do not post the comment here or resolve the threads here; Step 5c only verifies it
   already happened. If the report doesn't confirm both, treat it as a concern in the final
-  report (the reflagging loop will otherwise persist via this mixed-case path, not just the
-  all-REJECT path). For other, non-REJECT correctness-gap concerns, just log them in the
-  report. Either way, always proceed to Step 5c.5 (upsert PR record) — in the mixed case
-  there IS a new commit SHA to record, and in the all-REJECT, no-push case Step 5c.5 still
-  needs to run so it can reset `reviewState` to `pending` (see below), even though there is
-  no new commit SHA. Carry forward into Step 5c.5 whether this was the all-REJECT, no-push,
-  rebuttal-confirmed case — that's the condition that gates the `reviewState` reset there.
+  report (the reflagging loop will otherwise persist regardless of which no-push variant
+  produced it). For other, non-REJECT correctness-gap concerns, just log them in the
+  report. Either way, always proceed to Step 5c.5 (upsert PR record) — when a push happened
+  there IS a new commit SHA to record, and when no push happened Step 5c.5 still needs to
+  run so it can reset `reviewState` to `pending` (see below), even though there is no new
+  commit SHA. Carry forward into Step 5c.5 whether this cycle had no push
+  (`HEAD_SHA_POST_PATCH` unchanged from before dispatch) with at least one REJECTed finding
+  rebuttal-confirmed — regardless of whether every finding in the run was REJECTed — that's
+  the condition that gates the `reviewState` reset there.
 - **BLOCKED**: Release the pre-work claim from Step 5a.6 so a subsequent patch/review-patch
   run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
   never completed, so nothing is actually in flight:
@@ -788,7 +792,7 @@ if [ -n "$PR_RECORD_ID" ]; then
     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" \
     -d "{\"commitSha\": \"$HEAD_SHA_POST_PATCH\"}" > /dev/null 2>&1 || \
     echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
-  if [ "$ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]; then
+  if [ "$NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]; then
     curl -sf -X PATCH \
       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
       -H "Content-Type: application/json" \
@@ -801,17 +805,20 @@ else
 fi
 ```
 
-`ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED` is the condition carried forward from Step 5c: set
-it to `true` only for the all-REJECT, no-push case — this cycle was DONE_WITH_CONCERNS with
-every finding REJECTed, zero files changed (no push — `HEAD_SHA_POST_PATCH` is unchanged
-from before dispatch), and the rebuttal comment + inline-thread resolution were confirmed
-per Step 5c. In that case alone, `headRefOid` never changes, so without this reset the PR's
-`reviewState` would stay at whatever the prior review left it and the PR could never
+`NO_PUSH_REBUTTAL_CONFIRMED` is the condition carried forward from Step 5c: set it to
+`true` whenever this cycle was DONE_WITH_CONCERNS with at least one finding REJECTed, zero
+files changed (no push — `HEAD_SHA_POST_PATCH` is unchanged from before dispatch), and the
+rebuttal comment + inline-thread resolution were confirmed per Step 5c. This does not
+require every finding in the run to be REJECTed — a mixed run where the ACCEPTED/MODIFIED
+findings all resolved to zero-diff no-ops still qualifies, since what matters for the
+commit-SHA-based dedup is whether the SHA actually changed, not how the findings were
+classified. In this no-push case, `headRefOid` never changes, so without this reset the
+PR's `reviewState` would stay at whatever the prior review left it and the PR could never
 re-qualify as a review candidate in `check-review.ts`'s dedup — resetting it to `pending`
 here makes it re-qualify despite the unchanged commit SHA, so a fresh review can evaluate
-the rebuttal and post an actual APPROVE. The mixed case (push happened) and the plain DONE
-case leave `ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED` unset/`false` — they already re-qualify
-naturally via the changed commit SHA, so the `reviewState` reset must not fire there.
+the rebuttal and post an actual APPROVE. Any cycle where a push did happen leaves
+`NO_PUSH_REBUTTAL_CONFIRMED` unset/`false` — it already re-qualifies naturally via the
+changed commit SHA, so the `reviewState` reset must not fire there.
 
 Proceed to Step 5d (cleanup).
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -753,9 +753,11 @@ Parse the subagent's STATUS:
   already happened. If the report doesn't confirm both, treat it as a concern in the final
   report (the reflagging loop will otherwise persist via this mixed-case path, not just the
   all-REJECT path). For other, non-REJECT correctness-gap concerns, just log them in the
-  report. Either way, proceed to Step 5c.5 (upsert PR record) if a push happened (mixed
-  case — there IS a new commit SHA to record); skip Step 5c.5 only in the all-REJECT,
-  no-push case (there is no new commit SHA to record).
+  report. Either way, always proceed to Step 5c.5 (upsert PR record) — in the mixed case
+  there IS a new commit SHA to record, and in the all-REJECT, no-push case Step 5c.5 still
+  needs to run so it can reset `reviewState` to `pending` (see below), even though there is
+  no new commit SHA. Carry forward into Step 5c.5 whether this was the all-REJECT, no-push,
+  rebuttal-confirmed case — that's the condition that gates the `reviewState` reset there.
 - **BLOCKED**: Release the pre-work claim from Step 5a.6 so a subsequent patch/review-patch
   run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
   never completed, so nothing is actually in flight:
@@ -786,10 +788,30 @@ if [ -n "$PR_RECORD_ID" ]; then
     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" \
     -d "{\"commitSha\": \"$HEAD_SHA_POST_PATCH\"}" > /dev/null 2>&1 || \
     echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
+  if [ "$ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]; then
+    curl -sf -X PATCH \
+      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+      -d '{"reviewState": "pending"}' > /dev/null 2>&1 || \
+      echo "⚠ PATCH /prs/$PR_RECORD_ID reviewState reset failed — continuing"
+  fi
 else
   echo "⚠ no PR_RECORD_ID from pre-work claim — skipping PR record update"
 fi
 ```
+
+`ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED` is the condition carried forward from Step 5c: set
+it to `true` only for the all-REJECT, no-push case — this cycle was DONE_WITH_CONCERNS with
+every finding REJECTed, zero files changed (no push — `HEAD_SHA_POST_PATCH` is unchanged
+from before dispatch), and the rebuttal comment + inline-thread resolution were confirmed
+per Step 5c. In that case alone, `headRefOid` never changes, so without this reset the PR's
+`reviewState` would stay at whatever the prior review left it and the PR could never
+re-qualify as a review candidate in `check-review.ts`'s dedup — resetting it to `pending`
+here makes it re-qualify despite the unchanged commit SHA, so a fresh review can evaluate
+the rebuttal and post an actual APPROVE. The mixed case (push happened) and the plain DONE
+case leave `ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED` unset/`false` — they already re-qualify
+naturally via the changed commit SHA, so the `reviewState` reset must not fire there.
 
 Proceed to Step 5d (cleanup).
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -738,7 +738,13 @@ INSTRUCTIONS — follow in order:
 
 Parse the subagent's STATUS:
 
-- **DONE**: Record the findings addressed. Proceed to Step 5c.5 (upsert PR record).
+- **DONE**: Record the findings addressed. A `DONE` status always followed a push (no-push
+  cycles only ever report `DONE_WITH_CONCERNS` per Step 5b Instructions [D]), so this cycle
+  does not qualify for the `reviewState` reset:
+  ```bash
+  NO_PUSH_REBUTTAL_CONFIRMED=false
+  ```
+  Proceed to Step 5c.5 (upsert PR record).
 - **DONE_WITH_CONCERNS**: Read concerns. If any concern reports a REJECTed finding (per
   Step 5b Instructions [D], this fires whenever at least one finding was REJECTed —
   whether every finding in the run was REJECTed with no push at all, one branch of a mixed
@@ -761,7 +767,21 @@ Parse the subagent's STATUS:
   commit SHA. Carry forward into Step 5c.5 whether this cycle had no push
   (`HEAD_SHA_POST_PATCH` unchanged from before dispatch) with at least one REJECTed finding
   rebuttal-confirmed — regardless of whether every finding in the run was REJECTed — that's
-  the condition that gates the `reviewState` reset there.
+  the condition that gates the `reviewState` reset there. Make this explicit by setting
+  `NO_PUSH_REBUTTAL_CONFIRMED` before proceeding to Step 5c.5:
+  ```bash
+  if [ "$HEAD_SHA_POST_PATCH" = "$HEAD_SHA_PRE_PATCH" ] && \
+     [ <at least one REJECTed finding this cycle, with rebuttal comment posted and its
+        inline thread(s) resolved, per the confirmation check above> ]; then
+    NO_PUSH_REBUTTAL_CONFIRMED=true
+  else
+    NO_PUSH_REBUTTAL_CONFIRMED=false
+  fi
+  ```
+  The second condition is a judgment call from the subagent's STATUS/CONCERNS report, not a
+  literal shell test — evaluate it the same way you just evaluated the "confirm ... rebuttal
+  ... AND ... resolved the inline threads" check earlier in this bullet, then set the
+  variable accordingly before Step 5c.5 reads it.
 - **BLOCKED**: Release the pre-work claim from Step 5a.6 so a subsequent patch/review-patch
   run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
   never completed, so nothing is actually in flight:
@@ -805,20 +825,17 @@ else
 fi
 ```
 
-`NO_PUSH_REBUTTAL_CONFIRMED` is the condition carried forward from Step 5c: set it to
-`true` whenever this cycle was DONE_WITH_CONCERNS with at least one finding REJECTed, zero
-files changed (no push — `HEAD_SHA_POST_PATCH` is unchanged from before dispatch), and the
-rebuttal comment + inline-thread resolution were confirmed per Step 5c. This does not
-require every finding in the run to be REJECTed — a mixed run where the ACCEPTED/MODIFIED
-findings all resolved to zero-diff no-ops still qualifies, since what matters for the
-commit-SHA-based dedup is whether the SHA actually changed, not how the findings were
-classified. In this no-push case, `headRefOid` never changes, so without this reset the
-PR's `reviewState` would stay at whatever the prior review left it and the PR could never
-re-qualify as a review candidate in `check-review.ts`'s dedup — resetting it to `pending`
-here makes it re-qualify despite the unchanged commit SHA, so a fresh review can evaluate
-the rebuttal and post an actual APPROVE. Any cycle where a push did happen leaves
-`NO_PUSH_REBUTTAL_CONFIRMED` unset/`false` — it already re-qualifies naturally via the
-changed commit SHA, so the `reviewState` reset must not fire there.
+`NO_PUSH_REBUTTAL_CONFIRMED` is assigned in Step 5c, before this step runs — see there for
+the exact condition. It does not require every finding in the run to be REJECTed — a mixed
+run where the ACCEPTED/MODIFIED findings all resolved to zero-diff no-ops still qualifies,
+since what matters for the commit-SHA-based dedup is whether the SHA actually changed, not
+how the findings were classified. The rest of this paragraph is the "why": in this no-push
+case, `headRefOid` never changes, so without this reset the PR's `reviewState` would stay
+at whatever the prior review left it and the PR could never re-qualify as a review
+candidate in `check-review.ts`'s dedup — resetting it to `pending` here makes it re-qualify
+despite the unchanged commit SHA, so a fresh review can evaluate the rebuttal and post an
+actual APPROVE. Any cycle where a push did happen re-qualifies naturally via the changed
+commit SHA, so the `reviewState` reset must not fire there.
 
 Proceed to Step 5d (cleanup).
 


### PR DESCRIPTION
## Summary
- Fix `patch.md` Step 5c so an all-REJECT, no-diff patch cycle no longer skips Step 5c.5 entirely — it now always proceeds, carrying forward whether the rebuttal was confirmed.
- Step 5c.5 conditionally issues `PATCH /prs/{id}` with `{"reviewState": "pending"}` when the cycle was DONE_WITH_CONCERNS + zero files changed + rebuttal comment posted, letting the PR re-qualify in `check-review.ts`'s dedup despite an unchanged `headRefOid` so it can earn a real APPROVE.
- The ACCEPT/MODIFY push-a-commit path is untouched — the reset never fires when a new commit SHA already re-qualifies the PR naturally.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 5c.5 conditionally PATCHes reviewState:pending on the all-REJECT/no-push/rebuttal-confirmed case; existing patchCycles bump still fires unconditionally | MET | New `if [ "$ALL_REJECT_NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]` block added after the existing unconditional heartbeat + commitSha POST |
| 2 | ACCEPT/MODIFY push path unchanged; reset never fires on a path with a new commitSha | MET | Step 5b [D] untouched; new test asserts no `reviewState` mention there |
| 3 | check-review.ts needs no code change; existing test already covers reviewState:pending + unchanged commitSha eligibility | MET | Confirmed via `check-review.ts`'s dedup gate and the existing test "returns a candidate when PR record has reviewState=pending (even if commitSha matches)" — no code/test change needed there |
| 4 | Add coverage in patch.content.test.ts; no existing tests retired | MET | New "RPF-1.2" describe block added; the one pre-existing test whose assertion contradicted the new behavior was rewritten (not deleted) |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/ agent/src/check-review.unit.test.ts` — 253 pass, 0 fail
- `bunx biome lint` — clean
- `tsc --noEmit` (plugins/shipwright) — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
