### PR TITLE
docs: add day-to-day operations quick-start guide

### DIFF
--- a/site/src/content/docs/day-to-day-operations.mdx
+++ b/site/src/content/docs/day-to-day-operations.mdx
@@ -38,9 +38,9 @@ Once you have console access, work through this list before leaving the agent un
    expect is turned on. A standalone phase cron with `shipwright-loop` disabled is inert, so if
    nothing seems to be happening, that's the first thing to check.
 3. **Read the first cron logs.** Open `/admin/agents/:id/cron-logs` to see the run history for
-   every cron the agent owns — each run shows an outcome (`posted`, `dm`, `silent`, `skipped`, or
-   `error`), start time, duration, and (when the run dispatched work) the task or PR it acted on.
-   Filter by `?cronId=` or `?outcome=` to narrow the view.
+   every cron the agent owns — each run shows an outcome (`completed`, `failed`, or `skipped`),
+   start time, duration, and (when the run dispatched work) the task or PR it acted on. Filter by
+   `?cronId=` or `?outcome=` to narrow the view.
 4. **Check the work queue.** `/admin/agents/:id/work-queue` shows the agent's latest self-reported
    ranked queue — the tasks and PRs it sees as pending work, oldest first, across the dev-task,
    review, patch, and deploy phases. An empty queue with no snapshot yet usually means the agent
@@ -65,17 +65,17 @@ three things: cron health, the open-PR queue, and HITL escalations.
 `/admin/agents/:id/cron-logs` is the single place to check whether the agent's crons are actually
 running and doing useful work. Each row is one cron run, with:
 
-- **Outcome** — `posted` (result sent to a channel), `dm` (result sent as a direct message),
-  `silent` (nothing worth reporting), `skipped` (the run didn't execute — hover the badge for the
-  skip reason), or `error` (the run failed — hover the badge for the error message).
+- **Outcome** — `completed` (the run finished normally), `failed` (the run errored — hover the
+  badge for the error message), or `skipped` (the run didn't execute — hover the badge for the
+  skip reason).
 - **Owning cron, start time, duration, and — when the run dispatched against a task or PR — which
   one.**
 
-Use the `?cronId=` and `?outcome=` query filters to narrow down to, for example, only `error`
-outcomes, or only runs from `shipwright-loop`. A steady stream of `error` outcomes on the same
-cron is the clearest signal something needs attention. The agent detail page also surfaces each
-cron's last run time and outcome inline, so you can spot a stalled cron (no recent runs) without
-opening the full log.
+Use the `?cronId=` and `?outcome=` query filters to narrow down to, for example, only `failed`
+runs, or only runs from `shipwright-loop`. A steady stream of `failed` outcomes on the same cron
+is the clearest signal something needs attention. The agent detail page also surfaces each cron's
+last run time and outcome inline, so you can spot a stalled cron (no recent runs) without opening
+the full log.
 
 ### Triaging the open-PR queue
 

