### PR TITLE
feat(investigate-cron): add --item mode and admin-API run lookup

### DIFF
--- a/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
@@ -188,3 +188,74 @@ describe("SKILL.md — graceful no-match handling", () => {
     expect(hasFallback).toBe(true);
   });
 });
+
+describe("SKILL.md — --item mode", () => {
+  it("Usage section documents --item mode", () => {
+    expect(content).toContain("--item");
+  });
+
+  it("documents both accepted --item value forms (org/repo#N and bare taskId)", () => {
+    expect(content).toContain("org/repo#");
+  });
+
+  it("has a Step 0 that routes on --item vs name+time", () => {
+    const hasRouting =
+      content.includes("ITEM_ARG") ||
+      content.includes("item mode") ||
+      content.includes("item-mode");
+    expect(hasRouting).toBe(true);
+  });
+});
+
+describe("SKILL.md — admin API run lookup", () => {
+  it("references GET /agents/{id}/crons for resolving loopCronId/phaseId", () => {
+    const hasCronsEndpoint =
+      content.includes("/agents/$SHIPWRIGHT_AGENT_ID/crons") ||
+      content.includes("/agents/{id}/crons");
+    expect(hasCronsEndpoint).toBe(true);
+  });
+
+  it("references GET /agents/{id}/crons/{loopCronId}/runs", () => {
+    const hasRunsEndpoint =
+      content.includes("/crons/$LOOP_CRON_ID/runs") ||
+      content.includes("/crons/{loopCronId}/runs") ||
+      content.includes("/crons/${LOOP_CRON_ID}/runs");
+    expect(hasRunsEndpoint).toBe(true);
+  });
+
+  it("mentions loopCronId and phaseId concepts", () => {
+    expect(content).toContain("loopCronId");
+    expect(content).toContain("phaseId");
+  });
+
+  it("mentions itemId filtering for item mode", () => {
+    expect(content).toContain("itemId");
+  });
+
+  it("documents that runs endpoint filtering is done client-side, not via query params", () => {
+    const hasClientSideNote =
+      content.includes("client-side") || content.includes("client side");
+    expect(hasClientSideNote).toBe(true);
+  });
+
+  it("uses SHIPWRIGHT_AGENT_API_KEY bearer auth for admin API calls", () => {
+    expect(content).toContain(
+      "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY",
+    );
+  });
+});
+
+describe("SKILL.md — fallback: pre-admin-API history retained", () => {
+  it("labels the old ±90min/mtime approach as a documented fallback", () => {
+    const hasFallbackLabel =
+      content.includes("Fallback") || content.includes("fallback");
+    // Must still retain the old mtime window content alongside the fallback label
+    const hasOldWindowContent =
+      content.includes("90") && content.includes("mtime");
+    expect(hasFallbackLabel && hasOldWindowContent).toBe(true);
+  });
+
+  it("still mentions the [Cron job: string-matching approach as part of the fallback", () => {
+    expect(content).toContain("[Cron job:");
+  });
+});

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -281,7 +281,13 @@ the agent workspace root.
 **With an admin-API run resolved (preferred path):** you have an exact
 `startedAt` for the run (Step 1c). Use a tight window (e.g. ±5 minutes) around
 that timestamp against the `.jsonl` file mtimes to find the matching transcript
