### PR TITLE
feat(hitl): set default allowed tools for HITL Claude sessions

### DIFF
--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -57,6 +57,16 @@ import {
   type WorkTaskCandidate,
   selectNextWorkItem,
 } from "../agent/src/work-selector.ts";
+import { FLOOR_TOOLS } from "../agent/src/claude.ts";
+
+// ---------------------------------------------------------------------------
+// Allowed tools — FLOOR_TOOLS + web access, minus Bash/Agent (both can
+// execute arbitrary commands; keep them behind the approval prompt).
+// ---------------------------------------------------------------------------
+
+export const HITL_ALLOWED_TOOLS = [
+  ...new Set([...FLOOR_TOOLS, "WebSearch", "WebFetch"]),
+];
 
 // ---------------------------------------------------------------------------
 // Paths — anchored to this script, not cwd
@@ -726,13 +736,23 @@ async function runLoop(): Promise<void> {
     log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     console.log("");
 
-    const claude = Bun.spawn(["claude", command], {
-      cwd: WORKSPACE,
-      env: buildClaudeSpawnEnv(process.env),
-      stdout: "inherit",
-      stderr: "inherit",
-      stdin: "inherit",
-    });
+    const claude = Bun.spawn(
+      [
+        "claude",
+        "--permission-mode",
+        "acceptEdits",
+        "--allowedTools",
+        ...HITL_ALLOWED_TOOLS,
+        command,
+      ],
+      {
+        cwd: WORKSPACE,
+        env: buildClaudeSpawnEnv(process.env),
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "inherit",
+      },
+    );
 
     await claude.exited;
 

--- a/scripts/hitl.unit.test.ts
+++ b/scripts/hitl.unit.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   type Task,
+  HITL_ALLOWED_TOOLS,
   buildClaudeSpawnEnv,
   buildTaskCommand,
   computeProvisionPlan,
@@ -141,6 +142,23 @@ describe("computeProvisionPlan", () => {
     );
     expect(plan.missingDirs).toEqual([]);
     expect(plan.needsClaudeMd).toBe(true);
+  });
+});
+
+describe("HITL_ALLOWED_TOOLS", () => {
+  test("includes FLOOR_TOOLS and web access", () => {
+    for (const t of ["Read", "Write", "Edit", "Glob", "Grep", "TodoWrite", "Skill", "WebSearch", "WebFetch"]) {
+      expect(HITL_ALLOWED_TOOLS).toContain(t);
+    }
+  });
+
+  test("excludes Bash and Agent", () => {
+    expect(HITL_ALLOWED_TOOLS).not.toContain("Bash");
+    expect(HITL_ALLOWED_TOOLS).not.toContain("Agent");
+  });
+
+  test("contains no duplicates", () => {
+    expect(HITL_ALLOWED_TOOLS.length).toBe(new Set(HITL_ALLOWED_TOOLS).size);
   });
 });
 


### PR DESCRIPTION
## Summary
- HITL runner now spawns Claude with `--permission-mode acceptEdits` and an explicit `--allowedTools` list derived from `FLOOR_TOOLS` (Read, Write, Edit, Glob, Grep, TodoWrite, Skill) plus WebSearch and WebFetch
- Bash and Agent are excluded — both can execute arbitrary commands and should require interactive approval in HITL mode
- Adds unit tests for `HITL_ALLOWED_TOOLS` (includes expected tools, excludes Bash/Agent, no duplicates)

## Test plan
- [x] Existing `hitl.unit.test.ts` tests pass (34 pass, 4 pre-existing failures unrelated to this change)
- [x] New `HITL_ALLOWED_TOOLS` tests verify correct inclusions, exclusions, and dedup
- [ ] Manual: run `task hitl`, confirm Claude starts with file-write access and prompts for Bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)