### PR TITLE
feat: deploy.md all 6 escalation sites write PR-level hitl when no linked task

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -417,3 +417,104 @@ describe("deploy.md — unconditional admin merge (DSH-1.1)", () => {
     expect(step4bSection).not.toContain('approval_source == "self_review"');
   });
 });
+
+describe("deploy.md — PR-level hitl escalation on deploy-only-mode failures (PRB-3.2)", () => {
+  // The 6 escalation/failure sites that must now PATCH /prs/$PR_RECORD_ID with
+  // hitl:true + blockedReason when TASK_ID is empty (deploy-only mode), instead of
+  // silently skipping. Each is identified by a unique anchor string near its bash
+  // block, and the original TASK_ID-non-empty PATCH body that must remain unchanged.
+  const sites = [
+    {
+      name: "Post-merge CI failed (Step 5c)",
+      anchor: "Post-merge CI failed — {name}",
+      taskBody: '\\"status\\": \\"blocked\\", \\"note\\": \\"Post-merge CI failed — run ID: {id}\\"',
+    },
+    {
+      name: "Post-merge CI still pending after 10 minutes (Step 5c budget exhausted)",
+      anchor: "Post-merge CI still pending after 10 minutes",
+      taskBody:
+        '\\"status\\": \\"deployed\\", \\"deployedAt\\": \\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\\"',
+    },
+    {
+      name: "Deploy stage failed (Step 5b terminal conditions)",
+      anchor: "Deploy stage failed — nothing reached prod.",
+      taskBody: '\\"status\\": \\"blocked\\", \\"note\\": \\"Deploy stage failed — run ID: {id}\\"',
+    },
+    {
+      name: "Canary passed but Promote skipped (Step 5b terminal conditions)",
+      anchor: "Canary passed but Promote was skipped.",
+      taskBody: '"status": "blocked", "note": "canary_blocked: Promote skipped after canary success"',
+    },
+    {
+      name: "Pipeline timeout after 30 minutes (Step 5b terminal conditions)",
+      anchor: "Pipeline timeout after 30 minutes.",
+      taskBody: '"status": "blocked", "note": "Pipeline timeout after 30 minutes"',
+    },
+    {
+      name: "Canary failed — revert PR opened (Step 6)",
+      anchor: "CANARY FAILED — REVERT PR OPENED",
+      taskBody:
+        '\\"status\\": \\"blocked\\", \\"blockedAt\\": \\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\\", \\"note\\": \\"Canary failed after deploy. Revert PR opened: {revert_pr_url}\\"',
+    },
+  ];
+
+  function extractSiteSection(anchor: string): string {
+    const anchorIdx = content.indexOf(anchor);
+    expect(anchorIdx).toBeGreaterThan(-1);
+    // Grab a generous window after the anchor covering the print block + PATCH bash block.
+    return content.slice(anchorIdx, anchorIdx + 1200);
+  }
+
+  for (const site of sites) {
+    describe(site.name, () => {
+      it("PATCHes /prs/$PR_RECORD_ID with hitl:true + blockedReason when TASK_ID is empty", () => {
+        const section = extractSiteSection(site.anchor);
+        expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID");
+        expect(section).toContain("hitl");
+        expect(section).toContain("true");
+        expect(section).toContain("blockedReason");
+      });
+
+      it("still PATCHes /tasks/$TASK_ID with the original unchanged body when TASK_ID is non-empty", () => {
+        const section = extractSiteSection(site.anchor);
+        expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID");
+        expect(section).toContain(site.taskBody);
+      });
+
+      it("branches explicitly on whether TASK_ID is set (if/else), not a blanket skip", () => {
+        const section = extractSiteSection(site.anchor);
+        const hasConditional =
+          /if\s*\[\s*-n\s*"\$TASK_ID"\s*\]/.test(section) ||
+          /if\s*\[\s*-z\s*"\$TASK_ID"\s*\]/.test(section);
+        expect(hasConditional).toBe(true);
+      });
+    });
+  }
+
+  it("does not touch the 4 success-path deploy-only-mode sites (task merged, task deploying, post-merge-CI-passed, final handoff)", () => {
+    // Task merged (Step 4b)
+    const mergedIdx = content.indexOf("Mark the task merged via the task store");
+    expect(mergedIdx).toBeGreaterThan(-1);
+    const mergedSection = content.slice(mergedIdx, mergedIdx + 400);
+    expect(mergedSection).not.toContain("/prs/$PR_RECORD_ID\"");
+    expect(mergedSection).not.toContain('"hitl"');
+
+    // Task deploying (Step 5 intro)
+    const deployingIdx = content.indexOf("is the deploy duration). Skip if in deploy-only mode:");
+    expect(deployingIdx).toBeGreaterThan(-1);
+    const deployingSection = content.slice(deployingIdx, deployingIdx + 400);
+    expect(deployingSection).not.toContain('"hitl"');
+
+    // Post-merge CI passed -> deployed (Step 5c success)
+    const ciPassedIdx = content.indexOf("Post-merge CI passed ({elapsed}m)");
+    expect(ciPassedIdx).toBeGreaterThan(-1);
+    const ciPassedSection = content.slice(ciPassedIdx, ciPassedIdx + 400);
+    expect(ciPassedSection).not.toContain('"hitl"');
+
+    // Final handoff -> deployed (Step 8b)
+    const handoffIdx = content.indexOf("Skip if no task was found (deploy-only mode):");
+    expect(handoffIdx).toBeGreaterThan(-1);
+    const handoffSection = content.slice(handoffIdx, handoffIdx + 400);
+    expect(handoffSection).not.toContain('"hitl"');
+  });
+});

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -405,13 +405,22 @@ Print the handoff block (Step 9) with `Pipeline: post-merge CI ({pipeline_minute
 ✗ Post-merge CI failed — {name}
   Logs: gh run view {id} --log --failed
 ```
