### PR TITLE
feat: pass escalated task model tier to patch's fix subagents (MTR-2.1)

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -561,11 +561,15 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
     expect(section).toContain("reply dated *before* the");
   });
 
-  it("escalation case resolves the linked task via the PR record and PATCHes hitl: true", () => {
+  it("escalation case reuses the shared PR_TASK_ID from Step 2.1 and PATCHes hitl: true (no fresh taskId fetch)", () => {
     const section = getStep5a7Section();
-    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
     expect(section).toContain("PR_TASK_ID");
-    expect(section).toContain("taskId");
+    // No independent GET .../prs/$PR_RECORD_ID fetch for taskId purposes anymore — that
+    // resolution now lives once in Step 2.1 (MTR-2.1) and is only referenced here.
+    expect(section).not.toMatch(
+      /GET[^\n]*\n[^\n]*"\$SHIPWRIGHT_TASK_STORE_URL\/prs\/\$PR_RECORD_ID"[^\n]*\n[^\n]*taskId/,
+    );
+    expect(section).toMatch(/Step 2\.1|reuse/i);
     expect(section).toContain("-X PATCH");
     expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
     expect(section).toContain('"hitl": true');
@@ -697,5 +701,83 @@ describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation a
     expect(otherwiseIdx).toBeGreaterThan(-1);
     const otherwiseSection = section.slice(otherwiseIdx);
     expect(otherwiseSection).toContain("Step 6c");
+  });
+});
+
+describe("patch.md — shared patch model tier resolution (MTR-2.1)", () => {
+  function getStep2_1Section() {
+    const step2_1Idx = content.indexOf("## Step 2.1:");
+    const step2_5Idx = content.indexOf("## Step 2.5:");
+    expect(step2_1Idx).toBeGreaterThan(-1);
+    expect(step2_5Idx).toBeGreaterThan(-1);
+    return content.slice(step2_1Idx, step2_5Idx);
+  }
+
+  it("Step 2.1 exists between Step 2 (resolve target PR) and Step 2.5 (DIRTY handling)", () => {
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    const step2_1Idx = content.indexOf("## Step 2.1:");
+    const step2_5Idx = content.indexOf("## Step 2.5:");
+    expect(step2Idx).toBeGreaterThan(-1);
+    expect(step2_1Idx).toBeGreaterThan(step2Idx);
+    expect(step2_5Idx).toBeGreaterThan(step2_1Idx);
+  });
+
+  it("Step 2.1 resolves PR_TASK_ID via GET /prs?repo=...&prNumber=... using the .prs[0].taskId jq path", () => {
+    const section = getStep2_1Section();
+    expect(section).toContain("PR_TASK_ID");
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}");
+    expect(section).toContain(".prs[0].taskId // empty");
+  });
+
+  it("Step 2.1 documents the full escalation ladder (haiku->sonnet, sonnet->opus, opus->opus) and the no-task/failed-fetch sonnet fallback with no hard stop", () => {
+    const section = getStep2_1Section();
+    expect(section).toContain("PATCH_MODEL");
+    expect(section.toLowerCase()).toContain("haiku");
+    expect(section.toLowerCase()).toContain("sonnet");
+    expect(section.toLowerCase()).toContain("opus");
+    // Ladder direction: haiku -> sonnet, sonnet -> opus, opus stays opus.
+    expect(section).toMatch(/haiku[^\n]{0,40}(->|→)[^\n]{0,10}sonnet/i);
+    expect(section).toMatch(/sonnet[^\n]{0,40}(->|→)[^\n]{0,10}opus/i);
+    expect(section).toMatch(/opus[^\n]{0,60}(->|→)[^\n]{0,10}opus|opus.{0,40}stays opus/i);
+    // No-task / failed-fetch fallback: plain 'sonnet', no escalation, not a hard stop.
+    expect(section).toMatch(/PATCH_MODEL\s*=\s*"?sonnet"?/);
+    expect(section.toLowerCase()).toContain("no escalation");
+    expect(section.toLowerCase()).toContain("not a hard stop");
+    expect(section).toContain("⚠");
+  });
+
+  it("Step 2.1 notes the value is reused at Step 4b, Step 5b, Step 6c, and Step 5a.7 with no second fetch", () => {
+    const section = getStep2_1Section();
+    expect(section).toContain("Step 4b");
+    expect(section).toContain("Step 5b");
+    expect(section).toContain("Step 6c");
+    expect(section).toContain("Step 5a.7");
+  });
+
+  it("Step 4b dispatch (conflict resolution) passes model: PATCH_MODEL to the Agent() call", () => {
+    const step4bIdx = content.indexOf("### Step 4b: Dispatch Conflict Resolution Subagent");
+    const step4cIdx = content.indexOf("### Step 4c: Handle Subagent Status");
+    expect(step4bIdx).toBeGreaterThan(-1);
+    expect(step4cIdx).toBeGreaterThan(-1);
+    const section = content.slice(step4bIdx, step4cIdx);
+    expect(section).toContain("model: PATCH_MODEL");
+  });
+
+  it("Step 5b dispatch (finding fixes) passes model: PATCH_MODEL to the Agent() call", () => {
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    expect(step5bIdx).toBeGreaterThan(-1);
+    expect(step5cIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5bIdx, step5cIdx);
+    expect(section).toContain("model: PATCH_MODEL");
+  });
+
+  it("Step 6c dispatch (CI fixes) passes model: PATCH_MODEL to the Agent() call", () => {
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    const step6dIdx = content.indexOf("### Step 6d: Handle Subagent Status");
+    expect(step6cIdx).toBeGreaterThan(-1);
+    expect(step6dIdx).toBeGreaterThan(-1);
+    const section = content.slice(step6cIdx, step6dIdx);
+    expect(section).toContain("model: PATCH_MODEL");
   });
 });

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -84,6 +84,53 @@ gh pr view {number} --repo {org}/{repo} \
 
 ---
 
