### PR TITLE
feat: add live-GitHub review dedup to check-review.ts candidate selection

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -23,6 +23,7 @@
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import type { PrReviewData } from "./check-patch.ts";
 
 // ─── Task types ───────────────────────────────────────────────────────────────
 
@@ -116,6 +117,96 @@ export function isCleanApproveBody(body: string): boolean {
     body.trimStart().replace(/^\*+/, "").startsWith("APPROVE") ||
     VERDICT_APPROVE_LABEL.test(body)
   );
+}
+
+// ─── Live review-state classification ─────────────────────────────────────────
+//
+// Promoted from pr-state-reconciler.ts (RVD-1.1) — pure move, same bodies —
+// so check-review.ts's candidate selection can also dedup against live
+// GitHub review data (identity-agnostic, any author's terminal review
+// counts), not just pr-state-reconciler.ts's async background reconcile
+// pass. pr-state-reconciler.ts now imports these from here instead of
+// defining them locally.
+
+/** Filter a PR's reviews down to only those submitted at the current head commit. */
+export function reviewsAtHeadCommit(
+  data: PrReviewData,
+): PrReviewData["reviews"]["nodes"] {
+  const { headRefOid, reviews } = data;
+  return reviews.nodes.filter((r) => r.commit.oid === headRefOid);
+}
+
+/**
+ * CHU-2.4: does ANY review at all exist at the PR's current head commit?
+ * Extracted out of `classifyReviewState`'s existing `reviewsAtHead.length ===
+ * 0` check so the posted-scan pass can distinguish this specific null case
+ * ("nothing at head at all" — a posted verdict has gone stale because a new
+ * commit landed with no review yet targeting it) from the OTHER null case
+ * `classifyReviewState` returns (a genuine unresolved finding at head, which
+ * must leave a posted record untouched). `classifyReviewState`'s own
+ * existing behavior/signature is unchanged — it still returns null for both
+ * cases, exactly as before.
+ */
+export function hasAnyReviewAtHead(data: PrReviewData): boolean {
+  return reviewsAtHeadCommit(data).length > 0;
+}
+
+/**
+ * Classify a PR's review state from live GitHub review data. Mirrors the
+ * SHAPE of check-patch.ts's private `hasUnaddressedFindings` filtering
+ * (reviews-at-head, unresolved-threads-or-non-empty-body) but keyed on
+ * `isCleanApproveBody` for the approve/non-finding split instead of
+ * self-authorship — this reconciler exists specifically to catch an
+ * OUT-OF-BAND reviewer, so ANY author's clean-approve-shaped COMMENTED
+ * review counts, not just self-authored ones.
+ *
+ * Genuine findings are checked FIRST, independent of whether an approve also
+ * exists at head — an approve from one reviewer must never mask an unresolved
+ * thread or non-empty finding body left by a different reviewer's
+ * COMMENTED/CHANGES_REQUESTED review at the same head commit (mirrors
+ * `hasUnaddressedFindings`'s filtering order in check-patch.ts).
+ *
+ * Returns:
+ *   - "approved" — a real APPROVED review, or a clean-approve-shaped
+ *     COMMENTED review, at the current head commit, AND no genuine
+ *     unaddressed finding from any other review at the same head commit.
+ *   - "posted" — a terminal (no unresolved threads, no qualifying non-empty
+ *     finding body) non-approve review at the current head commit.
+ *   - null — no review at all at the current head commit, OR a genuine
+ *     unaddressed finding at the current head commit. Both cases must leave
+ *     the record completely untouched.
+ */
+export function classifyReviewState(
+  data: PrReviewData,
+): "approved" | "posted" | null {
+  const { reviewThreads } = data;
+  const reviewsAtHead = reviewsAtHeadCommit(data);
+  if (reviewsAtHead.length === 0) return null; // nothing at head — untouched
+
+  const qualifyingReviews = reviewsAtHead.filter(
+    (r) =>
+      (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
+      !isCleanApproveBody(r.body),
+  );
+
+  if (qualifyingReviews.length > 0) {
+    const unresolvedThreads = reviewThreads.nodes.filter((t) => !t.isResolved);
+    if (unresolvedThreads.length > 0) return null; // genuine finding — untouched
+
+    const hasFindingBody = qualifyingReviews.some(
+      (r) => r.body.trim().length > 0,
+    );
+    if (hasFindingBody) return null; // genuine finding — untouched
+  }
+
+  const hasApprove = reviewsAtHead.some(
+    (r) =>
+      r.state === "APPROVED" ||
+      (r.state === "COMMENTED" && isCleanApproveBody(r.body)),
+  );
+  if (hasApprove) return "approved";
+
+  return "posted"; // terminal, non-approve, no finding
 }
 
 export function readAllowSelfReview(workspacePath: string): boolean {

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -19,18 +19,22 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { PrReviewData, ReviewNode, ReviewThread } from "./check-patch.ts";
 import {
+  classifyReviewState,
   createBundleCompleteQuery,
   createPrRecordQuery,
   createTaskStatusQuery,
   createTaskStoreClient,
   getCurrentUser,
+  hasAnyReviewAtHead,
   isCleanApproveBody,
   isPrRecordBlockedForDispatch,
   isTaskBlockedForDispatch,
   parseCandidateId,
   resolveAllRepos,
   resolveRepos,
+  reviewsAtHeadCommit,
 } from "./check-helpers.ts";
 import * as checkHelpers from "./check-helpers.ts";
 
@@ -1471,6 +1475,217 @@ describe("isCleanApproveBody", () => {
   test("does not match a non-APPROVE verdict", () => {
     expect(isCleanApproveBody("Verdict: CHANGES_REQUESTED")).toBe(false);
     expect(isCleanApproveBody("Verdict: DISAPPROVE")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reviewsAtHeadCommit / hasAnyReviewAtHead / classifyReviewState (RVD-1.1)
+//
+// Promoted from pr-state-reconciler.ts — pr-state-reconciler.unit.test.ts
+// already exercises these thoroughly end-to-end via reconcileReviewState(),
+// so this block covers the pure functions directly (now that they're
+// check-helpers.ts's own exports) rather than duplicating every scenario.
+// ---------------------------------------------------------------------------
+
+function makeReviewNode(overrides: Partial<ReviewNode> = {}): ReviewNode {
+  return {
+    author: { login: "some-reviewer" },
+    state: "COMMENTED",
+    submittedAt: "2026-07-15T10:00:00.000Z",
+    commit: { oid: "head-sha" },
+    body: "",
+    ...overrides,
+  };
+}
+
+function makeReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    isResolved: true,
+    comments: { nodes: [{ author: { login: "some-reviewer" }, body: "" }] },
+    ...overrides,
+  };
+}
+
+function makeReviewData(overrides: Partial<PrReviewData> = {}): PrReviewData {
+  return {
+    headRefOid: "head-sha",
+    reviews: { nodes: [] },
+    reviewThreads: { nodes: [] },
+    comments: { nodes: [] },
+    ...overrides,
+  };
+}
+
+describe("reviewsAtHeadCommit", () => {
+  test("returns only reviews whose commit.oid matches headRefOid", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({ commit: { oid: "head-sha" }, body: "at head" }),
+          makeReviewNode({ commit: { oid: "old-sha" }, body: "stale" }),
+        ],
+      },
+    });
+    const result = reviewsAtHeadCommit(data);
+    expect(result).toHaveLength(1);
+    expect(result[0].body).toBe("at head");
+  });
+
+  test("returns an empty array when no reviews exist", () => {
+    expect(reviewsAtHeadCommit(makeReviewData())).toEqual([]);
+  });
+
+  test("returns an empty array when all reviews are at a stale commit", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: { nodes: [makeReviewNode({ commit: { oid: "old-sha" } })] },
+    });
+    expect(reviewsAtHeadCommit(data)).toEqual([]);
+  });
+});
+
+describe("hasAnyReviewAtHead", () => {
+  test("true when at least one review is at head", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: { nodes: [makeReviewNode({ commit: { oid: "head-sha" } })] },
+    });
+    expect(hasAnyReviewAtHead(data)).toBe(true);
+  });
+
+  test("false when no reviews exist at all", () => {
+    expect(hasAnyReviewAtHead(makeReviewData())).toBe(false);
+  });
+
+  test("false when reviews exist only at a stale commit", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: { nodes: [makeReviewNode({ commit: { oid: "old-sha" } })] },
+    });
+    expect(hasAnyReviewAtHead(data)).toBe(false);
+  });
+});
+
+describe("classifyReviewState", () => {
+  test("returns null when no review exists at head", () => {
+    expect(classifyReviewState(makeReviewData())).toBeNull();
+  });
+
+  test("returns null when reviews only exist at a stale commit", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: { nodes: [makeReviewNode({ commit: { oid: "old-sha" } })] },
+    });
+    expect(classifyReviewState(data)).toBeNull();
+  });
+
+  test("returns 'approved' for a real APPROVED review at head", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "APPROVED",
+            commit: { oid: "head-sha" },
+            body: "LGTM",
+          }),
+        ],
+      },
+    });
+    expect(classifyReviewState(data)).toBe("approved");
+  });
+
+  test("returns 'approved' for a clean-approve-shaped COMMENTED review at head, from any author", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            author: { login: "out-of-band-reviewer" },
+            state: "COMMENTED",
+            commit: { oid: "head-sha" },
+            body: "**APPROVE** — nothing else to add.",
+          }),
+        ],
+      },
+    });
+    expect(classifyReviewState(data)).toBe("approved");
+  });
+
+  test("returns 'posted' for a terminal non-approve review at head with no unresolved threads or finding body", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "COMMENTED",
+            commit: { oid: "head-sha" },
+            body: "",
+          }),
+        ],
+      },
+      reviewThreads: { nodes: [makeReviewThread({ isResolved: true })] },
+    });
+    expect(classifyReviewState(data)).toBe("posted");
+  });
+
+  test("returns null for a genuine unresolved finding at head (unresolved thread)", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "CHANGES_REQUESTED",
+            commit: { oid: "head-sha" },
+            body: "Please fix the auth flow.",
+          }),
+        ],
+      },
+      reviewThreads: { nodes: [makeReviewThread({ isResolved: false })] },
+    });
+    expect(classifyReviewState(data)).toBeNull();
+  });
+
+  test("returns null for a genuine finding via non-empty body, even with all threads resolved", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "COMMENTED",
+            commit: { oid: "head-sha" },
+            body: "Rename this variable before merging.",
+          }),
+        ],
+      },
+      reviewThreads: { nodes: [makeReviewThread({ isResolved: true })] },
+    });
+    expect(classifyReviewState(data)).toBeNull();
+  });
+
+  test("an approve from one reviewer never masks an independent unresolved finding from another reviewer at head", () => {
+    const data = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            author: { login: "reviewer-a" },
+            state: "CHANGES_REQUESTED",
+            commit: { oid: "head-sha" },
+            body: "This breaks the auth flow.",
+          }),
+          makeReviewNode({
+            author: { login: "reviewer-b" },
+            state: "APPROVED",
+            commit: { oid: "head-sha" },
+            body: "LGTM",
+          }),
+        ],
+      },
+      reviewThreads: { nodes: [makeReviewThread({ isResolved: false })] },
+    });
+    expect(classifyReviewState(data)).toBeNull();
   });
 });
 

