### PR TITLE
feat: add Created column to Tasks list (ATC-1.5)

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1536,6 +1536,7 @@ export function renderTasksPage(
   opts?: { error?: string; agentFilterActive?: boolean },
   suggestions?: { sessions?: string[]; repos?: string[]; agents?: string[] },
   readOnly = false,
+  timezone = "America/Los_Angeles",
 ): string {
   const errorHtml = opts?.error
     ? `<div class="alert alert-error">${escapeHtml(opts.error)}</div>`
@@ -1621,6 +1622,7 @@ export function renderTasksPage(
                       : d.toLocaleString("en-US", {
                           dateStyle: "medium",
                           timeStyle: "short",
+                          timeZone: timezone,
                         });
                   })(),
                 )

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1596,7 +1596,7 @@ export function renderTasksPage(
 
   const rows =
     tasks.length === 0
-      ? `<tr><td colspan="8" class="empty-state">No tasks found.</td></tr>`
+      ? `<tr><td colspan="9" class="empty-state">No tasks found.</td></tr>`
       : tasks
           .map((t) => {
             const agentId = t.claimedBy ?? t.assignee;
@@ -1612,6 +1612,19 @@ export function renderTasksPage(
                 : t.prUrl
                   ? `<a href="${escapeHtml(t.prUrl)}" style="color:#6366f1;text-decoration:none" title="View PR">#${t.pr ?? "PR"}</a>`
                   : '<span style="color:#9ca3af">—</span>';
+            const createdCell = t.createdAt
+              ? escapeHtml(
+                  (() => {
+                    const d = new Date(t.createdAt as string);
+                    return Number.isNaN(d.getTime())
+                      ? (t.createdAt as string)
+                      : d.toLocaleString("en-US", {
+                          dateStyle: "medium",
+                          timeStyle: "short",
+                        });
+                  })(),
+                )
+              : '<span style="color:#9ca3af">—</span>';
             const detailHref = `/admin/tasks/${escapeHtml(t.id)}${detailHrefSuffix}`;
             return `<tr${readOnly ? "" : ` data-href="${detailHref}" style="cursor:pointer"`}>
     <td class="mono" style="font-size:11px">${readOnly ? escapeHtml(t.id) : `<a href="${detailHref}" style="color:#6366f1;text-decoration:none" title="View details">${escapeHtml(t.id)}</a>`}</td>
@@ -1627,6 +1640,7 @@ export function renderTasksPage(
     }</td>
     <td class="col-repo mono" style="font-size:11px">${t.repo ? escapeHtml(t.repo) : '<span style="color:#9ca3af">—</span>'}</td>
     <td class="mono" style="font-size:11px">${prCell}</td>
+    <td class="col-created" style="font-size:12px">${createdCell}</td>
     ${
       readOnly
         ? ""
@@ -1788,6 +1802,7 @@ export function renderTasksPage(
               <th class="col-session">Session</th>
               <th class="col-repo">Repo</th>
               <th>PR</th>
+              <th class="col-created">Created</th>
               <th></th>
             </tr>
           </thead>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2101,6 +2101,7 @@ describe("renderTasksPage — Created column", () => {
     ).toLocaleString("en-US", {
       dateStyle: "medium",
       timeStyle: "short",
+      timeZone: "America/Los_Angeles",
     });
     expect(html).toContain(expected);
   });

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2025,9 +2025,9 @@ describe("renderTasksPage — PR column", () => {
     expect(html).toContain("—");
   });
 
-  test("empty state colspan is 8 (7 columns + 1 for new PR column)", () => {
+  test("empty state colspan is 9 (8 columns + 1 for new Created column)", () => {
     const html = render([]);
-    expect(html).toContain('colspan="8"');
+    expect(html).toContain('colspan="9"');
   });
 
   test("task with pr value uses indigo link color matching ID column style", () => {
@@ -2066,6 +2066,75 @@ describe("renderTasksPage — PR column", () => {
     const html = render([xssTask]);
     expect(html).not.toContain("<script>xss");
     expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+// ─── renderTasksPage — Created column (ATC-1.5) ──────────────────────────────
+
+describe("renderTasksPage — Created column", () => {
+  function render(tasks: TaskItem[]): string {
+    return renderTasksPage(
+      tasks,
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: tasks.length, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+  }
+
+  test("Created column header is present with col-created class", () => {
+    const html = render([]);
+    expect(html).toContain('<th class="col-created">Created</th>');
+  });
+
+  test("task with createdAt renders formatted date in Created cell", () => {
+    const taskWithCreatedAt: TaskItem = {
+      ...TASK_ITEM,
+      createdAt: "2026-07-10T09:30:00.000Z",
+    };
+    const html = render([taskWithCreatedAt]);
+    const expected = new Date(
+      taskWithCreatedAt.createdAt as string,
+    ).toLocaleString("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+    expect(html).toContain(expected);
+  });
+
+  test("task without createdAt shows em-dash in Created cell", () => {
+    const taskWithoutCreatedAt: TaskItem = {
+      ...TASK_ITEM,
+      createdAt: null,
+    };
+    const html = render([taskWithoutCreatedAt]);
+    const createdTdPattern =
+      /<td class="col-created"[^>]*>\s*<span style="color:#9ca3af">—<\/span>\s*<\/td>/;
+    expect(html).toMatch(createdTdPattern);
+  });
+
+  test("task with invalid createdAt falls back to raw string (NaN guard)", () => {
+    const taskWithInvalidCreatedAt: TaskItem = {
+      ...TASK_ITEM,
+      createdAt: "not-a-date",
+    };
+    const html = render([taskWithInvalidCreatedAt]);
+    expect(html).toContain("not-a-date");
+  });
+
+  test("empty state colspan is 9 (8 columns + 1 for new Created column)", () => {
+    const html = render([]);
+    expect(html).toContain('colspan="9"');
+  });
+
+  test("Created <th> and <td> join the col-session/col-repo mobile-hide set", () => {
+    const html = render([{ ...TASK_ITEM, createdAt: "2026-07-10T09:30:00.000Z" }]);
+    expect(html).toContain('<th class="col-created">Created</th>');
+    const createdTdPattern = /<td[^>]*class="[^"]*col-created[^"]*"[^>]*>/;
+    expect(html).toMatch(createdTdPattern);
   });
 });
 

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2125,11 +2125,6 @@ describe("renderTasksPage — Created column", () => {
     expect(html).toContain("not-a-date");
   });
 
-  test("empty state colspan is 9 (8 columns + 1 for new Created column)", () => {
-    const html = render([]);
-    expect(html).toContain('colspan="9"');
-  });
-
   test("Created <th> and <td> join the col-session/col-repo mobile-hide set", () => {
     const html = render([{ ...TASK_ITEM, createdAt: "2026-07-10T09:30:00.000Z" }]);
     expect(html).toContain('<th class="col-created">Created</th>');

--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -270,7 +270,7 @@ export function baseStyles(): string {
     }
     .state-tab { padding: 5px 14px; }
     @media (max-width: 640px) {
-      .col-session, .col-repo { display: none; }
+      .col-session, .col-repo, .col-created { display: none; }
       .col-review-cycles, .col-patch-cycles, .col-claimed-by { display: none; }
       .state-tab { padding: 13px 14px; }
       .vos-page {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -2082,6 +2082,8 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
           agentFilterActive: agentFilterIds !== null,
         },
         suggestions,
+        false,
+        timezone,
       ),
     );
   });
@@ -2833,6 +2835,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         undefined,
         undefined,
         true, // readOnly
+        timezone,
       ),
     );
   });


### PR DESCRIPTION
## Summary
- Adds a `Created` column to `renderTasksPage()`'s table, rendering `task.createdAt` — matching the underlying `createdAt` sort order and the sibling `renderPrsPage()` Created column pattern (ATC-1.1).
- Joins the new column to the existing `.col-session`/`.col-repo` mobile-hide set (`.col-created`) in `admin-ui-styles.ts`, given an 8th visible column on a 640px viewport warrants the same density fix.
- Adds unit test coverage in `admin-ui-pages.unit.test.ts` for the header, formatted-date rendering, missing-value fallback, invalid-date NaN guard, and the mobile-hide class.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | renderTasksPage()'s table has a new 'Created' column rendering task.createdAt | MET | `<th class="col-created">Created</th>` + per-row `createdCell` rendering `t.createdAt` |
| 2 | New column joins mobile-hide class set if row density warrants | MET | `.col-session, .col-repo, .col-created { display: none; }` in admin-ui-styles.ts |
| 3 | Unit test added asserting Created column renders correct value | MET | New `describe("renderTasksPage — Created column")` block, 5 tests, all passing |

## Test Plan
- [x] `bun test admin-ui-pages.unit.test.ts` — 422 pass, 0 fail
- [x] `bun test` (full admin suite) — 1330 pass, 0 fail, 175 skip
- [x] `tsc --noEmit` — clean
- [x] `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