+## Step 2.1: Resolve Patch Model Tier (MTR-2.1)
+
+Every dispatch this command makes — conflict resolution (Step 4b), finding fixes (Step
+5b), CI fixes (Step 6c) — is inherently a response to a failure signal (a conflict, a
+review finding, a red CI run). There's no "first attempt" the way `dev-task` has one, so
+`PATCH_MODEL` starts one tier above the linked task's planned tier rather than waiting to
+hit `dev-task`'s own BLOCKED-escalation ladder. Resolve it once here, right after Step 2
+resolves the target PR — this is independent of claim state (reading the linked task's
+model doesn't require holding a claim), and the computed value is reused as-is at Step 4b,
+Step 5b, Step 6c, and Step 5a.7. None of those four sites re-fetches it.
+
+```bash
+PR_TASK_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" | jq -r '.prs[0].taskId // empty')
+```
+
+- **`PR_TASK_ID` non-empty** (the PR has a linked task): fetch that task's planned model
+  and escalate one tier:
+  ```bash
+  TASK_MODEL=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" | jq -r '.model // "sonnet"')
+  ```
+  Compute `PATCH_MODEL` by escalating `TASK_MODEL` one tier up the same ladder
+  `dev-task.md`'s Step 5c BLOCKED handling already climbs — a patch dispatch is always
+  reacting to a problem the way a BLOCKED implementation subagent is, so it starts where
+  that ladder's first escalation would land, instead of waiting to hit it:
+  `haiku`->`sonnet`, `sonnet`->`opus`, `opus`->`opus` (already at the top tier — stays put).
+
+  | `TASK_MODEL` (or `model ?? 'sonnet'` if the field is unset) | `PATCH_MODEL` |
+  |---|---|
+  | `haiku` | `sonnet` |
+  | `sonnet` | `opus` |
+  | `opus` | `opus` (already at the top tier — stays put) |
+
+- **`PR_TASK_ID` is unresolved (empty), or either `curl -sf` call above fails (non-200)**:
+  `PATCH_MODEL = "sonnet"` — plain `sonnet`, with **no escalation**. Print a one-line
+  warning and continue; this is **not a hard stop**:
+  ```bash
+  PATCH_MODEL="sonnet"
+  echo "⚠ no linked task found (or lookup failed) for PR #{pr} — PATCH_MODEL defaulting to sonnet, no escalation"
+  ```
+  There's no known baseline tier to escalate from on a PR Shipwright didn't create (or
+  whose task record isn't reachable), so defaulting straight to `opus` would be a surprise
+  cost spike with no signal backing it — `sonnet` is the safe, unescalated default.
+
+---
+
 ## Step 2.5: Handle DIRTY PRs (Auto-Rebase Attempt)
 
 For each PR discovered in Step 2, use the `mergeStateStatus` field (already fetched in Step 2) to identify DIRTY PRs.
@@ -385,7 +432,9 @@ curl -s -o /dev/null -X POST \
   "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat"
 ```
 
-Dispatch a `general-purpose` subagent via the Agent tool with this prompt:
+Dispatch a `general-purpose` subagent via the Agent tool, passing `model: PATCH_MODEL`
+(resolved once in Step 2.1) so the conflict-resolution subagent runs at the escalated
+tier, with this prompt:
 
 ```
 You are resolving merge conflicts on a pull request. Merge the base branch, resolve all
@@ -627,11 +676,10 @@ still raised a finding this round.
 5 for this PR entirely — do not dispatch the fix subagent, do not post another rebuttal, and
 do not reset `reviewState`.
 
-1. Resolve the linked task from the PR record claimed in Step 5a.6:
-   ```bash
-   PR_TASK_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" | jq -r '.taskId // empty')
-   ```
+1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. (Step 2.1
+   fetched `GET /prs?repo={org}/{repo}&prNumber={pr}` and captured `.prs[0].taskId` right
+   after Step 2 resolved this same PR, independent of any claim, so it's already available
+   by the time this check runs.)
 2. If `PR_TASK_ID` is non-empty, PATCH it to `hitl: true` so the task is flagged for a human
    decision:
    ```bash
@@ -717,7 +765,9 @@ curl -s -o /dev/null -X POST \
   "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat"
 ```
 
-Dispatch a `general-purpose` subagent via the Agent tool with this prompt:
+Dispatch a `general-purpose` subagent via the Agent tool, passing `model: PATCH_MODEL`
+(resolved once in Step 2.1) so the fix subagent runs at the escalated tier, with this
+prompt:
 
 ```
 You are addressing review findings on a pull request. Apply fixes, validate, commit, push,
@@ -1172,7 +1222,9 @@ curl -s -o /dev/null -X POST \
   "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat"
 ```
 
-Dispatch a `general-purpose` subagent via the Agent tool with this prompt:
+Dispatch a `general-purpose` subagent via the Agent tool, passing `model: PATCH_MODEL`
+(resolved once in Step 2.1) so the CI-fix subagent runs at the escalated tier, with this
+prompt:
 
 ```
 You are fixing failing CI on a pull request. Diagnose the failures, apply fixes, validate locally, commit, and push.


### PR DESCRIPTION
## Summary
- Add a single shared `PATCH_MODEL` resolution step (Step 2.1) right after `patch.md`'s Step 2 resolves the target PR, escalating one tier above the linked task's planned model (`haiku`->`sonnet`, `sonnet`->`opus`, `opus`->`opus`), falling back to plain `sonnet` (no escalation, no hard stop) when no task is linked or the lookup fails.
- Reuse the resolved `PATCH_MODEL` at all three subagent dispatch sites (Step 4b conflict resolution, Step 5b finding fixes, Step 6c CI fixes) instead of inheriting the outer process's model.
- Replace Step 5a.7's ad-hoc `GET /prs/$PR_RECORD_ID -> .taskId` fetch with a reference to the shared `PR_TASK_ID` computed in Step 2.1 — no duplicate fetch.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Resolve PR_TASK_ID/PATCH_MODEL immediately after Step 2, with escalation ladder and safe fallback | MET |
| 2 | Step 5a.7 reuses shared PR_TASK_ID instead of its own fetch | MET |
| 3 | All three dispatch sites pass `model: PATCH_MODEL` | MET |
| 4 | Content-layer tests added/updated per spec (patch.content.test.ts) | MET |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/patch.content.test.ts` — 69/69 passing
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