--- a/site/src/content/docs/day-to-day-operations.mdx
+++ b/site/src/content/docs/day-to-day-operations.mdx
@@ -1,0 +1,131 @@
+---
+title: Day-to-Day Operations
+description: The operator quick-start — what you need, a first-day checklist, and the ongoing loop of checking cron health, triaging the PR queue, and responding to HITL escalations.
+section: Operations
+order: 2
+prev: "/docs/slack-integration"
+---
+
+# Day-to-Day Operations
+
+This is the operator quick-start for running a live Shipwright agent day to day. It covers what
+you need before you start, a first-day checklist, and the ongoing loop you'll repeat once the
+agent is running: checking cron health, triaging the open-PR queue, and noticing and responding
+to human-in-the-loop (HITL) escalations.
+
+## What you need
+
+- **A live, provisioned agent.** Either a managed agent provisioned via `/admin/provision` (see
+  [Slack Integration](/docs/slack-integration) for the Slack setup portion) or a self-hosted agent
+  running through `task stack` / a manual deployment (see
+  [Deploying to Cloud](/docs/deploying-to-cloud)).
+- **Admin console access.** The admin UI is at `/admin`, authenticated via Google OAuth. You need
+  an account allowed by the admin service's configured access list to sign in.
+- **Slack access, if the agent is Slack-connected.** Optional — only needed if the agent posts
+  cron results and takes DMs/mentions through Slack, as covered in
+  [Slack Integration](/docs/slack-integration). An agent can also run without Slack, driven
+  through the admin console's Chat tab instead.
+
+## Day one checklist
+
+Once you have console access, work through this list before leaving the agent unattended:
+
+1. **Find your agent.** Go to `/admin/agents` and open your agent's detail page
+   (`/admin/agents/:id`) to confirm it exists and see its configuration.
+2. **Check which crons are enabled.** The agent detail page lists its cron jobs. Pipeline phase
+   crons (`shipwright-dev-task`, `shipwright-review`, `shipwright-patch`, `shipwright-deploy`) and
+   the `shipwright-loop` orchestrator are the ones that drive autonomous work — confirm the set you
+   expect is turned on. A standalone phase cron with `shipwright-loop` disabled is inert, so if
+   nothing seems to be happening, that's the first thing to check.
+3. **Read the first cron logs.** Open `/admin/agents/:id/cron-logs` to see the run history for
+   every cron the agent owns — each run shows an outcome (`posted`, `dm`, `silent`, `skipped`, or
+   `error`), start time, duration, and (when the run dispatched work) the task or PR it acted on.
+   Filter by `?cronId=` or `?outcome=` to narrow the view.
+4. **Check the work queue.** `/admin/agents/:id/work-queue` shows the agent's latest self-reported
+   ranked queue — the tasks and PRs it sees as pending work, oldest first, across the dev-task,
+   review, patch, and deploy phases. An empty queue with no snapshot yet usually means the agent
+   hasn't ticked since this feature shipped, or `shipwright-loop` isn't enabled.
+5. **Look at open PRs.** `/admin/prs` lists PRs the agent has opened or is tracking, filterable by
+   `?state=`, `?reviewState=`, `?repo=`, and `?taskId=`. Skim it so you know what's in flight.
+6. **Look at tasks with an HITL gate.** `/admin/tasks?hitl=true` filters the task list to tasks
+   flagged `hitl: true`. If any are unfamiliar, open the task detail page
+   (`/admin/tasks/:id`) — it shows the raw `HITL: yes/no` field and, when the task is blocked, a
+   "Blocked Reason" field.
+7. **If Slack is connected, confirm you're in the loop.** Make sure you (or the right humans) are
+   in the channel or DM path the agent posts to, since that's how you'll hear about escalations —
+   see the "Noticing and responding to a HITL escalation" section below.
+
+## The ongoing loop
+
+Once the agent is up and running, day-to-day operation is mostly a light, recurring check across
+three things: cron health, the open-PR queue, and HITL escalations.
+
+### Reading cron health
+
+`/admin/agents/:id/cron-logs` is the single place to check whether the agent's crons are actually
+running and doing useful work. Each row is one cron run, with:
+
+- **Outcome** — `posted` (result sent to a channel), `dm` (result sent as a direct message),
+  `silent` (nothing worth reporting), `skipped` (the run didn't execute — hover the badge for the
+  skip reason), or `error` (the run failed — hover the badge for the error message).
+- **Owning cron, start time, duration, and — when the run dispatched against a task or PR — which
+  one.**
+
+Use the `?cronId=` and `?outcome=` query filters to narrow down to, for example, only `error`
+outcomes, or only runs from `shipwright-loop`. A steady stream of `error` outcomes on the same
+cron is the clearest signal something needs attention. The agent detail page also surfaces each
+cron's last run time and outcome inline, so you can spot a stalled cron (no recent runs) without
+opening the full log.
+
+### Triaging the open-PR queue
+
+`/admin/prs` is the queue view. Filter by `?state=` to see what's open vs. merged/closed, by
+`?reviewState=` to see what's pending review vs. already reviewed, and by `?repo=` or `?taskId=`
+to scope to a specific repository or task. Opening a PR row (`/admin/prs/:id`) shows its detail —
+useful for checking whether a PR has been sitting in the same review state longer than expected,
+or whether it's linked back to the task that produced it.
+
+The work-queue view (`/admin/agents/:id/work-queue`) complements this: it's the agent's own
+ranked view of what it intends to work on next, oldest first, across all four pipeline phases —
+handy for confirming the agent agrees with what you see in the PR list.
+
+### Noticing and responding to a HITL escalation
+
+Some tasks and PRs require a human before the agent can proceed — the `hitl: true` field marks
+these. This is a real gap worth understanding precisely, because there's no automated push
+notification built into the platform beyond the agent's own message:
+
+- **`hitl: true` with no notification sent yet** is an agent-actionable block — a properly
+  functioning agent is expected to post a message (typically to Slack) flagging the situation,
+  then record that it notified you.
+- **`hitl: true` with a notification already sent** means the agent has already flagged it and is
+  passively waiting on a human action.
+
+Several pipeline steps set `hitl: true` automatically on failure — for example, a post-merge CI
+failure, a deploy-stage or canary failure, a pipeline timeout, or an unresolved second round of
+review disagreement during patching.
+
+In practice, today, the two ways to notice an escalation are:
+
+1. **Watch for the agent's own Slack message.** If the agent is Slack-connected, this is usually
+   the first signal — it should post to its configured channel or DM you directly when it hits a
+   HITL gate.
+2. **Periodically check the admin console.** `/admin/tasks?hitl=true` filters to every task with
+   the HITL flag set. The task list shows a "Waiting: HITL" badge, though that badge alone doesn't
+   distinguish "notification already sent" from "notification still pending" — open the task
+   detail page (`/admin/tasks/:id`) for that distinction: it shows either "HITL gate (notification
+   sent — awaiting clearance)" or "HITL gate (notification pending)" under Blockers. `/admin/prs`
+   surfaces the same signal for PR-level blocks.
+
+Once you've picked up the escalation, `/shipwright:hitl {task-id}` is the command to run locally in
+Claude Code to work through it: it loads the task's context (including any `## Human steps`
+section), assists hands-on with infra execution (Terraform, Helm, kubectl, gcloud, and similar
+tooling are all fair game), and marks the task done in the task store once you confirm you're
+finished.
+
+## Next steps
+
+- Deep-dive the platform's underlying model — see [The Agent](/docs/the-agent) for cron internals
+  and the Prisma data model.
+- Revisit [Slack Integration](/docs/slack-integration) if you're still setting up how the agent
+  communicates with your team.

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -88,3 +88,6 @@ Once you have the local setup running, you can:
   See [The Plugin](/docs/the-plugin) for the full reference.
 - **Deploy to cloud** — run Shipwright as an always-on autonomous agent. See
   [Deploying to Cloud](/docs/deploying-to-cloud) for the full container setup.
