### PR TITLE
feat: insert pre-filing check into error-fix and fix source field

### DIFF
--- a/plugins/shipwright/skills/error-fix/SKILL.md
+++ b/plugins/shipwright/skills/error-fix/SKILL.md
@@ -99,6 +99,23 @@ If either call fails for a given issue (non-2xx), note it and skip that issue fo
 do not queue a task built on incomplete information. Include skipped-on-fetch-failure issues
 in the final summary as a distinct line (not the same as "already active" or "unmapped").
 
+Run each mapped issue fetched above through the pre-filing verification checklist —
+`references/pre-filing-verification.md` (relative to the plugin root) — before it proceeds
+any further toward becoming a task. This re-verifies the finding against the current repo
+state (the Sentry issue and the report snapshot may already be stale by the time this skill
+runs) and catches task ID / branch collisions early. Treat
+`references/pre-filing-verification.md` as canonical for how to apply the checklist. Per its
+four checks:
+- Drop issues whose cited call site no longer exists or whose described gap is already fixed
+  (Checklist Items 1–2) — do not queue a primary or companion task for them. Log them the same
+  way as other skipped issues (Step 10 summary).
+- Route issues that can't be confirmed by a literal check to HITL rather than assuming they're
+  safe to drop (Checklist Item 3) — this feeds into the `hitl` computation in Step 6/Step 7.
+- Checklist Item 4 (task ID / branch collisions) is satisfied by this skill's own Step 5 dedup
+  check; no separate action is needed here beyond noting the overlap.
+This runs once, here in Step 3, so both the `--dry-run` preview (Step 4) and the real queue
+path (Step 5 onward) operate on the same already-verified issue set.
+
 ---
 
 ## Step 4: Dry-Run Output (if --dry-run)
@@ -251,7 +268,7 @@ For each issue with a primary fix task to queue:
 {
   "id": "error-{sentry-issue-id}-{slug}",
   "title": "Error fix: {issue title}",
-  "source": "shipwright",
+  "source": "error-fix",
   "repo": "<repo dir name from error-report.md's Service → Repo Mapping table, or re-derived from state/error-patrol-ledger.json's serviceRepoMap if the report is stale>",
   "branch": "fix/error-{sentry-issue-id}-{slug}",
   "layer": "Background",
@@ -267,7 +284,7 @@ For each companion observability-fix task to queue:
 {
   "id": "error-{sentry-issue-id}-obs-{slug}",
   "title": "Error fix (observability): {call site description}",
-  "source": "shipwright",
+  "source": "error-fix",
   "repo": "<same repo derivation as the primary task>",
   "branch": "fix/error-{sentry-issue-id}-obs-{slug}",
   "layer": "Background",


### PR DESCRIPTION
## Summary
- Insert a call to `references/pre-filing-verification.md` at the end of error-fix's Step 3 (Sentry detail fetch), so every mapped issue is re-verified against current repo state before it can become a task
- Fix the hardcoded `"source": "shipwright"` literal to `"source": "error-fix"` in both task-creation JSON templates (primary fix task + companion observability-fix task)

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Steps 2-3 reference pre-filing-verification.md and instruct check before task creation | MET | New paragraph at end of Step 3 references `references/pre-filing-verification.md`, applies its 4 checks, runs before Step 8 task creation |
| 2 | Both task-creation templates source changed shipwright→error-fix, zero remaining occurrences | MET | Both JSON templates now `"source": "error-fix"`; grep confirms 0 remaining `"source": "shipwright"` |
| 3 | No test change needed — prose edit only | MET | Only SKILL.md modified; no content test exists for error-fix |

## Test Plan
- [x] `task lint` passing
- [x] `task check-strings` passing
- [x] Grep-verified zero remaining `"source": "shipwright"` occurrences in error-fix/SKILL.md
- [x] Pattern mirrors the CTV-1.2 precedent already merged for entropy-fix (PR #1967)

Generated with [Claude Code](https://claude.com/claude-code)
