### PR TITLE
feat: add origin-story timeline page to marketing site

### DIFF
--- a/docs/test-readiness/test-inventory.md
+++ b/docs/test-readiness/test-inventory.md
@@ -164,7 +164,7 @@
 | `site/src/content.config.ts` (Astro content collection schema) | 1. Pure business logic (schema def) | unit | low | n/a |
 | `site/src/data/config-vars.ts` (static config-var data) | 1. Pure business logic (data) | unit | low | n/a |
 | `site/src/consts.ts` | 1. Pure business logic (data) | unit | low | n/a |
-| `site/src/pages/*.astro` (marketing pages: index, architecture, compare, self-hosted, vs/devin, docs/*) | 6. User journey (rendered page + nav flow) | e2e (Playwright `*.spec.ts`) | high | n/a |
+| `site/src/pages/*.astro` (marketing pages: index, architecture, compare, self-hosted, vs/devin, story, docs/*) | 6. User journey (rendered page + nav flow) | e2e (Playwright `*.spec.ts`) | high | n/a |
 | `site/src/layouts/*.astro`, `components/*.astro` | 3. HTTP route (rendered fragment, no standalone contract) | e2e (covered via page-level spec, not independently) | medium | n/a |
 | **User journey: dev-task → review → patch → deploy pipeline** (task claim → PR open → review → patch → merge → deploy, spanning agent + task-store + admin + GitHub) | 6. User journey | e2e / smoke-composed (no browser; cross-service integration + GitHub fixtures) | critical | n/a |
 | **User journey: agent provisioning** (admin creates Agent → K8s Deployment/Secret → task-store/chat token minting → agent boots and reports health) | 6. User journey | e2e / smoke-composed | critical | n/a |

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -18,6 +18,7 @@ const discussionsUrl = "https://github.com/app-vitals/shipwright/discussions";
 const compareUrl = "/compare";
 const docsUrl = "/docs";
 const vsDevinUrl = "/vs/devin";
+const storyUrl = "/story";
 const year = new Date().getFullYear();
 ---
 
@@ -37,6 +38,7 @@ const year = new Date().getFullYear();
       Shipwright Harness · MIT-licensed · © {year}
     </p>
     <nav class="flex flex-wrap gap-x-6 gap-y-2 text-sm" aria-label="Footer">
+      <a href={storyUrl}>Story</a>
       <a href={REPO_URL}>GitHub</a>
       <a href={LICENSE_URL}>MIT License</a>
       <a href={claudeCodeUrl}>Claude Code</a>

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -50,4 +50,5 @@ export const PRIMARY_NAV_LINKS: NavLink[] = [
   { href: "/compare", label: "Compare" },
   { href: "/vs/devin", label: "vs Devin" },
   { href: "/architecture", label: "Architecture" },
+  { href: "/story", label: "Story" },
 ];

--- a/site/src/pages/story.astro
+++ b/site/src/pages/story.astro
@@ -1,0 +1,128 @@
+---
+// Origin-story timeline page (STY-1.1). Approved copy verbatim from
+// planning/site-timeline/PLAN.md — presentation-only, no backend/data-model/
+// API surface. Timeline content lives in this frontmatter array and is
+// mapped into a vertical rail + dot list, styled with a page-scoped <style>
+// block that reuses existing brand.css tokens only. Zero runtime JS.
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+const timelineEntries = [
+  {
+    date: "November 2025",
+    body: "Dan starts running Claude Code in the cloud. Dave starts building the first autonomous workflow plugin.",
+  },
+  {
+    date: "January 2026",
+    body: "The first real autonomous-loop plugin lands in the App Vitals marketplace, inspired by the open-source Ralph pattern. Auto-approve hooks, task types, plugin discovery — the pieces of a self-driving loop start coming together.",
+  },
+  {
+    date: "March 2026",
+    body: "We start building Vitals OS — and from day one, we run the build through our own emerging Shipwright workflow. First real product built by the thing we were building.",
+  },
+  {
+    date: "April 2026",
+    body: 'The automation backbone goes in: a dev-task runner, agent cron infrastructure, scheduled review/patch/deploy cycles. This is where "autonomous" stops being aspirational.',
+  },
+  {
+    date: "May 2026",
+    body: "Metrics wired in end to end. We can finally see what the agents are doing, not just trust that they're doing it.",
+  },
+  {
+    date: "June 2026",
+    body: "Shipwright graduates out of the marketplace into its own repo. We scrub every internal reference and open it up.",
+  },
+  {
+    date: "Late June 2026",
+    body: "Public launch.",
+  },
+  {
+    date: "Today",
+    body: "Two of us, shipping 50+ PRs a day, running production infrastructure for clients almost entirely through the loop we built for ourselves.",
+  },
+];
+---
+
+<BaseLayout
+  title="Our story — Shipwright Harness"
+  description="How Shipwright Harness went from a couple of engineers running Claude Code in the cloud to a public, MIT-licensed autonomous delivery agent — dogfooded the entire way."
+  pagefindIgnore={true}
+>
+  <!-- Page header -->
+  <section class="relative z-10 pt-16 pb-12">
+    <p class="sw-label">Our story</p>
+    <h1 class="sw-h1 mt-4 max-w-3xl">
+      From <span class="sw-gradient-text">side project</span> to the loop we run
+      production on.
+    </h1>
+    <p class="mt-5 max-w-2xl text-lg">
+      Shipwright wasn't planned as a product. It grew out of two engineers
+      trying to get more out of Claude Code, dogfooded on our own delivery
+      work the entire way. Here's the timeline, honestly.
+    </p>
+  </section>
+
+  <!-- Timeline -->
+  <section
+    class="sw-timeline relative z-10 pb-20"
+    style="border-top: 1px solid var(--sw-color-border-subtle); padding-top: 3rem;"
+  >
+    <ol class="sw-timeline-list">
+      {
+        timelineEntries.map((entry) => (
+          <li class="sw-timeline-item">
+            <span class="sw-timeline-dot" aria-hidden="true" />
+            <p class="sw-mono sw-label sw-timeline-date">{entry.date}</p>
+            <p class="mt-2 max-w-2xl" style="color: var(--sw-color-text-body);">
+              {entry.body}
+            </p>
+          </li>
+        ))
+      }
+    </ol>
+  </section>
+</BaseLayout>
+
+<style>
+  .sw-timeline-list {
+    position: relative;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .sw-timeline-item {
+    position: relative;
+    padding-left: 2rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .sw-timeline-item:last-child {
+    padding-bottom: 0;
+  }
+
+  /* Connecting rail — a single vertical line running behind every dot,
+     except after the last entry. */
+  .sw-timeline-item:not(:last-child)::before {
+    content: "";
+    position: absolute;
+    top: 0.4rem;
+    left: 0.3rem;
+    width: 1px;
+    height: 100%;
+    background: var(--sw-color-border-muted);
+  }
+
+  .sw-timeline-dot {
+    position: absolute;
+    top: 0.3rem;
+    left: 0;
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 50%;
+    background: var(--sw-color-brand-default);
+  }
+
+  .sw-timeline-date {
+    color: var(--sw-color-text-heading);
+  }
+</style>

--- a/site/tests/story.spec.ts
+++ b/site/tests/story.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
+
+// Fulfill external font CDN requests immediately so the page's 'load' event
+// fires even when CI can't reach external networks.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
+    (route) =>
+      route.fulfill({ status: 200, contentType: "text/css", body: "" }),
+  );
+});
+
+// /story — origin-story timeline page (STY-1.1). Approved copy verbatim
+// from planning/site-timeline/PLAN.md; presentation-only, zero runtime JS.
+
+test("story route responds 200", async ({ page }) => {
+  const response = await page.goto("/story");
+  expect(response?.status()).toBe(200);
+});
+
+test("story page has a visible h1", async ({ page }) => {
+  await page.goto("/story");
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+});
+
+test("story page renders all 8 timeline dates", async ({ page }) => {
+  await page.goto("/story");
+  const text = (await page.locator("main").textContent()) ?? "";
+  for (const date of [
+    "November 2025",
+    "January 2026",
+    "March 2026",
+    "April 2026",
+    "May 2026",
+    "June 2026",
+    "Late June 2026",
+    "Today",
+  ]) {
+    expect(text, `expected timeline date "${date}" to be present`).toContain(
+      date,
+    );
+  }
+});
+
+test("story nav link is present in the header", async ({ page }) => {
+  await page.goto("/story");
+  const nav = page.getByRole("navigation", { name: "Primary" });
+  await expect(nav.getByRole("link", { name: "Story", exact: true })).toHaveAttribute(
+    "href",
+    "/story",
+  );
+});
+
+test("story page ships no runtime JS beyond the analytics tag", async ({
+  page,
+}) => {
+  await page.goto("/story");
+  await expectNoRuntimeJsBeyondAnalytics(page);
+});


