### PR TITLE
feat: migrate work queue table onto shared data-table CSS

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -3197,24 +3197,26 @@ export function renderWorkQueuePage(opts: {
     </div>`
       : `<div style="margin-bottom:12px;font-size:12px;color:#6b7280">Last computed: ${escapeHtml(relativeTime(snapshot.computedAt, now))}</div>
     <div class="card">
-      <table class="runs-table">
-        <thead>
-          <tr>
-            <th>#</th>
-            <th>Type</th>
-            <th>Phase</th>
-            <th>Item</th>
-            <th>Age</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${
-            snapshot.items.length === 0
-              ? `<tr><td colspan="5" class="empty-state">Queue is empty — nothing pending.</td></tr>`
-              : snapshot.items.map(row).join("\n")
-          }
-        </tbody>
-      </table>
+      <div class="data-table-wrapper">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Type</th>
+              <th>Phase</th>
+              <th>Item</th>
+              <th>Age</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${
+              snapshot.items.length === 0
+                ? `<tr><td colspan="5" class="empty-state">Queue is empty — nothing pending.</td></tr>`
+                : snapshot.items.map(row).join("\n")
+            }
+          </tbody>
+        </table>
+      </div>
     </div>`;
 
   return `<!DOCTYPE html>
@@ -3223,11 +3225,7 @@ export function renderWorkQueuePage(opts: {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Work Queue — ${escapeHtml(agent.name)} — Shipwright Admin</title>
-  <style>${baseStyles()}
-    .runs-table { width:100%;border-collapse:collapse; }
-    .runs-table th { text-align:left;padding:8px 12px;font-size:12px;color:#6b7280;font-weight:600;border-bottom:1px solid #e5e7eb;text-transform:uppercase;letter-spacing:.05em; }
-    .runs-table td { padding:8px 12px;border-bottom:1px solid #f3f4f6; }
-  </style>
+  <style>${baseStyles()}</style>
 </head>
 <body>
   ${renderAdminToolbar(userName, "/admin/agents")}

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -23,6 +23,8 @@ import {
   type TaskStoreTokenItem,
   type TokenItem,
   type ToolItem,
+  type WorkQueueItem,
+  type WorkQueueSnapshotItem,
   renderAgentDetailPage,
   renderAgentsPage,
   renderChatPage,
@@ -38,6 +40,7 @@ import {
   renderTaskDetailPage,
   renderTasksPage,
   renderTokensPage,
+  renderWorkQueuePage,
 } from "./admin-ui-pages.ts";
 import { renderAdminToolbar } from "./admin-ui-styles.ts";
 import type { ChatMessage, ChatThread } from "./http-chat-client.ts";
@@ -4988,5 +4991,106 @@ describe("renderTokensPage — agent column linkability", () => {
     ]);
     expect(html).toContain("(admin)");
     expect(html).not.toContain("/admin/agents/");
+  });
+});
+
+describe("renderWorkQueuePage", () => {
+  const QUEUE_AGENT = { id: "agent-123", name: "Test Agent" };
+
+  function makeItem(overrides?: Partial<WorkQueueItem>): WorkQueueItem {
+    return {
+      type: "task",
+      id: "TSK-1",
+      title: "Sample task",
+      phase: "dev-task",
+      age: "2026-06-01T09:00:00Z",
+      ...overrides,
+    };
+  }
+
+  function render(
+    snapshot: WorkQueueSnapshotItem | null,
+    opts?: { now?: Date },
+  ): string {
+    return renderWorkQueuePage({
+      agent: QUEUE_AGENT,
+      snapshot,
+      userName: "admin@example.com",
+      now: opts?.now ?? new Date("2026-06-01T10:00:00Z"),
+    });
+  }
+
+  test("renders a valid HTML document", () => {
+    const html = render({
+      computedAt: new Date("2026-06-01T09:55:00Z"),
+      items: [makeItem()],
+    });
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("<html");
+    expect(html).toContain("</html>");
+    expect(html).toContain(
+      "<title>Work Queue — Test Agent — Shipwright Admin</title>",
+    );
+  });
+
+  test("renders empty state when snapshot is null", () => {
+    const html = render(null);
+    expect(html).toContain("No work queue snapshot yet");
+    expect(html).toContain("shipwright-loop cron ticks");
+  });
+
+  test("renders empty state when snapshot has no items", () => {
+    const html = render({
+      computedAt: new Date("2026-06-01T09:55:00Z"),
+      items: [],
+    });
+    expect(html).toContain("Queue is empty — nothing pending");
+  });
+
+  test("renders table wrapped in data-table-wrapper with class data-table", () => {
+    const html = render({
+      computedAt: new Date("2026-06-01T09:55:00Z"),
+      items: [makeItem()],
+    });
+    expect(html).toContain('<div class="data-table-wrapper">');
+    expect(html).toContain('<table class="data-table">');
+  });
+
+  test("renders queue items with correct columns", () => {
+    const html = render({
+      computedAt: new Date("2026-06-01T09:55:00Z"),
+      items: [
+        makeItem({
+          type: "task",
+          id: "TSK-1",
+          title: "First task",
+          phase: "dev-task",
+          age: "2026-06-01T09:00:00Z",
+        }),
+        makeItem({
+          type: "pr",
+          id: "PR-123",
+          title: "Review PR",
+          phase: "review",
+          age: "2026-06-01T08:30:00Z",
+        }),
+      ],
+    });
+    expect(html).toContain("<th>#</th>");
+    expect(html).toContain("<th>Type</th>");
+    expect(html).toContain("<th>Phase</th>");
+    expect(html).toContain("<th>Item</th>");
+    expect(html).toContain("<th>Age</th>");
+    expect(html).toContain("First task");
+    expect(html).toContain("Review PR");
+  });
+
+  test("renders a back link to the agent detail page", () => {
+    const html = render({
+      computedAt: new Date("2026-06-01T09:55:00Z"),
+      items: [makeItem()],
+    });
+    expect(html).toContain('href="/admin/agents/agent-123"');
+    expect(html).toContain("Test Agent");
   });
 });


### PR DESCRIPTION
## Summary
- Migrates `renderWorkQueuePage()`'s table onto the shared `.data-table` + `.data-table-wrapper` CSS pattern already used elsewhere in `admin-ui-pages.ts`
- Removes this page's own bespoke `.runs-table` inline CSS block (duplicated from Cron Logs)
- Adds unit test coverage for `renderWorkQueuePage`, which had none before this change

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | table uses class="data-table" wrapped in `<div class="data-table-wrapper">` | MET | admin-ui-pages.ts |
| 2 | .runs-table CSS block removed from inline `<style>` | MET | admin-ui-pages.ts |
| 3 | Unit test asserts wrapper div + data-table class | MET | admin-ui-pages.unit.test.ts |

## Test Plan
- Added `describe("renderWorkQueuePage", ...)` block: valid HTML doc, empty states (null snapshot / empty items), the wrapper+class assertion required by acceptance criteria, item-column rendering, and back-link rendering
- `bun test src/admin-ui-pages.unit.test.ts` — 423/423 pass
- `bunx biome lint` — clean
- `tsc --noEmit` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
