### PR TITLE
feat: add hitl task command for a hitl worker loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ task api        # start metrics dashboard in offline mode → http://localhost:3
 task ui         # same as task api (API and UI are one process)
 task dev        # dev supervisor: starts metrics + Ctrl-C kills all children
 task stack      # full dev stack in a tmux session (6 panes) — requires tmux + Docker + state/dev-agent.env
+task hitl       # human-in-the-loop runner: boots task-store (:3002) + admin (:3001), then loops — pulls the next ready task and launches Claude Code with the right command
 ```
 
 **`task stack` needs `state/dev-agent.env`** — if it's missing, the first `task stack` run auto-creates it from `state/dev-agent.env.example` and exits; fill in `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) in the newly-created file, then re-run `task stack`. See `docs/quickstart.md` for the full flow.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,6 +77,11 @@ tasks:
     cmds:
       - bun scripts/dev.ts
 
+  hitl:
+    desc: "Human-in-the-loop runner: boots task-store (:3002) + admin (:3001), then loops — pulls the next ready task and launches Claude Code with the right command. Uses shipwright.test as hostname (set SHIPWRIGHT_HITL_HOST to override)."
+    cmds:
+      - bun scripts/hitl.ts
+
   stack:
     aliases: [stack:up]
     desc: Launch the full dev stack in a tmux session (6 panes — metrics :3460, admin :3001, task-store :3002, chat-svc :3003, agent, logs). Chat with the agent at http://localhost:3001/admin/chat. Requires tmux; falls back to `task dev`.

