### PR TITLE
fix: trim SoftwareApplication description to match visible page text

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -58,7 +58,7 @@ const structuredData = {
       operatingSystem: "Cross-platform",
       url: `${siteUrl}/`,
       description:
-        "The open-source autonomous delivery agent for Claude Code — plan, build, review, and ship, on your own infrastructure.",
+        "The open-source autonomous delivery agent for Claude Code.",
       license: "https://opensource.org/licenses/MIT",
       isAccessibleForFree: true,
       offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },


### PR DESCRIPTION
## Summary

Trims the `SoftwareApplication` JSON-LD description in `site/src/layouts/BaseLayout.astro` from:

> "The open-source autonomous delivery agent for Claude Code — plan, build, review, and ship, on your own infrastructure."

to:

> "The open-source autonomous delivery agent for Claude Code."

The shorter form is already present in the hero, the `WebSite` schema, and the default `<meta name="description">`. The extended clause ("— plan, build, review, and ship…") was not visible on the page, causing the technical SEO audit's visible-content markup check to fail.

## Test plan
- [ ] `cd site && npm run build` passes
- [ ] `cd site && npm test` (Playwright) passes — the JSON-LD test checks for type presence, not description content
- [ ] Re-run technical SEO audit on staging — Visible-Content Markup should now PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)