### PR TITLE
feat: add author allowlist filter to hitl review candidates (HRA-1.1)

### DIFF
--- a/agent/src/check-review.ts
+++ b/agent/src/check-review.ts
@@ -98,6 +98,14 @@ export interface CheckReviewDeps {
     repo: string,
     prNumber: number,
   ) => Promise<LinkedTaskInfo | null>;
+  /**
+   * Optional author allowlist hook — dev-tool-only (wired in via
+   * scripts/hitl.ts's SHIPWRIGHT_HITL_AUTHORS env var). When set,
+   * getReviewCandidates() skips any PR whose pr.author.login this returns
+   * false for. Omitted entirely by buildProductionDeps() and every
+   * autonomous-loop caller, so their behavior is unchanged.
+   */
+  isAuthorAllowed?: (login: string) => boolean;
 }
 
 // ─── Core logic ───────────────────────────────────────────────────────────────
@@ -127,6 +135,8 @@ export async function getReviewCandidates(
     if (pr.author.login === "app/dependabot") continue;
     if (pr.labels?.some((l) => l.name === "automated")) continue;
     if (!deps.isSelfReviewAllowed && pr.author.login === currentUser) continue;
+    if (deps.isAuthorAllowed && !deps.isAuthorAllowed(pr.author.login))
+      continue;
 
     let record: PrRecord | null = null;
     try {
@@ -220,6 +230,13 @@ export async function buildProductionDeps(opts: {
   fetchFn?: typeof fetch;
   getScopedRepos?: () => string[];
   hasScopeSynced?: () => boolean;
+  /**
+   * Dev-tool-only author allowlist hook (scripts/hitl.ts's
+   * SHIPWRIGHT_HITL_AUTHORS). Autonomous-loop callers never pass this, so
+   * CheckReviewDeps.isAuthorAllowed stays undefined for them — unchanged
+   * behavior.
+   */
+  isAuthorAllowed?: (login: string) => boolean;
 }): Promise<CheckReviewDeps> {
   const workspacePath = resolveWorkspacePath();
   const allRepos = resolveAllRepos(workspacePath);
@@ -230,6 +247,7 @@ export async function buildProductionDeps(opts: {
     isSelfReviewAllowed: readAllowSelfReview(workspacePath),
     getScopedRepos: opts.getScopedRepos ?? agentReposRef.get,
     hasScopeSynced: opts.hasScopeSynced ?? agentReposRef.hasSynced,
+    ...(opts.isAuthorAllowed ? { isAuthorAllowed: opts.isAuthorAllowed } : {}),
     listOpenPrs: async (_repo: string) => {
       return mapReposTolerant(allRepos, "check-review", async (repo) => {
         const repoPrs = await ghJsonFn<PrInfo[]>([

--- a/agent/src/check-review.unit.test.ts
+++ b/agent/src/check-review.unit.test.ts
@@ -599,4 +599,34 @@ describe("getReviewCandidates", () => {
     );
     expect(result).toEqual([]);
   });
+
+  // ─── author allowlist filtering (HRA-1.1, dev-tool-only via hitl.ts) ──────
+
+  test("isAuthorAllowed filters out a PR whose author does not match", async () => {
+    const pr = makePr({ author: { login: "danmcaulay" } });
+    const deps: CheckReviewDeps = {
+      ...makeDeps([pr], async () => null),
+      isAuthorAllowed: (login) => login === "someone-else",
+    };
+    const result = await getReviewCandidates(deps);
+    expect(result).toEqual([]);
+  });
+
+  test("isAuthorAllowed passes through a PR whose author matches", async () => {
+    const pr = makePr({ author: { login: "danmcaulay" } });
+    const deps: CheckReviewDeps = {
+      ...makeDeps([pr], async () => null),
+      isAuthorAllowed: (login) => login === "danmcaulay",
+    };
+    const result = await getReviewCandidates(deps);
+    expect(result).toHaveLength(1);
+  });
+
+  test("isAuthorAllowed is a no-op when omitted (regression guard for autonomous-loop callers)", async () => {
+    const pr = makePr({ author: { login: "danmcaulay" } });
+    const deps = makeDeps([pr], async () => null);
+    expect(deps.isAuthorAllowed).toBeUndefined();
+    const result = await getReviewCandidates(deps);
+    expect(result).toHaveLength(1);
+  });
 });

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -20,6 +20,7 @@
  *   SHIPWRIGHT_HITL_HOME          — root dir (default: ~/.shipwright)
  *   SHIPWRIGHT_HITL_HOST          — hostname for service URLs (default: "localhost")
  *   SHIPWRIGHT_HITL_REPOS         — comma-separated org/repo list for the hitl agent (default: none)
+ *   SHIPWRIGHT_HITL_AUTHORS       — comma-separated GitHub usernames; when set, restricts review candidates to PRs authored by one of these logins (default: none, unfiltered — dev-tool-only, not wired into the autonomous loop)
  *   SHIPWRIGHT_HITL_POLL_INTERVAL — seconds between empty-queue polls (default: 15)
  */
 
@@ -98,6 +99,23 @@ export function parseHitlRepos(raw: string | undefined): string[] {
 }
 
 const HITL_REPOS = parseHitlRepos(process.env.SHIPWRIGHT_HITL_REPOS);
+
+/**
+ * Parses the comma-separated SHIPWRIGHT_HITL_AUTHORS env value into a list of
+ * GitHub usernames, trimming whitespace and dropping empty entries. Mirrors
+ * parseHitlRepos() exactly — dev-tool-only author allowlist, wired into
+ * getReviewCandidates() via CheckReviewDeps.isAuthorAllowed in runLoop().
+ */
+export function parseHitlAuthors(raw: string | undefined): string[] {
+  return raw
+    ? raw
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean)
+    : [];
+}
+
+const HITL_AUTHORS = parseHitlAuthors(process.env.SHIPWRIGHT_HITL_AUTHORS);
 const POLL_INTERVAL_S = Number(
   process.env.SHIPWRIGHT_HITL_POLL_INTERVAL ?? "15",
 );
@@ -553,6 +571,9 @@ async function runLoop(): Promise<void> {
       ghJson,
       getScopedRepos: () => allRepos,
       hasScopeSynced: () => true,
+      ...(HITL_AUTHORS.length > 0
+        ? { isAuthorAllowed: (login: string) => HITL_AUTHORS.includes(login) }
+        : {}),
     });
     patchDeps = await buildPatchDeps({
       ghJson,

--- a/scripts/hitl.unit.test.ts
+++ b/scripts/hitl.unit.test.ts
@@ -13,6 +13,7 @@ import {
   buildTaskCommand,
   computeProvisionPlan,
   ensureHitlAgent,
+  parseHitlAuthors,
   parseHitlRepos,
   parseTasksResponse,
   type Task,
@@ -186,6 +187,28 @@ describe("parseHitlRepos", () => {
 
   test("returns a single-entry list for a value with no commas", () => {
     expect(parseHitlRepos("org/solo")).toEqual(["org/solo"]);
+  });
+});
+
+describe("parseHitlAuthors", () => {
+  test("returns [] for undefined", () => {
+    expect(parseHitlAuthors(undefined)).toEqual([]);
+  });
+
+  test("returns [] for an empty string", () => {
+    expect(parseHitlAuthors("")).toEqual([]);
+  });
+
+  test("splits a comma-separated list, trims whitespace, and drops empty entries", () => {
+    expect(parseHitlAuthors("danmcaulay, dave ,,other-user,")).toEqual([
+      "danmcaulay",
+      "dave",
+      "other-user",
+    ]);
+  });
+
+  test("returns a single-entry list for a value with no commas", () => {
+    expect(parseHitlAuthors("danmcaulay")).toEqual(["danmcaulay"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an optional `isAuthorAllowed?: (login: string) => boolean` hook to `CheckReviewDeps`/`getReviewCandidates()` in `agent/src/check-review.ts` — skips a PR when the hook is set and returns false for `pr.author.login`; omitted entirely when unset, so autonomous-loop callers of `buildProductionDeps()` are unaffected.
- Wires it into `scripts/hitl.ts` via a new `SHIPWRIGHT_HITL_AUTHORS` env var (comma-separated GitHub usernames), parsed by `parseHitlAuthors()` — a byte-for-byte mirror of `parseHitlRepos()`. Dev-tool-only; not exposed to the autonomous loop or `agent-policy.md`.
- Documents `SHIPWRIGHT_HITL_AUTHORS` in `hitl.ts`'s own header env-var block only (mirrors the `SHIPWRIGHT_HITL_REPOS` line) — no `docs/configuration.md` change, per the Option A scope decision.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `CheckReviewDeps` gains optional `isAuthorAllowed?`; `getReviewCandidates()` skips a PR when the hook returns false; omitted entirely when unset | MET | Interface field + early `continue` check in the loop; `buildProductionDeps()` only spreads it in when provided |
| 2 | `parseHitlAuthors()` mirrors `parseHitlRepos()` exactly; `runLoop()` passes `isAuthorAllowed` into `buildReviewDeps()` only when `SHIPWRIGHT_HITL_AUTHORS` is set and non-empty | MET | New function + conditional spread into the `buildReviewDeps()` call |
| 3 | `SHIPWRIGHT_HITL_AUTHORS` documented in `hitl.ts`'s header env-var doc block only, no `docs/configuration.md` change | MET | Header JSDoc updated; no docs file touched |
| 4 | Unit tests only: 4-case `parseHitlAuthors` suite + 3-case `isAuthorAllowed` suite in `getReviewCandidates`, no existing tests retired | MET | `scripts/hitl.unit.test.ts` +4 tests, `agent/src/check-review.unit.test.ts` +3 tests |

## Test Plan
- `bun test agent/src/check-review.unit.test.ts scripts/hitl.unit.test.ts` — 71/71 pass
- Full-suite `bun test` — 4955 pass, 1 pre-existing failure (`claude.unit.test.ts`'s `extraAllowedTools` test, reproduces on clean `main`, unrelated to this diff)
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all 7 workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
