### PR TITLE
feat: escalate first-time BLOCKED status to HITL in patch.md (BHE-1.1)

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -874,3 +874,139 @@ describe("patch.md — [C.5] Add test coverage in fix subagent prompts (PTR-1.1)
     expect(eSection).toContain("TESTS_ADDED:");
   });
 });
+
+describe("patch.md — escalate first-time BLOCKED status to HITL before releasing the claim (BHE-1.1)", () => {
+  function getStep4cSection() {
+    const step4cIdx = content.indexOf("### Step 4c: Handle Subagent Status");
+    const step4c5Idx = content.indexOf("### Step 4c.5:");
+    expect(step4cIdx).toBeGreaterThan(-1);
+    expect(step4c5Idx).toBeGreaterThan(-1);
+    return content.slice(step4cIdx, step4c5Idx);
+  }
+
+  function getStep5cSection() {
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    const step5c5Idx = content.indexOf("### Step 5c.5:");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    expect(step5c5Idx).toBeGreaterThan(-1);
+    return content.slice(step5cIdx, step5c5Idx);
+  }
+
+  function getStep6dSection() {
+    const step6dIdx = content.indexOf("### Step 6d: Handle Subagent Status");
+    const step6d5Idx = content.indexOf("### Step 6d.5:");
+    expect(step6dIdx).toBeGreaterThan(-1);
+    expect(step6d5Idx).toBeGreaterThan(-1);
+    return content.slice(step6dIdx, step6d5Idx);
+  }
+
+  function getBlockedBranch(section: string) {
+    const blockedIdx = section.indexOf("**BLOCKED**");
+    expect(blockedIdx).toBeGreaterThan(-1);
+    return section.slice(blockedIdx);
+  }
+
+  function assertEscalationBeforeRelease(
+    section: string,
+    opts: { taskPatchSnippet: string; prPatchSnippet: string; commentTmpPath: string },
+  ) {
+    const blocked = getBlockedBranch(section);
+
+    // hitl PATCH to the linked task
+    expect(blocked).toContain(opts.taskPatchSnippet);
+    expect(blocked).toContain('"hitl": true');
+
+    // hitl + blockedReason PATCH fallback to the PR record
+    expect(blocked).toContain(opts.prPatchSnippet);
+    expect(blocked).toContain("blockedReason");
+
+    // PR comment via temp file
+    expect(blocked).toContain(`gh pr comment {pr} --repo {org}/{repo} --body-file ${opts.commentTmpPath}`);
+    expect(blocked).toContain(`rm ${opts.commentTmpPath}`);
+
+    // Ordering: hitl PATCH + comment must occur BEFORE the release call
+    const taskPatchIdx = blocked.indexOf(opts.taskPatchSnippet);
+    const prPatchIdx = blocked.indexOf(opts.prPatchSnippet);
+    const commentIdx = blocked.indexOf(`--body-file ${opts.commentTmpPath}`);
+    const releaseIdx = blocked.indexOf("/prs/$PR_RECORD_ID/release");
+
+    expect(releaseIdx).toBeGreaterThan(-1);
+    expect(taskPatchIdx).toBeGreaterThan(-1);
+    expect(taskPatchIdx).toBeLessThan(releaseIdx);
+    expect(prPatchIdx).toBeGreaterThan(-1);
+    expect(prPatchIdx).toBeLessThan(releaseIdx);
+    expect(commentIdx).toBeGreaterThan(-1);
+    expect(commentIdx).toBeLessThan(releaseIdx);
+  }
+
+  it("Step 4c BLOCKED branch escalates to HITL (task or PR record) and posts a PR comment before releasing the claim", () => {
+    const section = getStep4cSection();
+    assertEscalationBeforeRelease(section, {
+      taskPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
+      prPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
+      commentTmpPath: "/tmp/shipwright-patch-blocked-4c-{pr}.txt",
+    });
+    const blocked = getBlockedBranch(section);
+    expect(blocked.toLowerCase()).toContain("merge-conflict");
+  });
+
+  it("Step 5c BLOCKED branch (first-round, plain BLOCKED) escalates to HITL and posts a PR comment before releasing the claim", () => {
+    const section = getStep5cSection();
+    assertEscalationBeforeRelease(section, {
+      taskPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
+      prPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
+      commentTmpPath: "/tmp/shipwright-patch-blocked-5c-{pr}.txt",
+    });
+    const blocked = getBlockedBranch(section);
+    expect(blocked.toLowerCase()).toContain("review-finding fix");
+  });
+
+  it("Step 5c's BLOCKED escalation reuses PR_TASK_ID rather than re-fetching taskId", () => {
+    const section = getStep5cSection();
+    const blocked = getBlockedBranch(section);
+    expect(blocked).toContain("PR_TASK_ID");
+    expect(blocked).not.toMatch(
+      /GET[^\n]*\n[^\n]*"\$SHIPWRIGHT_TASK_STORE_URL\/prs\/\$PR_RECORD_ID"[^\n]*\n[^\n]*taskId/,
+    );
+  });
+
+  it("Step 6d BLOCKED branch escalates to HITL and posts a PR comment before releasing the claim", () => {
+    const section = getStep6dSection();
+    assertEscalationBeforeRelease(section, {
+      taskPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
+      prPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
+      commentTmpPath: "/tmp/shipwright-patch-blocked-6d-{pr}.txt",
+    });
+    const blocked = getBlockedBranch(section);
+    expect(blocked.toLowerCase()).toContain("ci-fix");
+  });
+
+  it("all three BLOCKED sites use distinct temp file names to avoid cross-worktree collisions", () => {
+    expect(content).toContain("/tmp/shipwright-patch-blocked-4c-{pr}.txt");
+    expect(content).toContain("/tmp/shipwright-patch-blocked-5c-{pr}.txt");
+    expect(content).toContain("/tmp/shipwright-patch-blocked-6d-{pr}.txt");
+  });
+
+  it("the existing Step 5a.7 second-round-disagreement escalation is unaffected by the new Step 5c BLOCKED escalation", () => {
+    const step5a7Idx = content.indexOf("### Step 5a.7: Second-Round Escalation Check (RPF-1.3)");
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    expect(step5a7Idx).toBeGreaterThan(-1);
+    expect(step5bIdx).toBeGreaterThan(step5a7Idx);
+    const step5a7Section = content.slice(step5a7Idx, step5bIdx);
+    expect(step5a7Section).toContain("/tmp/shipwright-patch-escalation-{pr}.txt");
+    expect(step5a7Section).toContain("second-round disagreement");
+  });
+
+  it("Step 6d's BLOCKED escalation is consistent with Step 6b.6's pre-dispatch hitl check (same PATCH targets)", () => {
+    const step6b6Idx = content.indexOf("### Step 6b.6: Escalation Check (CFE-1.1)");
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    const step6b6Section = content.slice(step6b6Idx, step6cIdx);
+    expect(step6b6Section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+    expect(step6b6Section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$');
+
+    const step6dSection = getStep6dSection();
+    const blocked = getBlockedBranch(step6dSection);
+    expect(blocked).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
+    expect(blocked).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+  });
+});

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -495,14 +495,53 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If the push already happened, log concerns and
   proceed to Step 4c.5 (upsert PR record). If the subagent did not push, note it in the
   final report and skip Step 4c.5.
-- **BLOCKED**: Release the pre-work claim from Step 4a.6 so a subsequent patch/review-patch
-  run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
-  never completed, so nothing is actually in flight:
-  ```bash
-  [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-  ```
+- **BLOCKED**: A generic BLOCKED release with no escalation flag makes this PR immediately
+  re-eligible for `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop`
+  tick — `claimedBy`/`hitl` are the only exclusions it checks, and releasing the claim below
+  clears the former without setting the latter. Escalate to HITL first, mirroring Step
+  5a.7's (RPF-1.3) escalation pattern, before releasing the claim:
+
+  1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If
+     non-empty, PATCH the linked task to `hitl: true` so it's flagged for a human decision:
+     ```bash
+     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       -H "Content-Type: application/json" \
+       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
+       -d '{"hitl": true}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+     ```
+     If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
+     instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
+     patch candidate every cycle, spinning forever:
+     ```bash
+     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       -H "Content-Type: application/json" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+       -d '{"hitl": true, "blockedReason": "merge-conflict resolution blocked — automated conflict resolution could not complete"}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /prs/$PR_RECORD_ID hitl flag failed — continuing"
+     ```
+     Still post the PR comment below either way.
+  2. Post a single PR comment stating a human decision is needed. Write the body to a temp
+     file first, same convention as Step 5a.7's escalation comment (heredocs break
+     permission glob matching):
+     ```bash
+     # Write to /tmp/shipwright-patch-blocked-4c-{pr}.txt:
+     #   The merge-conflict resolution subagent reported BLOCKED and could not complete —
+     #   flagging for a human decision instead of retrying indefinitely.
+     gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-blocked-4c-{pr}.txt
+     rm /tmp/shipwright-patch-blocked-4c-{pr}.txt
+     ```
+     The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
+     across all worktrees.
+  3. Release the pre-work claim from Step 4a.6 so a subsequent patch/review-patch run within
+     the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix never
+     completed, so nothing is actually in flight:
+     ```bash
+     [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+     ```
+
   Log the blocker. Skip Steps 4c.5 and 4d. Move to the next PR in List C.
   Include the blocker in the final report.
 
@@ -997,14 +1036,55 @@ Parse the subagent's STATUS:
   literal shell test — evaluate it the same way you just evaluated the "confirm ... rebuttal
   ... AND ... resolved the inline threads" check earlier in this bullet, then set the
   variable accordingly before Step 5c.5 reads it.
-- **BLOCKED**: Release the pre-work claim from Step 5a.6 so a subsequent patch/review-patch
-  run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
-  never completed, so nothing is actually in flight:
-  ```bash
-  [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-  ```
+- **BLOCKED**: This is a first-round BLOCKED report from the fix subagent itself — distinct
+  from Step 5a.7's (RPF-1.3) second-round-disagreement escalation, which fires *before*
+  dispatch when the same finding was already rebutted once. Here the subagent was dispatched
+  and came back unable to complete the fix. The same unbounded-retry risk applies: a generic
+  release with no escalation flag makes this PR immediately re-eligible for
+  `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop` tick. Escalate to
+  HITL first, mirroring Step 5a.7's escalation pattern, before releasing the claim:
+
+  1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If
+     non-empty, PATCH the linked task to `hitl: true` so it's flagged for a human decision:
+     ```bash
+     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       -H "Content-Type: application/json" \
+       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
+       -d '{"hitl": true}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+     ```
+     If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
+     instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
+     patch candidate every cycle, spinning forever:
+     ```bash
+     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       -H "Content-Type: application/json" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+       -d '{"hitl": true, "blockedReason": "review-finding fix blocked — automated fix subagent could not complete"}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /prs/$PR_RECORD_ID hitl flag failed — continuing"
+     ```
+     Still post the PR comment below either way.
+  2. Post a single PR comment stating a human decision is needed. Write the body to a temp
+     file first, same convention as Step 5a.7's escalation comment (heredocs break
+     permission glob matching):
+     ```bash
+     # Write to /tmp/shipwright-patch-blocked-5c-{pr}.txt:
+     #   The review-finding fix subagent reported BLOCKED and could not complete — flagging
+     #   for a human decision instead of retrying indefinitely.
+     gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-blocked-5c-{pr}.txt
+     rm /tmp/shipwright-patch-blocked-5c-{pr}.txt
+     ```
+     The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
+     across all worktrees.
+  3. Release the pre-work claim from Step 5a.6 so a subsequent patch/review-patch run within
+     the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix never
+     completed, so nothing is actually in flight:
+     ```bash
+     [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+     ```
+
   Log the blocker. Skip Steps 5c.5 and 5d. Move to the next qualifying PR.
   Include the blocker in the final report.
 
