### PR TITLE
feat: add Dockerfile and CI image build for mcp-server

### DIFF
--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -1,0 +1,92 @@
+name: Build and Push Mcp-Server Image
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  filter:
+    name: filter changed paths
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Resolve base SHA
+        id: base
+        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ steps.base.outputs.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          filters: |
+            changed:
+              - "mcp-server/**"
+              - "lib/**"
+              - "package.json"
+              - "bun.lock"
+              - ".github/workflows/build-mcp-server.yml"
+
+  build-and-push:
+    name: build / tag / push
+    needs: filter
+    if: needs.filter.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Compute next tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.DISPATCH_TOKEN }}
+          tag_prefix: "mcp-server-v"
+          default_bump: patch
+          fetch_all_tags: true
+          dry_run: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f mcp-server/Dockerfile \
+            --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
+            -t ghcr.io/app-vitals/shipwright-mcp-server:${{ steps.tag.outputs.new_tag }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push ghcr.io/app-vitals/shipwright-mcp-server:${{ steps.tag.outputs.new_tag }}
+
+      - name: Tag release
+        # Only create the git tag once the image has actually pushed. A tag with
+        # no image behind it silently breaks any downstream consumer that trusts
+        # the tag without verifying the image exists.
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
+            -f sha="${{ github.event.workflow_run.head_sha }}"

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -42,20 +42,21 @@ packaged a `.tgz` is allowed to finish rather than being cancelled mid-publish.
 Chart version bumps are **automated** by the
 [`auto-bump-chart.yml`](../.github/workflows/auto-bump-chart.yml) workflow.
 Whenever a release tag is pushed matching `agent-v*`, `admin-v*`, `metrics-v*`,
-`task-store-v*`, or `chat-v*` (created by the service build workflows on
-successful image push), the automation detects the tag, increments the chart
-patch version in `Chart.yaml`, pins each released tag into the matching
+`task-store-v*`, `chat-v*`, or `mcp-server-v*` (created by the service build
+workflows on successful image push), the automation detects the tag, increments
+the chart patch version in `Chart.yaml`, pins each released tag into the matching
 `values.yaml` image defaults, opens a PR (targeting `main`), and merges it
 once checks pass. Once the PR merges, `chart-release.yml` fires and publishes
 the new chart version. No manual version bump is required.
 
 The `values.yaml` pinning ensures the chart's GHCR image defaults (in the
-`admin`, `metrics`, `agent`, `taskStore`, and `chat` blocks) track the same
-releases the chart version is crediting — preventing a scenario where the
-bumped chart would be deployed with stale image tags. Each batched release
-tag is pinned into its corresponding `values.yaml` path(s); for example,
-`admin-v0.156.2` pins into `admin.image.tag`, and `agent-v1.5.0` pins into
-both `agent.image.tag` and `agent.provisioning.image.tag`.
+`admin`, `metrics`, `agent`, `taskStore`, `chat`, and `mcpServer` blocks)
+track the same releases the chart version is crediting — preventing a scenario
+where the bumped chart would be deployed with stale image tags. Each batched
+release tag is pinned into its corresponding `values.yaml` path(s); for example,
+`admin-v0.156.2` pins into `admin.image.tag`, `agent-v1.5.0` pins into
+both `agent.image.tag` and `agent.provisioning.image.tag`, and `mcp-server-v0.10.0`
+pins into `mcpServer.image.tag`.
 
 Services release independently, so it's common for two or three tags to land
 within seconds or minutes of each other. Rather than bumping the chart once

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -42,21 +42,20 @@ packaged a `.tgz` is allowed to finish rather than being cancelled mid-publish.
 Chart version bumps are **automated** by the
 [`auto-bump-chart.yml`](../.github/workflows/auto-bump-chart.yml) workflow.
 Whenever a release tag is pushed matching `agent-v*`, `admin-v*`, `metrics-v*`,
-`task-store-v*`, `chat-v*`, or `mcp-server-v*` (created by the service build
-workflows on successful image push), the automation detects the tag, increments
-the chart patch version in `Chart.yaml`, pins each released tag into the matching
+`task-store-v*`, or `chat-v*` (created by the service build workflows on
+successful image push), the automation detects the tag, increments the chart
+patch version in `Chart.yaml`, pins each released tag into the matching
 `values.yaml` image defaults, opens a PR (targeting `main`), and merges it
 once checks pass. Once the PR merges, `chart-release.yml` fires and publishes
 the new chart version. No manual version bump is required.
 
 The `values.yaml` pinning ensures the chart's GHCR image defaults (in the