--- a/agent/src/check-review.ts
+++ b/agent/src/check-review.ts
@@ -16,6 +16,15 @@
  * eligible; a query failure is also treated as eligible (graceful
  * degradation, matching the plugin's "err permissive" precheck philosophy).
  *
+ * RVD-1.1 adds a second, independent dedup signal against LIVE GitHub review
+ * data (via classifyReviewState(), promoted to check-helpers.ts from
+ * pr-state-reconciler.ts) — the task-store record alone can't see a review
+ * posted by an agent running against a DIFFERENT task-store instance, since
+ * that agent never wrote a record here. This check is identity-agnostic (any
+ * author's terminal review at the PR's current head commit counts) and
+ * applies regardless of what the task-store record says. Same fail-open
+ * philosophy: a fetchPrReviews failure is treated as eligible.
+ *
  * age is populated from the linked task's createdAt (via queryTaskStatus,
  * LPF-3.2), falling back to the PR's GitHub createdAt when no task is linked
  * or the lookup fails — readyForReviewAt is a necessarily-recent
@@ -32,18 +41,22 @@ import type { AgentAuthorAllowlistRef } from "./agent-author-allowlist-ref.ts";
 import { agentReposRef } from "./agent-repos-ref.ts";
 import {
   candidateId,
+  classifyReviewState,
   createBundleCompleteQuery,
   createPrRecordQuery,
   createTaskStatusQuery,
   getCurrentUser,
+  ghGraphql as ghGraphqlDefault,
   isPrRecordBlockedForDispatch,
   isTaskBlockedForDispatch,
   mapReposTolerant,
   readAllowSelfReview,
   resolveAllRepos,
   resolveWorkspacePath,
+  splitOrgRepo,
 } from "./check-helpers.ts";
 import type { LinkedTaskInfo } from "./check-helpers.ts";
