### PR TITLE
feat: pass linked task's model tier to review's code-reviewer subagent

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -93,3 +93,52 @@ describe("review.md — pre-claim fast path skips re-claiming (CBD-1.4)", () => 
     expect(section).toContain("strip the marker");
   });
 });
+
+describe("review.md — task model tier passed to code-reviewer subagent (MTR-1.1)", () => {
+  it("Step 4 (after the claim subsection, before Step 5) resolves TASK_MODEL from the linked task", () => {
+    const claimSectionIdx = content.indexOf("### Claim using pre-captured commit SHA");
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    expect(claimSectionIdx).toBeGreaterThan(-1);
+    expect(step5Idx).toBeGreaterThan(-1);
+    const section = content.slice(claimSectionIdx, step5Idx);
+
+    expect(section).toContain("/prs/$PR_RECORD_ID");
+    expect(section).toContain(".taskId");
+    expect(section).toContain("/tasks/");
+    expect(section).toContain("TASK_MODEL");
+  });
+
+  it("the TASK_MODEL lookup runs once, regardless of which Step 14 path produced PR_RECORD_ID", () => {
+    const claimSectionIdx = content.indexOf("### Claim using pre-captured commit SHA");
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const section = content.slice(claimSectionIdx, step5Idx);
+
+    // Only one lookup block should exist in this window (Step 14's two paths both
+    // reconverge here before Step 5, so a single occurrence covers both).
+    const occurrences = section.split("TASK_MODEL").length - 1;
+    expect(occurrences).toBeGreaterThan(0);
+    expect(section).toContain("PR_RECORD_ID");
+  });
+
+  it("the TASK_MODEL lookup fails gracefully -- warns and continues, never a hard stop", () => {
+    const claimSectionIdx = content.indexOf("### Claim using pre-captured commit SHA");
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const section = content.slice(claimSectionIdx, step5Idx);
+    const lookupIdx = section.indexOf("TASK_MODEL");
+    expect(lookupIdx).toBeGreaterThan(-1);
+    const lookupSection = section.slice(Math.max(0, lookupIdx - 800), lookupIdx + 800);
+
+    expect(lookupSection).toContain("continuing");
+    expect(lookupSection).not.toContain("set -e");
+  });
+
+  it("Step 7's code-reviewer dispatch passes model: TASK_MODEL ?? 'sonnet'", () => {
+    const step7Idx = content.indexOf("## Step 7: Deep Review");
+    const step8Idx = content.indexOf("## Step 8: Score and Classify Findings");
+    expect(step7Idx).toBeGreaterThan(-1);
+    expect(step8Idx).toBeGreaterThan(-1);
+    const section = content.slice(step7Idx, step8Idx);
+
+    expect(section).toContain("model: TASK_MODEL ?? 'sonnet'");
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -161,6 +161,33 @@ PR_CLAIM=$(curl -s -o /tmp/pr_claim.json -w '%{http_code}' -X POST \
 
 All subsequent steps run from `worktrees/{repo}-{branch-slug}/`.
 
+### Resolve the linked task's model tier
+
+Runs once here, regardless of which Step 14 path produced `PR_RECORD_ID` (Pre-Claim Fast
+Path or self-claim) — both paths reconverge at this point before Step 5 runs. Best-effort
+enrichment only: any failure leaves `TASK_MODEL` unset and prints a one-line warning, never
+a hard stop.
+
+```bash
+TASK_MODEL=""
+if [ -n "$PR_RECORD_ID" ]; then
+  PR_RECORD=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID") || echo "⚠ failed to fetch PR record for model lookup — continuing"
+  TASK_ID=$(echo "$PR_RECORD" | jq -r '.taskId // empty')
+  if [ -n "$TASK_ID" ]; then
+    TASK_RECORD=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID") || echo "⚠ failed to fetch task $TASK_ID for model lookup — continuing"
+    TASK_MODEL=$(echo "$TASK_RECORD" | jq -r '.model // empty')
+  fi
+else
+  echo "⚠ no PR_RECORD_ID available — skipping task model lookup"
+fi
+```
+
+A non-200 at either fetch (e.g. a 403 when the linked task is assigned to a different agent
+or unassigned — task-store agent tokens are scoped) leaves `TASK_MODEL` unset; Step 7 falls
+back to `'sonnet'`.
+
 ---
 
 ## Step 5: Gather Context
@@ -257,7 +284,9 @@ Note which categories are present (even if "none") — this drives review focus 
 Delegate the per-file review to the bundled `shipwright:code-reviewer` subagent. This
 keeps review context isolated from the main thread (policy, queue, posting).
 
-Dispatch via the Agent tool with `subagent_type: "shipwright:code-reviewer"` and pass
+Dispatch via the Agent tool with `subagent_type: "shipwright:code-reviewer"`, passing
+`model: TASK_MODEL ?? 'sonnet'` (the linked task's model tier resolved at the end of Step 4,
+falling back to `'sonnet'` when no task is linked or the lookup failed), and pass
 a single prompt block containing:
 
 - **PR metadata** — `number`, `title`, `author`, `headRefName`, `baseRefName`, `headRefOid`


### PR DESCRIPTION
## Summary
- Add a model-tier resolution lookup to `review.md`'s Step 4 (the reconvergence point after Step 14's Pre-Claim Fast Path and self-claim paths both establish `PR_RECORD_ID`), fetching the linked task's `model` field via `GET /prs/$PR_RECORD_ID` → `.taskId` → `GET /tasks/{taskId}` → `.model`
- Failures at either fetch (e.g. 403 on tasks scoped to a different agent) leave `TASK_MODEL` unset and print a one-line warning, matching the existing graceful-failure convention in `patch.md` — never a hard stop
- Wire `TASK_MODEL ?? 'sonnet'` into Step 7's `shipwright:code-reviewer` `Agent()` dispatch so review's cognitive work runs at the tier planning intended, instead of silently inheriting the outer process's fixed model

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Lookup fetches `/prs/$PR_RECORD_ID` → `taskId` → `/tasks/{taskId}` → `TASK_MODEL`, graceful non-200 fallback, no change to Step 14 control flow | MET |
| 2 | Step 7 dispatch passes `model: TASK_MODEL ?? 'sonnet'` | MET |
| 3 | Single lookup point covers both Step 14 paths, no duplicate fetch | MET |
| 4 | Content-layer test (`review.content.test.ts`) asserting lookup placement and Step 7 string; no existing tests retired | MET |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/review.content.test.ts` — 12/12 pass (8 existing + 4 new)
- `bunx biome lint plugins/shipwright/commands/` — clean
- `tsc --noEmit` (plugins/shipwright) — clean
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
