### PR TITLE
feat(hitl): wire review/patch candidates into HITL loop

### DIFF
--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -501,7 +501,7 @@ async function runLoop(): Promise<void> {
         continue;
       }
 
-      const preclaimMarker = `[preclaim:${claimResult.commitSha}]`;
+      const preclaimMarker = `[preclaim:${claimResult.id}:${claimResult.commitSha}]`;
       command =
         next.pr.phase === "review"
           ? `/shipwright:review ${next.pr.id} ${preclaimMarker}`

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -471,7 +471,15 @@ async function runLoop(): Promise<void> {
     let label: string;
 
     if (next.type === "task") {
-      const claimed = await client.claim(next.task.id);
+      let claimed: boolean;
+      try {
+        claimed = await client.claim(next.task.id);
+      } catch (err) {
+        log(
+          `task ${next.task.id} claim failed: ${err instanceof Error ? err.message : err}`,
+        );
+        continue;
+      }
       if (!claimed) {
         log(`task ${next.task.id} already claimed (409) — skipping`);
         continue;
@@ -490,12 +498,20 @@ async function runLoop(): Promise<void> {
         continue;
       }
 
-      const claimResult = await client.claimPr({
-        repo: parsed.repo,
-        prNumber: parsed.prNumber,
-        commitSha: next.pr.commitSha,
-        phase: next.pr.phase,
-      });
+      let claimResult: Awaited<ReturnType<typeof client.claimPr>>;
+      try {
+        claimResult = await client.claimPr({
+          repo: parsed.repo,
+          prNumber: parsed.prNumber,
+          commitSha: next.pr.commitSha,
+          phase: next.pr.phase,
+        });
+      } catch (err) {
+        log(
+          `PR ${next.pr.id} claim failed: ${err instanceof Error ? err.message : err}`,
+        );
+        continue;
+      }
       if (!claimResult) {
         log(`PR ${next.pr.id} already claimed (409) — skipping`);
         continue;

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -22,9 +22,39 @@
  *   SHIPWRIGHT_HITL_POLL_INTERVAL — seconds between empty-queue polls (default: 15)
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve, join } from "node:path";
 import { homedir } from "node:os";
+
+import {
+  buildProductionDeps as buildReviewDeps,
+  getReviewCandidates,
+  type CheckReviewDeps,
+} from "../agent/src/check-review.ts";
+import {
+  buildProductionDeps as buildPatchDeps,
+  getPatchCandidates,
+  type CheckPatchDeps,
+} from "../agent/src/check-patch.ts";
+import {
+  selectNextWorkItem,
+  type WorkPrCandidate,
+  type WorkTaskCandidate,
+} from "../agent/src/work-selector.ts";
+import {
+  createTaskStoreClient,
+  getCurrentUser,
+  ghGraphql,
+  ghJson,
+  parseCandidateId,
+  resolveAllRepos,
+} from "../agent/src/check-helpers.ts";
 
 // ---------------------------------------------------------------------------
 // Paths — anchored to this script, not cwd
@@ -295,6 +325,7 @@ export interface Task {
   title: string;
   status: string;
   hitl?: boolean;
+  createdAt?: string;
 }
 
 /**
@@ -367,22 +398,121 @@ async function runLoop(): Promise<void> {
   log(`worktrees: ${WORKTREES_DIR}`);
   log("press Ctrl-C to stop\n");
 
+  const repoEntries = existsSync(REPOS_DIR) ? readdirSync(REPOS_DIR) : [];
+  const hasRepos = repoEntries.length > 0;
+  if (!hasRepos) {
+    log(
+      "⚠ workspace/repos/ is empty — review/patch candidates will be skipped (task-only mode)",
+    );
+  }
+
+  // resolveWorkspacePath() (called inside buildReviewDeps/buildPatchDeps
+  // below) reads WORKSPACE_PATH — set it, plus the task-store env vars the
+  // agent-scoped client needs for claims, before building deps/client.
+  process.env.WORKSPACE_PATH = WORKSPACE;
+  process.env.SHIPWRIGHT_TASK_STORE_URL = TASK_STORE_URL;
+  process.env.SHIPWRIGHT_TASK_STORE_TOKEN = DEV_AGENT_TOKEN;
+
+  let reviewDeps: CheckReviewDeps | undefined;
+  let patchDeps: CheckPatchDeps | undefined;
+
+  if (hasRepos) {
+    const allRepos = resolveAllRepos(WORKSPACE);
+    // HITL has no agent config bundle to sync repo scope from — treat every
+    // cloned repo as always-in-scope.
+    reviewDeps = await buildReviewDeps({
+      ghJson,
+      getScopedRepos: () => allRepos,
+      hasScopeSynced: () => true,
+    });
+    patchDeps = await buildPatchDeps({
+      ghJson,
+      ghGraphql,
+      getCurrentUser,
+      getScopedRepos: () => allRepos,
+      hasScopeSynced: () => true,
+    });
+  }
+
+  const client = createTaskStoreClient();
+
   while (true) {
     const tasks = await fetchReadyTasks();
+    const taskCandidates: WorkTaskCandidate[] = tasks.map((t) => ({
+      id: t.id,
+      createdAt: t.createdAt ?? "",
+      title: t.title,
+    }));
 
-    if (tasks.length === 0) {
-      log(`no ready tasks — retrying in ${POLL_INTERVAL_S}s`);
+    let prCandidates: WorkPrCandidate[] = [];
+    if (hasRepos && reviewDeps && patchDeps) {
+      try {
+        const [reviewCands, patchCands] = await Promise.all([
+          getReviewCandidates(reviewDeps),
+          getPatchCandidates(patchDeps),
+        ]);
+        prCandidates = [...reviewCands, ...patchCands];
+      } catch (err) {
+        log(
+          `PR candidate collection failed: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
+    const next = selectNextWorkItem(taskCandidates, prCandidates);
+
+    if (!next) {
+      log(`no ready work — retrying in ${POLL_INTERVAL_S}s`);
       await sleep(POLL_INTERVAL_S * 1000);
       continue;
     }
 
-    const task = tasks[0];
-    const command = buildTaskCommand(task);
+    let command: string;
+    let label: string;
+
+    if (next.type === "task") {
+      const claimed = await client.claim(next.task.id);
+      if (!claimed) {
+        log(`task ${next.task.id} already claimed (409) — skipping`);
+        continue;
+      }
+      const fullTask = tasks.find((t) => t.id === next.task.id);
+      command = buildTaskCommand({ id: next.task.id, hitl: fullTask?.hitl });
+      label = `${next.task.id} — ${next.task.title ?? ""}`;
+    } else {
+      const parsed = parseCandidateId(next.pr.id);
+      if (!parsed) {
+        log(`malformed PR candidate id: ${next.pr.id} — skipping`);
+        continue;
+      }
+      if (!next.pr.phase) {
+        log(`PR candidate ${next.pr.id} missing phase — skipping`);
+        continue;
+      }
+
+      const claimResult = await client.claimPr({
+        repo: parsed.repo,
+        prNumber: parsed.prNumber,
+        commitSha: next.pr.commitSha,
+        phase: next.pr.phase,
+      });
+      if (!claimResult) {
+        log(`PR ${next.pr.id} already claimed (409) — skipping`);
+        continue;
+      }
+
+      const preclaimMarker = `[preclaim:${claimResult.commitSha}]`;
+      command =
+        next.pr.phase === "review"
+          ? `/shipwright:review ${next.pr.id} ${preclaimMarker}`
+          : `/shipwright:patch ${next.pr.id} ${preclaimMarker}`;
+      label = `${next.pr.id} — ${next.pr.title ?? ""}`;
+    }
 
     console.log("");
     log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    log(`next: ${task.id} — ${task.title}`);
-    log(`hitl: ${task.hitl ?? false} → ${command}`);
+    log(`next: ${label}`);
+    log(`type: ${next.type} → ${command}`);
     log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     console.log("");
 


### PR DESCRIPTION
## Summary
- Extends `scripts/hitl.ts` to collect review and patch PR candidates alongside task candidates on each poll iteration
- Merges all candidates via `selectNextWorkItem` (strict age-based FIFO across tasks, reviews, and patches)
- Pre-claims winners before dispatch: tasks via `client.claim(id)`, PRs via `client.claimPr(...)` with `[preclaim:sha]` marker appended to the command
- Routes dispatch correctly: tasks to `/shipwright:dev-task` or `/shipwright:hitl`; review PRs to `/shipwright:review`; patch PRs to `/shipwright:patch`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | HITL poll loop collects task, review, and patch candidates | MET |
| 2 | Candidates merged via selectNextWorkItem — strict age-based FIFO | MET |
| 3 | Task pre-claimed via client.claim(id); PR via client.claimPr with [preclaim:...] | MET |
| 4 | Dispatch routes correctly per type/phase | MET |
| 5 | Warning when workspace/repos/ empty, review/patch return [] | MET |
| 6 | 409 on pre-claim skips item and continues polling | MET |
| 7 | No cron-run/work-queue reporting, spin detection, or empty-queue backoff | MET |
| 8 | No new test files | MET |

## Test Plan
- [x] Existing hitl unit tests pass (14/14)
- [x] Lint clean (biome lint)
- [x] Format clean (biome format)
- [x] No new type errors introduced

Generated with [Claude Code](https://claude.com/claude-code)
