### PR TITLE
feat: add AgentMemberService + extend AgentService with missing query/update methods

### DIFF
--- a/admin/src/agent-members.ts
+++ b/admin/src/agent-members.ts
@@ -1,0 +1,60 @@
+/**
+ * agent/src/agent-members.ts
+ * AgentMemberService — authorized human members per agent (access control).
+ *
+ * Membership rows are keyed by [agentId, email] (unique constraint) — an
+ * email can be a member of multiple agents, and an agent can have multiple
+ * member emails.
+ */
+
+import type { AgentMember, PrismaClient } from "../prisma/client/index.js";
+
+export type { AgentMember };
+
+export class AgentMemberService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * List all memberships for a given agent.
+   */
+  async listByAgentId(agentId: string): Promise<AgentMember[]> {
+    return this.prisma.agentMember.findMany({ where: { agentId } });
+  }
+
+  /**
+   * List all memberships for a given email, case-sensitive as stored.
+   * Callers are expected to lowercase the email before calling.
+   */
+  async listByEmail(email: string): Promise<AgentMember[]> {
+    return this.prisma.agentMember.findMany({ where: { email } });
+  }
+
+  /**
+   * Returns whether a membership row exists for the given agentId+email pair.
+   */
+  async exists(agentId: string, email: string): Promise<boolean> {
+    const membership = await this.prisma.agentMember.findUnique({
+      where: { agentId_email: { agentId, email } },
+    });
+    return membership !== null;
+  }
+
+  /**
+   * Create a membership row for the given agentId and email.
+   * Throws (unique-constraint violation) if the membership already exists —
+   * callers are expected to catch and handle "already a member" as a no-op.
+   */
+  async add(agentId: string, email: string): Promise<AgentMember> {
+    return this.prisma.agentMember.create({ data: { agentId, email } });
+  }
+
+  /**
+   * Delete a membership by id, scoped to agentId. No-ops if the id doesn't
+   * exist or belongs to a different agent.
+   */
+  async remove(agentId: string, memberId: string): Promise<void> {
+    await this.prisma.agentMember.deleteMany({
+      where: { id: memberId, agentId },
+    });
+  }
+}