### PR DESCRIPTION
## Summary
- Add `/story` — a new marketing page telling Shipwright's origin story as a vertical timeline (8 entries, Nov 2025 → today), using the approved copy from `planning/site-timeline/PLAN.md` verbatim
- Add a "Story" link to the shared `PRIMARY_NAV_LINKS` (drives both desktop and mobile nav via `SiteHeader.astro`) and to `SiteFooter.astro`
- Add `site/tests/story.spec.ts` (Playwright): route 200, visible `<h1>`, all 8 dates present, nav link present, zero runtime JS beyond analytics
- Docs: refresh `docs/test-readiness/test-inventory.md` to list the new page

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `story.astro` renders all 8 timeline entries with exact approved copy, styled per existing page conventions, zero runtime JS | MET | Frontmatter array matches `PLAN.md` verbatim; uses `BaseLayout`, page-scoped CSS reusing `brand.css` tokens, no `<script>` |
| 2 | `BaseLayout.astro` nav (desktop + mobile) and footer link to `/story` | MET | `consts.ts`'s `PRIMARY_NAV_LINKS` (shared by `SiteHeader.astro` desktop+mobile) and `SiteFooter.astro` both updated |
| 3 | `tests/story.spec.ts` added (route 200, h1 visible, all 8 dates, nav link, no existing tests retired) | MET | All 5 assertions present in new spec file |
| 4 | `task lint && task typecheck` clean for changed files | MET | `bun run lint` and `bun run typecheck` both pass; `astro build` succeeds and emits `/story/index.html` |

## Test Plan
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean across all workspaces
- [x] `cd site && npm run build` — succeeds, `/story/index.html` generated
- [ ] `cd site && npm test` (Playwright) — could not run headless Chromium locally (sandbox is missing `libglib-2.0` and has no root/apt access to install `--with-deps`); CI's `Install Playwright chromium` step runs `--with-deps` as root and will execute this suite for real. Verified test assertions by static review against `SiteHeader.astro`'s `aria-label="Primary"` nav and the rendered `/story/index.html` build output.

Generated with [Claude Code](https://claude.com/claude-code)
