### PR TITLE
docs: add extending.md documenting the plugin+marketplace extension pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/metrics.md** — metrics service (B): JSON endpoints, server-rendered dashboard, dual auth (Bearer / session), and environment
 - **docs/agent.md** — Shipwright agent (C): runtime + admin CRUD APIs, the eleven-model Prisma store, and encryption/env notes
 - **docs/agent-api.md** — the admin CRUD API (D): agents, envs, crons, cron runs, tools, tokens, plugins, and chat-token-usage endpoints, plus auth paths
+- **docs/extending.md** — extending Shipwright without forking it: installing a companion plugin, command namespacing, custom crons for repo-specific automation, and the lightweight `.claude/shipwright/` override pattern
 - **docs/task-store.md** — task store service (D): the sole HTTP-service backend — tasks, PR tracking, tokens — and troubleshooting
 - **docs/mcp-tools.md** — generated MCP server tool reference (name, description, HTTP method/path, parameters, body) derived from task-store/openapi.json + the tool allowlist; regenerate with `bun run generate:mcp-docs`
 - **docs/chat.md** — chat service (D): auth model (admin vs. agent tokens, scope resolver), thread/message/token endpoints (incl. attachment streaming and the claim/reply queue), data model, and environment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,8 @@ prompt. A human can still invoke any of the four directly with an explicit targe
 
 The plugin is pure TypeScript with **no server, no database, and no external HTTP in production code** — only `unit` and `integration` test layers apply.
 
+A repo or team can extend this loop with its own commands, skills, or scheduled automation — via a companion marketplace plugin and/or a custom cron — without forking `plugins/shipwright/`. See **[extending.md](./extending.md)**.
+
 ## B — Metrics dashboard
 
 A Hono service that turns pipeline events into analytics. Two sets of read-only JSON endpoints: authenticated `/metrics/*` (summary, trends, features, queue, tokens) and unauthenticated `/public/*` (summary, trends, features, queue), plus session-gated `/dashboard` and public `/public/dashboard`. All served by a backend-agnostic `MetricsProvider` interface. The active backend is selected from env at startup: **fixtures** (offline) or **taskstore** (live task-store + admin APIs). See **[metrics.md](./metrics.md)**.
@@ -113,6 +115,7 @@ shipwright/
 
 ## See also
 
+- **[extending.md](./extending.md)** — extending Shipwright with a companion plugin and custom crons, without forking the plugin.
 - **[testing.md](./testing.md)** — the five-layer test architecture and isolation contract.
 - **[metrics.md](./metrics.md)** — metrics service API and dashboard.
 - **[agent.md](./agent.md)** — Shipwright agent runtime + admin APIs and data model.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -44,7 +44,7 @@ Crons are how Shipwright runs autonomous, scheduled behavior — the `shipwright
 POST /agents/:id/crons
 ```
 
