### PR TITLE
fix: remove dead exports from lib/sentry.ts unused interfaces

### DIFF
--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -14,13 +14,13 @@ type SentryLog = NonNullable<BunOptions["beforeSendLog"]> extends (
   ? L
   : never;
 
-export interface InitSentryOptions {
+interface InitSentryOptions {
   service: string;
   agentId?: string;
 }
 
 /** Narrowed to the one method initSentry calls, so tests can inject a fake without mock.module(). */
-export interface SentryClient {
+interface SentryClient {
   init: (options: Record<string, unknown>) => void;
 }
 


### PR DESCRIPTION
## Summary
- Removed the `export` keyword from `InitSentryOptions` and `SentryClient` in `lib/sentry.ts` — both interfaces have zero import sites outside their own defining file
- Both interfaces remain in the file since they're still used internally as parameter types for `buildSentryInitOptions` and `initSentry`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | InitSentryOptions no longer exported | MET | export removed at lib/sentry.ts:17 |
| 2 | SentryClient no longer exported | MET | export removed at lib/sentry.ts:23 |
| 3 | No behavior change — tests/typecheck pass | MET | full suite 4648 pass/0 fail, typecheck clean across all workspaces |
| 4 | No other exports touched | MET | diff is exactly these 2 lines |

## Test Plan
- `bun test lib/sentry.unit.test.ts` — 15 pass, 0 fail (unchanged behavior)
- `bun run --filter='*' --sequential typecheck` — clean across all 7 workspaces
- `bun test lib/ --coverage` — 203 pass, 0 fail; `lib/sentry.ts` at 100% line/function coverage
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