-Update via task store — skip if deploy-only mode:
+Update via task store if a task is linked; otherwise flag the PR record for human
+attention (deploy-only mode):
 ```bash
-curl -sf -X PATCH \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-  -d "{\"status\": \"blocked\", \"note\": \"Post-merge CI failed — run ID: {id}\"}" | jq .
+if [ -n "$TASK_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+    -d "{\"status\": \"blocked\", \"note\": \"Post-merge CI failed — run ID: {id}\"}" | jq .
+elif [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d "{\"hitl\": true, \"blockedReason\": \"Post-merge CI failed — run ID: {id}\"}" | jq .
+fi
 ```
 Stop.
 
@@ -420,13 +429,23 @@ Stop.
 ⚠ Post-merge CI still pending after 10 minutes — marking deployed.
   Check manually: gh api repos/{org}/{repo}/actions/runs?head_sha={SQUASH_SHA}
 ```
-Update the task store to `status=deployed` — skip if deploy-only mode:
+Update the task store to `status=deployed` if a task is linked; otherwise flag the PR
+record for human attention (deploy-only mode) — the deploy itself is marked done, but a
+human should still check the pending runs manually:
 ```bash
-curl -sf -X PATCH \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-  -d "{\"status\": \"deployed\", \"deployedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | jq .
+if [ -n "$TASK_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+    -d "{\"status\": \"deployed\", \"deployedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | jq .
+elif [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d "{\"hitl\": true, \"blockedReason\": \"Post-merge CI still pending after 10 minutes — marking deployed, check manually\"}" | jq .
+fi
 ```
 Print the handoff block (Step 9) with `Pipeline: post-merge CI (pending at timeout)`. Stop.
 
@@ -519,13 +538,22 @@ Re-surface this message every 5 minutes while the queue remains stuck.
   Run ID: {id}
   Collect logs: gh run view {id} --log --failed
 ```
-Update via task store — skip if deploy-only mode:
+Update via task store if a task is linked; otherwise flag the PR record for human
+attention (deploy-only mode):
 ```bash
-curl -sf -X PATCH \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-  -d "{\"status\": \"blocked\", \"note\": \"Deploy stage failed — run ID: {id}\"}" | jq .
+if [ -n "$TASK_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+    -d "{\"status\": \"blocked\", \"note\": \"Deploy stage failed — run ID: {id}\"}" | jq .
+elif [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d "{\"hitl\": true, \"blockedReason\": \"Deploy stage failed — run ID: {id}\"}" | jq .
+fi
 ```
 Stop.
 
@@ -539,13 +567,22 @@ Go to Step 6.
   Check: gh api repos/{org}/{repo}/actions/runs?per_page=10 --jq '.workflow_runs[] | select(.name == "Promote to Prod")'
   Likely cause: Promote workflow's `workflow_run.conclusion` did not match `success`.
 ```
-Update via task store — skip if deploy-only mode:
+Update via task store if a task is linked; otherwise flag the PR record for human
+attention (deploy-only mode):
 ```bash
-curl -sf -X PATCH \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-  -d '{"status": "blocked", "note": "canary_blocked: Promote skipped after canary success"}' | jq .
+if [ -n "$TASK_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+    -d '{"status": "blocked", "note": "canary_blocked: Promote skipped after canary success"}' | jq .
+elif [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d '{"hitl": true, "blockedReason": "canary_blocked: Promote skipped after canary success"}' | jq .
+fi
 ```
 Stop.
 
@@ -560,13 +597,22 @@ Go to Step 7.
     Canary:  {status}/{conclusion}
     Promote: {status}/{conclusion}
 ```
-Update via task store — skip if deploy-only mode:
+Update via task store if a task is linked; otherwise flag the PR record for human
+attention (deploy-only mode):
 ```bash
-curl -sf -X PATCH \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-  -d '{"status": "blocked", "note": "Pipeline timeout after 30 minutes"}' | jq .
+if [ -n "$TASK_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+    -d '{"status": "blocked", "note": "Pipeline timeout after 30 minutes"}' | jq .
+elif [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d '{"hitl": true, "blockedReason": "Pipeline timeout after 30 minutes"}' | jq .
+fi
 ```
 Stop.
 
@@ -625,14 +671,23 @@ Canary logs: gh run view {canary_run_id} --log --failed
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Update via task store — skip if deploy-only mode:
+Update via task store if a task is linked; otherwise flag the PR record for human
+attention (deploy-only mode):
 
 ```bash
-curl -sf -X PATCH \
-  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-  -d "{\"status\": \"blocked\", \"blockedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"note\": \"Canary failed after deploy. Revert PR opened: {revert_pr_url}\"}" | jq .
+if [ -n "$TASK_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+    -d "{\"status\": \"blocked\", \"blockedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"note\": \"Canary failed after deploy. Revert PR opened: {revert_pr_url}\"}" | jq .
+elif [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d "{\"hitl\": true, \"blockedReason\": \"Canary failed after deploy. Revert PR opened: {revert_pr_url}\"}" | jq .
+fi
 ```
 
 Stop.


### PR DESCRIPTION
## Summary
- All 6 deploy-pipeline escalation/failure sites in `plugins/shipwright/commands/deploy.md` now record a hitl escalation on the PR record when running in deploy-only mode (no linked task), instead of silently skipping.
- Each site branches on `$TASK_ID`: non-empty still PATCHes the task exactly as before; empty now PATCHes `$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID` with `{"hitl": true, "blockedReason": "..."}` (text matching the corresponding task-level note).
- `PR_RECORD_ID` is already claimed and in scope at every site (Step 4a's claim, reused through Step 9's handoff) — no new lookup needed.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 6 deploy-only-mode 'skip' branches now PATCH `/prs/$PR_RECORD_ID` with `hitl:true` and a matching `blockedReason`, instead of only skipping | MET |
| 2 | The TASK_ID-non-empty branches at each of the 6 sites are unchanged | MET |
| 3 | Safe to deploy standalone — no existing behavior removed | MET |
| 4 | `deploy.content.test.ts` updated to assert each of the 6 branches (content layer) | MET |

## Test Plan
- New describe block "PR-level hitl escalation on deploy-only-mode failures (PRB-3.2)" in `plugins/shipwright/commands/deploy.content.test.ts`, table-driven across all 6 sites plus a negative test confirming the 4 success-path sites (task merged, task deploying, post-merge-CI-passed, final handoff) remain untouched.
- `bun test plugins/shipwright/commands/deploy.content.test.ts` — 66 pass / 0 fail
- Lint (biome) and typecheck clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
