### PR TITLE
feat: default task creation to unassigned for agent tokens

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -74,7 +74,7 @@ Body (JSON): task fields. `title`, `status`, and `repo` are required. The `repo`
 POST /tasks/bulk
 ```
 
-Body: JSON array of task objects. Each task must have `title`, `status`, and `repo` fields. The `repo` key must be present on every task; `null` is accepted as a valid value for tasks that are not scoped to a specific repository. Skips conflicts (existing ID) rather than failing. Returns `{ inserted: number, updated: number, skipped: string[] }`, where `skipped` lists the IDs of tasks that collided with an existing task.
+Body: JSON array of task objects. Each task must have `title`, `status`, and `repo` fields. The `repo` key must be present on every task; `null` is accepted as a valid value for tasks that are not scoped to a specific repository. Agent tokens leave each task's `assignee` as supplied by the caller, defaulting to `null` (unassigned / pool task) when omitted. Skips conflicts (existing ID) rather than failing. Returns `{ inserted: number, updated: number, skipped: string[] }`, where `skipped` lists the IDs of tasks that collided with an existing task.
 
 #### Distinct values
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -66,7 +66,7 @@ Agent tokens with a repo scope return tasks where `assignee === agentId` OR `rep
 POST /tasks
 ```
 
-Body (JSON): task fields. `title`, `status`, and `repo` are required. The `repo` key must be present; `null` is accepted as a valid value for tasks that are not scoped to a specific repository. Agent tokens force `assignee` to their own ID. Returns `201` with the created task.
+Body (JSON): task fields. `title`, `status`, and `repo` are required. The `repo` key must be present; `null` is accepted as a valid value for tasks that are not scoped to a specific repository. Agent tokens leave `assignee` as supplied by the caller, defaulting to `null` (unassigned / pool task) when omitted. Returns `201` with the created task.
 
 #### Bulk insert
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -155,7 +155,10 @@ curl -sf -X POST \
 | `status` | Must be `"pending"` on creation |
 | `repo` | Routes `dev-task` to the correct worktree |
 | `branch` | `dev-task` creates the worktree from this; absent → task is skipped |
-| `assignee` | Agent ID of the agent that should own this task |
+
+`assignee` is optional — omit it to leave the task unassigned in the repo pool (claimable
+by any agent with repo access), or set it explicitly to pre-assign the task to a specific
+agent ID.
 
 Convention: `branch` = `feat/{id-lowercase}` (e.g. `feat/tss-x-1-my-task`).
 

--- a/plugins/shipwright/skills/task-store/references/task-schema.md
+++ b/plugins/shipwright/skills/task-store/references/task-schema.md
@@ -27,7 +27,7 @@ contract: the same shape whether the backend is GitHub Issues, Jira, or the loca
 | `layer` | string | `Shared`, `API`, `Database`, `Agent`, `CLI`, `Web`. |
 | `dependencies` | string[] | Task ids that must be satisfied before this is `--ready`. |
 | `branch` | string | Feature branch; used for same-branch dependency satisfaction. |
-| `assignee` | string | GitHub login of the owner. |
+| `assignee` | string | Agent ID to pre-assign at creation; optional — omitted/`null` leaves the task unassigned in the repo pool, claimable by any agent with repo access. |
 | `hours` | number | Estimate. |
 | `complexity` | number (1–5) | Planning / model-selection hint; out-of-range warns. |
 | `model` | `haiku` \| `sonnet` \| `opus` | Tier hint for model selection (no auto-mapping to a full model id). |

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -395,7 +395,7 @@ describe("task-store API (smoke)", () => {
 
   // ─── Agent token scoping ──────────────────────────────────────────────────
 
-  it("POST /tasks with agent token forces assignee to the agent's ID", async () => {
+  it("POST /tasks with agent token and no assignee in body defaults to unassigned (null)", async () => {
     const app = makeApp({
       tokenService: fakeAgentTokenService(),
       scopeResolver: makeScopeResolver(["example-org/repo"]),
@@ -414,7 +414,30 @@ describe("task-store API (smoke)", () => {
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as Task;
-    expect(body.assignee).toBe("agent-1");
+    expect(body.assignee).toBeNull();
+  });
+
+  it("POST /tasks with agent token honors an explicit assignee in the body", async () => {
+    const app = makeApp({
+      tokenService: fakeAgentTokenService(),
+      scopeResolver: makeScopeResolver(["example-org/repo"]),
+    });
+    const res = await app.request("/tasks", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AGENT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "New task",
+        status: "pending",
+        repo: "example-org/repo",
+        assignee: "agent-2",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Task;
+    expect(body.assignee).toBe("agent-2");
   });
 
   it("GET /tasks/:id returns 403 when agent token tries to read a task owned by a different agent", async () => {

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -80,7 +80,11 @@ function withBlockedBy(task: Task) {
 }
 
 function fakeTaskService(
-  opts: { tasks?: Task[]; onList?: (filters: unknown) => void } = {},
+  opts: {
+    tasks?: Task[];
+    onList?: (filters: unknown) => void;
+    onBulk?: (tasks: unknown) => void;
+  } = {},
 ): TaskServiceLike {
   const tasks = opts.tasks ?? [];
   return {
@@ -127,7 +131,8 @@ function fakeTaskService(
     async release(id: string) {
       return makeTask({ id, status: "pending" });
     },
-    async bulk() {
+    async bulk(data) {
+      opts.onBulk?.(data);
       return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
@@ -142,6 +147,28 @@ function makeAdminParent(app: OpenAPIHono<TaskStoreAuthEnv>) {
   parent.use("*", async (c, next) => {
     c.set("agentId", null);
     c.set("repos", null);
+    await next();
+  });
+  parent.onError((err, c) => {
+    if (err instanceof ApiError) {
+      return c.json({ error: err.message }, err.statusCode as 400);
+    }
+    return c.json({ error: "internal error" }, 500);
+  });
+  parent.route("/", app);
+  return parent;
+}
+
+/** Build a typed parent app that injects agent-token context (agentId set, scoped repos). */
+function makeAgentParent(
+  app: OpenAPIHono<TaskStoreAuthEnv>,
+  agentId: string,
+  repos: string[] | null = [],
+) {
+  const parent = new OpenAPIHono<TaskStoreAuthEnv>();
+  parent.use("*", async (c, next) => {
+    c.set("agentId", agentId);
+    c.set("repos", repos);
     await next();
   });
   parent.onError((err, c) => {
@@ -373,5 +400,104 @@ describe("createTasksRoutes — OpenAPIHono migration (TSM-1.2)", () => {
     const body = (await res.json()) as { sessions: string[]; repos: string[] };
     expect(Array.isArray(body.sessions)).toBe(true);
     expect(Array.isArray(body.repos)).toBe(true);
+  });
+});
+
+describe("POST / (create) — agent-token default assignee (UTA-1.1)", () => {
+  it("agent token, no assignee in body -> created task has assignee: null (unassigned pool task)", async () => {
+    const app = createTasksRoutes(fakeTaskService());
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "New task",
+        status: "pending",
+        repo: null,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Task;
+    expect(body.assignee).toBeNull();
+  });
+
+  it("agent token, explicit assignee in body -> honored, not overwritten to caller's own agentId", async () => {
+    const app = createTasksRoutes(fakeTaskService());
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "New task",
+        status: "pending",
+        repo: null,
+        assignee: "some-other-agent",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Task;
+    expect(body.assignee).toBe("some-other-agent");
+  });
+});
+
+describe("POST /bulk — agent-token default assignee (UTA-1.1)", () => {
+  it("agent token, tasks with no assignee field -> assignee stays unset/null per task", async () => {
+    let received: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        onBulk: (tasks) => {
+          received = tasks;
+        },
+      }),
+    );
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([
+        { title: "Task A", status: "pending", repo: null },
+        { title: "Task B", status: "pending", repo: null },
+      ]),
+    });
+    expect(res.status).toBe(200);
+    const tasks = received as Record<string, unknown>[];
+    expect(tasks).toHaveLength(2);
+    for (const t of tasks) {
+      expect(t.assignee).toBeUndefined();
+    }
+  });
+
+  it("agent token, explicit assignee per task -> honored, not overwritten", async () => {
+    let received: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        onBulk: (tasks) => {
+          received = tasks;
+        },
+      }),
+    );
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([
+        {
+          title: "Task A",
+          status: "pending",
+          repo: null,
+          assignee: "some-other-agent",
+        },
+        { title: "Task B", status: "pending", repo: null, assignee: "agent-1" },
+      ]),
+    });
+    expect(res.status).toBe(200);
+    const tasks = received as Record<string, unknown>[];
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]?.assignee).toBe("some-other-agent");
+    expect(tasks[1]?.assignee).toBe("agent-1");
   });
 });

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -141,29 +141,11 @@ function fakeTaskService(
   };
 }
 
-/** Build a typed parent app that injects admin context (agentId=null, repos=null). */
-function makeAdminParent(app: OpenAPIHono<TaskStoreAuthEnv>) {
-  const parent = new OpenAPIHono<TaskStoreAuthEnv>();
-  parent.use("*", async (c, next) => {
-    c.set("agentId", null);
-    c.set("repos", null);
-    await next();
-  });
-  parent.onError((err, c) => {
-    if (err instanceof ApiError) {
-      return c.json({ error: err.message }, err.statusCode as 400);
-    }
-    return c.json({ error: "internal error" }, 500);
-  });
-  parent.route("/", app);
-  return parent;
-}
-
-/** Build a typed parent app that injects agent-token context (agentId set, scoped repos). */
-function makeAgentParent(
+/** Build a typed parent app that injects the given auth context (agentId, repos). */
+function makeParent(
   app: OpenAPIHono<TaskStoreAuthEnv>,
-  agentId: string,
-  repos: string[] | null = [],
+  agentId: string | null,
+  repos: string[] | null,
 ) {
   const parent = new OpenAPIHono<TaskStoreAuthEnv>();
   parent.use("*", async (c, next) => {
@@ -179,6 +161,20 @@ function makeAgentParent(
   });
   parent.route("/", app);
   return parent;
+}
+
+/** Build a typed parent app that injects admin context (agentId=null, repos=null). */
+function makeAdminParent(app: OpenAPIHono<TaskStoreAuthEnv>) {
+  return makeParent(app, null, null);
+}
+
+/** Build a typed parent app that injects agent-token context (agentId set, scoped repos). */
+function makeAgentParent(
+  app: OpenAPIHono<TaskStoreAuthEnv>,
+  agentId: string,
+  repos: string[] | null = [],
+) {
+  return makeParent(app, agentId, repos);
 }
 
 describe("createTasksRoutes — OpenAPIHono migration (TSM-1.2)", () => {

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -9,7 +9,8 @@
  * Agent tokens (agentId set) are scoped to their own tasks:
  *   - reads return only tasks where assignee === agentId
  *   - writes are blocked on tasks owned by other agents (403)
- *   - creates force assignee = agentId
+ *   - creates leave assignee as supplied by the caller, defaulting to
+ *     null/unassigned (pool task) when omitted — not forced to agentId
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
@@ -551,10 +552,6 @@ export function createTasksRoutes(
       );
     }
     validateRepo(body.repo, agentId !== null ? repos : null);
-    // Agent tokens force assignee to their own ID.
-    if (agentId !== null) {
-      body.assignee = agentId;
-    }
     const created = await taskService.create(body as Prisma.TaskCreateInput);
     return c.json(created, 201);
   });
@@ -582,14 +579,7 @@ export function createTasksRoutes(
       }
       validateRepo(task.repo, agentId !== null ? repos : null);
     }
-    const tasks =
-      agentId !== null
-        ? (body as Record<string, unknown>[]).map((t) => ({
-            ...t,
-            assignee: agentId,
-          }))
-        : body;
-    const result = await taskService.bulk(tasks as Prisma.TaskCreateInput[]);
+    const result = await taskService.bulk(body as Prisma.TaskCreateInput[]);
     return c.json(result, 200);
   });
 


### PR DESCRIPTION
## Summary
- Removed the forced `assignee = agentId` default on `POST /tasks` and `POST /tasks/bulk` for agent-token callers — creates now leave `assignee` as whatever the caller supplied, defaulting to `null` (unassigned pool task) when omitted.
- This unblocks `TaskService.listReady()`'s existing OR-branch (`assignee === null` AND repo in scope), which previously never had a chance to match anything since every agent-created task was force-assigned to its creator.
- Refreshed `docs/task-store.md` to describe the new default.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | POST /tasks / POST /tasks/bulk, agent token, no `assignee` in body → `assignee: null` | MET |
| 2 | POST /tasks / POST /tasks/bulk, agent token, explicit `assignee` in body → honored | MET |
| 3 | GET /tasks?ready=true regression coverage for the unassigned+in-scope OR-branch | MET (pre-existing test at `task-store/src/tasks.integration.test.ts:465`) |
| 4 | Extend smoke/integration coverage; update `check-dev-task.unit.test.ts:36` fixture if needed | MET — 4 new smoke tests added; the fixture at that line is a generic default unrelated to the removed forced-assign behavior, no change needed |

## Test Plan
- `bun test task-store/` — 378 pass, 0 fail (102 skip: DB-backed integration tests, no test DB in this sandbox)
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all packages
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
