### PR TITLE
docs: fold speed baseline into test-system.md speed budgets (T-067)

### DIFF
--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -301,6 +301,25 @@ this repo does not tighten any budget below the default.
   condition (a) (budget miss) is the trigger to revisit, not a fixed test-count
   threshold.
 
+**Measured baseline (T-067, folding in T-002):** the default budget table above is no
+longer just a target — real per-layer numbers now exist in
+[`speed-baseline.md`](./speed-baseline.md), measured across all five workspaces (plugin,
+metrics dashboard, agent, admin, site). Every measured layer falls comfortably within
+budget:
+
+- **Unit:** 1.05s–2.50s per package (well under the <30s suite target)
+- **Integration:** 0.15s–5.35s per package (well under the <3 min suite target)
+- **Smoke:** 1.5s–4.6s per package (well under the <30s/<60s suite target;
+  `speed-baseline.md`'s per-package rows show 3.24s for admin and 4.62s for metrics)
+- **E2E:** 4s–40s via CI (metrics dashboard, admin UI, and site), well under the <30s
+  per-test 95p / <90s hard cap
+- **Full suite:** 34.23s wall-clock (3842 pass, 242 skip, 4084 tests across 198 files),
+  well within the <15 min full-PR budget
+
+See `speed-baseline.md` for the full per-package breakdown, methodology, and the exact
+verification command output. Future `/test-migration` passes should cite this baseline
+rather than re-flagging speed as "not measured."
+
 ## Shared helpers / utilities to build
 
 Per Step 9 — most of these already exist; only additions/extensions are called out

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -309,8 +309,8 @@ budget:
 
 - **Unit:** 1.05s–2.50s per package (well under the <30s suite target)
 - **Integration:** 0.15s–5.35s per package (well under the <3 min suite target)
-- **Smoke:** 1.5s–4.6s per package (well under the <30s/<60s suite target;
-  `speed-baseline.md`'s per-package rows show 3.24s for admin and 4.62s for metrics)
+- **Smoke:** 3.24s–4.62s per package (admin, metrics — the only two packages with
+  smoke-layer tests today), well under the <30s/<60s suite target
 - **E2E:** 4s–40s via CI (metrics dashboard, admin UI, and site), well under the <30s
   per-test 95p / <90s hard cap
 - **Full suite:** 34.23s wall-clock (3842 pass, 242 skip, 4084 tests across 198 files),


### PR DESCRIPTION
## Summary
- Folds the real per-layer speed measurements from `docs/test-readiness/speed-baseline.md` (T-002, merged in PR #1580) into `test-system.md`'s Speed budgets section, so future `/test-migration` passes stop flagging speed as an open/unmeasured item.
- Adds a "Measured baseline (T-067, folding in T-002)" paragraph with a cross-reference link and summarized per-layer ranges (unit, integration, smoke, e2e, full suite).
- Corrected the smoke-layer range during requirements verification: the task brief's own acceptance-criteria text cited "1.5-4.6s," but that figure traces back to admin's *integration* measurement (1.50s) in `speed-baseline.md`, not smoke. The doc now cites the actual smoke numbers (3.24s admin, 4.62s metrics — the only two packages with smoke-layer tests today).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Speed budgets cites speed-baseline.md's real numbers instead of "not measured" | MET | New "Measured baseline" paragraph links `speed-baseline.md` and replaces the open-item framing with real numbers |
| 2 | Per-layer numbers match speed-baseline.md exactly | MET | unit 1.05–2.50s, integration 0.15–5.35s, smoke 3.24–4.62s, e2e 4–40s, full suite 34.23s — all verified against speed-baseline.md's Section 3 table |
| 3 | Cross-reference link resolves | MET | `[speed-baseline.md](./speed-baseline.md)` — both files sit in `docs/test-readiness/` |
| 4 | Verification command passes | MET | Manual doc review: table present, numbers match source exactly, link resolves |

## Test Plan
- Docs-only change — no code/tests affected.
- `bunx biome lint docs/test-readiness/test-system.md` — clean.
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean.
- [x] Numbers cross-checked line-by-line against `docs/test-readiness/speed-baseline.md`'s Section 3 table.

Generated with [Claude Code](https://claude.com/claude-code)
