### PR TITLE
feat: detect same-branch sibling task ordering before claiming a bundled task

### DIFF
--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -36,7 +36,12 @@ describe("dev-task.md — explicit-target-only argument contract", () => {
   });
 
   it("removes the in_progress resume-check query from Step 1", () => {
-    expect(content).not.toContain("status=in_progress");
+    // The old bare self-scan (`?status=in_progress&assignee=$SHIPWRIGHT_AGENT_ID`, unscoped
+    // to any specific task) must be gone. The Same-Branch Sibling Check's targeted
+    // `?branch={branch}&status=in_progress` lookup is a different, legitimate query and is
+    // not banned by this guard.
+    expect(content).not.toContain("tasks?status=in_progress&assignee=$SHIPWRIGHT_AGENT_ID");
+    expect(content).not.toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress"');
     expect(content).not.toContain("Resuming interrupted task");
   });
 
@@ -155,6 +160,81 @@ describe("Step 4 — stale bundle branch detection", () => {
     // The check must derive the repo slug from git remote get-url and pass it as --repo.
     expect(content).toContain('--repo "$GH_REPO"');
     expect(content).toContain("remote get-url origin");
+  });
+});
+
+describe("Step 1 — same-branch sibling ordering check (bundled-task deferral)", () => {
+  it("adds a Same-Branch Sibling Check section after branch validation and before the TASK banner", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+
+    const branchValidationIdx = content.indexOf("**Validate required fields.**");
+    const bannerIdx = content.indexOf("TASK: {id}");
+    expect(branchValidationIdx).toBeGreaterThan(-1);
+    expect(bannerIdx).toBeGreaterThan(-1);
+    expect(branchValidationIdx).toBeLessThan(siblingCheckIdx);
+    expect(siblingCheckIdx).toBeLessThan(bannerIdx);
+  });
+
+  it("runs before Step 2's claim, avoiding a wasted claim-then-release cycle", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    expect(claimIdx).toBeGreaterThan(-1);
+    expect(siblingCheckIdx).toBeLessThan(claimIdx);
+  });
+
+  it("queries the task store for other in_progress tasks on the same branch", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(siblingCheckIdx, siblingCheckIdx + 2500);
+    expect(section).toContain("/tasks?branch={branch}&status=in_progress");
+  });
+
+  it("excludes the current task's own id from the sibling results", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(siblingCheckIdx, siblingCheckIdx + 2500);
+    expect(section).toMatch(/exclude.{0,60}own.{0,10}\{id\}|own.{0,10}\{id\}.{0,60}not a\s+sibling/is);
+  });
+
+  it("computes sibling freshness using the 35-minute claim TTL, mirroring the stale-claim reaper's two-case formula", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(siblingCheckIdx, siblingCheckIdx + 2500);
+    expect(section).toContain("DEFAULT_CLAIM_TTL_MS");
+    expect(section).toContain("lib/claim-ttl.ts");
+    expect(section).toMatch(/35.{0,10}minute/i);
+    expect(section).toMatch(/heartbeatAt.{0,80}within the last 35 minutes/is);
+    expect(section).toMatch(/heartbeatAt is null.{0,80}claimedAt.{0,80}within the last 35 minutes/is);
+  });
+
+  it("when a sibling is fresh: releases this task's own claim and stops silently, without proceeding", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(siblingCheckIdx, siblingCheckIdx + 3500);
+    expect(section).toMatch(/if any sibling is fresh/i);
+    expect(section).toContain("/tasks/{id}/release");
+    const releaseIdx = section.indexOf("/tasks/{id}/release");
+    const before = section.slice(Math.max(0, releaseIdx - 200), releaseIdx);
+    expect(before).toMatch(/-X POST/);
+    expect(section).toContain("[silent]");
+  });
+
+  it("when no sibling is fresh (none exist, or all stale): proceeds normally — no behavior change for genuinely orphaned/stale work", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(siblingCheckIdx, siblingCheckIdx + 4000);
+    expect(section).toMatch(/if no sibling is fresh/i);
+    expect(section).toMatch(/proceed(s|ing)? normally/i);
+    expect(section).toMatch(/Branch\/PR Reality Check.{0,120}unchanged|unchanged.{0,120}Branch\/PR Reality Check/is);
+  });
+
+  it("applies regardless of this task's own status (pending or resumed in_progress)", () => {
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(-1);
+    const section = content.slice(siblingCheckIdx, siblingCheckIdx + 1000);
+    expect(section).toMatch(/regardless of this task's own status/i);
   });
 });
 

