### PR TITLE
feat: let deploy.md read target repo's Deploy model before polling

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -10,6 +10,22 @@ beforeAll(() => {
   content = readFileSync(DEPLOY_MD_PATH, "utf-8");
 });
 
+function extractStep5aSection(md: string): string {
+  const match = md.match(
+    /### 5a\. No-Pipeline Detection[\s\S]*?(?=\n#{2,3} |\n---)/,
+  );
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
+function extractStep5bSection(md: string): string {
+  const match = md.match(
+    /### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/,
+  );
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
 describe("deploy.md — own-PRs-only check (AC1 & AC2)", () => {
   it("contains own GH login check (AGENT_LOGIN or 'own GH login')", () => {
     const hasAgentLogin = content.includes("AGENT_LOGIN");
@@ -267,14 +283,6 @@ describe("deploy.md — pre-claim fast path (CBD-1.6)", () => {
 });
 
 describe("deploy.md — chained in-Bash polling for Step 5b (AEW-1.1)", () => {
-  function extractStep5bSection(md: string): string {
-    const match = md.match(
-      /### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/,
-    );
-    expect(match).not.toBeNull();
-    return match?.[0] ?? "";
-  }
-
   it("Step 5b's polling implementation uses a chained in-Bash sleep loop (shell for-loop + sleep 60)", () => {
     const step5bSection = extractStep5bSection(content);
     expect(step5bSection).toContain("sleep 60");
@@ -325,14 +333,6 @@ describe("deploy.md — chained in-Bash polling for Step 5b (AEW-1.1)", () => {
 });
 
 describe("deploy.md — chained in-Bash polling for Step 5a (TCR-1.3)", () => {
-  function extractStep5aSection(md: string): string {
-    const match = md.match(
-      /### 5a\. No-Pipeline Detection[\s\S]*?(?=\n#{2,3} |\n---)/,
-    );
-    expect(match).not.toBeNull();
-    return match?.[0] ?? "";
-  }
-
   it("Step 5a's polling implementation uses an inline chained-Bash sleep loop (shell for-loop + sleep 30)", () => {
     const step5aSection = extractStep5aSection(content);
     expect(step5aSection).toContain("sleep 30");
@@ -378,22 +378,6 @@ describe("deploy.md — chained in-Bash polling for Step 5a (TCR-1.3)", () => {
 });
 
 describe("deploy.md — read target repo's Deploy model before polling (DPS-2.1)", () => {
-  function extractStep5aSection(md: string): string {
-    const match = md.match(
-      /### 5a\. No-Pipeline Detection[\s\S]*?(?=\n#{2,3} |\n---)/,
-    );
-    expect(match).not.toBeNull();
-    return match?.[0] ?? "";
-  }
-
-  function extractStep5bSection(md: string): string {
-    const match = md.match(
-      /### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/,
-    );
-    expect(match).not.toBeNull();
-    return match?.[0] ?? "";
-  }
-
   it("Step 5a instructs the agent to check the target repo's CLAUDE.md 'Deploy model' section before polling", () => {
     const step5aSection = extractStep5aSection(content);
     expect(step5aSection).toContain("CLAUDE.md");

--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -377,6 +377,69 @@ describe("deploy.md — chained in-Bash polling for Step 5a (TCR-1.3)", () => {
   });
 });
 
+describe("deploy.md — read target repo's Deploy model before polling (DPS-2.1)", () => {
+  function extractStep5aSection(md: string): string {
+    const match = md.match(
+      /### 5a\. No-Pipeline Detection[\s\S]*?(?=\n#{2,3} |\n---)/,
+    );
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  function extractStep5bSection(md: string): string {
+    const match = md.match(
+      /### 5b\. Monitor Pipeline[\s\S]*?(?=\n#{2,3} |\n---)/,
+    );
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("Step 5a instructs the agent to check the target repo's CLAUDE.md 'Deploy model' section before polling", () => {
+    const step5aSection = extractStep5aSection(content);
+    expect(step5aSection).toContain("CLAUDE.md");
+    expect(step5aSection).toContain("Deploy model");
+  });
+
+  it("Step 5a instructs skipping straight to Step 5c when the Deploy model section clearly states there is no pipeline", () => {
+    const step5aSection = extractStep5aSection(content);
+    const lower = step5aSection.toLowerCase();
+    expect(lower).toContain("no deploy pipeline");
+    expect(step5aSection).toContain("skip");
+    expect(step5aSection).toContain("Step 5c");
+  });
+
+  it("Step 5a states the fallback: ambiguous/absent/low-confidence reads fall back to today's unchanged poll behavior — never guess", () => {
+    const step5aSection = extractStep5aSection(content);
+    const lower = step5aSection.toLowerCase();
+    expect(lower).toContain("ambiguous");
+    expect(lower).toContain("never guess");
+  });
+
+  it("Step 5a's Deploy-model check reads only already-in-context CLAUDE.md — no new file read or tool call", () => {
+    const step5aSection = extractStep5aSection(content);
+    const lower = step5aSection.toLowerCase();
+    expect(lower).toContain("already in");
+    expect(lower).toContain("context");
+  });
+
+  it("Step 5b instructs using stage names from the Deploy model section when given", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).toContain("Deploy model");
+    const lower = step5bSection.toLowerCase();
+    expect(lower).toContain("stage name");
+  });
+
+  it("Step 5b preserves the literal Deploy/Canary/Promote to Prod defaults for the fallback case", () => {
+    const step5bSection = extractStep5bSection(content);
+    expect(step5bSection).toContain('`"Deploy"`');
+    expect(step5bSection).toContain('`"Canary"`');
+    expect(step5bSection).toContain('`"Promote to Prod"`');
+    expect(step5bSection).toContain(
+      "[{elapsed}m] Deploy: {status}/{conclusion} | Canary: {status}/{conclusion} | Promote: {status}/{conclusion}",
+    );
+  });
+});
+
 describe("deploy.md — unconditional admin merge (DSH-1.1)", () => {
   it("Step 4b contains exactly one unconditional --admin merge command", () => {
     const adminMergeCommand = "gh pr merge {pr} --repo {org}/{repo} --squash --admin";

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -329,6 +329,20 @@ curl -sf -X PATCH \
 
 ### 5a. No-Pipeline Detection
 
+**Check the target repo's Deploy model first.** The target repo's own `CLAUDE.md` is
+already in your context from the worktree checkout earlier in this flow — no new file
+read or tool call is needed. Look for a `## Deploy model` section:
+
+- **Clearly states there is no deploy pipeline** (e.g. a `direct` model, or explicit
+  language like "no deploy pipeline" / "ships via container/Helm/direct push with no
+  staging/canary/promote stages" — shipwright's own repo is an example: `Deploy model:
+  direct` — "ships via Helm chart + GHCR-pinned image tags, with no staging/production
+  GitHub Environments and no deploy-staging→canary→promote-to-production pipeline"):
+  skip the 5-minute poll below entirely and go straight to Step 5c.
+- **Describes a pipeline, is ambiguous, is absent, or you're not confident in your
+  read**: fall back to exactly today's behavior below — run the full 5-minute poll.
+  **Never guess.** When in doubt, poll.
+
 Before starting the full 30-minute pipeline watch, poll for a Deploy workflow run matching `SQUASH_SHA` for up to **5 minutes** (poll every 30 seconds, up to 10 polls).
 
 **Implementation: inline in-Bash sleep loop.** Do not wait between polls via a
@@ -455,6 +469,14 @@ call 2 covers minutes 8-16, call 3 covers minutes 16-24, call 4 covers minutes 2
 call may run fewer than 8 iterations to land on the 30-minute mark). Break out of the loop
 (and stop chaining further Bash calls) as soon as any terminal condition below is met —
 do not keep polling once Deploy has failed, Canary has resolved, or Promote has resolved.
+
+**Stage names: check the Deploy model section again.** If the target repo's `CLAUDE.md`
+`## Deploy model` section (same already-in-context read as Step 5a — no new file read)
+explicitly names its pipeline stages/workflow names, use those stage names for the
+progress labels and terminal-condition checks below in place of the defaults. If it
+doesn't name stages, is ambiguous, is absent, or you're not confident in your read,
+keep exactly today's literal `"Deploy"`/`"Canary"`/`"Promote to Prod"` three-stage table
+and print format unchanged — never guess.
 
 Track three stages by workflow name (`.name`):
 


### PR DESCRIPTION
## Summary
- Step 5a of `deploy.md` now instructs the live agent to check the target repo's already-in-context `CLAUDE.md` "## Deploy model" section before running the 5-minute Deploy-workflow poll, skipping straight to Step 5c when that section clearly states there's no deploy pipeline (e.g. shipwright's own `direct` model).
- Step 5b now instructs the agent to use stage names from that same section when a pipeline explicitly names them, for its progress labels and terminal-condition checks.
- Both additions include an explicit, never-guess fallback: ambiguous, absent, or low-confidence reads keep today's unchanged behavior (full 5-minute poll, literal `"Deploy"`/`"Canary"`/`"Promote to Prod"` stage names).
- Pure prose change — no new TypeScript code, parser, or config file. `check-deploy.ts`'s `fetchActiveDeployRuns` and the repo-config skill's reference doc have the same class of hardcoded-name assumption but are deliberately out of scope.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5a instructs reading target repo's CLAUDE.md "Deploy model" section first, skip 5-min poll only when it clearly states no pipeline | MET |
| 2 | Step 5b instructs using stage names from that section, when given, for progress labels/terminal-condition checks | MET |
| 3 | Explicit fallback: ambiguous/absent/low-confidence → today's exact behavior, never guess | MET |
| 4 | deploy.content.test.ts extended with additive coverage for both instructions; no existing test retired | MET |

## Test Plan
- Extended `plugins/shipwright/commands/deploy.content.test.ts` with a new `describe` block (6 tests) asserting the new Step 5a/5b instructions and fallback language.
- All 52 tests pass (47 pre-existing + new coverage), including every wording-preservation test for Step 5a/5b (5-minute/30-second/30-minute/60-second budgets, progress-print format, ARC desync section, `sleep 30`/`sleep 60` loops, no `ScheduleWakeup`).
- `task lint` clean.
- `task typecheck` passes across all 7 workspaces.
- Simplify pass: hoisted duplicated `extractStep5aSection`/`extractStep5bSection` regex helpers (previously copy-pasted across 3 describe blocks) to module scope.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
