### PR TITLE
fix: SHA-pin actions, harden permissions/credentials, fix template injection in workflows

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -83,6 +83,9 @@ jobs:
   debounce:
     name: debounce burst of release tags
     runs-on: ubuntu-latest
+    # This job only sleeps — it never touches the repo, so it needs none of
+    # the workflow-level contents:write / pull-requests:write permissions.
+    permissions: {}
     concurrency:
       group: chart-bump-debounce
       cancel-in-progress: true

--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -111,7 +111,7 @@ jobs:
       # Check out main (not the tag's commit) so we always bump from the
       # latest chart version on main rather than whatever state the tag points at.
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main

--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -46,14 +46,14 @@ jobs:
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Compute next tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "admin-v"
@@ -62,7 +62,7 @@ jobs:
           dry_run: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -5,9 +5,12 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Least privilege at the workflow level; the build-and-push job widens to
+# packages:write. Neither job needs contents:write — the "Tag release" step
+# creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the
+# built-in GITHUB_TOKEN, so no contents permission is needed on it at all.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   filter:
@@ -21,10 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve base SHA
         id: base
-        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=$(git rev-parse "$HEAD_SHA"~1)" >> "$GITHUB_OUTPUT"
 
       - name: Filter paths
         id: filter
@@ -45,11 +51,14 @@ jobs:
     needs: filter
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # docker/login-action push to GHCR
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute next tag
         id: tag
@@ -69,16 +78,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
           docker build \
             -f admin/Dockerfile \
             --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
-            -t ghcr.io/app-vitals/shipwright-admin:${{ steps.tag.outputs.new_tag }} \
+            -t ghcr.io/app-vitals/shipwright-admin:"$NEW_TAG" \
             .
 
       - name: Push Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
-          docker push ghcr.io/app-vitals/shipwright-admin:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-admin:"$NEW_TAG"
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
@@ -86,7 +99,9 @@ jobs:
         # the tag without verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
-            -f sha="${{ github.event.workflow_run.head_sha }}"
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="$HEAD_SHA"

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -47,14 +47,14 @@ jobs:
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Compute next tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "agent-v"
@@ -76,7 +76,7 @@ jobs:
           echo "version=${TAG#agent-v}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -5,9 +5,12 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Least privilege at the workflow level; the build-and-push job widens to
+# packages:write. Neither job needs contents:write — the "Tag release" step
+# creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the
+# built-in GITHUB_TOKEN, so no contents permission is needed on it at all.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   filter:
@@ -21,10 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve base SHA
         id: base
-        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=$(git rev-parse "$HEAD_SHA"~1)" >> "$GITHUB_OUTPUT"
 
       - name: Filter paths
         id: filter
@@ -46,11 +52,14 @@ jobs:
     needs: filter
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # docker/login-action push to GHCR
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute next tag
         id: tag
@@ -83,17 +92,22 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          AGENT_VERSION: ${{ steps.version.outputs.version }}
         run: |
           docker build \
             -f agent/Dockerfile \
-            --build-arg AGENT_VERSION=${{ steps.version.outputs.version }} \
+            --build-arg AGENT_VERSION="$AGENT_VERSION" \
             --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
-            -t ghcr.io/app-vitals/shipwright-agent:${{ steps.tag.outputs.new_tag }} \
+            -t ghcr.io/app-vitals/shipwright-agent:"$NEW_TAG" \
             .
 
       - name: Push Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
-          docker push ghcr.io/app-vitals/shipwright-agent:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-agent:"$NEW_TAG"
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
@@ -101,7 +115,9 @@ jobs:
         # the tag without verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
-            -f sha="${{ github.event.workflow_run.head_sha }}"
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="$HEAD_SHA"

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -46,14 +46,14 @@ jobs:
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Compute next tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "chat-v"
@@ -62,7 +62,7 @@ jobs:
           dry_run: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -5,9 +5,12 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Least privilege at the workflow level; the build-and-push job widens to
+# packages:write. Neither job needs contents:write — the "Tag release" step
+# creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the
+# built-in GITHUB_TOKEN, so no contents permission is needed on it at all.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   filter:
@@ -21,10 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve base SHA
         id: base
