### PR TITLE
feat: serialize dashboard client-side metric fetches

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -151,6 +151,8 @@ The `/public/*` endpoints require **no authentication**. Access is controlled by
 
 Unit + integration + smoke layers (`bun test --filter metrics`). Integration tests for the task-store backend inject `RecordedTaskStoreClient` + `RecordedAdminMetricsClient` doubles (from `metrics/src/providers/task-store-recorded.ts`) over canned cassettes and a fixed clock — pre-recorded sample results, no network calls; smoke tests drive the Hono app via `app.request()`. The suite stays fully offline with no external service URLs configured.
 
+The dashboard client (`metrics/src/dashboard/app.js`) is a plain browser `<script>` (not an ES module) that largely handles DOM manipulation and chart rendering — untestable in-process without browser globals. Its pure, injectable-fetch logic (`fetchSequential`) is extracted and unit-tested via a test-only export (`metrics/src/dashboard/app.unit.test.js`), while the bulk of `app.js` remains excluded from coverage as its code paths require a real browser. E2E Playwright tests cover the full dashboard UI (`metrics/e2e/dashboard.e2e.ts`).
+
 E2E layer (`task e2e` → `cd metrics && bunx playwright test`): Playwright Chromium headless tests against a real running Bun server (`metrics/e2e/test-server.ts`). Session cookies are signed with a pinned test secret (`e2e-test-session-secret-32b`). Test file: `metrics/e2e/dashboard.e2e.ts`. Config: `metrics/playwright.config.ts`.
 
 See [testing.md](./testing.md).

--- a/metrics/src/dashboard/app.js
+++ b/metrics/src/dashboard/app.js
@@ -92,35 +92,74 @@
 
   // ─── Fetch ────────────────────────────────────────────────────────────────
 
-  const API_BASE = `${window.__METRICS_BASE__ || ""}/metrics`;
+  function getApiBase() {
+    return `${window.__METRICS_BASE__ || ""}/metrics`;
+  }
+
+  /**
+   * Runs an ordered list of `{ url, parse, onError? }` entries one at a time —
+   * the next entry's `fetchImpl` call isn't issued until the previous entry's
+   * promise (fetch + parse) has settled. Pure and DOM-free: takes an
+   * injectable `fetchImpl` so it's unit-testable without browser globals.
+   *
+   * Per-entry error handling: if `onError` is provided, a rejection from
+   * either `fetchImpl(url)` or `parse(response)` is passed to it and its
+   * return value becomes that entry's result (e.g. fall back to null).
+   * Without `onError`, a rejection propagates immediately and aborts any
+   * remaining entries — matching a plain `await` with no `.catch()`.
+   */
+  async function fetchSequential(entries, fetchImpl) {
+    const results = [];
+    for (const { url, parse, onError } of entries) {
+      try {
+        const response = await fetchImpl(url);
+        results.push(await parse(response));
+      } catch (err) {
+        if (!onError) throw err;
+        results.push(onError(err));
+      }
+    }
+    return results;
+  }
 
   async function fetchAll(range) {
+    const API_BASE = getApiBase();
     const q = buildQuery(range);
     const [summary, trends, featuresRes, queueRes, tokensRes] =
-      await Promise.all([
-        fetch(`${API_BASE}/summary?${q}`).then((r) => r.json()),
-        fetch(`${API_BASE}/trends?${q}&groupBy=${groupByForRange(range)}`).then(
-          (r) => r.json(),
-        ),
-        fetch(`${API_BASE}/features?${q}`)
-          .then((r) => r.json())
-          .catch((err) => {
-            console.error("Features fetch failed:", err);
-            return null;
-          }),
-        fetch(`${API_BASE}/queue?${q}`)
-          .then((r) => r.json())
-          .catch((err) => {
-            console.error("Queue fetch failed:", err);
-            return null;
-          }),
-        fetch(`${API_BASE}/tokens?${q}`)
-          .then((r) => r.json())
-          .catch((err) => {
-            console.error("Tokens fetch failed:", err);
-            return null;
-          }),
-      ]);
+      await fetchSequential(
+        [
+          { url: `${API_BASE}/summary?${q}`, parse: (r) => r.json() },
+          {
+            url: `${API_BASE}/trends?${q}&groupBy=${groupByForRange(range)}`,
+            parse: (r) => r.json(),
+          },
+          {
+            url: `${API_BASE}/features?${q}`,
+            parse: (r) => r.json(),
+            onError: (err) => {
+              console.error("Features fetch failed:", err);
+              return null;
+            },
+          },
+          {
+            url: `${API_BASE}/queue?${q}`,
+            parse: (r) => r.json(),
+            onError: (err) => {
+              console.error("Queue fetch failed:", err);
+              return null;
+            },
+          },
+          {
+            url: `${API_BASE}/tokens?${q}`,
+            parse: (r) => r.json(),
+            onError: (err) => {
+              console.error("Tokens fetch failed:", err);
+              return null;
+            },
+          },
+        ],
+        fetch,
+      );
     // Cost efficiency is only fetched on the public (read-only) dashboard,
     // guarded by element presence so the authenticated page never fetches it.
     const costEffEl = document.getElementById('cost-efficiency-section');
@@ -1030,12 +1069,24 @@
 
   // ─── Boot ─────────────────────────────────────────────────────────────────
 
-  document.addEventListener("DOMContentLoaded", () => {
-    const activeBtn = document.querySelector(".date-btn.active");
-    if (activeBtn) currentRange = rangeFromButton(activeBtn);
-    initDateRangePicker();
-    initMetricClicks();
-    initTokenTrendsToggles();
-    refresh();
-  });
+  // Guarded so this file can be `import`-ed under bun:test (no DOM globals)
+  // purely to reach the pure fetchSequential helper below — see the test-only
+  // export block at the bottom of this IIFE.
+  if (typeof window !== "undefined") {
+    document.addEventListener("DOMContentLoaded", () => {
+      const activeBtn = document.querySelector(".date-btn.active");
+      if (activeBtn) currentRange = rangeFromButton(activeBtn);
+      initDateRangePicker();
+      initMetricClicks();
+      initTokenTrendsToggles();
+      refresh();
+    });
+  } else {
+    // Test-only escape hatch: app.js is loaded as a plain (non-module)
+    // browser <script>, so it can't use `export`. Under bun:test there's no
+    // `window`, so instead of booting the dashboard we expose the pure,
+    // DOM-free fetchSequential helper on globalThis for
+    // app.unit.test.js to import and exercise directly.
+    globalThis.__dashboardAppTestExports = { fetchSequential };
+  }
 })();

