### PR TITLE
feat: log busy-skip and backoff-skip early returns in runLoopTick (LPF-7.1)

### DIFF
--- a/agent/src/loop-orchestrator.ts
+++ b/agent/src/loop-orchestrator.ts
@@ -338,6 +338,12 @@ export function createLoopOrchestrator(
 
   // Persisted across ticks: guards against a second concurrent drain.
   let busy = false;
+  // LPF-7.1: set (via the injected clock) whenever `busy` flips to true and
+  // cleared everywhere `busy` resets to false (the backoff-skip early
+  // return and the tick's `finally` block) — lets the busy-skip warn below
+  // report how long the in-flight tick has been draining, with no stale
+  // leakage into a later tick.
+  let busySince: Date | null = null;
 
   // Spin detection state: tracks the last dispatched itemId and consecutive
   // repeat count to warn when the same item is dispatched repeatedly.
@@ -559,13 +565,21 @@ export function createLoopOrchestrator(
     // shipwright-loop gap can tell "still draining a prior tick" apart from
     // the backoff-active and genuinely-empty no-op paths below — see the
     // file's top doc comment / LTO-1.1 for why this matters.
+    // LPF-7.1: console.warn (not console.log) — a tick still busy on the
+    // next scheduled invocation is a stronger operator signal than a plain
+    // informational skip, and the elapsed time (derived from busySince via
+    // the injected clock) shows how long the prior tick has been draining.
     if (busy) {
-      console.log(
-        "[loop-orchestrator] tick skipped: busy — a prior tick is still draining",
+      const elapsedMs = busySince
+        ? clock.now().getTime() - busySince.getTime()
+        : 0;
+      console.warn(
+        `[loop-orchestrator] tick skipped: busy — a prior tick has been draining for ${elapsedMs}ms (still running)`,
       );
       return;
     }
     busy = true;
+    busySince = clock.now();
 
     // SKT-2.2 empty-queue backoff: if a prior tick's run of consecutive empty
     // ticks reached the configured threshold, skip this tick entirely — no
@@ -581,6 +595,7 @@ export function createLoopOrchestrator(
         `[loop-orchestrator] tick skipped: empty-queue backoff active — ${remainingMs}ms remaining until ${backoffUntil.toISOString()}`,
       );
       busy = false;
+      busySince = null;
       return;
     }
 
@@ -885,6 +900,7 @@ export function createLoopOrchestrator(
       }
     } finally {
       busy = false;
+      busySince = null;
     }
   };
 }

--- a/agent/src/loop-orchestrator.unit.test.ts
+++ b/agent/src/loop-orchestrator.unit.test.ts
@@ -653,37 +653,52 @@ describe("createLoopOrchestrator", () => {
     expect(messages).toEqual([]);
   });
 
-  test("LTO-1.1: the busy-flag no-op logs a distinguishable message before returning", async () => {
+  test("LPF-7.1: the busy-flag no-op warns a distinguishable message including elapsed busy time before returning", async () => {
     // First tick's qualification hangs until we release it, so the second
     // tick fires while the first is still draining and hits the busy guard.
+    // A mutable clock lets us advance wall-clock time between busy=true
+    // (set at the top of the first tick) and the second tick's busy-skip, so
+    // the elapsed-time content in the warn message is genuinely exercised
+    // rather than trivially 0ms.
     let release!: () => void;
     const gate = new Promise<void>((res) => {
       release = res;
     });
+    const { clock, advanceMs } = makeMutableClockForBackoff(
+      "2026-01-01T00:00:00Z",
+    );
 
-    const deps = makeDeps({
-      getDevTaskCandidates: async () => {
-        await gate;
-        return [];
-      },
-    });
+    const deps = {
+      ...makeDeps({
+        getDevTaskCandidates: async () => {
+          await gate;
+          return [];
+        },
+      }),
+      clock,
+    };
     const loop = createLoopOrchestrator(deps);
 
     const first = loop(ALL_PHASES_ON);
-    const logMessages = await withCapturedLogs(async () => {
+    advanceMs(5000);
+    const warnMessages = await withCapturedWarnings(async () => {
       // Second call while first is still draining — must no-op immediately
-      // and log a distinguishable "busy" message before returning.
+      // and warn a distinguishable "busy" message (including elapsed busy
+      // time) before returning.
       await loop(ALL_PHASES_ON);
     });
 
     release();
     await first;
 
-    expect(logMessages.length).toBeGreaterThan(0);
-    const busyLogs = logMessages.filter(
+    expect(warnMessages.length).toBeGreaterThan(0);
+    const busyLogs = warnMessages.filter(
       (msg) => msg.toLowerCase().includes("busy") || msg.includes("draining"),
     );
     expect(busyLogs.length).toBeGreaterThan(0);
+    // Must surface the elapsed time since busySince (5000ms, derived from the
+    // injected clock, not a raw Date.now()/new Date() call).
+    expect(busyLogs.some((msg) => msg.includes("5000"))).toBe(true);
   });
 
   test("skips disabled phases: a disabled phase's qualification fn is never called", async () => {
@@ -1647,6 +1662,15 @@ describe("createLoopOrchestrator", () => {
         expect(
           backoffLogs.some((msg) => msg.toLowerCase().includes("busy")),
         ).toBe(false);
+        // LPF-7.1: must include the active backoffUntil timestamp so an
+        // operator can tell exactly when the window ends, not just that
+        // backoff is active.
+        const expectedBackoffUntil = new Date(
+          clock.now().getTime() + 300000,
+        ).toISOString();
+        expect(
+          backoffLogs.some((msg) => msg.includes(expectedBackoffUntil)),
+        ).toBe(true);
       },
     );
   });


### PR DESCRIPTION
## Summary
- Busy-flag early return in `runLoopTick` now emits `console.warn` with a distinguishable "busy-skip" message including elapsed time since `busy` last flipped true (tracked via a new `busySince: Date | null` closure variable, driven by the injected clock).
- `busySince` is set on every busy-true transition and cleared everywhere `busy` resets to false (the backoff-skip early return and the tick's `finally` block), so it never leaks stale state into a later tick.
- Backoff-skip's existing cheap `console.log` (message + `backoffUntil` timestamp) is left untouched — no added computation, per the "as cheap as possible" invariant for in-window ticks.
- The "genuinely nothing to do" drain path is unchanged — still relies solely on `workQueueReporter`'s per-iteration snapshot.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | busy-skip: `console.warn`, distinct message, elapsed time from `busySince` | MET |
| 2 | backoff-skip: `console.log`, distinct message, includes `backoffUntil` | MET |
| 3 | `busySince` set via clock on busy=true, cleared everywhere busy resets to false | MET |
| 4 | genuinely-empty path unchanged | MET |
| 5 | Tests: extend busy-flag test w/ `withCapturedWarnings`; extend backoff test w/ `backoffUntil` assertion | MET |

## Test Plan
- Extended `agent/src/loop-orchestrator.unit.test.ts`'s existing busy-flag no-op test to assert the `console.warn` busy-skip message includes elapsed busy time (via an advanceable injected clock).
- Extended the existing backoff-active-skip test to assert the message includes the exact `backoffUntil` ISO timestamp.
- `bun test agent/src/loop-orchestrator.unit.test.ts` — 78 pass, 0 fail.
- `bun run lint`, `bun run typecheck` — clean.
- Coverage on `loop-orchestrator.ts`: 96% lines / 91.22% functions.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