+- **Learn the operator loop** — once an agent is live, see
+  [Day-to-Day Operations](/docs/day-to-day-operations) for the quick-start on cron health, PR
+  triage, and HITL escalations.

--- a/site/src/content/docs/slack-integration.mdx
+++ b/site/src/content/docs/slack-integration.mdx
@@ -4,6 +4,7 @@ description: Connect the Shipwright agent to Slack — Socket Mode setup, DMs, m
 section: Operations
 order: 1
 prev: "/docs/deploying-to-cloud"
+next: "/docs/day-to-day-operations"
 ---
 
 # Slack Integration

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -21,7 +21,7 @@ const personas = [
     title: "Operate",
     description:
       "Deploy Shipwright as a cloud agent and run it autonomously on a schedule in your infrastructure.",
-    link: "/docs/deploying-to-cloud",
+    link: "/docs/day-to-day-operations",
   },
 ];
 ---

--- a/site/tests/docs-day-to-day-operations.spec.ts
+++ b/site/tests/docs-day-to-day-operations.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+
+// Fulfill external font CDN requests immediately so the page's 'load' event
+// fires even when CI can't reach external networks.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
+    (route) =>
+      route.fulfill({ status: 200, contentType: "text/css", body: "" }),
+  );
+});
+
+// Day-to-day operations quick-start guide page tests (UDG-1.1)
+
+test("GET /docs/day-to-day-operations returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/day-to-day-operations");
+  expect(response?.status()).toBe(200);
+});
+
+test("day-to-day-operations page has h1 heading", async ({ page }) => {
+  await page.goto("/docs/day-to-day-operations");
+  const h1 = page.locator("h1");
+  await expect(h1).toBeVisible();
+});
+
+test("day-to-day-operations sidebar is present", async ({ page }) => {
+  await page.goto("/docs/day-to-day-operations");
+  const sidebar = page.locator("nav[aria-label='Docs navigation']");
+  await expect(sidebar).toBeVisible();
+});
+
+test("day-to-day-operations page has key section headings", async ({ page }) => {
+  await page.goto("/docs/day-to-day-operations");
+  // What you need section
+  const needHeading = page.locator("h2", { hasText: /what you need/i });
+  await expect(needHeading.first()).toBeVisible();
+  // Day one checklist section
+  const checklistHeading = page.locator("h2", { hasText: /day one checklist/i });
+  await expect(checklistHeading.first()).toBeVisible();
+  // Ongoing loop section
+  const loopHeading = page.locator("h2", { hasText: /the ongoing loop/i });
+  await expect(loopHeading.first()).toBeVisible();
+});
+
+test("day-to-day-operations page covers cron health, PR queue, and HITL", async ({
+  page,
+}) => {
+  await page.goto("/docs/day-to-day-operations");
+  const cronHeading = page.locator("h3, h2", { hasText: /cron health/i });
+  await expect(cronHeading.first()).toBeVisible();
+  const prQueueHeading = page.locator("h3, h2", { hasText: /pr queue/i });
+  await expect(prQueueHeading.first()).toBeVisible();
+  const hitlHeading = page.locator("h3, h2", { hasText: /hitl/i });
+  await expect(hitlHeading.first()).toBeVisible();
+});
+
+test("day-to-day-operations prev/next navigation links", async ({ page }) => {
+  await page.goto("/docs/day-to-day-operations");
+  // prev → slack-integration
+  const prevLink = page.locator("a[data-nav='prev']");
+  await expect(prevLink).toBeVisible();
+  expect(await prevLink.getAttribute("href")).toBe("/docs/slack-integration");
+});
+
+test("slack-integration page now links forward to day-to-day-operations", async ({
+  page,
+}) => {
+  await page.goto("/docs/slack-integration");
+  const nextLink = page.locator("a[data-nav='next']");
+  await expect(nextLink).toBeVisible();
+  expect(await nextLink.getAttribute("href")).toBe(
+    "/docs/day-to-day-operations",
+  );
+});

