### PR TITLE
feat: pilot Monitor tool for deploy Step 5a poll (MTP-1.1)

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -346,14 +346,13 @@ describe("deploy.md — chained in-Bash polling for Step 5b (AEW-1.1)", () => {
   });
 });
 
-describe("deploy.md — chained in-Bash polling for Step 5a (TCR-1.3)", () => {
-  it("Step 5a's polling implementation uses an inline chained-Bash sleep loop (shell for-loop + sleep 30)", () => {
+describe("deploy.md — Monitor-tool polling for Step 5a (MTP-1.1)", () => {
+  it("Step 5a's polling implementation names the Monitor tool and drops the old chained-Bash-loop framing", () => {
     const step5aSection = extractStep5aSection(content);
-    expect(step5aSection).toContain("sleep 30");
-    const hasForLoop =
-      /for\s+\w+\s+in\s+\$\(seq/.test(step5aSection) ||
-      step5aSection.includes("for i in");
-    expect(hasForLoop).toBe(true);
+    expect(step5aSection).toContain("Monitor");
+    const lower = step5aSection.toLowerCase();
+    expect(lower).not.toContain("inline in-bash sleep loop");
+    expect(lower).not.toContain("scheduled wakeup mechanism");
   });
 
   it("Step 5a's polling section does NOT instruct a per-poll ScheduleWakeup call or equivalent backgrounding language", () => {
@@ -364,12 +363,11 @@ describe("deploy.md — chained in-Bash polling for Step 5a (TCR-1.3)", () => {
     expect(lower).not.toContain("run it in the background");
   });
 
-  it("Step 5a explicitly states the implementation is chained in-Bash sleep loops, ruling out a scheduled wakeup mechanism", () => {
+  it("Step 5a explicitly states the implementation is the Monitor tool", () => {
     const step5aSection = extractStep5aSection(content);
     const lower = step5aSection.toLowerCase();
     expect(lower).toContain("implementation");
-    expect(lower).toContain("in-bash sleep loop");
-    expect(lower).toContain("scheduled wakeup mechanism");
+    expect(lower).toContain("monitor tool");
   });
 
   it("preserves the 5-minute budget and 30-second poll interval wording in Step 5a", () => {

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -353,26 +353,29 @@ read or tool call is needed. Look for a `## Deploy model` section:
 
 Before starting the full 30-minute pipeline watch, poll for a Deploy workflow run matching `SQUASH_SHA` for up to **5 minutes** (poll every 30 seconds, up to 10 polls).
 
-**Implementation: inline in-Bash sleep loop.** Do not wait between polls via a
-scheduled wakeup mechanism that resumes the session later (each resumption is a
-brand-new process invocation — costly and unnecessary here). Instead, run the
-30-second-interval checks as a shell-level loop inside a single Bash tool call. The
-full 5-minute/10-poll budget fits comfortably within one Bash call, well under Bash's
-practical ~10-minute ceiling, so — unlike Step 5b's 30-minute watch — no chaining
-across multiple Bash calls is needed here:
+**Implementation: Monitor tool.** A single Monitor call replaces the chained Bash
+sleep loop: the poll script below runs as a backgrounded shell command, and Monitor
+surfaces one event per stdout line. The script stays silent and emits nothing until a
+Deploy workflow run matching `SQUASH_SHA` appears — only then does it `echo` the match
+and `break`, ending the watch. Silence for the full budget is a valid terminal state
+here (it means "no Deploy workflow", not a crash): Monitor's own `timeout_ms` (default
+300000ms = 5 minutes, matching this budget exactly, so no override is needed) kills the
+process if nothing was ever emitted — that's the expected shape of the "no pipeline"
+outcome, not a failure.
 
-```bash
-for i in $(seq 1 10); do
-  REPO="{org}/{repo}"
-  gh api "repos/$REPO/actions/runs?per_page=50" \
-    --jq "[.workflow_runs[] | select(.head_sha == \"$SQUASH_SHA\" and .name == \"Deploy\") | {id, name, status, conclusion}]"
-  # break out of the loop immediately once a Deploy workflow run appears
-  sleep 30
-done
+```
+Monitor({
+  description: "Poll for Deploy workflow run matching SQUASH_SHA",
+  command: "REPO=\"{org}/{repo}\"; while true; do RESULT=$(gh api \"repos/$REPO/actions/runs?per_page=50\" --jq \"[.workflow_runs[] | select(.head_sha == \\\"$SQUASH_SHA\\\" and .name == \\\"Deploy\\\") | {id, name, status, conclusion}]\"); if [ \"$RESULT\" != \"[]\" ]; then echo \"$RESULT\"; break; fi; sleep 30; done",
+  timeout_ms: 300000,
+  persistent: false
+})
 ```
 
-- **Deploy workflow appears**: Break the 5-minute poll early and proceed to the main pipeline watch (Step 5b).
-- **No Deploy workflow after 5 minutes**: The repo has no deploy pipeline. Print:
+- **Deploy workflow appears** (Monitor reports an event — the poll script emitted the
+  matched run): Break the poll early and proceed to the main pipeline watch (Step 5b).
+- **No Deploy workflow after 5 minutes** (Monitor times out with no event emitted): The
+  repo has no deploy pipeline. Print:
   ```
   ⏭  No Deploy workflow triggered — watching post-merge CI runs on {SQUASH_SHA[0..7]}
   ```

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -366,7 +366,7 @@ outcome, not a failure.
 ```
 Monitor({
   description: "Poll for Deploy workflow run matching SQUASH_SHA",
-  command: "REPO=\"{org}/{repo}\"; while true; do RESULT=$(gh api \"repos/$REPO/actions/runs?per_page=50\" --jq \"[.workflow_runs[] | select(.head_sha == \\\"$SQUASH_SHA\\\" and .name == \\\"Deploy\\\") | {id, name, status, conclusion}]\"); if [ \"$RESULT\" != \"[]\" ]; then echo \"$RESULT\"; break; fi; sleep 30; done",
+  command: "REPO=\"{org}/{repo}\"; while true; do RESULT=$(gh api \"repos/$REPO/actions/runs?per_page=50\" --jq \"[.workflow_runs[] | select(.head_sha == \\\"$SQUASH_SHA\\\" and .name == \\\"Deploy\\\") | {id, name, status, conclusion}]\" 2>/dev/null) || RESULT=\"[]\"; if [ \"$RESULT\" != \"[]\" ]; then echo \"$RESULT\"; break; fi; sleep 30; done",
   timeout_ms: 300000,
   persistent: false
 })


### PR DESCRIPTION
## Summary
- Replace deploy.md Step 5a's chained in-Bash sleep loop with a single native Monitor tool call, as a narrow pilot before considering the same swap for Step 5b's 30-minute pipeline watch
- Update `deploy.content.test.ts`'s Step 5a describe block to assert on the Monitor-based implementation, while keeping the existing ScheduleWakeup-avoidance assertion (Monitor is the replacement, not a return to ScheduleWakeup)
- Step 5b and Step 5c sections/tests are untouched

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5a's implementation section instructs using the Monitor tool (not a chained in-Bash sleep loop) | MET |
| 2 | 5-minute budget and 30-second poll interval wording preserved in Step 5a | MET |
| 3 | Break-early-on-Deploy-workflow-appearing and fallback-to-Step-5c behavior preserved | MET |
| 4 | deploy.content.test.ts's Step 5a describe block updated to assert on the Monitor-based implementation and still asserts no ScheduleWakeup usage | MET |
| 5 | Step 5b and Step 5c sections and tests are unchanged | MET |
| 6 | task ci passes | MET |

## Test Plan
- `bun test plugins/shipwright/commands/deploy.content.test.ts` — 72/72 passing
- `bunx biome lint .` — clean
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- `bun scripts/check-config-docs.ts` — clean
- `bun run scripts/sync-version.ts --check` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all packages
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
