### PR TITLE
docs: refresh stale references for 2026-07-21 sync

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -155,7 +155,7 @@ Clears `claimedBy`, `claimedAt`, and `heartbeatAt`, resets `status=pending`. Use
 POST /tasks/:id/skip
 ```
 
-Increments `skipCount` by 1 and updates `lastSkippedAt` to now. When `skipCount` crosses the threshold (3, matching `SPIN_DETECTION_THRESHOLD`), automatically sets `hitl=true` and `blockedReason="Repeated no-op dispatch"` to halt further dispatches. Called by orchestrators that detect a task is being repeatedly re-selected but produces no visible outcome ([silent] dispatch). Returns `200` with the updated task.
+Increments `skipCount` by 1 and updates `lastSkippedAt` to now. When `skipCount` crosses the threshold (3, matching `SPIN_DETECTION_THRESHOLD`), automatically sets `hitl=true` and `blockedReason="Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)"` to halt further dispatches. Called by orchestrators that detect a task is being repeatedly re-selected but produces no visible outcome ([silent] dispatch). Returns `200` with the updated task.
 
 #### Reset skip tracking
 
@@ -282,7 +282,7 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 | `POST /prs/:id/complete` | `reviewState=posted`, increment `reviewCycles`, set `reviewedAt` |
 | `POST /prs/:id/patch` | Increment `patchCycles`, set `patchedAt`, clear `claimedBy`/`claimedAt`/`heartbeatAt`/`phase`. Conditionally reset `reviewState=pending` based on optional `commitSha` in body: if omitted, unconditionally reset to pending; if provided and differs from record's stored `commitSha`, reset to pending and update `commitSha`; if provided and matches, leave `reviewState` untouched (no-op patch cycle). |
 | `POST /prs/:id/release` | Clear `claimedBy`/`claimedAt`/`heartbeatAt`. Resets `reviewState=pending` unless it is already a terminal value (`posted`/`approved`), in which case `reviewState` is left untouched |
-| `POST /prs/:id/skip` | Increment `skipCount`, update `lastSkippedAt` to now. When `skipCount` crosses threshold (3), auto-set `hitl=true` and `blockedReason="Repeated no-op dispatch"` |
+| `POST /prs/:id/skip` | Increment `skipCount`, update `lastSkippedAt` to now. When `skipCount` crosses threshold (3), auto-set `hitl=true` and `blockedReason="Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)"` |
 | `POST /prs/:id/skip/reset` | Reset `skipCount` back to 0 and clear `lastSkippedAt` |
 
 #### PR state enums
@@ -299,7 +299,7 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 
 `blockedReason`: optional string — human-readable explanation for why this PR is blocked and requires human intervention (e.g., `"no linked task"`, `"second-round disagreement between reviewer and automated fix"`). Set via `PATCH /prs/:id`.
 
-`skipCount`: integer (default `0`) — consecutive count of times this PR has been dispatched but produced no visible outcome ([silent] dispatch). Incremented by `POST /prs/:id/skip`; reset by `POST /prs/:id/skip/reset`. When it crosses the threshold (3, matching `SPIN_DETECTION_THRESHOLD`), the service auto-sets `hitl=true` and `blockedReason="Repeated no-op dispatch"` to prevent infinite spin loops.
+`skipCount`: integer (default `0`) — consecutive count of times this PR has been dispatched but produced no visible outcome ([silent] dispatch). Incremented by `POST /prs/:id/skip`; reset by `POST /prs/:id/skip/reset`. When it crosses the threshold (3, matching `SPIN_DETECTION_THRESHOLD`), the service auto-sets `hitl=true` and `blockedReason="Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)"` to prevent infinite spin loops.
 
 `lastSkippedAt`: optional ISO timestamp — records when the most recent skip was recorded. Updated by `POST /prs/:id/skip`, cleared by `POST /prs/:id/skip/reset`.
 


### PR DESCRIPTION
## Summary

Automated docs-freshness sync since anchor `533c99ca` (last synced 2026-07-20).

- **`docs/task-store.md`**: fixed the documented `blockedReason` string for the skip-tracking auto-block feature. The doc claimed `blockedReason="Repeated no-op dispatch"` in three places (task skip endpoint, PR skip endpoint, `skipCount` field description), but the actual message set by `task-store/src/pull-request-service.ts` and `task-store/src/task-service.ts` is:
  ```
  Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)
  ```
  Verified directly against `SKIP_BLOCK_THRESHOLD` usage in both service files.

Everything else checked against the diff since the anchor (`docs/agent.md`, `docs/agent-api.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/extending.md`, `docs/metrics.md`, `docs/observability.md`, `docs/migration.md`) was already current — several recent PRs (e.g. #2080's Blocked-tab/hitl-badge work, the CBD-2.2 redispatch-cooldown feature, the CHU-2.3 `/release` reviewState fix) already landed with in-sync doc updates.

## Follow-up candidates (not filed, per docs-freshness cron policy — flagging only)

- `agent/src/claude.ts`'s new streaming `stream-json`/`ClaudeRunResult.streamIncomplete` behavior (CSU-1.1) has no doc coverage at all in `docs/agent.md`.
- `metrics/src/lib/coalescing-cache.ts` (new single-flight cache backing `TaskStoreProvider`) isn't in `docs/metrics.md`'s Key Files table.
- `docs/architecture.md`'s skill/command lists are missing several skills/commands that predate this sync's anchor (`canary-execution`, `error-resolve`, `repo-config`, `speed-budgets`, `brainstorm`, `hitl`, `learn`) — pre-existing gap, not introduced by this diff.
- `docs/README.md`'s Contents list is missing links to several existing docs (`agent-api.md`, `task-store.md`, `chat.md`, `mcp-tools.md`, `extending.md`, `helm-repo.md`, `migration.md`, `consolidation.md`) — pre-existing gap.

## Test plan

- [x] Docs-only change; no code affected.
- [x] Verified new wording against live source (`pull-request-service.ts:729`, `task-service.ts:486`).