### PR TITLE
feat: add Agent Type Zod schema, parser, and generated JSON Schema artifact

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -20,7 +20,9 @@
     "@sentry/hono": "^10.63.0",
     "@shipwright/lib": "*",
     "hono": "^4",
-    "zod": "^3"
+    "yaml": "^2.9.0",
+    "zod": "^3",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",

--- a/admin/src/agent-type-registry.content.test.ts
+++ b/admin/src/agent-type-registry.content.test.ts
@@ -1,0 +1,38 @@
+/**
+ * admin/src/agent-type-registry.content.test.ts
+ * Content-layer test: regenerates the AgentType JSON Schema in-memory from
+ * its Zod source and diffs it (deep-equal, not string-equal) against the
+ * committed docs/schemas/agent-type.schema.json artifact. This guarantees
+ * the committed artifact can never silently drift from the Zod source —
+ * `scripts/generate-agent-type-schema.ts` must be re-run (and its output
+ * re-committed) whenever AgentTypeManifestSchema changes.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { buildAgentTypeJsonSchema } from "./agent-type-registry.ts";
+
+const committedSchemaPath = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "docs",
+  "schemas",
+  "agent-type.schema.json",
+);
+
+describe("docs/schemas/agent-type.schema.json", () => {
+  it("matches the JSON Schema regenerated from AgentTypeManifestSchema", () => {
+    const regenerated = buildAgentTypeJsonSchema();
+    const committedRaw = readFileSync(committedSchemaPath, "utf-8");
+    const committed = JSON.parse(committedRaw);
+    expect(regenerated).toEqual(committed);
+  });
+
+  it("ends with exactly one trailing newline (matches the generator's write format)", () => {
+    const committedRaw = readFileSync(committedSchemaPath, "utf-8");
+    expect(committedRaw.endsWith("\n")).toBe(true);
+    expect(committedRaw.endsWith("\n\n")).toBe(false);
+  });
+});

--- a/admin/src/agent-type-registry.schema.unit.test.ts
+++ b/admin/src/agent-type-registry.schema.unit.test.ts
@@ -1,9 +1,9 @@
 /**
- * admin/src/agent-type-registry.content.test.ts
- * Content-layer test: regenerates the AgentType JSON Schema in-memory from
- * its Zod source and diffs it (deep-equal, not string-equal) against the
- * committed docs/schemas/agent-type.schema.json artifact. This guarantees
- * the committed artifact can never silently drift from the Zod source —
+ * admin/src/agent-type-registry.schema.unit.test.ts
+ * Regenerates the AgentType JSON Schema in-memory from its Zod source and
+ * diffs it (deep-equal, not string-equal) against the committed
+ * docs/schemas/agent-type.schema.json artifact. This guarantees the
+ * committed artifact can never silently drift from the Zod source —
  * `scripts/generate-agent-type-schema.ts` must be re-run (and its output
  * re-committed) whenever AgentTypeManifestSchema changes.
  */