@@ -1312,14 +1392,55 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If the push already happened, log concerns and
   proceed to Step 6d.5 (upsert PR record). If the subagent did not push, note it in the
   final report and skip Step 6d.5.
-- **BLOCKED**: Release the pre-work claim from Step 6b.5 so a subsequent patch/review-patch
-  run within the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix
-  never completed, so nothing is actually in flight:
-  ```bash
-  [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-  ```
+- **BLOCKED**: A generic BLOCKED release with no escalation flag makes this PR immediately
+  re-eligible for `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop`
+  tick — and, absent the `hitl` flag Step 6b.6 (CFE-1.1) checks for, also re-eligible to
+  have this same CI-fix subagent re-dispatched against it next cycle. Escalate to HITL
+  first, mirroring Step 5a.7's (RPF-1.3) escalation pattern, before releasing the claim —
+  this is the same `hitl` flag Step 6b.6 already reads pre-dispatch (it runs before dispatch,
+  this runs after a BLOCKED report; they compose without conflict):
+
+  1. Reuse `PR_TASK_ID`, already resolved in Step 6b.6 — no second fetch here. If
+     non-empty, PATCH the linked task to `hitl: true` so it's flagged for a human decision:
+     ```bash
+     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       -H "Content-Type: application/json" \
+       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
+       -d '{"hitl": true}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+     ```
+     If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
+     instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
+     patch candidate every cycle, spinning forever:
+     ```bash
+     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       -H "Content-Type: application/json" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+       -d '{"hitl": true, "blockedReason": "CI-fix blocked — automated CI-fix subagent could not complete"}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /prs/$PR_RECORD_ID hitl flag failed — continuing"
+     ```
+     Still post the PR comment below either way.
+  2. Post a single PR comment stating a human decision is needed. Write the body to a temp
+     file first, same convention as Step 5a.7's escalation comment (heredocs break
+     permission glob matching):
+     ```bash
+     # Write to /tmp/shipwright-patch-blocked-6d-{pr}.txt:
+     #   The CI-fix subagent reported BLOCKED and could not complete — flagging for a human
+     #   decision instead of retrying indefinitely.
+     gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-blocked-6d-{pr}.txt
+     rm /tmp/shipwright-patch-blocked-6d-{pr}.txt
+     ```
+     The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
+     across all worktrees.
+  3. Release the pre-work claim from Step 6b.5 so a subsequent patch/review-patch run within
+     the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix never
+     completed, so nothing is actually in flight:
+     ```bash
+     [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+     ```
+
   Log the blocker. Skip Steps 6d.5 and 6e. Move to the next PR in List D.
   Include the blocker in the final report.
 


