### PR TITLE
fix: wrap dependency graph in scrollable container on mobile

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2450,7 +2450,7 @@ function renderDependencyGraph(nodes: DependencyNode[]): string {
       ${edgePaths.join("\n      ")}
     </svg>`;
 
-  return `<div style="position:relative;width:${layout.width}px;height:${layout.height}px;overflow-x:auto">
+  return `<div style="position:relative;width:${layout.width}px;height:${layout.height}px">
       ${svgHtml}
       ${nodes.map(nodeCard).join("\n      ")}
     </div>`;
@@ -2515,7 +2515,9 @@ export function renderSessionDetailPage(
     dependencyNodes.length > 0
       ? `<div class="card" style="margin-bottom:16px">
       <div style="font-size:12px;font-weight:600;color:#374151;margin-bottom:12px;text-transform:uppercase;letter-spacing:.05em">Dependency graph</div>
+      <div class="data-table-wrapper">
       ${renderDependencyGraph(dependencyNodes)}
+    </div>
     </div>`
       : "";
 

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -5015,6 +5015,79 @@ describe("renderSessionDetailPage dependency graph", () => {
     expect(edges).toContainEqual(["TASK-CHILD-1", "TASK-SINK"]);
     expect(edges).toContainEqual(["TASK-CHILD-2", "TASK-SINK"]);
   });
+
+  test("graph is wrapped in .data-table-wrapper for horizontal scroll on mobile", () => {
+    const root: TaskItem = {
+      id: "TASK-ROOT",
+      title: "Root",
+      status: "pending",
+      session: SESSION_ID,
+      blockedBy: [],
+    };
+    const dependent: TaskItem = {
+      id: "TASK-DEP",
+      title: "Depends on root",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-ROOT"],
+      blockedBy: [{ type: "dependency", id: "TASK-ROOT", status: "pending" }],
+    };
+    const html = renderSessionDetailPage(
+      SESSION_ID,
+      [root, dependent],
+      USER_NAME,
+    );
+    const section = graphSection(html);
+    expect(section).toMatch(
+      /<div class="data-table-wrapper">\s*<div style="position:relative;/,
+    );
+  });
+
+  test("2-depth-column graph: wrapper (not inner graph div) carries overflow-x:auto, and inner width exceeds a phone viewport", () => {
+    const root: TaskItem = {
+      id: "TASK-A",
+      title: "Root",
+      status: "pending",
+      session: SESSION_ID,
+      blockedBy: [],
+    };
+    const dependent: TaskItem = {
+      id: "TASK-B",
+      title: "Depends on A",
+      status: "pending",
+      session: SESSION_ID,
+      dependencies: ["TASK-A"],
+      blockedBy: [{ type: "dependency", id: "TASK-A", status: "pending" }],
+    };
+    const html = renderSessionDetailPage(
+      SESSION_ID,
+      [root, dependent],
+      USER_NAME,
+    );
+    const section = graphSection(html);
+
+    // Wrapper carries the (class-based) overflow-x:auto; the inner graph div
+    // is exactly sized to its own content and must not duplicate it inline.
+    expect(section).toContain('<div class="data-table-wrapper">');
+    const innerDivMatch = section.match(
+      /<div style="position:relative;[^"]*"/,
+    );
+    expect(innerDivMatch).not.toBeNull();
+    expect(innerDivMatch?.[0]).not.toContain("overflow-x:auto");
+
+    // Confirm this is genuinely a 2-depth-column graph whose width exceeds a
+    // 375px phone viewport, so the wrapper's scroll is actually needed.
+    const layout = computeDependencyLayout(
+      computeDependencyNodes([root, dependent]),
+    );
+    const depths = [...layout.positions.values()].map((p) => p.depth);
+    const numColumns = new Set(depths).size;
+    expect(numColumns).toBe(2);
+    expect(layout.width).toBe(
+      40 * 2 + numColumns * 220 + (numColumns - 1) * 100,
+    );
+    expect(layout.width).toBeGreaterThan(375);
+  });
 });
 
 // ─── computeDependencyLayout ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Wrap `renderDependencyGraph()`'s output in `<div class="data-table-wrapper">` at its call site in `renderSessionDetailPage()`'s `depsSection`, reusing the existing generic scroll+shadow CSS class already applied to tables elsewhere in the file.
- Remove the dead `overflow-x:auto` from the graph's own inner div — that div is sized exactly to its content (via `computeDependencyLayout`) so it never overflows itself; the real overflow happens one level up, where the graph sits inside a plain `.card` with no scroll handling.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Graph wrapped in `<div class="data-table-wrapper">` at depsSection call site | MET | `admin-ui-pages.ts` — wrapper div added around `renderDependencyGraph(dependencyNodes)` |
| 2 | Dead `overflow-x:auto` removed from inner exactly-sized div | MET | `admin-ui-pages.ts` — style trimmed to `position:relative;width:...px;height:...px` |
| 3 | Unit test asserting wrapper present when dependencyNodes.length > 0 | MET | new test "graph is wrapped in .data-table-wrapper for horizontal scroll on mobile" |
| 4 | Unit test covering 2+ depth columns (width > 375px), wrapper carries overflow-x:auto not inner div | MET | new test "2-depth-column graph..." — wrapper class present, inner div's inline style lacks overflow-x:auto, layout.width (620px) > 375px |
| 5 | No changes to `computeDependencyLayout()`'s layout math | MET | diff touches only `renderDependencyGraph()` and `renderSessionDetailPage()` |

## Test Plan
- `bun test admin/src/admin-ui-pages.unit.test.ts` — 445 pass, 0 fail (includes 2 new tests, TDD red→green confirmed)
- `bunx biome lint admin/src` — clean
- `tsc --noEmit` (admin) — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
