### PR TITLE
feat: API schemas + CRUD/config route handlers for authorAllowlist

### DIFF
--- a/admin/openapi.json
+++ b/admin/openapi.json
@@ -35,6 +35,10 @@
             "type": "boolean",
             "example": false
           },
+          "typeName": {
+            "type": "string",
+            "example": "coding"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -50,6 +54,7 @@
           "id",
           "name",
           "selfHosted",
+          "typeName",
           "createdAt",
           "updatedAt"
         ]
@@ -81,6 +86,28 @@
           "selfHosted": {
             "type": "boolean",
             "example": false
+          },
+          "type": {
+            "type": "string",
+            "example": "coding"
+          },
+          "repos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "my-org/my-repo"
+            ]
+          },
+          "authorAllowlist": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "octocat"
+            ]
           }
         },
         "required": [
@@ -195,6 +222,15 @@
               "type": "string"
             }
           },
+          "authorAllowlist": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "typeName": {
+            "type": "string"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -202,6 +238,12 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "missingRequiredEnv": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -209,8 +251,11 @@
           "name",
           "selfHosted",
           "repos",
+          "authorAllowlist",
+          "typeName",
           "createdAt",
-          "updatedAt"
+          "updatedAt",
+          "missingRequiredEnv"
         ]
       },
       "PatchAgentBody": {
@@ -227,6 +272,15 @@
             },
             "example": [
               "my-org/my-repo"
+            ]
+          },
+          "authorAllowlist": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "octocat"
             ]
           }
         }
@@ -326,12 +380,17 @@
           "selfHosted": {
             "type": "boolean",
             "example": false
+          },
+          "typeName": {
+            "type": "string",
+            "example": "coding"
           }
         },
         "required": [
           "id",
           "name",
-          "selfHosted"
+          "selfHosted",
+          "typeName"
         ]
       },
       "Ok": {
@@ -1814,13 +1873,23 @@
               "org/repo1",
               "org/repo2"
             ]
