### PR TITLE
docs: specify GitHub source-reference channel for agent types (paper spec)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,4 +183,4 @@ To load additional context into a session, add `@docs/filename.md` entries here 
 - **docs/migration.md** — breaking changes and migration steps across versions (e.g. `AgentProvisioner.reconcile()` interface change)
 - **docs/observability.md** — Sentry error/log reporting: what's collected, what's scrubbed, how to disable, and self-hosted Sentry support
 - **docs/consolidation.md** — consolidation-patrol system: the ledger format, the decisions registry, and the cron (disabled by default, opt-in per agent)
-- **docs/agent-types.md** — authoring guide for Agent Type manifests: field reference, blank template, worked examples, and the FLOOR_TOOLS/no-secrets/crons-disabled rules; regenerate the JSON Schema with `bun run scripts/generate-agent-type-schema.ts`
+- **docs/agent-types.md** — authoring guide for Agent Type manifests: field reference, blank template, worked examples, the FLOOR_TOOLS/no-secrets/crons-disabled rules, and a "Specified, not implemented" spec for GitHub-hosted custom Agent Type source references; regenerate the JSON Schema with `bun run scripts/generate-agent-type-schema.ts`

--- a/docs/agent-types.content.test.ts
+++ b/docs/agent-types.content.test.ts
@@ -232,6 +232,76 @@ describe("docs/agent-types.md — Rules section", () => {
   });
 });
 
