### PR TITLE
refactor(site): centralize REPO_URL/INSTALL_CMD/LICENSE_URL in consts.ts

### DIFF
--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -5,3 +5,28 @@
  * so a URL swap is one line here and the tests cannot drift from the source.
  */
 export const BOOKING_URL = "https://vitals-os.com/cal/book/discovery";
+
+/**
+ * Canonical GitHub repo URL.
+ *
+ * Single source of truth — was redeclared as a local const across multiple
+ * pages and layouts; centralized here so a repo move is one line, not five.
+ */
+export const REPO_URL = "https://github.com/app-vitals/shipwright";
+
+/**
+ * Canonical plugin install command shown in CTAs across the site.
+ *
+ * Single source of truth — was redeclared as a local const across multiple
+ * pages; centralized here so the command cannot drift between pages.
+ */
+export const INSTALL_CMD = "/plugin install shipwright@app-vitals/shipwright";
+
+/**
+ * Canonical URL to the repo's LICENSE file.
+ *
+ * Single source of truth — was redeclared as a local const across multiple
+ * pages and layouts; centralized here so a license-location change is one line.
+ */
+export const LICENSE_URL =
+  "https://github.com/app-vitals/shipwright/blob/main/LICENSE";

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -4,7 +4,7 @@
 // fonts load via plain <link rel="stylesheet"> and the glow orb is pure CSS.
 import "../styles/brand.css";
 import Analytics from "../components/Analytics.astro";