+import type { PrReviewData } from "./check-patch.ts";
 import type { WorkPrCandidate } from "./work-selector.ts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -114,6 +127,20 @@ export interface CheckReviewDeps {
   // Bundle completeness gate: returns false if any bundle-mate task on the branch
   // is still pending/in_progress/blocked. PR is skipped when it returns false.
   isBundleComplete?: (branch: string) => Promise<boolean>;
+  /**
+   * Fetch head commit + reviews + review threads for a single PR (RVD-1.1).
+   * Used to dedup against LIVE GitHub review data, independent of the
+   * task-store PR record — a PR reviewed by an agent running against a
+   * DIFFERENT task-store instance leaves no trace in this instance's record,
+   * so the record-based dedup above can't see it. classifyReviewState()
+   * (check-helpers.ts) is identity-agnostic: any author's terminal review at
+   * the PR's current head commit counts, matching pr-state-reconciler.ts's
+   * reconcileReviewState() semantics. A throw/rejection here is caught and
+   * treated as "no terminal review at head" (fail open — PR stays eligible),
+   * matching this function's existing permissive-on-error philosophy for
+   * queryPrRecord failures above.
+   */
+  fetchPrReviews: (org: string, repo: string, pr: number) => Promise<PrReviewData>;
 }
 
 // ─── Core logic ───────────────────────────────────────────────────────────────
