### PR TITLE
fix: don't clobber terminal reviewState in PR release() (CHU-2.3)

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -261,7 +261,7 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 | `POST /prs/:id/heartbeat` | Touch `heartbeatAt` |
 | `POST /prs/:id/complete` | `reviewState=posted`, increment `reviewCycles`, set `reviewedAt` |
 | `POST /prs/:id/patch` | Increment `patchCycles`, set `patchedAt`, clear `claimedBy`/`claimedAt`/`heartbeatAt`/`phase`. Conditionally reset `reviewState=pending` based on optional `commitSha` in body: if omitted, unconditionally reset to pending; if provided and differs from record's stored `commitSha`, reset to pending and update `commitSha`; if provided and matches, leave `reviewState` untouched (no-op patch cycle). |
-| `POST /prs/:id/release` | Clear `claimedBy`/`claimedAt`/`heartbeatAt`, `reviewState=pending` |
+| `POST /prs/:id/release` | Clear `claimedBy`/`claimedAt`/`heartbeatAt`. Resets `reviewState=pending` unless it is already a terminal value (`posted`/`approved`), in which case `reviewState` is left untouched |
 
 #### PR state enums
 

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -567,17 +567,45 @@ export class PullRequestService implements PullRequestServiceLike {
     });
   }
 
-  /** Unclaim a PR — reset claim fields and return reviewState to pending. */
+  /**
+   * Unclaim a PR — always clears claim fields (claimedBy/claimedAt/heartbeatAt).
+   * reviewState is reset to 'pending' only if it is not already a terminal
+   * value ('posted' or 'approved'); a terminal reviewState is left untouched.
+   *
+   * Without this guard, a caller racing /complete or a direct PATCH that just
+   * set reviewState='posted'/'approved' would have that terminal verdict
+   * clobbered back to 'pending' by a subsequent release(), causing
+   * check-review / /shipwright:review to re-process a PR that was already
+   * reviewed and terminally verdicted on GitHub (18+ documented recurrences,
+   * app-vitals/shipwright CHU-2.3). Mirrors the same terminal-state guard
+   * already used by update() (posted/approved release, ~line 191) and
+   * patch()'s no-op-cycle guard (~line 411), and StaleClaimReaper.reap()'s
+   * equivalent SQL CASE expression.
+   */
   async release(id: string): Promise<PullRequest> {
+    const existing = await this.prisma.pullRequest.findUnique({
+      where: { id },
+    });
+    if (!existing) {
+      throw new NotFoundError("pr not found");
+    }
+
+    const updateData: Prisma.PullRequestUpdateInput = {
+      claimedBy: null,
+      claimedAt: null,
+      heartbeatAt: null,
+    };
+    if (
+      existing.reviewState !== "posted" &&
+      existing.reviewState !== "approved"
+    ) {
+      updateData.reviewState = "pending";
+    }
+
     try {
       return await this.prisma.pullRequest.update({
         where: { id },
-        data: {
-          reviewState: "pending",
-          claimedBy: null,
-          claimedAt: null,
-          heartbeatAt: null,
-        },
+        data: updateData,
       });
     } catch (err: unknown) {
       throw this.translateNotFound(err, "pr not found");

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -469,6 +469,114 @@ describe("PullRequestService.update() claim release on review post", () => {
   });
 });
 
+describe("PullRequestService.release()", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  test("reviewState:posted — preserves reviewState, still clears claim fields", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      reviewState: "posted",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.release("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect("reviewState" in data).toBe(false);
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+  });
+
+  test("reviewState:approved — preserves reviewState, still clears claim fields", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      reviewState: "approved",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.release("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect("reviewState" in data).toBe(false);
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+  });
+
+  test("reviewState:pending — resets reviewState=pending (no-op value), clears claim fields", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      reviewState: "pending",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.release("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("pending");
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+  });
+
+  test("reviewState:in_progress — resets reviewState=pending, clears claim fields", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      reviewState: "in_progress",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.release("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("pending");
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+  });
+
+  test("reviewState missing/null on existing record — resets reviewState=pending, clears claim fields", async () => {
+    const prisma = makePrismaDouble({
+      id: "pr-1",
+      claimedBy: "agent-a",
+    } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.release("pr-1");
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.reviewState).toBe("pending");
+    expect(data.claimedBy).toBeNull();
+    expect(data.claimedAt).toBeNull();
+    expect(data.heartbeatAt).toBeNull();
+  });
+
+  test("record does not exist — throws NotFoundError, does not call update", async () => {
+    const prisma = makePrismaDouble(null);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    let caught: unknown;
+    try {
+      await svc.release("missing-id");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(NotFoundError);
+    expect(prisma._updateCalls).toHaveLength(0);
+  });
+});
+
 describe("PullRequestService.complete() claim release", () => {
   const NOW = new Date("2026-07-10T12:00:00.000Z");
   const clock = FixedClock(NOW);


### PR DESCRIPTION
## Summary
- `PullRequestService.release()` no longer unconditionally resets `reviewState` to `"pending"` — it now only does so when the current `reviewState` is not already terminal (`"posted"` or `"approved"`), preventing a race where a `/complete` call or direct PATCH that just set a terminal verdict gets clobbered back to `"pending"` by a subsequent `release()`.
- `release()` now fetches the current record via `findUnique` first and throws `NotFoundError` explicitly if it's missing, mirroring the pattern already used in `patch()`.
- Doc comment above `release()` and the PR lifecycle table entry in `docs/task-store.md` updated to describe the new conditional behavior.

Root cause of 18+ documented recurrences of `check-review` / `/shipwright:review` re-processing PRs that were already reviewed and terminally verdicted on GitHub — follow-up to the CHU-2.1/CHU-2.2 claim-lifecycle-unification epic (CHU-2.3).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | release() does not reset reviewState to "pending" when current is "posted" or "approved" | MET | Conditional check in `release()`; covered by 2 new tests |
| 2 | release() resets reviewState to "pending" for non-terminal values | MET | Else-branch of same conditional; covered by 3 new tests (pending, in_progress, null/missing) |
| 3 | release() always clears claimedBy/claimedAt/heartbeatAt | MET | Unconditional in update payload; asserted in all 6 new tests |
| 4 | Existing tests continue to pass | MET | Full `bun test task-store`: 436 pass / 0 fail / 102 skip |
| 5 | New unit tests cover both branches | MET | 6 new tests in `pull-request-service.unit.test.ts`, including a not-found error path |

## Test Plan
- `bun test task-store/src/pull-request-service.unit.test.ts` — 6 new tests (posted-preserved, approved-preserved, pending-reset, in_progress-reset, missing-reviewState-reset, not-found-throws)
- `bun test task-store` — full suite, 436 pass / 0 fail / 102 skip, no regressions
- `bunx biome lint .` — clean (495 files)
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
