### PR TITLE
refactor(site): extract ComparisonTable/TryItCta/ChooseWhenGrid components

### DIFF
--- a/site/src/components/ChooseWhenGrid.astro
+++ b/site/src/components/ChooseWhenGrid.astro
@@ -1,0 +1,48 @@
+---
+// Shared two-card "Choose X when / Choose Y when" grid used across the
+// comparison pages (compare.astro x2, vs/devin.astro x1). Card order on the
+// page is left-to-right per the `cards` array — compare.astro always puts
+// the Shipwright card first, vs/devin.astro puts the competitor card first
+// — so this component does not hardcode which side is "Shipwright"; each
+// card carries its own label + labelColor. List items are plain strings
+// rendered as <li>; an item that needs inline markup (e.g. vs/devin.astro's
+// citation link inside one list item) can opt into set:html per-item via
+// `html: true` since that content is the page's own trusted static copy,
+// never user input.
+interface ListItem {
+  text: string;
+  // When true, `text` is raw trusted HTML and rendered via set:html instead
+  // of as plain text (needed for the one list item that embeds a citation
+  // <a> inline).
+  html?: boolean;
+}
+
+interface Card {
+  label: string;
+  labelColor: string;
+  items: ListItem[];
+}
+
+interface Props {
+  cards: [Card, Card];
+}
+
+const { cards } = Astro.props;
+---
+
+<div class="mt-8 grid gap-6 sm:grid-cols-2">
+  {cards.map((card) => (
+    <div class="sw-card">
+      <p class="sw-label" style={`color:${card.labelColor};`}>{card.label}</p>
+      <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
+        {card.items.map((item) =>
+          item.html ? (
+            <li set:html={item.text} />
+          ) : (
+            <li>{item.text}</li>
+          ),
+        )}
+      </ul>
+    </div>
+  ))}
+</div>

