### PR TITLE
feat: log loop-orchestrator no-op reasons (busy vs backoff vs empty)

### DIFF
--- a/agent/src/loop-orchestrator.ts
+++ b/agent/src/loop-orchestrator.ts
@@ -551,7 +551,16 @@ export function createLoopOrchestrator(
 
   return async function runLoopTick(jobs: CronJobLike[]): Promise<void> {
     // Concurrency guard: a prior tick is still draining — no-op immediately.
-    if (busy) return;
+    // LTO-1.1: logged (before returning) so an operator staring at a silent
+    // shipwright-loop gap can tell "still draining a prior tick" apart from
+    // the backoff-active and genuinely-empty no-op paths below — see the
+    // file's top doc comment / LTO-1.1 for why this matters.
+    if (busy) {
+      console.log(
+        "[loop-orchestrator] tick skipped: busy — a prior tick is still draining",
+      );
+      return;
+    }
     busy = true;
 
     // SKT-2.2 empty-queue backoff: if a prior tick's run of consecutive empty
@@ -559,7 +568,14 @@ export function createLoopOrchestrator(
     // candidate collection (no GitHub calls, no task-store queries) — until
     // the backoff window elapses. Checked before anything else so a tick
     // inside the window is as cheap as possible.
+    // LTO-1.1: logged (before releasing busy and returning) — distinguishable
+    // from the busy-flag skip above so the two silent-no-op causes aren't
+    // conflated from the outside.
     if (backoffUntil !== null && clock.now() < backoffUntil) {
+      const remainingMs = backoffUntil.getTime() - clock.now().getTime();
+      console.log(
+        `[loop-orchestrator] tick skipped: empty-queue backoff active — ${remainingMs}ms remaining until ${backoffUntil.toISOString()}`,
+      );
       busy = false;
       return;
     }
@@ -819,8 +835,22 @@ export function createLoopOrchestrator(
         backoffUntil = null;
       } else {
         consecutiveEmptyTicks += 1;
+        // LTO-1.1: a genuinely-empty tick (drained fully, saw zero
+        // candidates on every iteration) — distinguishable from both early
+        // returns above, and includes the resulting count so a string of
+        // these in the logs shows the climb toward emptyBackoffAttempts.
+        console.log(
+          `[loop-orchestrator] tick empty: no candidates collected this tick — consecutiveEmptyTicks now ${consecutiveEmptyTicks}`,
+        );
         if (consecutiveEmptyTicks >= emptyBackoffAttempts) {
           backoffUntil = new Date(clock.now().getTime() + emptyBackoffMs);
+          // LTO-1.1: fires only on the crossing tick (this branch is only
+          // entered once per backoff cycle, immediately before
+          // consecutiveEmptyTicks is reset below) — noting when backoff
+          // will next allow candidate collection again.
+          console.log(
+            `[loop-orchestrator] empty-queue backoff engaging: ${consecutiveEmptyTicks} consecutive empty ticks reached — backing off until ${backoffUntil.toISOString()}`,
+          );
           consecutiveEmptyTicks = 0;
         }
       }

--- a/agent/src/loop-orchestrator.unit.test.ts
+++ b/agent/src/loop-orchestrator.unit.test.ts
@@ -477,6 +477,31 @@ async function withCapturedWarnings(
   return warnMessages;
 }
 
+// ─── console.log / console.info capture (LTO-1.1) ──────────────────────────
+
+// Captures console.log AND console.info calls for the duration of `fn`,
+// restoring both originals afterward even if `fn` throws. Used to assert on
+// the distinguishable no-op-reason logs runLoopTick emits for the busy /
+// backoff-active / genuinely-empty / backoff-newly-engaging paths, without
+// caring which of the two methods a given call site happens to use.
+async function withCapturedLogs(fn: () => Promise<void>): Promise<string[]> {
+  const logMessages: string[] = [];
+  const originalLog = console.log.bind(console);
+  const originalInfo = console.info.bind(console);
+  const capture = (...args: unknown[]) => {
+    logMessages.push(args.map(String).join(" "));
+  };
+  console.log = capture;
+  console.info = capture;
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+    console.info = originalInfo;
+  }
+  return logMessages;
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("createLoopOrchestratorGetter", () => {
@@ -613,6 +638,39 @@ describe("createLoopOrchestrator", () => {
     await first;
     // First tick found nothing → still no dispatch.
     expect(messages).toEqual([]);
+  });
+
+  test("LTO-1.1: the busy-flag no-op logs a distinguishable message before returning", async () => {
+    // First tick's qualification hangs until we release it, so the second
+    // tick fires while the first is still draining and hits the busy guard.
+    let release!: () => void;
+    const gate = new Promise<void>((res) => {
+      release = res;
+    });
+
+    const deps = makeDeps({
+      getDevTaskCandidates: async () => {
+        await gate;
+        return [];
+      },
+    });
+    const loop = createLoopOrchestrator(deps);
+
+    const first = loop(ALL_PHASES_ON);
+    const logMessages = await withCapturedLogs(async () => {
+      // Second call while first is still draining — must no-op immediately
+      // and log a distinguishable "busy" message before returning.
+      await loop(ALL_PHASES_ON);
+    });
+
+    release();
+    await first;
+
+    expect(logMessages.length).toBeGreaterThan(0);
+    const busyLogs = logMessages.filter(
+      (msg) => msg.toLowerCase().includes("busy") || msg.includes("draining"),
+    );
+    expect(busyLogs.length).toBeGreaterThan(0);
   });
 
   test("skips disabled phases: a disabled phase's qualification fn is never called", async () => {
@@ -1499,6 +1557,112 @@ describe("createLoopOrchestrator", () => {
         calls.length = 0;
         await loop(ALL_PHASES_ON);
         expect(calls).toHaveLength(0);
+      },
+    );
+  });
+
+  test("LTO-1.1: each genuinely-empty tick logs a distinguishable message including the consecutiveEmptyTicks count", async () => {
+    await withEnvOverrides(
+      {
+        SHIPWRIGHT_LOOP_EMPTY_BACKOFF_ATTEMPTS: "3",
+        SHIPWRIGHT_LOOP_EMPTY_BACKOFF_MS: "300000",
+      },
+      async () => {
+        const { clock } = makeMutableClockForBackoff("2026-01-01T00:00:00Z");
+        const deps = { ...makeDeps({}), clock };
+        const loop = createLoopOrchestrator(deps);
+
+        const logMessages = await withCapturedLogs(async () => {
+          await loop(ALL_PHASES_ON);
+        });
+
+        const emptyLogs = logMessages.filter((msg) =>
+          msg.toLowerCase().includes("empty"),
+        );
+        expect(emptyLogs.length).toBeGreaterThan(0);
+        // Must surface the resulting consecutiveEmptyTicks count (1 after
+        // the first genuinely-empty tick).
+        expect(emptyLogs.some((msg) => msg.includes("1"))).toBe(true);
+      },
+    );
+  });
+
+  test("LTO-1.1: the backoff-active skip logs a distinguishable message including remaining time or the backoffUntil timestamp", async () => {
+    await withEnvOverrides(
+      {
+        SHIPWRIGHT_LOOP_EMPTY_BACKOFF_ATTEMPTS: "3",
+        SHIPWRIGHT_LOOP_EMPTY_BACKOFF_MS: "300000",
+      },
+      async () => {
+        const { clock } = makeMutableClockForBackoff("2026-01-01T00:00:00Z");
+        const deps = { ...makeDeps({}), clock };
+        const loop = createLoopOrchestrator(deps);
+
+        // 3 consecutive empty ticks arm backoff.
+        await loop(ALL_PHASES_ON);
+        await loop(ALL_PHASES_ON);
+        await loop(ALL_PHASES_ON);
+
+        // A 4th tick within the backoff window must log a distinguishable
+        // "backoff active" message before returning, distinct from the
+        // busy-flag and genuinely-empty messages.
+        const logMessages = await withCapturedLogs(async () => {
+          await loop(ALL_PHASES_ON);
+        });
+
+        expect(logMessages.length).toBeGreaterThan(0);
+        const backoffLogs = logMessages.filter((msg) =>
+          msg.toLowerCase().includes("backoff"),
+        );
+        expect(backoffLogs.length).toBeGreaterThan(0);
+        // Must not be confusable with the busy-flag message.
+        expect(
+          backoffLogs.some((msg) => msg.toLowerCase().includes("busy")),
+        ).toBe(false);
+      },
+    );
+  });
+
+  test("LTO-1.1: backoff newly engaging logs a distinguishable message noting until when, only on the crossing tick", async () => {
+    await withEnvOverrides(
+      {
+        SHIPWRIGHT_LOOP_EMPTY_BACKOFF_ATTEMPTS: "3",
+        SHIPWRIGHT_LOOP_EMPTY_BACKOFF_MS: "300000",
+      },
+      async () => {
+        const { clock } = makeMutableClockForBackoff("2026-01-01T00:00:00Z");
+        const deps = { ...makeDeps({}), clock };
+        const loop = createLoopOrchestrator(deps);
+
+        // First two empty ticks: below threshold, backoff must not engage.
+        const earlyLogs = await withCapturedLogs(async () => {
+          await loop(ALL_PHASES_ON);
+          await loop(ALL_PHASES_ON);
+        });
+        const earlyEngageLogs = earlyLogs.filter((msg) =>
+          msg.toLowerCase().includes("engag"),
+        );
+        expect(earlyEngageLogs).toHaveLength(0);
+
+        // Third empty tick crosses the threshold — backoff newly engages.
+        const crossingLogs = await withCapturedLogs(async () => {
+          await loop(ALL_PHASES_ON);
+        });
+        const engageLogs = crossingLogs.filter((msg) =>
+          msg.toLowerCase().includes("engag"),
+        );
+        expect(engageLogs.length).toBeGreaterThan(0);
+
+        // A subsequent tick inside the backoff window (the backoff-active
+        // skip) must NOT repeat the "newly engaging" message — only the
+        // crossing tick logs it.
+        const subsequentLogs = await withCapturedLogs(async () => {
+          await loop(ALL_PHASES_ON);
+        });
+        const repeatedEngageLogs = subsequentLogs.filter((msg) =>
+          msg.toLowerCase().includes("engag"),
+        );
+        expect(repeatedEngageLogs).toHaveLength(0);
       },
     );
   });


### PR DESCRIPTION
## Summary
- Adds distinguishable console.log messages to the three silent no-op paths in `runLoopTick` (busy-flag skip, backoff-active skip, genuinely-empty tick), plus a fourth message when empty-queue backoff newly engages.
- Purely additive logging — no change to busy/backoff/dispatch decision logic.
- Aimed at making unexplained multi-hour `shipwright-loop` activity gaps diagnosable from console output alone, since there's no cron-run-history API reachable from the agent sandbox.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Busy-flag skip logs before returning | MET |
| 2 | Backoff-active skip logs remaining time / backoffUntil timestamp | MET |
| 3 | Genuinely-empty tick logs consecutiveEmptyTicks count | MET |
| 4 | Backoff-newly-engaging logs until-when, only on the crossing tick | MET |
| 5 | All messages textually distinguishable (grep-able independently) | MET |
| 6 | Unit tests assert each no-op path's log via spy, not exact wording | MET |
| 7 | No behavior change to busy/backoff/dispatch logic | MET |

## Test Plan
- New unit tests in `agent/src/loop-orchestrator.unit.test.ts` cover all four log sites, including verifying the "newly engaging" message fires exactly once (crossing tick only).
- Full `agent/src/loop-orchestrator.unit.test.ts` suite (77 tests) passes.
- `bunx biome lint .` clean.
- `bun run --filter='*' --sequential typecheck` clean across all packages.
- Full repo `bun test` — 4881 pass; 1 pre-existing unrelated flake in `metrics/src/lib/errors.unit.test.ts` (passes in isolation on main, unrelated to this change).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
