### PR TITLE
feat: block claim-field and status:pending writes on generic task PATCH

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -99,7 +99,12 @@ Returns `404` if the task doesn't exist or is outside the agent's scope.
 PATCH /tasks/:id
 ```
 
-Body: partial task fields. Agent tokens can only update their own tasks (by `assignee` or `claimedBy`). Returns the updated task.
+Body: partial task fields. Agent tokens can only update their own tasks (by `assignee` or `claimedBy`). **Agent tokens cannot set the following fields via PATCH** — these are managed exclusively by their lifecycle endpoints:
+
+- `claimedBy`, `claimedAt`, `heartbeatAt` — use `/claim` or `/release`
+- `status: 'pending'` — use `/release` to unclaim, or `/claim` to reclaim
+
+Admin tokens (`agentId === null`) may set any field. Returns the updated task.
 
 #### Delete task
 

--- a/plugins/shipwright/skills/task-store/SKILL.md
+++ b/plugins/shipwright/skills/task-store/SKILL.md
@@ -101,6 +101,11 @@ No request body is sent — with an agent token, the task-store pins `claimedBy`
 calling agent's own ID server-side and ignores the body. A `409` means another agent
 already claimed the task since it was read as `ready` — skip it and pick the next one.
 
+This isn't just a race-avoidance convention — a generic `PATCH /tasks/:id` actively rejects
+(`400`) an agent token trying to set `claimedBy`, `claimedAt`, `heartbeatAt`, or
+`status: "pending"` directly. `/claim` and `/release` are the only supported ways to move
+those fields.
+
 ### Open a PR
 
 Must set `pr` and `prCreatedAt` together with the status:

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -539,3 +539,86 @@ describe("POST /bulk — agent-token default assignee (UTA-1.1)", () => {
     expect(tasks[1]?.assignee).toBe("agent-1");
   });
 });
+
+describe("PATCH /:id — lifecycle field guard (TPL-1.1)", () => {
+  it("agent token + claimedBy in body -> 400", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/t-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ claimedBy: "agent-2" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("/claim");
+    expect(body.error).toContain("/release");
+  });
+
+  it("agent token + claimedAt in body -> 400", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/t-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ claimedAt: new Date().toISOString() }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("agent token + heartbeatAt in body -> 400", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/t-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ heartbeatAt: new Date().toISOString() }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("agent token + status: 'pending' in body -> 400", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/t-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "pending" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("agent token + status: 'blocked' (control case) -> 200, unaffected", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAgentParent(app, "agent-1");
+
+    const res = await parent.request("/t-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "blocked" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("admin token + claimedBy in body -> 200 (admin bypass confirmed)", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/t-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ claimedBy: "agent-2" }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -66,6 +66,37 @@ async function readJson(c: {
   }
 }
 
+// Fields that gate task claim ownership. Agent tokens must go through the
+// dedicated /claim and /release routes to change these — never generic PATCH.
+// requireOwnership() grants PATCH access via repo scope alone (not just
+// assignee/claimant match), so without this guard a repo-scoped agent token
+// could overwrite an actively claimed task's status back to "pending",
+// making it immediately re-claimable by a different agent while the
+// original session still holds it (TaskService.claim()'s atomic UPDATE
+// gates solely on status = 'pending', never on claimedBy IS NULL).
+const LIFECYCLE_GUARD_KEYS = ["claimedBy", "claimedAt", "heartbeatAt"] as const;
+
+// admin tokens (agentId === null) are unrestricted, mirroring the existing
+// admin-bypass convention already used by requireOwnership.
+function assertNoLifecycleFieldWrite(
+  body: Record<string, unknown>,
+  agentId: string | null,
+): void {
+  if (agentId === null) return;
+  for (const key of LIFECYCLE_GUARD_KEYS) {
+    if (key in body) {
+      throw new BadRequestError(
+        `agent tokens cannot set '${key}' via PATCH — use /claim or /release`,
+      );
+    }
+  }
+  if (body.status === "pending") {
+    throw new BadRequestError(
+      "agent tokens cannot set status: 'pending' via PATCH — use /release to unclaim (or /claim to reclaim)",
+    );
+  }
+}
+
 // repos === null means admin token — bypass scope check; still enforce format.
 function validateRepo(repo: unknown, repos: string[] | null): void {
   if (repo === undefined || repo === null) return;
@@ -683,6 +714,7 @@ export function createTasksRoutes(
       repos ?? [],
     );
     const body = await readJson(c);
+    assertNoLifecycleFieldWrite(body, agentId);
     validateRepo(body.repo, agentId !== null ? repos : null);
     // Prevent agent tokens from reassigning tasks outside their ownership scope.
     // Only force-assign when the acting agent is the explicit assignee or claimedBy.


### PR DESCRIPTION
## Summary
- Add a denylist guard to `PATCH /tasks/:id` that rejects (400) agent-token bodies containing `claimedBy`, `claimedAt`, `heartbeatAt`, or `status: "pending"` — these must go through the dedicated `/claim` and `/release` routes.
- Admin tokens (`agentId === null`) remain unrestricted, matching the existing admin-bypass convention.
- Closes a work-stealing race: `requireOwnership()` grants PATCH access via repo scope alone, so a repo-scoped agent token could previously overwrite an actively claimed task's `status` back to `"pending"`, making it immediately re-claimable by a different agent while the original session still held it (`TaskService.claim()`'s atomic UPDATE gates solely on `status = 'pending'`, never `claimedBy IS NULL`).
- Refreshed `docs/task-store.md` to document the new PATCH restriction.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Agent-token PATCH rejects (400, points to `/claim`/`/release`) claimedBy/claimedAt/heartbeatAt/status:"pending" | MET |
| 2 | Admin tokens unaffected | MET |
| 3 | Every other status value/field remains freely PATCHable for agent tokens | MET |
| 4 | New `describe("PATCH /:id — lifecycle field guard (TPL-1.1)")` block in `tasks.openapi.smoke.test.ts`, 6 specified cases, no existing tests retired | MET |

## Test Plan
- 6 new smoke tests in `task-store/src/routes/tasks.openapi.smoke.test.ts`: 4 agent-token 400 cases, 1 agent-token control (`status:"blocked"` → 200), 1 admin-token bypass (→ 200).
- `cd task-store && bun test` — 403 pass / 0 fail / 131 skip (no regressions; one pre-existing unrelated stderr trace in `prs.openapi.smoke.test.ts`, confirmed present on `main` too).
- `bunx biome lint .` clean, `tsc --noEmit` clean.
- Coverage: `task-store/src/routes/tasks.ts` at 87.10% lines / 95.57% functions (target 80%/80%).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