--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -60,7 +60,7 @@ describe("dev-task.md — explicit-target-only argument contract", () => {
       /\*\*Found, `status == "in_progress"`\*\*:[\s\S]*?(?=\n- \*\*Found)/,
     );
     expect(inProgressBulletMatch).not.toBeNull();
-    const bullet = inProgressBulletMatch![0];
+    const bullet = inProgressBulletMatch?.[0];
     expect(bullet).toMatch(/Same-Branch Sibling Check/i);
   });
 });

--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -50,7 +50,18 @@ describe("dev-task.md — explicit-target-only argument contract", () => {
     // by the unconditional Branch/PR Reality Check in Step 4.
     expect(content).not.toMatch(/proceed\s+straight\s+to\s+Step 2's Orphan Check/i);
     expect(content).not.toContain("### Orphan Check (prior session recovery)");
-    expect(content).toMatch(/skip\s+Step 2's claim and proceed directly to Step 3/i);
+    expect(content).toMatch(/skip\s+Step 2's claim[\s\S]*?then proceed to Step 3/i);
+  });
+
+  it("in_progress path is explicitly routed through the Same-Branch Sibling Check before Step 3", () => {
+    // The in_progress bullet must not just skip to Step 3 — it must pass through the
+    // Same-Branch Sibling Check first, or a resumed task never runs that check.
+    const inProgressBulletMatch = content.match(
+      /\*\*Found, `status == "in_progress"`\*\*:[\s\S]*?(?=\n- \*\*Found)/,
+    );
+    expect(inProgressBulletMatch).not.toBeNull();
+    const bullet = inProgressBulletMatch![0];
+    expect(bullet).toMatch(/Same-Branch Sibling Check/i);
   });
 });
 

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -45,11 +45,12 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 - **404**: the task doesn't exist. Print `⚠ Task {task-id} not found.` and stop.
 - **Found, `status == "in_progress"`**: a prior session left this task in progress (or a
   human is manually re-running dev-task against it) — the task is already claimed, so skip
-  Step 2's claim and proceed directly to Step 3. Step 4's Branch/PR Reality Check (below)
-  runs unconditionally before worktree creation regardless of this status, so any stale
-  branch/PR left behind by the prior session is discovered and handled there — no separate
-  orphan-recovery path is needed here. Record `task_started_at` (current ISO timestamp) for
-  metrics.
+  Step 2's claim, run the Same-Branch Sibling Check (below) — it applies to resumed
+  in_progress tasks too, see that section — then proceed to Step 3. Step 4's Branch/PR
+  Reality Check (below) runs unconditionally before worktree creation regardless of this
+  status, so any stale branch/PR left behind by the prior session is discovered and handled
+  there — no separate orphan-recovery path is needed here. Record `task_started_at` (current
+  ISO timestamp) for metrics.
 - **Found, `status == "pending"`**: check dependency satisfaction before claiming (see
   "Dependency Check" below). If satisfied, proceed to Step 2's Mark In-Progress with this
   task.

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -93,6 +93,50 @@ curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 
 Post the message above and stop. A missing branch cannot be recovered from at runtime — worktree creation will fail silently if attempted.
 
+### Same-Branch Sibling Check
+
+Some tasks are bundled onto an existing branch by prose in their `description` rather than
+a tracked `dependencies` entry (e.g. "joins branch X, land after task Y is merged"). Before
+claiming (pending) or resuming (in_progress) this task, check whether another task is
+already actively working the same `{branch}` — claiming (or continuing to hold a claim on)
+a task whose same-branch prerequisite is still mid-flight wastes a claim cycle and starves
+the prerequisite. This applies regardless of this task's own status.
+
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={branch}&status=in_progress" | jq '.tasks'
+```
+
+Exclude this task's own `{id}` from the results — a task's own in_progress claim is not a
+sibling. For each remaining same-branch task, determine freshness using the same two-case
+formula the task-store's stale-claim reaper uses (`DEFAULT_CLAIM_TTL_MS` in
+`lib/claim-ttl.ts` — 35 minutes: the 30-minute `claude -p` session timeout plus a 5-minute
+buffer):
+
+- heartbeatAt is set and heartbeatAt is within the last 35 minutes → **fresh**
+- heartbeatAt is null and claimedAt is within the last 35 minutes → **fresh**
+- Otherwise → **stale** (indistinguishable from a crashed/stuck claim the reaper hasn't
+  caught yet — not legitimate concurrent work)
+
+**If any sibling is fresh:** defer — a same-branch prerequisite is still being actively
+worked. Release this task's own claim (a no-op if this task was never claimed):
+
+```bash
+curl -sf -X POST -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}/release" | jq .
+```
+
+Print:
+```
+⏭ Deferring to same-branch sibling {sibling-id} (in_progress, heartbeat fresh) — released own claim.
+```
+Respond `[silent]` and stop.
+
+**If no sibling is fresh** (none exist, or all are stale): no legitimate concurrent work to
+defer to — proceeds normally. A stale sibling's abandoned branch/PR (if any) is exactly
+what Step 4's Branch/PR Reality Check's existing incomplete/stale recovery path already
+handles, unchanged.
+
 Print:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -52,8 +52,8 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   there — no separate orphan-recovery path is needed here. Record `task_started_at` (current
   ISO timestamp) for metrics.
 - **Found, `status == "pending"`**: check dependency satisfaction before claiming (see
-  "Dependency Check" below). If satisfied, proceed to Step 2's Mark In-Progress with this
-  task.
+  "Dependency Check" below). If satisfied, run the Same-Branch Sibling Check (below), then
+  proceed to Step 2's Mark In-Progress with this task.
 - **Found, any other status** (e.g. `pr_open`, `blocked`, `merged`): not workable. Print
   `⚠ Task {task-id} has status "{status}" — nothing to do.` and stop.
 
@@ -105,8 +105,15 @@ the prerequisite. This applies regardless of this task's own status.
 
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={branch}&status=in_progress" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={branch}&status=in_progress&repo={repo}" | jq '.tasks'
 ```
