### PR TITLE
fix: default authorAllowlist to [] when syncing config bundle into agentAuthorAllowlistRef

### DIFF
--- a/agent/src/agent-author-allowlist-ref.ts
+++ b/agent/src/agent-author-allowlist-ref.ts
@@ -30,6 +30,24 @@ export interface AgentAuthorAllowlistRef {
   set(authorLogins: string[]): void;
 }
 
+/**
+ * Defaults a config-bundle's authorAllowlist to [] when the value is
+ * null/undefined before it's handed to agentAuthorAllowlistRef.set().
+ *
+ * The AgentConfigResponse type declares authorAllowlist as a non-nullable
+ * string[], but the live config-bundle API has been observed returning
+ * `null` in production (see Sentry issue 7633628941) — a runtime/type
+ * mismatch that, left unguarded, gets baked into the process-wide
+ * agentAuthorAllowlistRef singleton and later throws in any consumer that
+ * calls .length on the (null) result of ref.get(). Defaulting here, at the
+ * config-sync write site, protects every downstream consumer of the ref.
+ */
+export function resolveAuthorAllowlist(
+  authorAllowlist: string[] | null | undefined,
+): string[] {
+  return authorAllowlist ?? [];
+}
+
 /** Creates a new, independent agent author-allowlist ref defaulting to an empty list. */
 export function createAgentAuthorAllowlistRef(): AgentAuthorAllowlistRef {
   let authorLogins: string[] = [];

--- a/agent/src/agent-author-allowlist-ref.unit.test.ts
+++ b/agent/src/agent-author-allowlist-ref.unit.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "bun:test";
 import {
   agentAuthorAllowlistRef,
   createAgentAuthorAllowlistRef,
+  resolveAuthorAllowlist,
 } from "./agent-author-allowlist-ref.ts";
 
 describe("createAgentAuthorAllowlistRef", () => {
@@ -83,5 +84,47 @@ describe("agentAuthorAllowlistRef (process-wide singleton)", () => {
     agentAuthorAllowlistRef.set(["alice"]);
     expect(agentAuthorAllowlistRef.get()).toEqual(["alice"]);
     expect(independent.get()).toEqual(["should-not-leak"]);
+  });
+});
+
+describe("resolveAuthorAllowlist", () => {
+  // Regression coverage for AAL-2.3: the live config-bundle API has been
+  // observed returning authorAllowlist: null in production (Sentry issue
+  // 7633628941), even though AgentConfigResponse types it as a non-nullable
+  // string[]. syncConfig() must default this to [] before handing it to
+  // agentAuthorAllowlistRef.set(), so downstream .length checks never throw.
+  it("defaults a null authorAllowlist (as returned by the live config-bundle API) to []", () => {
+    const bundle = { authorAllowlist: null } as unknown as {
+      authorAllowlist: string[];
+    };
+
+    expect(resolveAuthorAllowlist(bundle.authorAllowlist)).toEqual([]);
+  });
+
+  it("defaults an undefined authorAllowlist to []", () => {
+    expect(resolveAuthorAllowlist(undefined)).toEqual([]);
+  });
+
+  it("syncing a null authorAllowlist into the ref does not throw and leaves get() as []", () => {
+    const ref = createAgentAuthorAllowlistRef();
+    const bundle = { authorAllowlist: null } as unknown as {
+      authorAllowlist: string[];
+    };
+
+    expect(() =>
+      ref.set(resolveAuthorAllowlist(bundle.authorAllowlist)),
+    ).not.toThrow();
+    expect(ref.get()).toEqual([]);
+    expect(ref.get().length).toBe(0);
+  });
+
+  it("passes through a real authorAllowlist array unchanged (no behavior change for real values)", () => {
+    const real = ["alice", "bob"];
+    expect(resolveAuthorAllowlist(real)).toBe(real);
+    expect(resolveAuthorAllowlist(real)).toEqual(["alice", "bob"]);
+  });
+
+  it("passes through an already-empty authorAllowlist array unchanged", () => {
+    expect(resolveAuthorAllowlist([])).toEqual([]);
   });
 });

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -17,7 +17,10 @@ import * as Sentry from "@sentry/bun";
 import { initSentry } from "@shipwright/lib/sentry";
 import { WebClient } from "@slack/web-api";
 import nodeCron from "node-cron";
-import { agentAuthorAllowlistRef } from "./agent-author-allowlist-ref.ts";
+import {
+  agentAuthorAllowlistRef,
+  resolveAuthorAllowlist,
+} from "./agent-author-allowlist-ref.ts";
 import { agentReposRef } from "./agent-repos-ref.ts";
 import { createChatPoller } from "./chat-poller.ts";
 import {
@@ -253,7 +256,7 @@ if (runtimeClient && agentId) {
       agentReposRef.set(bundle.repos);
 
       // Sync the agent's author-allowlist live ref
-      agentAuthorAllowlistRef.set(bundle.authorAllowlist);
+      agentAuthorAllowlistRef.set(resolveAuthorAllowlist(bundle.authorAllowlist));
     } catch (err) {
       if (
         (err as { statusCode?: number }).statusCode === 404 &&


### PR DESCRIPTION
## Summary
- `agent/src/index.ts:256` set `agentAuthorAllowlistRef` directly from `bundle.authorAllowlist` with no fallback, unlike `bundle.allowedTools ?? []` right above it. The live config-bundle API has been observed returning `authorAllowlist: null` in production, which throws downstream in `check-review.ts`'s `agentAuthorAllowlistRef.get().length === 0` check — killing `shipwright-loop` before it reaches candidate work.
- Confirmed via Sentry issue `7633628941` (`TypeError: undefined is not an object (evaluating 'agentAuthorAllowlistRef.get().length')`), unresolved, 3716 events across 3 distinct `agent_id`s, first seen 2026-07-26T05:00 UTC.
- Fix: extracted `resolveAuthorAllowlist()` into `agent/src/agent-author-allowlist-ref.ts`, defaulting `null`/`undefined` to `[]` at the config-sync write site (not the read site), so every consumer of the ref is protected.

## Acceptance Criteria
| Criterion | Status | Evidence |
|-----------|--------|----------|
| `syncConfig()` defaults `bundle.authorAllowlist` to `[]` before `agentAuthorAllowlistRef.set()` | MET | `index.ts` now calls `resolveAuthorAllowlist(bundle.authorAllowlist)` |
| Regression test covering `null`/`undefined` syncing without throwing | MET | 5 new cases in `agent-author-allowlist-ref.unit.test.ts` |
| No behavior change for bundles with a real `authorAllowlist` array | MET | Identity-preserving passthrough test (`toBe`) |

## Test Plan
- [x] New unit tests (`agent-author-allowlist-ref.unit.test.ts`): null → `[]`, undefined → `[]`, no-throw + `.length === 0` on sync, real array passthrough (identity-preserved), empty array passthrough
- [x] `bunx biome lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] 100% line/function coverage on the changed file
- [x] Targeted suite green (13/13); pre-existing full-suite flake in `cron-handler.smoke.test.ts` is unrelated (reproduces on clean `main`, 72/72 in isolation)

Generated with [Claude Code](https://claude.com/claude-code)
