### PR TITLE
fix(hitl): place command before variadic --allowedTools flag

### DIFF
--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -739,11 +739,11 @@ async function runLoop(): Promise<void> {
     const claude = Bun.spawn(
       [
         "claude",
+        command,
         "--permission-mode",
         "acceptEdits",
         "--allowedTools",
         ...HITL_ALLOWED_TOOLS,
-        command,
       ],
       {
         cwd: WORKSPACE,


### PR DESCRIPTION
## Summary
- The previous commit (#2239) placed the work-item command after `--allowedTools`, which is variadic and consumed it as a tool name instead of the prompt
- Moves `command` before `--allowedTools` so it's correctly parsed as the positional prompt argument

## Test plan
- [x] Verified `HITL_ALLOWED_TOOLS` unit tests still pass (contents unchanged)
- [ ] Run `task hitl` and confirm the work item is passed through to Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)