### PR TITLE
test: split real-disk I/O cases out of agent-type-manifest-loader.unit.test.ts (T-076)

### DIFF
--- a/admin/src/agent-type-manifest-loader.integration.test.ts
+++ b/admin/src/agent-type-manifest-loader.integration.test.ts
@@ -1,0 +1,35 @@
+/**
+ * admin/src/agent-type-manifest-loader.integration.test.ts
+ * Integration tests for AgentTypeRegistry's real-disk-backed default reader
+ * and lister.
+ *
+ * Unlike agent-type-manifest-loader.unit.test.ts (which injects a fake
+ * read/list and never touches the filesystem), these cases construct
+ * `AgentTypeRegistry` with no injected dependencies, so it falls through to
+ * `defaultManifestReader`/`defaultTypeDirLister` and reads the real,
+ * committed agent-types/ directory from disk. This is a genuine I/O-boundary
+ * crossing — see docs/testing.md for the integration-layer contract.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AgentTypeRegistry } from "./agent-type-manifest-loader.ts";
+
+describe("AgentTypeRegistry", () => {
+  it("loads the real committed coding manifest from disk via the default reader", () => {
+    // No injected reader — exercises defaultManifestReader against the real
+    // agent-types/coding/manifest.yaml so a broken repo-root path is caught.
+    const registry = new AgentTypeRegistry();
+    const manifest = registry.getManifest("coding");
+    expect(manifest.metadata.name).toBe("coding");
+    expect(manifest.crons.length).toBeGreaterThan(0);
+  });
+
+  it("listTypes discovers the real committed agent-types/ dir via the default list fn", () => {
+    // No injected list/read — exercises the real disk-backed discovery so a
+    // broken repo-root path or missing coding manifest is caught.
+    const registry = new AgentTypeRegistry();
+    const types = registry.listTypes();
+    expect(types.length).toBeGreaterThan(0);
+    expect(types.some((t) => t.name === "coding")).toBe(true);
+  });
+});

--- a/admin/src/agent-type-manifest-loader.unit.test.ts
+++ b/admin/src/agent-type-manifest-loader.unit.test.ts
@@ -97,15 +97,6 @@ describe("AgentTypeRegistry", () => {
     expect(reads).toBe(1);
   });
 
-  it("loads the real committed coding manifest from disk via the default reader", () => {
-    // No injected reader — exercises defaultManifestReader against the real
-    // agent-types/coding/manifest.yaml so a broken repo-root path is caught.
-    const registry = new AgentTypeRegistry();
-    const manifest = registry.getManifest("coding");
-    expect(manifest.metadata.name).toBe("coding");
-    expect(manifest.crons.length).toBeGreaterThan(0);
-  });
-
   // ─── tryGetManifest — non-fallback lookup ────────────────────────────────
   //
   // Unlike getManifest(), tryGetManifest() must NOT fall back to "coding" for
@@ -239,14 +230,5 @@ voice: true
     });
 
     expect(registry.listTypes()).toEqual([]);
-  });
-
-  it("listTypes discovers the real committed agent-types/ dir via the default list fn", () => {
-    // No injected list/read — exercises the real disk-backed discovery so a
-    // broken repo-root path or missing coding manifest is caught.
-    const registry = new AgentTypeRegistry();
-    const types = registry.listTypes();
-    expect(types.length).toBeGreaterThan(0);
-    expect(types.some((t) => t.name === "coding")).toBe(true);
   });
 });

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@
 | Layer | Framework | Boundary rule | Suffix |
 |---|---|---|---|
 | **Unit** | `bun test` | Pure logic — no I/O of any kind (no filesystem, network, or subprocess). | `*.unit.test.ts` |
-| **Integration** | `bun test` + injected recorded doubles | Real dependency behavior via recorded fixtures / injected doubles — exercises the seam without a live external service. | `*.integration.test.ts` |
+| **Integration** | `bun test` + injected recorded doubles | Real dependency behavior via recorded fixtures / injected doubles, or real filesystem I/O on committed repo content — exercises the seam without a live external service. | `*.integration.test.ts` |
 | **Smoke** | `bun test` + Hono `app.request()`, or `Bun.serve()` + `fetch()` | HTTP route contracts (status, shape, auth, errors). Prefer in-process `app.request()` (no real socket) for Hono apps; a real `Bun.serve()` boot with live `fetch()` is permitted when there's no in-process request seam (e.g. a bare-`Bun.serve()` server with no Hono app factory). | `*.smoke.test.ts` |
 | **E2E** | `@playwright/test` | Full browser-driven flows against a real running server. Marketing site home page (`site/*.spec.ts`); metrics dashboard (`metrics/e2e/*.e2e.ts`); admin UI (`admin/e2e/*.e2e.ts`). | `*.spec.ts` (in `site/`), `*.e2e.ts` (in `metrics/e2e/`, `admin/e2e/`) |
 | **Content** | `bun test` | Markdown/prompt-content-assertion tests — e.g. checking that a command's or skill's Markdown body contains expected sections/instructions/wording. Distinct from unit/integration/smoke: no real I/O boundary, just asserting on static content. | `*.content.test.ts` |


### PR DESCRIPTION
## Summary
- Relocated the 2 real-disk-I/O cases out of `admin/src/agent-type-manifest-loader.unit.test.ts` into a new `admin/src/agent-type-manifest-loader.integration.test.ts` sibling — these cases construct `AgentTypeRegistry` with no injected read/list, falling through to `defaultManifestReader`/`defaultTypeDirLister` and hitting the real filesystem, which doesn't belong in a `.unit.test.ts` file.
- The remaining 12 injected-DI cases stay in the unit file; no production code or logic changes.
- Refreshed `docs/testing.md` to clarify that the Integration layer's boundary rule also covers real filesystem I/O on committed repo content (not just recorded fixtures/injected doubles).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | The 2 real-disk-I/O cases relocated to new `.integration.test.ts` sibling | MET | Both `it()` blocks present verbatim in new file with correct import & header |
| 2 | The remaining 12 injected-DI cases stay in `.unit.test.ts` | MET | Diff shows only the 2 target cases removed; unit file untouched otherwise |
| 3 | Verification command passes | MET | `bun test admin/src/agent-type-manifest-loader.unit.test.ts admin/src/agent-type-manifest-loader.integration.test.ts` → 14 pass, 0 fail |

## Test Plan
- [x] `bun test admin/src/agent-type-manifest-loader.unit.test.ts admin/src/agent-type-manifest-loader.integration.test.ts` — 14 pass, 0 fail
- [x] `bunx biome lint .` — clean (553 files)
- [x] `cd admin && bunx tsc --noEmit` — clean
- [x] Full `bun test` — no regressions introduced (2 pre-existing flaky failures in `metrics/src/lib/errors.unit.test.ts` confirmed present on `main` under full-suite run, unrelated to this change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