--- a/admin/src/agent-members.unit.test.ts
+++ b/admin/src/agent-members.unit.test.ts
@@ -1,0 +1,250 @@
+/**
+ * agent/src/agent-members.unit.test.ts
+ * Unit tests for AgentMemberService (admin/src/agent-members.ts) — pure logic
+ * against an injected prisma test double. No real DB — see docs/testing.md
+ * for the unit-layer contract.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AgentMemberService } from "./agent-members.ts";
+
+// ─── In-memory prisma.agentMember test double ──────────────────────────────
+
+interface FakeAgentMemberRow {
+  id: string;
+  agentId: string;
+  email: string;
+  createdAt: Date;
+}
+
+function makeFakePrisma(seed: FakeAgentMemberRow[] = []) {
+  const rows = new Map<string, FakeAgentMemberRow>(seed.map((r) => [r.id, r]));
+  let nextId = 1;
+
+  const agentMember = {
+    async findMany({
+      where,
+    }: {
+      where?: { agentId?: string; email?: string };
+    } = {}): Promise<FakeAgentMemberRow[]> {
+      let all = Array.from(rows.values());
+      if (where?.agentId !== undefined) {
+        all = all.filter((r) => r.agentId === where.agentId);
+      }
+      if (where?.email !== undefined) {
+        all = all.filter((r) => r.email === where.email);
+      }
+      return all;
+    },
+    async findUnique({
+      where,
+    }: {
+      where: { agentId_email: { agentId: string; email: string } };
+    }): Promise<FakeAgentMemberRow | null> {
+      const { agentId, email } = where.agentId_email;
+      const row = Array.from(rows.values()).find(
+        (r) => r.agentId === agentId && r.email === email,
+      );
+      return row ?? null;
+    },
+    async create({
+      data,
+    }: {
+      data: { agentId: string; email: string };
+    }): Promise<FakeAgentMemberRow> {
+      const existing = Array.from(rows.values()).find(
+        (r) => r.agentId === data.agentId && r.email === data.email,
+      );
+      if (existing) {
+        throw new Error(
+          "Unique constraint failed on the fields: (`agentId`,`email`)",
+        );
+      }
+      const row: FakeAgentMemberRow = {
+        id: `member-${nextId++}`,
+        agentId: data.agentId,
+        email: data.email,
+        createdAt: new Date("2024-01-01"),
+      };
+      rows.set(row.id, row);
+      return row;
+    },
+    async deleteMany({
+      where,
+    }: {
+      where: { id: string; agentId: string };
+    }): Promise<{ count: number }> {
+      const row = rows.get(where.id);
+      if (row && row.agentId === where.agentId) {
+        rows.delete(where.id);
+        return { count: 1 };
+      }
+      return { count: 0 };
+    },
+  };
+
+  return { agentMember, __rows: rows };
+}
+
+type FakePrisma = ReturnType<typeof makeFakePrisma>;
+
+function seedRow(overrides: Partial<FakeAgentMemberRow> = {}): FakeAgentMemberRow {
+  return {
+    id: "member-existing",
+    agentId: "agent-1",
+    email: "person@example.com",
+    createdAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+// ─── listByAgentId ──────────────────────────────────────────────────────────
+
+describe("AgentMemberService.listByAgentId", () => {
+  it("returns all memberships for the given agentId", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "m1", agentId: "agent-1", email: "a@example.com" }),
+      seedRow({ id: "m2", agentId: "agent-1", email: "b@example.com" }),
+      seedRow({ id: "m3", agentId: "agent-2", email: "c@example.com" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    const result = await service.listByAgentId("agent-1");
+
+    expect(result.map((r) => r.email).sort()).toEqual([
+      "a@example.com",
+      "b@example.com",
+    ]);
+  });
+
+  it("returns an empty array when the agent has no memberships", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    expect(await service.listByAgentId("agent-1")).toEqual([]);
+  });
+});
+
+// ─── listByEmail ────────────────────────────────────────────────────────────
+
+describe("AgentMemberService.listByEmail", () => {
+  it("returns all memberships for the given email, case-sensitive as stored", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "m1", agentId: "agent-1", email: "person@example.com" }),
+      seedRow({ id: "m2", agentId: "agent-2", email: "person@example.com" }),
+      seedRow({ id: "m3", agentId: "agent-3", email: "other@example.com" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    const result = await service.listByEmail("person@example.com");
+
+    expect(result.map((r) => r.agentId).sort()).toEqual(["agent-1", "agent-2"]);
+  });
+
+  it("does not match on a differently-cased email", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "m1", agentId: "agent-1", email: "person@example.com" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    expect(await service.listByEmail("Person@example.com")).toEqual([]);
+  });
+
+  it("returns an empty array when no memberships match", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    expect(await service.listByEmail("nobody@example.com")).toEqual([]);
+  });
+});
+
+// ─── exists ─────────────────────────────────────────────────────────────────
+
+describe("AgentMemberService.exists", () => {
+  it("returns true when a membership row exists for the agentId+email pair", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ agentId: "agent-1", email: "person@example.com" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    expect(await service.exists("agent-1", "person@example.com")).toBe(true);
+  });
+
+  it("returns false when no membership row exists for the pair", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ agentId: "agent-1", email: "person@example.com" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    expect(await service.exists("agent-1", "someone-else@example.com")).toBe(
+      false,
+    );
+    expect(await service.exists("agent-2", "person@example.com")).toBe(false);
+  });
+
+  it("returns false when there are no memberships at all", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    expect(await service.exists("agent-1", "person@example.com")).toBe(false);
+  });
+});
+
+// ─── add ────────────────────────────────────────────────────────────────────
+
+describe("AgentMemberService.add", () => {
+  it("creates a membership row for the given agentId and email", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    const row = await service.add("agent-1", "person@example.com");
+
+    expect(row.agentId).toBe("agent-1");
+    expect(row.email).toBe("person@example.com");
+    expect(row.id).toBeDefined();
+  });
+
+  it("propagates a unique-constraint error when the membership already exists", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ agentId: "agent-1", email: "person@example.com" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    await expect(
+      (async () => service.add("agent-1", "person@example.com"))(),
+    ).rejects.toThrow();
+  });
+});
+
+// ─── remove ─────────────────────────────────────────────────────────────────
+
+describe("AgentMemberService.remove", () => {
+  it("deletes a membership by id when scoped to the correct agentId", async () => {
+    const row = seedRow({ id: "m1", agentId: "agent-1" });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    await service.remove("agent-1", "m1");
+
+    expect(await service.listByAgentId("agent-1")).toEqual([]);
+  });
+
+  it("no-ops when the memberId does not exist", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    await service.remove("agent-1", "missing");
+
+    expect(await service.listByAgentId("agent-1")).toEqual([]);
+  });
+
+  it("no-ops when the memberId exists but belongs to a different agentId", async () => {
+    const row = seedRow({ id: "m1", agentId: "agent-1" });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentMemberService(prisma as never);
+
+    await service.remove("agent-2", "m1");
+
+    expect(await service.listByAgentId("agent-1")).toEqual([row]);
+  });
+});

--- a/admin/src/agents.ts
+++ b/admin/src/agents.ts
@@ -57,6 +57,18 @@ export interface AgentIdAndRepos {
   repos: string[];
 }
 
+export interface AgentOption {
+  id: string;
+  name: string;
+}
+
+export interface UpdateAgentFieldsInput {
+  name?: string;
+  repos?: string[];
+  selfHosted?: boolean;
+  slackId?: string | null;
+}
+
 // ─── Select shapes ────────────────────────────────────────────────────────────
 
 const SUMMARY_SELECT = { id: true, name: true, selfHosted: true } as const;
@@ -164,6 +176,70 @@ export class AgentService {
     return this.prisma.agent.findUnique({
       where: { id },
       select: { id: true, repos: true },
+    });
+  }
+
+  /**
+   * List every agent, full record, no filtering — used by dashboard-style
+   * pages (e.g. /admin/agents isAdmin branch, /admin/provision, /admin/tasks,
+   * /admin/prs, /admin/chat) that want every field back in whatever default
+   * order Prisma returns.
+   */
+  async listAll(): Promise<AgentRecord[]> {
+    return this.prisma.agent.findMany();
+  }
+
+  /**
+   * List agents matching a given set of ids — used for batch-resolving
+   * agent ids to full records (e.g. the non-admin /admin/agents filter path
+   * and agentNames-resolution on the tasks/PRs pages).
+   */
+  async listByIds(ids: string[]): Promise<AgentRecord[]> {
+    return this.prisma.agent.findMany({ where: { id: { in: ids } } });
+  }
+
+  /**
+   * Search agents by name, case-insensitive substring match — used by the
+   * /admin/tasks agent-name filter.
+   */
+  async searchByName(query: string): Promise<AgentRecord[]> {
+    return this.prisma.agent.findMany({
+      where: { name: { contains: query, mode: "insensitive" } },
+    });
+  }
+
+  /**
+   * List {id, name} for all agents, ordered by name asc. Backs both the
+   * full-record-mapped-to-{id,name} call sites (chat page, provision pages)
+   * and the name-only autocomplete call site (tasks page).
+   */
+  async listOptions(): Promise<AgentOption[]> {
+    return this.prisma.agent.findMany({
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
+  }
+
+  /**
+   * Generic partial-field update for an agent's name/repos/selfHosted/slackId.
+   * Only fields present in the input are touched. Returns the full updated
+   * detail record.
+   */
+  async updateFields(
+    id: string,
+    input: UpdateAgentFieldsInput,
+  ): Promise<AgentDetail> {
+    return this.prisma.agent.update({
+      where: { id },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.repos !== undefined && { repos: input.repos }),
+        ...(input.selfHosted !== undefined && {
+          selfHosted: input.selfHosted,
+        }),
+        ...(input.slackId !== undefined && { slackId: input.slackId }),
+      },
+      select: DETAIL_SELECT,
     });
   }
 }