-        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=$(git rev-parse "$HEAD_SHA"~1)" >> "$GITHUB_OUTPUT"
 
       - name: Filter paths
         id: filter
@@ -45,11 +51,14 @@ jobs:
     needs: filter
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # docker/login-action push to GHCR
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute next tag
         id: tag
@@ -69,16 +78,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
           docker build \
             -f chat/Dockerfile \
             --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
-            -t ghcr.io/app-vitals/shipwright-chat:${{ steps.tag.outputs.new_tag }} \
+            -t ghcr.io/app-vitals/shipwright-chat:"$NEW_TAG" \
             .
 
       - name: Push Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
-          docker push ghcr.io/app-vitals/shipwright-chat:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-chat:"$NEW_TAG"
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
@@ -86,7 +99,9 @@ jobs:
         # the tag without verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
-            -f sha="${{ github.event.workflow_run.head_sha }}"
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="$HEAD_SHA"

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -5,9 +5,12 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Least privilege at the workflow level; the build-and-push job widens to
+# packages:write. Neither job needs contents:write — the "Tag release" step
+# creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the
+# built-in GITHUB_TOKEN, so no contents permission is needed on it at all.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   filter:
@@ -21,10 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve base SHA
         id: base
-        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=$(git rev-parse "$HEAD_SHA"~1)" >> "$GITHUB_OUTPUT"
 
       - name: Filter paths
         id: filter
@@ -45,11 +51,14 @@ jobs:
     needs: filter
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # docker/login-action push to GHCR
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute next tag
         id: tag
@@ -69,16 +78,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
           docker build \
             -f mcp-server/Dockerfile \
             --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
-            -t ghcr.io/app-vitals/shipwright-mcp-server:${{ steps.tag.outputs.new_tag }} \
+            -t ghcr.io/app-vitals/shipwright-mcp-server:"$NEW_TAG" \
             .
 
       - name: Push Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
-          docker push ghcr.io/app-vitals/shipwright-mcp-server:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-mcp-server:"$NEW_TAG"
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
@@ -86,7 +99,9 @@ jobs:
         # the tag without verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
-            -f sha="${{ github.event.workflow_run.head_sha }}"
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="$HEAD_SHA"

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -46,14 +46,14 @@ jobs:
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Compute next tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "mcp-server-v"
@@ -62,7 +62,7 @@ jobs:
           dry_run: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -46,14 +46,14 @@ jobs:
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Compute next tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "metrics-v"
@@ -62,7 +62,7 @@ jobs:
           dry_run: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -5,9 +5,12 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Least privilege at the workflow level; the build-and-push job widens to
+# packages:write. Neither job needs contents:write — the "Tag release" step
+# creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the
+# built-in GITHUB_TOKEN, so no contents permission is needed on it at all.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   filter:
@@ -21,10 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve base SHA
         id: base
-        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=$(git rev-parse "$HEAD_SHA"~1)" >> "$GITHUB_OUTPUT"
 
       - name: Filter paths
         id: filter
@@ -45,11 +51,14 @@ jobs:
     needs: filter
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # docker/login-action push to GHCR
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute next tag
         id: tag
@@ -69,16 +78,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
           docker build \
             -f metrics/Dockerfile \
             --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
-            -t ghcr.io/app-vitals/shipwright-metrics:${{ steps.tag.outputs.new_tag }} \
+            -t ghcr.io/app-vitals/shipwright-metrics:"$NEW_TAG" \
             .
 
       - name: Push Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
-          docker push ghcr.io/app-vitals/shipwright-metrics:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-metrics:"$NEW_TAG"
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
@@ -86,7 +99,9 @@ jobs:
         # the tag without verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
-            -f sha="${{ github.event.workflow_run.head_sha }}"
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="$HEAD_SHA"

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -46,14 +46,14 @@ jobs:
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Compute next tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.DISPATCH_TOKEN }}
           tag_prefix: "task-store-v"
@@ -62,7 +62,7 @@ jobs:
           dry_run: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -5,9 +5,12 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Least privilege at the workflow level; the build-and-push job widens to
