### PR TITLE
refactor: migrate admin-ui auth/membership routes to AgentMemberService

### DIFF
--- a/admin/e2e/test-server.ts
+++ b/admin/e2e/test-server.ts
@@ -170,6 +170,16 @@ function buildMockDeps(): AdminUIDeps {
     agentPluginService: {
       list: async () => [],
     },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+      }),
+      remove: async () => {},
+    },
     sessionSecret: ADMIN_E2E_SESSION_SECRET,
     googleClientId: "e2e-google-client-id",
     googleClientSecret: "e2e-google-client-secret",

--- a/admin/src/admin-dev-login.smoke.test.ts
+++ b/admin/src/admin-dev-login.smoke.test.ts
@@ -158,6 +158,17 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     agentPluginService: {
       list: async () => [],
     },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     sessionSecret: SESSION_SECRET,
     googleClientId: "test-google-client-id",
     googleClientSecret: "test-google-client-secret",

--- a/admin/src/admin-local-agent.smoke.test.ts
+++ b/admin/src/admin-local-agent.smoke.test.ts
@@ -193,6 +193,17 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     agentPluginService: {
       list: async () => [],
     },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     sessionSecret: SESSION_SECRET,
     googleClientId: "test-google-client-id",
     googleClientSecret: "test-google-client-secret",

