### PR TITLE
fix: mirror Step 5a.7 escalation check in patch.md Step 6 (CFE-1.1)

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -633,3 +633,69 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
     expect(section).toContain("reviewState");
   });
 });
+
+describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation already exists (CFE-1.1)", () => {
+  function getStep6b6Section() {
+    const step6b6Idx = content.indexOf("### Step 6b.6: Escalation Check (CFE-1.1)");
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b6Idx).toBeGreaterThan(-1);
+    expect(step6cIdx).toBeGreaterThan(-1);
+    return content.slice(step6b6Idx, step6cIdx);
+  }
+
+  it("Step 6b.6 exists between Step 6b.5 (claim) and Step 6c (dispatch)", () => {
+    const step6b5Idx = content.indexOf("### Step 6b.5: Claim PR Record (pre-work lock)");
+    const step6b6Idx = content.indexOf("### Step 6b.6: Escalation Check (CFE-1.1)");
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b5Idx).toBeGreaterThan(-1);
+    expect(step6b6Idx).toBeGreaterThan(step6b5Idx);
+    expect(step6cIdx).toBeGreaterThan(step6b6Idx);
+  });
+
+  it("the claim step (6b.5) hands off to 6b.6 in both branches, not straight to 6c", () => {
+    const step6b5Idx = content.indexOf("### Step 6b.5: Claim PR Record (pre-work lock)");
+    const step6b6Idx = content.indexOf("### Step 6b.6: Escalation Check (CFE-1.1)");
+    const section = content.slice(step6b5Idx, step6b6Idx);
+    expect(section).not.toContain("Proceed directly to Step 6c");
+    expect(section).not.toContain("Proceed to Step 6c");
+    expect(section).toContain("Proceed directly to Step 6b.6");
+    expect(section).toContain("Proceed to Step 6b.6");
+  });
+
+  it("references Step 5a.7 as the mirrored precedent for this check", () => {
+    const section = getStep6b6Section();
+    expect(section).toContain("5a.7");
+  });
+
+  it("fetches the PR record fresh and checks its hitl field", () => {
+    const section = getStep6b6Section();
+    expect(section).toContain("GET");
+    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+    expect(section).toContain("hitl");
+  });
+
+  it("also checks the linked task's hitl field when taskId is present", () => {
+    const section = getStep6b6Section();
+    expect(section).toContain("taskId");
+    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$');
+  });
+
+  it("true branch releases the claim, does not dispatch the fix subagent, and moves to the next PR in List D", () => {
+    const section = getStep6b6Section();
+    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+    const hasSkipLanguage =
+      /do not\s+dispatch.{0,40}fix subagent/is.test(section) ||
+      /skip.{0,40}fix subagent/is.test(section) ||
+      /fix subagent.{0,40}skip/is.test(section);
+    expect(hasSkipLanguage).toBe(true);
+    expect(section).toContain("next PR in List D");
+  });
+
+  it("otherwise branch proceeds normally to Step 6c", () => {
+    const section = getStep6b6Section();
+    const otherwiseIdx = section.indexOf("**Otherwise**");
+    expect(otherwiseIdx).toBeGreaterThan(-1);
+    const otherwiseSection = section.slice(otherwiseIdx);
+    expect(otherwiseSection).toContain("Step 6c");
+  });
+});

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1003,8 +1003,9 @@ git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WOR
 
 ## Step 6: Fix Failing CI in Worktree
 
-For each PR in List D, set up a worktree, collect CI failure output, and dispatch a fix
-subagent. Fully complete one PR (fix → push → cleanup) before moving to the next.
+For each PR in List D, set up a worktree, collect CI failure output, check for an
+already-recorded HITL escalation, and dispatch a fix subagent if none exists. Fully
+complete one PR (fix → push → cleanup) before moving to the next.
 
 ### Step 6a: Set Up Worktree
 
@@ -1080,9 +1081,9 @@ headRefOid=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefO
 
 - **`headRefOid == PRECLAIM_COMMIT_SHA`** (marker is current): trust it. Set
   `PR_RECORD_ID = PRECLAIM_RECORD_ID` and **skip this site's own `/prs/claim` call below**