+# packages:write. Neither job needs contents:write — the "Tag release" step
+# creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the
+# built-in GITHUB_TOKEN, so no contents permission is needed on it at all.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   filter:
@@ -21,10 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve base SHA
         id: base
-        run: echo "sha=$(git rev-parse ${{ github.event.workflow_run.head_sha }}~1)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=$(git rev-parse "$HEAD_SHA"~1)" >> "$GITHUB_OUTPUT"
 
       - name: Filter paths
         id: filter
@@ -45,11 +51,14 @@ jobs:
     needs: filter
     if: needs.filter.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # docker/login-action push to GHCR
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute next tag
         id: tag
@@ -69,16 +78,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
           docker build \
             -f task-store/Dockerfile \
             --label org.opencontainers.image.source=https://github.com/app-vitals/shipwright \
-            -t ghcr.io/app-vitals/shipwright-task-store:${{ steps.tag.outputs.new_tag }} \
+            -t ghcr.io/app-vitals/shipwright-task-store:"$NEW_TAG" \
             .
 
       - name: Push Docker image
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
         run: |
-          docker push ghcr.io/app-vitals/shipwright-task-store:${{ steps.tag.outputs.new_tag }}
+          docker push ghcr.io/app-vitals/shipwright-task-store:"$NEW_TAG"
 
       - name: Tag release
         # Only create the git tag once the image has actually pushed. A tag with
@@ -87,7 +100,9 @@ jobs:
         # verifying the image exists.
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ steps.tag.outputs.new_tag }}" \
-            -f sha="${{ github.event.workflow_run.head_sha }}"
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="$HEAD_SHA"

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -61,7 +61,13 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
+      # persist-credentials left at its default (true) intentionally: the
+      # "Commit and push to gh-pages" step below pushes from this checkout's
+      # working directory and relies on the token persisted into its local
+      # git config to authenticate that push.
       - name: Checkout gh-pages
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -106,13 +112,15 @@ jobs:
 
       - name: Commit and push to gh-pages
         working-directory: gh-pages
+        env:
+          CHART_VERSION: ${{ steps.chart-version.outputs.version }}
         run: |
           git add -- '*.tgz' index.yaml
           if git diff --cached --quiet; then
-            echo "No chart changes to publish (version ${{ steps.chart-version.outputs.version }} already on gh-pages)."
+            echo "No chart changes to publish (version ${CHART_VERSION} already on gh-pages)."
             exit 0
           fi
-          git commit -m "chart: publish shipwright ${{ steps.chart-version.outputs.version }}"
+          git commit -m "chart: publish shipwright ${CHART_VERSION}"
           git push origin gh-pages
 
   # Dry-run validation — runs ONLY on pull_request. Proves the chart packages and
@@ -125,6 +133,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -60,10 +60,10 @@ jobs:
       contents: write # push the .tgz + index.yaml to gh-pages
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: gh-pages
           path: gh-pages
@@ -74,7 +74,7 @@ jobs:
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.18.6
 
@@ -124,10 +124,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.18.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege at the workflow level; every job here only reads the repo
+# (checkout, build, test, docker build) — none pushes, opens PRs, or publishes
+# packages.
+permissions:
+  contents: read
+
 jobs:
   # Detects whether this run only touches the files auto-bump-chart.yml or
   # sync-plugin-version.yml commit — chart-version bumps (Chart.yaml,