-— this is a precision narrowing step now, not the primary matching mechanism:
+— this is a precision narrowing step now, not the primary matching mechanism.
+`startedAt` is ISO 8601 (e.g. `2026-07-21T01:11:46.391Z`) — convert it to epoch
+seconds first (in item mode, repeat this per entry in `ITEM_RUNS`):
+
+```bash
+RUN_STARTED_EPOCH=$(date -d "$RUN_STARTED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "${RUN_STARTED_AT%%.*}" +%s)
+```
 
 ```bash
 python3 -c "

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -97,7 +97,7 @@ filtered to just that phase:
 ```bash
 # Only needed in name+time mode.
 PHASE_ID=$(echo "$CRONS_JSON" | jq -r --arg loop "$LOOP_CRON_ID" --arg name "$CRON_NAME" \
-  '.crons[] | select(.parentCronId == $loop and .name == $name) | .id' | head -1)
+  '.crons[] | select(.parentCronId == $loop and (.name | sub("^shipwright-"; "")) == $name) | .id' | head -1)
 echo "phaseId: $PHASE_ID"
 ```
 
@@ -142,7 +142,7 @@ the run whose `startedAt` is closest to `TARGET_EPOCH` (computed in Step 2):
 ```bash
 BEST_RUN=$(jq -r --arg phase "$PHASE_ID" --argjson target "$TARGET_EPOCH" '
   map(select(.phaseId == $phase))
-  | map(. + {distance: (((.startedAt | fromdateiso8601) - $target) | if . < 0 then -. else . end)})
+  | map(. + {distance: ((((.startedAt | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601) - $target) | if . < 0 then -. else . end)})
   | sort_by(.distance)
   | first
 ' "$ALL_RUNS_FILE")

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -1,80 +1,195 @@
 ---
 name: investigate-cron
 description: >
-  Diagnose why a cron run behaved unexpectedly — finds the Claude Code session
-  transcript by cron name and approximate time, reads what the model did and why,
-  and explains it in plain language. No log files needed; the transcript is the
-  source of truth.
+  Diagnose why a cron run behaved unexpectedly — looks up the exact run via the
+  admin cron-runs API (by name+time or by PR/task id), finds the matching Claude
+  Code session transcript, reads what the model did and why, and explains it in
+  plain language. No log files needed; the transcript is the source of truth.
 ---
 
 # investigate-cron
 
-Diagnose a cron run by name and approximate execution time.
+Diagnose a cron run either by name and approximate execution time, or directly
+by the PR/task it was dispatched against.
 
-**Usage:** `/shipwright:investigate-cron <name> <time>`
+**Usage:**
+- `/shipwright:investigate-cron <name> <time>` — find the run of cron `<name>`
+  closest to `<time>`
+- `/shipwright:investigate-cron --item <org/repo#N|taskId>` — find every
+  dispatch across all four pipeline phases for a given PR or task
+
+Arguments:
 
 - `<name>` — cron name: `deploy`, `dev-task`, `patch`, `review`
-- `<time>` — approximate time the cron fired, e.g. `6pm`, `14:30`, `2:30pm PST`
+- `<time>` — approximate time the cron fired, e.g. `6pm`, `14:30`, `2:30pm PST`.
   Timezone defaults to Pacific if not specified.
+- `--item <org/repo#N|taskId>` — a PR (`org/repo#N`, e.g. `acme/x#123`) or a bare
+  task id (e.g. `IC-1.1`). When present, no time argument is needed or used.
 
-**Example:** `/shipwright:investigate-cron deploy 6pm`
+**Examples:**
+- `/shipwright:investigate-cron deploy 6pm`
+- `/shipwright:investigate-cron --item acme/x#123`
+- `/shipwright:investigate-cron --item IC-1.1`
 
 ---
 
-## Step 0: Bind invocation arguments
+## Step 0: Bind invocation arguments and pick a mode
 
-Before running any steps, extract the `<name>` and `<time>` arguments the user
-provided and bind them to shell variables. Everything else depends on these.
+Before running any steps, parse the invocation and detect which mode applies.
 
 ```bash
 # Set these from the user's invocation:
 #   /shipwright:investigate-cron <name> <time>
-CRON_NAME="<the <name> argument the user provided, e.g. deploy>"
-TIME_ARG="<the <time> argument the user provided, e.g. 6pm>"
+#   /shipwright:investigate-cron --item <org/repo#N|taskId>
+
+# If the first argument is literally "--item", route to item mode:
+if [ "$1" = "--item" ]; then
+  MODE="item"
+  ITEM_ARG="$2"   # e.g. "acme/x#123" or "IC-1.1"
+else
+  MODE="name-time"
+  CRON_NAME="$1"  # e.g. deploy
+  TIME_ARG="$2"   # e.g. 6pm
+fi
 ```
 
-For example, if the user ran `/shipwright:investigate-cron deploy 6pm`, then:
-```bash
-CRON_NAME="deploy"
-TIME_ARG="6pm"
-```
+For example:
+- `/shipwright:investigate-cron deploy 6pm` → `MODE=name-time`, `CRON_NAME="deploy"`, `TIME_ARG="6pm"`
+- `/shipwright:investigate-cron --item acme/x#123` → `MODE=item`, `ITEM_ARG="acme/x#123"`
 
-Do not proceed to Step 1 until both variables are set.
+`--item` mode skips time parsing entirely (Step 2 does not apply) — there is no
+target time to convert, since the runs endpoint returns every dispatch for that
+item directly.
+
+Do not proceed to Step 1 until the mode and its variables are set.
 
 ---
 
-## Step 1: Resolve the transcript directory
+## Step 1: Resolve the run via the admin cron-runs API
 
-Derive the transcript directory from the current working directory (CWD).
+The admin API (`$SHIPWRIGHT_API_URL`, authenticated with
+`Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY`, agent id `$SHIPWRIGHT_AGENT_ID`)
+is the primary, exact source for cron run history — it replaces guessing from
+transcript file mtimes. Both modes start by listing this agent's crons to find
+the loop cron and (in name+time mode) the phase cron.
 
-Claude Code stores session transcripts at:
-```
-~/.claude/projects/<encoded-cwd>/
-```
-
-The encoding rule: replace every `/` and `.` character with `-`.
+### 1a. List crons and resolve `loopCronId` (and `phaseId` for name+time mode)
 
 ```bash
-# Get the CWD and encode it
-CWD=$(pwd)
-ENCODED=$(echo "$CWD" | tr '/.' '-')
-TRANSCRIPT_DIR="$HOME/.claude/projects/$ENCODED"
-echo "Transcript directory: $TRANSCRIPT_DIR"
-ls "$TRANSCRIPT_DIR"/*.jsonl 2>/dev/null | head -20
+CRONS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons")
+
+# The loop cron is the top-level cron: parentCronId === null (typically
+# system === true and named "shipwright-loop"). Phase crons (dev-task, review,
+# patch, deploy) are children: parentCronId === <loop cron's id>.
+LOOP_CRON_ID=$(echo "$CRONS_JSON" | jq -r '.crons[] | select(.parentCronId == null and .system == true) | .id' | head -1)
+
+if [ -z "$LOOP_CRON_ID" ] || [ "$LOOP_CRON_ID" = "null" ]; then
+  echo "No loop cron found via admin API — falling back to the pre-admin-API path (see Fallback section below)."
+else
+  echo "loopCronId: $LOOP_CRON_ID"
+fi
 ```
 
-Example: `/data/agent/home/workspace` encodes to `-data-agent-home-workspace`,
-so transcripts live at `~/.claude/projects/-data-agent-home-workspace/`.
+Name+time mode additionally needs the phase cron's id (`phaseId`) so runs can be
+filtered to just that phase:
 
-If the directory doesn't exist or contains no `.jsonl` files, it means this
-workspace has no Claude Code session history at this path. Verify the CWD is
-the agent workspace root.
+```bash
+# Only needed in name+time mode.
+PHASE_ID=$(echo "$CRONS_JSON" | jq -r --arg loop "$LOOP_CRON_ID" --arg name "$CRON_NAME" \
+  '.crons[] | select(.parentCronId == $loop and .name == $name) | .id' | head -1)
+echo "phaseId: $PHASE_ID"
+```
+
+If `LOOP_CRON_ID` (or, in name+time mode, `PHASE_ID`) can't be resolved — the
+admin API is unreachable, this agent has no `shipwright-loop` cron, or no phase
+cron matches `<name>` — fall back to the pre-admin-API approach documented in
+the **Fallback: pre-admin-API history** section below, and skip the rest of
+this step.
+
+### 1b. List runs for the loop cron and filter client-side
+
+`GET /agents/{id}/crons/{cronId}/runs` only supports `limit`/`offset` — there is
+**no server-side `phaseId` or `itemId` query filter**. Fetch pages of runs and
+filter the returned `items` array in your own script; do not pass `phaseId=` or
+`itemId=` as query params, the server ignores them.
+
+```bash
+# Paginate through runs (limit=100 per page, cap at 5 pages / 500 runs).
+ALL_RUNS_FILE=$(mktemp)
+echo "[]" > "$ALL_RUNS_FILE"
+OFFSET=0
+LIMIT=100
+for PAGE in 1 2 3 4 5; do
+  PAGE_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+    "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons/$LOOP_CRON_ID/runs?limit=$LIMIT&offset=$OFFSET")
+  ITEMS=$(echo "$PAGE_JSON" | jq '.items')
+  TOTAL=$(echo "$PAGE_JSON" | jq -r '.total')
+  ALL_RUNS_FILE_NEW=$(mktemp)
+  jq -s '.[0] + .[1]' "$ALL_RUNS_FILE" <(echo "$ITEMS") > "$ALL_RUNS_FILE_NEW"
+  mv "$ALL_RUNS_FILE_NEW" "$ALL_RUNS_FILE"
+  OFFSET=$((OFFSET + LIMIT))
+  if [ "$OFFSET" -ge "$TOTAL" ]; then
+    break
+  fi
+done
+echo "Fetched $(jq 'length' "$ALL_RUNS_FILE") total runs for loopCronId=$LOOP_CRON_ID"
+```
+
+**Name+time mode** — filter client-side to `phaseId === <PHASE_ID>`, then pick
+the run whose `startedAt` is closest to `TARGET_EPOCH` (computed in Step 2):
+
+```bash
+BEST_RUN=$(jq -r --arg phase "$PHASE_ID" --argjson target "$TARGET_EPOCH" '
+  map(select(.phaseId == $phase))
+  | map(. + {distance: (((.startedAt | fromdateiso8601) - $target) | if . < 0 then -. else . end)})
+  | sort_by(.distance)
+  | first
+' "$ALL_RUNS_FILE")
+
+if [ "$BEST_RUN" = "null" ] || [ -z "$BEST_RUN" ]; then
+  echo "No runs found for phaseId=$PHASE_ID within the fetched page cap — fall back to the pre-admin-API path."
+else
+  RUN_STARTED_AT=$(echo "$BEST_RUN" | jq -r '.startedAt')
+  echo "Matched run: $(echo "$BEST_RUN" | jq -r '.id') startedAt=$RUN_STARTED_AT"
+fi
+```
+
+**Item mode** — filter client-side to `itemId === <ITEM_ARG>`, returning every
+matching run across all four phases, sorted chronologically:
+
+```bash
+ITEM_RUNS=$(jq -r --arg item "$ITEM_ARG" '
+  map(select(.itemId == $item)) | sort_by(.startedAt)
+' "$ALL_RUNS_FILE")
+
+echo "Found $(echo "$ITEM_RUNS" | jq 'length') dispatch(es) for item \"$ITEM_ARG\":"
+echo "$ITEM_RUNS" | jq -r '.[] | "  \(.startedAt)  phaseId=\(.phaseId)  outcome=\(.outcome)  skipped=\(.skipped)"'
+```
+
+If `ITEM_RUNS` is empty, no run was ever dispatched for that PR/task through the
+admin-tracked loop cron — either it predates run tracking, or the item was
+never processed. Fall back to the pre-admin-API path only if you have a rough
+time window to search from another source (e.g. `gh pr view` timestamps);
+otherwise report that no dispatch history exists.
+
+### 1c. From the resolved run to a transcript
+
+Once you have the run's exact `startedAt` (name+time mode: `RUN_STARTED_AT`;
+item mode: each entry in `ITEM_RUNS`), use it as a **tight window** — a few
+minutes, not ±90 — around the transcript directory's file mtimes in Step 3,
+since this is now a known exact event time rather than a guess. The transcript
+directory itself is still resolved the same way (see Step 3).
 
 ---
 
-## Step 2: Convert the time argument
+## Step 2: Convert the time argument (name+time mode only)
+
+Only applies when `MODE=name-time`. Item mode has no time argument and skips
+this step.
 
 Parse the `<time>` argument to a Unix epoch in the **Pacific timezone** (default).
+This produces `TARGET_EPOCH`, used in Step 1b to pick the closest run.
 
 ```python
 #!/usr/bin/env python3
@@ -137,8 +252,80 @@ echo "Target epoch: $TARGET_EPOCH ($(date -d @$TARGET_EPOCH 2>/dev/null || date 
 
 ## Step 3: Find matching sessions
 
-Search JSONL files in the transcript directory. Use `mtime` as a fast pre-filter:
-files modified within ±90 minutes of the target time are candidates.
+Derive the transcript directory from the current working directory (CWD), then
+locate the session(s) that correspond to the run(s) resolved in Step 1.
+
+Claude Code stores session transcripts at:
+```
+~/.claude/projects/<encoded-cwd>/
+```
+
+The encoding rule: replace every `/` and `.` character with `-`.
+
+```bash
+# Get the CWD and encode it
+CWD=$(pwd)
+ENCODED=$(echo "$CWD" | tr '/.' '-')
+TRANSCRIPT_DIR="$HOME/.claude/projects/$ENCODED"
+echo "Transcript directory: $TRANSCRIPT_DIR"
+ls "$TRANSCRIPT_DIR"/*.jsonl 2>/dev/null | head -20
+```
+
+Example: `/data/agent/home/workspace` encodes to `-data-agent-home-workspace`,
+so transcripts live at `~/.claude/projects/-data-agent-home-workspace/`.
+
+If the directory doesn't exist or contains no `.jsonl` files, it means this
+workspace has no Claude Code session history at this path. Verify the CWD is
+the agent workspace root.
+
+**With an admin-API run resolved (preferred path):** you have an exact
+`startedAt` for the run (Step 1c). Use a tight window (e.g. ±5 minutes) around
+that timestamp against the `.jsonl` file mtimes to find the matching transcript
+— this is a precision narrowing step now, not the primary matching mechanism:
+
+```bash
+python3 -c "
+import os, glob
+
+transcript_dir = '$TRANSCRIPT_DIR'
+run_started_epoch = $RUN_STARTED_EPOCH  # RUN_STARTED_AT converted to epoch seconds
+window = 300  # 5 minutes — tight, since we have an exact known event time
+
+candidates = []
+for path in glob.glob(os.path.join(transcript_dir, '*.jsonl')):
+    mtime = os.path.getmtime(path)
+    if abs(mtime - run_started_epoch) <= window:
+        candidates.append((mtime, path))
+
+candidates.sort()
+for mtime, path in candidates:
+    session_id = os.path.basename(path).replace('.jsonl', '')
+    print(f'{session_id}  mtime={mtime}  path={path}')
+"
+```
+
+If exactly one candidate is found, that's the transcript for the resolved run.
+If multiple are found, pick the one whose first entry timestamp is closest to
+`run_started_epoch`. If none are found, the transcript may have been pruned or
+this workspace's CWD doesn't match where the cron actually ran — see the
+**Fallback** section below or the no-match handler at the end.
+
+---
+
+## Fallback: pre-admin-API history
+
+Runs that predate admin-API run tracking (or that the admin API can't resolve
+for any reason — unreachable, no `shipwright-loop` cron found, no phase cron
+matching `<name>`, no runs returned for the resolved `phaseId`/`itemId` within
+the pagination cap) have no exact `startedAt` to anchor on. For those, fall
+back to the original fuzzy approach: a ±90 minute mtime window plus
+`[Cron job:]` string-matching in the transcript's first user message. This path
+only applies to `name-time` mode — `--item` mode has no time argument to build
+a fuzzy window from, so if the admin API has no runs for an item, report that
+no dispatch history was found rather than guessing.
+
+Search JSONL files in the transcript directory. Use `mtime` as a fast
+pre-filter: files modified within ±90 minutes of the target time are candidates.
 
 ```bash
 WINDOW=5400  # 90 minutes in seconds
@@ -262,6 +449,8 @@ print(f'=== SILENT: {ended_silently} ===')
 ```
 
 Run it against the matched session file and capture the output for synthesis.
+In item mode, run this once per session matched to each entry in `ITEM_RUNS` —
+the goal is a chronological narrative across all four phases, not a single run.
 
 **Key signals to look for:**
 
@@ -278,14 +467,16 @@ Run it against the matched session file and capture the output for synthesis.
 
 Produce a plain-language explanation covering:
 
-1. **Cron name** — which cron was investigated (`deploy`, `dev-task`, etc.)
-2. **Time** — when the session fired (from the JSONL mtime or first entry timestamp)
+1. **Cron name** — which cron was investigated (`deploy`, `dev-task`, etc.) — in item
+   mode, list every phase that dispatched against the item
+2. **Time** — when the session fired (from the resolved run's `startedAt`, or the
+   JSONL mtime/first entry timestamp when using the fallback path)
 3. **Session ID** — the JSONL filename (without `.jsonl`), for cross-referencing logs
 4. **What it did** — summarize the bash commands and assistant reasoning in 2–5 sentences
 5. **Conclusion** — what the cron decided and why (approved, skipped, silenced, errored)
 6. **Why (if unexpected)** — if the behavior was surprising, explain the root cause
 
-**Output format:**
+**Output format (name+time mode):**
 
 ```
 Cron: <name>
@@ -301,23 +492,41 @@ Why (if unexpected):
 <Root cause explanation if the result was surprising>
 ```
 
+**Output format (item mode)** — one entry per dispatch, chronological:
+
+```
+Item: <org/repo#N|taskId>
+Dispatch history (<N> run(s) across <phases>):
+
+[1] Phase: dev-task  Time: <startedAt> (session: <session-id>)
+    What happened: <narrative>
+    Conclusion: <decision>
+
+[2] Phase: review  Time: <startedAt> (session: <session-id>)
+    ...
+```
+
 ---
 
 ## No match / preCheck skipped
 
-If no matching session is found in the ±90 minute window:
+If no matching run/session is found (via the admin API or the fallback ±90
+minute window):
 
 ```
 No session found for cron "<name>" around <time> Pacific.
+(or, in item mode: No dispatch history found for item "<item>".)
 
 Possible reasons:
 1. The preCheck script returned non-zero — the cron was suppressed before Claude ran.
    Check logs/bodhi.log for "[preCheck]" lines around <time>.
 2. The cron was disabled at the time. Verify via:
       curl -s -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-        "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons" | jq '.[] | select(.name | test("<name>"))'
+        "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons" | jq '.crons[] | select(.name | test("<name>"))'
 3. The cron fired in a different workspace — check if $AGENT_HOME differs.
-4. The ±90 minute search window was too narrow. Try a broader time range.
+4. Name+time mode only: the ±90 minute fallback search window was too narrow. Try a broader time range.
+5. Item mode only: the item was never dispatched through the admin-tracked loop cron —
+   check the task store / GitHub directly for its history instead.
 ```
 
 For case 1, grep bodhi.log:
@@ -329,12 +538,17 @@ grep -i "precheck\|pre-check\|cron" logs/bodhi.log | tail -50
 
 ## Notes
 
-- This skill reads only transcript files — it does **not** require container stdout,
-  `bodhi.log`, or any external log system. The Claude Code session JSONL is the
-  authoritative record of what the model concluded and why.
+- This skill reads only the admin API and transcript files — it does **not** require
+  container stdout or any external log system beyond `logs/bodhi.log` for the preCheck
+  fallback case. The Claude Code session JSONL is the authoritative record of what the
+  model concluded and why; the admin API's `AgentCronRun` records are the authoritative
+  record of exactly when and against what item a cron fired.
+- Prefer the admin-API path (Step 1) over the fallback whenever the admin API is
+  reachable and returns run records — it gives an exact `startedAt` instead of a guess,
+  and item mode is only possible through it.
 - A `[silent]` response is **expected behavior** when the skill found nothing to do —
   look at the bash commands to understand what it checked.
-- Multiple sessions in the window: pick the one whose first entry timestamp (not mtime)
+- Multiple sessions in a window: pick the one whose first entry timestamp (not mtime)
   is closest to the target time.
 - JSONL entries with `type: "summary"` are condensed context records — skip them
   when extracting the narrative; they don't reflect actual model output.

--- a/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
@@ -188,3 +188,74 @@ describe("SKILL.md — graceful no-match handling", () => {
     expect(hasFallback).toBe(true);
   });
 });
+
+describe("SKILL.md — --item mode", () => {
+  it("Usage section documents --item mode", () => {
+    expect(content).toContain("--item");
+  });
+
+  it("documents both accepted --item value forms (org/repo#N and bare taskId)", () => {
+    expect(content).toContain("org/repo#");
+  });
+
+  it("has a Step 0 that routes on --item vs name+time", () => {
+    const hasRouting =
+      content.includes("ITEM_ARG") ||
+      content.includes("item mode") ||
+      content.includes("item-mode");
+    expect(hasRouting).toBe(true);
+  });
+});
+
+describe("SKILL.md — admin API run lookup", () => {
+  it("references GET /agents/{id}/crons for resolving loopCronId/phaseId", () => {
+    const hasCronsEndpoint =
+      content.includes("/agents/$SHIPWRIGHT_AGENT_ID/crons") ||
+      content.includes("/agents/{id}/crons");
+    expect(hasCronsEndpoint).toBe(true);
+  });
+
+  it("references GET /agents/{id}/crons/{loopCronId}/runs", () => {
+    const hasRunsEndpoint =
+      content.includes("/crons/$LOOP_CRON_ID/runs") ||
+      content.includes("/crons/{loopCronId}/runs") ||
+      content.includes("/crons/${LOOP_CRON_ID}/runs");
+    expect(hasRunsEndpoint).toBe(true);
+  });
+
+  it("mentions loopCronId and phaseId concepts", () => {
+    expect(content).toContain("loopCronId");
+    expect(content).toContain("phaseId");
+  });
+
+  it("mentions itemId filtering for item mode", () => {
+    expect(content).toContain("itemId");
+  });
+
+  it("documents that runs endpoint filtering is done client-side, not via query params", () => {
+    const hasClientSideNote =
+      content.includes("client-side") || content.includes("client side");
+    expect(hasClientSideNote).toBe(true);
+  });
+
+  it("uses SHIPWRIGHT_AGENT_API_KEY bearer auth for admin API calls", () => {
+    expect(content).toContain(
+      "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY",
+    );
+  });
+});
+
+describe("SKILL.md — fallback: pre-admin-API history retained", () => {
+  it("labels the old ±90min/mtime approach as a documented fallback", () => {
+    const hasFallbackLabel =
+      content.includes("Fallback") || content.includes("fallback");
+    // Must still retain the old mtime window content alongside the fallback label
+    const hasOldWindowContent =
+      content.includes("90") && content.includes("mtime");
+    expect(hasFallbackLabel && hasOldWindowContent).toBe(true);
+  });
+
+  it("still mentions the [Cron job: string-matching approach as part of the fallback", () => {
+    expect(content).toContain("[Cron job:");
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrites `plugins/shipwright/skills/investigate-cron/SKILL.md` to resolve cron runs via the admin cron-runs API (`GET /agents/{id}/crons`, `GET /agents/{id}/crons/{loopCronId}/runs`) instead of guessing from transcript file mtimes.
- Adds a new `--item <org/repo#N|taskId>` entry mode that returns the full cross-phase dispatch history for a given PR or task, alongside the existing `<name> <time>` mode.
- Retains the old ±90min mtime-window + `[Cron job:]` string-matching logic as a documented fallback for history predating admin-API run tracking.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 0 parses `--item` and routes; absence falls back to `<name> <time>` | MET | `SKILL.md` Step 0 branches on `[ "$1" = "--item" ]` |
| 2 | Name+time mode resolves `loopCronId`/`phaseId` via `GET /agents/{id}/crons`, then filters `GET .../runs` by `phaseId`, picks closest `startedAt` | MET | Steps 1a/1b resolve ids, fetch+filter runs client-side, sort by distance to target |
| 3 | Item mode filters same endpoint by `itemId`, returns all 4-phase dispatches in order | MET | Step 1b item-mode filters by `itemId`, sorts by `startedAt` |
| 4 | Old fuzzy ±90min/mtime + `[Cron job:]` retained as documented fallback, not deleted | MET | "Fallback: pre-admin-API history" section retains original logic verbatim |
| 5 | Both test files extended with new assertions; existing Step 1-5 assertions unmodified | MET | 3 new `describe` blocks added identically to both test files; 64/64 tests pass |

Note: `GET /agents/{id}/crons/{cronId}/runs` only supports `limit`/`offset` server-side — `phaseId`/`itemId` filtering is implemented client-side after paginated fetch, per the real API contract (verified against `admin/src/agents-api.ts` and `docs/agent-api.md`).

## Test Plan
- `bun test skills/investigate-cron/` — 64/64 pass (content-assertion tests against SKILL.md)
- `tsc --noEmit` — clean
- `bunx biome check` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