-`admin`, `metrics`, `agent`, `taskStore`, `chat`, and `mcpServer` blocks)
-track the same releases the chart version is crediting — preventing a scenario
-where the bumped chart would be deployed with stale image tags. Each batched
-release tag is pinned into its corresponding `values.yaml` path(s); for example,
-`admin-v0.156.2` pins into `admin.image.tag`, `agent-v1.5.0` pins into
-both `agent.image.tag` and `agent.provisioning.image.tag`, and `mcp-server-v0.10.0`
-pins into `mcpServer.image.tag`.
+`admin`, `metrics`, `agent`, `taskStore`, and `chat` blocks) track the same
+releases the chart version is crediting — preventing a scenario where the
+bumped chart would be deployed with stale image tags. Each batched release
+tag is pinned into its corresponding `values.yaml` path(s); for example,
+`admin-v0.156.2` pins into `admin.image.tag`, and `agent-v1.5.0` pins into
+both `agent.image.tag` and `agent.provisioning.image.tag`.
 
 Services release independently, so it's common for two or three tags to land
 within seconds or minutes of each other. Rather than bumping the chart once

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,71 @@
+# Shipwright MCP Server — container image
+#
+# Build from repo root:
+#   docker build -f mcp-server/Dockerfile -t shipwright-mcp-server .
+#
+# Run:
+#   docker run \
+#     -p 3010:3010 \
+#     shipwright-mcp-server
+#
+# Optional env vars:
+#   PORT — listen port (default: 3010)
+
+# ─── Stage 1: dependencies ────────────────────────────────────────────────────
+FROM oven/bun:1-slim AS deps
+
+WORKDIR /app
+
+# Copy workspace manifests for dependency install
+COPY package.json bun.lock ./
+COPY admin/package.json ./admin/
+COPY admin/prisma ./admin/prisma/
+COPY task-store/package.json ./task-store/
+COPY task-store/prisma ./task-store/prisma/
+COPY chat/package.json ./chat/
+COPY chat/prisma ./chat/prisma/
+COPY agent/package.json ./agent/
+COPY metrics/package.json ./metrics/
+COPY plugins/shipwright/package.json ./plugins/shipwright/
+COPY lib/package.json ./lib/
+COPY mcp-server/package.json ./mcp-server/
+
+RUN bun install --frozen-lockfile
+
+# ─── Stage 2: production image ────────────────────────────────────────────────
+FROM oven/bun:1-slim AS production
+
+# Install system dependencies (ca-certificates only — stateless service, no toolchain needed)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy hoisted + workspace-local node_modules from the deps stage. bun workspaces
+# install package-specific deps under the workspace dir (/app/mcp-server/node_modules),
+# NOT the hoisted root — both are required at runtime. lib/node_modules is also
+# copied defensively: bun nests a shared lib dependency under lib/node_modules
+# instead of hoisting it to root whenever a consuming service also declares that
+# same dependency directly (this broke task-store + @sentry/bun at runtime —
+# see app-vitals/shipwright#1187). mcp-server doesn't hit that today, but copying
+# lib/node_modules here means it can't happen silently if that changes.
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/mcp-server/node_modules ./mcp-server/node_modules
+COPY --from=deps /app/lib/node_modules ./lib/node_modules
+
+# Copy entire monorepo source
+COPY . .
+
+EXPOSE 3010
+
+# Run as a non-root user. The GKE deployment sets `runAsNonRoot: true`, and the
+# kubelet can only verify that when the image's USER is a numeric UID (it does
+# not read the image's /etc/passwd). uid 1000 is the `bun` user baked into the
+# oven/bun base image. Without this the container is refused at admission with
+# "container has runAsNonRoot and image will run as root".
+USER 1000
+
+ENTRYPOINT ["bun", "run", "mcp-server/src/main.ts"]


### PR DESCRIPTION
## Summary
- Add `mcp-server/Dockerfile` mirroring `task-store/Dockerfile`'s workspace-aware two-stage build (Bun base, non-root, no Prisma step since mcp-server has no schema)
- Wire mcp-server into the CI image-build/push pattern via `.github/workflows/build-mcp-server.yml`, matching `build-metrics.yml` with mcp-server-specific substitutions (paths filter, tag_prefix `mcp-server-v`, image `ghcr.io/app-vitals/shipwright-mcp-server`)

Without a published image, the TSM-3.1 Helm Deployment has nothing to pull and would ImagePullBackOff.

## Test plan
- [x] `bun test mcp-server` — 39 pass, 0 fail (includes existing `/health` coverage in `index.smoke.test.ts`)
- [x] `bunx biome lint .` — clean
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- [x] Structural diff of the new workflow YAML against `build-metrics.yml` confirms it matches exactly modulo the intended substitutions
- [x] Structural diff of the new Dockerfile's COPY list against `task-store/Dockerfile` confirms only the service-local `node_modules` line differs (no Prisma generate step, correctly omitted)
- [ ] `docker build -f mcp-server/Dockerfile .` + container `/health` check — **could not run**, no `docker` binary available in this sandbox. Recommend a manual or CI verification before merge.