### PR TITLE
docs: refresh stale references for 2026-07-19 sync

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The agent owns ten first-class Prisma models (`Agent` and its `Env` / `CronJob` / `CronRun` / `Tool` / `Token` / `Plugin` / `Member` children, plus `AgentCronRunModelBreakdown` for per-model token/cost breakdown and `AgentChatTokenUsageDailyByModel` for daily token usage rollups) on a **dedicated database** (`DATABASE_URL_SHIPWRIGHT_ADMIN`). Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer; agent API tokens are stored only as SHA-256 hashes.
+The agent owns eleven first-class Prisma models (`Agent` and its `Env` / `CronJob` / `CronRun` / `Tool` / `Token` / `Plugin` / `Member` children, plus `AgentCronRunModelBreakdown` for per-model token/cost breakdown, `AgentChatTokenUsageDailyByModel` for daily token usage rollups, and `AgentWorkQueueSnapshot` for the agent's latest ranked work-queue snapshot) on a **dedicated database** (`DATABASE_URL_SHIPWRIGHT_ADMIN`). Secrets at rest (env values, Slack/Anthropic keys) are AES-256-GCM encrypted at the service layer; agent API tokens are stored only as SHA-256 hashes.
 
 > The Dockerfile `ENTRYPOINT` is `bun run admin/src/main.ts`, which runs migrations, constructs all services, and mounts all admin + runtime routes. The implemented HTTP surfaces are the admin CRUD API (`admin/src/agents-api.ts`, auth via `api-auth.ts`), the runtime API (`admin/src/api.ts`), the server-rendered admin UI (`admin/src/admin-ui.ts`), the public read-only task board (`GET /public/tasks` — no auth, configurable repo scope), the Prisma store + service classes (all in the `@shipwright/admin` package), the Slack event handler (`slack.ts`), and the cron runtime (`cron-handler.ts`). On startup the runner calls `POST /agents/:id/crons/reconcile` to sync system crons.
 
@@ -57,6 +57,7 @@ Mounted at `/agents/*` (unified with the runtime API surface). Auth: **admin key
 | Tokens | `POST` / `GET` `/agents/:id/tokens`, `DELETE /agents/:id/tokens/:tokenId` |
 | Chat Tokens | `POST /agents/:id/chat-tokens/daily` (daily upsert: atomically accumulates Slack chat session token usage by `(agentId, date, model)`; body: `{date: YYYY-MM-DD, modelBreakdown: [{model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd}]}`; returns an array of updated daily rows `[{id, agentId, date, model, ...}]`), `GET /agents/chat-tokens/daily/stats` (admin-only: aggregated chat-token daily stats across all agents; query params: `from` / `to` (optional YYYY-MM-DD date strings); returns `{totals, byAgent, byModel, daily}`) |
 | Plugins | `POST` / `GET` / `PATCH` `/agents/:id/plugins`, `DELETE /agents/:id/plugins` |
+| Work Queue | `POST /agents/:id/work-queue` (pushes/upserts the agent's ranked work-queue snapshot, overwriting any prior snapshot; body: `{computedAt, items}`), `GET /agents/:id/work-queue` (fetches the latest snapshot; `404` if none pushed yet) |
 
 Token creation returns the **raw token once** at creation; only its SHA-256 hash is persisted, so validation is an O(1) hash-index lookup.
 
@@ -117,6 +118,7 @@ There is no HTTP chat endpoint on the agent. Chat flows through the chat service
 | `AgentToken` | Scoped API tokens | `token` (SHA-256 hash), `label`, `revokedAt`. |
 | `AgentPlugin` | Installed Claude Code plugins | `name` (package), `version` (null = latest), `enabled`, `createdAt`, `updatedAt`; unique per `[agentId, name]`. |
 | `AgentMember` | Authorized human members | `email`; unique per `[agentId, email]`. |
+| `AgentWorkQueueSnapshot` | Latest ranked work-queue snapshot | `agentId` (unique — one row per agent), `computedAt`, `items` (JSON `RankedWorkItem[]`). Upserted by `POST /agents/:id/work-queue`; overwrites any prior snapshot — there is no history, only the latest state. |
 
 All child models cascade-delete with their `Agent` (including `AgentCronRun` via `AgentCronJob`).
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -506,7 +506,7 @@ agent:
     enabled: true
     provider: whisper            # "whisper" (self-hosted pod) | "groq" (cloud STT)
     whisper:
-      image: onerahmet/openai-whisper-asr-webservice:latest  # pin a concrete tag in prod
+      image: onerahmet/openai-whisper-asr-webservice:v1.3.0  # default; do not float to :latest — the plain-text /asr contract is tightly coupled to this tag
       service:
         port: 9000               # in-cluster Service port → WHISPER_SERVICE_URL
       model: ""                  # ASR model name → ASR_MODEL (e.g. tiny, base, small, medium, large-v3, tiny.en); empty = image default


### PR DESCRIPTION
## Summary

Routine docs-freshness pass (`/research-docs --auto` equivalent) against the source diff since the last sync anchor (`5bdac2b0`). Checked every `docs/*.md` candidate whose content referenced a changed file/symbol; found and fixed two genuinely stale references.

- **docs/agent.md** — the Prisma model count/list ("ten first-class Prisma models") and the admin CRUD API endpoint table hadn't caught up to `AgentWorkQueueSnapshot` (added by the `admin/prisma/migrations/20260717010000_add_agent_work_queue_snapshot` migration and `admin/src/agent-work-queue.ts`). Updated the model count to eleven, added its Data Model row, and added the `POST`/`GET /agents/:id/work-queue` endpoint row.
- **docs/deploy-kubernetes.md** — the Whisper voice example YAML still showed `onerahmet/openai-whisper-asr-webservice:latest` with a "pin a concrete tag in prod" comment. The chart's actual default (`charts/shipwright/values.yaml`) is already pinned to `v1.3.0` with an explicit warning against floating to `:latest` (the plain-text `/asr` contract is tightly coupled to the tag). Updated the example to match.

All other candidate docs (README.md, architecture.md, chat.md, configuration.md, consolidation.md, helm-repo.md, metrics.md, migration.md, testing.md) were checked against current source (endpoint tables, env vars, file paths, workspace list, speed budgets, model counts) and found current — left untouched. `docs/mcp-tools.md` is a generated file; not hand-edited.

## Test plan
- [x] Reviewed `git diff` before committing — changes are two targeted content fixes only, no structural/heading changes.
- [x] No code changes; docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)