--- a/metrics/src/dashboard/app.unit.test.js
+++ b/metrics/src/dashboard/app.unit.test.js
@@ -1,0 +1,160 @@
+/**
+ * metrics/src/dashboard/app.unit.test.js
+ * Unit tests for the pure fetch-sequencing helper extracted from app.js
+ * (fetchSequential). app.js is a plain browser `<script>` (not an ES module,
+ * no DOM globals touched outside DOMContentLoaded) — importing it for its
+ * side effect exposes the pure helper on `globalThis.__dashboardAppTestExports`
+ * only when `window` is undefined (i.e. under bun:test), so this file needs
+ * no DOM/browser globals to run.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+
+let fetchSequential;
+
+beforeAll(async () => {
+  await import("./app.js");
+  ({ fetchSequential } = globalThis.__dashboardAppTestExports);
+});
+
+describe("fetchSequential", () => {
+  test("issues requests strictly sequentially — the 2nd request isn't issued until the 1st settles", async () => {
+    const callOrder = [];
+    let resolveFirst;
+    const firstPromise = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const fakeFetch = (url) => {
+      callOrder.push(url);
+      if (url === "/one") {
+        return firstPromise.then(() => ({
+          json: async () => ({ id: "one" }),
+        }));
+      }
+      return Promise.resolve({ json: async () => ({ id: url }) });
+    };
+
+    const entries = [
+      { url: "/one", parse: (r) => r.json() },
+      { url: "/two", parse: (r) => r.json() },
+      { url: "/three", parse: (r) => r.json() },
+    ];
+
+    const resultPromise = fetchSequential(entries, fakeFetch);
+
+    // Only the first request should have been issued so far — the second
+    // must not fire until the first request's promise settles.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(callOrder).toEqual(["/one"]);
+
+    resolveFirst();
+    const results = await resultPromise;
+
+    expect(callOrder).toEqual(["/one", "/two", "/three"]);
+    expect(results).toEqual([{ id: "one" }, { id: "/two" }, { id: "/three" }]);
+  });
+
+  test("a per-entry onError fallback (e.g. to null) does not abort subsequent requests", async () => {
+    const callOrder = [];
+    const fakeFetch = (url) => {
+      callOrder.push(url);
+      if (url === "/fails") {
+        return Promise.reject(new Error("boom"));
+      }
+      return Promise.resolve({ json: async () => ({ ok: url }) });
+    };
+
+    const errors = [];
+    const entries = [
+      { url: "/before", parse: (r) => r.json() },
+      {
+        url: "/fails",
+        parse: (r) => r.json(),
+        onError: (err) => {
+          errors.push(err);
+          return null;
+        },
+      },
+      { url: "/after", parse: (r) => r.json() },
+    ];
+
+    const results = await fetchSequential(entries, fakeFetch);
+
+    expect(callOrder).toEqual(["/before", "/fails", "/after"]);
+    expect(results).toEqual([{ ok: "/before" }, null, { ok: "/after" }]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect(errors[0].message).toBe("boom");
+  });
+
+  test("an entry without onError propagates its rejection (matches summary/trends' uncaught behavior)", async () => {
+    const fakeFetch = (url) => {
+      if (url === "/summary") return Promise.reject(new Error("summary down"));
+      return Promise.resolve({ json: async () => ({ ok: true }) });
+    };
+
+    const entries = [{ url: "/summary", parse: (r) => r.json() }];
+
+    await expect(fetchSequential(entries, fakeFetch)).rejects.toThrow(
+      "summary down",
+    );
+  });
+
+  test("a rejection with no onError still stops later entries from being issued (propagates immediately)", async () => {
+    const callOrder = [];
+    const fakeFetch = (url) => {
+      callOrder.push(url);
+      if (url === "/summary") return Promise.reject(new Error("summary down"));
+      return Promise.resolve({ json: async () => ({ ok: true }) });
+    };
+
+    const entries = [
+      { url: "/summary", parse: (r) => r.json() },
+      { url: "/trends", parse: (r) => r.json() },
+    ];
+
+    await expect(fetchSequential(entries, fakeFetch)).rejects.toThrow(
+      "summary down",
+    );
+    expect(callOrder).toEqual(["/summary"]);
+  });
+
+  test("parse errors also route through onError when provided", async () => {
+    const fakeFetch = () =>
+      Promise.resolve({
+        json: async () => {
+          throw new Error("bad json");
+        },
+      });
+
+    const errors = [];
+    const entries = [
+      {
+        url: "/queue",
+        parse: (r) => r.json(),
+        onError: (err) => {
+          errors.push(err);
+          return null;
+        },
+      },
+    ];
+
+    const results = await fetchSequential(entries, fakeFetch);
+    expect(results).toEqual([null]);
+    expect(errors).toHaveLength(1);
+  });
+
+  test("empty entries resolves to an empty array without calling fetch", async () => {
+    let called = false;
+    const fakeFetch = () => {
+      called = true;
+      return Promise.resolve({ json: async () => ({}) });
+    };
+
+    const results = await fetchSequential([], fakeFetch);
+    expect(results).toEqual([]);
+    expect(called).toBe(false);
+  });
+});

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -31,6 +31,14 @@ const EXCLUDE_PREFIXES = [
   "scripts/seed-task-store-token.ts",
   "scripts/seed-chat-tokens.ts",
   "scripts/seed-dev-agent.ts",
+
+  // Browser-loaded dashboard client — a plain (non-module) <script>, mostly
+  // DOM manipulation and chart rendering with no in-process request seam to
+  // unit test. Its pure, injectable-fetch logic (fetchSequential) is
+  // unit-tested via a guarded test-only export (see app.unit.test.js); that
+  // export requires importing the whole file, which would otherwise drag
+  // ~1000 lines of untestable DOM code into the aggregate gate.
+  "metrics/src/dashboard/app.js",
 ];
 
 // Paths containing this substring are excluded regardless of prefix


### PR DESCRIPTION
## Summary
- Change `fetchAll()` in `metrics/src/dashboard/app.js` to issue its 5 section requests (summary, trends, features, queue, tokens) sequentially instead of via `Promise.all`, reducing concurrent downstream DB connection pressure on task-store per dashboard load/refresh.
- Extract the ordered fetch-and-parse sequence into a pure, DOM-free `fetchSequential(entries, fetchImpl)` helper that takes an injectable fetch implementation, making it unit-testable without browser globals.
- Add `metrics/src/dashboard/app.unit.test.js` (net-new — this file previously had zero test coverage) covering strict sequential ordering, per-endpoint error fallback, and uncaught-rejection propagation.
- Exclude `metrics/src/dashboard/app.js` from the aggregate coverage gate (`scripts/check-coverage.ts`): reaching the new test-only export requires importing the whole file, which would otherwise drag ~1000 lines of untested DOM/chart-rendering code into the aggregate and fail CI.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `fetchAll(range)` issues its 5 section requests sequentially; existing per-endpoint error handling (catch-and-null for features/queue/tokens, uncaught for summary/trends) preserved exactly | MET |
| 2 | Ordered fetch-and-parse sequence extracted into a small pure helper accepting an injectable fetch implementation | MET |
| 3 | New `app.unit.test.js` validates sequential (non-concurrent) issuance and that a per-endpoint failure doesn't abort subsequent requests | MET |
| 4 | Conditional cost-efficiency fetch (guarded by `#cost-efficiency-section`) unchanged, still runs after the main sequence | MET |
| 5 | No existing tests retired — net-new coverage | MET |

## Test Plan
- `bun test` — 4748 pass / 0 fail (full repo suite)
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean
- `bun run scripts/check-coverage.ts` — aggregate gate passes (80.71% lines / 81.11% functions, matching main)
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- `bun scripts/check-config-docs.ts` — clean
- `bun run scripts/sync-version.ts --check` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
