### PR TITLE
docs: document source field conventions in task-schema reference

### DIFF
--- a/plugins/shipwright/skills/task-store/references/task-schema.md
+++ b/plugins/shipwright/skills/task-store/references/task-schema.md
@@ -45,10 +45,23 @@ contract: the same shape whether the backend is GitHub Issues, Jira, or the loca
 | `blockedAt` / `blockedReason` | ISO string / string | → `blocked` |
 | `cancelledAt` / `deployingAt` / `deployedAt` / `completedAt` | ISO string | corresponding status |
 | `mergeCommit` | string | merge commit SHA |
-| `source` / `issue` | string | backend tracking ref (e.g. `gh:owner/repo#123`) |
+| `source` / `issue` | string | provenance ref; see conventions below. Filterable via `GET /tasks?source=...`. |
 
 > **Legacy duplicates** appear in older records: `prNumber` (≈ `pr`), `prOpenedAt`
 > (≈ `prCreatedAt`). Prefer `pr` / `prCreatedAt`; readers should tolerate both.
+
+> **`source` conventions.** `source` records where a task came from and its value depends
+> on who created it:
+> - **`plan-session`** sets it to the real planning doc path that produced the task, e.g.
+>   `planning/{session}/PLAN.md`.
+> - **Automated `-fix` skills** set it to their own skill name as a literal string —
+>   `entropy-fix`, `error-fix`, `security-fix`, `consolidation-fix`, `test-fix`. This
+>   replaced an older generic `"shipwright"` literal used for the same purpose.
+> - **Legacy/manual values** still appear in older or hand-created records: a generic
+>   backend tracking ref (e.g. `gh:owner/repo#123`), a manually-set string, or a value
+>   imported from a GitHub issue.
+>
+> `source` is queryable — `GET /tasks?source=...` filters the list by exact match.
 
 ## Status lifecycle
 


### PR DESCRIPTION
## Summary
- Documented the `source` field's current conventions in `task-schema.md`: `plan-session` sets it to a real `planning/{session}/PLAN.md` path, the five automated `-fix` skills (`entropy-fix`, `error-fix`, `security-fix`, `consolidation-fix`, `test-fix`) set it to their own skill name (replacing the older generic `"shipwright"` literal), and legacy/manual/GitHub-issue-imported values still appear in older records.
- Noted that `source` is filterable via `GET /tasks?source=...` (per CTV-4.1).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | task-schema.md's source field description lists all current conventions: plan-session PLAN.md path, per-skill name for automated tasks, and generic/manual/gh-issue-imported legacy values | MET |
| 2 | task-schema.md mentions the source query-param filter is available | MET |
| 3 | No test change needed — documentation-only edit to a reference markdown file | MET |

## Test Plan
- Documentation-only change; no tests required per acceptance criteria.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
