### PR TITLE
fix: send valid empty JSON body on task claim to avoid parse errors

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -343,6 +343,10 @@ export function createTaskStoreClient(opts?: { fetchFn?: FetchFn }): {
       const res = await doFetch(`${baseUrl}/tasks/${id}/claim`, {
         method: "POST",
         headers,
+        // headers always declares Content-Type: application/json — send a
+        // valid empty object so the server's JSON body parser doesn't choke
+        // on a truly empty body (agent tokens ignore the body regardless).
+        body: "{}",
       });
       if (res.ok) return true;
       if (res.status === 409) return false;

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -698,6 +698,9 @@ describe("createTaskStoreClient query()", () => {
       "https://task-store.example.com/tasks/T-1/claim",
     );
     expect(capturedInit?.method).toBe("POST");
+    // headers always sets Content-Type: application/json — a truly empty
+    // body would fail the server's JSON parse
+    expect(capturedInit?.body).toBe("{}");
   });
 
   test("claim() returns true on 200", async () => {


### PR DESCRIPTION
## Summary
- `createTaskStoreClient().claim()` in `agent/src/check-helpers.ts` POSTs to `/tasks/:id/claim` with `Content-Type: application/json` but no request body
- The task-store's Hono JSON validator tries to parse the (empty) body and throws `Malformed JSON in request body`, logged as a handled exception on every single claim call
- Sentry: [VITALS-OS-44](https://app-vitals-llc.sentry.io/issues/7615930711/) — 596 occurrences since 2026-07-16, ongoing every ~minute via the `shipwright-loop` cron's claim-before-dispatch step
- Fix: send `body: "{}"` — a valid, empty JSON object. Agent-token claims ignore the request body server-side (`claimedBy` is pinned from the token), so this changes nothing behaviorally, just satisfies the parser.

## Test plan
- [x] `bun test agent/src/check-helpers.unit.test.ts` — 75 pass, including new assertion that `claim()` sends `body: "{}"`
- [x] `bunx biome lint` on changed files — clean
- [x] `bun run --filter='@shipwright/agent' typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)