### PR TITLE
feat: author agent-types/coding manifest capturing current defaults

### DIFF
--- a/agent-types/coding/manifest.content.test.ts
+++ b/agent-types/coding/manifest.content.test.ts
@@ -17,10 +17,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
-import {
-  type AgentTypeManifest,
-  parseAgentTypeManifest,
-} from "../../admin/src/agent-type-registry.ts";
+import { parseAgentTypeManifest } from "../../admin/src/agent-type-registry.ts";
 import { SYSTEM_CRONS } from "../../admin/src/system-crons.ts";
 
 const MANIFEST_PATH = join(import.meta.dir, "manifest.yaml");
@@ -33,9 +30,8 @@ describe("agent-types/coding/manifest.yaml — parses via AgentTypeRegistry", ()
     expect(() => parseAgentTypeManifest(rawContent)).not.toThrow();
   });
 
-  let manifest: AgentTypeManifest;
   it("produces a manifest object", () => {
-    manifest = parseAgentTypeManifest(rawContent);
+    const manifest = parseAgentTypeManifest(rawContent);
     expect(manifest).toBeDefined();
   });
 

--- a/agent-types/coding/manifest.content.test.ts
+++ b/agent-types/coding/manifest.content.test.ts
@@ -1,0 +1,229 @@
+/**
+ * agent-types/coding/manifest.content.test.ts
+ *
+ * Content-layer tests for agent-types/coding/manifest.yaml — the AgentType
+ * manifest expressing today's coding agent defaults in the Agent Type format
+ * (ATS-2.1). No real I/O boundary beyond reading the two static source files
+ * being compared; this is a content-assertion test, not integration.
+ *
+ * Parity note (temporary): this test compares the manifest's crons[] against
+ * the still-live admin/src/system-crons.ts SYSTEM_CRONS array. Both sources
+ * exist side by side until ATS-3.2 cuts SYSTEM_CRONS over to read from the
+ * manifest and deletes the TS array — at that point this parity assertion is
+ * retired and replaced by a golden regression test against the manifest
+ * alone. Do not delete this test before ATS-3.2 lands.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import {
+  type AgentTypeManifest,
+  parseAgentTypeManifest,
+} from "../../admin/src/agent-type-registry.ts";
+import { SYSTEM_CRONS } from "../../admin/src/system-crons.ts";
+
+const MANIFEST_PATH = join(import.meta.dir, "manifest.yaml");
+const rawContent = readFileSync(MANIFEST_PATH, "utf-8");
+
+// ─── Acceptance criterion 1 — schema-clean load ────────────────────────────
+
+describe("agent-types/coding/manifest.yaml — parses via AgentTypeRegistry", () => {
+  it("parses without throwing", () => {
+    expect(() => parseAgentTypeManifest(rawContent)).not.toThrow();
+  });
+
+  let manifest: AgentTypeManifest;
+  it("produces a manifest object", () => {
+    manifest = parseAgentTypeManifest(rawContent);
+    expect(manifest).toBeDefined();
+  });
+
+  it("has the expected apiVersion and kind", () => {
+    const manifest = parseAgentTypeManifest(rawContent);
+    expect(manifest.apiVersion).toBe("shipwright.dev/v1alpha1");
+    expect(manifest.kind).toBe("AgentType");
+  });
+});
+
+// ─── Acceptance criterion 4 — required top-level sections present ─────────
+
+describe("agent-types/coding/manifest.yaml — required top-level sections", () => {
+  const manifest = parseAgentTypeManifest(rawContent);
+
+  it("has a metadata section", () => {
+    expect(manifest.metadata).toBeDefined();
+    expect(manifest.metadata.name).toBe("coding");
+  });
+
+  it("has an identity section with templatesDir agent/workspace/", () => {
+    expect(manifest.identity).toBeDefined();
+    expect(manifest.identity.templatesDir).toBe("agent/workspace/");
+  });
+
+  it("has a crons array", () => {
+    expect(Array.isArray(manifest.crons)).toBe(true);
+  });
+
+  it("has a plugins array containing the shipwright plugin", () => {
+    expect(manifest.plugins).toContain("shipwright");
+  });
+
+  it("has a tools array", () => {
+    expect(Array.isArray(manifest.tools)).toBe(true);
+  });
+
+  it("has an env section with required and optional arrays", () => {
+    expect(manifest.env).toBeDefined();
+    expect(Array.isArray(manifest.env.required)).toBe(true);
+    expect(Array.isArray(manifest.env.optional)).toBe(true);
+  });
+
+  it("has an empty members array", () => {
+    expect(manifest.members).toEqual([]);
+  });
+
+  it("has an empty repos array", () => {
+    expect(manifest.repos).toEqual([]);
+  });
+
+  it("has chat and voice booleans, both enabled", () => {
+    expect(manifest.chat).toBe(true);
+    expect(manifest.voice).toBe(true);
+  });
+});
+
+// ─── Acceptance criterion 2 — exactly 13 cron entries ──────────────────────
+
+describe("agent-types/coding/manifest.yaml — cron count", () => {
+  it("has exactly 13 cron entries", () => {
+    const manifest = parseAgentTypeManifest(rawContent);
+    expect(manifest.crons).toHaveLength(13);
+  });
+
+  it("matches the SYSTEM_CRONS source count (sanity check on the fixture itself)", () => {
+    expect(SYSTEM_CRONS).toHaveLength(13);
+  });
+});
+
+// ─── Acceptance criterion 2 — byte-match parity vs SYSTEM_CRONS ────────────
+
+describe("agent-types/coding/manifest.yaml — cron parity vs SYSTEM_CRONS (temporary, retired in ATS-3.2)", () => {
+  const manifest = parseAgentTypeManifest(rawContent);
+
+  it("has a manifest cron entry for every SYSTEM_CRONS name, in the same order", () => {
+    const manifestNames = manifest.crons.map((c) => c.name);
+    const systemCronNames = SYSTEM_CRONS.map((c) => c.name);
+    expect(manifestNames).toEqual(systemCronNames);
+  });
+
+  for (const systemCron of SYSTEM_CRONS) {
+    describe(`cron "${systemCron.name}"`, () => {
+      it("byte-matches schedule, prompt, preCheck, silent, enabled, parentCron", () => {
+        const manifestCron = manifest.crons.find(
+          (c) => c.name === systemCron.name,
+        );
+        expect(manifestCron).toBeDefined();
+        if (!manifestCron) return;
+
+        expect(manifestCron.schedule).toBe(systemCron.schedule);
+        expect(manifestCron.prompt).toBe(systemCron.prompt);
+        expect(manifestCron.preCheck).toBe(systemCron.preCheck);
+        expect(manifestCron.silent).toBe(systemCron.silent ?? false);
+        expect(manifestCron.enabled).toBe(systemCron.enabled);
+        expect(manifestCron.parentCron).toBe(systemCron.parentCron);
+      });
+    });
+  }
+});
+
+// ─── Tools parity vs DEFAULT_AGENT_TOOLS (resolved decision A) ─────────────
+
+describe("agent-types/coding/manifest.yaml — tools parity vs DEFAULT_AGENT_TOOLS", () => {
+  it("byte-matches lib/agent-default-tools.ts DEFAULT_AGENT_TOOLS", async () => {
+    const { DEFAULT_AGENT_TOOLS } = await import(
+      "../../lib/agent-default-tools.ts"
+    );
+    const manifest = parseAgentTypeManifest(rawContent);
+    expect(manifest.tools).toEqual(DEFAULT_AGENT_TOOLS);
+  });
+});
+
+// ─── Acceptance criterion 3 — zero secret values anywhere in the file ──────
+
+describe("agent-types/coding/manifest.yaml — no secret values (public repo)", () => {
+  it("has no `value:` key anywhere in the raw YAML", () => {
+    expect(rawContent).not.toMatch(/^\s*value:/m);
+  });
+
+  it("has no `default:` key on an env entry (keys-only contract)", () => {
+    // A bare top-level "default:" key is not part of the schema at all; this
+    // guards against someone hand-adding one to an env entry by mistake.
+    expect(rawContent).not.toMatch(/^\s*default:\s*["'A-Za-z0-9]/m);
+  });
+
+  it("every required env entry has key/description/secret only — no value", () => {
+    const manifest = parseAgentTypeManifest(rawContent);
+    for (const entry of manifest.env.required) {
+      expect(Object.keys(entry).sort()).toEqual(
+        ["description", "key", "secret"].sort(),
+      );
+    }
+  });
+
+  it("every optional env entry has key/description/secret only — no value", () => {
+    const manifest = parseAgentTypeManifest(rawContent);
+    for (const entry of manifest.env.optional) {
+      expect(Object.keys(entry).sort()).toEqual(
+        ["description", "key", "secret"].sort(),
+      );
+    }
+  });
+
+  it("does not contain common secret-value patterns (sk-, xox, ghp_, AKIA, PEM headers)", () => {
+    const suspiciousPatterns = [
+      /sk-[a-zA-Z0-9]{10,}/,
+      /xox[baprs]-[a-zA-Z0-9-]+/,
+      /ghp_[a-zA-Z0-9]{20,}/,
+      /AKIA[0-9A-Z]{16}/,
+      /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+    ];
+    for (const pattern of suspiciousPatterns) {
+      expect(rawContent).not.toMatch(pattern);
+    }
+  });
+});
+
+// ─── env contract shape (CLAUDE_CODE_OAUTH_TOKEN required; GH_TOKEN + voice/chat optional) ─
+
+describe("agent-types/coding/manifest.yaml — env contract", () => {
+  const manifest = parseAgentTypeManifest(rawContent);
+
+  it("requires CLAUDE_CODE_OAUTH_TOKEN as a secret", () => {
+    const entry = manifest.env.required.find(
+      (e) => e.key === "CLAUDE_CODE_OAUTH_TOKEN",
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.secret).toBe(true);
+  });
+
+  it("lists GH_TOKEN as optional and secret", () => {
+    const entry = manifest.env.optional.find((e) => e.key === "GH_TOKEN");
+    expect(entry).toBeDefined();
+    expect(entry?.secret).toBe(true);
+  });
+
+  it("only CLAUDE_CODE_OAUTH_TOKEN is required (matches brief: GH_TOKEN + voice/chat vars are optional)", () => {
+    expect(manifest.env.required.map((e) => e.key)).toEqual([
+      "CLAUDE_CODE_OAUTH_TOKEN",
+    ]);
+  });
+
+  it("has no duplicate keys across required+optional", () => {
+    const allKeys = [
+      ...manifest.env.required.map((e) => e.key),
+      ...manifest.env.optional.map((e) => e.key),
+    ];
+    expect(new Set(allKeys).size).toBe(allKeys.length);
+  });
+});

--- a/agent-types/coding/manifest.yaml
+++ b/agent-types/coding/manifest.yaml
@@ -1,0 +1,203 @@
+# agent-types/coding/manifest.yaml
+#
+# AgentType manifest for the "coding" agent type — Shipwright's default
+# autonomous delivery agent. Expresses today's coding agent defaults
+# (ATS-2.1) in the Agent Type format: the SYSTEM_CRONS entries
+# (admin/src/system-crons.ts), the DEFAULT_AGENT_TOOLS tool set
+# (lib/agent-default-tools.ts), the bundled shipwright plugin, and the
+# agent's env contract.
+#
+# Validated against admin/src/agent-type-registry.ts's AgentTypeManifestSchema
+# (see agent-types/coding/manifest.content.test.ts for the parity assertions
+# against the still-live SYSTEM_CRONS TS source).
+#
+# Temporary parity note: crons[] below is transcribed byte-for-byte from
+# admin/src/system-crons.ts's SYSTEM_CRONS array, which remains the live
+# runtime source until ATS-3.2 cuts the seeding logic over to read this
+# manifest instead and deletes the TS array. Keep both in sync until then.
+apiVersion: shipwright.dev/v1alpha1
+kind: AgentType
+metadata:
+  name: coding
+  displayName: Coding Agent
+  description: >-
+    Shipwright's default autonomous delivery agent — runs the
+    spec-to-plan-to-execute-to-review-to-deploy loop via the shipwright
+    plugin, plus scheduled maintenance patrols (docs freshness, entropy,
+    error, security, and consolidation scans).
+  version: 1.0.0
+  skills:
+    - id: dev-task
+      name: Develop Task
+      description: >-
+        Picks up a ready task from the task store, implements it on a
+        feature branch with tests, and opens a pull request.
+    - id: review
+      name: Review Pull Request
+      description: >-
+        Reviews an explicitly named pull request against GitHub's live
+        state and the project's review policy, posting findings.
+    - id: patch
+      name: Patch Pull Request
+      description: >-
+        Applies fixes to an explicitly named pull request in response to
+        unresolved review threads or failing CI.
+    - id: deploy
+      name: Deploy Pull Request
+      description: >-
+        Merges and ships an explicitly named, approved, green pull
+        request per the repo's deploy model.
+    - id: maintenance-patrols
+      name: Maintenance Patrols
+      description: >-
+        Scheduled scans and fixes for docs freshness, test readiness,
+        entropy, errors, security, and consolidation opportunities.
+      tags:
+        - maintenance
+        - scheduled
+identity:
+  templatesDir: agent/workspace/
+crons:
+  - name: shipwright-dev-task
+    schedule: "* * * * *"
+    prompt: /shipwright:dev-task
+    silent: true
+    enabled: true
+    parentCron: shipwright-loop
+  - name: shipwright-patch
+    schedule: "* * * * *"
+    prompt: /shipwright:patch
+    silent: true
+    enabled: true
+    parentCron: shipwright-loop
+  - name: shipwright-review
+    schedule: "* * * * *"
+    prompt: /shipwright:review
+    silent: true
+    enabled: true
+    parentCron: shipwright-loop
+  - name: shipwright-deploy
+    schedule: "* * * * *"
+    prompt: /shipwright:deploy
+    silent: true
+    enabled: false
+    parentCron: shipwright-loop
+  - name: shipwright-loop
+    schedule: "* * * * *"
+    prompt: "internal: dispatched via handleLoopCronRequest, not run through Claude"
+    silent: true
+    enabled: false
+  - name: shipwright-test-readiness
+    schedule: "0 6 * * *"
+    prompt: /shipwright:test-readiness --full --publish
+    preCheck: shipwright:check-test-readiness.ts
+    silent: true
+    enabled: false
+  - name: shipwright-docs-freshness
+    schedule: "0 7 * * *"
+    prompt: /shipwright:research-docs --auto
+    preCheck: shipwright:check-docs-freshness.ts
+    silent: true
+    enabled: false
+  - name: learn-dream
+    schedule: "0 3 * * *"
+    preCheck: shipwright:check-learn-dream.ts
+    prompt: /shipwright:learn-dream --since 1d --review
+    silent: true
+    enabled: false
+  - name: dependabot-triage
+    schedule: "0 8 * * *"
+    prompt: /shipwright:triage-dependabot-prs
+    silent: true
+    enabled: false
+  - name: entropy-patrol-maintenance
+    schedule: "0 4 * * 1"
+    prompt: |-
+      /shipwright:entropy-scan
+      /shipwright:entropy-fix
+      After the fix run completes, write state/entropy-patrol-last-run.json: {"lastRun": "<ISO timestamp>"}. Use [silent] if no pr_worthy findings are found.
+    silent: true
+    enabled: false
+  - name: error-patrol-maintenance
+    schedule: "0 4 * * *"
+    prompt: |-
+      /shipwright:error-scan
+      /shipwright:error-fix
+      /shipwright:error-resolve
+      After the chain completes, write state/error-patrol-ledger.json's lastRun field: "<ISO timestamp>". Use [silent] if no new or regressed issues are found.
+    silent: true
+    preCheck: shipwright:check-error-patrol.ts
+    enabled: false
+  - name: security-patrol-maintenance
+    schedule: "0 6 * * 1"
+    prompt: |-
+      /shipwright:security-scan
+      /shipwright:security-fix
+      After the fix run completes, write state/security-patrol-last-run.json: {"lastRun": "<ISO timestamp>"}. Use [silent] if no pr_worthy findings are found.
+    silent: true
+    enabled: false
+  - name: consolidation-patrol-maintenance
+    schedule: "0 5 * * 1"
+    prompt: |-
+      /shipwright:consolidation-scan
+      /shipwright:consolidation-fix
+      After the chain completes, write state/consolidation-ledger.json's lastRun field: "<ISO timestamp>". Use [silent] if no ready_to_propose findings are found.
+    silent: true
+    preCheck: shipwright:check-consolidation-patrol.ts
+    enabled: false
+plugins:
+  - shipwright
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - WebSearch
+  - WebFetch
+  - Skill
+  - Agent
+env:
+  required:
+    - key: CLAUDE_CODE_OAUTH_TOKEN
+      description: >-
+        Claude Code OAuth token used to authenticate the agent's Claude
+        sessions (alternative to ANTHROPIC_API_KEY).
+      secret: true
+  optional:
+    - key: GH_TOKEN
+      description: >-
+        GitHub Personal Access Token, used as a fallback for GitHub API
+        access when GitHub App credentials are not configured.
+      secret: true
+    - key: SLACK_BOT_TOKEN
+      description: Slack bot user OAuth token, required for chat over Slack.
+      secret: true
+    - key: SLACK_APP_TOKEN
+      description: Slack app-level token for Socket Mode, required for chat over Slack.
+      secret: true
+    - key: SLACK_SIGNING_SECRET
+      description: Used to verify incoming Slack request signatures.
+      secret: true
+    - key: GROQ_API_KEY
+      description: Groq API key for voice transcription/processing.
+      secret: true
+    - key: ELEVENLABS_API_KEY
+      description: ElevenLabs API key for voice speech synthesis.
+      secret: true
+    - key: ELEVENLABS_VOICE_ID
+      description: ElevenLabs voice ID to use for speech synthesis.
+      secret: false
+    - key: WHISPER_SERVICE_URL
+      description: URL of a Whisper transcription service for voice input.
+      secret: false
+    - key: PIPER_VOICE
+      description: >-
+        Piper voice name to use for local (offline) speech synthesis when
+        no cloud voice provider is configured.
+      secret: false
+members: []
+repos: []
+chat: true
+voice: true


### PR DESCRIPTION
## Summary
- Adds `agent-types/coding/manifest.yaml`, expressing today's coding agent in the Agent Type format: all 13 `SYSTEM_CRONS` entries (schedules, prompts, preChecks, silent/enabled flags, parentCron links), the unified `DEFAULT_AGENT_TOOLS` tool set, the `shipwright` plugin, and the env contract (`CLAUDE_CODE_OAUTH_TOKEN` required; `GH_TOKEN` + voice/chat vars optional).
- Adds co-located `agent-types/coding/manifest.content.test.ts` — parses/validates the manifest via `AgentTypeRegistry`, asserts 13 crons + required sections, and runs a temporary byte-match parity check against the still-live `SYSTEM_CRONS` TS array (retired in ATS-3.2 when the TS source is deleted).
- No TS source modified — the manifest is authored alongside `SYSTEM_CRONS`; the runtime cut-over happens in ATS-3.2.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Manifest validates via the AgentTypeRegistry (schema-clean load of the real file) | MET | `parseAgentTypeManifest(rawContent)` — no-throw + correct apiVersion/kind, 3 passing tests |
| 2 | Cron entries byte-match the current SYSTEM_CRONS values | MET | All 13 crons transcribed verbatim; per-cron parity test against live `SYSTEM_CRONS` import, 13/13 passing |
| 3 | Env contract contains keys and metadata only — zero secret values | MET | Schema is `.strict()` (no `value` field); content-level regex checks for secret-value patterns, all passing |
| 4 | Co-located manifest.content.test.ts; no existing tests retired | MET | 38 tests added; `git diff --stat` shows only 2 new files |

## Test Plan
- `bun test agent-types/coding/manifest.content.test.ts` — 38/38 passing
- `task lint` — clean (551 files)
- `task typecheck` — clean across all 7 workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
