### PR TITLE
chore(chart): bump chart version to 1.7.79

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.7.79] - 2026-07-21
+
+### Changed
+
+- auto-bump to chart v1.7.79 triggered by release tag(s): `admin-v1.22.3`, `agent-v1.44.5`, `chat-v1.4.3`, `metrics-v1.4.3`, `task-store-v1.10.3`
+
 ## [1.7.78] - 2026-07-21
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.7.78
+version: 1.7.79
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,7 +29,15 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.7.78 triggered by release tag agent-v1.44.4"
+      description: "auto-bump to chart v1.7.79 triggered by release tag admin-v1.22.3"
+    - kind: changed
+      description: "auto-bump to chart v1.7.79 triggered by release tag agent-v1.44.5"
+    - kind: changed
+      description: "auto-bump to chart v1.7.79 triggered by release tag chat-v1.4.3"
+    - kind: changed
+      description: "auto-bump to chart v1.7.79 triggered by release tag metrics-v1.4.3"
+    - kind: changed
+      description: "auto-bump to chart v1.7.79 triggered by release tag task-store-v1.10.3"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -114,7 +114,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.22.0
+    tag: admin-v1.22.3
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -182,7 +182,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v1.4.0
+    tag: metrics-v1.4.3
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -298,7 +298,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.44.4
+    tag: agent-v1.44.5
     pullPolicy: ""
   service:
     port: 3000
@@ -321,7 +321,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.44.4
+      tag: agent-v1.44.5
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).
@@ -533,7 +533,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.10.1
+    tag: task-store-v1.10.3
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -598,7 +598,7 @@ chat:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-chat
-    tag: chat-v1.4.2
+    tag: chat-v1.4.3
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.7.78 → 1.7.79

**Triggering tags:**
- `admin-v1.22.3`
- `agent-v1.44.5`
- `chat-v1.4.3`
- `metrics-v1.4.3`
- `task-store-v1.10.3`

**New chart version:** `1.7.79`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.22.3`
- `agent.image.tag`: `agent-v1.44.5`
- `agent.provisioning.image.tag`: `agent-v1.44.5`
- `chat.image.tag`: `chat-v1.4.3`
- `metrics.image.tag`: `metrics-v1.4.3`
- `taskStore.image.tag`: `task-store-v1.10.3`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.7.79 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._