### PR TITLE
fix: unify deploy.md merge to unconditional --admin (DSH-1.1)

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -323,3 +323,30 @@ describe("deploy.md — chained in-Bash polling for Step 5b (AEW-1.1)", () => {
     expect(content).toContain("Re-surface this message every 5 minutes");
   });
 });
+
+describe("deploy.md — unconditional admin merge (DSH-1.1)", () => {
+  it("Step 4b contains exactly one unconditional --admin merge command", () => {
+    const adminMergeCommand = "gh pr merge {pr} --repo {org}/{repo} --squash --admin";
+    const occurrences = content.split(adminMergeCommand).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("does not contain a --auto merge command anywhere in the file", () => {
+    expect(content).not.toContain("--auto");
+  });
+
+  it("Step 4b's merge command selection is no longer branched on approval_source", () => {
+    const step4bMatch = content.match(
+      /### 4b\. Squash Merge[\s\S]*?(?=\n### 4c)/,
+    );
+    expect(step4bMatch).not.toBeNull();
+    const step4bSection = step4bMatch?.[0] ?? "";
+    // No conditional branching by approval source (the two-way GitHub-vs-self-review
+    // command selection this task removes) — informational mentions of
+    // approval_source are fine, but not a per-branch label distinguishing merge commands.
+    expect(step4bSection).not.toContain("**GitHub approval**");
+    expect(step4bSection).not.toContain("**Self-review**");
+    expect(step4bSection).not.toContain('approval_source == "github"');
+    expect(step4bSection).not.toContain('approval_source == "self_review"');
+  });
+});

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -244,12 +244,15 @@ gh pr merge {pr} --repo {org}/{repo} --squash --admin
 cannot satisfy natively when the approval came from a self-review rather than a second
 GitHub user). This is safe because Step 3a (approval — GitHub or self-review) and Step 3b
 (CI green) already independently verify the safety properties branch protection exists to
-enforce here — this repo's protection setup is intentionally simple (no CODEOWNERS, no
-staging/prod environments; see the repo's `CLAUDE.md`, "Deploy model: direct"). Queuing an
-auto-merge instead would only defer to GitHub's native branch-protection wait, which adds a
-fragile dependency on the required-status-check context name staying in sync with actual CI
-job names — it silently breaks on CI restructuring, and picking the wrong merge flag for the
-approval source is its own bug class. `--admin` avoids both.
+enforce here — this repo does have an active CODEOWNERS ruleset (`require_code_owner_review:
+true`, ruleset id 18495740) enforced on `main`, but both maintainer accounts are configured
+as `bypass_actors` on it, so `--admin` here is exercising an existing, already-authorized
+bypass rather than circumventing a live protection gate (no staging/prod environments either;
+see the repo's `CLAUDE.md`, "Deploy model: direct"). Queuing an auto-merge instead would only
+defer to GitHub's native branch-protection wait, which adds a fragile dependency on the
+required-status-check context name staying in sync with actual CI job names — it silently
+breaks on CI restructuring, and picking the wrong merge flag for the approval source is its
+own bug class. `--admin` avoids both.
 
 Poll for the merge to complete — check `gh pr view {pr} --json state --jq '.state'` every
 5 seconds, up to 60 seconds. When the state becomes `"MERGED"`, capture the squash SHA:

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -233,17 +233,23 @@ post-merge update in Step 4c — no second claim call is needed. Proceed to Step
 
 ### 4b. Squash Merge
 
-Squash merge the PR. The merge command depends on the approval source from Step 3a:
+Squash merge the PR immediately with `--admin`, unconditionally — regardless of
+`approval_source` from Step 3a:
 
-- **GitHub approval** (`approval_source == "github"`): queue via auto-merge (waits for branch protection to clear):
-  ```bash
-  gh pr merge {pr} --repo {org}/{repo} --squash --auto
-  ```
+```bash
+gh pr merge {pr} --repo {org}/{repo} --squash --admin
+```
 
-- **Self-review** (`approval_source == "self_review"`): merge immediately with `--admin` to bypass the "require approval" branch protection rule (GitHub cannot approve a PR authored by the same user — CI green is already verified in Step 3b, so safety properties are preserved):
-  ```bash
-  gh pr merge {pr} --repo {org}/{repo} --squash --admin
-  ```
+`--admin` bypasses branch protection (including the "require approval" rule, which GitHub
+cannot satisfy natively when the approval came from a self-review rather than a second
+GitHub user). This is safe because Step 3a (approval — GitHub or self-review) and Step 3b
+(CI green) already independently verify the safety properties branch protection exists to
+enforce here — this repo's protection setup is intentionally simple (no CODEOWNERS, no
+staging/prod environments; see the repo's `CLAUDE.md`, "Deploy model: direct"). Queuing an
+auto-merge instead would only defer to GitHub's native branch-protection wait, which adds a
+fragile dependency on the required-status-check context name staying in sync with actual CI
+job names — it silently breaks on CI restructuring, and picking the wrong merge flag for the
+approval source is its own bug class. `--admin` avoids both.
 
 Poll for the merge to complete — check `gh pr view {pr} --json state --jq '.state'` every
 5 seconds, up to 60 seconds. When the state becomes `"MERGED"`, capture the squash SHA:


### PR DESCRIPTION
## Summary
- Collapses `deploy.md` Step 4b's merge command selection from a two-branch (`--auto` for GitHub approval / `--admin` for self-review) path into a single unconditional `gh pr merge {pr} --repo {org}/{repo} --squash --admin`.
- Removes the wrong-command-selection bug class and the branch-protection required-status-context drift dependency that `--auto` relied on — Step 3a (approval) and Step 3b (CI green) already independently verify the safety properties branch protection would otherwise enforce.
- Adds net-new content-test coverage in `deploy.content.test.ts` asserting exactly one unconditional `--admin` merge command and zero `--auto` references anywhere in the file.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 4b's merge command selection is a single unconditional path (always `--admin`); the `--auto`/GitHub-approval branch is removed | MET | `deploy.md` Step 4b now has one merge command, no branching |
| 2 | Step 3a's approval determination logic is unchanged; Step 3c's summary still names the approval source (informational only) | MET | No edits to Step 3a/3c |
| 3 | Net-new test coverage: assert exactly one `--admin` command and no `--auto` anywhere; no existing tests removed | MET | 3 new tests added, 37 pre-existing tests untouched (40 total pass) |
| 4 | Safe to deploy standalone (markdown-only, no schema/interface changes) | MET | Diff touches only `deploy.md` + its content test |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/deploy.content.test.ts` — 40/40 pass (37 pre-existing + 3 new)
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all 7 packages
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