--- a/admin/src/agents.unit.test.ts
+++ b/admin/src/agents.unit.test.ts
@@ -429,7 +429,7 @@ describe("AgentService.searchByName", () => {
   it("returns agents whose name contains the query, case-insensitive", async () => {
     const prisma = makeFakePrisma([
       seedRow({ id: "a1", name: "Shipwright Bot" }),
-      seedRow({ id: "a2", name: "vitals-os agent" }),
+      seedRow({ id: "a2", name: "Other Product Agent" }),
       seedRow({ id: "a3", name: "Other" }),
     ]) as unknown as FakePrisma;
     const service = new AgentService(prisma as never);

--- a/admin/src/agents.unit.test.ts
+++ b/admin/src/agents.unit.test.ts
@@ -68,11 +68,28 @@ function makeFakePrisma(seed: FakeAgentRow[] = []) {
     async findMany({
       select,
       orderBy,
+      where,
     }: {
       select?: Partial<Record<keyof FakeAgentRow, boolean>>;
       orderBy?: { name?: "asc" | "desc" };
+      where?: {
+        id?: { in: string[] };
+        name?: { contains: string; mode?: "insensitive" };
+      };
     } = {}): Promise<FakeAgentRow[]> {
       let all = Array.from(rows.values());
+      if (where?.id) {
+        const ids = new Set(where.id.in);
+        all = all.filter((r) => ids.has(r.id));
+      }
+      if (where?.name) {
+        const { contains, mode } = where.name;
+        all = all.filter((r) =>
+          mode === "insensitive"
+            ? r.name.toLowerCase().includes(contains.toLowerCase())
+            : r.name.includes(contains),
+        );
+      }
       if (orderBy?.name) {
         all = [...all].sort((a, b) =>
           orderBy.name === "desc"
@@ -99,13 +116,20 @@ function makeFakePrisma(seed: FakeAgentRow[] = []) {
       select,
     }: {
       where: { id: string };
-      data: { selfHosted?: boolean; repos?: string[] };
+      data: {
+        name?: string;
+        slackId?: string | null;
+        selfHosted?: boolean;
+        repos?: string[];
+      };
       select?: Partial<Record<keyof FakeAgentRow, boolean>>;
     }): Promise<FakeAgentRow> {
       const row = rows.get(where.id);
       if (!row) throw new Error("record not found");
       const updated: FakeAgentRow = {
         ...row,
+        ...(data.name !== undefined && { name: data.name }),
+        ...(data.slackId !== undefined && { slackId: data.slackId }),
         ...(data.selfHosted !== undefined && { selfHosted: data.selfHosted }),
         ...(data.repos !== undefined && { repos: data.repos }),
         updatedAt: new Date("2024-01-02"),
@@ -336,5 +360,196 @@ describe("AgentService.getById", () => {
     const service = new AgentService(prisma as never);
 
     expect(await service.getById("missing")).toBeNull();
+  });
+});
+
+// ─── listAll ────────────────────────────────────────────────────────────────
+
+describe("AgentService.listAll", () => {
+  it("returns every agent with all fields, no filtering", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "Zeta" }),
+      seedRow({ id: "a2", name: "Alpha" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.listAll();
+
+    expect(result.map((r) => r.id).sort()).toEqual(["a1", "a2"]);
+    expect(result[0]).toHaveProperty("createdAt");
+    expect(result[0]).toHaveProperty("slackId");
+  });
+
+  it("returns an empty array when there are no agents", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.listAll()).toEqual([]);
+  });
+});
+
+// ─── listByIds ──────────────────────────────────────────────────────────────
+
+describe("AgentService.listByIds", () => {
+  it("returns only the agents matching the given ids", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "One" }),
+      seedRow({ id: "a2", name: "Two" }),
+      seedRow({ id: "a3", name: "Three" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.listByIds(["a1", "a3"]);
+
+    expect(result.map((r) => r.id).sort()).toEqual(["a1", "a3"]);
+  });
+
+  it("returns an empty array when no ids match", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "One" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.listByIds(["missing"])).toEqual([]);
+  });
+
+  it("returns an empty array when given an empty id list", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "One" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.listByIds([])).toEqual([]);
+  });
+});
+
+// ─── searchByName ───────────────────────────────────────────────────────────
+
+describe("AgentService.searchByName", () => {
+  it("returns agents whose name contains the query, case-insensitive", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "Shipwright Bot" }),
+      seedRow({ id: "a2", name: "vitals-os agent" }),
+      seedRow({ id: "a3", name: "Other" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.searchByName("ship");
+
+    expect(result.map((r) => r.id)).toEqual(["a1"]);
+  });
+
+  it("returns an empty array when nothing matches", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "Shipwright Bot" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.searchByName("nomatch")).toEqual([]);
+  });
+});
+
+// ─── listOptions ────────────────────────────────────────────────────────────
+
+describe("AgentService.listOptions", () => {
+  it("returns {id, name} for all agents, ordered by name asc", async () => {
+    const prisma = makeFakePrisma([
+      seedRow({ id: "a1", name: "Zeta" }),
+      seedRow({ id: "a2", name: "Alpha" }),
+    ]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.listOptions();
+
+    expect(result).toEqual([
+      { id: "a2", name: "Alpha" },
+      { id: "a1", name: "Zeta" },
+    ]);
+  });
+
+  it("returns an empty array when there are no agents", async () => {
+    const prisma = makeFakePrisma() as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    expect(await service.listOptions()).toEqual([]);
+  });
+});
+
+// ─── updateFields ───────────────────────────────────────────────────────────
+
+describe("AgentService.updateFields", () => {
+  it("updates only the provided fields and returns the full detail record", async () => {
+    const row = seedRow({
+      id: "a1",
+      name: "Old Name",
+      slackId: "U000",
+      selfHosted: false,
+      repos: ["org/old"],
+    });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateFields("a1", { name: "New Name" });
+
+    expect(updated.name).toBe("New Name");
+    expect(updated.slackId).toBe("U000");
+    expect(updated.selfHosted).toBe(false);
+    expect(updated.repos).toEqual(["org/old"]);
+  });
+
+  it("updates repos when provided", async () => {
+    const row = seedRow({ id: "a1", repos: [] });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateFields("a1", {
+      repos: ["org/new-repo"],
+    });
+
+    expect(updated.repos).toEqual(["org/new-repo"]);
+  });
+
+  it("updates selfHosted when provided", async () => {
+    const row = seedRow({ id: "a1", selfHosted: false });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateFields("a1", { selfHosted: true });
+
+    expect(updated.selfHosted).toBe(true);
+  });
+
+  it("updates slackId to null when explicitly passed null", async () => {
+    const row = seedRow({ id: "a1", slackId: "U123" });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateFields("a1", { slackId: null });
+
+    expect(updated.slackId).toBeNull();
+  });
+
+  it("leaves fields untouched when not provided", async () => {
+    const row = seedRow({
+      id: "a1",
+      name: "Untouched",
+      slackId: "U999",
+      selfHosted: true,
+      repos: ["org/keep"],
+    });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const updated = await service.updateFields("a1", {});
+
+    expect(updated).toEqual({
+      id: "a1",
+      name: "Untouched",
+      slackId: "U999",
+      selfHosted: true,
+      repos: ["org/keep"],
+      createdAt: row.createdAt,
+      updatedAt: new Date("2024-01-02"),
+    });
   });
 });

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -117,7 +117,7 @@ There is no HTTP chat endpoint on the agent. Chat flows through the chat service
 | `AgentTool` | Allowed tool patterns | `pattern` (e.g. `Read`, `Bash`), `enabled`, `createdAt`; unique per `[agentId, pattern]`. |
 | `AgentToken` | Scoped API tokens | `token` (SHA-256 hash), `label`, `revokedAt`. |
 | `AgentPlugin` | Installed Claude Code plugins | `name` (package), `version` (null = latest), `enabled`, `createdAt`, `updatedAt`; unique per `[agentId, name]`. |
-| `AgentMember` | Authorized human members | `email`; unique per `[agentId, email]`. |
+| `AgentMember` | Authorized human members | `id`, `agentId`, `email`, `createdAt`; unique per `[agentId, email]`. Managed by `AgentMemberService` (list by agent/email, check existence, add, remove). |
 | `AgentWorkQueueSnapshot` | Latest ranked work-queue snapshot | `agentId` (unique — one row per agent), `computedAt`, `items` (JSON `RankedWorkItem[]`). Upserted by `POST /agents/:id/work-queue`; overwrites any prior snapshot — there is no history, only the latest state. |
 
 All child models cascade-delete with their `Agent` (including `AgentCronRun` via `AgentCronJob`).

--- a/docs/test-readiness/test-inventory.md
+++ b/docs/test-readiness/test-inventory.md
@@ -101,7 +101,7 @@
 | `admin/src/agent-manifest.ts` (pure Deployment/Secret wire-object builders) | 1. Pure business logic | unit | critical | n/a |
 | `admin/src/agent-deletion.ts`, `agent-deletion-checklist.ts` | 2. Service-boundary code | integration | high | n/a |
 | `admin/src/agent-tokens.ts`, `token-crypto.ts`, `chat-markers.ts` | 1. Pure business logic (hash/encrypt given key) | unit | critical | n/a |
-| `admin/src/agent-envs.ts`, `agent-cron-jobs.ts`, `agent-cron-runs.ts`, `agent-cron-run-stats.ts`, `agent-tools.ts`, `agent-plugins.ts`, `agents.ts` (Prisma-backed services) | 2. Service-boundary code | integration | high | n/a |
+| `admin/src/agent-envs.ts`, `agent-cron-jobs.ts`, `agent-cron-runs.ts`, `agent-cron-run-stats.ts`, `agent-tools.ts`, `agent-plugins.ts`, `agent-members.ts`, `agents.ts` (Prisma-backed services) | 2. Service-boundary code | integration | high | n/a |
 | `admin/src/agent-chat-tokens.ts` (`AgentChatTokenService` — daily rollup, atomic upsert) | 2. Service-boundary code | integration | high | n/a |
 | `admin/src/agent-work-queue.ts` (`AgentWorkQueueService` — latest work-queue snapshot per agent) | 2. Service-boundary code | integration | medium | n/a |
 | `admin/src/clock.ts` | 1. Pure business logic | unit | medium | n/a |


### PR DESCRIPTION
## Summary
- Add `AgentMemberService` (`admin/src/agent-members.ts`) with `listByAgentId`, `listByEmail`, `exists`, `add`, `remove` — constructor-injected with `PrismaClient`, mirroring the existing per-entity service pattern (`AgentEnvService`, `AgentCronJobService`).
- Extend `AgentService` (`admin/src/agents.ts`) with `listAll`, `listByIds`, `searchByName`, `listOptions` (+ `AgentOption` type), and `updateFields` (+ `UpdateAgentFieldsInput` type) — covering the raw list/search/option-list/generic-update shapes `admin-ui.ts`'s route handlers need.
- No changes to `admin-ui.ts` or `agents-api.ts` in this PR — that rewiring is AAS-1.2/1.3/1.4.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New `AgentMemberService` with list-by-agent, list-by-email, exists, add, remove, constructor-injected with `PrismaClient` | MET |
| 2 | `AgentService` extended with the additional list/search/option-list/generic-update methods `admin-ui.ts` needs | MET |
| 3 | No changes to `admin-ui.ts` or `agents-api.ts` | MET |
| 4 | `*.unit.test.ts` coverage for every new/extended method on both services, injected Prisma test double, no real DB | MET |

## Test Plan
- `admin/src/agent-members.unit.test.ts` (new) — full coverage of all 5 `AgentMemberService` methods, incl. duplicate/unique-constraint and scoped-delete no-op edge cases.
- `admin/src/agents.unit.test.ts` (extended) — new describe blocks for all 5 new `AgentService` methods.
- 43/43 unit tests pass; 100% line/function coverage on both changed source files.
- Full repo suite: 4856 pass / 0 fail (5222 tests, 237 files).
- `bunx biome lint .` clean; `bun run --filter='*' --sequential typecheck` clean across all 7 workspaces.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