@@ -25,15 +31,20 @@ jobs:
     outputs:
       app: ${{ steps.filter.outputs.app }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Determine whether app code changed
         id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
           else
             # push to main: each merge here is one squash commit, so the
             # parent is exactly "what main looked like before this merge."
@@ -111,14 +122,16 @@ jobs:
       DATABASE_URL_SHIPWRIGHT_TASK_STORE: postgres://shipwright:shipwright@localhost:5432/shipwright_task_store_test
       DATABASE_URL_SHIPWRIGHT_CHAT: postgres://shipwright:shipwright@localhost:5432/shipwright_chat_test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 
       - name: Install go-task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.51.1
 
@@ -165,9 +178,11 @@ jobs:
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 
@@ -192,7 +207,9 @@ jobs:
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Build admin Docker image
         run: docker build -f admin/Dockerfile -t shipwright-admin:ci .
@@ -203,7 +220,9 @@ jobs:
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Build agent Docker image
         run: docker build -f agent/Dockerfile -t shipwright-agent:ci .
@@ -214,7 +233,9 @@ jobs:
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Build metrics Docker image
         run: docker build -f metrics/Dockerfile -t shipwright-metrics:ci .
@@ -224,14 +245,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 
       - name: Install go-task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.51.1
 
@@ -249,14 +272,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 
       - name: Install go-task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.51.1
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -32,6 +32,10 @@ jobs:
       contents: write # push site/dist to gh-pages
 
     steps:
+      # persist-credentials left at its default (true) intentionally:
+      # JamesIves/github-pages-deploy-action below is not passed an explicit
+      # token input, so it relies on the git credential persisted by this
+      # checkout to authenticate its push to gh-pages.
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 
@@ -50,7 +50,7 @@ jobs:
         run: cd site && bunx pagefind --site dist
 
       - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: site/dist

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # ct --check-version-increment diffs against target-branch
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
@@ -83,6 +84,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # ct needs full history to diff against target-branch
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -25,12 +25,12 @@ jobs:
     name: helm lint / unittest / validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # ct --check-version-increment diffs against target-branch
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           # helm-unittest v1.x's plugin.yaml uses the `platformHooks` schema
           # field, which Helm only understands from v3.18 onward. Keep this in
@@ -41,13 +41,13 @@ jobs:
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
 
       - name: Install kubeconform
-        uses: bmuschko/setup-kubeconform@v1
+        uses: bmuschko/setup-kubeconform@e5d264ec1eafe2314e750c429a9da7639dd5a003 # v1.1.0
         with:
           kubeconform-version: 0.6.7
 
       - name: Set up chart-testing
         # Installs the `ct` binary plus its yamllint + yamale dependencies.
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
         with:
           version: v3.12.0
 
@@ -80,24 +80,24 @@ jobs:
     name: ct install (kind)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # ct needs full history to diff against target-branch
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.18.6
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
         with:
           version: v3.12.0
 
       - name: Create kind cluster
         # cluster_name is pinned to "kind" — the `kind load` step below
         # side-loads the admin image into THAT cluster.
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: v0.24.0
           cluster_name: kind

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,7 +16,7 @@ jobs:
     name: Conventional-Commit PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5 (post-v5.5.2)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: guard
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ on:
         required: false
         default: false
 
+# Least privilege at the workflow level; the guard job's only GITHUB_TOKEN use
+# is the read-only collaborators/permission API call below. The release job
+# uses a scoped GitHub App token (see create-github-app-token below) for
+# everything else, not GITHUB_TOKEN, so no elevated permissions are needed here.
+permissions:
+  contents: read
+
 jobs:
   guard:
     name: Admin check
@@ -17,10 +24,11 @@ jobs:
       - name: Assert actor is admin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
         run: |
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          PERMISSION=$(gh api repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission --jq '.permission')
           if [ "$PERMISSION" != "admin" ]; then
-            echo "Error: ${{ github.actor }} is not a repo admin (got: $PERMISSION)" >&2
+            echo "Error: $ACTOR is not a repo admin (got: $PERMISSION)" >&2
             exit 1
           fi
 
@@ -34,6 +42,17 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Scoped to exactly what semantic-release needs: @semantic-release/git
+          # pushes release commits to main (contents), @semantic-release/github
+          # creates GitHub releases (contents) and comments on referenced
+          # issues/PRs (issues, pull-requests). Without this, the minted token
+          # would inherit the App's full blanket installation permissions.
+          # NOTE: v1.12.0 exposes per-resource `permission-<name>` inputs, not a
+          # single YAML `permissions:` block — see action.yml's generated
+          # permission-* inputs.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -92,13 +92,13 @@ jobs:
       # Check out main (not the tag's commit) so we always sync from the
       # latest state on main, same reasoning as auto-bump-chart.yml.
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
           ref: main
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
 

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -91,6 +91,11 @@ jobs:
     steps:
       # Check out main (not the tag's commit) so we always sync from the
       # latest state on main, same reasoning as auto-bump-chart.yml.
+      #
+      # persist-credentials left at its default (true) intentionally: the
+      # "Commit and push sync branch" step below pushes from this checkout's
+      # working directory and relies on the token persisted into its local
+      # git config to authenticate that push.
       - name: Checkout main
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -156,10 +161,14 @@ jobs:
       - name: Commit and push sync branch
         id: commit-push
         if: steps.idempotency.outputs.skip != 'true' && steps.diff.outputs.changed == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.version.outputs.branch }}
