### PR TITLE
fix: qualify state/reviews/ paths with WORKSPACE_ROOT in review.md

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -142,3 +142,92 @@ describe("review.md — task model tier passed to code-reviewer subagent (MTR-1.
     expect(section).toContain("model: TASK_MODEL ?? 'sonnet'");
   });
 });
+
+describe("review.md — state/reviews/ paths survive worktree checkout (RSP-1.1)", () => {
+  it("Step 1 captures WORKSPACE_ROOT before the Step 4 worktree checkout", () => {
+    const step1Idx = content.indexOf("## Step 1: Load Policy");
+    const step2Idx = content.indexOf("## Step 2: Clean Up Worktrees");
+    expect(step1Idx).toBeGreaterThan(-1);
+    expect(step2Idx).toBeGreaterThan(-1);
+    const section = content.slice(step1Idx, step2Idx);
+
+    expect(section).toContain("WORKSPACE_ROOT=$(pwd)");
+    expect(section).toContain("state/reviews/");
+  });
+
+  it("Step 4's worktree-transition line notes state/reviews/ as an exception", () => {
+    const transitionIdx = content.indexOf(
+      "All subsequent steps run from `worktrees/{repo}-{branch-slug}/`",
+    );
+    expect(transitionIdx).toBeGreaterThan(-1);
+    const section = content.slice(transitionIdx, transitionIdx + 400);
+
+    expect(section).toContain("state/reviews/");
+    expect(section).toContain("WORKSPACE_ROOT");
+  });
+
+  it("Step 9's write path is qualified with $WORKSPACE_ROOT", () => {
+    const step9Idx = content.indexOf("## Step 9: Write Review File");
+    const step10Idx = content.indexOf("## Step 10: Build Review JSON");
+    expect(step9Idx).toBeGreaterThan(-1);
+    expect(step10Idx).toBeGreaterThan(-1);
+    const section = content.slice(step9Idx, step10Idx);
+
+    expect(section).toContain("Write `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`");
+  });
+
+  it("Step 9's re-review detection tests for the file at $WORKSPACE_ROOT/state/reviews/", () => {
+    const step9Idx = content.indexOf("## Step 9: Write Review File");
+    const step10Idx = content.indexOf("## Step 10: Build Review JSON");
+    const section = content.slice(step9Idx, step10Idx);
+
+    expect(section).toContain(
+      "detected by the local file `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`",
+    );
+    expect(section).toContain("test -f $WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md");
+  });
+
+  it("Step 10's write path is qualified with $WORKSPACE_ROOT", () => {
+    const step10Idx = content.indexOf("## Step 10: Build Review JSON");
+    const step11Idx = content.indexOf("## Step 11: Post or Stage");
+    expect(step10Idx).toBeGreaterThan(-1);
+    expect(step11Idx).toBeGreaterThan(-1);
+    const section = content.slice(step10Idx, step11Idx);
+
+    expect(section).toContain("Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`");
+  });
+
+  it("Step 10's diff-line-mapping git diff call is unchanged -- cwd stays inside the worktree", () => {
+    const step10Idx = content.indexOf("## Step 10: Build Review JSON");
+    const step11Idx = content.indexOf("## Step 11: Post or Stage");
+    const section = content.slice(step10Idx, step11Idx);
+
+    expect(section).toContain("**Diff-line mapping**");
+    expect(section).toContain("git diff {base}...HEAD -- {file}");
+    // This must NOT be qualified with WORKSPACE_ROOT -- it correctly runs from
+    // inside the worktree, unlike the file-write paths above.
+    const diffLineIdx = section.indexOf("git diff {base}...HEAD -- {file}");
+    const surrounding = section.slice(Math.max(0, diffLineIdx - 100), diffLineIdx);
+    expect(surrounding).not.toContain("WORKSPACE_ROOT");
+  });
+
+  it("Step 11's --input flag references $WORKSPACE_ROOT/state/reviews/", () => {
+    const step11Idx = content.indexOf("## Step 11: Post or Stage");
+    const step11bIdx = content.indexOf("## Step 11b: Mark PullRequest Record Posted");
+    expect(step11Idx).toBeGreaterThan(-1);
+    expect(step11bIdx).toBeGreaterThan(-1);
+    const section = content.slice(step11Idx, step11bIdx);
+
+    expect(section).toContain("--input $WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json");
+  });
+
+  it("Step 14's cross-reference to the Step 9 re-review file is qualified with $WORKSPACE_ROOT", () => {
+    const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");
+    expect(step14Idx).toBeGreaterThan(-1);
+    const section = content.slice(step14Idx);
+
+    expect(section).toContain(
+      "the existing\n  `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`",
+    );
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -46,6 +46,13 @@ when a human runs `/shipwright:review` with no argument.
 
 ## Step 1: Load Policy
 
+Capture the workspace root before Step 4's worktree checkout moves cwd:
+```bash
+WORKSPACE_ROOT=$(pwd)
+```
+Steps 9-11 and Step 14 use `$WORKSPACE_ROOT` to reference `state/reviews/` — that directory
+only ever exists at the workspace root, never inside a worktree.
+
 Read `state/agent-policy.md`. If the file doesn't exist, use these conservative defaults:
 
 | Setting | Default |
@@ -159,7 +166,9 @@ PR_CLAIM=$(curl -s -o /tmp/pr_claim.json -w '%{http_code}' -X POST \
   (`git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force 2>/dev/null`),
   respond `[silent]`, and stop — there is no other PR to fall back to in explicit-target mode.
 
-All subsequent steps run from `worktrees/{repo}-{branch-slug}/`.
+All subsequent steps run from `worktrees/{repo}-{branch-slug}/` — except `state/reviews/`
+file operations (Steps 9-11, Step 14's cross-reference), which use `$WORKSPACE_ROOT`
+captured in Step 1, since `state/reviews/` only ever exists at the workspace root.
 
 ### Resolve the linked task's model tier
 
@@ -338,7 +347,7 @@ more, trim to the highest-confidence few.
 
 ## Step 9: Write Review File
 
-Write `state/reviews/PR_REVIEW_{pr}.md`:
+Write `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`:
 
 ```markdown
 # PR Review: #{pr} - {title}
@@ -403,8 +412,8 @@ Write `state/reviews/PR_REVIEW_{pr}.md`:
 
 ### Re-Review (Update)
 
-If this agent reviewed this PR before — detected by the local file `state/reviews/PR_REVIEW_{pr}.md`
-already existing (`test -f state/reviews/PR_REVIEW_{pr}.md`):
+If this agent reviewed this PR before — detected by the local file `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`
+already existing (`test -f $WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`):
 
 Append an update section instead of creating a new file. (Do not use `reviewCycles` from the
 task store — another agent may have incremented it without this agent ever reviewing, so the
@@ -460,7 +469,7 @@ treats it as an unaddressed finding forever. Always lead the body with the liter
 label, on both the initial-review and re-review paths (Steps 10/11 run identically for both;
 see Step 14's re-review flow).
 
-Write `state/reviews/pr_review_{pr}.json`:
+Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`:
 
 ```json
 {
@@ -504,7 +513,7 @@ should be held; the inline comments convey the specific feedback to the author.
 1. Submit via GitHub API, capturing both the exit status and the response body:
    ```bash
    POST_RESPONSE=$(gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews \
-     --input state/reviews/pr_review_{pr}.json)
+     --input $WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json)
    POST_EXIT=$?
    ```
 2. Capture `html_url` from `$POST_RESPONSE` (e.g. `echo "$POST_RESPONSE" | jq -r '.html_url'`).
@@ -714,7 +723,7 @@ gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
   ```
   Continue from **Step 4** (checkout into worktree) with this PR as the target. The
   Step 9 "Re-Review (Update)" mechanics append an update section to the existing
-  `state/reviews/PR_REVIEW_{pr}.md`, and Step 11 re-stages the record — the same
+  `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`, and Step 11 re-stages the record — the same
   policy-gated staging path any other review goes through. This command never posts
   it; running `/shipwright:review-staged` afterward is how the owner acts on it.
 


### PR DESCRIPTION
## Summary
- Captures `WORKSPACE_ROOT=$(pwd)` in Step 1 of `review.md`, before Step 4's worktree checkout moves cwd
- Qualifies every `state/reviews/` reference in Steps 9-11 and the Step 14 cross-reference with `$WORKSPACE_ROOT/`, since `state/reviews/` only ever exists at the workspace root, never inside a worktree
- Fixes the re-review detection bug where `test -f state/reviews/PR_REVIEW_{pr}.md` always missed from inside the worktree, causing genuine re-reviews to silently overwrite prior review history instead of appending an update section
- Leaves Step 10's diff-line-mapping `git diff` calls untouched — those correctly need cwd inside the worktree

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | WORKSPACE_ROOT=$(pwd) captured in Step 1 before Step 4's worktree checkout, with a note it's used for state/reviews/ paths | MET | review.md Step 1 adds `WORKSPACE_ROOT=$(pwd)` plus explanatory note |
| 2 | Step 9 write path, re-review test -f detection, Step 10 write path, Step 11 --input flag, and Step 14 cross-reference all use $WORKSPACE_ROOT/state/reviews/... | MET | All 5 locations qualified |
| 3 | Step 4's "run from the worktree" line gets a one-line caveat for state/reviews/ | MET | Caveat appended to existing sentence |
| 4 | Step 10's diff-line-mapping git diff calls left untouched | MET | `git diff {base}...HEAD -- {file}` unchanged |
| 5 | Content-layer test assertions added confirming $WORKSPACE_ROOT-qualified references | MET | 7 new tests added to review.content.test.ts |

## Test Plan
- `bun test plugins/shipwright/commands/review.content.test.ts` — 20 pass / 0 fail (7 new tests added for this fix)
- `bunx biome lint plugins/shipwright/commands/` — clean
- Full `task ci` — passes except 2 pre-existing, unrelated failures in `task-store/src/routes/prs.openapi.smoke.test.ts` (cross-test flakiness in the full suite run; confirmed 14/14 pass when run in isolation; file not touched by this change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