### PR DESCRIPTION
## Summary
- Mirrors the existing Step 5a.7 (RPF-1.3) second-round-disagreement HITL escalation pattern at three additional BLOCKED sites in `patch.md`: Step 4c (merge-conflict subagent), Step 5c (first-round review-finding fix subagent), and Step 6d (CI-fix subagent).
- On a first-time `BLOCKED` report, each site now PATCHes the linked task to `hitl:true` (reusing the already-resolved `PR_TASK_ID`), or falls back to PATCHing the PR record with `hitl:true` + a `blockedReason` describing the specific blocker when no linked task exists, and posts a PR comment naming the blocker — all before releasing the pre-work claim.
- Without this, `check-patch.ts`'s `getPatchCandidates()` (which only excludes a PR when `claimedBy` is set or `hitl` is true) would immediately re-qualify a BLOCKED PR on the next `shipwright-loop` tick, causing an unbounded retry loop with no backoff.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 4c: PATCH linked task hitl:true (or PR record hitl:true + blockedReason) and post PR comment before releasing claim | MET |
| 2 | Step 5c: same escalation for first-round BLOCKED; Step 5a.7's second-round-disagreement path unaffected | MET |
| 3 | Step 6d: same escalation for CI-fix BLOCKED; consistent with existing Step 6b.6 (CFE-1.1) pre-dispatch hitl check | MET |
| 4 | patch.content.test.ts updated to assert all three BLOCKED sites document the hitl/blockedReason PATCH and PR comment step | MET |

## Test Plan
- Added 8 new content-layer tests in `patch.content.test.ts` asserting the hitl PATCH, blockedReason fallback, PR comment (via distinct per-site temp files), and correct pre-release ordering at all three sites.
- Confirmed the existing Step 5a.7 escalation and Step 6b.6 pre-dispatch check remain untouched and compose correctly with the new logic.
- `NODE_ENV=test bun test plugins/shipwright/commands/patch.content.test.ts` — 83/83 passing.
- `bunx biome lint .` — clean.
- `bun run typecheck` (plugins/shipwright) — clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