+          VERSION_NAME: ${{ steps.version.outputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          BRANCH="${{ steps.version.outputs.branch }}"
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          BRANCH="$BRANCH_NAME"
+          VERSION="$VERSION_NAME"
+          TAG="$TAG_NAME"
 
           git checkout -b "$BRANCH"
           git add package.json plugins/shipwright/package.json \
@@ -180,10 +189,13 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          VERSION_NAME: ${{ steps.version.outputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
+          BRANCH_NAME: ${{ steps.version.outputs.branch }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG="${{ github.ref_name }}"
-          BRANCH="${{ steps.version.outputs.branch }}"
+          VERSION="$VERSION_NAME"
+          TAG="$TAG_NAME"
+          BRANCH="$BRANCH_NAME"
 
           PR_URL=$(gh pr create \
             --base main \


### PR DESCRIPTION
## Summary
- SHA-pin every third-party GitHub Actions reference across all 14 `.github/workflows/*.yml` files (was tag-pinned, e.g. `@v4` — mutable and spoofable) — resolves all `unpinned-uses` findings.
- Add `persist-credentials: false` to every `actions/checkout` step that doesn't need to push (resolves `artipacked`); checkouts that genuinely need to push (chart-release.yml's gh-pages publish, deploy-site.yml's gh-pages deploy, sync-plugin-version.yml's branch push) keep the default and are annotated with a comment explaining why.
- Narrow `permissions:` blocks to least privilege at workflow- and job-level across `ci.yml`, the six `build-*.yml` files, and `release.yml` (which previously had no `permissions:` block at all) — resolves `excessive-permissions`.
- Move untrusted/expression values out of direct `${{ }}` interpolation in `run:` shell blocks into `env:` vars (High-severity `template-injection` findings only): the "Resolve base SHA" and "Tag release" steps in all six `build-*.yml` files, `release.yml`'s "Assert actor is admin" step, and `sync-plugin-version.yml`'s "Commit and push sync branch" / "Open sync PR" steps.
- Scope `release.yml`'s `actions/create-github-app-token` step down from the App's full blanket installation permissions to exactly `contents: write`, `issues: write`, `pull-requests: write` (what `@semantic-release/git` and `@semantic-release/github` actually need) — resolves the `github-app` finding.

## Not addressed in this PR (judgment-dependent, left as follow-ups)
- **dangerous-triggers**: `workflow_run` trigger on all six `build-*.yml` files. Zizmor flags this trigger type as "almost always used insecurely" in general, but these workflows already gate on `github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'` and only build/push images + tag — changing the trigger model is a bigger architectural call than this PR's scope.
- **cache-poisoning**: `sync-plugin-version.yml`'s runtime-generated artifact publish pattern. Needs a closer look at the actual publish flow before a safe fix can be scoped.
- **template-injection (Informational)**: the 47 informational-severity findings (concentrated in `auto-bump-chart.yml` and `sync-plugin-version.yml`) were left untouched per the security patrol's own fix guidance — lower priority than the High-severity ones fixed here.

## Test Plan
- [x] All 14 modified workflow YAML files verified to parse correctly (`Bun.YAML.parse`)
- [x] Verified `actions/create-github-app-token@v1.12.0`'s actual `action.yml` input names (`permission-contents`, `permission-issues`, `permission-pull-requests`) against the upstream repo before using them
- [x] `bunx biome lint .` passes clean (no application code touched — YAML-only change)
- [x] Manually diffed every workflow file against `main` to confirm each fix matches its target finding without changing workflow behavior (triggers, job outcomes, and publish/tag/release mechanics are unchanged)
- Real validation happens once these workflows themselves run in CI on this PR

Generated with [Claude Code](https://claude.com/claude-code)
