### PR TITLE
refactor: check-deploy.ts shared blocked-check helpers + PR-level hitl gate

### DIFF
--- a/agent/src/check-deploy.ts
+++ b/agent/src/check-deploy.ts
@@ -28,6 +28,8 @@ import {
   createTaskStatusQuery,
   getCurrentUser,
   isCleanApproveBody,
+  isPrRecordBlockedForDispatch,
+  isTaskBlockedForDispatch,
   mapReposTolerant,
   readAllowSelfReview,
   resolveAllRepos,
@@ -70,6 +72,7 @@ export interface WorkflowRun {
 export interface PrRecord {
   readyForDeployAt?: string | null;
   claimedBy?: string | null;
+  hitl?: boolean | null;
 }
 
 export interface CheckDeployDeps {
@@ -233,9 +236,11 @@ export async function getDeployCandidates(
       // human has already been escalated to and needs to act; a task can be
       // hitl:true while still status:"pr_open", e.g. CI later goes green on
       // an already-escalated commit, so hitl and status are checked
-      // independently, not just status). A confirmed empty result (no linked
-      // task) is not disqualifying, but a lookup FAILURE fails CLOSED —
-      // deploy is consequential enough that "unknown" must not be treated as
+      // independently, not just status), routed through the shared
+      // isTaskBlockedForDispatch helper (PRB-2.1) instead of hand-rolled
+      // checks. A confirmed empty result (no linked task) is not
+      // disqualifying, but a lookup FAILURE fails CLOSED — deploy is
+      // consequential enough that "unknown" must not be treated as
       // "confirmed ready".
       let linkedTask: LinkedTaskInfo | null = null;
       if (deps.queryTaskStatus) {
@@ -247,8 +252,7 @@ export async function getDeployCandidates(
           );
           continue;
         }
-        if (linkedTask?.status === "blocked") continue;
-        if (linkedTask?.hitl === true) continue;
+        if (isTaskBlockedForDispatch(linkedTask)) continue;
       }
 
       if (deps.isBundleComplete) {
@@ -274,6 +278,10 @@ export async function getDeployCandidates(
         // NOT be treated as claimed — only an explicit claimedBy gates
         // candidacy, mirroring check-review.ts.
         if (record?.claimedBy != null) continue;
+        // A PR-record hitl:true gate (PRB-2.4) — lets a PR with no linked
+        // task at all still be excluded via its own PR-record hitl flag,
+        // alongside the linked-task hitl/blocked check above.
+        if (isPrRecordBlockedForDispatch(record)) continue;
       }
 
       candidates.push({

--- a/agent/src/check-deploy.unit.test.ts
+++ b/agent/src/check-deploy.unit.test.ts
@@ -564,6 +564,36 @@ describe("getDeployCandidates", () => {
     expect(result).toHaveLength(1);
   });
 
+  test("excludes a PR whose PR-record has hitl:true, even when there is no linked task at all (PRB-2.4)", async () => {
+    const pr = makeGhPr({
+      reviewDecision: "APPROVED",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    const deps = makeDeps({
+      prs: { "acme/example-repo": [pr] },
+      ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+    });
+    deps.queryTaskStatus = async () => null;
+    deps.queryPrRecord = async () => ({ hitl: true });
+    const result = await getDeployCandidates(deps);
+    expect(result).toEqual([]);
+  });
+
+  test("does NOT exclude a PR whose PR-record has hitl:false and no linked task", async () => {
+    const pr = makeGhPr({
+      reviewDecision: "APPROVED",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    const deps = makeDeps({
+      prs: { "acme/example-repo": [pr] },
+      ciRuns: { sha50: [{ status: "completed", conclusion: "success" }] },
+    });
+    deps.queryTaskStatus = async () => null;
+    deps.queryPrRecord = async () => ({ hitl: false });
+    const result = await getDeployCandidates(deps);
+    expect(result).toHaveLength(1);
+  });
+
   // ─── mergeStateStatus DIRTY exclusion ──────────────────────────────────
 
   test("APPROVED + green CI + mergeStateStatus DIRTY is excluded from candidates", async () => {


### PR DESCRIPTION
## Summary
- Replace `check-deploy.ts`'s inline `blocked`/`hitl` task checks with the shared `isTaskBlockedForDispatch` helper from PRB-2.1
- Add a new PR-level gate: `PrRecord.hitl` + `isPrRecordBlockedForDispatch(record)`, so a PR with no linked task at all can still be excluded via its own PR-record `hitl` flag

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Excludes a PR whose PR-record has `hitl:true`, even with no linked task | MET |
| 2 | Still excludes a PR whose linked task has `status:"blocked"` or `hitl:true` (now via shared helper) | MET |
| 3 | PR with `hitl:false`/no PR record and linked task in any other status remains eligible | MET |
| 4 | Safe to deploy standalone | MET |
| 5 | `check-deploy.unit.test.ts` extended with PR-record `hitl:true` exclusion case | MET |

## Test Plan
- `check-deploy.unit.test.ts`: 38/38 pass, including new PR-record `hitl:true` exclusion and `hitl:false` non-exclusion cases
- `tsc --noEmit` clean
- `biome lint` clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
