### PR TITLE
fix(admin): make task and PR references clickable across admin UI

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -24,6 +24,27 @@ import type { ModelBreakdownEntry } from "./openapi-schemas.ts";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+/** Renders a link to a task's detail page, styled like the rest of the admin UI's inline links. */
+function taskLink(taskId: string): string {
+  return `<a href="/admin/tasks/${escapeHtml(taskId)}" style="color:#6366f1;text-decoration:none">${escapeHtml(taskId)}</a>`;
+}
+
+/**
+ * Renders a link for a work-queue/cron-log item id, which is either a task id
+ * (e.g. "WLS-2.2") or a "repo#prNumber" PR reference (e.g. "acme/x#123") per
+ * the RankedWorkItem/CronRunItem id convention. Task ids link into the admin
+ * UI; PR references link out to GitHub since the internal PR record id isn't
+ * available in this shape. Falls back to plain escaped text if the PR
+ * reference doesn't parse.
+ */
+function workItemLink(type: "task" | "pr", id: string): string {
+  if (type === "task") return taskLink(id);
+  const match = id.match(/^(.+)#(\d+)$/);
+  if (!match) return escapeHtml(id);
+  const [, repo, prNumber] = match;
+  return `<a href="https://github.com/${escapeHtml(repo)}/pull/${escapeHtml(prNumber)}" target="_blank" rel="noopener" style="color:#6366f1;text-decoration:none">${escapeHtml(id)}</a>`;
+}
+
 /**
  * Returns a human-friendly relative timestamp.
  * Examples: "just now", "5 minutes ago", "2 hours ago", "3 days ago", "1 week ago"
@@ -1457,7 +1478,7 @@ export function renderTasksPage(
         if (b.type === "hitl") {
           return `<span class="badge badge-hitl" style="font-size:10px;margin-left:6px">Waiting: HITL</span>`;
         }
-        return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${escapeHtml(b.id)}</span>`;
+        return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${taskLink(b.id)}</span>`;
       })
       .join("");
   };
@@ -1739,12 +1760,16 @@ export function renderTaskDetailPage(
     </tr>`;
   }
 
-  function listField(label: string, items: string[] | undefined): string {
+  function listField(
+    label: string,
+    items: string[] | undefined,
+    linkItem = false,
+  ): string {
     if (!items || items.length === 0) return "";
     const listItems = items
       .map(
         (i) =>
-          `<li style="font-size:13px;margin-bottom:4px">${escapeHtml(i)}</li>`,
+          `<li style="font-size:13px;margin-bottom:4px">${linkItem ? taskLink(i) : escapeHtml(i)}</li>`,
       )
       .join("");
     return `<tr>
@@ -1845,7 +1870,7 @@ export function renderTaskDetailPage(
                     : "HITL gate (notification pending)";
                   return `<li style="font-size:14px;line-height:1.6;margin-bottom:4px">${escapeHtml(label)}</li>`;
                 }
-                return `<li style="font-size:14px;line-height:1.6;margin-bottom:4px">dep:${escapeHtml(b.id)} (${escapeHtml(b.status)})</li>`;
+                return `<li style="font-size:14px;line-height:1.6;margin-bottom:4px">dep:${taskLink(b.id)} (${escapeHtml(b.status)})</li>`;
               })
               .join("")}
           </ul>
@@ -1937,7 +1962,7 @@ export function renderTaskDetailPage(
 
   const depsSection =
     task.dependencies && task.dependencies.length > 0
-      ? listField("Dependencies", task.dependencies)
+      ? listField("Dependencies", task.dependencies, true)
       : "";
 
   return `<!DOCTYPE html>
@@ -2548,17 +2573,36 @@ export function renderPrDetailPage(
     </tr>`;
   }
 
+  function linkField(
+    label: string,
+    url: string | null | undefined,
+    text?: string,
+  ): string {
+    if (!url) return "";
+    return `<tr>
+      <td style="width:170px;padding:8px 12px;color:#6b7280;font-size:12px;font-weight:500;vertical-align:top">${escapeHtml(label)}</td>
+      <td style="padding:8px 12px;font-size:13px"><a href="${escapeHtml(url)}" target="_blank" rel="noopener" style="color:#6366f1">${escapeHtml(text ?? url)}</a></td>
+    </tr>`;
+  }
+
   const claimedByDisplay = pr.claimedBy
     ? agentNames[pr.claimedBy]
       ? `${agentNames[pr.claimedBy]} (${pr.claimedBy})`
       : pr.claimedBy
     : null;
 
+  const githubPrUrl = `https://github.com/${pr.repo}/pull/${pr.prNumber}`;
+
   const metaRows = [
     field("ID", pr.id, true),
     field("Repo", pr.repo),
-    field("PR Number", String(pr.prNumber)),
-    field("Task", pr.taskId),
+    linkField("PR Number", githubPrUrl, `#${pr.prNumber}`),
+    pr.taskId
+      ? `<tr>
+      <td style="width:170px;padding:8px 12px;color:#6b7280;font-size:12px;font-weight:500;vertical-align:top;white-space:nowrap">Task</td>
+      <td style="padding:8px 12px;font-size:13px">${taskLink(pr.taskId)}</td>
+    </tr>`
+      : "",
     field("State", pr.state),
     field("Review State", pr.reviewState),
     field("Review Cycles", String(pr.reviewCycles)),
@@ -2710,7 +2754,11 @@ export function renderCronLogsPage(opts: {
     // what kind of thing the id refers to.
     const itemCell =
       r.itemType && r.itemId
-        ? `<span class="badge" style="${ITEM_TYPE_BADGE_STYLE[r.itemType] ?? ITEM_TYPE_BADGE_STYLE_DEFAULT}">${escapeHtml(ITEM_TYPE_LABEL[r.itemType] ?? r.itemType)}</span> <span class="mono" style="font-size:12px">${escapeHtml(r.itemId)}</span>`
+        ? `<span class="badge" style="${ITEM_TYPE_BADGE_STYLE[r.itemType] ?? ITEM_TYPE_BADGE_STYLE_DEFAULT}">${escapeHtml(ITEM_TYPE_LABEL[r.itemType] ?? r.itemType)}</span> <span class="mono" style="font-size:12px">${
+            r.itemType === "task" || r.itemType === "pr"
+              ? workItemLink(r.itemType, r.itemId)
+              : escapeHtml(r.itemId)
+          }</span>`
         : "—";
 
     return `<tr>
@@ -2889,8 +2937,8 @@ export function renderWorkQueuePage(opts: {
     const typeCell = `<span class="badge" style="${ITEM_TYPE_BADGE_STYLE[item.type] ?? ITEM_TYPE_BADGE_STYLE_DEFAULT}">${escapeHtml(ITEM_TYPE_LABEL[item.type] ?? item.type)}</span>`;
     const phaseCell = `<span class="badge" style="${WORK_QUEUE_PHASE_BADGE_STYLE[item.phase] ?? WORK_QUEUE_PHASE_BADGE_STYLE_DEFAULT}">${escapeHtml(item.phase)}</span>`;
     const idTitleCell = item.title
-      ? `<span class="mono" style="font-size:12px">${escapeHtml(item.id)}</span> — ${escapeHtml(item.title)}`
-      : `<span class="mono" style="font-size:12px">${escapeHtml(item.id)}</span>`;
+      ? `<span class="mono" style="font-size:12px">${workItemLink(item.type, item.id)}</span> — ${escapeHtml(item.title)}`
+      : `<span class="mono" style="font-size:12px">${workItemLink(item.type, item.id)}</span>`;
     const ageDate = new Date(item.age);
     const ageIso = ageDate.toISOString();
     const ageCell = `<span title="${escapeHtml(ageIso)}">${escapeHtml(relativeTime(ageDate, now))}</span>`;

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -30,6 +30,16 @@ function taskLink(taskId: string): string {
 }
 
 /**
+ * Renders a link to an agent's detail page. `label` defaults to the agent id
+ * but callers pass a display name (e.g. "Xray Agent (agent-x)") when one is
+ * available from an `agentNames` lookup map, keeping the link text
+ * human-readable while still routing by id.
+ */
+function agentLink(agentId: string, label?: string): string {
+  return `<a href="/admin/agents/${escapeHtml(agentId)}" style="color:#6366f1;text-decoration:none">${escapeHtml(label ?? agentId)}</a>`;
+}
+
+/**
  * Renders a link for a work-queue/cron-log item id, which is either a task id
  * (e.g. "WLS-2.2") or a "repo#prNumber" PR reference (e.g. "acme/x#123") per
  * the RankedWorkItem/CronRunItem id convention. Task ids link into the admin
@@ -1478,7 +1488,7 @@ export function renderTasksPage(
         if (b.type === "hitl") {
           return `<span class="badge badge-hitl" style="font-size:10px;margin-left:6px">Waiting: HITL</span>`;
         }
-        return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${taskLink(b.id)}</span>`;
+        return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${readOnly ? escapeHtml(b.id) : taskLink(b.id)}</span>`;
       })
       .join("");
   };
@@ -1519,7 +1529,9 @@ export function renderTasksPage(
           .map((t) => {
             const agentId = t.claimedBy ?? t.assignee;
             const agentCell = agentId
-              ? escapeHtml(agentNames[agentId] ?? agentId)
+              ? readOnly
+                ? escapeHtml(agentNames[agentId] ?? agentId)
+                : agentLink(agentId, agentNames[agentId] ?? agentId)
               : '<span style="color:#9ca3af">—</span>';
             const blockerBadges = renderBlockerBadges(t.blockedBy);
             const prCell =
@@ -1748,6 +1760,17 @@ export function renderTaskDetailPage(
     </tr>`;
   }
 
+  function agentField(
+    label: string,
+    agentId: string | null | undefined,
+  ): string {
+    if (!agentId) return "";
+    return `<tr>
+      <td style="width:170px;padding:8px 12px;color:#6b7280;font-size:12px;font-weight:500;vertical-align:top;white-space:nowrap">${escapeHtml(label)}</td>
+      <td style="padding:8px 12px;font-size:13px;font-family:monospace;font-size:12px">${agentLink(agentId, agentNames[agentId] ? `${agentNames[agentId]} (${agentId})` : agentId)}</td>
+    </tr>`;
+  }
+
   function linkField(
     label: string,
     url: string | null | undefined,
@@ -1883,33 +1906,9 @@ export function renderTaskDetailPage(
     field("Type", task.type),
     field("Layer", task.layer),
     field("Source", task.source),
-    field(
-      "Assignee",
-      task.assignee
-        ? agentNames[task.assignee]
-          ? `${agentNames[task.assignee]} (${task.assignee})`
-          : task.assignee
-        : null,
-      true,
-    ),
-    field(
-      "Agent Hint",
-      task.agentHint
-        ? agentNames[task.agentHint]
-          ? `${agentNames[task.agentHint]} (${task.agentHint})`
-          : task.agentHint
-        : null,
-      true,
-    ),
-    field(
-      "Claimed By",
-      task.claimedBy
-        ? agentNames[task.claimedBy]
-          ? `${agentNames[task.claimedBy]} (${task.claimedBy})`
-          : task.claimedBy
-        : null,
-      true,
-    ),
+    agentField("Assignee", task.assignee),
+    agentField("Agent Hint", task.agentHint),
+    agentField("Claimed By", task.claimedBy),
     task.session
       ? `<tr>
       <td style="width:170px;padding:8px 12px;color:#6b7280;font-size:12px;font-weight:500;vertical-align:top;white-space:nowrap">Session</td>
@@ -2359,7 +2358,10 @@ export function renderPrsPage(
       : prs
           .map((pr) => {
             const claimedCell = pr.claimedBy
-              ? escapeHtml(agentNames[pr.claimedBy] ?? pr.claimedBy)
+              ? agentLink(
+                  pr.claimedBy,
+                  agentNames[pr.claimedBy] ?? pr.claimedBy,
+                )
               : '<span style="color:#9ca3af">—</span>';
             const taskCell = pr.taskId
               ? `<a href="/admin/tasks/${escapeHtml(pr.taskId)}" style="color:#6366f1;text-decoration:none">${escapeHtml(pr.taskId)}</a>`
@@ -2585,11 +2587,16 @@ export function renderPrDetailPage(
     </tr>`;
   }
 
-  const claimedByDisplay = pr.claimedBy
-    ? agentNames[pr.claimedBy]
-      ? `${agentNames[pr.claimedBy]} (${pr.claimedBy})`
-      : pr.claimedBy
-    : null;
+  function agentField(
+    label: string,
+    agentId: string | null | undefined,
+  ): string {
+    if (!agentId) return "";
+    return `<tr>
+      <td style="width:170px;padding:8px 12px;color:#6b7280;font-size:12px;font-weight:500;vertical-align:top;white-space:nowrap">${escapeHtml(label)}</td>
+      <td style="padding:8px 12px;font-size:13px;font-family:monospace;font-size:12px">${agentLink(agentId, agentNames[agentId] ? `${agentNames[agentId]} (${agentId})` : agentId)}</td>
+    </tr>`;
+  }
 
   const githubPrUrl = `https://github.com/${pr.repo}/pull/${pr.prNumber}`;
 
@@ -2609,8 +2616,8 @@ export function renderPrDetailPage(
     field("Patch Cycles", String(pr.patchCycles)),
     field("Commit SHA", pr.commitSha, true),
     field("Staged", pr.staged ? "yes" : "no"),
-    field("Claimed By", claimedByDisplay, true),
-    field("Agent ID", pr.agentId, true),
+    agentField("Claimed By", pr.claimedBy),
+    agentField("Agent ID", pr.agentId),
   ]
     .filter(Boolean)
     .join("\n");
@@ -2701,7 +2708,9 @@ export function renderCronLogsPage(opts: {
     const outcomeCell = `<span class="badge" style="${badgeStyle}" title="${escapeHtml(badgeTitle)}">${escapeHtml(outcomeLabel)}</span>`;
 
     const cronLabel = r.cron ? (r.cron.name ?? r.cron.schedule) : "—";
-    const cronCell = escapeHtml(cronLabel);
+    const cronCell = r.cron
+      ? `<a href="/admin/agents/${escapeHtml(agent.id)}/cron-logs?cronId=${escapeHtml(r.cron.id)}" style="color:#6366f1;text-decoration:none">${escapeHtml(cronLabel)}</a>`
+      : escapeHtml(cronLabel);
 
     const startedIso = new Date(r.startedAt).toISOString();
     const startedFmt = new Date(r.startedAt).toLocaleString("en-US", {
@@ -3115,7 +3124,7 @@ export SHIPWRIGHT_TASK_STORE_TOKEN=${escapeHtml(rawToken)}</pre>`
             (t) => `<tr>
           <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.id)}</td>
           <td>${escapeHtml(t.label ?? "—")}</td>
-          <td style="font-size:12px;color:#6b7280;font-family:monospace">${escapeHtml(t.agentId ?? "(admin)")}</td>
+          <td style="font-size:12px;color:#6b7280;font-family:monospace">${t.agentId ? agentLink(t.agentId) : "(admin)"}</td>
           <td>${fmt(t.createdAt)}</td>
           <td>${t.revokedAt ? `<span style="color:#dc2626">Revoked ${fmt(t.revokedAt)}</span>` : '<span style="color:#16a34a">Active</span>'}</td>
           <td>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1779,10 +1779,12 @@ describe("renderTasksPage — blocker badges", () => {
     expect(html).toContain("badge-hitl");
   });
 
-  // AC3: dep block renders with the dep ID "Blocked: REL-2.2"
-  test("dep block renders as 'Blocked: <dep-id>'", () => {
+  // AC3: dep block renders with the dep ID "Blocked: REL-2.2", linked to the dep's task page
+  test("dep block renders as 'Blocked: <dep-id>' linked to the dep's task page", () => {
     const html = render([PENDING_TASK_DEP]);
-    expect(html).toContain("Blocked: REL-2.2");
+    expect(html).toContain("Blocked:");
+    expect(html).toContain('<a href="/admin/tasks/REL-2.2"');
+    expect(html).toContain(">REL-2.2</a>");
     expect(html).toContain("badge-dep");
   });
 
@@ -1797,7 +1799,9 @@ describe("renderTasksPage — blocker badges", () => {
   test("task with multiple blockers renders all badges", () => {
     const html = render([PENDING_TASK_MULTI]);
     expect(html).toContain("Waiting: HITL");
-    expect(html).toContain("Blocked: REL-3.1");
+    expect(html).toContain("Blocked:");
+    expect(html).toContain('<a href="/admin/tasks/REL-3.1"');
+    expect(html).toContain(">REL-3.1</a>");
   });
 
   // AC5: badges are visually distinct from status badges (different CSS class)
@@ -2244,6 +2248,11 @@ describe("renderTaskDetailPage — blockers", () => {
     expect(html).toContain("pending");
   });
 
+  test("dependency blocker id links to its task detail page", () => {
+    const html = render();
+    expect(html).toContain('<a href="/admin/tasks/TS-dep"');
+  });
+
   test("shows hitl blocker type", () => {
     const html = render();
     expect(html.toLowerCase()).toContain("hitl");
@@ -2288,6 +2297,28 @@ describe("renderTaskDetailPage — blockers", () => {
     expect(blockersIdx).toBeGreaterThan(-1);
     expect(descriptionIdx).toBeGreaterThan(-1);
     expect(blockersIdx).toBeLessThan(descriptionIdx);
+  });
+});
+
+describe("renderTaskDetailPage — dependencies", () => {
+  function render(task: Partial<TaskItem> = {}): string {
+    return renderTaskDetailPage(
+      { ...TASK_DETAIL, ...task },
+      "user@example.com",
+      {},
+      "UTC",
+    );
+  }
+
+  test("dependency ids link to their task detail pages", () => {
+    const html = render({ dependencies: ["TASK-A", "TASK-B"] });
+    expect(html).toContain('<a href="/admin/tasks/TASK-A"');
+    expect(html).toContain('<a href="/admin/tasks/TASK-B"');
+  });
+
+  test("no dependencies field when dependencies is empty", () => {
+    const html = render({ dependencies: [] });
+    expect(html).not.toContain("Dependencies");
   });
 });
 
@@ -2907,6 +2938,24 @@ describe("renderPrDetailPage", () => {
     expect(html).toContain("TASK-99");
   });
 
+  test("taskId links to the task's detail page", () => {
+    const html = render();
+    expect(html).toContain('<a href="/admin/tasks/TASK-99"');
+  });
+
+  test("no Task row when taskId is absent", () => {
+    const html = render({ ...PR_DETAIL, taskId: null });
+    expect(html).not.toContain("/admin/tasks/");
+  });
+
+  test("PR number links out to the GitHub PR", () => {
+    const html = render();
+    expect(html).toContain(
+      '<a href="https://github.com/org/detail-repo/pull/99"',
+    );
+    expect(html).toContain(">#99</a>");
+  });
+
   test("renders commitSha field when present", () => {
     const html = render();
     expect(html).toContain("deadbeef");
@@ -3156,6 +3205,11 @@ describe("renderCronLogsPage", () => {
     expect(html).toMatch(/badge[^>]*>\s*Task/);
   });
 
+  test("Task item id links to its task detail page", () => {
+    const html = render([makeRun({ itemType: "task", itemId: "WLS-2.2" })]);
+    expect(html).toContain('<a href="/admin/tasks/WLS-2.2"');
+  });
+
   test("renders the run's itemType/itemId as a labeled PR badge when set", () => {
     const html = render([
       makeRun({ itemType: "pr", itemId: "app-vitals/shipwright#1234" }),
@@ -3167,6 +3221,15 @@ describe("renderCronLogsPage", () => {
     const bodyRowMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/);
     expect(bodyRowMatch).not.toBeNull();
     expect(bodyRowMatch?.[1]).not.toContain(">Task<");
+  });
+
+  test("PR item id links out to the GitHub PR", () => {
+    const html = render([
+      makeRun({ itemType: "pr", itemId: "app-vitals/shipwright#1234" }),
+    ]);
+    expect(html).toContain(
+      '<a href="https://github.com/app-vitals/shipwright/pull/1234"',
+    );
   });
 
   test("renders em-dash for the Item cell when itemType/itemId are null (no dispatch)", () => {

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -17,6 +17,7 @@ import {
   type PrListItem,
   type PullRequestItem,
   type TaskItem,
+  type TaskStoreTokenItem,
   type TokenItem,
   type ToolItem,
   renderAgentDetailPage,
@@ -33,6 +34,7 @@ import {
   renderSessionDetailPage,
   renderTaskDetailPage,
   renderTasksPage,
+  renderTokensPage,
 } from "./admin-ui-pages.ts";
 import { renderAdminToolbar } from "./admin-ui-styles.ts";
 import type { ChatMessage, ChatThread } from "./http-chat-client.ts";
@@ -2322,6 +2324,44 @@ describe("renderTaskDetailPage — dependencies", () => {
   });
 });
 
+describe("renderTaskDetailPage — agent field linkability", () => {
+  function render(
+    task: Partial<TaskItem> = {},
+    agentNames: Record<string, string> = {},
+  ): string {
+    return renderTaskDetailPage(
+      { ...TASK_DETAIL, ...task },
+      "user@example.com",
+      agentNames,
+      "UTC",
+    );
+  }
+
+  test("Assignee links to the agent detail page", () => {
+    const html = render({ assignee: "agent-a" });
+    expect(html).toContain('<a href="/admin/agents/agent-a"');
+  });
+
+  test("Agent Hint links to the agent detail page", () => {
+    const html = render({ agentHint: "agent-b" });
+    expect(html).toContain('<a href="/admin/agents/agent-b"');
+  });
+
+  test("Claimed By links to the agent detail page and shows display name", () => {
+    const html = render(
+      { claimedBy: "agent-c" },
+      { "agent-c": "Agent Charlie" },
+    );
+    expect(html).toContain('<a href="/admin/agents/agent-c"');
+    expect(html).toContain("Agent Charlie (agent-c)");
+  });
+
+  test("no Assignee/Agent Hint/Claimed By rows when unset", () => {
+    const html = render({ assignee: null, agentHint: null, claimedBy: null });
+    expect(html).not.toContain("/admin/agents/");
+  });
+});
+
 describe("renderTaskDetailPage — markdown", () => {
   function render(task: Partial<TaskItem> = {}): string {
     return renderTaskDetailPage(
@@ -2691,6 +2731,12 @@ describe("renderPrsPage", () => {
     expect(html).toContain("Updated");
   });
 
+  test("Claimed By cell links to the claiming agent's detail page", () => {
+    const html = render([PR_LIST_ITEM_1]);
+    expect(html).toContain('<a href="/admin/agents/agent-001"');
+    expect(html).toContain("Alpha Agent");
+  });
+
   test("renders 2+ PRs as table rows", () => {
     const html = render([PR_LIST_ITEM_1, PR_LIST_ITEM_2]);
     expect(html).toContain("org/repo-a");
@@ -2967,6 +3013,18 @@ describe("renderPrDetailPage", () => {
     expect(html).toContain("Xray Agent");
   });
 
+  test("claimedBy links to the agent detail page", () => {
+    const html = render();
+    expect(html).toContain('<a href="/admin/agents/agent-x"');
+  });
+
+  test("agentId links to the agent detail page", () => {
+    const html = render();
+    const matches = html.match(/<a href="\/admin\/agents\/agent-x"/g);
+    // both Claimed By and Agent ID resolve to agent-x here, so 2 links
+    expect(matches?.length).toBe(2);
+  });
+
   test("renders Timeline section with date fields", () => {
     const html = render();
     expect(html).toContain("Timeline");
@@ -3087,7 +3145,11 @@ describe("renderCronLogsPage", () => {
       crons: [CRON, OTHER_CRON],
       runs,
       filters: opts?.filters ?? {},
-      pagination: opts?.pagination ?? { total: runs.length, limit: 20, page: 1 },
+      pagination: opts?.pagination ?? {
+        total: runs.length,
+        limit: 20,
+        page: 1,
+      },
       userName: "admin@example.com",
       timezone: "America/Los_Angeles",
     });
@@ -3165,6 +3227,18 @@ describe("renderCronLogsPage", () => {
   test("renders the cron schedule when the owning cron has no name", () => {
     const html = render([makeRun({ cron: OTHER_CRON })]);
     expect(html).toContain("*/15 * * * *");
+  });
+
+  test("Cron column links to the same page filtered to that cron's id", () => {
+    const html = render([makeRun({ cron: CRON })]);
+    expect(html).toContain(
+      `<a href="/admin/agents/${CRON_AGENT.id}/cron-logs?cronId=${CRON.id}"`,
+    );
+  });
+
+  test("Cron column renders plain '—' with no link when the run has no cron", () => {
+    const html = render([makeRun({ cron: undefined })]);
+    expect(html).not.toContain("cron-logs?cronId=");
   });
 
   test("renders empty state when no runs match", () => {
@@ -3409,7 +3483,11 @@ describe("renderCronLogsPage", () => {
 
   test("outcome badge shows 'skipped' ahead of the outcome column value when skipped is true", () => {
     const html = render([
-      makeRun({ skipped: true, outcome: "error", skipReason: "pre-check failed" }),
+      makeRun({
+        skipped: true,
+        outcome: "error",
+        skipReason: "pre-check failed",
+      }),
     ]);
     // The badge itself renders "skipped", not "error" — mirrors
     // cronRunOutcomeLabel's skipped-takes-priority convention.
@@ -3491,6 +3569,49 @@ describe("renderTasksPage — mobile column hiding", () => {
     expect((sessionTdMatches ?? []).length).toBe(2);
     expect(repoTdMatches).not.toBeNull();
     expect((repoTdMatches ?? []).length).toBe(2);
+  });
+});
+
+// ─── renderTasksPage — readOnly suppresses internal /admin/ links ────────────
+
+describe("renderTasksPage — readOnly suppresses internal /admin/ links", () => {
+  const CLAIMED_BLOCKED_TASK: TaskItem = {
+    id: "TASK-3",
+    title: "Claimed and blocked task",
+    status: "blocked",
+    session: "session-abc",
+    repo: "org/repo",
+    assignee: null,
+    claimedBy: "agent-x",
+    blockedBy: [{ type: "dependency", id: "TASK-dep", status: "pending" }],
+  };
+
+  function render(readOnly: boolean): string {
+    return renderTasksPage(
+      [CLAIMED_BLOCKED_TASK],
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+      readOnly,
+    );
+  }
+
+  test("readOnly=false links the agent cell and the blocker badge", () => {
+    const html = render(false);
+    expect(html).toContain('<a href="/admin/agents/agent-x"');
+    expect(html).toContain('<a href="/admin/tasks/TASK-dep"');
+  });
+
+  test("readOnly=true renders the same ids as plain text, no /admin/ links", () => {
+    const html = render(true);
+    expect(html).toContain("agent-x");
+    expect(html).toContain("Blocked:");
+    expect(html).toContain("TASK-dep");
+    expect(html).not.toContain("/admin/");
   });
 });
 
@@ -4468,5 +4589,42 @@ describe("renderSessionDetailPage dependency graph", () => {
     expect(section).not.toContain("<img src=x onerror=alert(1)>");
     expect(section).not.toContain("<script>evil()</script>");
     expect(section).not.toContain("<b>dep</b>");
+  });
+});
+
+// ─── renderTokensPage — agent column linkability ─────────────────────────────
+
+describe("renderTokensPage — agent column linkability", () => {
+  function render(tokens: TaskStoreTokenItem[]): string {
+    return renderTokensPage(tokens, false, USER_NAME);
+  }
+
+  test("agent-scoped token links its Agent ID to the agent detail page", () => {
+    const html = render([
+      {
+        id: "tok-1",
+        label: "CI token",
+        agentId: "agent-y",
+        token: "sw_abc",
+        createdAt: "2026-06-01T10:00:00Z",
+        revokedAt: null,
+      },
+    ]);
+    expect(html).toContain('<a href="/admin/agents/agent-y"');
+  });
+
+  test("admin token (no agentId) renders '(admin)' with no agent link", () => {
+    const html = render([
+      {
+        id: "tok-2",
+        label: "Admin token",
+        agentId: null,
+        token: "sw_def",
+        createdAt: "2026-06-01T10:00:00Z",
+        revokedAt: null,
+      },
+    ]);
+    expect(html).toContain("(admin)");
+    expect(html).not.toContain("/admin/agents/");
   });
 });

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -4907,6 +4907,40 @@ describe("admin UI — public task board", () => {
     expect(html).not.toContain("admin_session");
   });
 
+  it("GET /public/tasks does not leak /admin/ links for claimed or blocked tasks", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        publicRepo: PUBLIC_REPO,
+        fetchTaskStoreTasks: async () => ({
+          tasks: [
+            {
+              id: "pub-task-3",
+              title: "Public task gamma",
+              status: "blocked",
+              session: "sess-pub",
+              repo: PUBLIC_REPO,
+              assignee: null,
+              claimedBy: "agent-pub",
+              blockedBy: [
+                { type: "dependency", id: "pub-task-1", status: "pending" },
+              ],
+            },
+          ],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        }),
+      }),
+    );
+    const res = await app.request("/public/tasks");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Public task gamma");
+    expect(html).toContain("Blocked:");
+    expect(html).toContain("agent-pub");
+    expect(html).not.toContain("/admin/");
+  });
+
   it("GET /public/tasks renders 200 even when no publicRepo configured (degraded mode)", async () => {
     const app = createAdminUIApp(
       makeMockDeps({

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -686,6 +686,40 @@ describe("admin UI — authenticated pages", () => {
     expect(html).toContain("dev-task");
     expect(html).toContain("review");
     expect(html).not.toContain("No work queue snapshot");
+    // task item links to its admin task detail page
+    expect(html).toContain('<a href="/admin/tasks/WLS-2.2"');
+  });
+
+  it("work queue PR item links out to GitHub using the repo#prNumber id", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        agentWorkQueueService: {
+          get: async () => ({
+            id: "snap-2",
+            agentId: AGENT_ID,
+            computedAt: new Date("2026-06-01T10:00:00Z"),
+            items: [
+              {
+                type: "pr",
+                id: "app-vitals/shipwright#4321",
+                title: "Fix flaky test",
+                phase: "review",
+                age: "2026-06-01T08:00:00Z",
+              },
+            ],
+            createdAt: new Date("2026-06-01T10:00:00Z"),
+          }),
+        },
+      }),
+    );
+    const res = await app.request(`/admin/agents/${AGENT_ID}/work-queue`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      '<a href="https://github.com/app-vitals/shipwright/pull/4321"',
+    );
   });
 
   it("authenticated GET /admin/agents/:id/cron-logs?cronId=... filters by cronId", async () => {


### PR DESCRIPTION
## Summary
Full sweep of the admin app for entities (tasks, PRs, agents, crons) rendered as plain text when they should be clickable.

**Tasks**
- Tasks-list blocker badges (`Blocked: <id>`) now link to the blocking task
- Task-detail Blockers section and Dependencies list now link to their task pages

**PRs**
- PR-detail `Task` field now links to the task
- PR-detail `PR Number` field now links out to GitHub — this page previously had **no outbound GitHub link at all**
- Cron-log & work-queue item cells (task or `repo#prNumber`) now link to the task or out to GitHub

**Agents**
- Tasks-list Agent column, task-detail Assignee/Agent Hint/Claimed By, PR-list and PR-detail Claimed By/Agent ID, and the tokens page's Agent column now link to `/admin/agents/:id`

**Crons**
- Cron-logs page's Cron column now links to the same page filtered to that cron's id

**Bug found + fixed along the way:** the unauthenticated public task board (`/public/tasks`, `readOnly=true`) reuses `renderTasksPage` for its rows. The new agent-cell link (and pre-existing blocker-badge task link) had no `readOnly` guard, so a claimed or blocked public task would have leaked internal `/admin/...` links to unauthenticated visitors. Both are now gated on `readOnly`, with regression tests covering the leak directly.

Out of scope: chat message bodies can mention task/PR/session ids in free text — auto-linkifying arbitrary text is a materially different feature from wiring up existing structured fields, left out of this pass.

## Test plan
- [x] `bun test admin/src/admin-ui-pages.unit.test.ts admin/src/admin-ui.smoke.test.ts` — 547 pass, new coverage for every new link and the public-board leak guard
- [x] `bun test` (full admin suite) — 1275 pass, 172 skip, 0 fail
- [x] `bun run typecheck` (admin) — clean
- [x] `bunx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)