### PR TITLE
docs: document the authorAllowlist agent field

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,15 @@ Configuration for the Shipwright Claude Code plugin (`plugins/shipwright/`). The
 
 Configuration for the Shipwright agent runtime (`agent/` and `admin/`). All options are env vars — there is no file-based fallback for agent config. Secrets must be supplied as env vars and are never stored in config files.
 
+### Per-agent fields
+
+Unlike the env vars below, these fields live on the Agent database record, not the environment — they're set via the admin API (`POST`/`PATCH /agents/:id`) or the admin UI, not env vars. See [`docs/agent-api.md`](./agent-api.md#agents) for the full request/response contract.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `repos` | `string[]` | `[]` | `org/repo` strings this agent is scoped to. Seeded from the Agent Type manifest at creation, editable via `PATCH /agents/:id` or the admin UI. |
+| `authorAllowlist` | `string[]` | `[]` | GitHub login strings permitted to trigger this agent's review/dev-task work. **Empty means unfiltered** — every authenticated author is allowed. Settable at creation (admin UI create-form field) and editable afterward (admin UI agent-detail page's add/delete rows, or `PATCH /agents/:id`). For local dev, `hitl.ts`'s `SHIPWRIGHT_HITL_AUTHORS` env var is the equivalent — it stays in sync with the persisted record via `PATCH` (see the `SHIPWRIGHT_HITL_AUTHORS` row under [Dev-only](#dev-only)). |
+
 ### Claude / Anthropic
 
 | Name | Type | Default | Description |


### PR DESCRIPTION
## Summary
- Adds a "Per-agent fields" table to `docs/configuration.md` under `## Agent Config`, documenting `repos` and `authorAllowlist` as Agent-record fields (distinct from the env-var tables around it), with the empty-means-unfiltered semantics for `authorAllowlist` called out explicitly.
- Covers the admin UI surfaces (create-form field, detail-page add/delete rows) and `hitl.ts`'s `SHIPWRIGHT_HITL_AUTHORS` as the local-dev equivalent that stays in sync with the record via `PATCH`.
- `docs/agent-api.md` already documents `authorAllowlist` on `POST`/`PATCH /agents` request bodies and the `GET /agents/:id/config` response (landed in #2213) — verified, no changes needed there.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | docs/configuration.md: authorAllowlist documented alongside repos, empty-means-unfiltered called out | MET |
| 2 | docs/agent-api.md: authorAllowlist on POST/PATCH /agents bodies and GET /agents/:id/config response | MET (pre-existing, verified) |
| 3 | No test change needed | MET — docs-only diff |
| 4 | Reflects final wired state per AAL-1.3/2.2/3.1 dependencies | MET — all three merged/deployed |

## Test Plan
- Documentation-only change; no test change needed.
- [x] `bun scripts/check-config-docs.ts` passes
- [x] `bun run scripts/sync-version.ts --check` passes
- [x] `bun plugins/shipwright/scripts/check-banned-strings.ts` passes

Generated with [Claude Code](https://claude.com/claude-code)