--- a/site/src/components/ComparisonTable.astro
+++ b/site/src/components/ComparisonTable.astro
@@ -1,0 +1,70 @@
+---
+// Shared table skeleton for the site's comparison pages (compare.astro,
+// self-hosted.astro, vs/devin.astro). The three source tables have distinct
+// column counts and per-cell markup (plain text, citation links, bold+span
+// combos), so this component DRYs the shared structural pieces —
+// table/thead/tbody scaffolding, header-cell styling, and the row
+// border/highlight pattern — while leaving each cell's exact style string
+// and markup page-owned (passed straight through) so the rendered output is
+// byte-identical to the hand-copied markup it replaces. Cell content is
+// pre-rendered HTML by the page (trusted static copy, never user input) and
+// injected with set:html so callers can compose arbitrary per-column markup
+// (spans, citation links, nested elements) without Astro's lack of
+// render-prop support getting in the way.
+interface Column {
+  label: string;
+  // Full inline style string for the <th>, exactly as the source page wrote
+  // it (kept page-owned since compare.astro's first-column left-padding and
+  // vs/devin.astro's brand-colored "Shipwright" header both need custom
+  // values that don't reduce to one shared formula).
+  style: string;
+}
+
+interface Cell {
+  // Full inline style string for the <td>, exactly as the source page wrote
+  // it (padding, color, white-space, etc. all vary per column/table).
+  style: string;
+  // Pre-rendered HTML for the cell body.
+  html: string;
+}
+
+interface Row {
+  cells: Cell[];
+  // Highlight this row as the "self" (Shipwright) row: brand-soft background
+  // on the row. compare.astro and self-hosted.astro use this; vs/devin.astro
+  // never sets it (its table has no highlighted row).
+  highlight?: boolean;
+}
+
+interface Props {
+  columns: Column[];
+  rows: Row[];
+}
+
+const { columns, rows } = Astro.props;
+---
+
+<div class="mt-6 overflow-x-auto">
+  <table style="width:100%; border-collapse:collapse;">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--sw-color-border-muted);">
+        {columns.map((col) => (
+          <th style={col.style}>
+            {col.label}
+          </th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map((row) => (
+        <tr
+          style={`border-bottom: 1px solid var(--sw-color-border-subtle);${row.highlight ? " background: var(--sw-color-brand-soft);" : ""}`}
+        >
+          {row.cells.map((cell) => (
+            <td style={cell.style} set:html={cell.html} />
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>

--- a/site/src/components/TryItCta.astro
+++ b/site/src/components/TryItCta.astro
@@ -1,0 +1,24 @@
+---
+// Shared "Try it" CTA section at the bottom of every comparison page
+// (compare.astro, self-hosted.astro, vs/devin.astro). The base CTA — h2,
+// paragraph, install command, GitHub + discovery-call buttons — is
+// byte-identical across all three. self-hosted.astro and vs/devin.astro
+// each append their own trailing-links paragraph after the CTA buttons;
+// compare.astro renders the bare CTA. That page-specific trailing markup is
+// supplied via the default slot so it stays page-owned.
+import { BOOKING_URL, INSTALL_CMD, REPO_URL } from "../consts";
+---
+
+<section id="cta" class="relative z-10 py-20 pb-24" style="border-top: 1px solid var(--sw-color-border-subtle);">
+  <h2>Try it</h2>
+  <p class="mt-3 max-w-2xl">
+    Install the plugin into Claude Code and run a task end to end. Free, MIT,
+    runs on your own infra.
+  </p>
+  <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
+  <div class="mt-6 flex flex-wrap items-center gap-4">
+    <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
+    <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
+  </div>
+  <slot />
+</section>

--- a/site/src/lib/html-escape.ts
+++ b/site/src/lib/html-escape.ts
@@ -1,0 +1,12 @@
+// Matches Astro's own text-node escaping for {expression} interpolation, so
+// components using set:html to compose per-cell/per-item markup (e.g.
+// ComparisonTable) produce the same entity-encoded output as plain JSX-style
+// interpolation would (e.g. "codebase Q&A" -> "Q&amp;A").
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -7,7 +7,9 @@
 // Claude-native. Zero runtime JS; all static HTML inlined at build time.
 // Brand tokens only.
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { BOOKING_URL, INSTALL_CMD, REPO_URL } from "../consts";
+import ChooseWhenGrid from "../components/ChooseWhenGrid.astro";
+import ComparisonTable from "../components/ComparisonTable.astro";
+import TryItCta from "../components/TryItCta.astro";
 
 // Market structure: 3-pole framing of the AI coding agent space.
 // Shipwright occupies the middle pole — team AI workflow, not copilot UX
@@ -148,7 +150,74 @@ const tableColumns = [
   { key: "cronScheduling", label: "Cron / Scheduling" },
   { key: "slackWorkflow", label: "Slack-Native Workflow" },
   { key: "testsFirst", label: "Tests-First Enforcement" },
-];
+] as const;
+
+// Matches Astro's own text-node escaping for {expression} interpolation so
+// set:html-rendered cells produce the same entity-encoded output as the
+// original JSX-interpolated markup (e.g. "codebase Q&A" -> Q&amp;A).
+function esc(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ComparisonTable props for the landscape table. Header/cell style strings
+// are reproduced exactly from the original hand-copied <table> markup.
+const landscapeColumns = tableColumns.map((col, i) => ({
+  label: col.label,
+  style: `text-align:left; padding:0.6rem 1rem 0.6rem ${i === 0 ? "0" : ""}; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;`,
+}));
+
+const landscapeRows = landscape.map((row) => ({
+  highlight: row.self,
+  cells: [
+    {
+      style: "padding:0.7rem 1rem 0.7rem 0; vertical-align:top;",
+      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${esc(row.tool)} </span>`,
+    },
+    {
+      style:
+        "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body); white-space:nowrap;",
+      html: esc(row.license),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.models),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.taskQueue),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.teamVisibility),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.policyControls),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.humanReviewGate),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.cronScheduling),
+    },
+    {
+      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.slackWorkflow),
+    },
+    {
+      style:
+        "padding:0.7rem 0 0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: esc(row.testsFirst),
+    },
+  ],
+}));
 ---
 
 <BaseLayout
@@ -217,45 +286,7 @@ const tableColumns = [
       Agents pull from a background task queue and land review-ready PRs, and the
       commercial tier is moving fast.
     </p>
-    <div class="mt-6 overflow-x-auto">
-      <table style="width:100%; border-collapse:collapse;">
-        <thead>
-          <tr style="border-bottom: 1px solid var(--sw-color-border-muted);">
-            {tableColumns.map((col, i) => (
-              <th
-                style={`text-align:left; padding:0.6rem 1rem 0.6rem ${i === 0 ? "0" : ""}; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;`}
-              >
-                {col.label}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {landscape.map((row) => (
-            <tr
-              style={`border-bottom: 1px solid var(--sw-color-border-subtle);${row.self ? " background: var(--sw-color-brand-soft);" : ""}`}
-            >
-              <td style="padding:0.7rem 1rem 0.7rem 0; vertical-align:top;">
-                <span
-                  style={`font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};`}
-                >
-                  {row.tool}
-                </span>
-              </td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body); white-space:nowrap;">{row.license}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.models}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.taskQueue}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.teamVisibility}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.policyControls}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.humanReviewGate}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.cronScheduling}</td>
-              <td style="padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.slackWorkflow}</td>
-              <td style="padding:0.7rem 0 0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">{row.testsFirst}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <ComparisonTable columns={landscapeColumns} rows={landscapeRows} />
     <p class="mt-6 max-w-2xl sw-editorial">
       The pattern in this table: individual copilots (Cursor, GitHub Copilot Agent
       in simple mode) are optimized for single-developer productivity — no team
@@ -346,24 +377,28 @@ helm install shipwright shipwright/shipwright</code></pre>
       PRs). If you want maximum model flexibility and a mature ecosystem today,
       it is an excellent choice. Here is where the two genuinely differ:
     </p>
-    <div class="mt-8 grid gap-6 sm:grid-cols-2">
-      <div class="sw-card">
-        <p class="sw-label" style="color:var(--sw-color-brand-default);">Choose Shipwright when</p>
-        <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
-          <li>You have already chosen Claude Code and want a pipeline tuned for it, not averaged across providers.</li>
-          <li>You want tests written first and landed with every change, gated by CI, by default.</li>
-          <li>You want a plan a human approves before the agent builds — structured autonomy with a checkpoint.</li>
-        </ul>
-      </div>
-      <div class="sw-card">
-        <p class="sw-label" style="color:var(--sw-color-support-patriot-bright);">Choose OpenHands (or the field) when</p>
-        <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
-          <li>You need BYOK / model-agnostic across many providers, including local models.</li>
-          <li>You want the largest community and the most mature ecosystem available right now.</li>
-          <li>You are not committed to a single runtime and want to keep that optionality.</li>
-        </ul>
-      </div>
-    </div>
+    <ChooseWhenGrid
+      cards={[
+        {
+          label: "Choose Shipwright when",
+          labelColor: "var(--sw-color-brand-default)",
+          items: [
+            { text: "You have already chosen Claude Code and want a pipeline tuned for it, not averaged across providers." },
+            { text: "You want tests written first and landed with every change, gated by CI, by default." },
+            { text: "You want a plan a human approves before the agent builds — structured autonomy with a checkpoint." },
+          ],
+        },
+        {
+          label: "Choose OpenHands (or the field) when",
+          labelColor: "var(--sw-color-support-patriot-bright)",
+          items: [
+            { text: "You need BYOK / model-agnostic across many providers, including local models." },
+            { text: "You want the largest community and the most mature ecosystem available right now." },
+            { text: "You are not committed to a single runtime and want to keep that optionality." },
+          ],
+        },
+      ]}
+    />
   </section>
 
   <!-- Focused head-to-head: Augment Code -->
@@ -377,26 +412,30 @@ helm install shipwright shipwright/shipwright</code></pre>
       codebase-aware Q&A. It is well-funded and enterprise-focused, with real
       autonomous-agent chops. Here is where the two differ:
     </p>
-    <div class="mt-8 grid gap-6 sm:grid-cols-2">
-      <div class="sw-card">
-        <p class="sw-label" style="color:var(--sw-color-brand-default);">Choose Shipwright when</p>
-        <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
-          <li>You want MIT / self-hosted on your own infra, not a managed SaaS with enterprise contracts.</li>
-          <li>You want a human to approve the plan before code is written — not review after the fact on a PR the agent already opened.</li>
-          <li>Tests-first and CI-green are enforced by the pipeline, not left to the agent's judgment.</li>
-          <li>You have committed to Claude Code and want a pipeline tuned for it, not a router averaging across providers.</li>
-        </ul>
-      </div>
-      <div class="sw-card">
-        <p class="sw-label" style="color:var(--sw-color-support-patriot-bright);">Choose Augment Code when</p>
-        <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
-          <li>Your codebase is very large and you want a purpose-built context engine across hundreds of thousands of files.</li>
-          <li>You want a managed service with enterprise security certifications and no self-hosting overhead.</li>
-          <li>Your team already lives in the IDE and Slack, and wants agent access woven into both.</li>
-          <li>Model flexibility across providers matters more than depth on a single runtime.</li>
-        </ul>
-      </div>
-    </div>
+    <ChooseWhenGrid
+      cards={[
+        {
+          label: "Choose Shipwright when",
+          labelColor: "var(--sw-color-brand-default)",
+          items: [
+            { text: "You want MIT / self-hosted on your own infra, not a managed SaaS with enterprise contracts." },
+            { text: "You want a human to approve the plan before code is written — not review after the fact on a PR the agent already opened." },
+            { text: "Tests-first and CI-green are enforced by the pipeline, not left to the agent's judgment." },
+            { text: "You have committed to Claude Code and want a pipeline tuned for it, not a router averaging across providers." },
+          ],
+        },
+        {
+          label: "Choose Augment Code when",
+          labelColor: "var(--sw-color-support-patriot-bright)",
+          items: [
+            { text: "Your codebase is very large and you want a purpose-built context engine across hundreds of thousands of files." },
+            { text: "You want a managed service with enterprise security certifications and no self-hosting overhead." },
+            { text: "Your team already lives in the IDE and Slack, and wants agent access woven into both." },
+            { text: "Model flexibility across providers matters more than depth on a single runtime." },
+          ],
+        },
+      ]}
+    />
   </section>
 
   <!-- Customizability section -->
@@ -480,16 +519,5 @@ helm install shipwright shipwright/shipwright</code></pre>
   </section>
 
   <!-- CTA / COSS bridge -->
-  <section id="cta" class="relative z-10 py-20 pb-24" style="border-top: 1px solid var(--sw-color-border-subtle);">
-    <h2>Try it</h2>
-    <p class="mt-3 max-w-2xl">
-      Install the plugin into Claude Code and run a task end to end. Free, MIT,
-      runs on your own infra.
-    </p>
-    <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
-    <div class="mt-6 flex flex-wrap items-center gap-4">
-      <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
-      <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
-    </div>
-  </section>
+  <TryItCta />
 </BaseLayout>

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -10,6 +10,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import ChooseWhenGrid from "../components/ChooseWhenGrid.astro";
 import ComparisonTable from "../components/ComparisonTable.astro";
 import TryItCta from "../components/TryItCta.astro";
+import { escapeHtml } from "../lib/html-escape";
 
 // Market structure: 3-pole framing of the AI coding agent space.
 // Shipwright occupies the middle pole — team AI workflow, not copilot UX
@@ -152,18 +153,6 @@ const tableColumns = [
   { key: "testsFirst", label: "Tests-First Enforcement" },
 ] as const;
 
-// Matches Astro's own text-node escaping for {expression} interpolation so
-// set:html-rendered cells produce the same entity-encoded output as the
-// original JSX-interpolated markup (e.g. "codebase Q&A" -> Q&amp;A).
-function esc(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
 // ComparisonTable props for the landscape table. Header/cell style strings
 // are reproduced exactly from the original hand-copied <table> markup.
 const landscapeColumns = tableColumns.map((col, i) => ({
@@ -176,45 +165,45 @@ const landscapeRows = landscape.map((row) => ({
   cells: [
     {
       style: "padding:0.7rem 1rem 0.7rem 0; vertical-align:top;",
-      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${esc(row.tool)} </span>`,
+      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${escapeHtml(row.tool)} </span>`,
     },
     {
       style:
         "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body); white-space:nowrap;",
-      html: esc(row.license),
+      html: escapeHtml(row.license),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.models),
+      html: escapeHtml(row.models),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.taskQueue),
+      html: escapeHtml(row.taskQueue),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.teamVisibility),
+      html: escapeHtml(row.teamVisibility),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.policyControls),
+      html: escapeHtml(row.policyControls),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.humanReviewGate),
+      html: escapeHtml(row.humanReviewGate),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.cronScheduling),
+      html: escapeHtml(row.cronScheduling),
     },
     {
       style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.slackWorkflow),
+      html: escapeHtml(row.slackWorkflow),
     },
     {
       style:
         "padding:0.7rem 0 0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: esc(row.testsFirst),
+      html: escapeHtml(row.testsFirst),
     },
   ],
 }));

--- a/site/src/pages/self-hosted.astro
+++ b/site/src/pages/self-hosted.astro
@@ -8,7 +8,8 @@
 // competitor-naming policy this page operates under. OpenCode is
 // deliberately not named (unverified — never-print list).
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { BOOKING_URL, INSTALL_CMD, REPO_URL } from "../consts";
+import ComparisonTable from "../components/ComparisonTable.astro";
+import TryItCta from "../components/TryItCta.astro";
 
 const verifiedDate = "July 14, 2026";
 
@@ -68,6 +69,56 @@ const architectureRows = [
     self: false,
   },
 ];
+
+// ComparisonTable props for the architecture table. Header/cell style
+// strings are reproduced exactly from the original hand-copied <table>
+// markup.
+const architectureColumns = [
+  {
+    label: "Tool",
+    style: "text-align:left; padding:0.6rem 1rem 0.6rem 0; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;",
+  },
+  {
+    label: "License",
+    style: "text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;",
+  },
+  {
+    label: "Architecture",
+    style: "text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;",
+  },
+];
+
+// Matches Astro's own text-node escaping for {expression} interpolation so
+// set:html-rendered cells produce the same entity-encoded output as the
+// original JSX-interpolated markup (e.g. Cursor's -> Cursor&#39;s).
+function esc(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const architectureTableRows = architectureRows.map((row) => ({
+  highlight: row.self,
+  cells: [
+    {
+      style: "padding:0.9rem 1rem 0.9rem 0; vertical-align:top;",
+      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${esc(row.tool)} </span>`,
+    },
+    {
+      style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: ` ${esc(row.license)} `,
+    },
+    {
+      style: "padding:0.9rem 1rem 0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: row.citation
+        ? ` <strong>${esc(row.architecture)}</strong> <span> ${esc(row.detail)}</span>  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
+        : ` <strong>${esc(row.architecture)}</strong> <span> ${esc(row.detail)}</span>  `,
+    },
+  ],
+}));
 ---
 
 <BaseLayout
@@ -105,53 +156,7 @@ const architectureRows = [
       stays in the vendor's cloud) or gates full self-hosting behind an
       Enterprise sales conversation.
     </p>
-    <div class="mt-6 overflow-x-auto">
-      <table style="width:100%; border-collapse:collapse;">
-        <thead>
-          <tr style="border-bottom: 1px solid var(--sw-color-border-muted);">
-            <th style="text-align:left; padding:0.6rem 1rem 0.6rem 0; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;">
-              Tool
-            </th>
-            <th style="text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;">
-              License
-            </th>
-            <th style="text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;">
-              Architecture
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            architectureRows.map((row) => (
-              <tr style={`border-bottom: 1px solid var(--sw-color-border-subtle);${row.self ? " background: var(--sw-color-brand-soft);" : ""}`}>
-                <td style="padding:0.9rem 1rem 0.9rem 0; vertical-align:top;">
-                  <span
-                    style={`font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};`}
-                  >
-                    {row.tool}
-                  </span>
-                </td>
-                <td style="padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">
-                  {row.license}
-                </td>
-                <td style="padding:0.9rem 1rem 0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">
-                  <strong>{row.architecture}</strong>
-                  <span> {row.detail}</span>
-                  {row.citation && (
-                    <>
-                      {" "}
-                      <a href={row.citation} class="text-sm">
-                        [source]
-                      </a>
-                    </>
-                  )}
-                </td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
-    </div>
+    <ComparisonTable columns={architectureColumns} rows={architectureTableRows} />
     <p class="mt-6 max-w-2xl sw-editorial">
       "Self-hosted" is table-stakes marketing language across the field now —
       the architecture underneath it is what actually differs. Full head to
@@ -170,19 +175,9 @@ const architectureRows = [
   </section>
 
   <!-- CTA -->
-  <section id="cta" class="relative z-10 py-20 pb-24" style="border-top: 1px solid var(--sw-color-border-subtle);">
-    <h2>Try it</h2>
-    <p class="mt-3 max-w-2xl">
-      Install the plugin into Claude Code and run a task end to end. Free,
-      MIT, runs on your own infra.
-    </p>
-    <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
-    <div class="mt-6 flex flex-wrap items-center gap-4">
-      <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
-      <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
-    </div>
+  <TryItCta>
     <p class="mt-8 max-w-2xl">
       <a href="/compare">See how Shipwright compares to the rest of the field →</a>
     </p>
-  </section>
+  </TryItCta>
 </BaseLayout>

--- a/site/src/pages/self-hosted.astro
+++ b/site/src/pages/self-hosted.astro
@@ -10,6 +10,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ComparisonTable from "../components/ComparisonTable.astro";
 import TryItCta from "../components/TryItCta.astro";
+import { escapeHtml } from "../lib/html-escape";
 
 const verifiedDate = "July 14, 2026";
 
@@ -88,34 +89,22 @@ const architectureColumns = [
   },
 ];
 
-// Matches Astro's own text-node escaping for {expression} interpolation so
-// set:html-rendered cells produce the same entity-encoded output as the
-// original JSX-interpolated markup (e.g. Cursor's -> Cursor&#39;s).
-function esc(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
 const architectureTableRows = architectureRows.map((row) => ({
   highlight: row.self,
   cells: [
     {
       style: "padding:0.9rem 1rem 0.9rem 0; vertical-align:top;",
-      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${esc(row.tool)} </span>`,
+      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${escapeHtml(row.tool)} </span>`,
     },
     {
       style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: ` ${esc(row.license)} `,
+      html: ` ${escapeHtml(row.license)} `,
     },
     {
       style: "padding:0.9rem 1rem 0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
       html: row.citation
-        ? ` <strong>${esc(row.architecture)}</strong> <span> ${esc(row.detail)}</span>  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
-        : ` <strong>${esc(row.architecture)}</strong> <span> ${esc(row.detail)}</span>  `,
+        ? ` <strong>${escapeHtml(row.architecture)}</strong> <span> ${escapeHtml(row.detail)}</span>  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
+        : ` <strong>${escapeHtml(row.architecture)}</strong> <span> ${escapeHtml(row.detail)}</span>  `,
     },
   ],
 }));

--- a/site/src/pages/vs/devin.astro
+++ b/site/src/pages/vs/devin.astro
@@ -6,7 +6,10 @@
 // future edit — see brand/MESSAGING.md D10 for the surface-scoped
 // competitor-naming policy this page operates under.
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { BOOKING_URL, INSTALL_CMD, LICENSE_URL, REPO_URL } from "../../consts";
+import ChooseWhenGrid from "../../components/ChooseWhenGrid.astro";
+import ComparisonTable from "../../components/ComparisonTable.astro";
+import TryItCta from "../../components/TryItCta.astro";
+import { LICENSE_URL } from "../../consts";
 
 const verifiedDate = "July 14, 2026";
 
@@ -46,6 +49,57 @@ const comparisonRows = [
     citation: src.pricing,
   },
 ];
+
+// ComparisonTable props for the dimension table. Header/cell style strings
+// are reproduced exactly from the original hand-copied <table> markup. This
+// table has no "self" highlight row — values are pre-split into
+// shipwright/devin columns instead, so every row uses the same neutral
+// border style.
+const dimensionColumns = [
+  {
+    label: "Dimension",
+    style: "text-align:left; padding:0.6rem 1rem 0.6rem 0; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;",
+  },
+  {
+    label: "Shipwright",
+    style: "text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-brand-default); white-space:nowrap;",
+  },
+  {
+    label: "Devin",
+    style: "text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;",
+  },
+];
+
+// Matches Astro's own text-node escaping for {expression} interpolation so
+// set:html-rendered cells produce the same entity-encoded output as the
+// original JSX-interpolated markup (e.g. agent's -> agent&#39;s).
+function esc(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const dimensionRows = comparisonRows.map((row) => ({
+  cells: [
+    {
+      style: "padding:0.9rem 1rem 0.9rem 0; vertical-align:top; font-family:var(--sw-font-display); font-weight:600; color:var(--sw-color-text-heading); white-space:nowrap;",
+      html: ` ${esc(row.dimension)} `,
+    },
+    {
+      style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: ` ${esc(row.shipwright)} `,
+    },
+    {
+      style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+      html: row.citation
+        ? ` ${esc(row.devin)}  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
+        : ` ${esc(row.devin)} `,
+    },
+  ],
+}));
 ---
 
 <BaseLayout
@@ -85,48 +139,7 @@ const comparisonRows = [
       Each piece of that sentence is a real, cited difference — not a single
       empty-category claim.
     </p>
-    <div class="mt-6 overflow-x-auto">
-      <table style="width:100%; border-collapse:collapse;">
-        <thead>
-          <tr style="border-bottom: 1px solid var(--sw-color-border-muted);">
-            <th style="text-align:left; padding:0.6rem 1rem 0.6rem 0; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;">
-              Dimension
-            </th>
-            <th style="text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-brand-default); white-space:nowrap;">
-              Shipwright
-            </th>
-            <th style="text-align:left; padding:0.6rem 1rem; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;">
-              Devin
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            comparisonRows.map((row) => (
-              <tr style="border-bottom: 1px solid var(--sw-color-border-subtle);">
-                <td style="padding:0.9rem 1rem 0.9rem 0; vertical-align:top; font-family:var(--sw-font-display); font-weight:600; color:var(--sw-color-text-heading); white-space:nowrap;">
-                  {row.dimension}
-                </td>
-                <td style="padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">
-                  {row.shipwright}
-                </td>
-                <td style="padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);">
-                  {row.devin}
-                  {row.citation && (
-                    <>
-                      {" "}
-                      <a href={row.citation} class="text-sm">
-                        [source]
-                      </a>
-                    </>
-                  )}
-                </td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
-    </div>
+    <ComparisonTable columns={dimensionColumns} rows={dimensionRows} />
 
     <!-- License quote: the actual MIT license line from this repo. -->
     <div class="sw-callout mt-8 max-w-3xl">
@@ -170,31 +183,33 @@ const comparisonRows = [
   <!-- Choose Devin when / Choose Shipwright when. -->
   <section class="relative z-10 pb-16" style="border-top: 1px solid var(--sw-color-border-subtle); padding-top: 3rem;">
     <h2>Choose Devin when</h2>
-    <div class="mt-8 grid gap-6 sm:grid-cols-2">
-      <div class="sw-card">
-        <p class="sw-label" style="color:var(--sw-color-support-patriot-bright);">Choose Devin when</p>
-        <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
-          <li>You want a fully managed, vendor-hosted service with no infrastructure to run yourself.</li>
-          <li>The task is well-scoped and isolated enough that fire-and-forget autonomy fits.</li>
-          <li>
-            You need off-the-shelf enterprise attestations — Cognition states
-            SOC 2 Type II certification since September 2024 and lists
-            ISO/IEC 27001:2022 on{" "}
-            <a href={src.trust}>trust.cognition.ai</a>.
-          </li>
-          <li>You are not committed to Claude Code and want a proprietary-model agent instead.</li>
-        </ul>
-      </div>
-      <div class="sw-card">
-        <p class="sw-label" style="color:var(--sw-color-brand-default);">Choose Shipwright when</p>
-        <ul class="mt-3 flex flex-col gap-2" style="color:var(--sw-color-text-body); padding-left:1.1rem; list-style:disc;">
-          <li>You want the full pipeline — including the deploy stage — not just an opened PR.</li>
-          <li>The code and the agent that writes it both need to stay entirely inside your own cloud, control plane included.</li>
-          <li>MIT licensing matters to you: audit every line, fork it, no vendor lock-in.</li>
-          <li>You've already committed to Claude Code and want a pipeline built for it, not averaged across providers.</li>
-        </ul>
-      </div>
-    </div>
+    <ChooseWhenGrid
+      cards={[
+        {
+          label: "Choose Devin when",
+          labelColor: "var(--sw-color-support-patriot-bright)",
+          items: [
+            { text: "You want a fully managed, vendor-hosted service with no infrastructure to run yourself." },
+            { text: "The task is well-scoped and isolated enough that fire-and-forget autonomy fits." },
+            {
+              text: ` You need off-the-shelf enterprise attestations — Cognition states SOC 2 Type II certification since September 2024 and lists ISO/IEC 27001:2022 on <a href="${src.trust}">trust.cognition.ai</a>. `,
+              html: true,
+            },
+            { text: "You are not committed to Claude Code and want a proprietary-model agent instead." },
+          ],
+        },
+        {
+          label: "Choose Shipwright when",
+          labelColor: "var(--sw-color-brand-default)",
+          items: [
+            { text: "You want the full pipeline — including the deploy stage — not just an opened PR." },
+            { text: "The code and the agent that writes it both need to stay entirely inside your own cloud, control plane included." },
+            { text: "MIT licensing matters to you: audit every line, fork it, no vendor lock-in." },
+            { text: "You've already committed to Claude Code and want a pipeline built for it, not averaged across providers." },
+          ],
+        },
+      ]}
+    />
   </section>
 
   <!-- Economics — price-free framing (D5). -->
@@ -209,21 +224,11 @@ const comparisonRows = [
   </section>
 
   <!-- CTA -->
-  <section id="cta" class="relative z-10 py-20 pb-24" style="border-top: 1px solid var(--sw-color-border-subtle);">
-    <h2>Try it</h2>
-    <p class="mt-3 max-w-2xl">
-      Install the plugin into Claude Code and run a task end to end. Free,
-      MIT, runs on your own infra.
-    </p>
-    <pre class="sw-code mt-4 w-fit"><code>{INSTALL_CMD}</code></pre>
-    <div class="mt-6 flex flex-wrap items-center gap-4">
-      <a href={REPO_URL} class="sw-btn">View on GitHub ↗</a>
-      <a href={BOOKING_URL} class="sw-btn sw-btn-secondary">Book a discovery call</a>
-    </div>
+  <TryItCta>
     <p class="mt-8 max-w-2xl">
       <a href="/compare">See how Shipwright compares to the rest of the field →</a>
       <span class="mx-2" style="color: var(--sw-color-text-muted);">·</span>
       <a href="/self-hosted">What "self-hosted" actually means →</a>
     </p>
-  </section>
+  </TryItCta>
 </BaseLayout>

--- a/site/src/pages/vs/devin.astro
+++ b/site/src/pages/vs/devin.astro
@@ -10,6 +10,7 @@ import ChooseWhenGrid from "../../components/ChooseWhenGrid.astro";
 import ComparisonTable from "../../components/ComparisonTable.astro";
 import TryItCta from "../../components/TryItCta.astro";
 import { LICENSE_URL } from "../../consts";
+import { escapeHtml } from "../../lib/html-escape";
 
 const verifiedDate = "July 14, 2026";
 
@@ -70,33 +71,21 @@ const dimensionColumns = [
   },
 ];
 
-// Matches Astro's own text-node escaping for {expression} interpolation so
-// set:html-rendered cells produce the same entity-encoded output as the
-// original JSX-interpolated markup (e.g. agent's -> agent&#39;s).
-function esc(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
 const dimensionRows = comparisonRows.map((row) => ({
   cells: [
     {
       style: "padding:0.9rem 1rem 0.9rem 0; vertical-align:top; font-family:var(--sw-font-display); font-weight:600; color:var(--sw-color-text-heading); white-space:nowrap;",
-      html: ` ${esc(row.dimension)} `,
+      html: ` ${escapeHtml(row.dimension)} `,
     },
     {
       style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: ` ${esc(row.shipwright)} `,
+      html: ` ${escapeHtml(row.shipwright)} `,
     },
     {
       style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
       html: row.citation
-        ? ` ${esc(row.devin)}  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
-        : ` ${esc(row.devin)} `,
+        ? ` ${escapeHtml(row.devin)}  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
+        : ` ${escapeHtml(row.devin)} `,
     },
   ],
 }));


### PR DESCRIPTION
## Summary
- Extract three shared Astro components (`ComparisonTable.astro`, `TryItCta.astro`, `ChooseWhenGrid.astro`) under `site/src/components/`
- Apply them across the 3 comparison pages (`compare.astro`, `self-hosted.astro`, `vs/devin.astro`), replacing hand-copied markup
- Pure refactor — verified byte-for-byte equivalence (modulo insignificant whitespace/entity-encoding) against the pre-refactor build output

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | New components exist and are used by all 3 pages in place of hand-copied markup | MET |
| 2 | TryItCta.astro supports the extra trailing links self-hosted/devin add | MET |
| 3 | No rendered HTML/visual output changes on any of the 3 pages | MET |
| 4 | No new tests added; existing specs (compare/self-hosted/vs-devin .spec.ts) unmodified | MET |

## Test Plan
- [x] `npm run build:check` (astro build + brand-lint) passes clean
- [x] Diffed generated `dist/{compare,self-hosted,vs/devin}/index.html` against a build of `origin/main` — only whitespace/line-wrap and HTML-entity (`'` vs `&#39;`) differences remain, which are DOM-identical and invisible to the existing Playwright specs' `textContent()`-based assertions
- [ ] `npx playwright test` — cannot run in this sandbox (headless Chromium can't launch, missing system dep); CI will run the existing `compare.spec.ts` / `self-hosted.spec.ts` / `vs-devin.spec.ts` unmodified

Generated with [Claude Code](https://claude.com/claude-code)