+          },
+          "authorAllowlist": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "octocat"
+            ]
           }
         },
         "required": [
           "env",
           "allowedTools",
           "plugins",
-          "repos"
+          "repos",
+          "authorAllowlist"
         ]
       },
       "RuntimeError": {

--- a/admin/src/agents-api.integration.test.ts
+++ b/admin/src/agents-api.integration.test.ts
@@ -462,6 +462,31 @@ describeOrSkip("admin CRUD API (integration)", () => {
     expect(getBody.repos).toEqual(["my-org/my-repo"]);
   });
 
+  // ─── authorAllowlist field round-trip ──────────────────────────────────────────
+
+  it("PATCH /agents/:id with authorAllowlist sets the field; GET /agents/:id returns it", async () => {
+    // PATCH to set authorAllowlist
+    const patchRes = await app.request(`/agents/${agentId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ authorAllowlist: ["octocat"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(patchRes.status).toBe(200);
+    const patchBody = await patchRes.json();
+    expect(patchBody.authorAllowlist).toEqual(["octocat"]);
+
+    // GET to confirm persisted value
+    const getRes = await app.request(`/agents/${agentId}`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.authorAllowlist).toEqual(["octocat"]);
+  });
+
   // ─── Work queue snapshot upsert semantics ─────────────────────────────────────
 
   it("POST /work-queue twice overwrites the row rather than creating a second one", async () => {

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -2676,6 +2676,211 @@ describe("admin API — repos field", () => {
   });
 });
 
+// ─── authorAllowlist field smoke tests ────────────────────────────────────────
+
+describe("admin API — authorAllowlist field", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  it("POST /agents with authorAllowlist: ['not valid'] returns 400 (invalid login)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request("/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "New Agent",
+        authorAllowlist: ["not valid"],
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/github login/i);
+  });
+
+  it("POST /agents with authorAllowlist: ['octocat'] returns 201 and includes it", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      agentService: {
+        ...base.agentService,
+        create: async (input: {
+          name: string;
+          slackId?: string | null;
+          selfHosted?: boolean;
+          authorAllowlist?: string[];
+        }) => ({
+          id: "agent-new-id",
+          name: input.name,
+          slackId: input.slackId ?? null,
+          selfHosted: input.selfHosted ?? false,
+          repos: [],
+          authorAllowlist: input.authorAllowlist ?? [],
+          typeName: "coding",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          missingRequiredEnv: [],
+        }),
+      },
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request("/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "New Agent", authorAllowlist: ["octocat"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.authorAllowlist).toEqual(["octocat"]);
+  });
+
+  it("PATCH /agents/:id with authorAllowlist: ['not valid'] returns 400 (invalid login)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ authorAllowlist: ["not valid"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/github login/i);
+  });
+
+  it("PATCH /agents/:id with authorAllowlist: ['octocat'] returns 200", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      agentService: {
+        ...base.agentService,
+        getDetail: async (id: string) =>
+          id === AGENT_ID
+            ? {
+                id: AGENT_ID,
+                name: "Existing Agent",
+                slackId: null,
+                selfHosted: false,
+                repos: [],
+                authorAllowlist: [],
+                typeName: "coding",
+                createdAt: new Date("2024-01-01"),
+                updatedAt: new Date("2024-01-01"),
+                missingRequiredEnv: [],
+              }
+            : null,
+        updateSelfHosted: async (
+          id: string,
+          input: {
+            selfHosted?: boolean;
+            repos?: string[];
+            authorAllowlist?: string[];
+          },
+        ) => ({
+          id,
+          name: "Existing Agent",
+          slackId: null,
+          selfHosted: input.selfHosted ?? false,
+          repos: input.repos ?? [],
+          authorAllowlist: input.authorAllowlist ?? [],
+          typeName: "coding",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          missingRequiredEnv: [],
+        }),
+      },
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ authorAllowlist: ["octocat"] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authorAllowlist).toEqual(["octocat"]);
+  });
+
+  it("PATCH /agents/:id with authorAllowlist: [] clears it and returns 200 with authorAllowlist: []", async () => {
+    const base = makeMockDeps();
+    const deps: AdminDeps = {
+      ...base,
+      agentService: {
+        ...base.agentService,
+        getDetail: async (id: string) =>
+          id === AGENT_ID
+            ? {
+                id: AGENT_ID,
+                name: "Existing Agent",
+                slackId: null,
+                selfHosted: false,
+                repos: [],
+                authorAllowlist: ["octocat"],
+                typeName: "coding",
+                createdAt: new Date("2024-01-01"),
+                updatedAt: new Date("2024-01-01"),
+                missingRequiredEnv: [],
+              }
+            : null,
+        updateSelfHosted: async (
+          id: string,
+          input: {
+            selfHosted?: boolean;
+            repos?: string[];
+            authorAllowlist?: string[];
+          },
+        ) => ({
+          id,
+          name: "Existing Agent",
+          slackId: null,
+          selfHosted: input.selfHosted ?? false,
+          repos: input.repos ?? [],
+          authorAllowlist: input.authorAllowlist ?? [],
+          typeName: "coding",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          missingRequiredEnv: [],
+        }),
+      },
+    };
+    const app = createAdminApp(deps);
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ authorAllowlist: [] }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authorAllowlist).toEqual([]);
+  });
+
+  it("GET /agents/:id returns authorAllowlist field (empty array for existing agents)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.authorAllowlist)).toBe(true);
+    expect(body.authorAllowlist).toEqual([]);
+  });
+});
+
 // ─── Cron runs smoke tests ────────────────────────────────────────────────────
 
 describe("admin API — cron runs", () => {

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -239,6 +239,7 @@ const GetAgentResultSchema = z
     slackId: z.string().nullable().optional(),
     selfHosted: z.boolean(),
     repos: z.array(z.string()),
+    authorAllowlist: z.array(z.string()),
     typeName: z.string(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
@@ -988,6 +989,9 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       selfHosted: body.selfHosted ?? false,
       typeName,
       repos,
+      ...(body.authorAllowlist !== undefined
+        ? { authorAllowlist: body.authorAllowlist }
+        : {}),
     });
 
     // Seed AgentTool/AgentPlugin/AgentMember rows from the resolved
@@ -1094,6 +1098,9 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
     const agent = await agentService.updateSelfHosted(agentId, {
       selfHosted: body.selfHosted,
       ...(body.repos !== undefined ? { repos: body.repos } : {}),
+      ...(body.authorAllowlist !== undefined
+        ? { authorAllowlist: body.authorAllowlist }
+        : {}),
     });
     return c.json(serializeAgent(agent), 200);
   });
@@ -1718,6 +1725,7 @@ function serializeAgent(agent: {
   slackId: string | null | undefined;
   selfHosted: boolean;
   repos?: string[];
+  authorAllowlist?: string[];
   typeName: string;
   createdAt: Date;
   updatedAt: Date;
@@ -1729,6 +1737,7 @@ function serializeAgent(agent: {
     slackId: agent.slackId,
     selfHosted: agent.selfHosted,
     repos: agent.repos ?? [],
+    authorAllowlist: agent.authorAllowlist ?? [],
     typeName: agent.typeName,
     createdAt: agent.createdAt.toISOString(),
     updatedAt: agent.updatedAt.toISOString(),

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -35,6 +35,7 @@ interface MockAgent {
   id: string;
   name: string;
   repos: string[];
+  authorAllowlist: string[];
 }
 
 // ─── Mock factories ───────────────────────────────────────────────────────────
@@ -74,14 +75,30 @@ function makeMockAgentCronJobService(crons: Map<string, AgentCronJob[]>): {
 }
 
 function makeMockAgentService(agents: Map<string, MockAgent>): {
-  getById: (agentId: string) => Promise<{ id: string; repos: string[] } | null>;
+  getById: (
+    agentId: string,
+  ) => Promise<{
+    id: string;
+    repos: string[];
+    authorAllowlist: string[];
+  } | null>;
 } {
   return {
     async getById(
       agentId: string,
-    ): Promise<{ id: string; repos: string[] } | null> {
+    ): Promise<{
+      id: string;
+      repos: string[];
+      authorAllowlist: string[];
+    } | null> {
       const agent = agents.get(agentId);
-      return agent ? { id: agent.id, repos: agent.repos } : null;
+      return agent
+        ? {
+            id: agent.id,
+            repos: agent.repos,
+            authorAllowlist: agent.authorAllowlist,
+          }
+        : null;
     },
   };
 }
@@ -157,6 +174,7 @@ function buildApp(opts?: {
   plugins?: MockPlugin[];
   crons?: AgentCronJob[];
   repos?: string[];
+  authorAllowlist?: string[];
 }) {
   const hasAgent = opts?.hasAgent ?? true;
   const bundle: AgentEnvBundle | null =
@@ -172,6 +190,7 @@ function buildApp(opts?: {
   ];
   const crons = opts?.crons ?? [makeCron(KNOWN_AGENT_ID, "cron-1")];
   const repos = opts?.repos ?? ["org/repo1", "org/repo2"];
+  const authorAllowlist = opts?.authorAllowlist ?? [];
 
   const agents = new Map<string, MockAgent>();
   const bundles = new Map<string, AgentEnvBundle | null>();
@@ -183,6 +202,7 @@ function buildApp(opts?: {
       id: KNOWN_AGENT_ID,
       name: "Test Agent",
       repos,
+      authorAllowlist,
     });
     bundles.set(KNOWN_AGENT_ID, bundle);
     pluginMap.set(KNOWN_AGENT_ID, plugins);
@@ -231,6 +251,28 @@ describe("GET /:id/config (mounted as GET /agents/:id/config from root)", () => 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.repos).toEqual([]);
+  });
+
+  test("200 returns authorAllowlist exactly as stored on the agent", async () => {
+    const app = buildApp({ authorAllowlist: ["octocat", "hubot"] });
+    const res = await app.request(`/${KNOWN_AGENT_ID}/config`, {
+      headers: { Authorization: `Bearer ${VALID_ADMIN_KEY}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authorAllowlist).toEqual(["octocat", "hubot"]);
+  });
+
+  test("200 returns authorAllowlist as an empty array when the agent has none", async () => {
+    const app = buildApp({ authorAllowlist: [] });
+    const res = await app.request(`/${KNOWN_AGENT_ID}/config`, {
+      headers: { Authorization: `Bearer ${VALID_ADMIN_KEY}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authorAllowlist).toEqual([]);
   });
 
   test("parses the canonical plugin@marketplace spec, defaulting bare names to shipwright", async () => {
@@ -403,7 +445,7 @@ function buildCombinedApp() {
     },
     agentService: {
       async getById() {
-        return { id: COMBINED_AGENT_ID, repos: [] };
+        return { id: COMBINED_AGENT_ID, repos: [], authorAllowlist: [] };
       },
     },
     prisma: {

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -43,6 +43,7 @@ export interface AgentConfigResponse {
   allowedTools: string[];
   plugins: AgentPlugin[];
   repos: string[];
+  authorAllowlist: string[];
 }
 
 interface AgentEnvServiceLike {
@@ -67,7 +68,9 @@ interface AgentCronJobServiceLike {
 }
 
 interface AgentServiceLike {
-  getById(agentId: string): Promise<{ id: string; repos: string[] } | null>;
+  getById(
+    agentId: string,
+  ): Promise<{ id: string; repos: string[]; authorAllowlist: string[] } | null>;
 }
 
 interface PrismaLike {
@@ -200,6 +203,7 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
           : { plugin: p.name.slice(0, at), marketplace: p.name.slice(at + 1) };
       }),
       repos: agent.repos,
+      authorAllowlist: agent.authorAllowlist,
     };
 
     return c.json(response, 200);

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -7,6 +7,7 @@
  */
 
 import { z } from "@hono/zod-openapi";
+import { isGithubLogin } from "@shipwright/lib/github-login";
 import { isOrgRepo } from "@shipwright/lib/org-repo";
 
 // ─── Common ───────────────────────────────────────────────────────────────────
@@ -90,6 +91,18 @@ export const CreateAgentBodySchema = z
       )
       .optional()
       .openapi({ example: ["my-org/my-repo"] }),
+    /**
+     * Initial authorAllowlist[] — GitHub logins permitted to trigger this
+     * agent. Mirrors PatchAgentBodySchema's authorAllowlist shape.
+     */
+    authorAllowlist: z
+      .array(
+        z.string().refine(isGithubLogin, {
+          message: "each entry must be a valid GitHub login",
+        }),
+      )
+      .optional()
+      .openapi({ example: ["octocat"] }),
   })
   .openapi("CreateAgentBody");
 
@@ -104,6 +117,14 @@ export const PatchAgentBodySchema = z
       )
       .optional()
       .openapi({ example: ["my-org/my-repo"] }),
+    authorAllowlist: z
+      .array(
+        z.string().refine(isGithubLogin, {
+          message: "each entry must be a valid GitHub login",
+        }),
+      )
+      .optional()
+      .openapi({ example: ["octocat"] }),
   })
   .openapi("PatchAgentBody");
 
@@ -837,6 +858,7 @@ export const AgentConfigResponseSchema = z
     allowedTools: z.array(z.string()).openapi({ example: ["Read", "Write"] }),
     plugins: z.array(AgentConfigPluginSchema),
     repos: z.array(z.string()).openapi({ example: ["org/repo1", "org/repo2"] }),
+    authorAllowlist: z.array(z.string()).openapi({ example: ["octocat"] }),
   })
   .openapi("AgentConfigResponse");
 

--- a/agent/src/cutover-validate.integration.test.ts
+++ b/agent/src/cutover-validate.integration.test.ts
@@ -36,7 +36,7 @@ function makeCron(id: string): AgentCronJob {
 }
 
 function makeConfig(env: Record<string, string>): AgentConfigResponse {
-  return { env, allowedTools: [], plugins: [], repos: [] };
+  return { env, allowedTools: [], plugins: [], repos: [], authorAllowlist: [] };
 }
 
 // ─── Recorded double ──────────────────────────────────────────────────────────

--- a/agent/src/entrypoint.integration.test.ts
+++ b/agent/src/entrypoint.integration.test.ts
@@ -25,6 +25,7 @@ const SAMPLE_CONFIG: AgentConfigResponse = {
   allowedTools: ["Read", "Write", "Bash"],
   plugins: [{ marketplace: "my-market", plugin: "my-plugin" }],
   repos: [],
+  authorAllowlist: [],
 };
 
 // ─── Temp dir helpers ──────────────────────────────────────────────────────────
@@ -249,6 +250,7 @@ describe("runEntrypoint — config with empty env", () => {
       allowedTools: [],
       plugins: [],
       repos: [],
+      authorAllowlist: [],
     };
     const configClient = new RecordedShipwrightConfigClient(emptyConfig);
     const { deps, exitCodes, spawnCalls } = makeDeps(configClient);

--- a/agent/src/shipwright-runtime-client.integration.test.ts
+++ b/agent/src/shipwright-runtime-client.integration.test.ts
@@ -23,6 +23,7 @@ const SAMPLE_CONFIG: AgentConfigResponse = {
   allowedTools: ["Read", "Bash"],
   plugins: [{ marketplace: "shipwright", plugin: "my-plugin" }],
   repos: [],
+  authorAllowlist: [],
 };
 
 const SAMPLE_CRONS: AgentCronJob[] = [

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.72.0",
+      "version": "1.75.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -99,7 +99,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.72.0",
+      "version": "1.75.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -117,7 +117,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.72.0",
+      "version": "1.75.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -48,8 +48,9 @@ Body:
 | `selfHosted` | no | `true` if the agent runs outside Kubernetes (default `false`) |
 | `type` | no | Agent Type name (default `"coding"`). Unknown type → `400`, zero rows created |
 | `repos` | no | Array of `org/repo` strings, merged with the resolved type's manifest `repos[]` |
+| `authorAllowlist` | no | Array of GitHub login strings — authors permitted to file pull requests scoped to this agent (default empty array = all authenticated users) |
 
-Returns `201` with `{ id, name, slackId, selfHosted, repos, typeName, createdAt, updatedAt, missingRequiredEnv }`. Returns `400` for an unknown `type`.
+Returns `201` with `{ id, name, slackId, selfHosted, repos, authorAllowlist, typeName, createdAt, updatedAt, missingRequiredEnv }`. Returns `400` for an unknown `type`.
 
 ### List agents
 
@@ -65,7 +66,9 @@ Admin-only. Returns all agents with `id`, `name`, `selfHosted`, and `typeName` f
 GET /agents/:id
 ```
 
-Admin-only. Returns the full agent record including `selfHosted`, `repos`, `typeName`, and `missingRequiredEnv`.
+Admin-only. Returns the full agent record including `selfHosted`, `repos`, `authorAllowlist`, `typeName`, and `missingRequiredEnv`.
+
+`authorAllowlist` is an array of GitHub login strings — authors whose pull requests are permitted to target this agent. When empty or unset, all authenticated users are allowed.
 
 `missingRequiredEnv` is an array of required env var keys declared by the agent's type manifest that have no corresponding `AgentEnv` row yet — key names only, never values. This is purely informational (ATS-4.2).
 
@@ -75,7 +78,7 @@ Admin-only. Returns the full agent record including `selfHosted`, `repos`, `type
 PATCH /agents/:id
 ```
 
-Admin-only. Updatable fields: `selfHosted` (boolean), `repos` (array of `org/repo` strings — each entry is validated for format). `typeName` is not updatable via this route. Returns the updated agent.
+Admin-only. Updatable fields: `selfHosted` (boolean), `repos` (array of `org/repo` strings — each entry is validated for format), `authorAllowlist` (array of GitHub login strings — usernames of authors permitted to file pull requests scoped to this agent). `typeName` is not updatable via this route. Returns the updated agent.
 
 ### Delete agent
 
@@ -526,5 +529,6 @@ Used by the agent harness on startup and during the config sync loop. Returns th
 - `allowedTools` — array of tool patterns
 - `plugins` — installed plugins with derived marketplace URLs
 - `repos` — array of `org/repo` strings (scoped repositories this agent may access)
+- `authorAllowlist` — array of GitHub login strings (authors permitted to file pull requests scoped to this agent; empty array = all authenticated users allowed)
 
 Returns `404` if the agent doesn't exist.

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -1584,6 +1584,8 @@ export interface components {
             slackId?: string | null;
             /** @example false */
             selfHosted: boolean;
+            /** @example coding */
+            typeName: string;
             /**
              * Format: date-time
              * @example 2026-01-01T00:00:00.000Z
@@ -1606,6 +1608,20 @@ export interface components {
             slackId?: string;
             /** @example false */
             selfHosted?: boolean;
+            /** @example coding */
+            type?: string;
+            /**
+             * @example [
+             *       "my-org/my-repo"
+             *     ]
+             */
+            repos?: string[];
+            /**
+             * @example [
+             *       "octocat"
+             *     ]
+             */
+            authorAllowlist?: string[];
         };
         ReconcileAgentsResult: {
             recreated: string[];
@@ -1632,10 +1648,13 @@ export interface components {
             slackId?: string | null;
             selfHosted: boolean;
             repos: string[];
+            authorAllowlist: string[];
+            typeName: string;
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
+            missingRequiredEnv: string[];
         };
         PatchAgentBody: {
             /** @example false */
@@ -1646,6 +1665,12 @@ export interface components {
              *     ]
              */
             repos?: string[];
+            /**
+             * @example [
+             *       "octocat"
+             *     ]
+             */
+            authorAllowlist?: string[];
         };
         FailedStep: {
             /** @example k8s */
@@ -1684,6 +1709,8 @@ export interface components {
             name: string;
             /** @example false */
             selfHosted: boolean;
+            /** @example coding */
+            typeName: string;
         };
         Ok: {
             /** @enum {boolean} */
@@ -1882,10 +1909,10 @@ export interface components {
             /** @example null */
             error: string | null;
             /**
-             * @description Pipeline phase this run served (dev-task/review/patch/deploy). Null for legacy five-job crons.
-             * @example dev-task
+             * @description Child AgentCronJob id (FK) of the pipeline phase this run served (dev-task/review/patch/deploy). Null for legacy five-job crons or ticks with no phase attribution.
+             * @example clx0987654321
              */
-            phase: string | null;
+            phaseId: string | null;
             /**
              * @description Work item type this run was dispatched against ("task" | "pr"). Null when the tick had no dispatch (skipped tick, empty queue).
              * @example task
@@ -1934,10 +1961,10 @@ export interface components {
             /** @example null */
             error?: string | null;
             /**
-             * @description Pipeline phase this run served (dev-task/review/patch/deploy)
-             * @example dev-task
+             * @description Child AgentCronJob id (FK) of the pipeline phase this run served (dev-task/review/patch/deploy)
+             * @example clx0987654321
              */
-            phase?: string | null;
+            phaseId?: string | null;
             /**
              * @description Work item type this run was dispatched against ("task" | "pr")
              * @example task
@@ -2257,6 +2284,12 @@ export interface components {
              *     ]
              */
             repos: string[];
+            /**
+             * @example [
+             *       "octocat"
+             *     ]
+             */
+            authorAllowlist: string[];
         };
         RuntimeError: {
             /** @example Not found */

--- a/lib/github-login.ts
+++ b/lib/github-login.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns true when `s` is a valid GitHub login: alphanumeric characters and
+ * single hyphens only, no leading/trailing hyphen, no consecutive hyphens,
+ * and a max length of 39 characters (GitHub's own username constraints).
+ */
+export function isGithubLogin(s: string): boolean {
+  return (
+    s.length > 0 && s.length <= 39 && /^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/.test(s)
+  );
+}

--- a/lib/github-login.unit.test.ts
+++ b/lib/github-login.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { isGithubLogin } from "./github-login.ts";
+
+describe("isGithubLogin — valid strings", () => {
+  test("returns true for a simple login", () => {
+    expect(isGithubLogin("octocat")).toBe(true);
+  });
+
+  test("returns true for a login with hyphens and numbers", () => {
+    expect(isGithubLogin("my-org-1")).toBe(true);
+  });
+
+  test("returns true for a single character login", () => {
+    expect(isGithubLogin("a")).toBe(true);
+  });
+
+  test("returns true for a login at the max length of 39 characters", () => {
+    expect(isGithubLogin("a".repeat(39))).toBe(true);
+  });
+});
+
+describe("isGithubLogin — invalid strings", () => {
+  test("returns false for an empty string", () => {
+    expect(isGithubLogin("")).toBe(false);
+  });
+
+  test("returns false for a login over 39 characters", () => {
+    expect(isGithubLogin("a".repeat(40))).toBe(false);
+  });
+
+  test("returns false for a login with a leading hyphen", () => {
+    expect(isGithubLogin("-octocat")).toBe(false);
+  });
+
+  test("returns false for a login with a trailing hyphen", () => {
+    expect(isGithubLogin("octocat-")).toBe(false);
+  });
+
+  test("returns false for a login with consecutive hyphens", () => {
+    expect(isGithubLogin("octo--cat")).toBe(false);
+  });
+
+  test("returns false for a login containing an underscore", () => {
+    expect(isGithubLogin("octo_cat")).toBe(false);
+  });
+
+  test("returns false for a login containing a space", () => {
+    expect(isGithubLogin("octo cat")).toBe(false);
+  });
+
+  test("returns false for a login containing a slash", () => {
+    expect(isGithubLogin("octo/cat")).toBe(false);
+  });
+});

--- a/lib/package.json
+++ b/lib/package.json
@@ -7,6 +7,7 @@
     "./admin-types": "./admin-types.ts",
     "./agent-default-tools": "./agent-default-tools.ts",
     "./claim-ttl": "./claim-ttl.ts",
+    "./github-login": "./github-login.ts",
     "./org-repo": "./org-repo.ts",
     "./pricing": "./pricing.ts",
     "./request-context": "./request-context.ts",


### PR DESCRIPTION
## Summary
- Exposes `authorAllowlist` on the admin API surface: optional on `CreateAgentBodySchema`/`PatchAgentBodySchema`, required on `AgentConfigResponseSchema`, mirroring `repos` at every call site
- Wires create/patch handlers and `serializeAgent` in `admin/src/agents-api.ts`, and the `GET /:id/config` runtime response in `admin/src/api.ts`, to pass `authorAllowlist` through
- Adds `lib/github-login.ts` (`isGithubLogin()`) as the Zod `.refine()` validator for allowlist entries, mirroring `lib/org-repo.ts`'s `isOrgRepo()`
- Regenerates `admin/openapi.json` / `lib/admin-types.ts` to reflect the new field
- Refreshes `docs/agent-api.md` for the new field

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `lib/github-login.ts` + unit tests mirroring `org-repo.unit.test.ts` | MET |
| 2 | `authorAllowlist` added to Create/Patch/ConfigResponse schemas | MET |
| 3 | `agents-api.ts` create/patch handlers + `serializeAgent`/`GetAgentResultSchema` pass it through | MET |
| 4 | `api.ts` `AgentServiceLike.getById` + `GET /:id/config` include it | MET |
| 5 | `lib/admin-types.ts` regenerated to include it | MET |
| 6 | Integration/smoke round-trip tests added, no existing test removed | MET |
| 7 | Depends on AAL-1.1 (merged to main, service layer already supports authorAllowlist) | MET |

## Test Plan
- `lib/github-login.unit.test.ts` — valid/invalid GitHub login cases
- `admin/src/agents-api.smoke.test.ts` — create/patch validation (400 on invalid login) and round-trip (201/200, clear via `[]`)
- `admin/src/agents-api.integration.test.ts` — PATCH → GET round-trip
- `admin/src/api.smoke.test.ts` — `GET /:id/config` reflects `authorAllowlist`
- [x] `bunx biome lint .` clean
- [x] `bun run --filter='*' --sequential typecheck` clean across all workspaces
- [x] Full `bun test`: 5085 pass, 2 pre-existing failures confirmed unrelated (reproduce identically on `main` with zero local changes: `scripts/quickstart.smoke.test.ts` sandbox/mise environment issue, `agent/src/claude.unit.test.ts` "extraAllowedTools" test)

Generated with [Claude Code](https://claude.com/claude-code)
