### PR TITLE
fix: route agent-config plugin fetch through AgentPluginService

### DIFF
--- a/admin/src/admin-spec.smoke.test.ts
+++ b/admin/src/admin-spec.smoke.test.ts
@@ -37,13 +37,11 @@ function buildSpecApp() {
         return null;
       },
     },
-    prisma: {
-      agentPlugin: {
-        async findMany() {
-          return [];
-        },
+    agentPluginService: {
+      async listEnabled() {
+        return [];
       },
-    } as never,
+    },
     adminApiKeys: parseAdminApiKeys(`admin:${ADMIN_API_KEY}:*`),
     agentTokenService: { validate: async () => null },
     sessionSecret: SESSION_SECRET,

--- a/admin/src/agent-plugins.ts
+++ b/admin/src/agent-plugins.ts
@@ -29,6 +29,17 @@ export class AgentPluginService {
   }
 
   /**
+   * List enabled plugins for a given agent, ordered by createdAt.
+   * Filters `enabled: true` server-side.
+   */
+  async listEnabled(agentId: string): Promise<AgentPlugin[]> {
+    return this.prisma.agentPlugin.findMany({
+      where: { agentId, enabled: true },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
    * Add a plugin for the given agent.
    * Uses upsert so re-adding an existing plugin updates its version and re-enables it.
    */

--- a/admin/src/agent-plugins.unit.test.ts
+++ b/admin/src/agent-plugins.unit.test.ts
@@ -1,0 +1,43 @@
+/**
+ * agent/src/agent-plugins.unit.test.ts
+ * Unit tests for AgentPluginService.listEnabled — pure logic over an injected
+ * Prisma double, no real DB.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import type { PrismaClient } from "../prisma/client/index.js";
+import { AgentPluginService } from "./agent-plugins.ts";
+
+describe("AgentPluginService.listEnabled", () => {
+  it("filters by enabled: true server-side", async () => {
+    const findMany = mock(async () => []);
+    const prisma = { agentPlugin: { findMany } } as unknown as PrismaClient;
+    const service = new AgentPluginService(prisma);
+
+    await service.listEnabled("agent-1");
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { agentId: "agent-1", enabled: true },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("returns only the enabled plugins the query resolves", async () => {
+    const enabledPlugin = {
+      id: "p1",
+      agentId: "agent-1",
+      name: "shipwright@shipwright",
+      version: null,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const findMany = mock(async () => [enabledPlugin]);
+    const prisma = { agentPlugin: { findMany } } as unknown as PrismaClient;
+    const service = new AgentPluginService(prisma);
+
+    const result = await service.listEnabled("agent-1");
+
+    expect(result).toEqual([enabledPlugin]);
+  });
+});

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -103,23 +103,12 @@ function makeMockAgentService(agents: Map<string, MockAgent>): {
   };
 }
 
-function makeMockPrisma(plugins: Map<string, MockPlugin[]>): {
-  agentPlugin: {
-    findMany: (args: {
-      where: { agentId: string; enabled: boolean };
-    }) => Promise<MockPlugin[]>;
-  };
+function makeMockAgentPluginService(plugins: Map<string, MockPlugin[]>): {
+  listEnabled: (agentId: string) => Promise<MockPlugin[]>;
 } {
   return {
-    agentPlugin: {
-      async findMany({
-        where,
-      }: {
-        where: { agentId: string; enabled: boolean };
-      }): Promise<MockPlugin[]> {
-        const all = plugins.get(where.agentId) ?? [];
-        return all.filter((p) => p.enabled === where.enabled);
-      },
+    async listEnabled(agentId: string): Promise<MockPlugin[]> {
+      return (plugins.get(agentId) ?? []).filter((p) => p.enabled);
     },
   };
 }
@@ -213,7 +202,7 @@ function buildApp(opts?: {
     agentEnvService: makeMockAgentEnvService(bundles),
     agentCronJobService: makeMockAgentCronJobService(cronMap),
     agentService: makeMockAgentService(agents),
-    prisma: makeMockPrisma(pluginMap) as never,
+    agentPluginService: makeMockAgentPluginService(pluginMap),
     adminApiKeys: parseAdminApiKeys(`admin:${VALID_ADMIN_KEY}:*`),
     agentTokenService: { validate: async () => null },
     sessionSecret: SESSION_SECRET,
@@ -448,13 +437,11 @@ function buildCombinedApp() {
         return { id: COMBINED_AGENT_ID, repos: [], authorAllowlist: [] };
       },
     },
-    prisma: {
-      agentPlugin: {
-        async findMany() {
-          return [];
-        },
+    agentPluginService: {
+      async listEnabled() {
+        return [];
       },
-    } as never,
+    },
     adminApiKeys: parseAdminApiKeys(`admin:${COMBINED_ADMIN_KEY}:*`),
     agentTokenService: { validate: async () => null },
     sessionSecret: COMBINED_SESSION_SECRET,

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -73,19 +73,15 @@ interface AgentServiceLike {
   ): Promise<{ id: string; repos: string[]; authorAllowlist: string[] } | null>;
 }
 
-interface PrismaLike {
-  agentPlugin: {
-    findMany(args: {
-      where: { agentId: string; enabled: boolean };
-    }): Promise<Array<{ name: string }>>;
-  };
+interface AgentPluginServiceLike {
+  listEnabled(agentId: string): Promise<Array<{ name: string }>>;
 }
 
 export interface AgentRuntimeDeps {
   agentEnvService: AgentEnvServiceLike;
   agentCronJobService: AgentCronJobServiceLike;
   agentService: AgentServiceLike;
-  prisma: PrismaLike;
+  agentPluginService: AgentPluginServiceLike;
   /** Session secret for cookie auth (SHIPWRIGHT_SESSION_SECRET). */
   sessionSecret: string;
   /** Parsed SHIPWRIGHT_ADMIN_API_KEYS — optional; absent means env key auth is disabled. */
@@ -156,7 +152,12 @@ const getCronsRoute = createRoute({
  * Inject real services for production; inject mocks for tests.
  */
 export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
-  const { agentEnvService, agentCronJobService, agentService, prisma } = deps;
+  const {
+    agentEnvService,
+    agentCronJobService,
+    agentService,
+    agentPluginService,
+  } = deps;
 
   const app = new OpenAPIHono();
 
@@ -185,7 +186,7 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     // Fetch env bundle and plugins in parallel
     const [bundle, plugins] = await Promise.all([
       agentEnvService.getConfigBundle(id),
-      prisma.agentPlugin.findMany({ where: { agentId: id, enabled: true } }),
+      agentPluginService.listEnabled(id),
     ]);
 
     const response: AgentConfigResponse = {

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -423,7 +423,7 @@ async function startServer(): Promise<void> {
     agentEnvService,
     agentCronJobService,
     agentService,
-    prisma: prisma as never,
+    agentPluginService,
     sessionSecret,
     adminApiKeys,
     agentTokenService,

--- a/admin/src/server.smoke.test.ts
+++ b/admin/src/server.smoke.test.ts
@@ -57,7 +57,7 @@ function buildComposedApp() {
       listWithRunSummary: notImplemented,
     },
     agentService: { getById: notImplemented },
-    prisma: stubPrisma,
+    agentPluginService: { listEnabled: notImplemented },
     sessionSecret: SESSION_SECRET,
     agentTokenService: stubAgentTokenService,
   });

--- a/scripts/generate-admin-spec.ts
+++ b/scripts/generate-admin-spec.ts
@@ -36,18 +36,11 @@ const runtimeApp = createAgentRuntimeApp({
       return [];
     },
   },
-  prisma: {
-    agent: {
-      async findUnique() {
-        return null;
-      },
+  agentPluginService: {
+    async listEnabled() {
+      return [];
     },
-    agentPlugin: {
-      async findMany() {
-        return [];
-      },
-    },
-  } as never,
+  },
   adminApiKeys,
   agentTokenService: { validate: async () => null },
   sessionSecret: SESSION_SECRET,


### PR DESCRIPTION
## Summary
- Entropy patrol finding (`entropy-architecture_layering-shipwright-2026-W31`): `GET /:id/config`'s handler called `prisma.agentPlugin.findMany(...)` directly instead of routing through `AgentPluginService`, bypassing the service-layer boundary used by the rest of the codebase.
- Added `AgentPluginService.listEnabled(agentId)` and routed the handler through it; dropped `prisma` from `AgentRuntimeDeps` entirely since it had no other consumer.
- Updated the smoke-test mocks and `scripts/generate-admin-spec.ts` to stub `agentPluginService.listEnabled` instead of `prisma`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `AgentPluginService.listEnabled` added, covered by unit test | MET |
| 2 | `admin/src/api.ts` no longer references `prisma`/`PrismaLike` | MET |
| 3 | `admin/src/main.ts` wiring passes `agentPluginService` | MET |
| 4 | Existing smoke tests updated and passing, no response-shape change | MET |

## Test Plan
- [x] New unit test for `AgentPluginService.listEnabled` (`admin/src/agent-plugins.unit.test.ts`)
- [x] `bun test admin/src/agent-plugins.unit.test.ts admin/src/api.smoke.test.ts admin/src/server.smoke.test.ts admin/src/admin-spec.smoke.test.ts` — 26 pass
- [x] Full `admin` suite: 1490 pass, 0 fail
- [x] `bun run --filter='*' --sequential typecheck` — all workspaces pass
- [x] `admin/openapi.json` output confirmed byte-identical after the `generate-admin-spec.ts` mock update

Generated with [Claude Code](https://claude.com/claude-code)