+
+Scoping by `{repo}` matters for repo-scoped agent tokens: the task-store's list handler
+filters those via `agentScope: { agentId, repos }` — an OR union across every repo in the
+token's scope, not a single repo. An unscoped `branch`+`status` query from an agent whose
+token spans multiple repos could match an in_progress task on an identically-named branch in
+a different scoped repo, causing a false-positive deferral. `?repo=` applies as an additional
+AND condition on top of `agentScope`'s OR, narrowing correctly to this task's own repo.
 
 Exclude this task's own `{id}` from the results — a task's own in_progress claim is not a
 sibling. For each remaining same-branch task, determine freshness using the same two-case


### PR DESCRIPTION
## Summary
- Adds a "Same-Branch Sibling Check" to `dev-task` Step 1, run after branch validation and before Step 2's claim
- Detects an actively-worked (fresh-heartbeat) sibling task on the same `branch` via `GET /tasks?branch={branch}&status=in_progress`, using the task-store's own 35-minute claim-TTL formula (`DEFAULT_CLAIM_TTL_MS`) to judge freshness
- On a fresh sibling: releases this task's own claim and stops silently instead of proceeding, avoiding the repeated claim-then-release churn seen on prose-bundled tasks (e.g. SECP-1.2 waiting on SECP-1.1)
- Stale/orphaned same-branch siblings fall through unchanged to Step 4's existing Branch/PR Reality Check recovery path — no behavior change there

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Detects a same-branch sibling in_progress with fresh heartbeat and defers (releases claim) instead of proceeding | MET | New "### Same-Branch Sibling Check" section in `dev-task.md` Step 1 |
| 2 | No change in behavior for genuinely orphaned/stale same-branch work | MET | Explicit fallthrough to Step 4's unchanged incomplete/stale recovery path |

## Test Plan
- 8 new content assertions in `dev-task.content.test.ts` covering: section placement (before claim, after branch validation), the `branch=`+`status=in_progress` query, self-exclusion, the 35-min TTL freshness formula, the release+`[silent]` defer path, and the unchanged stale fallthrough
- Narrowed one pre-existing guard test that banned the literal substring `status=in_progress` (originally guarding against the retired bare self-scan) so it no longer collides with this new, legitimately-scoped query
- `bun test plugins/shipwright/` — 896/896 pass
- `task lint`, `task check-strings`, `tsc --noEmit` — all clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