--- a/admin/src/admin-tokens.smoke.test.ts
+++ b/admin/src/admin-tokens.smoke.test.ts
@@ -250,6 +250,17 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       revoke: async () => null,
     },
     agentPluginService: { list: async () => [] },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     provisioner: {
       provision: async () => ({
         resourceName: "r",

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -241,6 +241,17 @@ function makeMockDeps(
     agentPluginService: {
       list: async () => [],
     },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async () => ({
+        id: "m1",
+        agentId: AGENT_ID,
+        email: "member@example.com",
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     sessionSecret: SESSION_SECRET,
     googleClientId: GOOGLE_CLIENT_ID,
     googleClientSecret: GOOGLE_CLIENT_SECRET,
@@ -548,7 +559,12 @@ describe("admin UI — authenticated pages", () => {
 
   it("nests shipwright-loop phase crons under the loop row instead of listing them flat", async () => {
     const LOOP_ID = "cron-loop-1";
-    const PHASES = ["shipwright-dev-task", "shipwright-review", "shipwright-patch", "shipwright-deploy"];
+    const PHASES = [
+      "shipwright-dev-task",
+      "shipwright-review",
+      "shipwright-patch",
+      "shipwright-deploy",
+    ];
     const phaseCrons = PHASES.map((name, i) => ({
       ...MOCK_CRON,
       id: `cron-phase-${i}`,
@@ -2859,6 +2875,18 @@ describe("admin UI — member access control", () => {
           deleteMany: async () => ({ count: 0 }),
         },
       },
+      agentMemberService: {
+        listByEmail: async () => [],
+        exists: async (_agentId: string, email: string) =>
+          email === MEMBER_EMAIL,
+        add: async () => ({
+          id: "m1",
+          agentId: AGENT_ID,
+          email: MEMBER_EMAIL,
+          createdAt: new Date(),
+        }),
+        remove: async () => {},
+      },
     });
     const app = createAdminUIApp(deps);
     const res = await app.request(`/admin/agents/${AGENT_ID}`, {
@@ -2960,6 +2988,27 @@ describe("admin UI — member access control", () => {
           deleteMany: async () => ({ count: 0 }),
         },
       },
+      agentMemberService: {
+        listByEmail: async (email: string) =>
+          email === MEMBER_EMAIL
+            ? [
+                {
+                  id: "m1",
+                  agentId: AGENT_ID,
+                  email: MEMBER_EMAIL,
+                  createdAt: new Date(),
+                },
+              ]
+            : [],
+        exists: async () => false,
+        add: async () => ({
+          id: "m1",
+          agentId: AGENT_ID,
+          email: MEMBER_EMAIL,
+          createdAt: new Date(),
+        }),
+        remove: async () => {},
+      },
     });
     const app = createAdminUIApp(deps);
     const res = await app.request("/admin/agents", {
@@ -3050,6 +3099,27 @@ describe("admin UI — member access control", () => {
           }),
           deleteMany: async () => ({ count: 0 }),
         },
+      },
+      agentMemberService: {
+        listByEmail: async (email: string) =>
+          email === MEMBER_EMAIL
+            ? [
+                {
+                  id: "m1",
+                  agentId: AGENT_ID,
+                  email: MEMBER_EMAIL,
+                  createdAt: new Date(),
+                },
+              ]
+            : [],
+        exists: async () => false,
+        add: async () => ({
+          id: "m1",
+          agentId: AGENT_ID,
+          email: MEMBER_EMAIL,
+          createdAt: new Date(),
+        }),
+        remove: async () => {},
       },
     });
     const app = createAdminUIApp(deps);
@@ -3497,6 +3567,15 @@ describe("admin UI — member management routes", () => {
           deleteMany: async () => ({ count: 0 }),
         },
       },
+      agentMemberService: {
+        listByEmail: async () => [],
+        exists: async () => false,
+        add: async (agentId: string, email: string) => {
+          created = { agentId, email };
+          return { id: "m-new", agentId, email, createdAt: new Date() };
+        },
+        remove: async () => {},
+      },
     });
     const app = createAdminUIApp(deps);
     const body = new URLSearchParams({ email: "newmember@example.com" });
@@ -3571,6 +3650,19 @@ describe("admin UI — member management routes", () => {
             deletedId = where.id;
             return { count: 1 };
           },
+        },
+      },
+      agentMemberService: {
+        listByEmail: async () => [],
+        exists: async () => false,
+        add: async () => ({
+          id: "m1",
+          agentId: AGENT_ID,
+          email: "member@example.com",
+          createdAt: new Date(),
+        }),
+        remove: async (_agentId: string, memberId: string) => {
+          deletedId = memberId;
         },
       },
     });

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -57,6 +57,7 @@ import type { ManualStep } from "./agent-deletion-checklist.ts";
 import type { DeleteAgentFullyDeps } from "./agent-deletion.ts";
 import { deleteAgentFully } from "./agent-deletion.ts";
 import type { AgentEnvService } from "./agent-envs.ts";
+import type { AgentMemberService } from "./agent-members.ts";
 import type { AgentPluginService } from "./agent-plugins.ts";
 import type { AgentProvisioner } from "./agent-provisioner.ts";
 import type { AgentTokenService } from "./agent-tokens.ts";
@@ -223,6 +224,10 @@ export interface AdminUIDeps {
     "listForAgent" | "create" | "revoke"
   >;
   agentPluginService: Pick<AgentPluginService, "list">;
+  agentMemberService: Pick<
+    AgentMemberService,
+    "listByEmail" | "exists" | "add" | "remove"
+  >;
   provisioner: AgentProvisioner;
   /**
    * Cleanup deps for the full delete-agent orchestration (POST
@@ -457,6 +462,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     agentToolService,
     agentTokenService,
     agentPluginService,
+    agentMemberService,
     provisioner,
     taskStore,
     chatService,
@@ -624,9 +630,9 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       .includes(userInfo.email.toLowerCase());
 
     if (!isAdmin) {
-      const memberships = await prisma.agentMember.findMany({
-        where: { email: userInfo.email.toLowerCase() },
-      });
+      const memberships = await agentMemberService.listByEmail(
+        userInfo.email.toLowerCase(),
+      );
       if (memberships.length === 0) {
         return new Response("Forbidden", { status: 403 });
       }
@@ -691,9 +697,9 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     if (c.var.isAdmin) {
       agents = await prisma.agent.findMany();
     } else {
-      const memberships = await prisma.agentMember.findMany({
-        where: { email: c.var.userEmail.toLowerCase() },
-      });
+      const memberships = await agentMemberService.listByEmail(
+        c.var.userEmail.toLowerCase(),
+      );
       const agentIds = memberships.map((m) => m.agentId);
       agents = await prisma.agent.findMany({ where: { id: { in: agentIds } } });
     }
@@ -728,10 +734,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     isAdmin: boolean,
   ): Promise<boolean> {
     if (isAdmin) return true;
-    const membership = await prisma.agentMember.findUnique({
-      where: { agentId_email: { agentId, email: userEmail.toLowerCase() } },
-    });
-    return membership !== null;
+    return agentMemberService.exists(agentId, userEmail.toLowerCase());
   }
 
   const ERROR_MESSAGES: Record<string, string> = {
@@ -1929,7 +1932,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }
     if (email) {
       try {
-        await prisma.agentMember.create({ data: { agentId, email } });
+        await agentMemberService.add(agentId, email);
       } catch {
         // unique constraint violation — already a member, ignore
       }
@@ -1949,9 +1952,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     }
     if (memberId) {
       try {
-        await prisma.agentMember.deleteMany({
-          where: { id: memberId, agentId },
-        });
+        await agentMemberService.remove(agentId, memberId);
       } catch {
         // already gone, ignore
       }

--- a/admin/src/chat.smoke.test.ts
+++ b/admin/src/chat.smoke.test.ts
@@ -8,12 +8,6 @@
 
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
-import type {
-  ChatClient,
-  ChatMessage,
-  ChatThread,
-  ThreadStats,
-} from "./http-chat-client.ts";
 import { createAdminUIApp } from "./admin-ui.ts";
 import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
 import type {
@@ -21,6 +15,12 @@ import type {
   GoogleTokenResponse,
   GoogleUserInfo,
 } from "./google-auth-client.ts";
+import type {
+  ChatClient,
+  ChatMessage,
+  ChatThread,
+  ThreadStats,
+} from "./http-chat-client.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -317,6 +317,17 @@ function makeBaseDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       revoke: async () => MOCK_TOKEN,
     },
     agentPluginService: { list: async () => [] },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     provisioner: {
       provision: async () => ({
         resourceName: "r",

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -31,6 +31,7 @@ import { AgentCronJobService } from "./agent-cron-jobs.ts";
 import { AgentCronRunStatsService } from "./agent-cron-run-stats.ts";
 import { AgentCronRunService } from "./agent-cron-runs.ts";
 import { AgentEnvService } from "./agent-envs.ts";
+import { AgentMemberService } from "./agent-members.ts";
 import { AgentPluginService } from "./agent-plugins.ts";
 import type { AgentProvisioner } from "./agent-provisioner.ts";
 import {
@@ -350,6 +351,7 @@ async function startServer(): Promise<void> {
   const agentToolService = new AgentToolService(prisma);
   const agentTokenService = new AgentTokenService(prisma);
   const agentPluginService = new AgentPluginService(prisma);
+  const agentMemberService = new AgentMemberService(prisma);
   const agentChatTokenService = new AgentChatTokenService(prisma);
   const agentCronRunStatsService = new AgentCronRunStatsService(prisma);
   const agentWorkQueueService = new AgentWorkQueueService(prisma);
@@ -604,6 +606,7 @@ async function startServer(): Promise<void> {
     agentToolService,
     agentTokenService,
     agentPluginService,
+    agentMemberService,
     provisioner,
     taskStore: deletionTaskStore,
     chatService: deletionChatService,

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -244,6 +244,17 @@ function makeMockDeps(
     agentPluginService: {
       list: async () => [],
     },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     sessionSecret: SESSION_SECRET,
     googleClientId: "test-google-client-id",
     googleClientSecret: "test-google-client-secret",

--- a/admin/src/server.smoke.test.ts
+++ b/admin/src/server.smoke.test.ts
@@ -173,6 +173,12 @@ function buildComposedApp() {
       revoke: notImplemented,
     },
     agentPluginService: { list: notImplemented },
+    agentMemberService: {
+      listByEmail: notImplemented,
+      exists: notImplemented,
+      add: notImplemented,
+      remove: notImplemented,
+    },
     provisioner: {
       provision: notImplemented,
       deprovision: notImplemented,

--- a/admin/src/slack-provisioning.integration.test.ts
+++ b/admin/src/slack-provisioning.integration.test.ts
@@ -209,6 +209,17 @@ function makeMockDeps(
     agentPluginService: {
       list: async () => [],
     },
+    agentMemberService: {
+      listByEmail: async () => [],
+      exists: async () => false,
+      add: async (agentId: string, email: string) => ({
+        id: "m1",
+        agentId,
+        email,
+        createdAt: new Date(),
+      }),
+      remove: async () => {},
+    },
     sessionSecret: SESSION_SECRET,
     googleClientId: "test-google-client-id",
     googleClientSecret: "test-google-client-secret",


### PR DESCRIPTION
## Summary
- Wires the `AgentMemberService` added in AAS-1.1 into `admin/src/main.ts` and `admin/src/admin-ui.ts` (it was added but never instantiated/injected)
- Migrates 5 auth/membership call sites in `admin-ui.ts` — the OAuth login membership fallback, the `/admin/agents` list non-admin filter, `assertAgentAccess()`, and the add/remove member routes — from direct `prisma.agentMember.*` calls to the injected `AgentMemberService`
- Leaves the two out-of-scope display-only `prisma.agentMember.findMany` calls (agent detail page member table) untouched, as scoped by the task

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Login flow's admin-allowlist-then-membership-fallback check now goes through AgentMemberService | MET | OAuth callback now calls `agentMemberService.listByEmail(...)` |
| 2 | Membership existence check + add/remove member routes go through AgentMemberService, no direct prisma.agentMember.* remains in these handlers | MET | `assertAgentAccess()` calls `.exists(...)`; member routes call `.add`/`.remove` |
| 3 | No change to route paths/request/response shapes/auth behavior | MET | Internal refactor only; all existing tests pass unmodified in behavior |
| 4 | Smoke test coverage for login flow + add/remove routes, no existing tests retired | MET | 5 existing tests updated with matching `agentMemberService` mocks; no tests deleted |

## Test Plan
- `NODE_ENV=test bun test admin/src/admin-ui.smoke.test.ts` — 172 pass, 0 fail
- `NODE_ENV=test bun test admin/` — 1450 pass, 0 fail across the admin package
- `bunx tsc --noEmit` (admin) — clean
- `task ci` (lint → check-strings → typecheck → check-config-docs → check-version-sync → test:coverage → secret-scan) — passed
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
