### PR TITLE
fix: raise dedup query limit and add pagination guard to fix-skill dedup checks

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -52,12 +52,26 @@ Query params:
 | `pr` | number | Filter by PR number |
 | `branch` | string | Filter by branch name |
 | `hitl` | `true` or `false` | Filter by HITL (human-in-the-loop) flag: return tasks with or without the flag set |
-| `limit` | number | Page size |
-| `offset` | number | Page offset |
+| `limit` | number | Page size. Defaults to `50` when omitted. |
+| `offset` | number | Page offset. Defaults to `0` when omitted. |
 | `sort` | string | `asc` (default) or `desc` — orders results by `createdAt`. Default preserves existing ascending order for all callers. |
 | `updatedSince` | string | ISO timestamp. Only return tasks with `updatedAt >= this value`. A conservative pre-filter (not a precise sync anchor). Omitting it preserves current (unfiltered) behavior. |
 
-Returns `{ tasks: Task[], total: number }`.
+Returns `{ tasks: Task[], total: number, limit: number, offset: number }`. `total` is the
+count of *all* tasks matching the filters, independent of `limit`/`offset` — compare it
+against `tasks.length` to detect truncation. A caller that queries without an explicit
+`&limit=` and gets back 50 tasks with `total: 137` has only seen the first page; re-issue the
+query with `&limit=` raised (or page via `&offset=`, accumulating pages until the summed
+`tasks.length >= total`) rather than treating the 50-task response as the full result set.
+This matters most for any dedup-style check (e.g. `entropy-fix`/`error-fix`/`test-fix`/
+`consolidation-fix`'s "Dedup Check" steps) that queries `?status=pending`/`?status=in_progress`
+before filing new tasks — an unbounded default-limit query on a repo with more than 50 active
+tasks will silently miss the tail of the list.
+
+`?ready=true` (or `?state=ready`) and `?state=blocked` are unpaginated convenience endpoints —
+they compute over the entire task graph (dependency resolution needs every task, not a
+`limit`/`offset` slice) and always return every matching task in one response. Their `total`
+is simply `tasks.length`; `limit`/`offset` query params have no effect on these two branches.
 
 Agent tokens with a repo scope return tasks where `assignee === agentId` OR `repo` is in the agent's scope (pool tasks). Agent tokens without a repo scope see only tasks where `assignee === agentId`.
 

--- a/plugins/shipwright/skills/consolidation-fix/SKILL.md
+++ b/plugins/shipwright/skills/consolidation-fix/SKILL.md
@@ -193,17 +193,29 @@ Derive `repo-slug` from it too: the last path segment, lowercased — e.g.
 `app-vitals/shipwright` → `shipwright`. This slug is used in task IDs throughout
 this skill (Step 6, Step 8) to keep IDs unique per repo.
 
-Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`):
+Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`). `GET /tasks`
+defaults to `limit=50` and truncates silently unless the caller raises it — pass an
+explicit high `limit=1000` on both queries:
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}&limit=1000" | jq .
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}&limit=1000" | jq .
 ```
 
 The `&repo=` filter scopes dedup to tasks for the repo currently being scanned —
 without it, a pattern active for one repo would incorrectly block or interfere with
 dedup for a different repo.
+
+**Pagination guard — do not silently proceed with a partial result set.** `limit=1000`
+covers the common case, but a repo can still have more than 1000 active tasks. After
+each call, check the response's `total` field against the number of tasks actually
+returned (`.tasks | length`): if `total <= tasks.length`, the page is complete. If
+`total > tasks.length`, the first `limit=1000` page did not cover every active task —
+re-run the same query with `&offset=1000` (then `&offset=2000`, and so on) and merge
+the `.tasks` arrays until `tasks.length` (summed across pages) `>= total`. Only treat
+the dedup query as complete once every page has been fetched this way; never build the
+"already active" set (below) from a page that fails this check.
 
 Parse both `.tasks` arrays. From the combined results, collect tasks where:
 - `source == "shipwright"`, OR

--- a/plugins/shipwright/skills/entropy-fix/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.content.test.ts
@@ -1,0 +1,59 @@
+/**
+ * entropy-fix content tests — pagination-safe dedup query (task-store
+ * /tasks pagination gap).
+ *
+ * Step 6q.1's dedup check queries `GET /tasks?status=pending&repo=...` and
+ * `status=in_progress&repo=...` unbounded. task-store's plain GET /tasks
+ * path defaults to `limit=50` and signals truncation via a `total` field
+ * (task-service.ts `list()`), but a consumer that doesn't raise the limit
+ * and check `total` against what it actually received silently undercounts
+ * once a repo has more than 50 active tasks — exactly the failure mode that
+ * let three already-queued tasks slip past dedup on 2026-07-23.
+ *
+ * These tests assert Step 6q.1 documents: an explicit high `limit=1000` on
+ * both dedup queries, and a guard that checks the response's `total` field
+ * against what was fetched and pages via `offset` if `total` is still not
+ * fully covered.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+
+function readSkill(): string {
+  return readFileSync(SKILL_MD_PATH, "utf8");
+}
+
+describe("entropy-fix — SKILL.md exists", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+});
+
+describe("entropy-fix — Step 6q.1 dedup query is pagination-safe", () => {
+  it("raises the dedup query limit well above the API's default page size", () => {
+    expect(readSkill()).toContain("limit=1000");
+  });
+
+  it("documents checking the response's total field against what was fetched", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("total");
+    expect(lower).toMatch(/check(ing)?.{0,40}total|total.{0,40}check/s);
+  });
+
+  it("documents paging via offset when total exceeds the fetched page", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("offset");
+    expect(lower).toContain("page");
+  });
+
+  it("does not silently proceed with a partial result set", () => {
+    const lower = readSkill().toLowerCase();
+    expect(
+      lower.includes("do not silently proceed") ||
+        lower.includes("never silently proceed") ||
+        lower.includes("without a partial"),
+    ).toBe(true);
+  });
+});

--- a/plugins/shipwright/skills/entropy-fix/SKILL.md
+++ b/plugins/shipwright/skills/entropy-fix/SKILL.md
@@ -148,16 +148,28 @@ Derive `repo-slug` from it too: the last path segment, lowercased — e.g. `app-
 → `shipwright`. This slug is used in task IDs throughout this skill (6q.3, 6q.6) to keep IDs
 unique per repo.
 
-Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`):
+Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`). `GET /tasks` defaults to
+`limit=50` and truncates silently unless the caller raises it — pass an explicit high
+`limit=1000` on both queries:
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}&limit=1000" | jq .
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}&limit=1000" | jq .
 ```
 
 The `&repo=` filter scopes dedup to tasks for the repo currently being scanned — without it, a
 rule active for one repo would incorrectly block or interfere with dedup for a different repo.
+
+**Pagination guard — do not silently proceed with a partial result set.** `limit=1000`
+covers the common case, but a repo can still have more than 1000 active tasks. After each
+call, check the response's `total` field against the number of tasks actually returned
+(`.tasks | length`): if `total <= tasks.length`, the page is complete. If `total >
+tasks.length`, the first `limit=1000` page did not cover every active task — re-run the same
+query with `&offset=1000` (then `&offset=2000`, and so on) and merge the `.tasks` arrays
+until `tasks.length` (summed across pages) `>= total`. Only treat the dedup query as complete
+once every page has been fetched this way; never build the "already active" set (below) from
+a page that fails this check.
 
 Parse both `.tasks` arrays. From the combined results, collect tasks where:
 - `source == "shipwright"`, OR

--- a/plugins/shipwright/skills/error-fix/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/error-fix/SKILL.content.test.ts
@@ -1,0 +1,61 @@
+/**
+ * error-fix content tests — pagination-safe dedup query (task-store /tasks
+ * pagination gap).
+ *
+ * Step 5's dedup check queries `GET /tasks?status=pending` and
+ * `status=in_progress` unbounded (repo-unscoped — error-fix dedups
+ * globally, not per-repo). task-store's plain GET /tasks path defaults to
+ * `limit=50` and signals truncation via a `total` field (task-service.ts
+ * `list()`), but a consumer that doesn't raise the limit and check `total`
+ * against what it actually received silently undercounts once the active
+ * task count exceeds 50 — exactly the failure mode that let three
+ * already-queued tasks slip past dedup on 2026-07-23 (test-fix's own
+ * dedup query, same shape).
+ *
+ * These tests assert Step 5 documents: an explicit high `limit=1000` on
+ * both dedup queries, and a guard that checks the response's `total` field
+ * against what was fetched and pages via `offset` if `total` is still not
+ * fully covered.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+
+function readSkill(): string {
+  return readFileSync(SKILL_MD_PATH, "utf8");
+}
+
+describe("error-fix — SKILL.md exists", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+});
+
+describe("error-fix — Step 5 dedup query is pagination-safe", () => {
+  it("raises the dedup query limit well above the API's default page size", () => {
+    expect(readSkill()).toContain("limit=1000");
+  });
+
+  it("documents checking the response's total field against what was fetched", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("total");
+    expect(lower).toMatch(/check(ing)?.{0,40}total|total.{0,40}check/s);
+  });
+
+  it("documents paging via offset when total exceeds the fetched page", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("offset");
+    expect(lower).toContain("page");
+  });
+
+  it("does not silently proceed with a partial result set", () => {
+    const lower = readSkill().toLowerCase();
+    expect(
+      lower.includes("do not silently proceed") ||
+        lower.includes("never silently proceed") ||
+        lower.includes("without a partial"),
+    ).toBe(true);
+  });
+});

--- a/plugins/shipwright/skills/error-fix/SKILL.md
+++ b/plugins/shipwright/skills/error-fix/SKILL.md
@@ -159,13 +159,24 @@ Stop after printing.
 
 Skip this step entirely if `--dry-run` was passed (handled in Step 4 instead).
 
-Run:
+Run. `GET /tasks` defaults to `limit=50` and truncates silently unless the caller raises it —
+pass an explicit high `limit=1000` on both queries:
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&limit=1000" | jq .
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&limit=1000" | jq .
 ```
