### PR TITLE
feat: narrow hardcoded floor to FLOOR_TOOLS

### DIFF
--- a/agent/src/claude.ts
+++ b/agent/src/claude.ts
@@ -24,6 +24,30 @@ export function setLiveClaudeConfig(patch: Partial<LiveClaudeConfig>): void {
   Object.assign(liveClaudeConfig, patch);
 }
 
+/**
+ * The unconditional tool floor granted to every Claude session, regardless of
+ * what's seeded in the AgentTool DB table. These are read-only or
+ * context-only tools with no meaningful security delta from Read (which is
+ * already assumed safe) — they are permanently non-revocable.
+ *
+ * Bash, WebSearch, WebFetch, and Agent are deliberately NOT included here:
+ * they now flow entirely through `liveClaudeConfig.allowedTools` /
+ * `extraAllowedTools`, sourced from the AgentTool DB table (seeded at agent
+ * creation and backfilled for existing agents — see
+ * lib/agent-default-tools.ts). This is the capability-narrowing step: an
+ * agent with no AgentTool rows (or a 404'd config bundle) no longer gets
+ * Bash/WebSearch/WebFetch/Agent for free.
+ */
+export const FLOOR_TOOLS = [
+  "Read",
+  "Write",
+  "Edit",
+  "Glob",
+  "Grep",
+  "TodoWrite",
+  "Skill",
+];
+
 export interface TokenUsage {
   input_tokens: number;
   output_tokens: number;
@@ -206,22 +230,8 @@ export function createRunClaude(
     const resolvedExtraAllowedTools =
       extraAllowedTools ?? liveClaudeConfig.allowedTools;
 
-    const hardcodedTools = [
-      "Read",
-      "Write",
-      "Edit",
-      "Glob",
-      "Grep",
-      "Bash",
-      "WebSearch",
-      "WebFetch",
-      "Skill",
-      "Agent",
-      "TodoWrite",
-    ];
-
     // Deduplicate tools: Set preserves insertion order, so first-occurrence wins
-    const deduplicatedTools = [...new Set([...hardcodedTools, ...resolvedExtraAllowedTools])];
+    const deduplicatedTools = [...new Set([...FLOOR_TOOLS, ...resolvedExtraAllowedTools])];
 
     const args = [
       "-p",

--- a/agent/src/claude.unit.test.ts
+++ b/agent/src/claude.unit.test.ts
@@ -797,20 +797,20 @@ describe("extraAllowedTools", () => {
 
     const allowedIdx = cmd.indexOf("--allowedTools");
     const extraIdx = cmd.indexOf("mcp__extra__tool");
-    const agentIdx = cmd.indexOf("Agent"); // built-in tool near the end
+    const skillIdx = cmd.indexOf("Skill"); // built-in floor tool, last in FLOOR_TOOLS order
 
     expect(extraIdx).toBeGreaterThan(allowedIdx);
-    expect(extraIdx).toBeGreaterThan(agentIdx);
+    expect(extraIdx).toBeGreaterThan(skillIdx);
   });
 
-  test("dedup: allowedTools includes a built-in tool (Bash), final args contains it exactly once", async () => {
+  test("dedup: allowedTools includes a built-in tool (Bash, from DB), final args contains it exactly once", async () => {
     const runClaude = createRunClaude(
       mockSpawn as typeof Bun.spawn,
       testSessions,
       MODEL,
       WORKSPACE,
       fakeSentryClient,
-      ["Bash", "mcp__extra__tool"], // Bash is already in the hardcoded 11
+      ["Bash", "mcp__extra__tool"], // Bash is no longer hardcoded; now DB/extraAllowedTools-only
     );
 
     await runClaude("test");
@@ -824,7 +824,7 @@ describe("extraAllowedTools", () => {
     expect(toolsInCmd).toContain("mcp__extra__tool");
   });
 
-  test("dedup: empty allowedTools still contains exactly 11 hardcoded tools with no duplicates", async () => {
+  test("dedup: empty allowedTools still contains exactly the 7 FLOOR_TOOLS with no duplicates", async () => {
     const runClaudeEmpty = createRunClaude(
       mockSpawn as typeof Bun.spawn,
       testSessions,
@@ -839,21 +839,17 @@ describe("extraAllowedTools", () => {
 
     const toolsInCmd = extractAllowedTools(cmd);
 
-    // Verify exactly 11 hardcoded tools
-    const hardcodedTools = [
+    // Verify exactly the 7 FLOOR_TOOLS
+    const floorTools = [
       "Read",
       "Write",
       "Edit",
       "Glob",
       "Grep",
-      "Bash",
-      "WebSearch",
-      "WebFetch",
-      "Skill",
-      "Agent",
       "TodoWrite",
+      "Skill",
     ];
-    expect(toolsInCmd).toEqual(hardcodedTools);
+    expect(toolsInCmd).toEqual(floorTools);
 
     // Verify no duplicates: unique count equals total count
     const uniqueTools = new Set(toolsInCmd);
@@ -867,7 +863,7 @@ describe("extraAllowedTools", () => {
       MODEL,
       WORKSPACE,
       fakeSentryClient,
-      ["Bash", "Write", "mcp__tool1", "Read", "mcp__tool2"], // Bash, Write, and Read are built-in
+      ["Bash", "Write", "mcp__tool1", "Read", "mcp__tool2"], // Write and Read are floor; Bash comes from DB
     );
 
     await runClaude("test");
@@ -885,6 +881,73 @@ describe("extraAllowedTools", () => {
     expect(toolsInCmd).toContain("Read");
     expect(toolsInCmd).toContain("mcp__tool1");
     expect(toolsInCmd).toContain("mcp__tool2");
+  });
+
+  test("empty liveClaudeConfig.allowedTools: Bash/WebSearch/WebFetch/Agent are NOT in final args, only the 7 floor tools are present", async () => {
+    const runClaudeEmpty = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+      [], // simulates liveClaudeConfig.allowedTools === [] (no AgentTool rows / config bundle 404)
+    );
+
+    await runClaudeEmpty("test");
+    const [cmd] = mockSpawn.mock.calls[0] as [string[]];
+
+    const toolsInCmd = extractAllowedTools(cmd);
+
+    expect(toolsInCmd).not.toContain("Bash");
+    expect(toolsInCmd).not.toContain("WebSearch");
+    expect(toolsInCmd).not.toContain("WebFetch");
+    expect(toolsInCmd).not.toContain("Agent");
+
+    expect(toolsInCmd).toEqual([
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "TodoWrite",
+      "Skill",
+    ]);
+  });
+
+  test("liveClaudeConfig.allowedTools includes Bash and Agent (from DB): final args include them exactly once each alongside the 7 floor tools", async () => {
+    const runClaude = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+      ["Bash", "Agent"], // simulates liveClaudeConfig.allowedTools seeded from AgentTool DB rows
+    );
+
+    await runClaude("test");
+    const [cmd] = mockSpawn.mock.calls[0] as [string[]];
+
+    const toolsInCmd = extractAllowedTools(cmd);
+
+    const bashCount = toolsInCmd.filter((tool) => tool === "Bash").length;
+    const agentCount = toolsInCmd.filter((tool) => tool === "Agent").length;
+    expect(bashCount).toBe(1);
+    expect(agentCount).toBe(1);
+
+    for (const floorTool of [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "TodoWrite",
+      "Skill",
+    ]) {
+      expect(toolsInCmd).toContain(floorTool);
+    }
+
+    const uniqueTools = new Set(toolsInCmd);
+    expect(uniqueTools.size).toBe(toolsInCmd.length);
   });
 });
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -48,7 +48,7 @@ Mounted at `/agents/*` (unified with the runtime API surface). Auth: **admin key
 
 | Resource | Endpoints |
 |---|---|
-| Agents | `POST /agents` (admin-only: creates agent, seeds default tools `["Bash", "WebSearch", "WebFetch", "Agent"]`, returns `{id, name, slackId, selfHosted, repos, createdAt, updatedAt}` with `201`), `GET /agents/:id` (admin-only: fetches agent record), `GET /agents` (admin-only: lists agents), `PATCH /agents/:id` (admin-only: updates agent fields like `selfHosted` and `repos`; repos validation: each entry must be `org/repo` format), `POST /agents/:id/provision` (admin-only: provisions a managed agent or returns `{skipped: true, reason: "self-hosted"}` for self-hosted agents) |
+| Agents | `POST /agents` (admin-only: creates agent, seeds default AgentTool rows via `lib/agent-default-tools.ts` (e.g., Bash, WebSearch, WebFetch, Agent) at creation time, returns `{id, name, slackId, selfHosted, repos, createdAt, updatedAt}` with `201`), `GET /agents/:id` (admin-only: fetches agent record), `GET /agents` (admin-only: lists agents), `PATCH /agents/:id` (admin-only: updates agent fields like `selfHosted` and `repos`; repos validation: each entry must be `org/repo` format), `POST /agents/:id/provision` (admin-only: provisions a managed agent or returns `{skipped: true, reason: "self-hosted"}` for self-hosted agents) |
 | Envs | `POST` / `GET` / `PATCH` `/agents/:id/envs`, `DELETE /agents/:id/envs/:key` |
 | Crons | `POST` `/agents/:id/crons`, `PATCH` / `DELETE` `/agents/:id/crons/:cronId`, `POST /agents/:id/crons/reconcile`, `POST` / `GET` / `PATCH` `/agents/:id/crons/:cronId/runs/{runId}` |
 | Cron Run Stats | `GET /agents/all/cron-runs/stats` (admin-only: returns aggregated token stats across all agents; query params: `from` / `to` (optional ISO datetime); returns `{totals, byAgent, byCron, byModel, byCronModel, daily, byPhase}`) |
@@ -121,6 +121,47 @@ There is no HTTP chat endpoint on the agent. Chat flows through the chat service
 | `AgentWorkQueueSnapshot` | Latest ranked work-queue snapshot | `agentId` (unique — one row per agent), `computedAt`, `items` (JSON `RankedWorkItem[]`). Upserted by `POST /agents/:id/work-queue`; overwrites any prior snapshot — there is no history, only the latest state. |
 
 All child models cascade-delete with their `Agent` (including `AgentCronRun` via `AgentCronJob`).
+
+## Tool management and narrowing
+
+The agent runtime implements a two-tier tool authorization system to narrowly grant Claude access to tools: **floor tools** (unconditional, always present) and **allowed tools** (DB-driven, configurable per agent).
+
+### Floor tools
+
+When the agent spawns a Claude session, it always includes a fixed set of 7 **floor tools** (`FLOOR_TOOLS` constant in `agent/src/claude.ts`):
+
+- `Read` — read-only file access (safe, no side effects)
+- `Write` — create new files (safe, limited blast radius)
+- `Edit` — modify existing file content (safe, scoped)
+- `Glob` — pattern-based file discovery (safe, read-only)
+- `Grep` — content search (safe, read-only)
+- `Skill` — invoke built-in skills (safe by design; does not grant additional system access)
+- `TodoWrite` — legacy task-tracking tool (safe, limited scope)
+
+These tools are **non-revocable** — they are not derivable from the `AgentTool` database table and are always granted, regardless of agent configuration. They have no meaningful security delta from `Read` (which is the assumed safe baseline) and enable essential read-only operations without privileging escalation.
+
+**Crucially**, `Bash`, `WebSearch`, `WebFetch`, and `Agent` are **not** in the floor set. These are high-privilege tools (arbitrary system execution, external HTTP, sub-agent spawning) and must be explicitly seeded into the agent's `AgentTool` table to be available. An agent with no `AgentTool` rows (or a 404'd config bundle from the admin API) receives only the 7 floor tools and cannot execute shell commands, fetch external URLs, or dispatch sub-agents.
+
+### Configurable allowed tools (`AgentTool` table)
+
+Tools beyond the floor set are configured via the `AgentTool` database table (one row per tool pattern per agent). When `POST /agents` creates a new agent, it seeds default `AgentTool` rows for high-privilege tools (e.g., Bash, WebSearch, WebFetch, Agent) via the `lib/agent-default-tools.ts` module. Operators and integrations can then toggle individual tools on/off via the admin UI or the `/agents/:id/tools` CRUD API.
+
+The agent's config sync loop (every 60 seconds) fetches the agent's full tool list from `/agents/:id/config`, decrypts it, and merges with the floor tools. Deduplication preserves insertion order (floor-tools-first, then extra-allowed-tools), so floor tools always take precedence in the final list.
+
+**Tool changes flow:**
+1. Operator/integration updates AgentTool rows via the admin API (`POST`/`PATCH`/`DELETE /agents/:id/tools/:toolId`)
+2. Agent's 60-second config sync fetches updated `allowedTools` from `/agents/:id/config`
+3. Next Claude session (up to 1 minute later) sees the new tool list — no pod restart required
+
+### Example: narrowing an agent to read-only mode
+
+To disable shell access and external requests for a risky agent:
+
+1. Call `DELETE /agents/:id/tools/Bash` (via admin API)
+2. Call `DELETE /agents/:id/tools/WebSearch` (via admin API)
+3. Call `DELETE /agents/:id/tools/WebFetch` (via admin API)
+
+On the agent's next config sync, Claude will no longer have access to shell execution or external HTTP — only the 7 floor tools remain. The agent can still read files, search locally, and invoke safe skills.
 
 ## Default system crons
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -155,11 +155,15 @@ The agent's config sync loop (every 60 seconds) fetches the agent's full tool li
 
 ### Example: narrowing an agent to read-only mode
 
-To disable shell access and external requests for a risky agent:
+To disable shell access and external requests for a risky agent, note that the `:toolId` path
+param on the tools routes is the `AgentTool` row's cuid **primary key**, not the tool's `pattern`
+string — so you first need to look up the row ids:
 
-1. Call `DELETE /agents/:id/tools/Bash` (via admin API)
-2. Call `DELETE /agents/:id/tools/WebSearch` (via admin API)
-3. Call `DELETE /agents/:id/tools/WebFetch` (via admin API)
+1. Call `GET /agents/:id/tools` (via admin API) and find the rows whose `pattern` is `"Bash"`,
+   `"WebSearch"`, and `"WebFetch"`, noting each row's `id`.
+2. Call `DELETE /agents/:id/tools/:toolId` for the `Bash` row's `id`.
+3. Call `DELETE /agents/:id/tools/:toolId` for the `WebSearch` row's `id`.
+4. Call `DELETE /agents/:id/tools/:toolId` for the `WebFetch` row's `id`.
 
 On the agent's next config sync, Claude will no longer have access to shell execution or external HTTP — only the 7 floor tools remain. The agent can still read files, search locally, and invoke safe skills.
 


### PR DESCRIPTION
## Summary
- Replace the hardcoded 11-tool `--allowedTools` array in `agent/src/claude.ts` with a `FLOOR_TOOLS` constant containing only the 7 permanently non-revocable tools: Read, Write, Edit, Glob, Grep, TodoWrite, Skill.
- Bash, WebSearch, WebFetch, and Agent are no longer hardcoded — they now flow entirely through `liveClaudeConfig.allowedTools` / `extraAllowedTools`, sourced from the AgentTool DB table (seeded by DAT-1.2, backfilled by DAT-2.1).
- Update existing unit tests to assert the new 7-tool baseline, and add two new tests covering the empty-DB-rows case (no Bash/WebSearch/WebFetch/Agent) and the DB-populated case (Bash/Agent present exactly once).

## ⚠️ Deploy ordering
Per the task description: this must not go live before **DAT-1.2** (new-agent seeding) and **DAT-2.1** (existing-agent backfill) are both fully deployed, or every existing agent instantly loses Bash/WebSearch/WebFetch/Agent access. Current status: DAT-1.2 is merged and in the deploy pipeline (`deploying`), DAT-2.1 is `done`. Please confirm DAT-1.2 has finished deploying before merging/deploying this PR.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | claude.ts no longer hardcodes Bash/WebSearch/WebFetch/Agent; only 7 floor tools remain | MET |
| 2 | Existing tests updated from old 11-tool array to new 7-tool baseline | MET |
| 3 | New test: empty allowedTools → Bash/WebSearch/WebFetch/Agent absent, 7 floor tools present | MET |
| 4 | New test: allowedTools with Bash+Agent (DB) → present exactly once alongside floor tools | MET |

## Test Plan
- `bun test agent/src/claude.unit.test.ts` — 57/57 passing
- `tsc --noEmit` — clean
- `biome lint` — clean
- Coverage: 100% lines on `agent/src/claude.ts`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
