### PR TITLE
feat: nest phase toggles under shipwright-loop in admin cron UI

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -149,6 +149,7 @@ export interface CronJobItem {
   enabled: boolean;
   name: string | null;
   system: boolean;
+  parentCronId: string | null;
   preCheck?: string | null;
   lastRun?: {
     startedAt: Date;
@@ -684,13 +685,19 @@ export function renderAgentDetailPage(
           )
           .join("\n");
 
-  const systemCrons = crons.filter((c) => c.system);
-  const customCrons = crons.filter((c) => !c.system);
+  // Top-level rows exclude any cron parented under another (e.g. shipwright-loop's
+  // dev-task/review/patch/deploy phases) — those render nested beneath their
+  // parent instead. `crons` (unfiltered) stays available below to look up each
+  // top-level cron's children by parentCronId.
+  const topLevelCrons = crons.filter((c) => !c.parentCronId);
+  const systemCrons = topLevelCrons.filter((c) => c.system);
+  const customCrons = topLevelCrons.filter((c) => !c.system);
 
-  function renderCronRow(c: CronJobItem): string {
+  /** Renders the reusable Logs/Toggle[/Delete] action cell shared by top-level and nested cron rows. */
+  function renderCronActions(c: CronJobItem): string {
     const toggleLabel = c.enabled ? "Disable" : "Enable";
     const toggleTarget = c.enabled ? "false" : "true";
-    const actions = `
+    return `
       <a href="/admin/agents/${escapeHtml(agent.id)}/cron-logs?cronId=${escapeHtml(c.id)}" class="btn btn-secondary" style="font-size:11px;padding:3px 8px;margin-right:4px;text-decoration:none">Logs</a>
       <form method="POST" action="/admin/agents/${escapeHtml(agent.id)}/crons/${escapeHtml(c.id)}/toggle" style="display:inline">
         <input type="hidden" name="enabled" value="${toggleTarget}" />
@@ -703,6 +710,59 @@ export function renderAgentDetailPage(
       </form>`
           : ""
       }`;
+  }
+
+  /**
+   * Renders the nested "Phases of <parent>" block for a top-level cron's
+   * children (e.g. shipwright-loop's dev-task/review/patch/deploy phases).
+   * Returns "" when there are no children, so parents without phases (all
+   * custom crons, and any system cron other than shipwright-loop) render
+   * exactly as before — no empty block.
+   */
+  function renderNestedPhasesRow(parent: CronJobItem, children: CronJobItem[]): string {
+    if (children.length === 0) return "";
+    const parentLabel = parent.name ?? parent.id;
+    const childRows = children
+      .map((child) => {
+        const lastRunOutcomeLabel = child.lastRun
+          ? cronRunOutcomeLabel(child.lastRun)
+          : null;
+        return `<tr>
+          <td style="padding-left:20px">${escapeHtml(child.name ? `${child.name}: ${child.prompt}` : child.prompt)}</td>
+          <td class="mono">${escapeHtml(child.schedule)}</td>
+          <td><span class="badge ${child.enabled ? "badge-green" : "badge-gray"}">${child.enabled ? "enabled" : "disabled"}</span></td>
+          <td style="font-size:11px">${
+            child.lastRun?.startedAt
+              ? `<span class="badge" style="${cronOutcomeStyle(lastRunOutcomeLabel)}">${escapeHtml(lastRunOutcomeLabel ?? "unknown")}</span>`
+              : `<span style="color:#d1d5db">never</span>`
+          }</td>
+          <td style="white-space:nowrap">${renderCronActions(child)}</td>
+        </tr>`;
+      })
+      .join("\n");
+    return `<tr>
+      <td colspan="7" style="background:#f9fafb;padding:12px 12px 12px 32px">
+        <div style="font-size:11px;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:8px">Phases of ${escapeHtml(parentLabel)}</div>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Phase</th>
+              <th>Schedule</th>
+              <th>Status</th>
+              <th>Last run</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${childRows}
+          </tbody>
+        </table>
+      </td>
+    </tr>`;
+  }
+
+  function renderCronRow(c: CronJobItem): string {
+    const actions = renderCronActions(c);
     // Full inline edit (schedule, prompt, channel, preCheck), collapsed behind a
     // <details> so the table stays readable. Posts to /update → cronService.update.
     // System crons get NO edit form — their contents are owned by
@@ -732,6 +792,9 @@ export function renderAgentDetailPage(
       <div style="font-size:11px;color:#6b7280;margin-top:4px">${c.runCountToday ?? 0} run${(c.runCountToday ?? 0) === 1 ? "" : "s"}</div>`
       : `<div style="color:#d1d5db">never</div>`;
 
+    const children = crons.filter((child) => child.parentCronId === c.id);
+    const nestedPhasesRow = renderNestedPhasesRow(c, children);
+
     return `<tr>
       <td class="mono">${escapeHtml(c.schedule)}</td>
       <td style="max-width:280px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(c.name ? `${c.name}: ${c.prompt}` : c.prompt)}</td>
@@ -740,7 +803,8 @@ export function renderAgentDetailPage(
       <td><span class="badge ${c.enabled ? "badge-green" : "badge-gray"}">${c.enabled ? "enabled" : "disabled"}</span></td>
       <td style="font-size:11px">${lastRunHtml}</td>
       <td style="white-space:nowrap">${actions}${editForm}</td>
-    </tr>`;
+    </tr>
+    ${nestedPhasesRow}`;
   }
 
   const systemCronRows =

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -75,6 +75,7 @@ const SYSTEM_CRON: CronJobItem = {
   enabled: true,
   name: "health-check",
   system: true,
+  parentCronId: null,
   preCheck: "shipwright:check-dev-task.ts",
 };
 
@@ -87,6 +88,7 @@ const CUSTOM_CRON: CronJobItem = {
   enabled: false,
   name: null,
   system: false,
+  parentCronId: null,
 };
 
 const TOOL_ENABLED: ToolItem = {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -546,6 +546,72 @@ describe("admin UI — authenticated pages", () => {
     expect(html).toContain("admin@example.com");
   });
 
+  it("nests shipwright-loop phase crons under the loop row instead of listing them flat", async () => {
+    const LOOP_ID = "cron-loop-1";
+    const PHASES = ["shipwright-dev-task", "shipwright-review", "shipwright-patch", "shipwright-deploy"];
+    const phaseCrons = PHASES.map((name, i) => ({
+      ...MOCK_CRON,
+      id: `cron-phase-${i}`,
+      name,
+      system: true,
+      parentCronId: LOOP_ID,
+      lastRun: null,
+      runCountToday: 0,
+    }));
+    const loopCron = {
+      ...MOCK_CRON,
+      id: LOOP_ID,
+      name: "shipwright-loop",
+      system: true,
+      parentCronId: null,
+      lastRun: null,
+      runCountToday: 0,
+    };
+
+    const app = createAdminUIApp(
+      makeMockDeps({
+        agentCronJobService: {
+          list: async () => [loopCron, ...phaseCrons],
+          listWithRunSummary: async () => [loopCron, ...phaseCrons],
+          get: async () => MOCK_CRON,
+          create: async () => MOCK_CRON,
+          setEnabled: async () => MOCK_CRON,
+          update: async () => MOCK_CRON,
+          delete: async () => {},
+          reconcileSystemCrons: async () => ({
+            created: 0,
+            updated: 0,
+            deleted: 0,
+          }),
+        },
+      }),
+    );
+    const res = await app.request(`/admin/agents/${AGENT_ID}`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Nested section is clearly labeled as belonging to shipwright-loop.
+    const labelIndex = html.indexOf("Phases of shipwright-loop");
+    expect(labelIndex).toBeGreaterThan(-1);
+
+    // Each phase's toggle form is present and wired to the existing toggle route.
+    for (const phase of phaseCrons) {
+      const toggleAction = `action="/admin/agents/${AGENT_ID}/crons/${phase.id}/toggle"`;
+      expect(html).toContain(toggleAction);
+      // The toggle form must appear after the "Phases of shipwright-loop" label,
+      // i.e. nested beneath the loop row rather than as a flat top-level row.
+      const toggleIndex = html.indexOf(toggleAction);
+      expect(toggleIndex).toBeGreaterThan(labelIndex);
+    }
+
+    // The loop's own toggle form is still rendered as the top-level row.
+    expect(html).toContain(
+      `action="/admin/agents/${AGENT_ID}/crons/${LOOP_ID}/toggle"`,
+    );
+  });
+
   it("authenticated GET /admin/agents/:id/cron-logs returns 200 with empty state", async () => {
     const app = createAdminUIApp(makeMockDeps());
     const res = await app.request(`/admin/agents/${AGENT_ID}/cron-logs`, {


### PR DESCRIPTION
## Summary
- Excludes any cron row with a non-null `parentCronId` (the four `shipwright-loop` phase crons: dev-task/review/patch/deploy) from the flat top-level admin cron table.
- Nests those phase rows directly beneath the `shipwright-loop` row in a labeled "Phases of shipwright-loop" section, each with the same enable/disable toggle control as top-level crons.
- Parent-child matching is generic (`child.parentCronId === parent.id`), not hardcoded to the loop by name, so it stays correct if another cron gains children in the future.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | The 4 phase cron rows no longer appear as flat top-level entries in the admin cron table | MET | `topLevelCrons = crons.filter((c) => !c.parentCronId)` feeds `systemCrons`/`customCrons` |
| 2 | The shipwright-loop row visually nests its 4 phase children beneath it, each independently toggleable | MET | `renderNestedPhasesRow()` renders each child via the shared `renderCronActions()` toggle form |
| 3 | The nested phase section is clearly labeled as belonging to shipwright-loop | MET | Renders "Phases of shipwright-loop" label above the nested child rows |
| 4 | Smoke test asserting exclusion from top-level + nested inclusion with working toggle forms | MET | New smoke test in `admin-ui.smoke.test.ts` asserts label presence and toggle-form wiring/ordering |

## Test Plan
- New smoke test: `"nests shipwright-loop phase crons under the loop row instead of listing them flat"` (Hono in-process `app.request()`)
- `bun test src/admin-ui.smoke.test.ts src/admin-ui-pages.unit.test.ts` — 579 pass, 0 fail
- `bun run --filter='*' --sequential typecheck` — clean
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
