### PR TITLE
feat: insert pre-filing verification check into consolidation-fix and fix task source field

### DIFF
--- a/plugins/shipwright/skills/consolidation-fix/SKILL.md
+++ b/plugins/shipwright/skills/consolidation-fix/SKILL.md
@@ -119,6 +119,32 @@ Never trust the report's promotion decision as still current; re-check live.
 5. This is a judgment-based match, not exact string equality — read both
    descriptions and decide whether they describe the same duplication, the same
    comparison style Step 3 of `consolidation-scan` uses when surveying.
+6. For each entry that survives the decisions-registry check above, also run it
+   through the pre-filing verification checklist —
+   `references/pre-filing-verification.md` (relative to the plugin root) — before it
+   proceeds any further. The registry check above only re-verifies suppression
+   status; it says nothing about whether the occurrence list itself is still
+   accurate, since the report is a snapshot that may already be stale by the time
+   this skill runs. Treat `references/pre-filing-verification.md` as canonical for
+   how to apply the checklist. Per its four checks:
+   - For each occurrence (`file:line`) in the candidate's occurrence list, verify
+     the file/line still exists and the duplication pattern is still actually
+     present there (Checklist Items 1–2). If every occurrence has been resolved or
+     no longer matches the described pattern, drop the candidate entirely — do not
+     queue a task for it. Print: `Skipping {fingerprint} — stale, no remaining
+     occurrences match the described pattern`. If only some occurrences are stale,
+     drop those from the occurrence list and proceed with the remaining ones (the
+     Step 6 execution plan and Step 8 task JSON are built from the surviving
+     occurrences only).
+   - Route candidates whose occurrences can't be confirmed by a literal check to
+     HITL rather than assuming they're safe to drop (Checklist Item 3) — this feeds
+     into the `hitl` computation in Step 7.
+   - Checklist Item 4 (task ID / branch collisions) is satisfied by this skill's
+     own Step 5 dedup check; no separate action is needed here beyond noting the
+     overlap.
+   This runs once, here in Step 3, so both the `--dry-run` preview (Step 4) and the
+   real queue path (Step 5 onward) operate on the same already-verified candidate
+   set.
 
 ---
 
@@ -285,7 +311,7 @@ For each remaining candidate, build a task object. Reuse the `repo` and
 {
   "id": "consolidation-{fingerprint-or-slug}-{repo-slug}-{YYYY-Www}",
   "title": "Consolidation: {pattern description}",
-  "source": "shipwright",
+  "source": "consolidation-fix",
   "repo": "<repo, as detected in Step 5>",
   "branch": "feat/consolidation-{fingerprint-or-slug}-{short-description}",
   "layer": "Shared",


### PR DESCRIPTION
## Summary
- Extends consolidation-fix's existing Step 3 (the only one of the five patrol-fix skills that already re-checks live state before filing) with `references/pre-filing-verification.md`'s code-level staleness checks — verifying cited occurrences still exist and still match the described duplication pattern, not just re-checking `consolidation-decisions.md` suppression status.
- Partially-stale candidates drop only the stale occurrences and proceed with the rest; fully-stale candidates are dropped entirely; unconfirmable occurrences route to HITL.
- Fixes the task-creation JSON template's hardcoded `"source": "shipwright"` to `"source": "consolidation-fix"` so queued tasks identify which automated skill filed them (matches the entropy-fix/error-fix precedent from CTV-1.2/CTV-1.3).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 3 of consolidation-fix/SKILL.md references `plugins/shipwright/references/pre-filing-verification.md`, extending the existing consolidation-decisions.md re-check to also cover code-level staleness | MET |
| 2 | Task-creation JSON template's `source` field reads `"consolidation-fix"` instead of `"shipwright"` | MET |
| 3 | No test change needed — SKILL.md prose edit; existing consolidation-fix static content checks still pass unchanged | MET |

## Test Plan
- [x] `bun test plugins/shipwright/test/consolidation-fix.content.test.ts` — 29 pass
- [x] `bun test plugins/shipwright/test/consolidation.content.test.ts plugins/shipwright/test/consolidation-decisions.content.test.ts` — 40 pass
- [x] `task lint`, `task check-strings` — clean

Generated with [Claude Code](https://claude.com/claude-code)
