### PR TITLE
feat: add Set-based dedup to allowedTools merge

### DIFF
--- a/agent/src/claude.ts
+++ b/agent/src/claude.ts
@@ -206,14 +206,7 @@ export function createRunClaude(
     const resolvedExtraAllowedTools =
       extraAllowedTools ?? liveClaudeConfig.allowedTools;
 
-    const args = [
-      "-p",
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--permission-mode",
-      "acceptEdits",
-      "--allowedTools",
+    const hardcodedTools = [
       "Read",
       "Write",
       "Edit",
@@ -225,7 +218,20 @@ export function createRunClaude(
       "Skill",
       "Agent",
       "TodoWrite",
-      ...resolvedExtraAllowedTools,
+    ];
+
+    // Deduplicate tools: Set preserves insertion order, so first-occurrence wins
+    const deduplicatedTools = [...new Set([...hardcodedTools, ...resolvedExtraAllowedTools])];
+
+    const args = [
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--permission-mode",
+      "acceptEdits",
+      "--allowedTools",
+      ...deduplicatedTools,
       "--model",
       resolvedModel,
       ...(resolvedFallbackModel

--- a/agent/src/claude.unit.test.ts
+++ b/agent/src/claude.unit.test.ts
@@ -798,6 +798,114 @@ describe("extraAllowedTools", () => {
     expect(extraIdx).toBeGreaterThan(allowedIdx);
     expect(extraIdx).toBeGreaterThan(agentIdx);
   });
+
+  test("dedup: allowedTools includes a built-in tool (Bash), final args contains it exactly once", async () => {
+    const runClaude = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+      ["Bash", "mcp__extra__tool"], // Bash is already in the hardcoded 11
+    );
+
+    await runClaude("test");
+    const [cmd] = mockSpawn.mock.calls[0] as [string[]];
+
+    const allowedIdx = cmd.indexOf("--allowedTools");
+    expect(allowedIdx).toBeGreaterThan(-1);
+
+    // Find all tools in --allowedTools section
+    const toolsInCmd: string[] = [];
+    for (let i = allowedIdx + 1; i < cmd.length; i++) {
+      if (cmd[i].startsWith("-")) break;
+      toolsInCmd.push(cmd[i]);
+    }
+
+    // Count occurrences of Bash
+    const bashCount = toolsInCmd.filter((tool) => tool === "Bash").length;
+    expect(bashCount).toBe(1);
+    expect(toolsInCmd).toContain("mcp__extra__tool");
+  });
+
+  test("dedup: empty allowedTools still contains exactly 11 hardcoded tools with no duplicates", async () => {
+    const runClaudeEmpty = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+      [], // empty extraAllowedTools
+    );
+
+    await runClaudeEmpty("test");
+    const [cmd] = mockSpawn.mock.calls[0] as [string[]];
+
+    const allowedIdx = cmd.indexOf("--allowedTools");
+    expect(allowedIdx).toBeGreaterThan(-1);
+
+    // Find all tools in --allowedTools section
+    const toolsInCmd: string[] = [];
+    for (let i = allowedIdx + 1; i < cmd.length; i++) {
+      if (cmd[i].startsWith("-")) break;
+      toolsInCmd.push(cmd[i]);
+    }
+
+    // Verify exactly 11 hardcoded tools
+    const hardcodedTools = [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash",
+      "WebSearch",
+      "WebFetch",
+      "Skill",
+      "Agent",
+      "TodoWrite",
+    ];
+    expect(toolsInCmd).toEqual(hardcodedTools);
+
+    // Verify no duplicates: unique count equals total count
+    const uniqueTools = new Set(toolsInCmd);
+    expect(uniqueTools.size).toBe(toolsInCmd.length);
+  });
+
+  test("dedup: multiple overlapping tools, only unique entries in final args", async () => {
+    const runClaude = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+      ["Bash", "Write", "mcp__tool1", "Read", "mcp__tool2"], // Bash, Write, and Read are built-in
+    );
+
+    await runClaude("test");
+    const [cmd] = mockSpawn.mock.calls[0] as [string[]];
+
+    const allowedIdx = cmd.indexOf("--allowedTools");
+    expect(allowedIdx).toBeGreaterThan(-1);
+
+    // Find all tools in --allowedTools section
+    const toolsInCmd: string[] = [];
+    for (let i = allowedIdx + 1; i < cmd.length; i++) {
+      if (cmd[i].startsWith("-")) break;
+      toolsInCmd.push(cmd[i]);
+    }
+
+    // Verify no duplicates
+    const uniqueTools = new Set(toolsInCmd);
+    expect(uniqueTools.size).toBe(toolsInCmd.length);
+
+    // Verify all expected tools are present
+    expect(toolsInCmd).toContain("Bash");
+    expect(toolsInCmd).toContain("Write");
+    expect(toolsInCmd).toContain("Read");
+    expect(toolsInCmd).toContain("mcp__tool1");
+    expect(toolsInCmd).toContain("mcp__tool2");
+  });
 });
 
 // ─── totalCostUsd and modelUsage from JSON output ────────────────────────────

