### PR TITLE
feat: wire real per-call onProgress into index.ts's cron and loop-orchestrator adapters

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -159,23 +159,7 @@ const workQueueReporter =
 
 const cronDeps: CronHandlerDeps = {
   slack,
-  // `runner` (createRunClaude's return value) takes `sessionKey` as its
-  // second positional param, not the per-call `onProgress` (CSU-3.2) that
-  // CronHandlerDeps' `runner` type now accepts — an incompatible use of the
-  // same arg slot. createRunClaude only supports binding a single onProgress
-  // callback at construction time (shared across every call this one runner
-  // instance ever makes, for cron/Slack/chat too), not a distinct callback
-  // per invocation, so it cannot route a per-dispatch callback to the right
-  // runId here. Adapting by dropping onProgress means this particular
-  // runner never emits mid-run progress pushes for generic cron dispatches
-  // (they still get the CSU-3.2 partial-usage-on-failure fix via
-  // ClaudeTimeoutError.partialModelUsage on the catch path, just not the
-  // live push while running) — wiring true per-call progress would need a
-  // claude.ts change (out of scope here; see loop-orchestrator.ts and
-  // cron-handler.ts's onProgress plumbing, which is what a
-  // construction-time-bound wiring would forward into). Same limitation as
-  // getLoopOrchestrator's adapter below (CSU-3.1), second occurrence.
-  runner: (message) => runner(message),
+  runner: (message, onProgress) => runner(message, undefined, onProgress),
   formatter: markdownToSlack,
   onSession: async (channel: string, ts: string, sessionId: string) => {
     await sessions.set(threadKey(channel, ts), sessionId);
@@ -379,22 +363,7 @@ const loopJobsRef = createJobsRef<CronJobLike>();
 // wiring cost, and its construction errors surface at fire time (logged by the
 // cron callback's try/catch) rather than crashing agent startup.
 const getLoopOrchestrator = createLoopOrchestratorGetter({
-  // `runner` (createRunClaude's return value) takes `sessionKey` as its
-  // second positional param, not the per-call `onProgress` (CSU-3.1) that
-  // createLoopOrchestratorGetter's `runner` type now accepts — an
-  // incompatible use of the same arg slot. createRunClaude only supports
-  // binding a single onProgress callback at construction time (shared across
-  // every call this one runner instance ever makes, for cron/Slack/chat too),
-  // not a distinct callback per invocation, so it cannot route a per-dispatch
-  // callback to the right runId here. Adapting by dropping onProgress means
-  // this particular runner never emits mid-run progress pushes (loop dispatch
-  // still gets the CSU-3.1 partial-usage-on-failure fix via
-  // ClaudeTimeoutError.partialModelUsage on the catch path, just not the
-  // live push while running) — wiring true per-call progress would need a
-  // claude.ts change (out of scope here; see loop-orchestrator.ts's
-  // onProgress plumbing, which is what a construction-time-bound wiring
-  // would forward into).
-  runner: (message) => runner(message),
+  runner: (message, onProgress) => runner(message, undefined, onProgress),
   cronRunReporter: cronRunReporter ?? new NoopCronRunReporter(),
   workQueueReporter,
 });


### PR DESCRIPTION
## Summary
- Forward the per-call `onProgress` argument into the shared `runner`'s new third param at both `cronDeps.runner` and `getLoopOrchestrator`'s runner adapter, instead of silently dropping it
- Delete the two stale doc comments that explained why `onProgress` couldn't be routed per-call — now actively wrong since CSU-4.1 added the slot
- This makes `cronRunReporter.recordProgress` (CSU-2.1) and the CSU-3.1/CSU-3.2 `onProgress`-consuming closures in `loop-orchestrator.ts`/`cron-handler.ts` actually receive live turn-by-turn progress in production, instead of only ever seeing the timeout/crash partial-usage fallback

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | cronDeps.runner forwards onProgress into shared runner's third param | MET | `runner: (message, onProgress) => runner(message, undefined, onProgress)` |
| 2 | getLoopOrchestrator's runner adapter forwards onProgress the same way | MET | Identical pattern applied |
| 3 | Two stale doc comments deleted | MET | Both comment blocks removed |
| 4 | No test added (documented rationale) | MET | index.ts is the untested composition-root/bootstrap file; correctness already covered by CSU-4.1's claude.ts tests plus existing cron-handler.ts/loop-orchestrator.ts tests |

## Test Plan
- [x] `tsc --noEmit` passes across all workspaces
- [x] `bunx biome lint .` passes
- [x] Full test suite passes (1 pre-existing unrelated failure in `claude.unit.test.ts`'s `extraAllowedTools` test, confirmed present on `main` before this change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
