### PR TITLE
fix: verify GitHub review post succeeded before marking PR record posted

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -472,15 +472,30 @@ should be held; the inline comments convey the specific feedback to the author.
 
 ### If `auto_post_reviews` is true (policy):
 
-1. Submit via GitHub API:
+1. Submit via GitHub API, capturing both the exit status and the response body:
    ```bash
-   gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews \
-     --input state/reviews/pr_review_{pr}.json
+   POST_RESPONSE=$(gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews \
+     --input state/reviews/pr_review_{pr}.json)
+   POST_EXIT=$?
    ```
-2. Capture `html_url` from response
-3. Run Step 11b to mark the PR record posted.
-4. Print: `Posted review for #{pr}: {html_url}`
-5. Post Slack message (see below)
+2. Capture `html_url` from `$POST_RESPONSE` (e.g. `echo "$POST_RESPONSE" | jq -r '.html_url'`).
+3. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `html_url` both count as failure:
+   - **Success** (`POST_EXIT == 0` and `html_url` present): continue to steps 4-6 below.
+   - **Failure**: the GitHub post did not land, so nothing was actually reviewed at HEAD.
+     Do not run Step 11b — marking the record posted here would let
+     `check-review.ts`'s `commitSha`/`reviewState` dedup permanently hide this PR from
+     future review candidacy even though no review exists on GitHub. Instead:
+     1. Release the claim so the record returns to `reviewState: "pending"`:
+        ```bash
+        curl -s -o /dev/null -X POST \
+          -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+          "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/release"
+        ```
+     2. Print a warning: `Warning: review post for #{pr} failed (exit {POST_EXIT}) — released claim, will retry next pass.`
+     3. Stop — do not proceed to Step 11b or the Slack message below.
+4. Run Step 11b to mark the PR record posted.
+5. Print: `Posted review for #{pr}: {html_url}`
+6. Post Slack message (see below)
 
 ### If `auto_post_reviews` is false (default):
 

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -128,3 +128,45 @@ describe("review.md — WLS-3.2 explicit-target-only", () => {
     expect(content.includes("Skip Step 3 (queue building)")).toBe(false);
   });
 });
+
+describe("review.md — RPF-1.4 verify review post before complete", () => {
+  let autoPostSection: string;
+
+  beforeAll(() => {
+    const startIdx = content.indexOf("### If `auto_post_reviews` is true (policy):");
+    const endIdx = content.indexOf("### If `auto_post_reviews` is false (default):");
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    autoPostSection = content.slice(startIdx, endIdx);
+  });
+
+  it("checks that the GitHub post succeeded before proceeding to Step 11b", () => {
+    // Must reference checking success (exit status / html_url) before invoking Step 11b
+    const step11bIdx = autoPostSection.indexOf("Step 11b");
+    expect(step11bIdx).toBeGreaterThan(-1);
+    const beforeStep11b = autoPostSection.slice(0, step11bIdx);
+    expect(beforeStep11b.toLowerCase()).toMatch(/success|succeed|failed|failure|exit/);
+    expect(beforeStep11b.includes("html_url")).toBe(true);
+  });
+
+  it("on post failure, calls POST /prs/{PR_RECORD_ID}/release instead of Step 11b", () => {
+    expect(autoPostSection.includes("/release")).toBe(true);
+  });
+
+  it("on post failure, does not proceed to Step 11b", () => {
+    const failureIdx = autoPostSection.toLowerCase().indexOf("**failure**");
+    expect(failureIdx).toBeGreaterThan(-1);
+    const releaseIdx = autoPostSection.indexOf("/release");
+    expect(releaseIdx).toBeGreaterThan(-1);
+    expect(releaseIdx).toBeGreaterThan(failureIdx);
+    // The failure branch must explicitly say to stop instead of running Step 11b
+    const failureBranch = autoPostSection.slice(failureIdx, releaseIdx + 500);
+    expect(failureBranch.includes("do not proceed to Step 11b")).toBe(true);
+  });
+
+  it("the success path still runs Step 11b, unchanged in behavior", () => {
+    expect(autoPostSection.includes("Run Step 11b to mark the PR record posted")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `review.md` Step 11's `auto_post_reviews:true` path now checks the exit status of the `gh api -X POST .../pulls/{pr}/reviews` call and that `html_url` was captured, before proceeding to Step 11b.
- On a detected post failure, it releases the PR record's claim (`POST /prs/{PR_RECORD_ID}/release`) instead of marking it posted, so a later review pass retries the PR instead of `check-review.ts`'s `commitSha`/`reviewState` dedup permanently hiding it.
- The existing success path (post succeeds → Step 11b → `complete()`) is unchanged in behavior.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 11 explicitly checks POST exit/html_url before Step 11b | MET |
| 2 | On failure, calls `/prs/{PR_RECORD_ID}/release` instead of Step 11b | MET |
| 3 | Success path unchanged in behavior | MET |
| 4 | New describe block in `review.unit.test.ts` covering success check + release-on-failure | MET |

## Test Plan
- Added `describe("review.md — RPF-1.4 verify review post before complete")` to `plugins/shipwright/commands/review.unit.test.ts` (4 new tests), following the file's existing content-assertion convention for this command.
- `bun test plugins/shipwright/commands/review.unit.test.ts` — 20/20 pass.
- `cd plugins/shipwright && bun test` — 727/727 pass across the package.
- `bunx tsc --noEmit` in `plugins/shipwright` — clean.
- `bunx biome lint .` — clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
