### PR TITLE
chore(chart): bump chart version to 1.7.99

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.7.99] - 2026-07-22
+
+### Changed
+
+- auto-bump to chart v1.7.99 triggered by release tag(s): `admin-v1.25.0`, `chat-v1.5.0`, `metrics-v1.7.0`, `task-store-v1.14.0`
+
 ## [1.7.98] - 2026-07-22
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.7.98
+version: 1.7.99
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,7 +29,13 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "manual chart version bump to v1.7.98 required by ct lint --check-version-increment (no chart content change in #2059)"
+      description: "auto-bump to chart v1.7.99 triggered by release tag admin-v1.25.0"
+    - kind: changed
+      description: "auto-bump to chart v1.7.99 triggered by release tag chat-v1.5.0"
+    - kind: changed
+      description: "auto-bump to chart v1.7.99 triggered by release tag metrics-v1.7.0"
+    - kind: changed
+      description: "auto-bump to chart v1.7.99 triggered by release tag task-store-v1.14.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -114,7 +114,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.24.0
+    tag: admin-v1.25.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -182,7 +182,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v1.6.0
+    tag: metrics-v1.7.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -533,7 +533,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.13.0
+    tag: task-store-v1.14.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -598,7 +598,7 @@ chat:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-chat
-    tag: chat-v1.4.4
+    tag: chat-v1.5.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.7.98 → 1.7.99

**Triggering tags:**
- `admin-v1.25.0`
- `chat-v1.5.0`
- `metrics-v1.7.0`
- `task-store-v1.14.0`

**New chart version:** `1.7.99`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.25.0`
- `chat.image.tag`: `chat-v1.5.0`
- `metrics.image.tag`: `metrics-v1.7.0`
- `taskStore.image.tag`: `task-store-v1.14.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.7.99 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._