### PR TITLE
fix: listBlocked() surfaces hitl-gated tasks at any non-terminal status

### DIFF
--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -225,9 +225,17 @@ export class TaskService implements TaskServiceLike {
   }
 
   /**
-   * Blocked tasks: status === "blocked" OR (status === "pending" AND blockedBy.length > 0).
+   * Blocked tasks: status === "blocked" OR (status is open/non-terminal AND
+   * blockedBy.length > 0).
    *
-   * Captures explicitly blocked tasks, HITL-gated tasks, and dep-blocked pending tasks.
+   * Captures explicitly blocked tasks, HITL-gated tasks, and dep-blocked tasks
+   * at any non-terminal status (pending, in_progress, pr_open, approved) — not
+   * just "pending". A task can be claimed and moved to in_progress/pr_open
+   * while still hitl-gated (dispatch's resolveReadyTasks already excludes
+   * hitl:true tasks regardless of status), so listBlocked must surface that
+   * signal at any open status too, not silently drop it. Terminal statuses
+   * (CLOSED_STATUSES) are always excluded even if blockedBy is non-empty.
+   *
    * Loads the full task graph so computeBlockedBy can resolve all dependency IDs.
    *
    * Agent tokens are scoped to their own tasks: pass agentId to filter by assignee.
@@ -239,6 +247,7 @@ export class TaskService implements TaskServiceLike {
     const allTasks = await this.prisma.task.findMany();
     const useRepoScope =
       agentId !== undefined && repos !== undefined && repos.length > 0;
+    const closedStatuses = new Set<string>(CLOSED_STATUSES);
     return allTasks
       .map((t: Task) => ({ ...t, blockedBy: computeBlockedBy(t, allTasks) }))
       .filter((t: TaskWithBlockedBy) => {
@@ -249,8 +258,8 @@ export class TaskService implements TaskServiceLike {
           if (!ownedByAssignee && !inRepoScope) return false;
         }
         if (t.status === "blocked") return true;
-        if (t.status === "pending") return t.blockedBy.length > 0;
-        return false;
+        if (closedStatuses.has(t.status)) return false;
+        return t.blockedBy.length > 0;
       });
   }
 

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -31,14 +31,13 @@ function makeMinimalTask(overrides: Partial<MinimalTask> = {}): MinimalTask {
 function listBlockedLogic(
   allTasks: MinimalTask[],
 ): (MinimalTask & { blockedBy: ReturnType<typeof computeBlockedBy> })[] {
+  const closed = new Set<string>(CLOSED_STATUSES);
   return allTasks
     .filter((t) => {
       if (t.status === "blocked") return true;
-      if (t.status === "pending") {
-        const blockedBy = computeBlockedBy(t, allTasks);
-        return blockedBy.length > 0;
-      }
-      return false;
+      if (closed.has(t.status)) return false;
+      const blockedBy = computeBlockedBy(t, allTasks);
+      return blockedBy.length > 0;
     })
     .map((t) => ({ ...t, blockedBy: computeBlockedBy(t, allTasks) }));
 }
@@ -242,12 +241,77 @@ describe("listBlocked logic (unit)", () => {
     expect(result).toHaveLength(0);
   });
 
-  it("does not return non-pending tasks (in_progress, pr_open, etc.)", () => {
+  it("returns non-pending open-status tasks (in_progress, pr_open, approved) with a hitl gate or unresolved dependency", () => {
+    const tasks = [
+      makeMinimalTask({
+        id: "t1",
+        status: "in_progress",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
+      makeMinimalTask({
+        id: "t2",
+        status: "pr_open",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
+      makeMinimalTask({
+        id: "t3",
+        status: "approved",
+        dependencies: ["dep-1"],
+      }),
+      makeMinimalTask({ id: "dep-1", status: "in_progress" }),
+    ];
+    const result = listBlockedLogic(tasks);
+    const ids = result.map((t) => t.id);
+    expect(ids).toContain("t1");
+    expect(ids).toContain("t2");
+    expect(ids).toContain("t3");
+    expect(ids).not.toContain("dep-1");
+  });
+
+  it("does not return non-pending open-status tasks with no blockedBy (in_progress, pr_open, approved)", () => {
     const tasks = [
       makeMinimalTask({ id: "t1", status: "in_progress" }),
       makeMinimalTask({ id: "t2", status: "pr_open" }),
       makeMinimalTask({ id: "t3", status: "approved" }),
-      makeMinimalTask({ id: "t4", status: "done" }),
+    ];
+    const result = listBlockedLogic(tasks);
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not return closed-status tasks even with a non-empty blockedBy (hitl gate)", () => {
+    const tasks = [
+      makeMinimalTask({
+        id: "t1",
+        status: "merged",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
+      makeMinimalTask({
+        id: "t2",
+        status: "done",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
+      makeMinimalTask({
+        id: "t3",
+        status: "deploying",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
+      makeMinimalTask({
+        id: "t4",
+        status: "deployed",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
+      makeMinimalTask({
+        id: "t5",
+        status: "cancelled",
+        hitl: true,
+        hitlNotifiedAt: null,
+      }),
     ];
     const result = listBlockedLogic(tasks);
     expect(result).toHaveLength(0);

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -393,6 +393,84 @@ describeOrSkip("Task store schema (integration)", () => {
     expect(titles).not.toContain("Other blocked out of scope");
   });
 
+  // ─── TaskService.listBlocked() surfaces hitl-gated tasks at any open status ─
+
+  it("listBlocked() returns an in_progress task with hitl:true (GET /tasks?state=blocked parity)", async () => {
+    const taskService = new TaskService(prisma);
+
+    const hitlGated = await prisma.task.create({
+      data: {
+        title: "In-progress hitl-gated task",
+        status: "in_progress",
+        hitl: true,
+        hitlNotifiedAt: null,
+      },
+    });
+    const notGated = await prisma.task.create({
+      data: {
+        title: "In-progress task with no hitl gate",
+        status: "in_progress",
+        hitl: false,
+      },
+    });
+
+    const result = await taskService.listBlocked();
+    const ids = result.map((t) => t.id);
+
+    expect(ids).toContain(hitlGated.id);
+    expect(ids).not.toContain(notGated.id);
+  });
+
+  it("listBlocked() returns a pr_open task with hitl:true", async () => {
+    const taskService = new TaskService(prisma);
+
+    const hitlGated = await prisma.task.create({
+      data: {
+        title: "PR-open hitl-gated task",
+        status: "pr_open",
+        hitl: true,
+        hitlNotifiedAt: null,
+      },
+    });
+
+    const result = await taskService.listBlocked();
+    const found = result.find((t) => t.id === hitlGated.id);
+
+    expect(found).toBeDefined();
+    expect(found?.blockedBy).toContainEqual({ type: "hitl" });
+  });
+
+  it("listBlocked() does not return an in_progress task with no hitl gate and no unresolved dependency", async () => {
+    const taskService = new TaskService(prisma);
+
+    const notBlocked = await prisma.task.create({
+      data: {
+        title: "In-progress, not blocked",
+        status: "in_progress",
+        hitl: false,
+      },
+    });
+
+    const result = await taskService.listBlocked();
+    expect(result.map((t) => t.id)).not.toContain(notBlocked.id);
+  });
+
+  it("listBlocked() does not return a merged task even with hitl:true", async () => {
+    const taskService = new TaskService(prisma);
+
+    const merged = await prisma.task.create({
+      data: {
+        title: "Merged hitl task",
+        status: "merged",
+        hitl: true,
+        hitlNotifiedAt: null,
+      },
+    });
+
+    const result = await taskService.listBlocked();
+    expect(result.map((t) => t.id)).not.toContain(merged.id);
+  });
+
   // ─── TaskService.distinct() repo scope ────────────────────────────────────
 
   it("distinct() without scopeRepos only returns sessions/repos from own tasks", async () => {


### PR DESCRIPTION
## Summary
- `listBlocked()` (task-store/src/task-service.ts) only surfaced the `blockedBy` signal (hitl-gated or dep-blocked) for tasks with `status === "pending"`, silently dropping the same signal once a task moved to `in_progress`, `pr_open`, or `approved` — even though `computeBlockedBy()` already computes it correctly regardless of status.
- Extended the final filter branch to check `blockedBy.length > 0` for any non-terminal (non-`CLOSED_STATUSES`) status, using the shared `CLOSED_STATUSES` source of truth from `task-store/src/statuses.ts`.
- Rewrote the unit test that previously asserted the buggy behavior, updated the `listBlockedLogic()` test helper to mirror the production fix, and added integration tests covering `GET /tasks?state=blocked` returning `in_progress`/`pr_open` tasks with `hitl:true`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | listBlocked() returns hitl/dep-blocked tasks at any non-terminal status | MET |
| 2 | Excludes terminal/closed statuses even with non-empty blockedBy | MET |
| 3 | Unit test rewritten + listBlockedLogic() helper mirrors fix | MET |
| 4 | Integration test for GET /tasks?state=blocked at in_progress/pr_open with hitl:true | MET |
| 5 | No existing blocked/pending test behavior changed | MET |

## Test Plan
- `bun test src/task-service.unit.test.ts` — 31 pass, 0 fail
- `bun test` (full task-store suite) — 387 pass, 108 skip (integration tests requiring a real DB — will run in CI), 0 fail
- `tsc --noEmit` — clean
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