-  — the orchestrator's `/prs/claim` already holds this PR under `phase: "patch"`. Proceed
-  directly to Step 6c (`PR_RECORD_ID` is reused by the post-fix update in Step 6d.5, same
-  as the self-claim path).
+  — the orchestrator's `/prs/claim` already holds this PR under `phase: "patch"`.
+  Proceed directly to Step 6b.6 (`PR_RECORD_ID` is reused by the post-fix update in Step
+  6d.5, same as the self-claim path).
 - **`headRefOid != PRECLAIM_COMMIT_SHA`** (stale marker — new commits landed between the
   orchestrator's claim and now) **or no marker present**: fall back to self-claiming
   exactly as today — run the claim below unchanged.
@@ -1106,7 +1107,59 @@ Skip the rest of Step 6 for this PR. Move to the next PR in List D. If no candid
 remain, continue to Step 7.
 
 **Otherwise** (`200` or `201`): the claim succeeded. `PR_RECORD_ID` is reused by the
-post-fix update in Step 6d.5 — no second claim call is needed. Proceed to Step 6c.
+post-fix update in Step 6d.5 — no second claim call is needed. Proceed to Step 6b.6.
+
+### Step 6b.6: Escalation Check (CFE-1.1)
+
+Step 5a.7 (RPF-1.3) escalates a second-round review disagreement to HITL instead of
+dispatching a third automated fix — but it only guards List A (review findings). Once that
+escalation comment exists on the PR, CPF-2.3's reply-after-review exclusion drops the PR
+from List A on the next cycle (the comment postdates the review). If CI is still failing,
+Step 3c puts the same PR into List D, and without this check Step 6 would dispatch a
+CI-fix subagent that directly contradicts the HITL decision Step 5a.7 already recorded —
+re-attempting exactly what that step decided not to retry a third time. Nothing else resets
+`readyForPatchAt` or `reviewState` after that escalation releases its claim, so this can
+re-trigger every patch cycle. Before dispatching the CI-fix subagent, check whether this PR
+already has an unresolved HITL escalation.
+
+1. Fetch the PR record fresh via `GET` — do not trust a possibly-stale claim response, same
+   "re-fetch fresh" principle Step 6b.5's Pre-Claim Fast Path already applies to
+   `headRefOid`:
+   ```bash
+   PR_RECORD=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID")
+   PR_HITL=$(echo "$PR_RECORD" | jq -r '.hitl // false')
+   PR_TASK_ID=$(echo "$PR_RECORD" | jq -r '.taskId // empty')
+   ```
+2. If `PR_TASK_ID` is non-empty, also fetch the linked task and check its `hitl` field:
+   ```bash
+   TASK_HITL=false
+   if [ -n "$PR_TASK_ID" ]; then
+     TASK_HITL=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" | jq -r '.hitl // false')
+   fi
+   ```
+
+**If `PR_HITL` is `true` OR `TASK_HITL` is `true`** (an unresolved HITL escalation already
+exists — most likely from Step 5a.7 on this same PR, this cycle or a prior one): skip —
+do not dispatch the fix subagent, since doing so would silently contradict the escalation
+decision already recorded on the PR.
+
+1. Release the pre-work claim from Step 6b.5 — no fix is in flight, this cycle intentionally
+   stops short of dispatching one:
+   ```bash
+   curl -s -o /dev/null -X POST \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+   ```
+2. Print:
+   ```
+   ⏸ PR #{pr} already has an unresolved HITL escalation — skipping CI-fix dispatch.
+   ```
+3. Move to the next PR in List D. If no candidates remain, continue to Step 7.
+
+**Otherwise** (neither the PR record nor its linked task has `hitl: true`): no escalation
+is on record for this PR — proceed normally to Step 6c.
 
 ### Step 6c: Dispatch Fix Subagent
 


### PR DESCRIPTION
## Summary
- `patch.md` Step 6 (List D, failing CI) now mirrors Step 5a.7's (RPF-1.3) second-round escalation check before dispatching a CI-fix subagent.
- New `Step 6b.6: Escalation Check (CFE-1.1)` fetches the PR record's `hitl` flag (and its linked task's `hitl` flag, if any) and skips dispatch — releasing the pre-work claim instead — when an unresolved HITL escalation already exists, rather than re-attempting a fix the reviewer/system already decided needs a human.
- Fixes the loop observed on vitals-os#3318: once Step 5a.7 escalates a review finding to HITL and posts a comment, CPF-2.3's reply-after-review exclusion drops the PR from List A, but failing CI puts it right back into List D — and without this check, Step 6 would dispatch a contradictory CI-fix subagent every patch cycle.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 6 checks for an existing unresolved HITL escalation (PR record `hitl` via `GET /prs/{id}`, or linked task `hitl` via `GET /tasks/{id}`) before dispatching the CI-fix subagent | MET | New Step 6b.6 fetches both |
| 2 | If an escalation exists, skip dispatch (release claim, print message, move to next PR) rather than re-attempting | MET | True branch releases claim, skips dispatch |
| 3 | If no escalation exists, proceed normally to Step 6c (no regression) | MET | Otherwise branch falls through to Step 6c |
| 4 | Step 4/List C left untouched (explicitly out of scope per task) | MET | No changes outside Step 6 |

## Test Plan
- Added `describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation already exists (CFE-1.1)", ...)` to `patch.content.test.ts` covering section positioning, both Step 6b.5 hand-off updates, the PR-record/linked-task `hitl` fetches, the release+skip+next-PR true branch, and the otherwise-proceeds-to-6c fallthrough.
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 62 pass, 0 fail (includes all pre-existing RPF-1.3/CLM-2.1/CBD-1.5 tests, confirming no regressions).
- `bunx biome check` clean on touched files; `plugins/shipwright` package `typecheck` clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