+// ─── GitHub source references (ATS-5.2, paper spec) ────────────────────────
+
+describe("docs/agent-types.md — GitHub source references section", () => {
+  const sectionHeading = "## GitHub source references";
+  const sectionStart = content.indexOf(sectionHeading);
+  const generatedSchemaStart = content.indexOf("## Generated JSON Schema");
+
+  it(`contains a "${sectionHeading}" heading`, () => {
+    expect(sectionStart).toBeGreaterThan(-1);
+  });
+
+  it("is placed before the Generated JSON Schema section", () => {
+    expect(generatedSchemaStart).toBeGreaterThan(sectionStart);
+  });
+
+  const section = content.slice(sectionStart, generatedSchemaStart);
+
+  it('carries the "Specified, not implemented" marker', () => {
+    expect(section).toContain("Specified, not implemented");
+  });
+
+  it("documents the reference grammar (github:owner/repo[/path]@ref)", () => {
+    expect(section).toContain("github:owner/repo");
+    expect(section).toContain("@ref");
+  });
+
+  it("documents the pinning rule — @ref required, tag or commit SHA only, no branch tracking", () => {
+    expect(section).toMatch(/tag or commit sha/i);
+    expect(section).toMatch(/no branch(es)? tracking|not a branch|branches? (are|is) not/i);
+  });
+
+  it("documents owner/repo validation via lib/org-repo.ts's isOrgRepo", () => {
+    expect(section).toContain("lib/org-repo.ts");
+    expect(section).toContain("isOrgRepo");
+  });
+
+  it("documents the conventional layout — manifest.yaml required, identity templates dir optional", () => {
+    expect(section).toContain("manifest.yaml");
+    expect(section).toMatch(/identity templates?( directory| dir)?.{0,40}optional|optional.{0,40}identity templates?/i);
+  });
+
+  it("documents private-repo auth via the agent-env mechanism and GitHub App auth", () => {
+    expect(section).toMatch(/agent-env|AgentEnv/);
+    expect(section).toContain("agent/src/github-app-auth.ts");
+    expect(section).toContain("@octokit/auth-app");
+  });
+
+  it("mentions a single reserved-but-unused optional manifest field for the future schema hook", () => {
+    expect(section).toMatch(/reserved/i);
+    expect(section).toContain("`source`");
+  });
+
+  it('has a "Security requirements" subsection', () => {
+    expect(section).toMatch(/security requirements/i);
+  });
+
+  const securityStart = section.search(/security requirements/i);
+  const securitySection = section.slice(securityStart);
+
+  it("the Security requirements subsection mandates ref pinning, content review, and allowlisting as future work", () => {
+    expect(securitySection).toMatch(/ref pinning|pin(ning)? (the |a )?ref/i);
+    expect(securitySection).toMatch(/content review/i);
+    expect(securitySection).toMatch(/allowlist/i);
+  });
+
+  it("frames this as an external-code-injection surface (third-party manifest/markdown becomes agent config/prompt)", () => {
+    expect(securitySection).toMatch(/code injection|code-injection/i);
+  });
+});
+
 // ─── CLAUDE.md Reference index ─────────────────────────────────────────────
 
 describe("CLAUDE.md — Reference index includes docs/agent-types.md", () => {

--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -269,6 +269,53 @@ Agent Type names are resolved from a **built-in registry first**. As of this wri
 
 Treat this section as the intended contract for authors, not a description of already-enforced runtime behavior — check `admin/src/agent-type-registry.ts` and its surrounding modules for the current implementation status before relying on shadow-rejection actually happening today.
 
+## GitHub source references
+
+> **Specified, not implemented.** This section documents the intended design for plugging a custom Agent Type manifest in from a user's GitHub repo. No fetch logic, loader, or schema field described here exists yet — nothing in this section should be read as already-shipped behavior. It exists so the eventual implementation has an agreed contract to build against, and so reviewers have something concrete to hold that implementation to.
+
+### Reference grammar and pinning
+
+A GitHub source reference has the form:
+
+```
+github:owner/repo[/path]@ref
+```
+
+- `owner/repo` — the GitHub repository hosting the Agent Type manifest.
+- `/path` — optional; a subdirectory within the repo where the manifest lives, for repos that host more than one Agent Type or that keep the manifest alongside unrelated code. Omitted, the manifest is expected at the repo root.
+- `@ref` — **required, no exceptions.** `ref` must resolve to a tag or a commit SHA — **never a branch name**. A branch is a moving pointer; an Agent Type manifest controls what crons an agent runs and what tools it's granted, so a moving reference would let upstream repo activity silently change a running agent's crons/tools without any action on the agent owner's part. That is not acceptable, hence the grammar has no unpinned form and no branch tracking mode — branches are explicitly out of scope for `ref`. A future loader must reject a reference whose `ref` segment is missing or is not a tag or commit SHA.
+
+### `owner/repo` validation
+
+The `owner/repo` portion of the reference is validated with the same rule already used elsewhere in this codebase for org/repo strings: [`lib/org-repo.ts`](../lib/org-repo.ts)'s `isOrgRepo` — split on `/`, require exactly two non-empty parts. A future loader is expected to reuse `isOrgRepo` directly rather than reimplement the check.
+
+### Conventional layout
+
+At the referenced path (repo root, or `/path` when given), the loader expects a conventional layout:
+
+- `manifest.yaml` — **required.** The `AgentType` manifest itself, in the same `shipwright.dev/v1alpha1` format documented above in this guide.
+- an identity templates directory — **optional.** Workspace template files matching what `identity.templatesDir` in the manifest points at (see [Identity](#identity)). When absent, the referenced type is expected to fall back to a built-in default templates directory rather than fail to load.
+
+No other files at the referenced path carry meaning to the loader; a repo is free to host other content alongside these.
+
+### Private-repo auth
+
+A source reference may point at a private repository. Fetching it is expected to reuse the **existing agent-env mechanism** — the same encrypted `AgentEnv` key/value store already used for every other per-agent credential (see [Env contract](#env-contract) above) — to supply a GitHub token, rather than inventing a new credential-storage path for this one feature.
+
+The likely fetch mechanism is the GitHub App auth already implemented in [`agent/src/github-app-auth.ts`](../agent/src/github-app-auth.ts) (`createAppAuth` from `@octokit/auth-app`, installation-token caching with proactive refresh) — the same mechanism the agent runtime already uses to authenticate its own GitHub API calls. A future implementation should prefer that path over asking users to mint and store a separate personal access token, falling back to a PAT (mirroring the existing `GH_TOKEN` optional-env pattern in the worked env example above) only where a GitHub App installation isn't available for the target repo.
+
+This guide reserves a single **optional**, reserved-but-unused top-level manifest field name, `source`, as the intended future hook for "this Agent Type's canonical manifest was fetched from this GitHub reference" — a string carrying the `github:owner/repo[/path]@ref` value. `source` is **not** present in `AgentTypeManifestSchema` today; it is named here only so a future schema change has an agreed field name to add, not to declare it live.
+
+### Security requirements
+
+A GitHub source reference is an **external-code-injection surface**: the referenced repo's `manifest.yaml` becomes an agent's live cron/tool/env configuration, and any markdown or prompt content it pulls in (workspace templates, skill/command bodies) becomes text an agent will treat as instructions. Both are attacker-controlled the moment a source reference points at a repo the agent owner doesn't fully trust or doesn't control the write access to. Before any implementation of this feature ships, it must include:
+
+- **Ref pinning is mandatory, not advisory.** The grammar above already forbids branch tracking; the loader must enforce it (reject on load, not just recommend in docs) so a manifest's source can never silently drift to new upstream content.
+- **Content review before first use.** A source reference must not be auto-fetched and auto-applied the first time it's configured without a human reviewing the manifest (and any templates it pulls in) at the pinned ref — analogous to reviewing a dependency before adding it, not just trusting a URL.
+- **Allowlisting.** The set of `owner/repo` values a deployment is willing to fetch custom Agent Type manifests from must be explicitly allowlisted by an operator, not open to any public GitHub repo by default. An unlisted `owner/repo` must fail closed.
+
+These three requirements are **required work for the future implementation pass** — none of them exist today because none of the fetch/load code exists today.
+
 ## Generated JSON Schema
 
 The full JSON Schema for `AgentTypeManifestSchema` is generated from the Zod source of truth and committed at [`docs/schemas/agent-type.schema.json`](./schemas/agent-type.schema.json). Regenerate it after any schema change:


### PR DESCRIPTION
## Summary
- Adds a new "GitHub source references" section to `docs/agent-types.md` — a normative-but-unimplemented (paper) spec for plugging in custom Agent Types hosted in a user's GitHub repo.
- Documents the reference grammar (`github:owner/repo[/path]@ref`), the mandatory tag-or-commit-SHA pinning rule (no branch tracking), `owner/repo` validation via `lib/org-repo.ts`'s `isOrgRepo`, the conventional layout (`manifest.yaml` required, identity templates dir optional), private-repo auth via the existing agent-env mechanism (noting GitHub App auth as the likely fetch path), and a Security requirements subsection (ref pinning, content review, allowlisting) framing this as an external-code-injection surface.
- The section carries an explicit **"Specified, not implemented"** marker, test-guarded so it can't silently ship as implemented behavior. No fetch logic, loader, or schema fields were added — only a single reserved-but-unused `source` field name is mentioned in prose.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Grammar, pinning rule, layout convention, private-repo auth, and security requirements are each present in the section | MET |
| 2 | The "Specified, not implemented" marker is present and guarded by the content test so the section cannot silently ship as implemented | MET |
| 3 | No implementation code, schema fields beyond a single reserved optional source field, or fetch logic is introduced | MET |
| 4 | Tests: extend docs/agent-types.content.test.ts to assert the section, its five required parts, and the not-implemented marker; no existing tests retired | MET |

## Test Plan
- `NODE_ENV=test bun test docs/agent-types.content.test.ts` — 72/72 pass (61 pre-existing + 11 new)
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all packages
- `bun run scripts/check-config-docs.ts` — clean
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
