### PR TITLE
feat: add consolidation-decisions.md registry format (CVG-1.2)

### DIFF
--- a/.claude/shipwright/consolidation-decisions.md
+++ b/.claude/shipwright/consolidation-decisions.md
@@ -1,0 +1,72 @@
+# Consolidation Decisions
+
+A repo-tracked, project-level registry of duplication/pattern decisions made over
+time. This is not a set of detection rules (that's `references/principles.md`) —
+it's a record of specific `consolidation-scan` findings that were looked at and
+deliberately accepted as debt, so the scan stops re-flagging them every run.
+
+**Who edits this file:** humans, not agents. Entries are added during review of a
+`consolidation-fix` PR (when a proposed convergence is rejected as not worth doing
+right now) or proactively (when the team already knows a pattern is duplicated by
+design and wants to pre-empt the scan flagging it). This file lives at the same
+override tier as `.claude/shipwright/principles.md` — repo-local, human-owned,
+loaded by the skill but never written by it.
+
+**How `consolidation-scan` consumes it:** Step 1 of the skill checks for this file.
+If it's missing, that's a graceful no-op — "no suppressions configured" — the same
+tier as a missing `principles.md` override. If it exists, the skill loads and parses
+entries generically (it does not hardcode the exact heading/field structure below —
+it reads defensively for "one entry per accepted pattern, with a description and an
+optional revisit condition" and skips anything it can't confidently interpret) and
+builds an in-memory suppression list. That list is consulted twice: loosely during
+the survey (to avoid re-describing an already-accepted pattern) and authoritatively
+before promotion (the actual gate that stops a suppressed pattern from being
+reported again) — unless the entry's revisit condition has been met, in which case
+the suppression no longer applies and the pattern is eligible to resurface.
+
+---
+
+## Entry Format
+
+Each decision is one `###` entry with a fixed field order:
+
+```
+### <short pattern name>
+
+**Pattern:** <what duplication/pattern this covers — specific enough that
+  consolidation-scan's fingerprint for it can be matched against this entry>
+**Decision:** <accept as debt | reject convergence | other explicit call>
+**Rationale:** <why this is justified complexity, not accidental duplication>
+**Revisit:** <the condition under which this decision should be reconsidered —
+  an occurrence-count threshold, a churn signal, a triggering event, or a date>
+```
+
+Keep **Pattern** concrete enough to match against a real fingerprint, not a vague
+category — a future reader (human or `consolidation-scan` itself) should be able to
+tell whether a newly-surveyed candidate is "the same thing" as this entry.
+
+---
+
+## Decisions
+
+### No abstraction layer over Claude Code
+
+**Pattern:** Shipwright's plugin, agent, and services couple directly to Claude
+Code's APIs and conventions in multiple places (command/skill definitions, the
+agent's session-driving logic, config surfaces) rather than going through a shared
+internal abstraction. Looked at superficially, this can resemble duplicated
+"Claude-Code-specific glue" scattered across the codebase — a pattern
+`consolidation-scan` could plausibly flag as worth converging behind one interface.
+**Decision:** Do not build a shared abstraction layer over Claude Code. Shipwright
+is built directly on top of Claude Code by design.
+**Rationale:** Direct coupling keeps upgrading to new Claude Code features easy —
+there's no intermediate layer to update, extend, or reconcile first. It also means
+the team doesn't have to reason about an extra abstraction boundary that, today,
+has exactly one implementation behind it and therefore adds indirection without
+adding flexibility. This is justified complexity (or rather, justified
+non-abstraction) that should not be flagged for consolidation — it's distinct from
+accidental duplication that should converge, because there is no second
+implementation for an abstraction to unify.
+**Revisit:** Revisit if Shipwright needs to support a second agent harness or LLM
+provider — at that point an abstraction boundary becomes justified, because there
+would be a real second implementation to unify behind a shared interface.

--- a/plugins/shipwright/test/consolidation-decisions.content.test.ts
+++ b/plugins/shipwright/test/consolidation-decisions.content.test.ts
@@ -1,0 +1,106 @@
+/**
+ * consolidation-decisions.md content tests — CVG-1.2
+ *
+ * Verifies the repo-tracked consolidation-decisions registry
+ * (.claude/shipwright/consolidation-decisions.md) exists, documents its own
+ * entry format, explains who maintains it and how `consolidation-scan`
+ * consumes it, and carries a real seeded entry: shipwright's own decision
+ * not to build an abstraction layer over Claude Code.
+ *
+ * Content-assertion only: existsSync/readFileSync, no I/O beyond local file
+ * reads (mirrors principles-content.content.test.ts).
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/test/ → repo root
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+const registryPath = join(repoRoot, ".claude", "shipwright", "consolidation-decisions.md");
+
+function readRegistry(): string {
+  return readFileSync(registryPath, "utf8");
+}
+
+/** Extract the markdown block for a `### <heading>` entry, up to the next `##`/`###`. */
+function entryBlock(content: string, headingSubstring: string): string {
+  const headingLineMatch = content
+    .split("\n")
+    .find((line) => line.startsWith("###") && line.includes(headingSubstring));
+  if (!headingLineMatch) return "";
+  const start = content.indexOf(headingLineMatch);
+  const rest = content.slice(start + headingLineMatch.length);
+  const next = rest.search(/\n#{2,3}\s/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+// ── File exists ─────────────────────────────────────────────────────────────
+
+describe("consolidation-decisions.md — file", () => {
+  it(".claude/shipwright/consolidation-decisions.md exists", () => {
+    expect(existsSync(registryPath)).toBe(true);
+  });
+});
+
+// ── Top-of-file doc-comment explains maintenance and consumption ────────────
+
+describe("consolidation-decisions.md — top-of-file doc-comment", () => {
+  it("explains humans edit this file", () => {
+    expect(readRegistry().toLowerCase()).toContain("human");
+  });
+
+  it("mentions review of consolidation-fix PRs as an editing occasion", () => {
+    expect(readRegistry().toLowerCase()).toContain("consolidation-fix");
+  });
+
+  it("explains consolidation-scan consumes/reads this file", () => {
+    expect(readRegistry()).toContain("consolidation-scan");
+  });
+
+  it("mentions the suppression list consolidation-scan builds from this file", () => {
+    expect(readRegistry().toLowerCase()).toContain("suppression");
+  });
+});
+
+// ── Documented entry format ──────────────────────────────────────────────────
+
+describe("consolidation-decisions.md — documented entry format", () => {
+  const requiredFields = ["**Pattern:**", "**Decision:**", "**Rationale:**", "**Revisit:**"];
+
+  for (const field of requiredFields) {
+    it(`documents the ${field} field`, () => {
+      expect(readRegistry()).toContain(field);
+    });
+  }
+});
+
+// ── Seeded entry: Claude Code non-abstraction decision ──────────────────────
+
+describe("consolidation-decisions.md — seeded Claude Code non-abstraction entry", () => {
+  it("mentions Claude Code", () => {
+    expect(readRegistry()).toContain("Claude Code");
+  });
+
+  it("mentions not building an abstraction layer", () => {
+    expect(readRegistry().toLowerCase()).toContain("abstraction layer");
+  });
+
+  it("has a Pattern field with recognizable content in the same entry as the decision", () => {
+    const block = entryBlock(readRegistry(), "Claude Code");
+    expect(block).toContain("**Pattern:**");
+    expect(block).toContain("**Decision:**");
+    expect(block).toContain("**Rationale:**");
+    expect(block).toContain("**Revisit:**");
+  });
+
+  it("rationale mentions upgrading to new Claude Code features stays easy", () => {
+    const block = entryBlock(readRegistry(), "Claude Code");
+    expect(block.toLowerCase()).toContain("upgrad");
+  });
+
+  it("revisit condition names a concrete triggering event (second harness/provider)", () => {
+    const block = entryBlock(readRegistry(), "Claude Code");
+    expect(block.toLowerCase()).toMatch(/second (agent )?(harness|provider|llm)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `.claude/shipwright/consolidation-decisions.md` — a repo-tracked, human-maintained registry of accepted-debt duplication decisions, read generically by `consolidation-scan` (CVG-1.1) to suppress matching fingerprints unless a revisit condition is met.
- Document the entry format (`**Pattern:**` / `**Decision:**` / `**Rationale:**` / `**Revisit:**` fields), mirroring the field style already used in `references/principles.md`.
- Seed the file with one real worked example: shipwright's own decision not to build an abstraction layer over Claude Code, framed as justified complexity that should not be flagged for consolidation.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `.claude/shipwright/consolidation-decisions.md` exists with a documented entry format | MET | File added with an "Entry Format" section defining the four fields |
| 2 | Contains at least one real, concrete accepted-debt entry (the Claude Code non-abstraction decision) | MET | "No abstraction layer over Claude Code" entry with Pattern/Decision/Rationale/Revisit |
| 3 | File explains at the top who maintains it and how consolidation-scan consumes it | MET | "Who edits this file" and "How consolidation-scan consumes it" sections |

## Test Plan
- New content test `plugins/shipwright/test/consolidation-decisions.content.test.ts` (14 tests) verifies file existence, top-of-file doc-comment content, documented field format, and the seeded entry — written first (RED), confirmed failing, then made to pass (GREEN).
- Full plugin test suite: 139 pass, 0 fail.
- `task lint` and `task typecheck` clean across all workspaces.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
