### PR TITLE
feat: add agent-author-allowlist-ref.ts (mirrors agent-repos-ref.ts)

### DIFF
--- a/agent/src/agent-author-allowlist-ref.ts
+++ b/agent/src/agent-author-allowlist-ref.ts
@@ -1,0 +1,63 @@
+/**
+ * agent/src/agent-author-allowlist-ref.ts
+ *
+ * A tiny mutable box holding the agent's most recently synced allowlist of
+ * author logins (GitHub username/login strings) permitted to trigger review,
+ * so downstream consumers can read a live view without closing over a single
+ * syncConfig() tick. Kept pure and zero-I/O so it's unit-testable in
+ * isolation — mirrors loop-jobs-ref.ts's style.
+ */
+
+export interface AgentAuthorAllowlistRef {
+  /**
+   * Returns the most recently set author-allowlist, or [] if set() was never
+   * called. Callers that need to distinguish "never synced" (config-bundle
+   * fetch has never succeeded — e.g. a persistent 404) from "synced to a
+   * deliberately empty allowlist" must check hasSynced() rather than
+   * inferring it from an empty get() result, since both states return [].
+   */
+  get(): string[];
+  /**
+   * True once set() has been called at least once. Consumers that gate on
+   * the allowlist should fail open (skip filtering / allow) while this is
+   * false, so a persistent config-sync failure doesn't silently exclude
+   * every author from triggering review — before this ref existed, the
+   * allowlist was never a triggering gate at all, and that pre-sync
+   * behavior must be preserved.
+   */
+  hasSynced(): boolean;
+  /** Replaces the current author-allowlist. */
+  set(authorLogins: string[]): void;
+}
+
+/** Creates a new, independent agent author-allowlist ref defaulting to an empty list. */
+export function createAgentAuthorAllowlistRef(): AgentAuthorAllowlistRef {
+  let authorLogins: string[] = [];
+  let synced = false;
+
+  return {
+    get(): string[] {
+      return authorLogins;
+    },
+    hasSynced(): boolean {
+      return synced;
+    },
+    set(next: string[]): void {
+      authorLogins = next;
+      synced = true;
+    },
+  };
+}
+
+/**
+ * The process-wide agent author-allowlist ref. check-review.ts's
+ * buildProductionDeps will default its author-allowlist-checking dependency
+ * to `.get`/`.hasSynced` from this same instance (in AAL-2.2, not wired up
+ * yet), so allowlist changes take effect on the very next
+ * candidate-collection call without requiring loop-orchestrator.ts (which
+ * builds those deps once and reuses them for the orchestrator's lifetime) to
+ * be touched at all. If the agent's config bundle never becomes available,
+ * `hasSynced()` stays false for the process lifetime — consumers must fail
+ * open in that case.
+ */
+export const agentAuthorAllowlistRef: AgentAuthorAllowlistRef = createAgentAuthorAllowlistRef();

--- a/agent/src/agent-author-allowlist-ref.unit.test.ts
+++ b/agent/src/agent-author-allowlist-ref.unit.test.ts
@@ -1,0 +1,87 @@
+/**
+ * agent/src/agent-author-allowlist-ref.unit.test.ts
+ *
+ * Unit tests for createAgentAuthorAllowlistRef() — pure logic, no I/O.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  agentAuthorAllowlistRef,
+  createAgentAuthorAllowlistRef,
+} from "./agent-author-allowlist-ref.ts";
+
+describe("createAgentAuthorAllowlistRef", () => {
+  it("initial get() before any set() returns an empty/safe default", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    expect(ref.get()).toEqual([]);
+  });
+
+  it("hasSynced() is false before any set() call", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    expect(ref.hasSynced()).toBe(false);
+  });
+
+  it("hasSynced() becomes true after the first set(), even if set to an empty list", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    ref.set([]);
+    expect(ref.hasSynced()).toBe(true);
+    expect(ref.get()).toEqual([]);
+  });
+
+  it("hasSynced() stays true after subsequent set() calls, regardless of value", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    ref.set(["alice"]);
+    expect(ref.hasSynced()).toBe(true);
+
+    ref.set([]);
+    expect(ref.hasSynced()).toBe(true);
+  });
+
+  it("returns the most recently set allowlist regardless of how many times set() was called", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    const first = ["alice"];
+    const second = ["bob"];
+    const third = ["carol", "dave"];
+
+    ref.set(first);
+    expect(ref.get()).toBe(first);
+
+    ref.set(second);
+    expect(ref.get()).toBe(second);
+
+    ref.set(third);
+    expect(ref.get()).toEqual(third);
+  });
+
+  it("multiple independent ref instances don't share state", () => {
+    const refA = createAgentAuthorAllowlistRef();
+    const refB = createAgentAuthorAllowlistRef();
+
+    refA.set(["alice"]);
+
+    expect(refA.get()).toEqual(["alice"]);
+    expect(refB.get()).toEqual([]);
+    expect(refA.hasSynced()).toBe(true);
+    expect(refB.hasSynced()).toBe(false);
+  });
+
+  it("set() with an empty array is reflected by the next get()", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    ref.set(["alice"]);
+    expect(ref.get()).toHaveLength(1);
+
+    ref.set([]);
+    expect(ref.get()).toEqual([]);
+  });
+});
+
+describe("agentAuthorAllowlistRef (process-wide singleton)", () => {
+  it("is a working ref that reflects set() through get(), independent of createAgentAuthorAllowlistRef() instances", () => {
+    const independent = createAgentAuthorAllowlistRef();
+    independent.set(["should-not-leak"]);
+
+    agentAuthorAllowlistRef.set(["alice"]);
+    expect(agentAuthorAllowlistRef.get()).toEqual(["alice"]);
+    expect(independent.get()).toEqual(["should-not-leak"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `agent/src/agent-author-allowlist-ref.ts`, a structural mirror of `agent-repos-ref.ts`: an `AgentAuthorAllowlistRef` interface (`get()`/`hasSynced()`/`set()`), a `createAgentAuthorAllowlistRef()` factory, and a process-wide `agentAuthorAllowlistRef` singleton.
- Kept pure and zero-I/O, mirroring the sibling's doc-comment style and fail-open `hasSynced()` semantics, adapted for author logins instead of repos.
- No wiring into `index.ts` or `check-review.ts` yet — that lands in AAL-2.2.

## Acceptance Criteria
| Criterion | Status |
|-----------|--------|
| Exports `AgentAuthorAllowlistRef`, `createAgentAuthorAllowlistRef()`, `agentAuthorAllowlistRef` matching sibling's shape/doc comments | ✅ MET |
| Unit test mirrors `agent-repos-ref.unit.test.ts`'s cases (default empty+not-synced, set() updates get()+flips hasSynced(), independent instances) | ✅ MET |
| No wiring into index.ts or check-review.ts | ✅ MET |

## Test Plan
- `bun test agent/src/agent-author-allowlist-ref.unit.test.ts` — 8/8 passing, 100% line/function coverage
- `bunx biome lint` — clean
- `cd agent && bun run typecheck` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