--- a/site/tests/docs-platform.spec.ts
+++ b/site/tests/docs-platform.spec.ts
@@ -278,15 +278,18 @@ test("key headings visible in slack-integration page", async ({ page }) => {
   await expect(markersHeading).toBeVisible();
 });
 
-test("prev/next navigation on slack-integration page (terminal page)", async ({ page }) => {
+test("prev/next navigation on slack-integration page", async ({ page }) => {
   await page.goto("/docs/slack-integration");
   // prev → deploying-to-cloud
   const prevLink = page.locator("a[data-nav='prev']");
   await expect(prevLink).toBeVisible();
   expect(await prevLink.getAttribute("href")).toBe("/docs/deploying-to-cloud");
-  // no next link — slack-integration is the terminal page; no broken/empty href allowed
+  // next → day-to-day-operations (UDG-1.1) — slack-integration is no longer terminal
   const nextLink = page.locator("a[data-nav='next']");
-  await expect(nextLink).toHaveCount(0);
+  await expect(nextLink).toBeVisible();
+  expect(await nextLink.getAttribute("href")).toBe(
+    "/docs/day-to-day-operations",
+  );
 });
 
 test("mobile sidebar slides in when toggle is tapped", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add `site/src/content/docs/day-to-day-operations.mdx` — the operator quick-start covering what you need to get started, a first-day checklist, and the ongoing loop (cron health, PR queue triage, HITL escalation response)
- Wire up cross-links: `slack-integration.mdx` now has `next:` pointing here, `getting-started.mdx`'s Next steps links here, and the `/docs` landing page's "Operate" persona card now points here instead of `deploying-to-cloud`
- Every operational claim in the new page is grounded in actual source (admin routes in `admin/src/admin-ui.ts`, rendering in `admin/src/admin-ui-pages.ts`, HITL semantics in `task-store/src/blocked-by.ts`, and `plugins/shipwright/commands/hitl.md`) — a follow-up commit corrected an initial inaccuracy about cron run outcome values (`completed`/`failed`/`skipped`, not `posted`/`dm`/`silent`/`skipped`/`error`)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New page exists, section: Operations, order: 2, renders at /docs/day-to-day-operations | MET |
| 2 | Every operational claim verified against actual source, no invented UI elements | MET |
| 3 | slack-integration.mdx `next` field + getting-started.mdx Next steps + docs/index.astro Operate card updated | MET |
| 4 | site/tests/docs-day-to-day-operations.spec.ts added (e2e), no existing tests retired | MET |

## Test Plan
- New Playwright spec `site/tests/docs-day-to-day-operations.spec.ts` asserts 200 status, h1, sidebar, key section headings, and prev/next nav links
- Existing `docs-platform.spec.ts` slack-integration nav test updated (not deleted) to reflect the new forward link
- `npm run build:check` (astro build + brand-lint) passes clean
- `task check-strings` passes
- `bunx biome check` passes on changed files
- [x] Pre-commit checks passing

Note: Playwright's browser could not launch in the implementation sandbox (missing system lib, no root access) — verified equivalent assertions via built HTML output and a live `astro preview` curl instead. CI installs chromium with full system deps and should run the new spec directly.

Generated with [Claude Code](https://claude.com/claude-code)