--- a/admin/src/agent-type-registry.ts
+++ b/admin/src/agent-type-registry.ts
@@ -1,0 +1,227 @@
+/**
+ * admin/src/agent-type-registry.ts
+ *
+ * Agent Type manifest schema — the single source of truth for the
+ * `shipwright.dev/v1alpha1` / `AgentType` YAML manifest that declares an
+ * agent type's identity, crons, plugins, tools, env contract, membership,
+ * repos, and chat/voice toggles.
+ *
+ * Named "agent-type-registry" (not "manifest") to avoid colliding with the
+ * two existing "manifest" concepts in this repo: the Kubernetes manifests in
+ * ./agent-manifest.ts and the Slack app manifest. This module is unrelated
+ * to either — it's a declarative spec fed into scripts/CLI tooling, not a
+ * wire type, so it uses plain `zod` rather than `@hono/zod-openapi`'s
+ * `.openapi()`-augmented `z` (kept simple for zod-to-json-schema conversion).
+ *
+ * Manifests are treated as a trust boundary: they may originate from
+ * third-party contributors, so every object schema is `.strict()` (unknown
+ * keys rejected, not silently stripped) and the env contract is
+ * deliberately keys-only — no `value`/`default` field is permitted on an
+ * env entry, so a manifest can declare *that* a var is needed without ever
+ * carrying a real value.
+ */
+
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { isOrgRepo } from "@shipwright/lib/org-repo";
+
+/** RFC1123 label pattern (see admin/src/agent-manifest.ts's sanitizeAgentName). */
+const RFC1123_NAME = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+// ─── metadata.skills[] (A2A-aligned) ───────────────────────────────────────
+
+/**
+ * Minimal A2A (Agent2Agent) "skill" shape: what the agent type can do, as a
+ * small catalog entry. Kept intentionally narrow — id/name/description plus
+ * optional free-form tags — since this repo has no existing A2A convention
+ * to align with beyond the general shape of an agent capability card.
+ */
+const AgentTypeSkillSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    description: z.string().min(1),
+    tags: z.array(z.string()).optional(),
+  })
+  .strict();
+
+// ─── metadata ───────────────────────────────────────────────────────────────
+
+const AgentTypeMetadataSchema = z
+  .object({
+    name: z
+      .string()
+      .regex(RFC1123_NAME, "metadata.name must be a valid RFC1123 label"),
+    displayName: z.string().min(1),
+    description: z.string().min(1),
+    version: z.string().min(1),
+    skills: z.array(AgentTypeSkillSchema),
+  })
+  .strict();
+
+// ─── identity ───────────────────────────────────────────────────────────────
+
+const AgentTypeIdentitySchema = z
+  .object({
+    templatesDir: z.string().min(1),
+  })
+  .strict();
+
+// ─── crons[] ────────────────────────────────────────────────────────────────
+
+/**
+ * A single cron template declared inside an AgentType manifest. Distinct
+ * from the runtime, DB-backed AgentCronJobSchema (admin/src/openapi-schemas.ts)
+ * and CreateAgentCronJobInput (admin/src/agent-cron-jobs.ts) — those describe
+ * per-agent-instance rows already created in Postgres; this describes a
+ * *template* inside a versioned spec. `parentCron` here is a name reference
+ * resolved within this manifest's own crons[] array (validated by the
+ * top-level schema's superRefine below), not a DB id reference.
+ */
+const AgentTypeCronSchema = z
+  .object({
+    name: z.string().min(1),
+    schedule: z.string().min(1),
+    prompt: z.string().min(1),
+    preCheck: z.string().optional(),
+    silent: z.boolean().optional().default(false),
+    enabled: z.boolean().optional().default(true),
+    parentCron: z.string().optional(),
+  })
+  .strict();
+
+// ─── env contract ───────────────────────────────────────────────────────────
+
+/**
+ * A single env contract entry. Keys-only by design: a manifest declares that
+ * a var is needed (and whether it's secret) — it never carries a `value` or
+ * `default`. `.strict()` ensures an unexpected `value` key is rejected, not
+ * silently stripped, since manifests are potential third-party input.
+ */
+const AgentTypeEnvEntrySchema = z
+  .object({
+    key: z.string().min(1),
+    description: z.string().min(1),
+    secret: z.boolean(),
+  })
+  .strict();
+
+const AgentTypeEnvSchema = z
+  .object({
+    required: z.array(AgentTypeEnvEntrySchema),
+    optional: z.array(AgentTypeEnvEntrySchema),
+  })
+  .strict();
+
+// ─── resources override (optional) ─────────────────────────────────────────
+
+/**
+ * Optional override of the default agent container resources (see
+ * AGENT_CONTAINER_RESOURCES in admin/src/agent-manifest.ts). All fields
+ * optional — a manifest may override just one of requests/limits.
+ */
+const AgentTypeResourceListSchema = z
+  .object({
+    cpu: z.string().optional(),
+    memory: z.string().optional(),
+    "ephemeral-storage": z.string().optional(),
+  })
+  .strict();
+
+const AgentTypeResourcesSchema = z
+  .object({
+    requests: AgentTypeResourceListSchema.optional(),
+    limits: AgentTypeResourceListSchema.optional(),
+  })
+  .strict();
+
+// ─── Top-level AgentType manifest ──────────────────────────────────────────
+
+export const AgentTypeManifestSchema = z
+  .object({
+    apiVersion: z.literal("shipwright.dev/v1alpha1"),
+    kind: z.literal("AgentType"),
+    metadata: AgentTypeMetadataSchema,
+    identity: AgentTypeIdentitySchema,
+    crons: z.array(AgentTypeCronSchema),
+    plugins: z.array(z.string()),
+    tools: z.array(z.string()),
+    env: AgentTypeEnvSchema,
+    members: z.array(z.string()),
+    repos: z.array(
+      z.string().refine(isOrgRepo, {
+        message: "each repo must be in org/repo format",
+      }),
+    ),
+    chat: z.boolean(),
+    voice: z.boolean(),
+    resources: AgentTypeResourcesSchema.optional(),
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    const cronNames = new Set(manifest.crons.map((c) => c.name));
+    manifest.crons.forEach((cron, index) => {
+      if (cron.parentCron === undefined) return;
+      if (cron.parentCron === cron.name) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["crons", index, "parentCron"],
+          message: `parentCron "${cron.parentCron}" cannot reference its own cron entry`,
+        });
+        return;
+      }
+      if (!cronNames.has(cron.parentCron)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["crons", index, "parentCron"],
+          message: `parentCron "${cron.parentCron}" does not match any cron name in this manifest`,
+        });
+      }
+    });
+  });
+
+export type AgentTypeManifest = z.infer<typeof AgentTypeManifestSchema>;
+
+// ─── Parsing ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse and validate a YAML AgentType manifest string.
+ *
+ * Pure — no I/O. `content` is the already-read YAML text; throws a
+ * descriptive Error (with the underlying ZodError's field-path issues
+ * embedded in `message`, and the ZodError itself reachable via `cause`) if
+ * the manifest fails schema validation.
+ */
+export function parseAgentTypeManifest(content: string): AgentTypeManifest {
+  const raw: unknown = parseYaml(content);
+  const result = AgentTypeManifestSchema.safeParse(raw);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`invalid AgentType manifest — ${details}`, {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+// ─── JSON Schema generation ─────────────────────────────────────────────────
+
+/**
+ * Build the JSON-serializable JSON Schema object for AgentTypeManifestSchema.
+ *
+ * Pure — no file I/O — so both scripts/generate-agent-type-schema.ts's CLI
+ * entrypoint and its content test can call this directly instead of shelling
+ * out. The `zod-to-json-schema` import is kept in this module (rather than
+ * in the scripts/ entrypoint) so Bun's node_modules resolution — which walks
+ * up from the *importing file's* directory — finds it via admin/node_modules,
+ * where it's declared as a direct dependency.
+ */
+export function buildAgentTypeJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(
+    AgentTypeManifestSchema,
+    "AgentTypeManifest",
+  ) as Record<string, unknown>;
+}

--- a/admin/src/agent-type-registry.unit.test.ts
+++ b/admin/src/agent-type-registry.unit.test.ts
@@ -1,0 +1,436 @@
+/**
+ * admin/src/agent-type-registry.unit.test.ts
+ * Unit tests for the pure Agent Type manifest schema + parser. No I/O, no
+ * network, no fs — parseAgentTypeManifest takes a YAML string in memory and
+ * returns/throws in-process.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  AgentTypeManifestSchema,
+  parseAgentTypeManifest,
+} from "./agent-type-registry.ts";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const validManifestYaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: dude-agent
+  displayName: The Dude
+  description: A laid-back team member agent.
+  version: 1.0.0
+  skills:
+    - id: chill
+      name: Stay Chill
+      description: Keeps things mellow.
+      tags: [vibe]
+identity:
+  templatesDir: templates/dude
+crons:
+  - name: morning-brief
+    schedule: "0 9 * * 1-5"
+    prompt: Run the morning brief.
+plugins:
+  - "@shipwright/plugin"
+tools:
+  - Read
+  - Write
+env:
+  required:
+    - key: SHIPWRIGHT_API_URL
+      description: Base URL of the admin API.
+      secret: false
+  optional:
+    - key: GROQ_API_KEY
+      description: Optional Groq API key for voice.
+      secret: true
+members:
+  - alice
+repos:
+  - my-org/my-repo
+chat: true
+voice: false
+`;
+
+function parseYamlFixture(yaml: string) {
+  return parseAgentTypeManifest(yaml);
+}
+
+// ─── Valid manifest ─────────────────────────────────────────────────────────
+
+describe("parseAgentTypeManifest — valid manifest", () => {
+  it("parses a valid minimal manifest successfully", () => {
+    const manifest = parseYamlFixture(validManifestYaml);
+    expect(manifest.apiVersion).toBe("shipwright.dev/v1alpha1");
+    expect(manifest.kind).toBe("AgentType");
+    expect(manifest.metadata.name).toBe("dude-agent");
+    expect(manifest.identity.templatesDir).toBe("templates/dude");
+    expect(manifest.crons).toHaveLength(1);
+    expect(manifest.chat).toBe(true);
+    expect(manifest.voice).toBe(false);
+  });
+
+  it("accepts a cron whose parentCron resolves to a sibling cron name", () => {
+    const yaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: dude-agent
+  displayName: The Dude
+  description: A laid-back team member agent.
+  version: 1.0.0
+  skills: []
+identity:
+  templatesDir: templates/dude
+crons:
+  - name: parent-cron
+    schedule: "0 9 * * 1-5"
+    prompt: Parent prompt.
+  - name: child-cron
+    schedule: "0 10 * * 1-5"
+    prompt: Child prompt.
+    parentCron: parent-cron
+plugins: []
+tools: []
+env:
+  required: []
+  optional: []
+members: []
+repos: []
+chat: true
+voice: false
+`;
+    const manifest = parseYamlFixture(yaml);
+    expect(manifest.crons[1].parentCron).toBe("parent-cron");
+  });
+});
+
+// ─── Acceptance criterion 1 — failure cases ────────────────────────────────
+
+describe("parseAgentTypeManifest — invalid manifests fail with field-path errors", () => {
+  it("rejects a cron missing its required schedule field", () => {
+    const yaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: dude-agent
+  displayName: The Dude
+  description: desc
+  version: 1.0.0
+  skills: []
+identity:
+  templatesDir: templates/dude
+crons:
+  - name: bad-cron
+    prompt: Missing schedule.
+plugins: []
+tools: []
+env:
+  required: []
+  optional: []
+members: []
+repos: []
+chat: true
+voice: false
+`;
+    expect(() => parseYamlFixture(yaml)).toThrow();
+    try {
+      parseYamlFixture(yaml);
+      throw new Error("expected parseAgentTypeManifest to throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain("crons");
+      expect(message).toContain("schedule");
+    }
+  });
+
+  it("rejects an unknown top-level field", () => {
+    const yaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: dude-agent
+  displayName: The Dude
+  description: desc
+  version: 1.0.0
+  skills: []
+identity:
+  templatesDir: templates/dude
+crons: []
+plugins: []
+tools: []
+env:
+  required: []
+  optional: []
+members: []
+repos: []
+chat: true
+voice: false
+unknownField: surprise
+`;
+    expect(() => parseYamlFixture(yaml)).toThrow();
+    try {
+      parseYamlFixture(yaml);
+      throw new Error("expected parseAgentTypeManifest to throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain("unknownField");
+    }
+  });
+
+  it("rejects an env entry carrying a value key (trust boundary)", () => {
+    const yaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: dude-agent
+  displayName: The Dude
+  description: desc
+  version: 1.0.0
+  skills: []
+identity:
+  templatesDir: templates/dude
+crons: []
+plugins: []
+tools: []
+env:
+  required:
+    - key: SOME_KEY
+      description: has a value, which is forbidden
+      secret: false
+      value: "should not be allowed"
+  optional: []
+members: []
+repos: []
+chat: true
+voice: false
+`;
+    expect(() => parseYamlFixture(yaml)).toThrow();
+    try {
+      parseYamlFixture(yaml);
+      throw new Error("expected parseAgentTypeManifest to throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain("env");
+      expect(message).toContain("value");
+    }
+  });
+
+  it("rejects a dangling parentCron reference", () => {
+    const yaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: dude-agent
+  displayName: The Dude
+  description: desc
+  version: 1.0.0
+  skills: []
+identity:
+  templatesDir: templates/dude
+crons:
+  - name: only-cron
+    schedule: "0 9 * * 1-5"
+    prompt: Prompt.
+    parentCron: does-not-exist
+plugins: []
+tools: []
+env:
+  required: []
+  optional: []
+members: []
+repos: []
+chat: true
+voice: false
+`;
+    expect(() => parseYamlFixture(yaml)).toThrow();
+    try {
+      parseYamlFixture(yaml);
+      throw new Error("expected parseAgentTypeManifest to throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain("parentCron");
+    }
+  });
+
+  it("rejects a non-RFC1123 metadata.name", () => {
+    const yaml = `
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: Dude_Agent!
+  displayName: The Dude
+  description: desc
+  version: 1.0.0
+  skills: []
+identity:
+  templatesDir: templates/dude
+crons: []
+plugins: []
+tools: []
+env:
+  required: []
+  optional: []
+members: []
+repos: []
+chat: true
+voice: false
+`;
+    expect(() => parseYamlFixture(yaml)).toThrow();
+    try {
+      parseYamlFixture(yaml);
+      throw new Error("expected parseAgentTypeManifest to throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain("metadata");
+      expect(message).toContain("name");
+    }
+  });
+});
+
+// ─── Schema-level checks (direct safeParse, matching repo convention) ──────
+
+describe("AgentTypeManifestSchema.safeParse", () => {
+  it("rejects a self-referencing parentCron", () => {
+    const result = AgentTypeManifestSchema.safeParse({
+      apiVersion: "shipwright.dev/v1alpha1",
+      kind: "AgentType",
+      metadata: {
+        name: "dude-agent",
+        displayName: "The Dude",
+        description: "desc",
+        version: "1.0.0",
+        skills: [],
+      },
+      identity: { templatesDir: "templates/dude" },
+      crons: [
+        {
+          name: "self-cron",
+          schedule: "0 9 * * 1-5",
+          prompt: "Prompt.",
+          parentCron: "self-cron",
+        },
+      ],
+      plugins: [],
+      tools: [],
+      env: { required: [], optional: [] },
+      members: [],
+      repos: [],
+      chat: true,
+      voice: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults silent/enabled on a cron entry when omitted", () => {
+    const result = AgentTypeManifestSchema.safeParse({
+      apiVersion: "shipwright.dev/v1alpha1",
+      kind: "AgentType",
+      metadata: {
+        name: "dude-agent",
+        displayName: "The Dude",
+        description: "desc",
+        version: "1.0.0",
+        skills: [],
+      },
+      identity: { templatesDir: "templates/dude" },
+      crons: [
+        {
+          name: "morning-brief",
+          schedule: "0 9 * * 1-5",
+          prompt: "Prompt.",
+        },
+      ],
+      plugins: [],
+      tools: [],
+      env: { required: [], optional: [] },
+      members: [],
+      repos: [],
+      chat: true,
+      voice: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.crons[0].silent).toBe(false);
+      expect(result.data.crons[0].enabled).toBe(true);
+    }
+  });
+
+  it("rejects a bad apiVersion literal", () => {
+    const result = AgentTypeManifestSchema.safeParse({
+      apiVersion: "shipwright.dev/v1",
+      kind: "AgentType",
+      metadata: {
+        name: "dude-agent",
+        displayName: "The Dude",
+        description: "desc",
+        version: "1.0.0",
+        skills: [],
+      },
+      identity: { templatesDir: "templates/dude" },
+      crons: [],
+      plugins: [],
+      tools: [],
+      env: { required: [], optional: [] },
+      members: [],
+      repos: [],
+      chat: true,
+      voice: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a repos entry not in org/repo format", () => {
+    const result = AgentTypeManifestSchema.safeParse({
+      apiVersion: "shipwright.dev/v1alpha1",
+      kind: "AgentType",
+      metadata: {
+        name: "dude-agent",
+        displayName: "The Dude",
+        description: "desc",
+        version: "1.0.0",
+        skills: [],
+      },
+      identity: { templatesDir: "templates/dude" },
+      crons: [],
+      plugins: [],
+      tools: [],
+      env: { required: [], optional: [] },
+      members: [],
+      repos: ["not-a-valid-repo"],
+      chat: true,
+      voice: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an optional resources override", () => {
+    const result = AgentTypeManifestSchema.safeParse({
+      apiVersion: "shipwright.dev/v1alpha1",
+      kind: "AgentType",
+      metadata: {
+        name: "dude-agent",
+        displayName: "The Dude",
+        description: "desc",
+        version: "1.0.0",
+        skills: [],
+      },
+      identity: { templatesDir: "templates/dude" },
+      crons: [],
+      plugins: [],
+      tools: [],
+      env: { required: [], optional: [] },
+      members: [],
+      repos: [],
+      chat: true,
+      voice: false,
+      resources: {
+        requests: { cpu: "500m", memory: "2Gi", "ephemeral-storage": "1Gi" },
+        limits: { memory: "8Gi", "ephemeral-storage": "1Gi" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/admin/src/agent-type-registry.unit.test.ts
+++ b/admin/src/agent-type-registry.unit.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { stringify as stringifyYaml } from "yaml";
 import {
   AgentTypeManifestSchema,
   parseAgentTypeManifest,
@@ -13,56 +14,98 @@ import {
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
 
-const validManifestYaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: dude-agent
-  displayName: The Dude
-  description: A laid-back team member agent.
-  version: 1.0.0
-  skills:
-    - id: chill
-      name: Stay Chill
-      description: Keeps things mellow.
-      tags: [vibe]
-identity:
-  templatesDir: templates/dude
-crons:
-  - name: morning-brief
-    schedule: "0 9 * * 1-5"
-    prompt: Run the morning brief.
-plugins:
-  - "@shipwright/plugin"
-tools:
-  - Read
-  - Write
-env:
-  required:
-    - key: SHIPWRIGHT_API_URL
-      description: Base URL of the admin API.
-      secret: false
-  optional:
-    - key: GROQ_API_KEY
-      description: Optional Groq API key for voice.
-      secret: true
-members:
-  - alice
-repos:
-  - my-org/my-repo
-chat: true
-voice: false
-`;
+/** A minimal valid manifest object. Pass overrides for the fields a test cares about. */
+function baseManifest(overrides: Record<string, unknown> = {}) {
+  return {
+    apiVersion: "shipwright.dev/v1alpha1",
+    kind: "AgentType",
+    metadata: {
+      name: "dude-agent",
+      displayName: "The Dude",
+      description: "A laid-back team member agent.",
+      version: "1.0.0",
+      skills: [],
+    },
+    identity: { templatesDir: "templates/dude" },
+    crons: [],
+    plugins: [],
+    tools: [],
+    env: { required: [], optional: [] },
+    members: [],
+    repos: [],
+    chat: true,
+    voice: false,
+    ...overrides,
+  };
+}
 
-function parseYamlFixture(yaml: string) {
-  return parseAgentTypeManifest(yaml);
+/** Round-trips a manifest object through YAML so tests exercise the real parse path. */
+function parseManifestYaml(manifest: Record<string, unknown>) {
+  return parseAgentTypeManifest(stringifyYaml(manifest));
+}
+
+function expectThrowsWithMessage(manifest: Record<string, unknown>, ...fragments: string[]) {
+  expect(() => parseManifestYaml(manifest)).toThrow();
+  try {
+    parseManifestYaml(manifest);
+    throw new Error("expected parseAgentTypeManifest to throw");
+  } catch (err) {
+    const message = (err as Error).message;
+    for (const fragment of fragments) {
+      expect(message).toContain(fragment);
+    }
+  }
 }
 
 // ─── Valid manifest ─────────────────────────────────────────────────────────
 
 describe("parseAgentTypeManifest — valid manifest", () => {
   it("parses a valid minimal manifest successfully", () => {
-    const manifest = parseYamlFixture(validManifestYaml);
+    const manifest = parseManifestYaml(
+      baseManifest({
+        metadata: {
+          name: "dude-agent",
+          displayName: "The Dude",
+          description: "A laid-back team member agent.",
+          version: "1.0.0",
+          skills: [
+            {
+              id: "chill",
+              name: "Stay Chill",
+              description: "Keeps things mellow.",
+              tags: ["vibe"],
+            },
+          ],
+        },
+        crons: [
+          {
+            name: "morning-brief",
+            schedule: "0 9 * * 1-5",
+            prompt: "Run the morning brief.",
+          },
+        ],
+        plugins: ["@shipwright/plugin"],
+        tools: ["Read", "Write"],
+        env: {
+          required: [
+            {
+              key: "SHIPWRIGHT_API_URL",
+              description: "Base URL of the admin API.",
+              secret: false,
+            },
+          ],
+          optional: [
+            {
+              key: "GROQ_API_KEY",
+              description: "Optional Groq API key for voice.",
+              secret: true,
+            },
+          ],
+        },
+        members: ["alice"],
+        repos: ["my-org/my-repo"],
+      }),
+    );
     expect(manifest.apiVersion).toBe("shipwright.dev/v1alpha1");
     expect(manifest.kind).toBe("AgentType");
     expect(manifest.metadata.name).toBe("dude-agent");
@@ -73,36 +116,23 @@ describe("parseAgentTypeManifest — valid manifest", () => {
   });
 
   it("accepts a cron whose parentCron resolves to a sibling cron name", () => {
-    const yaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: dude-agent
-  displayName: The Dude
-  description: A laid-back team member agent.
-  version: 1.0.0
-  skills: []
-identity:
-  templatesDir: templates/dude
-crons:
-  - name: parent-cron
-    schedule: "0 9 * * 1-5"
-    prompt: Parent prompt.
-  - name: child-cron
-    schedule: "0 10 * * 1-5"
-    prompt: Child prompt.
-    parentCron: parent-cron
-plugins: []
-tools: []
-env:
-  required: []
-  optional: []
-members: []
-repos: []
-chat: true
-voice: false
-`;
-    const manifest = parseYamlFixture(yaml);
+    const manifest = parseManifestYaml(
+      baseManifest({
+        crons: [
+          {
+            name: "parent-cron",
+            schedule: "0 9 * * 1-5",
+            prompt: "Parent prompt.",
+          },
+          {
+            name: "child-cron",
+            schedule: "0 10 * * 1-5",
+            prompt: "Child prompt.",
+            parentCron: "parent-cron",
+          },
+        ],
+      }),
+    );
     expect(manifest.crons[1].parentCron).toBe("parent-cron");
   });
 });
@@ -111,182 +141,72 @@ voice: false
 
 describe("parseAgentTypeManifest — invalid manifests fail with field-path errors", () => {
   it("rejects a cron missing its required schedule field", () => {
-    const yaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: dude-agent
-  displayName: The Dude
-  description: desc
-  version: 1.0.0
-  skills: []
-identity:
-  templatesDir: templates/dude
-crons:
-  - name: bad-cron
-    prompt: Missing schedule.
-plugins: []
-tools: []
-env:
-  required: []
-  optional: []
-members: []
-repos: []
-chat: true
-voice: false
-`;
-    expect(() => parseYamlFixture(yaml)).toThrow();
-    try {
-      parseYamlFixture(yaml);
-      throw new Error("expected parseAgentTypeManifest to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("crons");
-      expect(message).toContain("schedule");
-    }
+    expectThrowsWithMessage(
+      baseManifest({
+        crons: [{ name: "bad-cron", prompt: "Missing schedule." }],
+      }),
+      "crons",
+      "schedule",
+    );
   });
 
   it("rejects an unknown top-level field", () => {
-    const yaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: dude-agent
-  displayName: The Dude
-  description: desc
-  version: 1.0.0
-  skills: []
-identity:
-  templatesDir: templates/dude
-crons: []
-plugins: []
-tools: []
-env:
-  required: []
-  optional: []
-members: []
-repos: []
-chat: true
-voice: false
-unknownField: surprise
-`;
-    expect(() => parseYamlFixture(yaml)).toThrow();
-    try {
-      parseYamlFixture(yaml);
-      throw new Error("expected parseAgentTypeManifest to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("unknownField");
-    }
+    expectThrowsWithMessage(
+      baseManifest({ unknownField: "surprise" }),
+      "unknownField",
+    );
   });
 
   it("rejects an env entry carrying a value key (trust boundary)", () => {
-    const yaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: dude-agent
-  displayName: The Dude
-  description: desc
-  version: 1.0.0
-  skills: []
-identity:
-  templatesDir: templates/dude
-crons: []
-plugins: []
-tools: []
-env:
-  required:
-    - key: SOME_KEY
-      description: has a value, which is forbidden
-      secret: false
-      value: "should not be allowed"
-  optional: []
-members: []
-repos: []
-chat: true
-voice: false
-`;
-    expect(() => parseYamlFixture(yaml)).toThrow();
-    try {
-      parseYamlFixture(yaml);
-      throw new Error("expected parseAgentTypeManifest to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("env");
-      expect(message).toContain("value");
-    }
+    expectThrowsWithMessage(
+      baseManifest({
+        env: {
+          required: [
+            {
+              key: "SOME_KEY",
+              description: "has a value, which is forbidden",
+              secret: false,
+              value: "should not be allowed",
+            },
+          ],
+          optional: [],
+        },
+      }),
+      "env",
+      "value",
+    );
   });
 
   it("rejects a dangling parentCron reference", () => {
-    const yaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: dude-agent
-  displayName: The Dude
-  description: desc
-  version: 1.0.0
-  skills: []
-identity:
-  templatesDir: templates/dude
-crons:
-  - name: only-cron
-    schedule: "0 9 * * 1-5"
-    prompt: Prompt.
-    parentCron: does-not-exist
-plugins: []
-tools: []
-env:
-  required: []
-  optional: []
-members: []
-repos: []
-chat: true
-voice: false
-`;
-    expect(() => parseYamlFixture(yaml)).toThrow();
-    try {
-      parseYamlFixture(yaml);
-      throw new Error("expected parseAgentTypeManifest to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("parentCron");
-    }
+    expectThrowsWithMessage(
+      baseManifest({
+        crons: [
+          {
+            name: "only-cron",
+            schedule: "0 9 * * 1-5",
+            prompt: "Prompt.",
+            parentCron: "does-not-exist",
+          },
+        ],
+      }),
+      "parentCron",
+    );
   });
 
   it("rejects a non-RFC1123 metadata.name", () => {
-    const yaml = `
-apiVersion: shipwright.dev/v1alpha1
-kind: AgentType
-metadata:
-  name: Dude_Agent!
-  displayName: The Dude
-  description: desc
-  version: 1.0.0
-  skills: []
-identity:
-  templatesDir: templates/dude
-crons: []
-plugins: []
-tools: []
-env:
-  required: []
-  optional: []
-members: []
-repos: []
-chat: true
-voice: false
-`;
-    expect(() => parseYamlFixture(yaml)).toThrow();
-    try {
-      parseYamlFixture(yaml);
-      throw new Error("expected parseAgentTypeManifest to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("metadata");
-      expect(message).toContain("name");
-    }
+    expectThrowsWithMessage(
+      baseManifest({
+        metadata: {
+          name: "Dude_Agent!",
+          displayName: "The Dude",
+          description: "desc",
+          version: "1.0.0",
+          skills: [],
+        },
+      }),
+      "metadata",
+      "name",
+    );
   });
 });
 
@@ -294,63 +214,29 @@ voice: false
 
 describe("AgentTypeManifestSchema.safeParse", () => {
   it("rejects a self-referencing parentCron", () => {
-    const result = AgentTypeManifestSchema.safeParse({
-      apiVersion: "shipwright.dev/v1alpha1",
-      kind: "AgentType",
-      metadata: {
-        name: "dude-agent",
-        displayName: "The Dude",
-        description: "desc",
-        version: "1.0.0",
-        skills: [],
-      },
-      identity: { templatesDir: "templates/dude" },
-      crons: [
-        {
-          name: "self-cron",
-          schedule: "0 9 * * 1-5",
-          prompt: "Prompt.",
-          parentCron: "self-cron",
-        },
-      ],
-      plugins: [],
-      tools: [],
-      env: { required: [], optional: [] },
-      members: [],
-      repos: [],
-      chat: true,
-      voice: false,
-    });
+    const result = AgentTypeManifestSchema.safeParse(
+      baseManifest({
+        crons: [
+          {
+            name: "self-cron",
+            schedule: "0 9 * * 1-5",
+            prompt: "Prompt.",
+            parentCron: "self-cron",
+          },
+        ],
+      }),
+    );
     expect(result.success).toBe(false);
   });
 
   it("defaults silent/enabled on a cron entry when omitted", () => {
-    const result = AgentTypeManifestSchema.safeParse({
-      apiVersion: "shipwright.dev/v1alpha1",
-      kind: "AgentType",
-      metadata: {
-        name: "dude-agent",
-        displayName: "The Dude",
-        description: "desc",
-        version: "1.0.0",
-        skills: [],
-      },
-      identity: { templatesDir: "templates/dude" },
-      crons: [
-        {
-          name: "morning-brief",
-          schedule: "0 9 * * 1-5",
-          prompt: "Prompt.",
-        },
-      ],
-      plugins: [],
-      tools: [],
-      env: { required: [], optional: [] },
-      members: [],
-      repos: [],
-      chat: true,
-      voice: false,
-    });
+    const result = AgentTypeManifestSchema.safeParse(
+      baseManifest({
+        crons: [
+          { name: "morning-brief", schedule: "0 9 * * 1-5", prompt: "Prompt." },
+        ],
+      }),
+    );
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.crons[0].silent).toBe(false);
@@ -359,78 +245,28 @@ describe("AgentTypeManifestSchema.safeParse", () => {
   });
 
   it("rejects a bad apiVersion literal", () => {
-    const result = AgentTypeManifestSchema.safeParse({
-      apiVersion: "shipwright.dev/v1",
-      kind: "AgentType",
-      metadata: {
-        name: "dude-agent",
-        displayName: "The Dude",
-        description: "desc",
-        version: "1.0.0",
-        skills: [],
-      },
-      identity: { templatesDir: "templates/dude" },
-      crons: [],
-      plugins: [],
-      tools: [],
-      env: { required: [], optional: [] },
-      members: [],
-      repos: [],
-      chat: true,
-      voice: false,
-    });
+    const result = AgentTypeManifestSchema.safeParse(
+      baseManifest({ apiVersion: "shipwright.dev/v1" }),
+    );
     expect(result.success).toBe(false);
   });
 
   it("rejects a repos entry not in org/repo format", () => {
-    const result = AgentTypeManifestSchema.safeParse({
-      apiVersion: "shipwright.dev/v1alpha1",
-      kind: "AgentType",
-      metadata: {
-        name: "dude-agent",
-        displayName: "The Dude",
-        description: "desc",
-        version: "1.0.0",
-        skills: [],
-      },
-      identity: { templatesDir: "templates/dude" },
-      crons: [],
-      plugins: [],
-      tools: [],
-      env: { required: [], optional: [] },
-      members: [],
-      repos: ["not-a-valid-repo"],
-      chat: true,
-      voice: false,
-    });
+    const result = AgentTypeManifestSchema.safeParse(
+      baseManifest({ repos: ["not-a-valid-repo"] }),
+    );
     expect(result.success).toBe(false);
   });
 
   it("accepts an optional resources override", () => {
-    const result = AgentTypeManifestSchema.safeParse({
-      apiVersion: "shipwright.dev/v1alpha1",
-      kind: "AgentType",
-      metadata: {
-        name: "dude-agent",
-        displayName: "The Dude",
-        description: "desc",
-        version: "1.0.0",
-        skills: [],
-      },
-      identity: { templatesDir: "templates/dude" },
-      crons: [],
-      plugins: [],
-      tools: [],
-      env: { required: [], optional: [] },
-      members: [],
-      repos: [],
-      chat: true,
-      voice: false,
-      resources: {
-        requests: { cpu: "500m", memory: "2Gi", "ephemeral-storage": "1Gi" },
-        limits: { memory: "8Gi", "ephemeral-storage": "1Gi" },
-      },
-    });
+    const result = AgentTypeManifestSchema.safeParse(
+      baseManifest({
+        resources: {
+          requests: { cpu: "500m", memory: "2Gi", "ephemeral-storage": "1Gi" },
+          limits: { memory: "8Gi", "ephemeral-storage": "1Gi" },
+        },
+      }),
+    );
     expect(result.success).toBe(true);
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,9 @@
         "@sentry/hono": "^10.63.0",
         "@shipwright/lib": "*",
         "hono": "^4",
+        "yaml": "^2.9.0",
         "zod": "^3",
+        "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
         "@playwright/test": "^1.49.0",
@@ -44,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.59.0",
+      "version": "1.71.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -97,7 +99,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.59.0",
+      "version": "1.71.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -115,7 +117,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.59.0",
+      "version": "1.71.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/schemas/agent-type.schema.json
+++ b/docs/schemas/agent-type.schema.json
@@ -1,0 +1,243 @@
+{
+  "$ref": "#/definitions/AgentTypeManifest",
+  "definitions": {
+    "AgentTypeManifest": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "const": "shipwright.dev/v1alpha1"
+        },
+        "kind": {
+          "type": "string",
+          "const": "AgentType"
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            },
+            "displayName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "skills": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "description"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "name",
+            "displayName",
+            "description",
+            "version",
+            "skills"
+          ],
+          "additionalProperties": false
+        },
+        "identity": {
+          "type": "object",
+          "properties": {
+            "templatesDir": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "templatesDir"
+          ],
+          "additionalProperties": false
+        },
+        "crons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "schedule": {
+                "type": "string",
+                "minLength": 1
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1
+              },
+              "preCheck": {
+                "type": "string"
+              },
+              "silent": {
+                "type": "boolean",
+                "default": false
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "parentCron": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "schedule",
+              "prompt"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "properties": {
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "secret": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key",
+                  "description",
+                  "secret"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "optional": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AgentTypeManifest/properties/env/properties/required/items"
+              }
+            }
+          },
+          "required": [
+            "required",
+            "optional"
+          ],
+          "additionalProperties": false
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "repos": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chat": {
+          "type": "boolean"
+        },
+        "voice": {
+          "type": "boolean"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                },
+                "ephemeral-storage": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "limits": {
+              "$ref": "#/definitions/AgentTypeManifest/properties/resources/properties/requests"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "apiVersion",
+        "kind",
+        "metadata",
+        "identity",
+        "crons",
+        "plugins",
+        "tools",
+        "env",
+        "members",
+        "repos",
+        "chat",
+        "voice"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/scripts/generate-agent-type-schema.ts
+++ b/scripts/generate-agent-type-schema.ts
@@ -1,0 +1,24 @@
+/**
+ * scripts/generate-agent-type-schema.ts
+ * Generate the JSON Schema artifact for the AgentType manifest from its Zod
+ * source of truth (admin/src/agent-type-registry.ts).
+ *
+ * Output: `docs/schemas/agent-type.schema.json` — a committed JSON file.
+ * Regenerate with:
+ *   bun run scripts/generate-agent-type-schema.ts
+ */
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildAgentTypeJsonSchema } from "../admin/src/agent-type-registry.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+const outPath = join(repoRoot, "docs", "schemas", "agent-type.schema.json");
+
+if (import.meta.main) {
+  const schema = buildAgentTypeJsonSchema();
+  writeFileSync(outPath, `${JSON.stringify(schema, null, 2)}\n`);
+  console.log(`Wrote AgentType JSON Schema to ${outPath}`);
+}


### PR DESCRIPTION
## Summary
- Add `admin/src/agent-type-registry.ts`: `AgentTypeManifestSchema` (Zod, `.strict()` throughout) and pure `parseAgentTypeManifest(content)` for the `shipwright.dev/v1alpha1`/`AgentType` YAML manifest — metadata (RFC1123 name, A2A-aligned skills), identity, crons (with `parentCron` name resolution via `superRefine`), plugins, tools, keys-only env contract (rejects value-bearing entries as a trust boundary), members, repos, chat/voice toggles, optional resources override
- Add `scripts/generate-agent-type-schema.ts` + committed `docs/schemas/agent-type.schema.json`, generated via `zod-to-json-schema` from the Zod source
- Add `yaml` and `zod-to-json-schema` as explicit direct dependencies of `admin/package.json` (previously only transitive)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Invalid manifests fail with field-path errors (bad cron shape, unknown top-level field, env value, dangling parentCron, non-RFC1123 name) | MET |
| 2 | `docs/schemas/agent-type.schema.json` regenerates deterministically from the Zod source via the script | MET |
| 3 | `yaml` and `zod-to-json-schema` are direct dependencies of `admin/package.json` | MET |
| 4 | New `agent-type-registry.unit.test.ts` (pure, no I/O) + content test diffing the regenerated schema against the committed artifact; no existing tests retired | MET |

## Test Plan
- `bun test admin/src/agent-type-registry.unit.test.ts admin/src/agent-type-registry.content.test.ts` — 14 pass, 100% line/function coverage on the new module
- `NODE_ENV=test bun test` (full suite) — 4968 pass, 1 pre-existing unrelated failure (`agent/src/claude.unit.test.ts`, confirmed failing on `main` too)
- `bun run lint` — clean
- `bun run --filter='*' --sequential typecheck` — all workspaces pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
