### PR TITLE
feat: wrap tokens page table for consistent mobile scroll

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -3454,19 +3454,21 @@ export SHIPWRIGHT_TASK_STORE_TOKEN=${escapeHtml(rawToken)}</pre>`
     ${errorBanner}
     ${rawTokenBanner}
     <div class="card" style="overflow:auto">
-      <table class="data-table" style="width:100%">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Label</th>
-            <th>Agent</th>
-            <th>Created</th>
-            <th>Status</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>${rows}</tbody>
-      </table>
+      <div class="data-table-wrapper">
+        <table class="data-table" style="width:100%">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Label</th>
+              <th>Agent</th>
+              <th>Created</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
     </div>
     ${createForm}
   </div>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -5185,6 +5185,22 @@ describe("renderTokensPage — agent column linkability", () => {
     expect(html).toContain("(admin)");
     expect(html).not.toContain("/admin/agents/");
   });
+
+  test("table is wrapped in .data-table-wrapper", () => {
+    const html = render([
+      {
+        id: "tok-1",
+        label: "CI token",
+        agentId: "agent-y",
+        token: "sw_abc",
+        createdAt: "2026-06-01T10:00:00Z",
+        revokedAt: null,
+      },
+    ]);
+    expect(html).toMatch(
+      /<div class="data-table-wrapper">\s*<table class="data-table"/,
+    );
+  });
 });
 
 describe("renderWorkQueuePage", () => {


### PR DESCRIPTION
## Summary
- Wraps the Tokens page (`renderTokensPage()`) table in `<div class="data-table-wrapper">` for consistent mobile scroll behavior, matching the pattern already applied to other admin pages in this session.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | renderTokensPage()'s table is wrapped in `<div class="data-table-wrapper">` | MET | admin-ui-pages.ts:3457-3473 |
| 2 | Unit test in admin-ui-pages.unit.test.ts asserts the wrapper div is present | MET | admin-ui-pages.unit.test.ts:5188-5203 |

## Test Plan
- New unit test asserts `<div class="data-table-wrapper">` wraps `<table class="data-table">` in renderTokensPage() output
- `bun test src/admin-ui-pages.unit.test.ts` — 444 pass, 0 fail
- [x] Pre-commit checks passing (lint, typecheck)

Generated with [Claude Code](https://claude.com/claude-code)
