### PR TITLE
docs(test-readiness): re-confirm naming/runner isolation (T-075)

### DIFF
--- a/docs/test-readiness/naming.md
+++ b/docs/test-readiness/naming.md
@@ -113,6 +113,33 @@ rename work landed since T-048:
 
 Still no cross-runner discovery gaps.
 
+**Re-confirmed (T-075):** re-ran the isolation check per-entry-point against the
++18-file delta this cycle, which includes the 4 new Agent Type manifest test files
+(`admin/src/agent-type-manifest-loader.unit.test.ts`,
+`admin/src/agent-type-registry.unit.test.ts`,
+`admin/src/agent-type-registry.schema.unit.test.ts`,
+`agent-types/coding/manifest.content.test.ts`):
+
+- `bun test unit` (positional pattern match) discovered 118 files, all matching
+  `*.unit.test.ts` — including the 3 new Agent Type unit test files above. `bun test
+  integration` discovered 56 files, all matching `*.integration.test.ts`. `bun test
+  smoke` discovered 43 files, all matching `*.smoke.test.ts`. Zero cross-layer files in
+  any of the three filtered scans.
+- `bunx playwright test --list` against `metrics/playwright.config.ts` discovered 31
+  tests in exactly 1 file (`dashboard.e2e.ts`); against `admin/playwright.config.ts`, 25
+  tests in exactly 2 files (`agents-page.e2e.ts`, `login-page.e2e.ts`) — no
+  unit/integration/smoke/content file picked up by either.
+- `cd site && npx playwright test --list` discovered 220 tests in exactly 20 files, all
+  matching `*.spec.ts` — `site/tests/` contains only those 20 spec files plus the
+  non-test `helpers.ts`.
+- Coverage still has no separate `pathIgnorePatterns` — it inherits the same `[test]`
+  config as the `bun test` scan above, so the same zero-bleed isolation applies.
+- `plugins/shipwright/test/test-naming-convention.content.test.ts` (the automated
+  regression guard) passes: 11/11 tests.
+
+The 4 new Agent Type manifest test files landed inside the existing suffix convention,
+not a parallel one. Still no cross-runner discovery gaps.
+
 ## Collision rules
 
 1. **One suffix per file.** A test file must match exactly one row in the suffix table.


### PR DESCRIPTION
## Summary
- Re-ran the T-048/T-068 cross-runner isolation check now that the Agent Type manifest system added 4 new test files this cycle (+18-file delta), per T-075's mandatory M1 re-verification.
- Confirmed `bun test unit`/`integration`/`smoke` filters, the metrics/admin Playwright configs, site's `*.spec.ts` test directory, and the coverage config each still discover only their own layer's files, with zero cross-layer bleed.
- Docs-only change — no source code touched, as expected for a verification-only task.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Each runner (Jest/Bun testMatch, Playwright testMatch, coverage exclude) confirmed to discover only its own layer's files, including this cycle's 4 new Agent Type manifest test files | MET | `bun test unit`: 118 files, all `*.unit.test.ts`, including the 3 new Agent Type unit test files. `bun test integration`: 56 files, all `*.integration.test.ts`. `bun test smoke`: 43 files, all `*.smoke.test.ts`. Zero cross-layer matches in any scan. `metrics/playwright.config.ts`: 31 tests / 1 file (`dashboard.e2e.ts`). `admin/playwright.config.ts`: 25 tests / 2 files (`agents-page.e2e.ts`, `login-page.e2e.ts`). Coverage inherits `bun test`'s `pathIgnorePatterns` (no separate config). |
| 2 | Verification commands pass: `bun test --filter unit`/`integration`/`smoke` each return zero cross-layer files; `cd site && npx playwright test --list` returns only `*.spec.ts` | MET | All three `bun test` filters confirmed zero cross-layer files (see above). `cd site && npx playwright test --list`: 220 tests in exactly 20 files, all `*.spec.ts` (`site/tests/` contains only those 20 spec files + non-test `helpers.ts`). Automated regression guard `plugins/shipwright/test/test-naming-convention.content.test.ts`: 11/11 pass. |

## Test Plan
- [x] `bun test unit --test-name-pattern "ZZZ_NO_SUCH_TEST_ZZZ" --pass-with-no-tests` — 118 files, zero cross-layer matches
- [x] `bun test integration --test-name-pattern "ZZZ_NO_SUCH_TEST_ZZZ" --pass-with-no-tests` — 56 files, zero cross-layer matches
- [x] `bun test smoke --test-name-pattern "ZZZ_NO_SUCH_TEST_ZZZ" --pass-with-no-tests` — 43 files, zero cross-layer matches
- [x] `cd site && npx playwright test --list` — 220 tests / 20 `*.spec.ts` files
- [x] `bunx playwright test --list` in `metrics/` and `admin/` — each discovers only its own `*.e2e.ts` file(s)
- [x] `bun test plugins/shipwright/test/test-naming-convention.content.test.ts` — 11/11 pass
- [x] `task lint`, `task check-strings`, `task check-version-sync`, `task check-config-docs` — all pass
- [x] `task test:coverage` — 2 pre-existing failures in `agent/src/claude.unit.test.ts` reproduce identically on `main` (unrelated to this docs-only change, no files under `agent/` touched on this branch)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
