### PR TITLE
fix: PATCH task blocked status on dev-task Step 5c dead-end BLOCKED

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -99,12 +99,14 @@ Returns `404` if the task doesn't exist or is outside the agent's scope.
 PATCH /tasks/:id
 ```
 
-Body: partial task fields. Agent tokens can only update their own tasks (by `assignee` or `claimedBy`). **Agent tokens cannot set the following fields via PATCH** — these are managed exclusively by their lifecycle endpoints:
+Body: partial task fields. Agent tokens can only update their own tasks (by `assignee` or `claimedBy`). Writable fields (agents): `status` (except `'pending'`), `blockedReason`, `description`, `note`, `model`, and any other fields not listed below. **Agent tokens cannot set the following fields via PATCH** — these are managed exclusively by their lifecycle endpoints:
 
 - `claimedBy`, `claimedAt`, `heartbeatAt` — use `/claim` or `/release`
 - `status: 'pending'` — use `/release` to unclaim, or `/claim` to reclaim
 
 Admin tokens (`agentId === null`) may set any field. Returns the updated task.
+
+**Common use:** Agents use PATCH to set `status: 'blocked'` alongside `blockedReason` when an implementation attempt hits an unrecoverable dead end (e.g., after exhausting model-upgrade escalations in dev-task Step 5c).
 
 #### Delete task
 

--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -249,6 +249,59 @@ describe("Step 1 — same-branch sibling ordering check (bundled-task deferral)"
   });
 });
 
+describe("dev-task.md Step 5c — BLOCKED dead-end PATCHes task status (BHE-1.2)", () => {
+  it("PATCHes status:'blocked' with a blockedReason when the model-upgrade ladder is exhausted and the blocker is a genuine dead end", () => {
+    const step5cIdx = content.indexOf("### 5c. Handle Subagent Status");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5cIdx, step5cIdx + 2500);
+
+    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}"');
+    expect(section).toMatch(/-X PATCH/);
+    expect(section).toMatch(/-d '\{"status": "blocked", "blockedReason": "[a-z_]+"\}'/);
+  });
+
+  it("uses the same curl shape as Steps 1/7/9/9b.5 (curl -sf -X PATCH ... | jq .)", () => {
+    const step5cIdx = content.indexOf("### 5c. Handle Subagent Status");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5cIdx, step5cIdx + 2500);
+
+    expect(section).toContain("curl -sf -X PATCH -H \"Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN\"");
+    expect(section).toContain('-H "Content-Type: application/json"');
+    expect(section).toMatch(/\| jq \./);
+  });
+
+  it("does NOT fire the blocked-status PATCH for the context/size/plan cases the step already knows how to resolve", () => {
+    const step5cIdx = content.indexOf("### 5c. Handle Subagent Status");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5cIdx, step5cIdx + 2500);
+
+    // The three self-correcting branches (context, too-large, wrong-plan) must appear
+    // BEFORE the blocked-status PATCH, and the PATCH must be scoped to the remaining
+    // dead-end case only — not interleaved into each resolvable branch.
+    const contextIdx = section.search(/context problem, provide more context/i);
+    const tooLargeIdx = section.search(/task is too large, break it into smaller sub-tasks/i);
+    const planIdx = section.search(/plan is wrong, escalate to the user/i);
+    const patchIdx = section.search(/-X PATCH/);
+
+    expect(contextIdx).toBeGreaterThan(-1);
+    expect(tooLargeIdx).toBeGreaterThan(-1);
+    expect(planIdx).toBeGreaterThan(-1);
+    expect(patchIdx).toBeGreaterThan(-1);
+    expect(contextIdx).toBeLessThan(patchIdx);
+    expect(tooLargeIdx).toBeLessThan(patchIdx);
+    expect(planIdx).toBeLessThan(patchIdx);
+  });
+
+  it("does not comment on or close a PR — Step 5c runs before Step 9 (PR creation), so no PR exists yet", () => {
+    const step5cIdx = content.indexOf("### 5c. Handle Subagent Status");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5cIdx, step5cIdx + 2500);
+
+    expect(section).not.toContain("gh pr comment");
+    expect(section).not.toContain("gh pr close");
+  });
+});
+
 describe("Step 4 — unconditional branch/PR reality check (DOH-1.1)", () => {
   it("runs the reality check before any `git worktree add -b {branch}` invocation, regardless of task-store status", () => {
     const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -510,7 +510,16 @@ Parse the subagent's STATUS report:
 - **DONE**: Proceed to Step 6.
 - **DONE_WITH_CONCERNS**: Read the concerns. If they indicate correctness or scope gaps, address them before Step 6. If they are observations only (e.g., "this file is growing large"), note them and proceed.
 - **NEEDS_CONTEXT**: Provide the missing context and re-dispatch with the same prompt augmented with the answer.
-- **BLOCKED**: First, attempt a model upgrade: if the effective model (`task.model ?? 'sonnet'`) is 'haiku', re-dispatch with 'sonnet' and set `EFFECTIVE_MODEL = 'sonnet'`; if the effective model is 'sonnet', re-dispatch with 'opus' and set `EFFECTIVE_MODEL = 'opus'`. Re-dispatch the subagent once at the upgraded tier with the same prompt plus the blocker context appended. If still BLOCKED after the upgrade re-dispatch, or if the effective model is already 'opus', assess the blocker: if it is a context problem, provide more context; if the task is too large, break it into smaller sub-tasks; if the plan is wrong, escalate to the user.
+- **BLOCKED**: First, attempt a model upgrade: if the effective model (`task.model ?? 'sonnet'`) is 'haiku', re-dispatch with 'sonnet' and set `EFFECTIVE_MODEL = 'sonnet'`; if the effective model is 'sonnet', re-dispatch with 'opus' and set `EFFECTIVE_MODEL = 'opus'`. Re-dispatch the subagent once at the upgraded tier with the same prompt plus the blocker context appended. If still BLOCKED after the upgrade re-dispatch, or if the effective model is already 'opus', assess the blocker: if it is a context problem, provide more context; if the task is too large, break it into smaller sub-tasks; if the plan is wrong, escalate to the user. Otherwise — a genuine dead end the model-upgrade ladder could not resolve — mark the task blocked via the task store API:
+
+  ```bash
+  curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
+    -d '{"status": "blocked", "blockedReason": "implementation_blocked_after_model_escalation"}' | jq .
+  ```
+  Stop. No PR exists yet at this point in the pipeline (Step 5 runs before Step 9's PR
+  creation), so there is no PR to comment on or close.
 
 ### 5d. Renew the Claim Heartbeat
 


### PR DESCRIPTION
## Summary
- `dev-task.md` Step 5c's BLOCKED handling now PATCHes the task to `status:'blocked'` with a `blockedReason` when the model-upgrade ladder (haiku → sonnet → opus) is exhausted and the blocker is a genuine dead end — mirroring the exact PATCH shape already used at Steps 1/7/9/9b.5 in the same file.
- Previously this dead-end case just said "escalate to the user" with no task-store write, so the task stayed `in_progress` until the claim TTL reaper reset it back to `pending`, where it re-qualified as ready with no memory of the prior failure and looped indefinitely.
- The PATCH is scoped to only fire when the blocker is *not* a context/size/plan problem the step already knows how to resolve (those branches still self-correct via re-dispatch).
- Refreshed `docs/task-store.md` to document the new `blockedReason` write path.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 5c: when still BLOCKED after the model-upgrade re-dispatch (or already at opus) and the blocker isn't context/size/plan-resolvable, PATCH `status:'blocked'` + `blockedReason`, same curl shape as Steps 1/7/9/9b.5 | MET | `dev-task.md` Step 5c now includes the PATCH with `blockedReason: "implementation_blocked_after_model_escalation"` |
| 2 | Fix does not fire for the context/size/plan cases the step already resolves | MET | PATCH is gated behind "Otherwise —" after the three self-correcting branches; test asserts ordering |
| 3 | `dev-task.content.test.ts` updated to assert Step 5c documents the blocked-status PATCH (content-layer test only, matching BHE-1.1 rationale) | MET | 4 new tests added |

## Test Plan
- `bun test plugins/shipwright/commands/dev-task.content.test.ts` — 44/44 pass
- `bun test plugins/shipwright/commands/` — 353/353 pass
- `bun test` (full suite) — 5138 pass, 2 pre-existing failures unrelated to this change (confirmed failing on `main` too: `agent/src/claude.unit.test.ts`, `scripts/quickstart.smoke.test.ts`)
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- `bunx biome lint .` — clean
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
