### PR TITLE
feat: add source filter to task-store API

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -44,6 +44,7 @@ Query params:
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
 | `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
+| `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string | Filter by repo (`org/repo` format) |
 | `assignee` | string | Filter by assignee (admin tokens only; agent tokens see only their own tasks) |

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -377,6 +377,7 @@ export const TaskListQuerySchema = z.object({
     .enum(["open", "closed", "in_progress", "ready", "blocked"])
     .optional()
     .openapi({ example: "open" }),
+  source: z.string().optional().openapi({ example: "entropy-fix" }),
   session: z.string().optional().openapi({ example: "session-123" }),
   repo: z.string().optional().openapi({ example: "org/repo" }),
   assignee: z.string().optional().openapi({ example: "user@example.com" }),

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -302,6 +302,42 @@ describe("createTasksRoutes — OpenAPIHono migration (TSM-1.2)", () => {
     expect(res.status).toBe(400);
   });
 
+  it("GET /?source=entropy-fix passes source through to taskService.list()", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?source=entropy-fix");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { source?: string }).source).toBe("entropy-fix");
+  });
+
+  it("GET / with no source param passes source: undefined through to taskService.list() (existing behavior)", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/");
+    expect(res.status).toBe(200);
+    expect((receivedFilters as { source?: string }).source).toBeUndefined();
+  });
+
   it("GET /?hitl=true passes hitl: true through to taskService.list()", async () => {
     const task = makeTask({ id: "t-1", hitl: true });
     let receivedFilters: unknown;

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -493,6 +493,7 @@ export function createTasksRoutes(
     const result = await taskService.list({
       status: c.req.query("status"),
       state,
+      source: c.req.query("source"),
       session: c.req.query("session"),
       repo: c.req.query("repo"),
       claimedBy: c.req.query("claimedBy"),

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -48,6 +48,7 @@ export interface TaskListFilters {
   status?: string;
   /** High-level lifecycle filter: "open" | "closed" | "in_progress". */
   state?: "open" | "closed" | "in_progress";
+  source?: string;
   session?: string;
   repo?: string;
   assignee?: string;
@@ -127,6 +128,7 @@ export class TaskService implements TaskServiceLike {
     } else if (filters.state === "in_progress") {
       where.status = { in: ["in_progress", "pr_open", "approved"] };
     }
+    if (filters.source) where.source = filters.source;
     if (filters.session) where.session = filters.session;
     if (filters.claimedBy) where.claimedBy = filters.claimedBy;
     if (filters.pr !== undefined) where.pr = filters.pr;

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -848,6 +848,59 @@ describeOrSkip("Task store schema (integration)", () => {
     ).rejects.toThrow();
   });
 
+  // ─── TaskService.list() source filter ───────────────────────────────────────
+
+  it("list({ source }) returns only tasks whose source exactly matches, excluding other/null sources", async () => {
+    const taskService = new TaskService(prisma);
+
+    const matchingTask = await prisma.task.create({
+      data: {
+        title: "Entropy fix task",
+        status: "pending",
+        source: "entropy-fix",
+      },
+    });
+    await prisma.task.create({
+      data: {
+        title: "Plan session task",
+        status: "pending",
+        source: "plan-session",
+      },
+    });
+    await prisma.task.create({
+      data: {
+        title: "No source task",
+        status: "pending",
+      },
+    });
+
+    const result = await taskService.list({ source: "entropy-fix" });
+
+    expect(result.tasks.map((t) => t.id)).toEqual([matchingTask.id]);
+  });
+
+  it("list() without source returns tasks regardless of source (preserves current unfiltered behavior)", async () => {
+    const taskService = new TaskService(prisma);
+
+    await prisma.task.create({
+      data: {
+        title: "Entropy fix task",
+        status: "pending",
+        source: "entropy-fix",
+      },
+    });
+    await prisma.task.create({
+      data: {
+        title: "No source task",
+        status: "pending",
+      },
+    });
+
+    const result = await taskService.list({});
+
+    expect(result.total).toBe(2);
+  });
+
   // ─── TaskService.list() blockedBy dependency lookup scoping ────────────────
 
   it("resolves blockedBy for a dependency outside the current page/pagination window", async () => {


### PR DESCRIPTION
## Summary
- Adds an optional `source` query param to `GET /tasks` in the task-store API, so callers can filter tasks by exact `source` match (e.g. `?source=entropy-fix`)
- Threads `source` through `TaskListQuerySchema` (OpenAPI), `TaskListFilters`, and `TaskService.list()`'s Prisma where-clause, following the same pattern as `session`/`branch`
- Refreshes `docs/task-store.md`'s query-param table to document the new filter

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /tasks?source=<value> filters exactly; omitting returns unfiltered | MET | routes/tasks.ts passes `source` through; task-service.ts applies `if (filters.source) where.source = filters.source;` |
| 2 | Integration test in tasks.integration.test.ts against real test DB | MET | Two new tests: exact-match filtering + unfiltered-when-omitted, real Prisma client |
| 3 | Smoke test in tasks.openapi.smoke.test.ts for OpenAPI schema | MET | Two new tests confirming `source` passes through and doesn't break route validation |
| 4 | Safe to deploy standalone | MET | Purely additive optional query param; no schema migration; no change to existing filter behavior |

## Test Plan
- `task-store/src/tasks.integration.test.ts`: `list({ source })` narrows to exact matches, excluding other/null sources; `list({})` still returns the unfiltered set
- `task-store/src/routes/tasks.openapi.smoke.test.ts`: `GET /?source=X` passes `source: "X"` through to the filters object; `GET /` with no param passes `source: undefined`
- Full task-store suite: 375 pass, 0 fail, 104 skip (pre-existing skip baseline — integration tests require a real Postgres DB not available in the dev sandbox; they run in CI)
- [x] Pre-commit checks passing (lint, typecheck clean)

Generated with [Claude Code](https://claude.com/claude-code)