@@ -151,6 +178,24 @@ export async function getReviewCandidates(
       record = await deps.queryPrRecord(pr.repo ?? "", pr.number);
     } catch {
       // Query failed → treat as eligible (no dedup)
+    }
+
+    // Live-GitHub review dedup (RVD-1.1) — a second, independent signal from
+    // the task-store record above: skip this PR when a terminal review
+    // already exists at its CURRENT head commit on GitHub, regardless of
+    // author and regardless of what the task-store record says (it may have
+    // no record at all, e.g. an agent running against a different
+    // task-store instance already reviewed it). Applied unconditionally
+    // before the record-based eligibility checks below, since it excludes
+    // rather than includes. A fetch failure is caught and treated as "no
+    // terminal review" — fail open, matching queryPrRecord's own permissive-
+    // on-error handling above.
+    try {
+      const [org, repoName] = splitOrgRepo(pr.repo ?? "");
+      const reviewData = await deps.fetchPrReviews(org, repoName, pr.number);
+      if (classifyReviewState(reviewData) !== null) continue;
+    } catch {
+      // Fetch failed → treat as "no terminal review" (no dedup)
     }
 
     // Task-store task lookup, used to source the age field from the linked
@@ -242,6 +287,14 @@ export async function getReviewCandidates(
 
 export async function buildProductionDeps(opts: {
   ghJson: <T>(args: string[]) => Promise<T>;
+  /**
+   * Optional override for the GraphQL client backing fetchPrReviews
+   * (RVD-1.1) — mirrors check-patch.ts's buildProductionDeps's required
+   * ghGraphql param, but kept optional here (defaulting to check-helpers.ts's
+   * shared ghGraphql) so existing callers/tests that only pass ghJson keep
+   * working unchanged.
+   */
+  ghGraphql?: <T>(query: string) => Promise<T>;
   fetchFn?: typeof fetch;
   getScopedRepos?: () => string[];
   hasScopeSynced?: () => boolean;
@@ -268,6 +321,7 @@ export async function buildProductionDeps(opts: {
   const workspacePath = resolveWorkspacePath();
   const allRepos = resolveAllRepos(workspacePath);
   const { ghJson: ghJsonFn } = opts;
+  const ghGraphqlFn = opts.ghGraphql ?? ghGraphqlDefault;
   const authorAllowlistRef = opts.authorAllowlistRef ?? agentAuthorAllowlistRef;
 
   return {
@@ -298,5 +352,45 @@ export async function buildProductionDeps(opts: {
     queryPrRecord: createPrRecordQuery<PrRecord>({ fetchFn: opts.fetchFn }),
     queryTaskStatus: createTaskStatusQuery({ fetchFn: opts.fetchFn }),
     isBundleComplete: createBundleCompleteQuery({ fetchFn: opts.fetchFn }),
+    fetchPrReviews: async (org: string, repo: string, pr: number) => {
+      const query = `{
+  repository(owner: "${org}", name: "${repo}") {
+    pullRequest(number: ${pr}) {
+      headRefOid
+      reviews(first: 50) {
+        nodes {
+          author { login }
+          state
+          submittedAt
+          commit { oid }
+          body
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 1) {
+            nodes {
+              author { login }
+              body
+            }
+          }
+        }
+      }
+      comments(last: 50) {
+        nodes {
+          author { login }
+          body
+          createdAt
+        }
+      }
+    }
+  }
+}`;
+      const response = await ghGraphqlFn<{
+        data: { repository: { pullRequest: PrReviewData } };
+      }>(query);
+      return response.data.repository.pullRequest;
+    },
   };
 }

--- a/agent/src/check-review.unit.test.ts
+++ b/agent/src/check-review.unit.test.ts
@@ -16,6 +16,7 @@ import {
   createAgentAuthorAllowlistRef,
 } from "./agent-author-allowlist-ref.ts";
 import type { LinkedTaskInfo } from "./check-helpers.ts";
+import type { PrReviewData, ReviewNode } from "./check-patch.ts";
 import {
   type CheckReviewDeps,
   type PrInfo,
@@ -40,6 +41,20 @@ function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
   };
 }
 
+/** Default fetchPrReviews stub: no reviews at all — "no terminal review", every PR stays eligible. */
+async function defaultFetchPrReviews(
+  _org: string,
+  _repo: string,
+  _pr: number,
+): Promise<PrReviewData> {
+  return {
+    headRefOid: "abc123def456",
+    reviews: { nodes: [] },
+    reviewThreads: { nodes: [] },
+    comments: { nodes: [] },
+  };
+}
+
 function makeDeps(
   prs: PrInfo[],
   queryPrRecordFn: (
@@ -57,6 +72,11 @@ function makeDeps(
   ],
   hasScopeSynced: () => boolean = () => true,
   isBundleComplete?: (branch: string) => Promise<boolean>,
+  fetchPrReviews: (
+    org: string,
+    repo: string,
+    pr: number,
+  ) => Promise<PrReviewData> = defaultFetchPrReviews,
 ): CheckReviewDeps {
   return {
     listOpenPrs: async (_repo: string) => prs,
@@ -66,7 +86,31 @@ function makeDeps(
     getScopedRepos,
     hasScopeSynced,
     queryTaskStatus,
+    fetchPrReviews,
     ...(isBundleComplete ? { isBundleComplete } : {}),
+  };
+}
+
+// ─── Live-review fixture helpers (RVD-1.1) ───────────────────────────────────
+
+function makeReviewNode(overrides: Partial<ReviewNode> = {}): ReviewNode {
+  return {
+    author: { login: "some-reviewer" },
+    state: "COMMENTED",
+    submittedAt: "2026-07-15T10:00:00.000Z",
+    commit: { oid: "abc123def456" },
+    body: "",
+    ...overrides,
+  };
+}
+
+function makeReviewData(overrides: Partial<PrReviewData> = {}): PrReviewData {
+  return {
+    headRefOid: "abc123def456",
+    reviews: { nodes: [] },
+    reviewThreads: { nodes: [] },
+    comments: { nodes: [] },
+    ...overrides,
   };
 }
 
@@ -233,6 +277,7 @@ describe("getReviewCandidates", () => {
       isSelfReviewAllowed: false,
       getScopedRepos: () => [pr.repo ?? ""],
       hasScopeSynced: () => true,
+      fetchPrReviews: defaultFetchPrReviews,
     };
     const result = await getReviewCandidates(deps);
     expect(result).toHaveLength(1);
@@ -684,6 +729,124 @@ describe("getReviewCandidates", () => {
     );
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("example-org/example-repo#42");
+  });
+
+  // ─── live-GitHub review dedup (RVD-1.1) ──────────────────────────────────
+
+  test("excludes a PR with a live terminal review at head from a non-self author, even with no task-store record (identity-agnostic dedup)", async () => {
+    const pr = makePr({ headRefOid: "head-sha" });
+    const reviewData = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            author: { login: "out-of-band-reviewer" },
+            state: "APPROVED",
+            commit: { oid: "head-sha" },
+            body: "LGTM",
+          }),
+        ],
+      },
+    });
+    const result = await getReviewCandidates(
+      makeDeps(
+        [pr],
+        async () => null, // no task-store record — this instance never claimed it
+        "bodhi-agent",
+        false,
+        async () => null,
+        undefined,
+        undefined,
+        undefined,
+        async () => reviewData,
+      ),
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("includes a PR whose only live reviews are at a stale (non-head) commit", async () => {
+    const pr = makePr({ headRefOid: "head-sha" });
+    const reviewData = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "APPROVED",
+            commit: { oid: "old-stale-sha" },
+            body: "LGTM",
+          }),
+        ],
+      },
+    });
+    const result = await getReviewCandidates(
+      makeDeps(
+        [pr],
+        async () => null,
+        "bodhi-agent",
+        false,
+        async () => null,
+        undefined,
+        undefined,
+        undefined,
+        async () => reviewData,
+      ),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("example-org/example-repo#42");
+  });
+
+  test("fails open (stays eligible) when fetchPrReviews throws/rejects", async () => {
+    const pr = makePr({ headRefOid: "head-sha" });
+    const result = await getReviewCandidates(
+      makeDeps(
+        [pr],
+        async () => null,
+        "bodhi-agent",
+        false,
+        async () => null,
+        undefined,
+        undefined,
+        undefined,
+        async () => {
+          throw new Error("GraphQL rate limited");
+        },
+      ),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("example-org/example-repo#42");
+  });
+
+  test("a live terminal review at head still excludes the PR even when the task-store record independently says eligible", async () => {
+    // The second, independent signal: even a fresh/pending task-store record
+    // must not override a live terminal review at head.
+    const pr = makePr({ headRefOid: "head-sha" });
+    const reviewData = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "COMMENTED",
+            commit: { oid: "head-sha" },
+            body: "",
+          }),
+        ],
+      },
+      reviewThreads: { nodes: [{ isResolved: true, comments: { nodes: [] } }] },
+    });
+    const result = await getReviewCandidates(
+      makeDeps(
+        [pr],
+        async () => ({ commitSha: null, reviewState: "pending" }),
+        "bodhi-agent",
+        false,
+        async () => null,
+        undefined,
+        undefined,
+        undefined,
+        async () => reviewData,
+      ),
+    );
+    expect(result).toEqual([]);
   });
 });
 