+
+**Pagination guard — do not silently proceed with a partial result set.** `limit=1000`
+covers the common case, but the active-task count across all repos can still exceed 1000.
+After each call, check the response's `total` field against the number of tasks actually
+returned (`.tasks | length`): if `total <= tasks.length`, the page is complete. If `total >
+tasks.length`, the first `limit=1000` page did not cover every active task — re-run the same
+query with `&offset=1000` (then `&offset=2000`, and so on) and merge the `.tasks` arrays
+until `tasks.length` (summed across pages) `>= total`. Only treat the dedup query as complete
+once every page has been fetched this way; never build the "already active" set (below) from
+a page that fails this check.
 
 Parse both `.tasks` arrays. From the combined results, collect tasks where:
 - `source == "shipwright"`, OR

--- a/plugins/shipwright/skills/test-fix/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-fix/SKILL.content.test.ts
@@ -1,0 +1,59 @@
+/**
+ * test-fix content tests — pagination-safe dedup query (task-store /tasks
+ * pagination gap).
+ *
+ * Step 4's dedup check queries `GET /tasks?status=pending&repo=...` and
+ * `status=in_progress&repo=...` unbounded. task-store's plain GET /tasks
+ * path defaults to `limit=50` and signals truncation via a `total` field
+ * (task-service.ts `list()`), but a consumer that doesn't raise the limit
+ * and check `total` against what it actually received silently undercounts
+ * once a repo has more than 50 active tasks — exactly the failure mode that
+ * let three already-queued tasks slip past dedup on 2026-07-23.
+ *
+ * These tests assert Step 4 documents: an explicit high `limit=1000` on
+ * both dedup queries, and a guard that checks the response's `total` field
+ * against what was fetched and pages via `offset` if `total` is still not
+ * fully covered.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+
+function readSkill(): string {
+  return readFileSync(SKILL_MD_PATH, "utf8");
+}
+
+describe("test-fix — SKILL.md exists", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+});
+
+describe("test-fix — Step 4 dedup query is pagination-safe", () => {
+  it("raises the dedup query limit well above the API's default page size", () => {
+    expect(readSkill()).toContain("limit=1000");
+  });
+
+  it("documents checking the response's total field against what was fetched", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("total");
+    expect(lower).toMatch(/check(ing)?.{0,40}total|total.{0,40}check/s);
+  });
+
+  it("documents paging via offset when total exceeds the fetched page", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("offset");
+    expect(lower).toContain("page");
+  });
+
+  it("does not silently proceed with a partial result set", () => {
+    const lower = readSkill().toLowerCase();
+    expect(
+      lower.includes("do not silently proceed") ||
+        lower.includes("never silently proceed") ||
+        lower.includes("without a partial"),
+    ).toBe(true);
+  });
+});

--- a/plugins/shipwright/skills/test-fix/SKILL.md
+++ b/plugins/shipwright/skills/test-fix/SKILL.md
@@ -117,17 +117,29 @@ previously fixed for entropy-fix's task IDs.
 Skip this step entirely if `--dry-run` was passed (Step 6 handles the dry-run preview
 instead — no dedup query is made).
 
-Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`):
+Run (URL-encode the detected repo, e.g. `app-vitals%2Fshipwright`). `GET /tasks` defaults to
+`limit=50` and truncates silently unless the caller raises it — pass an explicit high
+`limit=1000` on both queries:
 ```bash
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=pending&repo={url-encoded-repo}&limit=1000" | jq .
 curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}" | jq '.tasks'
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?status=in_progress&repo={url-encoded-repo}&limit=1000" | jq .
 ```
 
 The `&repo=` filter scopes dedup to tasks for the repo currently being scanned — without it,
 a T-NNN active for one repo would incorrectly block or interfere with dedup for a different
 repo.
+
+**Pagination guard — do not silently proceed with a partial result set.** `limit=1000`
+covers the common case, but a repo can still have more than 1000 active tasks. After each
+call, check the response's `total` field against the number of tasks actually returned
+(`.tasks | length`): if `total <= tasks.length`, the page is complete. If `total >
+tasks.length`, the first `limit=1000` page did not cover every active task — re-run the same
+query with `&offset=1000` (then `&offset=2000`, and so on) and merge the `.tasks` arrays
+until `tasks.length` (summed across pages) `>= total`. Only treat the dedup query as complete
+once every page has been fetched this way; never build the "already active" set (below) from
+a page that fails this check.
 
 Parse both `.tasks` arrays. From the combined results, collect tasks where:
 - `source == "test-fix"`, AND

--- a/plugins/shipwright/test/consolidation-fix.content.test.ts
+++ b/plugins/shipwright/test/consolidation-fix.content.test.ts
@@ -109,6 +109,35 @@ describe("consolidation-fix — dedup mechanism mirrors entropy-fix", () => {
   });
 });
 
+// ── Dedup query is pagination-safe (task-store /tasks pagination gap) ──────
+
+describe("consolidation-fix — dedup query is pagination-safe", () => {
+  it("raises the dedup query limit well above the API's default page size", () => {
+    expect(readSkill()).toContain("limit=1000");
+  });
+
+  it("documents checking the response's total field against what was fetched", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("total");
+    expect(lower).toMatch(/check(ing)?.{0,40}total|total.{0,40}check/s);
+  });
+
+  it("documents paging via offset when total exceeds the fetched page", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("offset");
+    expect(lower).toContain("page");
+  });
+
+  it("does not silently proceed with a partial result set", () => {
+    const lower = readSkill().toLowerCase();
+    expect(
+      lower.includes("do not silently proceed") ||
+        lower.includes("never silently proceed") ||
+        lower.includes("without a partial"),
+    ).toBe(true);
+  });
+});
+
 // ── "Consolidation:" title prefix ────────────────────────────────────────────
 
 describe("consolidation-fix — queued task titles use a 'Consolidation:' prefix", () => {


### PR DESCRIPTION
## Summary
- Verified `GET /tasks`'s plain list path already returns `{ tasks, total, limit, offset }` (PR #670, pre-dates this bug) — acceptance criterion 1 was already satisfied at the API layer, so no API code changed; `docs/task-store.md` now documents that contract and how to detect truncation.
- The real gap was on the consumer side: `test-fix`, `entropy-fix`, `error-fix`, and `consolidation-fix`'s "Dedup Check" steps queried `GET /tasks?status=pending`/`status=in_progress` unbounded, with no `limit` and no check of `total` — silently undercounting once a repo's active-task count exceeded the API's default `limit=50`. This is exactly what let 3 already-queued tasks slip past dedup on 2026-07-23.
- Updated all four skills' dedup queries to pass `&limit=1000` and added a documented pagination guard: compare the response's `total` against `tasks.length`, and page via `&offset=` until every active task is collected — never build the dedup set from a partial page.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | GET /tasks either returns all results by default or clearly signals truncation via `total`/`hasMore` | MET | Already implemented in `task-store/src/task-service.ts` (`list()` returns `{tasks, total, limit, offset}`); now documented in `docs/task-store.md`. |
| 2 | Dedup-style consumers (test-fix/entropy-fix/error-fix/consolidation-fix) can detect truncation and page through | MET | All four `SKILL.md` dedup sections raise `limit` and document the `total`-vs-fetched pagination guard, backed by new/extended `*.content.test.ts` assertions. |

## Test Plan
- [x] New `SKILL.content.test.ts` added for `test-fix`, `entropy-fix`, `error-fix` (mirrors existing `security-scan/SKILL.content.test.ts` pattern) — TDD RED confirmed before the `SKILL.md` edits, GREEN after.
- [x] `consolidation-fix.content.test.ts`'s existing dedup-mechanism block extended with the same pagination-safe assertions.
- [x] `bun test plugins/shipwright/` — 1072 pass, 0 fail.
- [x] `task lint`, `task check-strings`, `task check-config-docs` — all clean.
- [ ] `task typecheck` / full `task ci` — not runnable in this sandbox (`tsc` binary absent, no local Postgres for task-store integration/smoke suite); confirmed as a pre-existing environment gap, not introduced by this change. This PR only touches Markdown and `bun:test`-only test files (no new TS types), so the risk is low — CI will run the full gate.

Generated with [Claude Code](https://claude.com/claude-code)
