### PR TITLE
fix: deploy.md must not mark task blocked on merge-conflict failure

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -206,6 +206,20 @@ describe("deploy.md — pre-merge PR claim lock (CLM-2.2)", () => {
     const claimIdx = content.indexOf("/prs/claim");
     expect(releaseIdx).toBeGreaterThan(claimIdx);
   });
+
+  it("does not PATCH task status to blocked on a merge-timeout/conflict failure", () => {
+    // Merge conflicts are routine and self-recoverable (check-patch.ts fixes any DIRTY
+    // PR regardless of task status) — writing status:"blocked" here would hide the PR
+    // from check-deploy.ts's candidate list even after patch resolves it, stranding the
+    // task until a human notices. This section must leave task status untouched.
+    const timeoutIdx = content.indexOf("did not complete within 60 seconds");
+    expect(timeoutIdx).toBeGreaterThan(-1);
+    const nextSectionIdx = content.indexOf("### 4c.", timeoutIdx);
+    expect(nextSectionIdx).toBeGreaterThan(timeoutIdx);
+    const failureSection = content.slice(timeoutIdx, nextSectionIdx);
+    expect(failureSection).not.toContain('"status": "blocked"');
+    expect(failureSection.toLowerCase()).toContain("do not patch the task");
+  });
 });
 
 describe("deploy.md — pre-claim fast path (CBD-1.6)", () => {

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -277,6 +277,14 @@ Then print and stop:
   Check the PR on GitHub — it may require a human to resolve a merge conflict or branch protection issue.
 ```
 
+**Do not PATCH the task to `status: "blocked"` here.** A merge conflict is routine and
+self-recoverable — `check-patch.ts`'s candidate logic already detects any `DIRTY` PR
+independent of task status and fixes it automatically, no human required. Marking the task
+`blocked` would hide it from `check-deploy.ts`'s candidate list (which explicitly skips PRs
+whose linked task is `blocked`) even after patch resolves the conflict, stranding it until a
+human notices and corrects the record by hand. Leave the task's status exactly as it was;
+`check-deploy.ts` will reconsider the PR once `mergeStateStatus` clears.
+
 Print:
 ```
 ✓ Merged PR #{pr} → main


### PR DESCRIPTION
## Summary
- Yesterday `vitals-os#3152` (task `GMD-7.2`) got stuck in `status: "blocked"` for over 24h after a routine merge conflict, even though `/shipwright:patch` auto-resolved the conflict four separate times within two hours of the block.
- Root cause: `deploy.md`'s Step 4b merge-failure branch never explicitly instructed leaving task status untouched — it only says print+release-claim — but the deploy session extrapolated a `blocked` write from the *other* terminal-failure branches in the same doc (Deploy stage failed, Canary failed, pipeline timeout), which do write `blocked`.
- That extrapolation was wrong here: `check-patch.ts` already detects any `DIRTY` PR independent of task status and fixes it with no human involved. Writing `blocked` just hid the PR from `check-deploy.ts`'s candidate list (which explicitly skips PRs whose linked task is `blocked`) even after patch cleared the conflict.
- Adds an explicit instruction in Step 4b: do not PATCH task status on this failure path. Adds a content test asserting the failure-branch section contains no `"status": "blocked"` write.

## Test plan
- [x] `bun test plugins/shipwright/commands/deploy.content.test.ts` — 47 pass, including the new assertion
- [x] `bunx biome lint` on changed files — clean
- [x] Manually verified this section's live text at the time of the incident (commit `0d1feee7`) already lacked a `blocked` write, confirming the write was agent-added judgment, not a stale doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)