--- a/agent/src/loop-orchestrator.ts
+++ b/agent/src/loop-orchestrator.ts
@@ -1057,7 +1057,7 @@ export async function createProductionLoopOrchestrator(
   opts: LoopOrchestratorProductionOptions,
 ): Promise<(jobs: CronJobLike[]) => Promise<void>> {
   const devTaskDeps = buildDevTaskDeps();
-  const reviewDeps = await buildReviewDeps({ ghJson });
+  const reviewDeps = await buildReviewDeps({ ghJson, ghGraphql });
   const patchDeps = await buildPatchDeps({ ghJson, ghGraphql, getCurrentUser });
   const deployDeps = await buildDeployDeps({ ghJson });
   const taskStoreClient = createTaskStoreClient();

--- a/agent/src/pr-state-reconciler.ts
+++ b/agent/src/pr-state-reconciler.ts
@@ -69,8 +69,9 @@
 
 import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import {
+  classifyReviewState,
   createPrRecordQuery,
-  isCleanApproveBody,
+  hasAnyReviewAtHead,
   resolveAllRepos,
   resolveWorkspacePath,
   splitOrgRepo,
@@ -717,85 +718,12 @@ export async function reconcilePrState(
 }
 
 // ─── reconcileReviewState ───────────────────────────────────────────────────────
-
-/** Filter a PR's reviews down to only those submitted at the current head commit. */
-function reviewsAtHeadCommit(
-  data: PrReviewData,
-): PrReviewData["reviews"]["nodes"] {
-  const { headRefOid, reviews } = data;
-  return reviews.nodes.filter((r) => r.commit.oid === headRefOid);
-}
-
-/**
- * CHU-2.4: does ANY review at all exist at the PR's current head commit?
- * Extracted out of `classifyReviewState`'s existing `reviewsAtHead.length ===
- * 0` check so the posted-scan pass can distinguish this specific null case
- * ("nothing at head at all" — a posted verdict has gone stale because a new
- * commit landed with no review yet targeting it) from the OTHER null case
- * `classifyReviewState` returns (a genuine unresolved finding at head, which
- * must leave a posted record untouched). `classifyReviewState`'s own
- * existing behavior/signature is unchanged — it still returns null for both
- * cases, exactly as before.
- */
-function hasAnyReviewAtHead(data: PrReviewData): boolean {
-  return reviewsAtHeadCommit(data).length > 0;
-}
-
-/**
- * Classify a PR's review state from live GitHub review data. Mirrors the
- * SHAPE of check-patch.ts's private `hasUnaddressedFindings` filtering
- * (reviews-at-head, unresolved-threads-or-non-empty-body) but keyed on
- * `isCleanApproveBody` for the approve/non-finding split instead of
- * self-authorship — this reconciler exists specifically to catch an
- * OUT-OF-BAND reviewer, so ANY author's clean-approve-shaped COMMENTED
- * review counts, not just self-authored ones.
- *
- * Genuine findings are checked FIRST, independent of whether an approve also
- * exists at head — an approve from one reviewer must never mask an unresolved
- * thread or non-empty finding body left by a different reviewer's
- * COMMENTED/CHANGES_REQUESTED review at the same head commit (mirrors
- * `hasUnaddressedFindings`'s filtering order in check-patch.ts).
- *
- * Returns:
- *   - "approved" — a real APPROVED review, or a clean-approve-shaped
- *     COMMENTED review, at the current head commit, AND no genuine
- *     unaddressed finding from any other review at the same head commit.
- *   - "posted" — a terminal (no unresolved threads, no qualifying non-empty
- *     finding body) non-approve review at the current head commit.
- *   - null — no review at all at the current head commit, OR a genuine
- *     unaddressed finding at the current head commit. Both cases must leave
- *     the record completely untouched.
- */
-function classifyReviewState(data: PrReviewData): "approved" | "posted" | null {
-  const { reviewThreads } = data;
-  const reviewsAtHead = reviewsAtHeadCommit(data);
-  if (reviewsAtHead.length === 0) return null; // nothing at head — untouched
-
-  const qualifyingReviews = reviewsAtHead.filter(
-    (r) =>
-      (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
-      !isCleanApproveBody(r.body),
-  );
-
-  if (qualifyingReviews.length > 0) {
-    const unresolvedThreads = reviewThreads.nodes.filter((t) => !t.isResolved);
-    if (unresolvedThreads.length > 0) return null; // genuine finding — untouched
-
-    const hasFindingBody = qualifyingReviews.some(
-      (r) => r.body.trim().length > 0,
-    );
-    if (hasFindingBody) return null; // genuine finding — untouched
-  }
-
-  const hasApprove = reviewsAtHead.some(
-    (r) =>
-      r.state === "APPROVED" ||
-      (r.state === "COMMENTED" && isCleanApproveBody(r.body)),
-  );
-  if (hasApprove) return "approved";
-
-  return "posted"; // terminal, non-approve, no finding
-}
+//
+// reviewsAtHeadCommit/hasAnyReviewAtHead/classifyReviewState now live in
+// check-helpers.ts (RVD-1.1) — promoted so check-review.ts's candidate
+// selection can reuse the same live-review classification for its own
+// identity-agnostic dedup, not just this file's async background reconcile
+// pass. Imported above; see check-helpers.ts for the full doc comments.
 
 /**
  * A record is "actively claimed" (skip it — never overwrite a live claim's


### PR DESCRIPTION
## Summary
- Promotes `reviewsAtHeadCommit`/`hasAnyReviewAtHead`/`classifyReviewState` from `pr-state-reconciler.ts` (module-private) into `check-helpers.ts` (exported) as a pure move — `pr-state-reconciler.ts` now imports them back, no behavior change.
- Adds an injectable `fetchPrReviews` dep to `CheckReviewDeps` and uses it in `getReviewCandidates()` to skip a PR whenever `classifyReviewState` finds a terminal review at the PR's current head commit, regardless of author — closing the gap where a PR reviewed by an agent on a different task-store instance had no local record and was re-selected for review.
- `fetchPrReviews` failures fail open (PR stays eligible), matching the function's existing permissive-on-error philosophy for task-store record-query failures.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `reviewsAtHeadCommit`/`hasAnyReviewAtHead`/`classifyReviewState` exported from `check-helpers.ts`; `pr-state-reconciler.ts` imports them; existing pr-state-reconciler tests pass unmodified | MET |
| 2 | `getReviewCandidates()` gains a `fetchPrReviews` dep and excludes a PR when `classifyReviewState` is non-null at `pr.headRefOid`, regardless of author | MET |
| 3 | A `fetchPrReviews` failure/throw is caught and treated as "no terminal review" (PR stays eligible) | MET |
| 4 | New unit tests: exclusion on live terminal review (non-self author), inclusion when reviews only at stale commit, fail-open on fetch error; no existing tests removed; check-helpers.ts coverage for the three promoted functions | MET |

## Test Plan
- `bun test agent/src/check-review.unit.test.ts agent/src/check-helpers.unit.test.ts agent/src/pr-state-reconciler.unit.test.ts` — 249 pass, 0 fail (75 pre-existing pr-state-reconciler tests unmodified, 4 new check-review tests, 14 new check-helpers tests)
- `task lint` — clean
- `task typecheck` — clean (all 7 workspaces)
- `task test:coverage` — 5181 pass / 1 fail. The 1 failure (`claude.unit.test.ts` › `extraAllowedTools` › "empty extraAllowedTools produces identical args to no extraAllowedTools") is pre-existing on `main` (verified independently) and unrelated to this change.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