-import { BOOKING_URL } from "../consts";
+import { BOOKING_URL, LICENSE_URL, REPO_URL } from "../consts";
 
 interface Props {
   title?: string;
@@ -66,8 +66,6 @@ const structuredData = {
 };
 
 // Footer links (SWW-2.3): repo, license, platform, community.
-const repoUrl = "https://github.com/app-vitals/shipwright";
-const licenseUrl = "https://github.com/app-vitals/shipwright/blob/main/LICENSE";
 const claudeCodeUrl = "https://claude.com/claude-code";
 const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
 const compareUrl = "/compare";
@@ -185,7 +183,7 @@ const year = new Date().getFullYear();
         <a href={compareUrl} class="sw-label">Compare</a>
         <a href={vsDevinUrl} class="sw-label">vs Devin</a>
         <a href={architectureUrl} class="sw-label">Architecture</a>
-        <a href={repoUrl} class="sw-label">GitHub ↗</a>
+        <a href={REPO_URL} class="sw-label">GitHub ↗</a>
         <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a call</a>
       </nav>
 
@@ -220,7 +218,7 @@ const year = new Date().getFullYear();
           <a href={architectureUrl} class="sw-label">Architecture</a>
         </li>
         <li>
-          <a href={repoUrl} class="sw-label">GitHub ↗</a>
+          <a href={REPO_URL} class="sw-label">GitHub ↗</a>
         </li>
         <li>
           <a href={BOOKING_URL} class="sw-label">Book a call</a>
@@ -306,8 +304,8 @@ const year = new Date().getFullYear();
           Shipwright Harness · MIT-licensed · © {year}
         </p>
         <nav class="flex flex-wrap gap-x-6 gap-y-2 text-sm" aria-label="Footer">
-          <a href={repoUrl}>GitHub</a>
-          <a href={licenseUrl}>MIT License</a>
+          <a href={REPO_URL}>GitHub</a>
+          <a href={LICENSE_URL}>MIT License</a>
           <a href={claudeCodeUrl}>Claude Code</a>
           <a href={discussionsUrl}>GitHub Discussions</a>
           <a href={compareUrl}>Compare</a>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -8,7 +8,7 @@
 import { getCollection } from "astro:content";
 import "../styles/brand.css";
 import Analytics from "../components/Analytics.astro";
-import { BOOKING_URL } from "../consts";
+import { BOOKING_URL, LICENSE_URL, REPO_URL } from "../consts";
 
 interface Heading {
   depth: number;
@@ -65,8 +65,6 @@ const year = new Date().getFullYear();
 // Filter to headings depth 2 and 3 for the TOC.
 const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 
-const repoUrl = "https://github.com/app-vitals/shipwright";
-const licenseUrl = "https://github.com/app-vitals/shipwright/blob/main/LICENSE";
 const claudeCodeUrl = "https://claude.com/claude-code";
 const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
 ---
@@ -309,7 +307,7 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
       <nav class="hidden md:flex items-center gap-6" aria-label="Primary">
         <a href="/docs" class="sw-label">Docs</a>
         <a href="/compare" class="sw-label">Compare</a>
-        <a href={repoUrl} class="sw-label">GitHub ↗</a>
+        <a href={REPO_URL} class="sw-label">GitHub ↗</a>
         <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a call</a>
       </nav>
     </header>
@@ -341,7 +339,7 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
             <ul style="list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem;">
               <li><a href="/docs" class="docs-sidebar-link">Docs</a></li>
               <li><a href="/compare" class="docs-sidebar-link">Compare</a></li>
-              <li><a href={repoUrl} class="docs-sidebar-link">GitHub ↗</a></li>
+              <li><a href={REPO_URL} class="docs-sidebar-link">GitHub ↗</a></li>
               <li><a href={BOOKING_URL} class="docs-sidebar-link">Book a call</a></li>
             </ul>
           </nav>
@@ -470,8 +468,8 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
           Shipwright Harness · MIT-licensed · © {year}
         </p>
         <nav class="flex flex-wrap gap-x-6 gap-y-2 text-sm" aria-label="Footer">
-          <a href={repoUrl}>GitHub</a>
-          <a href={licenseUrl}>MIT License</a>
+          <a href={REPO_URL}>GitHub</a>
+          <a href={LICENSE_URL}>MIT License</a>
           <a href={claudeCodeUrl}>Claude Code</a>
           <a href={discussionsUrl}>GitHub Discussions</a>
           <a href={BOOKING_URL}>Book a call</a>

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -7,10 +7,7 @@
 // Claude-native. Zero runtime JS; all static HTML inlined at build time.
 // Brand tokens only.
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { BOOKING_URL } from "../consts";
-
-const repoUrl = "https://github.com/app-vitals/shipwright";
-const installCmd = "/plugin install shipwright@app-vitals/shipwright";
+import { BOOKING_URL, INSTALL_CMD, REPO_URL } from "../consts";
 
 // Market structure: 3-pole framing of the AI coding agent space.
 // Shipwright occupies the middle pole — team AI workflow, not copilot UX
@@ -489,9 +486,9 @@ helm install shipwright shipwright/shipwright</code></pre>
       Install the plugin into Claude Code and run a task end to end. Free, MIT,
       runs on your own infra.
     </p>
-    <pre class="sw-code mt-4 w-fit"><code>{installCmd}</code></pre>
+    <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
     <div class="mt-6 flex flex-wrap items-center gap-4">
-      <a href={repoUrl} class="sw-btn">View on GitHub ↗</a>
+      <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
       <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
     </div>
   </section>

--- a/site/src/pages/self-hosted.astro
+++ b/site/src/pages/self-hosted.astro
@@ -8,10 +8,8 @@
 // competitor-naming policy this page operates under. OpenCode is
 // deliberately not named (unverified — never-print list).
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { BOOKING_URL } from "../consts";
+import { BOOKING_URL, INSTALL_CMD, REPO_URL } from "../consts";
 
-const repoUrl = "https://github.com/app-vitals/shipwright";
-const installCmd = "/plugin install shipwright@app-vitals/shipwright";
 const verifiedDate = "July 14, 2026";
 
 // Sources (Appendix, devin-alternative-positioning-research.md).
@@ -178,9 +176,9 @@ const architectureRows = [
       Install the plugin into Claude Code and run a task end to end. Free,
       MIT, runs on your own infra.
     </p>
-    <pre class="sw-code mt-4 w-fit"><code>{installCmd}</code></pre>
+    <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
     <div class="mt-6 flex flex-wrap items-center gap-4">
-      <a href={repoUrl} class="sw-btn">View on GitHub ↗</a>
+      <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
       <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
     </div>
     <p class="mt-8 max-w-2xl">

--- a/site/src/pages/vs/devin.astro
+++ b/site/src/pages/vs/devin.astro
@@ -6,11 +6,8 @@
 // future edit — see brand/MESSAGING.md D10 for the surface-scoped
 // competitor-naming policy this page operates under.
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { BOOKING_URL } from "../../consts";
+import { BOOKING_URL, INSTALL_CMD, LICENSE_URL, REPO_URL } from "../../consts";
 
-const repoUrl = "https://github.com/app-vitals/shipwright";
-const installCmd = "/plugin install shipwright@app-vitals/shipwright";
-const licenseUrl = "https://github.com/app-vitals/shipwright/blob/main/LICENSE";
 const verifiedDate = "July 14, 2026";
 
 // Sources (Appendix, devin-alternative-positioning-research.md).
@@ -134,7 +131,7 @@ const comparisonRows = [
     <!-- License quote: the actual MIT license line from this repo. -->
     <div class="sw-callout mt-8 max-w-3xl">
       <p class="sw-mono text-sm" style="color: var(--sw-color-text-muted);">
-        From <a href={licenseUrl}>Shipwright's LICENSE</a>:
+        From <a href={LICENSE_URL}>Shipwright's LICENSE</a>:
       </p>
       <p class="mt-2">
         "Permission is hereby granted, free of charge, to any person
@@ -218,9 +215,9 @@ const comparisonRows = [
       Install the plugin into Claude Code and run a task end to end. Free,
       MIT, runs on your own infra.
     </p>
-    <pre class="sw-code mt-4 w-fit"><code>{installCmd}</code></pre>
+    <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
     <div class="mt-6 flex flex-wrap items-center gap-4">
-      <a href={repoUrl} class="sw-btn">View on GitHub ↗</a>
+      <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
       <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
     </div>
     <p class="mt-8 max-w-2xl">


### PR DESCRIPTION
## Summary
- Adds `REPO_URL`, `INSTALL_CMD`, and `LICENSE_URL` to `site/src/consts.ts`, following the same single-source-of-truth pattern as the existing `BOOKING_URL` export.
- Updates `compare.astro`, `self-hosted.astro`, `vs/devin.astro`, `BaseLayout.astro`, and `DocsLayout.astro` to import these constants instead of redeclaring identical local consts.
- Pure refactor — no rendered output changes; all string values are byte-identical to what was previously hardcoded.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `consts.ts` exports `REPO_URL`/`INSTALL_CMD`/`LICENSE_URL` with the exact same string values | ✅ Met |
| 2 | All 5 files import from `consts.ts` instead of declaring local consts | ✅ Met |
| 3 | No rendered HTML output changes | ✅ Met (build output byte-diffed identical before/after) |
| 4 | No new tests added; existing e2e specs must pass unchanged | ⚠️ See Test Plan note |

## Test Plan
- [x] `cd site && npm run build` — Astro build succeeds, 22 pages built
- [x] Built HTML output for all 5 affected routes (`/compare`, `/self-hosted`, `/vs/devin`, and pages using `BaseLayout`/`DocsLayout`) byte-diffed identical pre- and post-refactor
- [x] `task lint` — clean, no Biome findings
- [ ] `cd site && npm test` (Playwright e2e: `compare.spec.ts`, `self-hosted.spec.ts`, `vs-devin.spec.ts`, `home.spec.ts`, `booking-cta.spec.ts`) — **could not run in the dev sandbox**: Chromium fails to launch due to missing system shared libraries (`libglib-2.0.so.0`/`libnspr4.so`) with no root access to install them. This is a pre-existing sandbox limitation confirmed on both the base branch and this branch (identical failure mode). Please run `cd site && npm test` in CI/a full environment before merging to confirm the e2e suite is green.

Generated with [Claude Code](https://claude.com/claude-code)