--- a/agent/src/claude.unit.test.ts
+++ b/agent/src/claude.unit.test.ts
@@ -709,6 +709,17 @@ describe("extraAllowedTools", () => {
   // biome-ignore lint/suspicious/noExplicitAny: mock return type
   let mockSpawn: any;
 
+  // Extracts the tool names listed after --allowedTools, up to the next flag
+  function extractAllowedTools(cmd: string[]): string[] {
+    const allowedIdx = cmd.indexOf("--allowedTools");
+    const tools: string[] = [];
+    for (let i = allowedIdx + 1; i < cmd.length; i++) {
+      if (cmd[i].startsWith("-")) break;
+      tools.push(cmd[i]);
+    }
+    return tools;
+  }
+
   beforeEach(() => {
     mockGetSession.mockClear();
     mockSetSession.mockClear();
@@ -764,15 +775,8 @@ describe("extraAllowedTools", () => {
     await runClaude("test");
     const [cmd] = mockSpawn.mock.calls[0] as [string[]];
 
-    const allowedIdx = cmd.indexOf("--allowedTools");
-    expect(allowedIdx).toBeGreaterThan(-1);
-
-    // Find all args after --allowedTools until the next flag or end
-    const toolsInCmd: string[] = [];
-    for (let i = allowedIdx + 1; i < cmd.length; i++) {
-      if (cmd[i].startsWith("-")) break;
-      toolsInCmd.push(cmd[i]);
-    }
+    expect(cmd.indexOf("--allowedTools")).toBeGreaterThan(-1);
+    const toolsInCmd = extractAllowedTools(cmd);
 
     expect(toolsInCmd).toContain("mcp__my_server__my_tool");
     expect(toolsInCmd).toContain("mcp__other__tool");
@@ -812,15 +816,7 @@ describe("extraAllowedTools", () => {
     await runClaude("test");
     const [cmd] = mockSpawn.mock.calls[0] as [string[]];
 
-    const allowedIdx = cmd.indexOf("--allowedTools");
-    expect(allowedIdx).toBeGreaterThan(-1);
-
-    // Find all tools in --allowedTools section
-    const toolsInCmd: string[] = [];
-    for (let i = allowedIdx + 1; i < cmd.length; i++) {
-      if (cmd[i].startsWith("-")) break;
-      toolsInCmd.push(cmd[i]);
-    }
+    const toolsInCmd = extractAllowedTools(cmd);
 
     // Count occurrences of Bash
     const bashCount = toolsInCmd.filter((tool) => tool === "Bash").length;
@@ -841,15 +837,7 @@ describe("extraAllowedTools", () => {
     await runClaudeEmpty("test");
     const [cmd] = mockSpawn.mock.calls[0] as [string[]];
 
-    const allowedIdx = cmd.indexOf("--allowedTools");
-    expect(allowedIdx).toBeGreaterThan(-1);
-
-    // Find all tools in --allowedTools section
-    const toolsInCmd: string[] = [];
-    for (let i = allowedIdx + 1; i < cmd.length; i++) {
-      if (cmd[i].startsWith("-")) break;
-      toolsInCmd.push(cmd[i]);
-    }
+    const toolsInCmd = extractAllowedTools(cmd);
 
     // Verify exactly 11 hardcoded tools
     const hardcodedTools = [
@@ -885,15 +873,7 @@ describe("extraAllowedTools", () => {
     await runClaude("test");
     const [cmd] = mockSpawn.mock.calls[0] as [string[]];
 
-    const allowedIdx = cmd.indexOf("--allowedTools");
-    expect(allowedIdx).toBeGreaterThan(-1);
-
-    // Find all tools in --allowedTools section
-    const toolsInCmd: string[] = [];
-    for (let i = allowedIdx + 1; i < cmd.length; i++) {
-      if (cmd[i].startsWith("-")) break;
-      toolsInCmd.push(cmd[i]);
-    }
+    const toolsInCmd = extractAllowedTools(cmd);
 
     // Verify no duplicates
     const uniqueTools = new Set(toolsInCmd);


### PR DESCRIPTION
## Summary
- Deduplicates the `--allowedTools` CLI args in `agent/src/claude.ts` `_buildArgs()` by merging the hardcoded 11-tool base list with `resolvedExtraAllowedTools` via `[...new Set([...])]`, preserving first-occurrence order.
- No capability change — the hardcoded 11 tools are unchanged; this only prevents duplicate tool names from being passed to `claude -p` once AgentTool DB rows overlapping the hardcoded list are seeded (DAT-1.2, DAT-2.1).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `_buildArgs()` output for `--allowedTools` contains no duplicate tool names even when `resolvedExtraAllowedTools` overlaps with the hardcoded base list | MET | `claude.ts` — `[...new Set([...hardcodedTools, ...resolvedExtraAllowedTools])]` |
| 2 | Unit test: `liveClaudeConfig.allowedTools` includes a tool already in the hardcoded base list (e.g. `Bash`), final args contains it exactly once | MET | new test "dedup: allowedTools includes a built-in tool (Bash)..." |
| 3 | Unit test: `liveClaudeConfig.allowedTools` empty, final args contains exactly the 11 hardcoded tools with no duplicates | MET | new test "dedup: empty allowedTools still contains exactly 11 hardcoded tools..." |
| 4 | No existing `claude.ts` unit tests need behavior changes beyond dedup assertions | MET | 55/55 tests pass; pre-existing `extraAllowedTools` suite unchanged in assertions |

## Test Plan
- `bun test src/claude.unit.test.ts` — 55 pass, 0 fail (3 new dedup tests + all pre-existing tests unchanged)
- 100% line coverage on `agent/src/claude.ts`
- `bunx biome lint .` — clean
- `tsc --noEmit` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
