### PR TITLE
docs: cross-link architecture page to new operator docs

### DIFF
--- a/site/src/pages/architecture.astro
+++ b/site/src/pages/architecture.astro
@@ -45,36 +45,42 @@ const components = [
     typeClass: "coord",
     name: "task-store",
     desc: "The coordination layer between task sources and executing agents. Owns task state, prevents duplicate work, tracks which agent owns what. Receives from planning and maintenance crons; feeds the core loop.",
+    link: "/docs/task-store-api",
   },
   {
     type: "Core Loop",
     typeClass: "core",
     name: "dev-task",
     desc: "Picks up the next ready task from the task store. Explores the codebase, implements, opens a PR. Runs on a per-agent cron. The workhorse.",
+    link: "/docs/commands-reference",
   },
   {
     type: "Core Loop",
     typeClass: "core",
     name: "review",
     desc: "Reviews open PRs from any agent. Stages findings or posts inline comments. Enforces policy: blocking vs. advisory thresholds, auto-approve criteria. Agent-to-agent review — human override always available.",
+    link: "/docs/commands-reference",
   },
   {
     type: "Core Loop",
     typeClass: "core",
     name: "patch",
     desc: "Addresses unresolved review findings on open PRs. Fixes blocking issues, pushes to the branch, and triggers re-review. The PR loops through review and patch until all findings are resolved.",
+    link: "/docs/commands-reference",
   },
   {
     type: "Core Loop",
     typeClass: "core",
     name: "deploy",
     desc: "Merges PRs that are approved and CI-green. Human override always available.",
+    link: "/docs/commands-reference",
   },
   {
     type: "Feedback Layer",
     typeClass: "memory",
     name: "memory",
     desc: "Captures corrections and cross-session patterns from the core loop. Routes improvements to CLAUDE.md and skills so the agent gets smarter with every cycle. Powered by learning loop (inline capture) and dreaming (async transcript mining).",
+    link: "/docs/agent-skills",
   },
 ];
 ---
@@ -109,7 +115,7 @@ const components = [
       <div class="input-box input-maint">
         <div class="input-tag tag-maint">Maintenance Crons</div>
         <div class="input-title">Background hygiene</div>
-        <p class="input-sub">Per-repo, scheduled. Each cron feeds tasks to the task store.</p>
+        <p class="input-sub">Per-repo, scheduled. Each cron feeds tasks to the task store. <a href="/docs/cron-jobs">Cron mechanics →</a> · <a href="/docs/agent-skills">Skills catalog →</a></p>
         <div class="maint-chips">
           <div class="chip">
             <div class="chip-name">Entropy Patrol</div>
@@ -161,7 +167,7 @@ const components = [
 
     <!-- Core Loop -->
     <div class="core-loop-box">
-      <div class="core-tag">Core Loop — per-agent, cron-driven</div>
+      <div class="core-tag">Core Loop — per-agent, cron-driven <a href="/docs/the-shipwright-loop">Learn more →</a></div>
       <div class="pipeline">
 
         <div class="pipe-step">
@@ -224,7 +230,7 @@ const components = [
             <div class={`comp-tag comp-tag-${c.typeClass}`}>{c.type}</div>
             <div class="comp-name">{c.name}</div>
           </div>
-          <p class="comp-desc">{c.desc}</p>
+          <p class="comp-desc">{c.desc} {c.link && <a href={c.link}>Learn more →</a>}</p>
         </div>
       ))}
     </div>

--- a/site/tests/architecture.spec.ts
+++ b/site/tests/architecture.spec.ts
@@ -69,3 +69,24 @@ test("architecture page ships no runtime JS beyond the analytics tag", async ({
   await page.goto("/architecture");
   await expectNoRuntimeJsBeyondAnalytics(page);
 });
+
+test("architecture page links to the new operator docs pages", async ({
+  page,
+}) => {
+  await page.goto("/architecture");
+  // Core Loop section -> the-shipwright-loop
+  await expect(
+    page.locator('a[href="/docs/the-shipwright-loop"]'),
+  ).toHaveCount(1);
+  // Maintenance Crons chips -> cron-jobs and agent-skills
+  await expect(page.locator('a[href="/docs/cron-jobs"]')).toHaveCount(1);
+  // agent-skills is linked from both the Maintenance Crons chips and the
+  // Memory Component Reference row.
+  await expect(page.locator('a[href="/docs/agent-skills"]')).toHaveCount(2);
+  // dev-task/review/patch/deploy Component Reference rows -> commands-reference
+  await expect(
+    page.locator('a[href="/docs/commands-reference"]'),
+  ).toHaveCount(4);
+  // Task Store row reuses the existing task-store-api link target
+  await expect(page.locator('a[href="/docs/task-store-api"]')).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary
- Adds "learn more" links from the architecture page's diagram and Component Reference rows to the six operator docs pages added this session
- Core Loop diagram section links to `/docs/the-shipwright-loop`; Maintenance Crons chips link to `/docs/cron-jobs` and `/docs/agent-skills`
- dev-task/review/patch/deploy Component Reference rows link to `/docs/commands-reference`; Memory row links to `/docs/agent-skills`; Task Store row reuses the existing `/docs/task-store-api` link target
- All new links reuse the site's global default `<a>` styling — no new CSS classes, tokens, or raw hex values added

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New links at the described sections | MET | Links added to Core Loop tag, Maintenance Crons subtitle, and 6 Component Reference rows (task-store, dev-task, review, patch, deploy, memory) |
| 2 | No new raw hex / bespoke CSS | MET | Plain `<a>` tags only, relying on the existing global `a { color: ... }` rule in brand.css; no new `<style>` rules added |
| 3 | Every linked href verified to resolve | MET | Confirmed all 6 dependency tasks (UDG-1.1–1.4, UDG-2.1–2.2) merged via task-store before starting; confirmed all 5 target `.mdx` files exist and appear in `astro build` output |
| 4 | Test decision: extend architecture.spec.ts | MET | Added one new test asserting exact link counts per href; no existing assertions removed |

## Test Plan
- [x] `astro build` succeeds and generates `/docs/the-shipwright-loop`, `/docs/cron-jobs`, `/docs/agent-skills`, `/docs/commands-reference`, `/docs/task-store-api`
- [x] Verified exact href counts in the built HTML match the new Playwright assertions (1/1/2/4/1)
- [x] `brand-lint` passes on the built architecture page (no off-palette colors)
- [x] `biome lint` passes on changed files
- [ ] Playwright e2e suite (`site/tests/architecture.spec.ts`) — could not execute locally in this sandbox (missing system shared libs for headless Chrome, no root to install); will run in CI's `site` job, which installs Playwright with `--with-deps`

Generated with [Claude Code](https://claude.com/claude-code)