-A cron created through this endpoint defaults to a normal (non-system) cron unless you explicitly mark it as a system cron — system crons are reserved for Shipwright's own built-in maintenance jobs and are managed separately (see [agent-api.md](./agent-api.md#cron-jobs)). Non-system crons you create can be updated or deleted freely through the same CRUD routes; system crons cannot.
+A cron created through this endpoint is always a normal (non-system) cron — system crons are reserved for Shipwright's own built-in maintenance jobs, created internally via reconciliation, and cannot be created through this public route (see [agent-api.md](./agent-api.md#cron-jobs)). Non-system crons you create can be updated or deleted freely through the same CRUD routes; system crons cannot.
 
 The cron's `prompt` field is a **plain string** — it is not scoped to any particular plugin. That means a custom cron's prompt can invoke any command from any plugin installed on the agent, including your own companion plugin's commands:
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,77 @@
+# Extending Shipwright
+
+> How a repo or team adds its own commands, skills, or scheduled automation on top of the shipwright plugin — without forking Shipwright itself.
+
+## Overview
+
+The `shipwright` plugin (artifact **A**, see [architecture.md](./architecture.md)) is repo-agnostic and ships one delivery loop: spec → plan → execute → review → deploy. A team that wants its own commands, skills, or repo-specific scheduled behavior on top of that loop has two supported paths, depending on how much they need:
+
+- **A companion plugin** — a separate Claude Code marketplace plugin (their own repo, their own marketplace) installed alongside `shipwright` on the same agent, adding new commands/skills under their own namespace.
+- **A custom cron** — a scheduled prompt on the agent that invokes a command from an installed plugin (shipwright's or a companion's), for autonomous behavior specific to their repo.
+
+Neither path requires modifying `plugins/shipwright/` — that directory stays generic, shared, and upgradeable.
+
+## Installing a companion plugin
+
+`AgentPlugin` is a **list**, not a single-plugin slot: an agent can have any number of plugins installed side by side, including `shipwright` plus one or more companion plugins from your own repo or marketplace.
+
+Install one via the admin CRUD API:
+
+```
+POST /agents/:id/plugins
+```
+
+Body: `{ name: string, version?: string, enabled?: boolean }`. See [agent-api.md](./agent-api.md#plugins) for the full request/response shape, plus `GET`/`PATCH`/`DELETE /agents/:id/plugins` for listing, updating, and removing plugins.
+
+`name` follows the marketplace convention `plugin-name@marketplace-name` (e.g. `shipwright@shipwright`). Installing your own plugin (`mycompany-tools@mycompany-marketplace`) does not disturb the existing `shipwright@shipwright` install — both rows coexist on the agent, and the agent's Claude Code session loads commands and skills from every enabled plugin.
+
+## Namespacing convention
+
+Claude Code commands are namespaced by plugin name — `shipwright`'s commands are invoked as `/shipwright:dev-task`, `/shipwright:review`, etc. Give your companion plugin its own name (e.g. `mycompany`) so its commands land under a distinct prefix:
+
+```
+/mycompany:deploy-notify
+/mycompany:changelog-sync
+```
+
+This avoids any collision with `/shipwright:*` commands, keeps it obvious at a glance which plugin owns which command, and lets you install, update, or remove your plugin independently of shipwright's own release cadence.
+
+## Custom cron jobs for scheduled automation
+
+Crons are how Shipwright runs autonomous, scheduled behavior — the `shipwright-loop` and maintenance crons (entropy patrol, docs freshness, etc.) are all system crons under the hood. You can add your own **non-system** cron the same way, via the same API:
+
+```
+POST /agents/:id/crons
+```
+
+A cron created through this endpoint defaults to a normal (non-system) cron unless you explicitly mark it as a system cron — system crons are reserved for Shipwright's own built-in maintenance jobs and are managed separately (see [agent-api.md](./agent-api.md#cron-jobs)). Non-system crons you create can be updated or deleted freely through the same CRUD routes; system crons cannot.
+
+The cron's `prompt` field is a **plain string** — it is not scoped to any particular plugin. That means a custom cron's prompt can invoke any command from any plugin installed on the agent, including your own companion plugin's commands:
+
+```json
+{
+  "schedule": "0 9 * * 1-5",
+  "prompt": "/mycompany:changelog-sync",
+  "channel": "C0123456789",
+  "name": "changelog-sync-weekdays"
+}
+```
+
+This is the mechanism for repo-specific scheduled/autonomous behavior — a nightly report, a weekly changelog sync, a custom compliance check — that doesn't belong in the shared `shipwright` plugin. See [agent-api.md](./agent-api.md#cron-jobs) for the full field reference (schedule validation, delivery-target rules, `preCheck`, etc.).
+
+## Lightweight customization without a companion plugin
+
+If all you need is to tweak config or data — not add a new command or skill — a full companion plugin is overkill. The `entropy-scan` skill supports a local override file under `.claude/shipwright/` in the target repo, checked before falling back to the plugin's shipped default — the reference pattern for this kind of lightweight customization:
+
+- Default: `<plugin-dir>/references/principles.md`
+- Override: `.claude/shipwright/principles.md` (project-local, used in its entirety when present — no merging with the default)
+
+Run `/entropy-scan --init` to seed the override file from the plugin default, then edit it to match your project's norms (disable entries, change severity, add project-specific checks). See [`skills/entropy-scan/references/customization.md`](../plugins/shipwright/skills/entropy-scan/references/customization.md) for the full pattern.
+
+Reach for this first if you just need different data or thresholds; reach for a companion plugin when you need genuinely new commands, skills, or scheduled behavior that doesn't fit inside shipwright's existing commands.
+
+## See also
+
+- **[agent-api.md](./agent-api.md)** — full request/response schemas for the Plugins and Cron jobs endpoints.
+- **[architecture.md](./architecture.md)** — the four-artifact design and where the plugin fits.
+- **[`skills/entropy-scan/references/customization.md`](../plugins/shipwright/skills/entropy-scan/references/customization.md)** — the `.claude/shipwright/principles.md` override pattern in full.


### PR DESCRIPTION
## Summary
- Add `docs/extending.md` documenting how a repo/team extends Shipwright with a companion plugin, command namespacing, custom crons for scheduled automation, and the entropy-scan override pattern for lightweight config customization
- Cross-link the new doc from `CLAUDE.md`'s `## Reference` section and `docs/architecture.md`
- Every technical claim in the doc was re-verified against current source (not copied from planning): `AgentPlugin` list model (`admin/src/agent-plugins.integration.test.ts`), non-system cron defaulting (`admin/src/agent-cron-jobs.ts`), and the entropy-scan `--init`/override pattern

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | docs/extending.md documents companion-plugin install, namespacing, custom cron, entropy-scan override | MET | All 5 sections present in docs/extending.md |
| 2 | Technical claims re-verified against live code | MET | Confirmed `system: input.system ?? false` (agent-cron-jobs.ts:225), 3-plugin list() test (agent-plugins.integration.test.ts:91-99), agent-api.md anchors exist, entropy-scan `--init` flag confirmed |
| 3 | CLAUDE.md Reference section one-line entry | MET | Added, matches existing bullet format |
| 4 | docs/architecture.md mentions extension pattern + links to extending.md | MET | Added in "A — Plugin" section and "See also" |
| 5 | Test decision documented and justified | MET | No test added — free-standing reference doc, content-test carve-out doesn't apply |

## Test Plan
- [x] `task lint` passing
- [x] `task check-strings` passing (no banned strings)
- [x] `task typecheck` passing across all packages
- [x] All links/anchors manually verified to resolve (docs/agent-api.md#plugins, #cron-jobs; relative path to skills/entropy-scan/references/customization.md)
- [x] No new test needed per acceptance criteria (docs-only, no I/O boundary)

Generated with [Claude Code](https://claude.com/claude-code)
