### PR TITLE
feat: export task-store-types from @shipwright/lib

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -13,6 +13,7 @@
     "./request-context": "./request-context.ts",
     "./secret-env-vars": "./secret-env-vars.ts",
     "./sentry": "./sentry.ts",
+    "./task-store-types": "./task-store-types.ts",
     "./web/*": "./web/*"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds a `"./task-store-types"` entry to `lib/package.json`'s exports map, mirroring the existing `"./admin-types"` entry, so other workspaces can import the generated OpenAPI types via `@shipwright/lib/task-store-types`.
- `lib/task-store-types.ts` was already generated and committed via `generate:task-store-types` but was never wired into the package's export surface — this closes that gap.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `lib/package.json` exports includes `"./task-store-types": "./task-store-types.ts"` | MET |
| 2 | `task typecheck` passes across the lib workspace (no consumers yet, no behavior change) | MET |
| 3 | No test changes needed — package-manifest-only change; `lib/task-store-types.unit.test.ts` unaffected | MET |

## Test Plan
- [x] `NODE_ENV=test bun test lib/task-store-types.unit.test.ts` — 3/3 pass
- [x] `bun run --filter='*' --sequential typecheck` — all workspaces pass
- [x] `task ci` run locally — 2 unrelated pre-existing failures in `agent/src/claude.unit.test.ts` reproduce identically on main and are driven by this sandbox's `ANTHROPIC_FALLBACK_MODEL` env var, unrelated to this change

Generated with [Claude Code](https://claude.com/claude-code)
