### PR TITLE
feat: add consolidation-patrol-maintenance cron (disabled) (CVG-1.4)

### DIFF
--- a/admin/src/system-crons.ts
+++ b/admin/src/system-crons.ts
@@ -101,4 +101,13 @@ export const SYSTEM_CRONS: readonly SystemCron[] = [
     preCheck: "shipwright:check-error-patrol.ts",
     enabled: false,
   },
+  {
+    name: "consolidation-patrol-maintenance",
+    schedule: "0 5 * * 1",
+    prompt:
+      '/shipwright:consolidation-scan\n/shipwright:consolidation-fix\nAfter the chain completes, write state/consolidation-ledger.json\'s lastRun field: "<ISO timestamp>". Use [silent] if no ready_to_propose findings are found.',
+    silent: true,
+    preCheck: "shipwright:check-consolidation-patrol.ts",
+    enabled: false,
+  },
 ] as const;

--- a/admin/src/system-crons.unit.test.ts
+++ b/admin/src/system-crons.unit.test.ts
@@ -87,6 +87,7 @@ describe("SYSTEM_CRONS pipeline schedule staggering", () => {
       "dependabot-triage": "0 8 * * *",
       "entropy-patrol-maintenance": "0 4 * * 1",
       "error-patrol-maintenance": "0 4 * * *",
+      "consolidation-patrol-maintenance": "0 5 * * 1",
     };
     for (const [name, schedule] of Object.entries(expected)) {
       const cron = SYSTEM_CRONS.find((c) => c.name === name);
@@ -96,11 +97,11 @@ describe("SYSTEM_CRONS pipeline schedule staggering", () => {
 });
 
 describe("SYSTEM_CRONS", () => {
-  test("exports exactly eleven crons", () => {
-    expect(SYSTEM_CRONS).toHaveLength(11);
+  test("exports exactly twelve crons", () => {
+    expect(SYSTEM_CRONS).toHaveLength(12);
   });
 
-  test("cron names are the eleven expected crons", () => {
+  test("cron names are the twelve expected crons", () => {
     const names = SYSTEM_CRONS.map((c) => c.name);
     expect(names).toContain("shipwright-dev-task");
     expect(names).toContain("shipwright-patch");
@@ -112,6 +113,7 @@ describe("SYSTEM_CRONS", () => {
     expect(names).toContain("dependabot-triage");
     expect(names).toContain("entropy-patrol-maintenance");
     expect(names).toContain("error-patrol-maintenance");
+    expect(names).toContain("consolidation-patrol-maintenance");
     expect(names).toContain("shipwright-loop");
   });
 
@@ -252,6 +254,7 @@ describe("SYSTEM_CRONS", () => {
         c.name !== "dependabot-triage" &&
         c.name !== "entropy-patrol-maintenance" &&
         c.name !== "error-patrol-maintenance" &&
+        c.name !== "consolidation-patrol-maintenance" &&
         c.name !== "shipwright-loop",
     );
     for (const cron of pollingCrons) {
@@ -373,6 +376,52 @@ describe("SYSTEM_CRONS", () => {
       (c) => c.name === "error-patrol-maintenance",
     );
     expect(cron?.prompt).toContain("[silent]");
+  });
+
+  test("consolidation-patrol-maintenance cron has schedule 0 5 * * 1", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "consolidation-patrol-maintenance",
+    );
+    expect(cron?.schedule).toBe("0 5 * * 1");
+  });
+
+  test("consolidation-patrol-maintenance cron has enabled: false", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "consolidation-patrol-maintenance",
+    );
+    expect(cron?.enabled).toBe(false);
+  });
+
+  test("consolidation-patrol-maintenance cron has correct preCheck", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "consolidation-patrol-maintenance",
+    );
+    expect(cron?.preCheck).toBe("shipwright:check-consolidation-patrol.ts");
+  });
+
+  test("consolidation-patrol-maintenance prompt chains /shipwright:consolidation-scan and /shipwright:consolidation-fix", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "consolidation-patrol-maintenance",
+    );
+    expect(cron?.prompt).toContain("/shipwright:consolidation-scan");
+    expect(cron?.prompt).toContain("/shipwright:consolidation-fix");
+  });
+
+  test("consolidation-patrol-maintenance prompt writes consolidation-ledger.json's lastRun field, not a separate last-run file", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "consolidation-patrol-maintenance",
+    );
+    expect(cron?.prompt).toContain("consolidation-ledger.json");
+    expect(cron?.prompt).toContain("lastRun");
+    expect(cron?.prompt).not.toContain("consolidation-patrol-last-run.json");
+  });
+
+  test("consolidation-patrol-maintenance prompt uses [silent] when no ready_to_propose findings are found", () => {
+    const cron = SYSTEM_CRONS.find(
+      (c) => c.name === "consolidation-patrol-maintenance",
+    );
+    expect(cron?.prompt).toContain("[silent]");
+    expect(cron?.prompt).toContain("ready_to_propose");
   });
 
   // ── No old plugin-prefix refs anywhere in prompts ──────────────────────────

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -122,7 +122,7 @@ All child models cascade-delete with their `Agent` (including `AgentCronRun` via
 
 ## Default system crons
 
-Every new agent is seeded with eleven system crons (the canonical definitions live in [`admin/src/system-crons.ts`](../admin/src/system-crons.ts) and are reconciled onto each agent at startup via `POST /agents/:id/crons/reconcile`). Three are **enabled by default** (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`); the rest are opt-in (toggle in the admin UI or via `PATCH /agents/:id/crons/:cronId`). All run `silent` (they post to Slack only on a result worth surfacing, or on error). Some carry a `preCheck` script whose stdout becomes the actual prompt, so a cron only spends a Claude turn when there is real work ready.
+Every new agent is seeded with twelve system crons (the canonical definitions live in [`admin/src/system-crons.ts`](../admin/src/system-crons.ts) and are reconciled onto each agent at startup via `POST /agents/:id/crons/reconcile`). Three are **enabled by default** (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`); the rest are opt-in (toggle in the admin UI or via `PATCH /agents/:id/crons/:cronId`). All run `silent` (they post to Slack only on a result worth surfacing, or on error). Some carry a `preCheck` script whose stdout becomes the actual prompt, so a cron only spends a Claude turn when there is real work ready.
 
 The four pipeline crons (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`,
 `shipwright-deploy`) are **loop-driven, item-addressed executors, not self-discovering

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -150,6 +150,7 @@ note and the fix (enable `shipwright-loop`).
 | `dependabot-triage` | `0 8 * * *` (daily, 08:00) | off | Reviews and triages open Dependabot PRs. |
 | `entropy-patrol-maintenance` | `0 4 * * 1` (weekly, Mon 04:00) | off | Scans for code entropy and fixes what's PR-worthy. |
 | `error-patrol-maintenance` | `0 4 * * *` (daily, 04:00) | off | Scans for unresolved Sentry errors and fixes what's PR-worthy. |
+| `consolidation-patrol-maintenance` | `0 5 * * 1` (weekly, Mon 05:00) | off | Scans for emerging duplicate/similar code patterns that have stabilized across multiple runs and proposes consolidation for what's ready. Recommended to stay disabled after merge until `state/consolidation-ledger.json` has accumulated a few weeks of real signal. |
 
 ## Environment
 

--- a/docs/test-readiness/test-inventory.md
+++ b/docs/test-readiness/test-inventory.md
@@ -129,7 +129,7 @@
 | `plugins/shipwright/scripts/check-deploy.ts`, `check-review.ts`, `check-patch.ts`, `check-dev-task.ts` (cron prechecks) | 2. Service-boundary code | integration | critical | n/a |
 | `plugins/shipwright/scripts/check-helpers.ts` (`isCleanApproveBody`, GitHub wrappers) | 1. Pure business logic (parsing) + 2. service-boundary (`ghJson`) | unit (pure parts) / integration (I/O parts) | critical | n/a |
 | `plugins/shipwright/scripts/check-banned-strings.ts` (`scanForBannedStrings`) | 1. Pure business logic | unit | high | n/a |
-| `plugins/shipwright/scripts/check-docs-freshness.ts`, `check-dependabot-triage.ts`, `check-error-patrol.ts`, `check-learn-dream.ts`, `check-review-patch.ts`, `check-test-readiness.ts` (cron prechecks, multi-repo) | 2. Service-boundary code | integration | high | n/a |
+| `plugins/shipwright/scripts/check-consolidation-patrol.ts`, `check-docs-freshness.ts`, `check-dependabot-triage.ts`, `check-error-patrol.ts`, `check-learn-dream.ts`, `check-review-patch.ts`, `check-test-readiness.ts` (cron prechecks, multi-repo) | 2. Service-boundary code | integration | high | n/a |
 | `plugins/shipwright/scripts/classify_test_layer.ts` (`classifyPath`) | 1. Pure business logic | unit | high | n/a |
 | `plugins/shipwright/scripts/ci-checks.ts` (`parseActionsChecks`) | 1. Pure business logic | unit | medium | n/a |
 | `plugins/shipwright/scripts/clock.ts` | 1. Pure business logic | unit | medium | n/a |

--- a/plugins/shipwright/scripts/check-consolidation-patrol.ts
+++ b/plugins/shipwright/scripts/check-consolidation-patrol.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+/**
+ * plugins/shipwright/scripts/check-consolidation-patrol.ts
+ *
+ * Pre-check for the consolidation-patrol-maintenance cron.
+ *
+ * Reads state/consolidation-ledger.json (see
+ * skills/consolidation-scan/references/ledger-schema.md for the schema) and
+ * looks for candidates worth waking a full Claude session for:
+ *   - Already `ready_to_propose` (met the Rule of Three promotion bar).
+ *   - Still `tracking` but with `occurrence_count >= 2` — one observation away
+ *     from the count threshold. occurrence_count alone doesn't promote a
+ *     candidate (consecutive_stable_runs and suppression checks also apply —
+ *     see the ledger schema's promotion rule), but it's a cheap proxy signal
+ *     worth surfacing; the consolidation-scan/consolidation-fix skills remain
+ *     authoritative on whether there's real work.
+ *
+ * - A missing ledger is a normal first run (no candidates could possibly
+ *   exist yet) → exit 1 (nothing to do).
+ * - A ledger that fails to read/parse → exit 0 (permissive; can't rule out
+ *   work exists).
+ * - Zero interesting candidates → exit 1 (nothing to do).
+ * - At least one interesting candidate → exit 0 with a short summary as stdout.
+ *
+ * Usage:
+ *   bun plugins/shipwright/scripts/check-consolidation-patrol.ts
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface LedgerCandidate {
+  description: string;
+  files: string[];
+  occurrence_count: number;
+  consecutive_stable_runs: number;
+  status: "tracking" | "ready_to_propose";
+  firstSeen: string;
+  lastSeen: string;
+}
+
+interface Ledger {
+  lastRun: string | null;
+  candidates: Record<string, LedgerCandidate>;
+}
+
+interface Deps {
+  readLedger: () => Ledger | null;
+}
+
+interface RunResult {
+  exit: 0 | 1;
+  output: string;
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * True if a candidate is worth waking a full Claude session for: already
+ * promoted, or a tracking candidate one occurrence away from the count
+ * threshold. Mirrors the "close to the stabilization threshold" bar from
+ * the ledger schema's promotion rule.
+ */
+function isInteresting(candidate: LedgerCandidate): boolean {
+  if (candidate.status === "ready_to_propose") return true;
+  return candidate.status === "tracking" && candidate.occurrence_count >= 2;
+}
+
+export async function run(deps: Deps): Promise<RunResult> {
+  let ledger: Ledger | null;
+  try {
+    ledger = deps.readLedger();
+  } catch {
+    // Read/parse failure — unknown state, exit permissively per the
+    // precheck contract's "err permissive" rule.
+    return {
+      exit: 0,
+      output: "Consolidation ledger unreadable — running permissively.",
+    };
+  }
+
+  // Missing ledger — normal first run, no candidates could possibly exist yet.
+  if (ledger === null) {
+    return { exit: 1, output: "" };
+  }
+
+  const interestingCount = Object.values(ledger.candidates).filter(
+    isInteresting,
+  ).length;
+
+  if (interestingCount === 0) {
+    return { exit: 1, output: "" };
+  }
+
+  return {
+    exit: 0,
+    output: `${interestingCount} consolidation candidate(s) near the stabilization threshold — running consolidation-patrol check.`,
+  };
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+function buildProductionDeps(): Deps {
+  const cwd = process.cwd();
+
+  return {
+    readLedger: (): Ledger | null => {
+      const ledgerPath = join(cwd, "state", "consolidation-ledger.json");
+      if (!existsSync(ledgerPath)) return null;
+      // A missing file is the normal "no candidates yet" case (handled
+      // above), but a present-and-unparsable file is genuinely unknown
+      // state — let JSON.parse throw so run() can tell the two apart and
+      // exit permissively (0) rather than treating corruption as "nothing
+      // to do" (1).
+      return JSON.parse(readFileSync(ledgerPath, "utf-8")) as Ledger;
+    },
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const deps = buildProductionDeps();
+  const result = await run(deps);
+  if (result.exit === 0) {
+    process.stdout.write(`${result.output}\n`);
+  }
+  process.exit(result.exit);
+}
+
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts
+++ b/plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts
+ *
+ * Unit tests for check-consolidation-patrol.ts
+ *
+ * Design: the script exports a `run(deps)` function that accepts injected
+ * dependencies. Tests inject stub implementations — no file I/O is executed.
+ * No mock.module()/global.fetch overrides per the repo's test isolation rule.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { run } from "./check-consolidation-patrol.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface LedgerCandidate {
+  description: string;
+  files: string[];
+  occurrence_count: number;
+  consecutive_stable_runs: number;
+  status: "tracking" | "ready_to_propose";
+  firstSeen: string;
+  lastSeen: string;
+}
+
+interface Ledger {
+  lastRun: string | null;
+  candidates: Record<string, LedgerCandidate>;
+}
+
+function makeDeps(overrides: { readLedger?: () => Ledger | null }) {
+  return {
+    readLedger:
+      overrides.readLedger ?? (() => ({ lastRun: null, candidates: {} })),
+  };
+}
+
+function candidate(
+  overrides: Partial<LedgerCandidate> = {},
+): LedgerCandidate {
+  return {
+    description: "Shared retry-with-backoff logic",
+    files: ["src/a.ts", "src/b.ts"],
+    occurrence_count: 1,
+    consecutive_stable_runs: 0,
+    status: "tracking",
+    firstSeen: "2026-07-01T00:00:00.000Z",
+    lastSeen: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("check-consolidation-patrol", () => {
+  test("exits 1 when the ledger is missing (normal first run — no candidates possible)", async () => {
+    const deps = makeDeps({ readLedger: () => null });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when the ledger has zero candidates", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({ lastRun: "2026-07-01T00:00:00.000Z", candidates: {} }),
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 1 when all candidates are tracking with occurrence_count < 2", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        candidates: {
+          fp1: candidate({ occurrence_count: 1, status: "tracking" }),
+        },
+      }),
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(1);
+    expect(result.output).toBe("");
+  });
+
+  test("exits 0 when a candidate is ready_to_propose", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        candidates: {
+          fp1: candidate({
+            occurrence_count: 3,
+            consecutive_stable_runs: 2,
+            status: "ready_to_propose",
+          }),
+        },
+      }),
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 when a tracking candidate has occurrence_count >= 2 (close to threshold)", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        candidates: {
+          fp1: candidate({ occurrence_count: 2, status: "tracking" }),
+        },
+      }),
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  test("exits 0 with a summary mentioning the count of interesting candidates", async () => {
+    const deps = makeDeps({
+      readLedger: () => ({
+        lastRun: "2026-07-01T00:00:00.000Z",
+        candidates: {
+          fp1: candidate({
+            occurrence_count: 3,
+            consecutive_stable_runs: 2,
+            status: "ready_to_propose",
+          }),
+          fp2: candidate({ occurrence_count: 2, status: "tracking" }),
+          fp3: candidate({ occurrence_count: 1, status: "tracking" }),
+        },
+      }),
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output).toContain("2");
+  });
+
+  test("exits 0 permissively when the ledger is unreadable/corrupt (readLedger throws)", async () => {
+    const deps = makeDeps({
+      readLedger: () => {
+        throw new Error("corrupt JSON");
+      },
+    });
+    const result = await run(deps);
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new `consolidation-patrol-maintenance` system cron (disabled by default), modeled directly on `entropy-patrol-maintenance` — chains `/shipwright:consolidation-scan` then `/shipwright:consolidation-fix`, writes `state/consolidation-ledger.json`'s `lastRun` field, and stays `[silent]` when there are no `ready_to_propose` findings
- Adds a precheck script `plugins/shipwright/scripts/check-consolidation-patrol.ts` that cheaply checks the consolidation ledger for candidates near the stabilization threshold before waking a full Claude session, following the repo's precheck contract (best-effort, permissive-on-uncertainty)
- Updates `docs/agent.md` and `docs/test-readiness/test-inventory.md` to reflect the new cron and precheck script

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New `consolidation-patrol-maintenance` entry added to `SYSTEM_CRONS` with `enabled: false` | MET | `admin/src/system-crons.ts` |
| 2 | Prompt chains `/shipwright:consolidation-scan` then `/shipwright:consolidation-fix`, matching `entropy-patrol-maintenance`'s chaining style | MET | same entry's `prompt` field |
| 3 | No existing cron entries modified or removed | MET | diff is purely additive |
| 4 | Precheck script (if added) follows the precheck contract (best-effort, permissive-on-uncertainty) | MET | `check-consolidation-patrol.ts` exits 0 permissively on ledger read/parse failure, exits 1 when there's nothing interesting |

## Operational Note
Recommend leaving this cron **disabled** even after merge until `state/consolidation-ledger.json` has accumulated a few weeks of real signal, so the first `consolidation-fix` run isn't acting on a cold start.

## Test Plan
- [x] `admin/src/system-crons.unit.test.ts` — updated to cover the new cron entry (schedule, `enabled: false`, `preCheck`, prompt chaining, `[silent]`/`ready_to_propose` behavior)
- [x] `plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts` — new, covers missing ledger, zero/near-threshold/ready candidates, and corrupt-ledger permissive-exit behavior
- [x] Full `admin` and `plugins/shipwright` test suites pass locally
- [x] `tsc --noEmit` clean for both `admin` and `plugins/shipwright`
- [x] `biome lint` clean on all changed files

Generated with [Claude Code](https://claude.com/claude-code)