--- a/agent/src/pr-state-reconciler.unit.test.ts
+++ b/agent/src/pr-state-reconciler.unit.test.ts
@@ -1581,15 +1581,23 @@ describe("buildProductionDeps — task-store GET /tasks pagination (TCR-1.2)", (
   const savedTaskStoreEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
+    savedTaskStoreEnv.WORKSPACE_PATH = process.env.WORKSPACE_PATH;
     savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_URL =
       process.env.SHIPWRIGHT_TASK_STORE_URL;
     savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_TOKEN =
       process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    process.env.WORKSPACE_PATH = "/nonexistent/workspace-for-unit-test";
     process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.test";
     process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "fake-token";
   });
 
   afterEach(() => {
+    if (savedTaskStoreEnv.WORKSPACE_PATH === undefined) {
+      // biome-ignore lint/performance/noDelete: restore to fully-unset state
+      delete process.env.WORKSPACE_PATH;
+    } else {
+      process.env.WORKSPACE_PATH = savedTaskStoreEnv.WORKSPACE_PATH;
+    }
     if (savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_URL === undefined) {
       // biome-ignore lint/performance/noDelete: restore to fully-unset state
       delete process.env.SHIPWRIGHT_TASK_STORE_URL;
@@ -2564,15 +2572,23 @@ describe("buildProductionDeps — updatedSince filtering (PSR-1.1)", () => {
   const savedTaskStoreEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
+    savedTaskStoreEnv.WORKSPACE_PATH = process.env.WORKSPACE_PATH;
     savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_URL =
       process.env.SHIPWRIGHT_TASK_STORE_URL;
     savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_TOKEN =
       process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    process.env.WORKSPACE_PATH = "/nonexistent/workspace-for-unit-test";
     process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.test";
     process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "fake-token";
   });
 
   afterEach(() => {
+    if (savedTaskStoreEnv.WORKSPACE_PATH === undefined) {
+      // biome-ignore lint/performance/noDelete: restore to fully-unset state
+      delete process.env.WORKSPACE_PATH;
+    } else {
+      process.env.WORKSPACE_PATH = savedTaskStoreEnv.WORKSPACE_PATH;
+    }
     if (savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_URL === undefined) {
       // biome-ignore lint/performance/noDelete: restore to fully-unset state
       delete process.env.SHIPWRIGHT_TASK_STORE_URL;
@@ -2651,15 +2667,23 @@ describe("buildReviewStateProductionDeps — updatedSince filtering (PSR-1.1)", 
   const savedTaskStoreEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
+    savedTaskStoreEnv.WORKSPACE_PATH = process.env.WORKSPACE_PATH;
     savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_URL =
       process.env.SHIPWRIGHT_TASK_STORE_URL;
     savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_TOKEN =
       process.env.SHIPWRIGHT_TASK_STORE_TOKEN;
+    process.env.WORKSPACE_PATH = "/nonexistent/workspace-for-unit-test";
     process.env.SHIPWRIGHT_TASK_STORE_URL = "https://task-store.example.test";
     process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "fake-token";
   });
 
   afterEach(() => {
+    if (savedTaskStoreEnv.WORKSPACE_PATH === undefined) {
+      // biome-ignore lint/performance/noDelete: restore to fully-unset state
+      delete process.env.WORKSPACE_PATH;
+    } else {
+      process.env.WORKSPACE_PATH = savedTaskStoreEnv.WORKSPACE_PATH;
+    }
     if (savedTaskStoreEnv.SHIPWRIGHT_TASK_STORE_URL === undefined) {
       // biome-ignore lint/performance/noDelete: restore to fully-unset state
       delete process.env.SHIPWRIGHT_TASK_STORE_URL;

--- a/agent/workspace/CLAUDE-HITL.md.template
+++ b/agent/workspace/CLAUDE-HITL.md.template
@@ -1,0 +1,50 @@
+# Shipwright HITL Workspace
+
+You are running in a human-in-the-loop Shipwright workspace. A human operator
+is driving — follow their lead and assist interactively.
+
+## Workspace
+
+### Repos
+
+`repos/<repo>` is always on `main`. Use for reading, research, and reference only.
+Never edit files in `repos/` directly.
+
+**Before any work on a repo** — pull first:
+```bash
+git -C repos/<repo> pull
+```
+
+### Worktrees
+
+All active work — features, bug fixes, reviewing a specific branch — happens in
+`worktrees/<repo>-<branch>`. No exceptions.
+
+**New branch:**
+```bash
+git -C repos/<repo> pull
+git -C repos/<repo> worktree add worktrees/<repo>-<branch> origin/main -b <branch>
+```
+
+**Existing branch (e.g. for review):**
+```bash
+git -C repos/<repo> fetch origin
+git -C repos/<repo> worktree add worktrees/<repo>-<branch> origin/<branch>
+```
+
+### Shipwright Commands
+
+- **Planning:** `/shipwright:plan-session`
+- **Execution:** `/shipwright:dev-task {task-id}`
+- **HITL tasks:** `/shipwright:hitl {task-id}`
+- **Review:** `/shipwright:review {org/repo#number}`
+
+Query the task store:
+```bash
+curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?ready=true" | jq '.tasks'
+```
+
+### Reviews
+
+Review artifacts live in `state/reviews/`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,8 +187,11 @@ On Kubernetes these env vars are a deploy-time option of the Helm chart rather t
 |---|---|---|---|
 | `ADMIN_DEV_AUTH` | `bool` | `false` | Enables `GET /admin/dev-login` (bypasses Google OAuth, mints a dev session). Blocked when `NODE_ENV=production`. |
 | `METRICS_DASHBOARD_DEV_AUTH` | `bool` | `false` | Bypasses `/dashboard` session auth and `/metrics/*` API auth for local dev. Must not be enabled in production — exits with an error if `NODE_ENV=production`. |
-| `TASK_STORE_SEED_ADMIN_TOKEN` | `string` | — | Bootstrap admin token seeded into the task-store on startup. Used only in local dev (`task stack`) to provision a bootstrapped admin token without manual token creation. Not a real secret — used only against the local dev Postgres instance. Ignored if empty. |
+| `TASK_STORE_SEED_ADMIN_TOKEN` | `string` | — | Bootstrap admin token seeded into the task-store on startup. Used only in local dev (`task stack` and `task hitl`) to provision a bootstrapped admin token without manual token creation. Not a real secret — used only against the local dev Postgres instance. Ignored if empty. |
 | `CHAT_SEED_ADMIN_TOKEN` | `string` | — | Bootstrap admin token seeded into the chat service on startup. Used only in local dev to provision a bootstrapped admin token without manual token creation. Not a real secret — used only against the local dev Postgres instance. Ignored if empty. |
+| `SHIPWRIGHT_HITL_HOME` | `string` | `~/.shipwright` | Root directory for the human-in-the-loop runner workspace (`task hitl`). The workspace contains `repos/`, `worktrees/`, `state/reviews/`, and `.claude/` subdirectories. |
+| `SHIPWRIGHT_HITL_HOST` | `string` | `shipwright.test` | Hostname for service URLs in the HITL runner. Used to construct URLs for task-store and admin services (e.g. `http://shipwright.test:3002` for task-store). |
+| `SHIPWRIGHT_HITL_POLL_INTERVAL` | `number` | `15` | Polling interval in seconds for the HITL runner's task fetch loop. When no ready tasks are found, the runner waits this many seconds before retrying. |
 
 ---
 

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -312,6 +312,7 @@ async function runLoop(): Promise<void> {
       continue;
     }
 
+    // biome-ignore lint/correctness/noUnreachable: dispatch scaffolded but gated until task-selection is wired
     continue;
 
     const task = tasks[0];

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -18,7 +18,7 @@
  *
  * Env overrides:
  *   SHIPWRIGHT_HITL_HOME          — root dir (default: ~/.shipwright)
- *   SHIPWRIGHT_HITL_HOST          — hostname for service URLs (default: "shipwright.test")
+ *   SHIPWRIGHT_HITL_HOST          — hostname for service URLs (default: "localhost")
  *   SHIPWRIGHT_HITL_POLL_INTERVAL — seconds between empty-queue polls (default: 15)
  */
 
@@ -43,7 +43,7 @@ const WORKTREES_DIR = join(WORKSPACE, "worktrees");
 
 const TASK_STORE_PORT = 3002;
 const ADMIN_PORT = 3001;
-const HOST = process.env.SHIPWRIGHT_HITL_HOST ?? "shipwright.test";
+const HOST = process.env.SHIPWRIGHT_HITL_HOST ?? "localhost";
 const TASK_STORE_URL = `http://${HOST}:${TASK_STORE_PORT}`;
 const ADMIN_URL = `http://${HOST}:${ADMIN_PORT}`;
 const DEV_TOKEN = "dev-task-store-admin-token";
@@ -101,6 +101,23 @@ const HITL_TEMPLATE = join(
   "CLAUDE-HITL.md.template",
 );
 
+/**
+ * Pure planning step for provisionWorkspace(): given the set of dirs the
+ * workspace needs and an injectable existence check, report which dirs are
+ * missing and whether CLAUDE.md still needs to be seeded. Kept side-effect
+ * free so it's unit-testable without touching the real filesystem.
+ */
+export function computeProvisionPlan(
+  dirs: string[],
+  claudeMdPath: string,
+  exists: (path: string) => boolean,
+): { missingDirs: string[]; needsClaudeMd: boolean } {
+  return {
+    missingDirs: dirs.filter((dir) => !exists(dir)),
+    needsClaudeMd: !exists(claudeMdPath),
+  };
+}
+
 function provisionWorkspace(): void {
   const dirs = [
     WORKSPACE,
@@ -109,23 +126,21 @@ function provisionWorkspace(): void {
     join(WORKSPACE, "state", "reviews"),
     join(WORKSPACE, ".claude"),
   ];
+  const claudeMd = join(WORKSPACE, "CLAUDE.md");
 
-  let created = false;
-  for (const dir of dirs) {
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-      created = true;
-    }
+  const plan = computeProvisionPlan(dirs, claudeMd, existsSync);
+
+  for (const dir of plan.missingDirs) {
+    mkdirSync(dir, { recursive: true });
   }
 
-  const claudeMd = join(WORKSPACE, "CLAUDE.md");
-  if (!existsSync(claudeMd)) {
+  if (plan.needsClaudeMd) {
     const template = readFileSync(HITL_TEMPLATE, "utf8");
     writeFileSync(claudeMd, template, { flag: "wx" });
     log("seeded CLAUDE.md");
   }
 
-  if (created) {
+  if (plan.missingDirs.length > 0) {
     log(`workspace provisioned: ${WORKSPACE}`);
   }
 }
@@ -275,11 +290,36 @@ function killServices(handles: ServiceHandle[]): void {
 // Task loop
 // ---------------------------------------------------------------------------
 
-interface Task {
+export interface Task {
   id: string;
   title: string;
   status: string;
   hitl?: boolean;
+}
+
+/**
+ * Pure response-shape parsing for fetchReadyTasks(): tolerates a missing or
+ * malformed `tasks` field so callers get [] rather than throwing.
+ */
+export function parseTasksResponse(data: unknown): Task[] {
+  if (
+    data &&
+    typeof data === "object" &&
+    Array.isArray((data as { tasks?: unknown }).tasks)
+  ) {
+    return (data as { tasks: Task[] }).tasks;
+  }
+  return [];
+}
+
+/**
+ * Picks the command to launch for a given ready task: HITL tasks route to
+ * /shipwright:hitl, everything else to the standard autonomous dev-task flow.
+ */
+export function buildTaskCommand(task: Pick<Task, "id" | "hitl">): string {
+  return task.hitl
+    ? `/shipwright:hitl ${task.id}`
+    : `/shipwright:dev-task ${task.id}`;
 }
 
 async function fetchReadyTasks(): Promise<Task[]> {
@@ -287,12 +327,36 @@ async function fetchReadyTasks(): Promise<Task[]> {
     const res = await fetch(`${TASK_STORE_URL}/tasks?ready=true`, {
       headers: { Authorization: `Bearer ${DEV_TOKEN}` },
     });
-    if (!res.ok) return [];
-    const data = (await res.json()) as { tasks: Task[] };
-    return data.tasks ?? [];
-  } catch {
+    if (!res.ok) {
+      log(`fetchReadyTasks: task-store returned ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return parseTasksResponse(data);
+  } catch (err) {
+    log(
+      `fetchReadyTasks: failed to reach ${TASK_STORE_URL} (${err instanceof Error ? err.message : err}) — check SHIPWRIGHT_HITL_HOST`,
+    );
     return [];
   }
+}
+
+/**
+ * Builds the env passed to the spawned `claude` process: the caller's base
+ * env (typically process.env) overlaid with the task-store connection and
+ * repo/worktree dirs the dispatched command needs. Pure aside from reading
+ * its argument, so it's testable without spawning a real process.
+ */
+export function buildClaudeSpawnEnv(
+  baseEnv: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  return {
+    ...baseEnv,
+    SHIPWRIGHT_TASK_STORE_URL: TASK_STORE_URL,
+    SHIPWRIGHT_TASK_STORE_TOKEN: DEV_AGENT_TOKEN,
+    SHIPWRIGHT_REPO_DIR: REPOS_DIR,
+    SHIPWRIGHT_WORKTREE_DIR: WORKTREES_DIR,
+  };
 }
 
 async function runLoop(): Promise<void> {
@@ -313,9 +377,7 @@ async function runLoop(): Promise<void> {
     }
 
     const task = tasks[0];
-    const command = task.hitl
-      ? `/shipwright:hitl ${task.id}`
-      : `/shipwright:dev-task ${task.id}`;
+    const command = buildTaskCommand(task);
 
     console.log("");
     log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -326,13 +388,7 @@ async function runLoop(): Promise<void> {
 
     const claude = Bun.spawn(["claude", command], {
       cwd: WORKSPACE,
-      env: {
-        ...process.env,
-        SHIPWRIGHT_TASK_STORE_URL: TASK_STORE_URL,
-        SHIPWRIGHT_TASK_STORE_TOKEN: DEV_AGENT_TOKEN,
-        SHIPWRIGHT_REPO_DIR: REPOS_DIR,
-        SHIPWRIGHT_WORKTREE_DIR: WORKTREES_DIR,
-      },
+      env: buildClaudeSpawnEnv(process.env),
       stdout: "inherit",
       stderr: "inherit",
       stdin: "inherit",

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -1,0 +1,382 @@
+/**
+ * scripts/hitl.ts
+ * Human-in-the-loop dev runner — provisions a workspace (mirroring agent
+ * setup.ts), boots task-store + admin, then loops: fetch the next ready
+ * task → launch Claude Code with the right command.
+ *
+ * Usage:
+ *   task hitl
+ *   bun /path/to/shipwright/scripts/hitl.ts
+ *
+ * Workspace layout (mirrors ensureAgentHome):
+ *   ~/.shipwright/
+ *     workspace/          ← Claude Code's cwd
+ *       repos/            ← SHIPWRIGHT_REPO_DIR (git clones, main branch)
+ *       worktrees/        ← SHIPWRIGHT_WORKTREE_DIR (feature branches)
+ *       state/reviews/
+ *       .claude/
+ *
+ * Env overrides:
+ *   SHIPWRIGHT_HITL_HOME          — root dir (default: ~/.shipwright)
+ *   SHIPWRIGHT_HITL_HOST          — hostname for service URLs (default: "shipwright.test")
+ *   SHIPWRIGHT_HITL_POLL_INTERVAL — seconds between empty-queue polls (default: 15)
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Paths — anchored to this script, not cwd
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const HITL_HOME =
+  process.env.SHIPWRIGHT_HITL_HOME ?? join(homedir(), ".shipwright");
+const WORKSPACE = join(HITL_HOME, "workspace");
+const REPOS_DIR = join(WORKSPACE, "repos");
+const WORKTREES_DIR = join(WORKSPACE, "worktrees");
+
+// ---------------------------------------------------------------------------
+// Constants — mirrors dev-tmux.ts defaults; no env vars required
+// ---------------------------------------------------------------------------
+
+const TASK_STORE_PORT = 3002;
+const ADMIN_PORT = 3001;
+const HOST = process.env.SHIPWRIGHT_HITL_HOST ?? "shipwright.test";
+const TASK_STORE_URL = `http://${HOST}:${TASK_STORE_PORT}`;
+const ADMIN_URL = `http://${HOST}:${ADMIN_PORT}`;
+const DEV_TOKEN = "dev-task-store-admin-token";
+const DEV_AGENT_TOKEN = "dev-task-store-hitl-token";
+const POLL_INTERVAL_S = Number(
+  process.env.SHIPWRIGHT_HITL_POLL_INTERVAL ?? "15",
+);
+
+const DEV_DB_USER = process.env.USER ?? "";
+const DEV_DB_PREFIX = DEV_DB_USER ? `${DEV_DB_USER}@` : "";
+const DEV_DATABASE_URL = `postgresql://${DEV_DB_PREFIX}localhost:5432/shipwright_dev`;
+const DEV_TASK_STORE_DATABASE_URL = `postgresql://${DEV_DB_PREFIX}localhost:5432/shipwright_task_store_dev`;
+
+const DUMMY_ENCRYPTION_KEY =
+  "0000000000000000000000000000000000000000000000000000000000000000";
+const DUMMY_SESSION_SECRET = "dev-session-secret-not-for-production-use!";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function log(msg: string) {
+  console.log(`[hitl] ${msg}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForHealth(url: string, label: string): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${url}/health`);
+      if (res.ok) {
+        log(`${label} healthy`);
+        return;
+      }
+    } catch {
+      // not up yet
+    }
+    await sleep(500);
+  }
+  throw new Error(`${label} did not become healthy within 30s`);
+}
+
+// ---------------------------------------------------------------------------
+// Workspace provisioning — mirrors agent/src/setup.ts ensureAgentHome()
+// ---------------------------------------------------------------------------
+
+const HITL_TEMPLATE = join(
+  REPO_ROOT,
+  "agent",
+  "workspace",
+  "CLAUDE-HITL.md.template",
+);
+
+function provisionWorkspace(): void {
+  const dirs = [
+    WORKSPACE,
+    REPOS_DIR,
+    WORKTREES_DIR,
+    join(WORKSPACE, "state", "reviews"),
+    join(WORKSPACE, ".claude"),
+  ];
+
+  let created = false;
+  for (const dir of dirs) {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+      created = true;
+    }
+  }
+
+  const claudeMd = join(WORKSPACE, "CLAUDE.md");
+  if (!existsSync(claudeMd)) {
+    const template = readFileSync(HITL_TEMPLATE, "utf8");
+    writeFileSync(claudeMd, template, { flag: "wx" });
+    log("seeded CLAUDE.md");
+  }
+
+  if (created) {
+    log(`workspace provisioned: ${WORKSPACE}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Preflight: workspace + migrations + token seed
+// ---------------------------------------------------------------------------
+
+async function runPreflight(): Promise<void> {
+  provisionWorkspace();
+
+  log("running task-store prisma generate + migrate...");
+  const tsGen = Bun.spawnSync(
+    ["bunx", "prisma", "generate", "--schema=prisma/schema.prisma"],
+    { cwd: join(REPO_ROOT, "task-store"), stdout: "inherit", stderr: "inherit" },
+  );
+  if (tsGen.exitCode !== 0) throw new Error("task-store prisma generate failed");
+
+  const tsMigrate = Bun.spawnSync(
+    ["bunx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"],
+    {
+      cwd: join(REPO_ROOT, "task-store"),
+      env: {
+        ...process.env,
+        DATABASE_URL_SHIPWRIGHT_TASK_STORE: DEV_TASK_STORE_DATABASE_URL,
+      },
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+  if (tsMigrate.exitCode !== 0) throw new Error("task-store migrate failed");
+
+  log("seeding task-store admin and agent tokens...");
+  const adminSeed = Bun.spawnSync(
+    [
+      "bun",
+      "run",
+      join(REPO_ROOT, "scripts", "seed-task-store-token.ts"),
+      "--db-url",
+      DEV_TASK_STORE_DATABASE_URL,
+      "--token",
+      DEV_TOKEN,
+    ],
+    { cwd: REPO_ROOT, stdout: "inherit", stderr: "inherit" },
+  );
+  if (adminSeed.exitCode !== 0) throw new Error("admin token seed failed");
+
+  const agentSeed = Bun.spawnSync(
+    [
+      "bun",
+      "run",
+      join(REPO_ROOT, "scripts", "seed-task-store-token.ts"),
+      "--db-url",
+      DEV_TASK_STORE_DATABASE_URL,
+      "--token",
+      DEV_AGENT_TOKEN,
+      "--agent-id",
+      "hitl",
+    ],
+    { cwd: REPO_ROOT, stdout: "inherit", stderr: "inherit" },
+  );
+  if (agentSeed.exitCode !== 0) throw new Error("agent token seed failed");
+
+  log("running admin prisma generate + migrate...");
+  const adminGen = Bun.spawnSync(
+    ["bunx", "prisma", "generate", "--schema=prisma/schema.prisma"],
+    { cwd: join(REPO_ROOT, "admin"), stdout: "inherit", stderr: "inherit" },
+  );
+  if (adminGen.exitCode !== 0) throw new Error("admin prisma generate failed");
+
+  const adminMigrate = Bun.spawnSync(
+    ["bunx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"],
+    {
+      cwd: join(REPO_ROOT, "admin"),
+      env: {
+        ...process.env,
+        DATABASE_URL_SHIPWRIGHT_ADMIN: DEV_DATABASE_URL,
+      },
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+  if (adminMigrate.exitCode !== 0) throw new Error("admin migrate failed");
+}
+
+// ---------------------------------------------------------------------------
+// Service spawning
+// ---------------------------------------------------------------------------
+
+type ServiceHandle = {
+  label: string;
+  proc: ReturnType<typeof Bun.spawn>;
+};
+
+function startServices(): ServiceHandle[] {
+  const taskStore = Bun.spawn(
+    ["bun", "run", join(REPO_ROOT, "task-store", "src", "main.ts")],
+    {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PORT: String(TASK_STORE_PORT),
+        DATABASE_URL_SHIPWRIGHT_TASK_STORE: DEV_TASK_STORE_DATABASE_URL,
+        TASK_STORE_SEED_ADMIN_TOKEN: DEV_TOKEN,
+      },
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+
+  const admin = Bun.spawn(
+    ["bun", join(REPO_ROOT, "admin", "src", "main.ts")],
+    {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PORT: String(ADMIN_PORT),
+        DATABASE_URL_SHIPWRIGHT_ADMIN: DEV_DATABASE_URL,
+        SHIPWRIGHT_ENCRYPTION_KEY: DUMMY_ENCRYPTION_KEY,
+        SHIPWRIGHT_SESSION_SECRET: DUMMY_SESSION_SECRET,
+        ADMIN_DEV_AUTH: "true",
+        SHIPWRIGHT_TASK_STORE_URL: TASK_STORE_URL,
+        SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN: DEV_TOKEN,
+      },
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+
+  return [
+    { label: "task-store", proc: taskStore },
+    { label: "admin", proc: admin },
+  ];
+}
+
+function killServices(handles: ServiceHandle[]): void {
+  for (const h of handles) {
+    try {
+      h.proc.kill("SIGINT");
+    } catch {
+      // already dead
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task loop
+// ---------------------------------------------------------------------------
+
+interface Task {
+  id: string;
+  title: string;
+  status: string;
+  hitl?: boolean;
+}
+
+async function fetchReadyTasks(): Promise<Task[]> {
+  try {
+    const res = await fetch(`${TASK_STORE_URL}/tasks?ready=true`, {
+      headers: { Authorization: `Bearer ${DEV_TOKEN}` },
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { tasks: Task[] };
+    return data.tasks ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function runLoop(): Promise<void> {
+  log(`task loop started — polling ${TASK_STORE_URL}`);
+  log(`admin UI: ${ADMIN_URL}/admin/dev-login`);
+  log(`workspace: ${WORKSPACE}`);
+  log(`repos:     ${REPOS_DIR}`);
+  log(`worktrees: ${WORKTREES_DIR}`);
+  log("press Ctrl-C to stop\n");
+
+  while (true) {
+    const tasks = await fetchReadyTasks();
+
+    if (tasks.length === 0) {
+      log(`no ready tasks — retrying in ${POLL_INTERVAL_S}s`);
+      await sleep(POLL_INTERVAL_S * 1000);
+      continue;
+    }
+
+    continue;
+
+    const task = tasks[0];
+    const command = task.hitl
+      ? `/shipwright:hitl ${task.id}`
+      : `/shipwright:dev-task ${task.id}`;
+
+    console.log("");
+    log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    log(`next: ${task.id} — ${task.title}`);
+    log(`hitl: ${task.hitl ?? false} → ${command}`);
+    log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    console.log("");
+
+    const claude = Bun.spawn(["claude", command], {
+      cwd: WORKSPACE,
+      env: {
+        ...process.env,
+        SHIPWRIGHT_TASK_STORE_URL: TASK_STORE_URL,
+        SHIPWRIGHT_TASK_STORE_TOKEN: DEV_AGENT_TOKEN,
+        SHIPWRIGHT_REPO_DIR: REPOS_DIR,
+        SHIPWRIGHT_WORKTREE_DIR: WORKTREES_DIR,
+      },
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "inherit",
+    });
+
+    await claude.exited;
+
+    log(`claude exited (code ${claude.exitCode}) — continuing loop`);
+    console.log("");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const handles: ServiceHandle[] = [];
+
+  const shutdown = () => {
+    log("shutting down services...");
+    killServices(handles);
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  try {
+    await runPreflight();
+
+    log("starting task-store and admin...");
+    handles.push(...startServices());
+
+    await Promise.all([
+      waitForHealth(`http://localhost:${TASK_STORE_PORT}`, "task-store"),
+      waitForHealth(`http://localhost:${ADMIN_PORT}`, "admin"),
+    ]);
+
+    await runLoop();
+  } catch (err) {
+    console.error(`[hitl] fatal: ${err}`);
+    killServices(handles);
+    process.exit(1);
+  }
+}

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -312,9 +312,6 @@ async function runLoop(): Promise<void> {
       continue;
     }
 
-    // biome-ignore lint/correctness/noUnreachable: dispatch scaffolded but gated until task-selection is wired
-    continue;
-
     const task = tasks[0];
     const command = task.hitl
       ? `/shipwright:hitl ${task.id}`

--- a/scripts/hitl.unit.test.ts
+++ b/scripts/hitl.unit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * scripts/hitl.unit.test.ts
+ * Unit tests for the pure logic in scripts/hitl.ts — command selection,
+ * task-store response parsing, workspace-provisioning idempotency planning,
+ * and the env built for the spawned Claude process. Everything with a real
+ * I/O boundary (fs, fetch, Bun.spawn) is exercised through injected doubles
+ * or by construction, never mocked globally.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildClaudeSpawnEnv,
+  buildTaskCommand,
+  computeProvisionPlan,
+  parseTasksResponse,
+  type Task,
+} from "./hitl.ts";
+
+describe("buildTaskCommand", () => {
+  test("routes hitl tasks to /shipwright:hitl", () => {
+    expect(buildTaskCommand({ id: "HTC-1.1", hitl: true })).toBe(
+      "/shipwright:hitl HTC-1.1",
+    );
+  });
+
+  test("routes non-hitl tasks to /shipwright:dev-task", () => {
+    expect(buildTaskCommand({ id: "PV-1.2", hitl: false })).toBe(
+      "/shipwright:dev-task PV-1.2",
+    );
+  });
+
+  test("treats a missing hitl field as non-hitl", () => {
+    expect(buildTaskCommand({ id: "PV-1.2" })).toBe(
+      "/shipwright:dev-task PV-1.2",
+    );
+  });
+});
+
+describe("parseTasksResponse", () => {
+  test("returns the tasks array when present", () => {
+    const tasks: Task[] = [
+      { id: "PV-1.2", title: "Do the thing", status: "pending" },
+    ];
+    expect(parseTasksResponse({ tasks })).toEqual(tasks);
+  });
+
+  test("returns [] when tasks is missing", () => {
+    expect(parseTasksResponse({})).toEqual([]);
+  });
+
+  test("returns [] when tasks is not an array", () => {
+    expect(parseTasksResponse({ tasks: "nope" })).toEqual([]);
+  });
+
+  test("returns [] for null", () => {
+    expect(parseTasksResponse(null)).toEqual([]);
+  });
+
+  test("returns [] for a non-object", () => {
+    expect(parseTasksResponse("not json")).toEqual([]);
+  });
+});
+
+describe("computeProvisionPlan", () => {
+  test("reports all dirs missing and CLAUDE.md needed on a fresh workspace", () => {
+    const plan = computeProvisionPlan(
+      ["/ws", "/ws/repos", "/ws/worktrees"],
+      "/ws/CLAUDE.md",
+      () => false,
+    );
+    expect(plan.missingDirs).toEqual(["/ws", "/ws/repos", "/ws/worktrees"]);
+    expect(plan.needsClaudeMd).toBe(true);
+  });
+
+  test("reports nothing missing when everything already exists", () => {
+    const plan = computeProvisionPlan(
+      ["/ws", "/ws/repos"],
+      "/ws/CLAUDE.md",
+      () => true,
+    );
+    expect(plan.missingDirs).toEqual([]);
+    expect(plan.needsClaudeMd).toBe(false);
+  });
+
+  test("reports only the dirs that don't yet exist", () => {
+    const existing = new Set(["/ws"]);
+    const plan = computeProvisionPlan(
+      ["/ws", "/ws/repos", "/ws/worktrees"],
+      "/ws/CLAUDE.md",
+      (path) => existing.has(path),
+    );
+    expect(plan.missingDirs).toEqual(["/ws/repos", "/ws/worktrees"]);
+    expect(plan.needsClaudeMd).toBe(true);
+  });
+
+  test("CLAUDE.md need is independent of dir existence", () => {
+    const plan = computeProvisionPlan(["/ws"], "/ws/CLAUDE.md", (path) =>
+      path === "/ws",
+    );
+    expect(plan.missingDirs).toEqual([]);
+    expect(plan.needsClaudeMd).toBe(true);
+  });
+});
+
+describe("buildClaudeSpawnEnv", () => {
+  test("overlays task-store and workspace dir vars onto the base env", () => {
+    const base = { PATH: "/usr/bin", SOME_OTHER_VAR: "keep-me" };
+    const env = buildClaudeSpawnEnv(base);
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.SOME_OTHER_VAR).toBe("keep-me");
+    expect(env.SHIPWRIGHT_TASK_STORE_URL).toMatch(/^http:\/\//);
+    expect(typeof env.SHIPWRIGHT_TASK_STORE_TOKEN).toBe("string");
+    expect(typeof env.SHIPWRIGHT_REPO_DIR).toBe("string");
+    expect(typeof env.SHIPWRIGHT_WORKTREE_DIR).toBe("string");
+  });
+
+  test("does not mutate the base env object", () => {
+    const base = { PATH: "/usr/bin" };
+    buildClaudeSpawnEnv(base);
+    expect(Object.keys(base)).toEqual(["PATH"]);
+  });
+});

--- a/scripts/seed-task-store-token.ts
+++ b/scripts/seed-task-store-token.ts
@@ -34,9 +34,10 @@ export function hashRawToken(raw: string): string {
 export interface SeedArgs {
   dbUrl?: string;
   token?: string;
+  agentId?: string;
 }
 
-/** Parse `--db-url`/`--token` flags (both `--flag value` and `--flag=value`). */
+/** Parse `--db-url`/`--token`/`--agent-id` flags (both `--flag value` and `--flag=value`). */
 export function parseSeedArgs(argv: string[]): SeedArgs {
   const read = (name: string): string | undefined => {
     for (let i = 0; i < argv.length; i++) {
@@ -46,7 +47,7 @@ export function parseSeedArgs(argv: string[]): SeedArgs {
     }
     return undefined;
   };
-  return { dbUrl: read("db-url"), token: read("token") };
+  return { dbUrl: read("db-url"), token: read("token"), agentId: read("agent-id") };
 }
 
 /** Minimal slice of PrismaClient this seeder needs — keeps the double tiny. */
@@ -54,14 +55,16 @@ interface TaskTokenUpserter {
   taskToken: {
     upsert(args: {
       where: { token: string };
-      create: { token: string; label: string | null; agentId: null };
+      create: { token: string; label: string | null; agentId: string | null };
       update: Record<string, never>;
     }): Promise<unknown>;
   };
 }
 
 /**
- * Idempotently upsert an admin token (agentId null) by its hashed raw value.
+ * Idempotently upsert a token (admin or agent-scoped) by its hashed raw value.
+ * When agentId is null, the token is unrestricted (admin). When agentId is set,
+ * the token is scoped to that agent.
  * The empty `update` makes re-runs a no-op — running `task stack` repeatedly
  * never creates duplicates or rotates the token.
  */
@@ -69,11 +72,12 @@ export async function seedTaskStoreAdminToken(opts: {
   prisma: TaskTokenUpserter;
   rawToken: string;
   label?: string;
+  agentId?: string;
 }): Promise<void> {
   const hashed = hashRawToken(opts.rawToken);
   await opts.prisma.taskToken.upsert({
     where: { token: hashed },
-    create: { token: hashed, label: opts.label ?? null, agentId: null },
+    create: { token: hashed, label: opts.label ?? null, agentId: opts.agentId ?? null },
     update: {},
   });
 }
@@ -85,7 +89,7 @@ if (import.meta.main) {
     "../task-store/prisma/client/index.js"
   );
 
-  const { dbUrl, token } = parseSeedArgs(process.argv.slice(2));
+  const { dbUrl, token, agentId } = parseSeedArgs(process.argv.slice(2));
   const databaseUrl = dbUrl ?? process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE;
 
   if (!databaseUrl) {
@@ -103,14 +107,17 @@ if (import.meta.main) {
 
   const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
   try {
+    const label = agentId ? `dev-${agentId}` : "dev-admin";
     await seedTaskStoreAdminToken({
       // biome-ignore lint/suspicious/noExplicitAny: generated client satisfies the upsert slice
       prisma: prisma as any,
       rawToken: token,
-      label: "dev-admin",
+      label,
+      agentId,
     });
+    const tokenType = agentId ? `agent-scoped (${agentId})` : "admin";
     console.log(
-      "[seed-task-store-token] admin token ready (idempotent upsert).",
+      `[seed-task-store-token] ${tokenType} token ready (idempotent upsert).`,
     );
   } finally {
     await prisma.$disconnect();

--- a/scripts/seed-task-store-token.ts
+++ b/scripts/seed-task-store-token.ts
@@ -63,10 +63,7 @@ interface TaskTokenUpserter {
 
 /**
  * Idempotently upsert a token (admin or agent-scoped) by its hashed raw value.
- * When agentId is null, the token is unrestricted (admin). When agentId is set,
- * the token is scoped to that agent.
- * The empty `update` makes re-runs a no-op — running `task stack` repeatedly
- * never creates duplicates or rotates the token.
+ * The empty `update` makes re-runs a no-op.
  */
 export async function seedTaskStoreAdminToken(opts: {
   prisma: TaskTokenUpserter;

--- a/scripts/seed-task-store-token.unit.test.ts
+++ b/scripts/seed-task-store-token.unit.test.ts
@@ -34,17 +34,48 @@ describe("parseSeedArgs", () => {
   test("parses --db-url and --token in space form", () => {
     expect(
       parseSeedArgs(["--db-url", "postgresql://x/y", "--token", "abc"]),
-    ).toEqual({ dbUrl: "postgresql://x/y", token: "abc" });
+    ).toEqual({ dbUrl: "postgresql://x/y", token: "abc", agentId: undefined });
   });
 
   test("parses --db-url= and --token= in equals form", () => {
     expect(
       parseSeedArgs(["--db-url=postgresql://x/y", "--token=abc"]),
-    ).toEqual({ dbUrl: "postgresql://x/y", token: "abc" });
+    ).toEqual({ dbUrl: "postgresql://x/y", token: "abc", agentId: undefined });
   });
 
   test("returns undefined fields when flags are absent", () => {
-    expect(parseSeedArgs([])).toEqual({ dbUrl: undefined, token: undefined });
+    expect(parseSeedArgs([])).toEqual({
+      dbUrl: undefined,
+      token: undefined,
+      agentId: undefined,
+    });
+  });
+
+  test("parses --agent-id in space form", () => {
+    expect(
+      parseSeedArgs([
+        "--db-url",
+        "postgresql://x/y",
+        "--token",
+        "abc",
+        "--agent-id",
+        "hitl",
+      ]),
+    ).toEqual({
+      dbUrl: "postgresql://x/y",
+      token: "abc",
+      agentId: "hitl",
+    });
+  });
+
+  test("parses --agent-id= in equals form", () => {
+    expect(
+      parseSeedArgs(["--token=abc", "--agent-id=hitl"]),
+    ).toEqual({
+      dbUrl: undefined,
+      token: "abc",
+      agentId: "hitl",
+    });
   });
 });
 
@@ -81,6 +112,28 @@ describe("seedTaskStoreAdminToken", () => {
       agentId: null,
     });
     // Empty update => idempotent: re-running leaves an existing token untouched.
+    expect(args.update).toEqual({});
+  });
+
+  test("upserts an agent-scoped token (agentId set) keyed by the hashed raw value", async () => {
+    const { prisma, calls } = makePrismaDouble();
+    await seedTaskStoreAdminToken({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      prisma: prisma as any,
+      rawToken: "dev-task-store-hitl-token",
+      label: "dev-hitl",
+      agentId: "hitl",
+    });
+
+    expect(calls).toHaveLength(1);
+    const args = calls[0];
+    const hashed = hashRawToken("dev-task-store-hitl-token");
+    expect(args.where).toEqual({ token: hashed });
+    expect(args.create).toEqual({
+      token: hashed,
+      label: "dev-hitl",
+      agentId: "hitl",
+    });
     expect(args.update).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- Extend `seedTaskStoreAdminToken` to accept an optional `agentId` parameter, enabling agent-scoped token seeding alongside admin tokens
- Update the HITL runner preflight to seed two tokens: admin (`dev-admin`) and agent-scoped (`dev-hitl`, `agentId: "hitl"`)
- Pass the agent-scoped token as `SHIPWRIGHT_TASK_STORE_TOKEN` to the spawned Claude process so claim/claimPr operations work correctly
- Add `task hitl` to Taskfile.yml, include the HITL workspace template, and check in `scripts/hitl.ts`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `seedTaskStoreAdminToken` accepts optional `agentId`; upserted row has `agentId` populated | MET |
| 2 | HITL preflight seeds both admin and agent tokens | MET |
| 3 | Agent token passed to Claude process; admin token for runner queries | MET |
| 4 | Unit test for agent-scoped seed path | MET |
| 5 | Existing admin-token unit tests remain green | MET |

## Test Plan
- [x] All 9 unit tests pass (including 3 new: agent-id parsing x2, agent-scoped upsert)
- [x] Existing admin-token tests unchanged and green
- [x] Biome lint clean on all changed files
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
