### PR TITLE
test: add fail-open catch-path coverage for isBundleComplete (T-077)

### DIFF
--- a/agent/src/check-review.unit.test.ts
+++ b/agent/src/check-review.unit.test.ts
@@ -662,6 +662,26 @@ describe("getReviewCandidates", () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("example-org/example-repo#42");
   });
+
+  test("includes a PR when isBundleComplete rejects for its branch (fail-open)", async () => {
+    const pr = makePr({ headRefName: "feat/bundle-check-throws" });
+    const result = await getReviewCandidates(
+      makeDeps(
+        [pr],
+        async () => null,
+        "bodhi-agent",
+        false,
+        async () => null,
+        undefined,
+        undefined,
+        async () => {
+          throw new Error("bundle status check failed");
+        },
+      ),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("example-org/example-repo#42");
+  });
 });
 
 describe("buildProductionDeps isAuthorAllowed default (AAL-2.2)", () => {


### PR DESCRIPTION
## Summary
- Adds a unit test proving the fail-open catch path in `getReviewCandidates`'s `isBundleComplete` check (`agent/src/check-review.ts:173-177`): when `isBundleComplete` rejects, the PR proceeds as a candidate rather than being excluded.
- Modeled directly on the two adjacent bundle-gate test cases, using a distinct fixture branch name to avoid collisions.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New test(...) block added in agent/src/check-review.unit.test.ts, modeled on the two adjacent bundle-gate cases | MET |
| 2 | Injects `async () => { throw new Error(...) }` as isBundleComplete | MET |
| 3 | Asserts getReviewCandidates's result still includes the PR when isBundleComplete rejects | MET |
| 4 | Verification command `bun test agent/src/check-review.unit.test.ts` passes | MET |

## Test Plan
- `bun test agent/src/check-review.unit.test.ts` — 45 pass, 0 fail
- `bunx biome lint .` — clean
- `tsc --noEmit` — clean
- Verified fail-open assertion actually distinguishes behavior: temporarily flipped production `.catch(() => true)` to `.catch(() => false)`, confirmed the new test fails, then reverted (production code unchanged in final diff)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
