### PR TITLE
feat: add synchronous live-GitHub review pre-check to review.md Step 14

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -103,6 +103,24 @@ export function parseAllowSelfReview(content: string): boolean {
 export const VERDICT_APPROVE_LABEL = /verdict\**\s*:\s*\**approve\b/i;
 
 /**
+ * The canonical TS-side pattern that `plugins/shipwright/commands/review.md`'s
+ * Step 14 Live-Review Pre-Check (RVD-1.2) mirrors as a bash/jq regex, since
+ * review.md is bash/gh/curl-driven and can't import TS. Unlike
+ * `VERDICT_APPROVE_LABEL` (APPROVE only, used for self-review clean-approve
+ * detection), this also matches COMMENT — because review.md's own Step 10
+ * always posts a `Verdict: APPROVE` or `Verdict: COMMENT` line, and BOTH
+ * represent "already reviewed, terminal" as far as the live-review pre-check
+ * is concerned (mirrors the intent of `classifyReviewState()`'s "posted" vs
+ * "approved" split, but collapsed into a single boolean here since Step 14
+ * only needs to know whether ANY terminal review exists at the current head
+ * commit). Not currently consumed anywhere in TS — it exists purely as the
+ * source of truth for the bash regex embedded in review.md, verified in sync
+ * via a content test in plugins/shipwright/commands/review.unit.test.ts.
+ */
+export const VERDICT_TERMINAL_LABEL =
+  /verdict\**\s*:\s*\**(approve|comment)\b/i;
+
+/**
  * True when a review body is a clean APPROVE verdict, matched either by:
  * - a leading `APPROVE` (after stripping leading markdown bold markers), or
  * - a "Verdict: APPROVE" label anywhere in the body (the narrative

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -35,6 +35,7 @@ import {
   resolveAllRepos,
   resolveRepos,
   reviewsAtHeadCommit,
+  VERDICT_TERMINAL_LABEL,
 } from "./check-helpers.ts";
 import * as checkHelpers from "./check-helpers.ts";
 
@@ -1475,6 +1476,48 @@ describe("isCleanApproveBody", () => {
   test("does not match a non-APPROVE verdict", () => {
     expect(isCleanApproveBody("Verdict: CHANGES_REQUESTED")).toBe(false);
     expect(isCleanApproveBody("Verdict: DISAPPROVE")).toBe(false);
+  });
+});
+
+describe("VERDICT_TERMINAL_LABEL", () => {
+  test("matches 'Verdict: APPROVE'", () => {
+    expect(VERDICT_TERMINAL_LABEL.test("Verdict: APPROVE")).toBe(true);
+  });
+
+  test("matches 'Verdict: COMMENT'", () => {
+    expect(VERDICT_TERMINAL_LABEL.test("Verdict: COMMENT")).toBe(true);
+  });
+
+  test("matches case-insensitively", () => {
+    expect(VERDICT_TERMINAL_LABEL.test("verdict: approve")).toBe(true);
+    expect(VERDICT_TERMINAL_LABEL.test("VERDICT: COMMENT")).toBe(true);
+  });
+
+  test("matches with markdown bold markers around either word", () => {
+    expect(VERDICT_TERMINAL_LABEL.test("**Verdict**: **APPROVE**")).toBe(true);
+    expect(
+      VERDICT_TERMINAL_LABEL.test("verdict: **comment** — see notes"),
+    ).toBe(true);
+  });
+
+  test("matches a narrative label trailing reasoning on the same line", () => {
+    expect(
+      VERDICT_TERMINAL_LABEL.test(
+        "All 5 acceptance criteria met. Verdict: APPROVE (posted as COMMENT — GitHub disallows self-approval via the API).",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match a non-terminal verdict", () => {
+    expect(VERDICT_TERMINAL_LABEL.test("Verdict: CHANGES_REQUESTED")).toBe(
+      false,
+    );
+  });
+
+  test("does not match plain narrative text with no Verdict label", () => {
+    expect(VERDICT_TERMINAL_LABEL.test("Looks good, no blocking issues.")).toBe(
+      false,
+    );
   });
 });
 

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -309,3 +309,103 @@ describe("review.md — Step 5 unresolved-feedback skip marks reviewed-at-commit
     expect(unresolvedSection).toContain("issue-level PR comments");
   });
 });
+
+describe("review.md — Step 14 live-review pre-check (RVD-1.2)", () => {
+  let step14Section: string;
+
+  beforeAll(() => {
+    const step14Idx = content.indexOf(
+      "## Step 14: Resolve and Claim the Target PR",
+    );
+    const step14EndIdx = content.indexOf(
+      "## Review Quality Rules",
+      step14Idx,
+    );
+    expect(step14Idx).toBeGreaterThan(-1);
+    expect(step14EndIdx).toBeGreaterThan(step14Idx);
+    step14Section = content.slice(step14Idx, step14EndIdx);
+  });
+
+  it("Step 14 contains a Live-Review Pre-Check (RVD-1.2) heading", () => {
+    expect(step14Section).toContain("### Live-Review Pre-Check (RVD-1.2)");
+  });
+
+  it("the Live-Review Pre-Check heading appears before the Pre-Claim Fast Path heading", () => {
+    const preCheckIdx = content.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    expect(preCheckIdx).toBeGreaterThan(-1);
+    expect(fastPathIdx).toBeGreaterThan(-1);
+    expect(preCheckIdx).toBeLessThan(fastPathIdx);
+  });
+
+  it("the Live-Review Pre-Check section appears before the task-store record fetch", () => {
+    const preCheckIdx = content.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const recordFetchIdx = content.indexOf(
+      "Fetch the PR record from the task store",
+    );
+    expect(preCheckIdx).toBeGreaterThan(-1);
+    expect(recordFetchIdx).toBeGreaterThan(-1);
+    expect(preCheckIdx).toBeLessThan(recordFetchIdx);
+  });
+
+  it("the section references VERDICT_TERMINAL_LABEL and check-helpers.ts by name", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    expect(preCheckIdx).toBeGreaterThan(-1);
+    expect(fastPathIdx).toBeGreaterThan(preCheckIdx);
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("VERDICT_TERMINAL_LABEL");
+    expect(section).toContain("check-helpers.ts");
+  });
+
+  it("the section documents no-claim / no-checkout / no-author-filtering behavior", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    expect(section.toLowerCase()).toContain("no claim");
+    expect(section.toLowerCase()).toContain("no checkout");
+    expect(section.toLowerCase()).toContain("no author filtering");
+  });
+
+  it("the section runs a gh api graphql query and checks reviews at headRefOid", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("gh api graphql -f query=");
+    expect(section).toContain("headRefOid");
+    expect(section).toContain("reviews(first: 50)");
+    expect(section).toContain("commit {");
+  });
+
+  it("the section prints a cross-task-store skip message and stops before checkout/claim", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("cross-task-store");
+    expect(section.toLowerCase()).toContain("stop");
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -13,6 +13,14 @@ claims are atomic, so two agents won't review the same commit simultaneously. Th
 narrative itself is still written locally to `state/reviews/PR_REVIEW_{pr}.md` and
 `state/reviews/pr_review_{pr}.json` for posting.
 
+Dedup is two-layered: the task-store-local atomic claim above prevents two agents *on the
+same task-store instance* from racing on the same commit, but it's blind to reviews posted
+by an agent running against a *different* task-store instance, or by a human running this
+command directly. Step 14's live-GitHub pre-check is the cross-task-store defense layer that
+closes that gap — it queries GitHub directly for a terminal review at the current head
+commit before any claim or checkout happens, independent of what the local task-store record
+says.
+
 > **Task store setup:** This command updates task status in the Shipwright task store after review. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
 
 ---
@@ -678,6 +686,59 @@ Arguments section for the required no-argument `[silent]` stop.
    ```
    Fall back to the current workspace repo if the command fails.
    **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
+
+### Live-Review Pre-Check (RVD-1.2)
+
+Run this **before** the Pre-Claim Fast Path below and before any task-store record fetch —
+and even when a pre-claim marker is present. A pre-claim marker only proves the
+orchestrator's own task-store instance had this PR queued; it says nothing about whether
+some OTHER reviewer (an agent running against a different task-store instance, or a human)
+already posted a terminal review at this exact head commit. This is the cross-task-store
+defense layer described at the top of this file — it catches the race window between
+candidate selection and dispatch, and the case of a human invoking this command directly
+with an explicit PR#, both of which the task-store-record dedup further down in Step 14
+can't see.
+
+Query GitHub directly for reviews at the current head commit:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "{org}", name: "{repo}") {
+    pullRequest(number: {pr}) {
+      headRefOid
+      reviews(first: 50) {
+        nodes {
+          body
+          commit {
+            oid
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest as $pr | [$pr.reviews.nodes[] | select(.commit.oid == $pr.headRefOid) | .body] | any(test("verdict\\**\\s*:\\s*\\**(approve|comment)\\b"; "i"))'
+```
+
+This filters reviews down to only those submitted at the current `headRefOid`, then tests
+whether ANY of their bodies matches a terminal verdict label. The jq program outputs `true`
+or `false`.
+
+This bash regex mirrors `agent/src/check-helpers.ts`'s exported `VERDICT_TERMINAL_LABEL` —
+a literal `Verdict:` label match rather than the fuller thread/finding-body analysis
+`classifyReviewState()` does. That's acceptable here because review.md's own postings (Step
+10) always carry an explicit `Verdict: APPROVE` or `Verdict: COMMENT` line, so a literal
+label match is sufficient to detect "already reviewed, terminal" at this commit. There is
+no author filtering — a review from any identity counts, not just self-authored ones.
+
+**If the jq output is `true`** (a terminal review already exists at head on GitHub): print
+```
+Skipping #{pr} — a review already exists at this commit ({headRefOid[0..7]}) on GitHub (cross-task-store check), nothing to do.
+```
+Stop. No claim, no checkout (no worktree checkout happens).
+
+**If the jq output is `false`**: continue to the Pre-Claim Fast Path subsection immediately
+below, unchanged.
 
 ### Pre-Claim Fast Path (CBD-1.4)
 

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -702,7 +702,7 @@ can't see.
 Query GitHub directly for reviews at the current head commit:
 
 ```bash
-gh api graphql -f query='
+precheck=$(gh api graphql -f query='
 {
   repository(owner: "{org}", name: "{repo}") {
     pullRequest(number: {pr}) {
@@ -717,12 +717,15 @@ gh api graphql -f query='
       }
     }
   }
-}' --jq '.data.repository.pullRequest as $pr | [$pr.reviews.nodes[] | select(.commit.oid == $pr.headRefOid) | .body] | any(test("verdict\\**\\s*:\\s*\\**(approve|comment)\\b"; "i"))'
+}' --jq '.data.repository.pullRequest as $pr | {headRefOid: $pr.headRefOid, terminal: ([$pr.reviews.nodes[] | select(.commit.oid == $pr.headRefOid) | .body] | any(test("verdict\\**\\s*:\\s*\\**(approve|comment)\\b"; "i")))}')
+headRefOid=$(echo "$precheck" | jq -r '.headRefOid')
+terminal=$(echo "$precheck" | jq -r '.terminal')
 ```
 
 This filters reviews down to only those submitted at the current `headRefOid`, then tests
-whether ANY of their bodies matches a terminal verdict label. The jq program outputs `true`
-or `false`.
+whether ANY of their bodies matches a terminal verdict label. The jq program outputs a JSON
+object with the `headRefOid` string and a `terminal` boolean, captured into shell variables
+of the same names.
 
 This bash regex mirrors `agent/src/check-helpers.ts`'s exported `VERDICT_TERMINAL_LABEL` —
 a literal `Verdict:` label match rather than the fuller thread/finding-body analysis
@@ -731,13 +734,13 @@ a literal `Verdict:` label match rather than the fuller thread/finding-body anal
 label match is sufficient to detect "already reviewed, terminal" at this commit. There is
 no author filtering — a review from any identity counts, not just self-authored ones.
 
-**If the jq output is `true`** (a terminal review already exists at head on GitHub): print
+**If `$terminal` is `true`** (a terminal review already exists at head on GitHub): print
 ```
-Skipping #{pr} — a review already exists at this commit ({headRefOid[0..7]}) on GitHub (cross-task-store check), nothing to do.
+Skipping #{pr} — a review already exists at this commit (${headRefOid:0:7}) on GitHub (cross-task-store check), nothing to do.
 ```
 Stop. No claim, no checkout (no worktree checkout happens).
 
-**If the jq output is `false`**: continue to the Pre-Claim Fast Path subsection immediately
+**If `$terminal` is `false`**: continue to the Pre-Claim Fast Path subsection immediately
 below, unchanged.
 
 ### Pre-Claim Fast Path (CBD-1.4)

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -170,3 +170,45 @@ describe("review.md — RPF-1.4 verify review post before complete", () => {
     );
   });
 });
+
+describe("review.md — RVD-1.2 live-review pre-check regex parity", () => {
+  const CHECK_HELPERS_PATH = join(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "agent",
+    "src",
+    "check-helpers.ts",
+  );
+
+  it("bash jq regex in Step 14's Live-Review Pre-Check matches check-helpers.ts's VERDICT_TERMINAL_LABEL", () => {
+    const checkHelpersSource = readFileSync(CHECK_HELPERS_PATH, "utf-8");
+
+    const tsMatch = checkHelpersSource.match(
+      /export const VERDICT_TERMINAL_LABEL =\s*\/(.*)\/i;/,
+    );
+    expect(tsMatch).not.toBeNull();
+    const tsPattern = tsMatch?.[1] ?? "";
+    expect(tsPattern.length).toBeGreaterThan(0);
+
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    expect(preCheckIdx).toBeGreaterThan(-1);
+    expect(fastPathIdx).toBeGreaterThan(preCheckIdx);
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    const jqMatch = section.match(/test\("([^"]+)";\s*"i"\)/);
+    expect(jqMatch).not.toBeNull();
+    const jqPattern = jqMatch?.[1] ?? "";
+    expect(jqPattern.length).toBeGreaterThan(0);
+
+    // The jq pattern lives inside a single-quoted bash heredoc string, so a
+    // literal backslash must be doubled (`\\`) to survive jq's own string
+    // parsing. Normalize that back down to a single backslash to compare
+    // against the TS regex literal's source text.
+    const normalizedJqPattern = jqPattern.replace(/\\\\/g, "\\");
+
+    expect(normalizedJqPattern).toBe(tsPattern);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a live-GitHub review pre-check to `review.md` Step 14, running before the pre-claim marker check and task-store record fetch — the cross-task-store defense layer that catches reviews posted by an agent on a different task-store instance, or by a human invoking `/shipwright:review` directly, neither of which the task-store-local dedup can see.
- Adds `VERDICT_TERMINAL_LABEL` to `agent/src/check-helpers.ts` as the canonical TS-side pattern the new bash/jq check mirrors, with a content test asserting the two stay in sync.
- Updates the command's top-of-file dedup description to describe the two-layer model (task-store-local atomic claim + this cross-task-store defense layer).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 14 gains the live-review pre-check before any task-store or worktree operation, matching the described skip behavior (no claim, no checkout) | MET |
| 2 | Bash regex mirrors check-helpers.ts's canonical verdict pattern; content test asserts parity | MET |
| 3 | No author filtering — a review from any identity counts | MET |
| 4 | Top-of-file dedup description updated to describe the cross-task-store defense layer | MET |
| 5 | New tests in review.content.test.ts (ordering) and review.unit.test.ts (regex parity); no existing tests removed | MET |

## Test Plan
- `cd agent && bun test src/check-helpers.unit.test.ts` — 128 pass (7 new, covering VERDICT_TERMINAL_LABEL)
- `cd plugins/shipwright && bun test commands/review.unit.test.ts commands/review.content.test.ts` — 54 pass (7 new)
- `tsc --noEmit` clean in both `agent/` and `plugins/shipwright/`
- `bunx biome lint`/`format` clean on all touched files
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
