### PR TITLE
docs: rewrite CLAUDE.md.template for shipwright-loop model + Slack AskUserQuestion note

### DIFF
--- a/agent/workspace/CLAUDE.md.template
+++ b/agent/workspace/CLAUDE.md.template
@@ -16,6 +16,12 @@ and post results to a configured Slack channel.
 Incoming messages are prefixed with `[Name]: ` where `Name` is the Slack display
 name of the sender. Use this to know who you're talking to.
 
+### Clarifying Questions
+
+Do not call the `AskUserQuestion` tool in this Slack-mediated session — there's no card UI
+to render it into and the call errors. If you need to ask a clarifying question, just ask it
+as plain text in your reply.
+
 ### Response Markers
 
 Embed markers anywhere in your response to trigger side effects. Markers are
@@ -85,9 +91,14 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.tasks'
 ```
 
-The `shipwright-dev-task` cron picks up the next pending item every 30 minutes. The
-`shipwright-review` and `shipwright-patch` crons run as independent phases — review posts
-findings, patch addresses them — both enabled by default.
+`dev-task`, `review`, `patch`, and `deploy` are **explicit-target-only executors** — none of
+them self-discovers work. Candidate selection happens upstream, once per tick, in the
+`shipwright-loop` cron: its candidate providers merge dev-task/review/patch/deploy
+candidates and pick exactly one winning item via strict age-based FIFO, then dispatch the
+matching command with the winning task id or `org/repo#number` embedded directly in the
+prompt. `dev-task`, `review`, and `patch` are enabled by default; `deploy` is opt-in. A
+standalone phase cron with `shipwright-loop` disabled is **silently inert** — its prompt
+carries no target, so every tick responds `[silent]` and does nothing.
 
 ### Policy
 

--- a/agent/workspace/CLAUDE.md.template.content.test.ts
+++ b/agent/workspace/CLAUDE.md.template.content.test.ts
@@ -1,0 +1,64 @@
+/**
+ * CLAUDE.md.template content regression guard — DPF-1.1
+ *
+ * Verifies the deployed-agent template's "Shipwright" section describes the
+ * shipwright-loop-driven, explicit-target-only pipeline model (WLS-6.1), not
+ * the stale self-discovering-cron model it replaced. Also verifies the
+ * template tells Slack-mediated agents not to use AskUserQuestion.
+ *
+ * Content-assertion only: readFileSync, no I/O beyond local file reads.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// agent/workspace/ → repo root
+const repoRoot = resolve(import.meta.dir, "..", "..");
+
+function repoPath(...parts: string[]): string {
+  return join(repoRoot, ...parts);
+}
+
+function readTemplate(): string {
+  return readFileSync(repoPath("agent/workspace/CLAUDE.md.template"), "utf8");
+}
+
+describe("CLAUDE.md.template — shipwright-loop model", () => {
+  it("mentions the shipwright-loop cron as the driver", () => {
+    expect(readTemplate()).toContain("shipwright-loop");
+  });
+
+  it("describes dev-task/review/patch/deploy as explicit-target-only executors", () => {
+    expect(readTemplate().toLowerCase()).toContain("explicit-target-only");
+  });
+
+  it("mentions strict age-based FIFO work selection", () => {
+    expect(readTemplate().toLowerCase()).toContain("fifo");
+  });
+
+  it("notes a standalone phase cron with shipwright-loop disabled is silently inert", () => {
+    expect(readTemplate().toLowerCase()).toContain("silently inert");
+  });
+
+  it("does not claim dev-task picks up pending items on a fixed schedule independent of the loop", () => {
+    expect(readTemplate()).not.toContain(
+      "picks up the next pending item every 30 minutes",
+    );
+  });
+
+  it("does not describe review/patch as independently self-discovering phases", () => {
+    expect(readTemplate()).not.toContain(
+      "run as independent phases — review posts",
+    );
+  });
+});
+
+describe("CLAUDE.md.template — Slack AskUserQuestion note", () => {
+  it("mentions AskUserQuestion", () => {
+    expect(readTemplate()).toContain("AskUserQuestion");
+  });
+
+  it("instructs asking clarifying questions as plain text instead", () => {
+    expect(readTemplate().toLowerCase()).toContain("plain text");
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrites `agent/workspace/CLAUDE.md.template`'s "Shipwright" section to accurately describe the shipwright-loop-driven, explicit-target-only pipeline model (WLS-6.1 / PR #1849) instead of the stale self-discovering-cron-on-a-fixed-schedule model it previously described.
- Adds a new "Clarifying Questions" note instructing Slack-mediated agents not to call `AskUserQuestion` (no card UI, errors there) and to ask as plain text instead.
- Adds `agent/workspace/CLAUDE.md.template.content.test.ts`, a new content test (following the `fixture-terminology.content.test.ts` pattern) asserting the corrected loop-model language is present, the old self-discovering-cron language is gone, and the AskUserQuestion/Slack note exists.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Shipwright section accurately describes shipwright-loop-driven, explicit-target-only model | MET | Rewritten paragraph matches `docs/agent.md`'s "Default system crons" section and `docs/migration.md`'s WLS-6.1 entry |
| 2 | No remaining language implying fixed-schedule self-discovery | MET | Stale "picks up the next pending item every 30 minutes" / "run as independent phases" paragraph fully replaced; content test asserts both stale phrases are absent |
| 3 | New note tells Slack-mediated agents not to use AskUserQuestion, ask as plain text instead | MET | New "### Clarifying Questions" subsection added under "How You Work" |
| 4 | New `agent/workspace/CLAUDE.md.template.content.test.ts` following `fixture-terminology.content.test.ts` pattern | MET | New file created, same `readFileSync`/`describe`/`it` pattern, 8 passing assertions (positive + negative) |

## Test Plan
- [x] New content test (`bun test agent/workspace/CLAUDE.md.template.content.test.ts`) — 8/8 pass
- [x] `bunx biome lint .` — clean
- [x] `bunx biome format --check .` — clean
- [x] `task check-strings` — no banned strings
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
