### PR TITLE
feat: add hitl/hitlNotifiedAt/blockedReason to PullRequest schema + PATCH endpoint

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -249,7 +249,7 @@ Returns `404` if not found.
 PATCH /prs/:id
 ```
 
-Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`, `reviewState`, `phase`, `readyForReviewAt`, `readyForPatchAt`, `readyForDeployAt`. All other fields are managed by lifecycle endpoints. Returns `400` if no writable fields are provided.
+Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`, `reviewState`, `phase`, `readyForReviewAt`, `readyForPatchAt`, `readyForDeployAt`, `hitl`, `hitlNotifiedAt`, `blockedReason`. All other fields are managed by lifecycle endpoints. Returns `400` if no writable fields are provided.
 
 **Side effect:** When `state` is set to `merged` or `closed`, the claim fields (`claimedBy`, `claimedAt`, `heartbeatAt`, `phase`) are automatically cleared. This ensures that merged or closed PRs are no longer held by an agent claim.
 
@@ -271,6 +271,12 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 `reviewState`: `pending` → `in_progress` → `posted` | `approved`
 
 `phase`: `review` | `patch` | `deploy` — tracks which pipeline phase the PR is currently in. Set via `PATCH /prs/:id`. The `readyForReviewAt`, `readyForPatchAt`, and `readyForDeployAt` timestamps record when the PR became ready for each phase; COALESCE across them gives a unified queue-entry time.
+
+`hitl`: boolean (default `false`) — when `true`, blocks automation on this PR until a human intervenes. Used to pause a PR with no linked task. Set via `PATCH /prs/:id`.
+
+`hitlNotifiedAt`: optional ISO timestamp — records when a human was notified about this PR's blocked state. Set via `PATCH /prs/:id`.
+
+`blockedReason`: optional string — human-readable explanation for why this PR is blocked (e.g., `"no linked task"`). Set via `PATCH /prs/:id`.
 
 #### PR timestamp fields
 

--- a/task-store/prisma/migrations/20260720160000_add_hitl_fields_to_pull_request/migration.sql
+++ b/task-store/prisma/migrations/20260720160000_add_hitl_fields_to_pull_request/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: add hitl/hitlNotifiedAt/blockedReason to PullRequest
+ALTER TABLE "PullRequest" ADD COLUMN "hitl" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PullRequest" ADD COLUMN "hitlNotifiedAt" TEXT;
+ALTER TABLE "PullRequest" ADD COLUMN "blockedReason" TEXT;

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -168,6 +168,9 @@ model PullRequest {
   readyForReviewAt  String?
   readyForPatchAt   String?
   readyForDeployAt  String?
+  hitl              Boolean       @default(false)
+  hitlNotifiedAt    String?
+  blockedReason     String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -320,6 +320,17 @@ export const PullRequestSchema = z
       .nullable()
       .optional()
       .openapi({ example: null }),
+    hitl: z.boolean().default(false).openapi({ example: false }),
+    hitlNotifiedAt: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "2026-01-02T00:00:00.000Z" }),
+    blockedReason: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "no linked task" }),
     createdAt: z
       .string()
       .datetime()

--- a/task-store/src/openapi-schemas.unit.test.ts
+++ b/task-store/src/openapi-schemas.unit.test.ts
@@ -100,6 +100,9 @@ const validPullRequest = {
   readyForReviewAt: yesterday,
   readyForPatchAt: null,
   readyForDeployAt: null,
+  hitl: false,
+  hitlNotifiedAt: null,
+  blockedReason: null,
   createdAt: yesterday,
   updatedAt: now,
 };
@@ -404,6 +407,29 @@ describe("PullRequestSchema", () => {
       expect(result.data.patchCycles).toBe(5);
       expect(result.data.reviewCycles).toBe(3);
     }
+  });
+
+  test("parses pull request with hitl/hitlNotifiedAt/blockedReason set", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      hitl: true,
+      hitlNotifiedAt: yesterday,
+      blockedReason: "no linked task",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.hitl).toBe(true);
+      expect(result.data.hitlNotifiedAt).toBe(yesterday);
+      expect(result.data.blockedReason).toBe("no linked task");
+    }
+  });
+
+  test("rejects non-boolean hitl", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      hitl: "yes",
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -1074,6 +1074,28 @@ describe("/prs routes (smoke)", () => {
     expect(body.readyForDeployAt).toBe(readyAt);
   });
 
+  it("PATCH /prs/:id updates hitl, hitlNotifiedAt, and blockedReason", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", hitl: false }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const notifiedAt = "2026-07-20T00:00:00.000Z";
+    const res = await app.request("/prs/pr-1", {
+      method: "PATCH",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        hitl: true,
+        hitlNotifiedAt: notifiedAt,
+        blockedReason: "no linked task",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequest;
+    expect(body.hitl).toBe(true);
+    expect(body.hitlNotifiedAt).toBe(notifiedAt);
+    expect(body.blockedReason).toBe("no linked task");
+  });
+
   it("PATCH /prs/:id returns 400 for agent token with out-of-scope repo", async () => {
     const store = new Map<string, PullRequest>();
     store.set("pr-1", makePr({ id: "pr-1", repo: "other-org/other-repo" }));

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -577,6 +577,44 @@ describe("PullRequestService.release()", () => {
   });
 });
 
+describe("PullRequestService.update() hitl/hitlNotifiedAt/blockedReason pass-through", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  test("update() persists hitl/hitlNotifiedAt/blockedReason and returns them", async () => {
+    const prisma = makePrismaDouble({ id: "pr-1" } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    const result = await svc.update("pr-1", {
+      hitl: true,
+      hitlNotifiedAt: NOW.toISOString(),
+      blockedReason: "no linked task",
+    });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect(data.hitl).toBe(true);
+    expect(data.hitlNotifiedAt).toBe(NOW.toISOString());
+    expect(data.blockedReason).toBe("no linked task");
+    expect(result.hitl).toBe(true);
+    expect(result.hitlNotifiedAt).toBe(NOW.toISOString());
+    expect(result.blockedReason).toBe("no linked task");
+  });
+
+  test("update() omitting hitl/hitlNotifiedAt/blockedReason does not touch them", async () => {
+    const prisma = makePrismaDouble({ id: "pr-1" } as Partial<PullRequest>);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.update("pr-1", { commitSha: "sha-unrelated" });
+
+    expect(prisma._updateCalls).toHaveLength(1);
+    const { data } = prisma._updateCalls[0];
+    expect("hitl" in data).toBe(false);
+    expect("hitlNotifiedAt" in data).toBe(false);
+    expect("blockedReason" in data).toBe(false);
+  });
+});
+
 describe("PullRequestService.complete() claim release", () => {
   const NOW = new Date("2026-07-10T12:00:00.000Z");
   const clock = FixedClock(NOW);

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -445,6 +445,9 @@ export function createPrsRoutes(
   // Pipeline phase tracking:
   //   phase, readyForReviewAt, readyForPatchAt, readyForDeployAt — set by
   //   the review/patch/deploy skills to record when a PR enters each phase
+  //
+  // PR-level HITL (blocks automation on a PR with no linked Task):
+  //   hitl, hitlNotifiedAt, blockedReason
   const PATCH_ALLOWED_FIELDS: Array<keyof PullRequest> = [
     "staged",
     "commitSha",
@@ -457,6 +460,9 @@ export function createPrsRoutes(
     "readyForReviewAt",
     "readyForPatchAt",
     "readyForDeployAt",
+    "hitl",
+    "hitlNotifiedAt",
+    "blockedReason",
   ];
 
   // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime


### PR DESCRIPTION
## Summary
- Add `hitl`, `hitlNotifiedAt`, `blockedReason` fields to the `PullRequest` Prisma model, mirroring `Task`'s existing hitl fields, plus a new `blockedReason` field for observability
- Wire the three fields into `PATCH_ALLOWED_FIELDS` in `task-store/src/routes/prs.ts` so `PATCH /prs/:id` can set them; `GET /prs` and `GET /prs/:id` return them via the updated `PullRequestSchema`
- Purely additive — no backfill, no NOT NULL constraint changes on existing rows; enables future automation to pause on a PR that has no linked Task record (out of scope for this PR — schema + PATCH plumbing only)

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | PullRequest model has hitl/hitlNotifiedAt/blockedReason + migration | MET | `schema.prisma` updated; `20260720160000_add_hitl_fields_to_pull_request/migration.sql` adds all 3 columns additively |
| 2 | PATCH /prs/:id accepts & persists the 3 fields; GET returns them | MET | `PATCH_ALLOWED_FIELDS` updated; `PullRequestSchema` updated; smoke test confirms PATCH round-trip |
| 3 | Safe to deploy standalone | MET | Purely additive migration, `hitl` defaults false, others nullable — no renames/constraints |
| 4 | Unit + smoke test coverage per TEST DECISION | MET | `pull-request-service.unit.test.ts` + `openapi-schemas.unit.test.ts` (unit); `prs.smoke.test.ts` (smoke) |

## Test Plan
- `task-store/src/pull-request-service.unit.test.ts` — confirms `update()` persists and returns hitl/hitlNotifiedAt/blockedReason, and that omitting them on PATCH doesn't null them out
- `task-store/src/openapi-schemas.unit.test.ts` — PullRequestSchema parses the 3 new fields, rejects non-boolean `hitl`
- `task-store/src/prs.smoke.test.ts` — `PATCH /prs/:id` with the 3 fields returns 200 and persists them
- [x] Pre-commit checks passing (lint, typecheck, full repo test suite: 4580 pass / 0 fail, coverage gate 80.67%/81.36% vs 80%/80% threshold)

Generated with [Claude Code](https://claude.com/claude-code)
