### PR TITLE
test: add lib/agent-default-tools.ts unit test (T-072)

### DIFF
--- a/lib/agent-default-tools.unit.test.ts
+++ b/lib/agent-default-tools.unit.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_ADMIN_AGENT_TOOLS, DEFAULT_AGENT_TOOLS } from "./agent-default-tools.ts";
+
+describe("DEFAULT_ADMIN_AGENT_TOOLS", () => {
+  test("is a non-empty array", () => {
+    expect(Array.isArray(DEFAULT_ADMIN_AGENT_TOOLS)).toBe(true);
+    expect(DEFAULT_ADMIN_AGENT_TOOLS.length).toBeGreaterThan(0);
+  });
+
+  test("contains expected tool patterns", () => {
+    const expectedEntries = ["Bash", "WebSearch", "WebFetch", "Agent"];
+
+    for (const entry of expectedEntries) {
+      expect(DEFAULT_ADMIN_AGENT_TOOLS).toContain(entry);
+    }
+  });
+
+  test("has exactly the expected number of entries (catches accidental additions/removals)", () => {
+    expect(DEFAULT_ADMIN_AGENT_TOOLS.length).toBe(4);
+  });
+
+  test("every entry is a non-empty string", () => {
+    for (const entry of DEFAULT_ADMIN_AGENT_TOOLS) {
+      expect(typeof entry).toBe("string");
+      expect(entry.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("has no duplicate entries", () => {
+    const uniqueEntries = new Set(DEFAULT_ADMIN_AGENT_TOOLS);
+    expect(uniqueEntries.size).toBe(DEFAULT_ADMIN_AGENT_TOOLS.length);
+  });
+});
+
+describe("DEFAULT_AGENT_TOOLS", () => {
+  test("is a non-empty array", () => {
+    expect(Array.isArray(DEFAULT_AGENT_TOOLS)).toBe(true);
+    expect(DEFAULT_AGENT_TOOLS.length).toBeGreaterThan(0);
+  });
+
+  test("contains expected tool patterns", () => {
+    const expectedEntries = [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash",
+      "WebSearch",
+      "WebFetch",
+      "Skill",
+      "Agent",
+    ];
+
+    for (const entry of expectedEntries) {
+      expect(DEFAULT_AGENT_TOOLS).toContain(entry);
+    }
+  });
+
+  test("has exactly the expected number of entries (catches accidental additions/removals)", () => {
+    expect(DEFAULT_AGENT_TOOLS.length).toBe(10);
+  });
+
+  test("every entry is a non-empty string", () => {
+    for (const entry of DEFAULT_AGENT_TOOLS) {
+      expect(typeof entry).toBe("string");
+      expect(entry.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("has no duplicate entries", () => {
+    const uniqueEntries = new Set(DEFAULT_AGENT_TOOLS);
+    expect(uniqueEntries.size).toBe(DEFAULT_AGENT_TOOLS.length);
+  });
+
+  test("is a superset of DEFAULT_ADMIN_AGENT_TOOLS", () => {
+    for (const entry of DEFAULT_ADMIN_AGENT_TOOLS) {
+      expect(DEFAULT_AGENT_TOOLS).toContain(entry);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a unit test for `lib/agent-default-tools.ts`, covering the two pure constant arrays `DEFAULT_ADMIN_AGENT_TOOLS` and `DEFAULT_AGENT_TOOLS`
- Asserts non-empty, exact membership, exact count, string-type, no-duplicate, and superset invariants, mirroring the precedent in `lib/secret-env-vars.unit.test.ts`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | DEFAULT_ADMIN_AGENT_TOOLS and DEFAULT_AGENT_TOOLS array contents asserted (membership + non-empty) | MET | Non-empty checks + toContain membership assertions for all expected entries in both arrays, plus exact-count/dup/type guards |
| 2 | Verification command `bun test lib/agent-default-tools.unit.test.ts` passes | MET | 11 pass, 0 fail |

## Test Plan
- [x] `bun test lib/agent-default-tools.unit.test.ts` — 11 pass, 0 fail
- [x] `bun test lib/` — 219 pass, 0 fail (no regressions)
- [x] Coverage on `lib/agent-default-tools.ts`: 100% funcs / 100% lines
- [x] `bunx biome lint lib/agent-default-tools.unit.test.ts` — clean

Generated with [Claude Code](https://claude.com/claude-code)
