### PR TITLE
feat: rewrite speed measurement policy to aggregate-first two-tier model

### DIFF
--- a/plugins/shipwright/assets/templates/test-migration.md.tmpl
+++ b/plugins/shipwright/assets/templates/test-migration.md.tmpl
@@ -78,13 +78,25 @@
 
 ## Speed measurement
 
-- **Measured:** {{SPEED_MEASURED}}  (yes/no)
-- **Current per-layer p95:**
-  - Unit: {{UNIT_P95}}
-  - Integration: {{INTEGRATION_P95}}
-  - Smoke: {{SMOKE_P95}}
-  - E2E: {{E2E_P95}}
-- **Tests over hard cap:** {{OVER_HARD_CAP_LIST}}
+### Tier 1 — aggregate (always measured)
+
+- **Aggregate wall-clock:** {{AGGREGATE_WALL_CLOCK}}  vs. <15 min Full PR pipeline budget
+- **Pass / fail / skip counts (from CI):** {{AGGREGATE_PASS_FAIL_SKIP}}
+
+### Tier 2 — per-layer breakdown (conditional)
+
+- **Tier 2 triggered:** {{TIER2_TRIGGERED}}  (yes/no — per speed-budgets' escalation formula)
+
+If yes:
+  - **Current per-layer p95:**
+    - Unit: {{UNIT_P95}}
+    - Integration: {{INTEGRATION_P95}}
+    - Smoke: {{SMOKE_P95}}
+    - E2E: {{E2E_P95}}
+  - **Tests over hard cap:** {{OVER_HARD_CAP_LIST}}
+
+If no: Tier 2 not triggered — suite is within the Tier 1 aggregate budget. Do not fabricate
+per-layer numbers.
 
 ## Next step
 

--- a/plugins/shipwright/assets/templates/test-readiness-plan.md.tmpl
+++ b/plugins/shipwright/assets/templates/test-readiness-plan.md.tmpl
@@ -26,7 +26,19 @@
 - **Target canary count (from inventory):** {{TARGET_CANARY_COUNT}}
 - **Gap:** {{CANARY_GAP}}
 
-### Speed status (current p95 per layer)
+### Speed status (Tier 1 aggregate vs. budget; per-layer p95 only if Tier 2 triggered)
+
+**Tier 1 — aggregate (always measured):**
+
+| Aggregate wall-clock | Budget | Ratio |
+|---|---|---|
+| {{AGGREGATE_WALL_CLOCK}} | <15 min (Full PR pipeline) | {{AGGREGATE_RATIO}} |
+
+**Tier 2 triggered:** {{TIER2_TRIGGERED}}  (yes/no — per speed-budgets' escalation formula)
+
+Populated only if Tier 2 triggered — otherwise, "Tier 2 not triggered — suite is within the
+Tier 1 aggregate budget" and the table below is omitted rather than filled with fabricated
+per-layer numbers.
 
 | Layer | Current p95 | Target p95 | Over hard cap? |
 |---|---|---|---|
@@ -56,6 +68,17 @@
 {{THE_GAP_NARRATIVE}}
 
 ### Speed delta
+
+**Tier 1 — aggregate-vs-budget (leads; always populated):**
+
+| Aggregate wall-clock | Budget | Ratio / time-to-close |
+|---|---|---|
+| {{AGGREGATE_WALL_CLOCK}} | <15 min (Full PR pipeline) | {{AGGREGATE_RATIO}} |
+
+**Tier 2 — per-layer ratio (conditional on Tier 2 having triggered — do not fabricate
+per-layer numbers when only the Tier 1 aggregate is available):**
+
+**Tier 2 triggered:** {{TIER2_TRIGGERED}}  (yes/no)
 
 | Layer | Current | Target | Ratio |
 |---|---|---|---|

--- a/plugins/shipwright/commands/test-roadmap.md
+++ b/plugins/shipwright/commands/test-roadmap.md
@@ -43,4 +43,4 @@ The output is intended to be handed to:
 ## Notes
 
 - Read-only. The synthesis step never modifies source or test files.
-- Includes a mandatory **speed delta** section — current per-layer p95 vs. target.
+- Includes a mandatory **speed delta** section — leads with the Tier 1 aggregate wall-clock vs. budget; per-layer p95 numbers are included only when Tier 2 was actually triggered.

--- a/plugins/shipwright/skills/speed-budgets/SKILL.md
+++ b/plugins/shipwright/skills/speed-budgets/SKILL.md
@@ -63,12 +63,52 @@ See `test-design/SKILL.md` Step 6 for the explicit threshold on when per-workspa
 
 - **`test-inventory`** does not measure speed (no tests exist for some items). It only assigns layer.
 - **`test-design`** copies the budget table into `test-system.md` and adds the parallelization plan.
-- **`test-migration`** measures existing tests against the table. Hard-cap violation → `rebuild`. Soft 95p violation → `promote`.
-- **`test-roadmap`** includes a mandatory **speed delta** section: current per-layer p95 vs. target.
+- **`test-migration`** measures existing tests against the table. Hard-cap violation → `rebuild`. Soft 95p violation → `promote`. Its Step 4a/4b split mirrors this skill's two-tier model.
+- **`test-roadmap`** includes a mandatory **speed delta** section: aggregate wall-clock vs. the <15 min budget (Tier 1), with per-layer p95 vs. target included only when Tier 2 was actually triggered.
 
 ## Measuring speed (for Phase 3)
 
-If actually running the suite is feasible, capture per-test timings via the test runner's reporter:
+### Two-tier measurement model
+
+Speed measurement is aggregate-first, not per-layer-first. An audit sandbox rarely has the
+live Postgres / service infrastructure a per-layer breakdown needs — but that infra gap is not
+itself a speed problem, and it must never be treated as one.
+
+- **Tier 1 — aggregate (default, always-on).** Pull the full-suite wall-clock, pass/fail/skip
+  counts, and file/test counts from the most recent green CI run of the `lint / typecheck /
+  test` job — the job that runs with real Postgres via `task test:coverage`. This is always
+  obtainable: it requires only `gh` CLI access to the repo's Actions history, not local
+  service infra. Tier 1 alone is a complete, valid measurement.
+- **Tier 2 — per-layer breakdown (conditional).** Only performed when the escalation formula
+  below trips. Captures per-test timings and aggregates them to per-layer count, 95p, and
+  suite wall-time.
+
+**Escalation formula (Tier 1 → Tier 2):** if the aggregate wall-clock exceeds 50% of the <15
+min Full-PR-pipeline budget (i.e. >7.5 min), sustained across 2 consecutive measurements,
+escalate to Tier 2. A single over-50% reading is not enough — it must repeat on the next
+measurement before the per-layer breakdown is warranted. Below that threshold, Tier 1 is the
+complete and sufficient answer; do not manufacture Tier 2 work for a suite that's comfortably
+in budget.
+
+### Tier 1 — pull the CI aggregate
+
+Pull the most recent green run of the `lint / typecheck / test` job:
+
+```bash
+gh run list --workflow=<ci-workflow> --status=success --limit=1
+gh run view <run-id> --log
+```
+
+Record: total tests, total files, wall-clock duration, skip count, fail count (should be 0 on
+a green run). Compare the wall-clock against the <15 min Full PR pipeline budget from the
+table above — that comparison alone answers "are we converging" for the vast majority of
+repos, with no local Postgres or per-layer infra required.
+
+### Tier 2 — per-layer breakdown (only when escalation formula trips)
+
+Only run this tier if Tier 1's aggregate wall-clock triggered the escalation formula above. If
+actually running the suite locally is feasible, capture per-test timings via the test runner's
+reporter:
 
 - Vitest / Jest: `--reporter=json` or `--reporter=verbose`
 - bun test: built-in timing output
@@ -80,7 +120,7 @@ Aggregate to:
 - Per-layer suite wall-time
 - Top N slowest tests in each layer
 
-These numbers populate the speed-delta section in Phase 4.
+These numbers populate the speed-delta section in Phase 4, alongside the Tier 1 aggregate.
 
 ## Ongoing CI enforcement
 

--- a/plugins/shipwright/skills/test-migration/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-migration/SKILL.content.test.ts
@@ -46,11 +46,28 @@ describe("SKILL.md — Failure modes: measurement-only items carried forward acr
     expect(hasCarryoverBullet).toBe(true);
   });
 
-  it("references a threshold of 3 or more consecutive cycles", () => {
-    const hasThreshold = /\b3\b[^.]*consecutive|\bconsecutive\b[^.]*\b3\b/i.test(
-      content,
-    );
-    expect(hasThreshold).toBe(true);
+  it("gates mandatory M1 escalation on an actual Tier-1 budget breach, not a bare cycle count", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    expect(failureModesIdx).toBeGreaterThan(-1);
+    const section = content.slice(failureModesIdx);
+    const hasTier1BreachGate =
+      /Tier[\s-]?1/i.test(section) && /budget breach/i.test(section);
+    expect(hasTier1BreachGate).toBe(true);
+  });
+
+  it("references speed-budgets' escalation formula rather than a bare cycle-count threshold", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    const section = content.slice(failureModesIdx);
+    expect(section).toContain("speed-budgets");
+    expect(section).toMatch(/escalation formula/i);
+  });
+
+  it("does not gate mandatory M1 escalation on persistence across cycles alone", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    const section = content.slice(failureModesIdx);
+    const hasBareCycleCountGate =
+      /\b3\b[^.]*consecutive|\bconsecutive\b[^.]*\b3\b/i.test(section);
+    expect(hasBareCycleCountGate).toBe(false);
   });
 
   it("requires test-roadmap to place the item as the first/mandatory M1 task by construction", () => {

--- a/plugins/shipwright/skills/test-migration/SKILL.md
+++ b/plugins/shipwright/skills/test-migration/SKILL.md
@@ -93,9 +93,32 @@ For each existing test, read enough to determine:
 3. **Whether it matches its claimed layer** — a `.test.ts` next to a route handler that spins up a DB connection is doing integration work even if filed as unit
 4. **Whether it's the canonical owner of that functionality** — search for other tests that exercise the same property
 
-### Step 4 — measure speed (optional but recommended)
+### Step 4 — measure speed
 
-If the user opted in (or it's cheap to do so), actually run the test suite once and capture per-test timings. A unit test taking 3 seconds is doing integration work. Speed is a strong layer-mismatch signal — flag for rebuild.
+Speed measurement is aggregate-first, split into an always-on aggregate pull and a
+conditional per-layer breakdown. This mirrors `speed-budgets/SKILL.md`'s two-tier model —
+treat that skill's escalation formula as canonical.
+
+#### Step 4a — pull the aggregate (always)
+
+Pull the aggregate wall-clock and pass/fail/skip counts from the most recent green CI run of
+the `lint / typecheck / test` job, via `gh run list` / `gh run view --log`. No local Postgres
+or per-layer infra is needed for this step — it's always obtainable from CI history alone.
+Compare the aggregate wall-clock against speed-budgets' <15 min Full PR pipeline budget. This
+step is mandatory and runs on every `/test-migration` invocation.
+
+#### Step 4b — per-layer breakdown (conditional)
+
+Only run this step if Step 4a's aggregate wall-clock trips the Tier 2 escalation trigger
+defined in `speed-budgets/SKILL.md` (aggregate exceeds 50% of the <15 min budget, sustained
+across 2 consecutive measurements). When triggered, actually run the suite and capture
+per-test timings via the runner's reporter; a unit test taking 3 seconds is doing integration
+work — speed is a strong layer-mismatch signal, flag for rebuild.
+
+A suite that's comfortably in budget after Step 4a alone is a valid, complete outcome for this
+step — do not treat the absence of local per-layer infra (e.g. no Postgres in the sandbox) as
+a gap requiring escalation. The infra gap is not a speed problem unless Step 4a's aggregate
+actually breaches the Tier 2 trigger.
 
 ### Step 5 — assign buckets
 
@@ -142,4 +165,4 @@ Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-migration.md.tmpl`. Write to `
 - **Don't mark "passes locally" as reuse-grade.** It must pass locally AND assert behavior AND be at the canonical layer AND meet speed budget.
 - **Don't accept "we already have an E2E for that" as canary coverage.** Canary requires read-only or self-cleaning; most E2E tests are not.
 - **Don't skip the risk callout on `delete` verdicts.** A test currently flagged green being recommended for deletion is the single most reviewable judgment call in the report.
-- **Don't let a carried-forward measurement-only item hide behind a clean file-bucketing pass.** A repo can reach a "clean" steady state — zero rebuild/delete/net-new test files — for several consecutive `/test-migration` runs while a real, load-bearing measurement-only item (not a test file — e.g. a per-layer speed measurement) stays unaddressed, because it depends on infrastructure the audit sandbox itself doesn't have (live DB/service access). Track any measurement-only item across cycles; if it has been carried forward unactioned across 3 or more consecutive cycles, it must be surfaced explicitly in this artifact so `/test-roadmap` can act on it. Do not rely on the roadmap author noticing the streak in prose — when the threshold is hit, `/test-roadmap` must place the item as the first Milestone 1 (M1) task by construction, the same way the naming-convention task is guaranteed a Milestone 1 slot.
+- **Don't let a carried-forward measurement-only item hide behind a clean file-bucketing pass.** A repo can reach a "clean" steady state — zero rebuild/delete/net-new test files — for several consecutive `/test-migration` runs while a real, load-bearing measurement-only item (not a test file — e.g. a per-layer speed measurement gated behind Step 4b) stays carried forward unactioned, typically because Step 4a's aggregate has never actually breached speed-budgets' escalation formula and so Step 4b's per-layer infra (live DB/service access) was never exercised. That is not, by itself, a gap requiring escalation — Tier 2 infra being unavailable on a suite that's otherwise in budget is an expected, valid state, not a finding. Track any measurement-only item across cycles, but gate the mandatory-M1 trigger on an actual **Tier 1 budget breach**: only when Step 4a's aggregate has tripped speed-budgets' escalation formula (aggregate exceeds 50% of the <15 min budget, sustained across 2 consecutive measurements) AND the resulting Tier 2 item remains carried forward unactioned does it need to be surfaced explicitly in this artifact so `/test-roadmap` can act on it. Do not rely on the roadmap author noticing the streak in prose — when the Tier 1 budget breach gate is hit, `/test-roadmap` must place the item as the first Milestone 1 (M1) task by construction, the same way the naming-convention task is guaranteed a Milestone 1 slot.

--- a/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
@@ -75,3 +75,64 @@ describe("SKILL.md — E2E classification guardrail", () => {
     expect(hasNote).toBe(true);
   });
 });
+
+describe("SKILL.md — Speed delta leads with the aggregate-vs-budget number", () => {
+  it("has a Speed delta bullet in section 3 (The gap)", () => {
+    expect(content).toMatch(/\*\*Speed delta\*\*/);
+  });
+
+  it("leads with aggregate-vs-budget rather than per-layer p95 alone", () => {
+    const speedDeltaIdx = content.indexOf("**Speed delta**");
+    expect(speedDeltaIdx).toBeGreaterThan(-1);
+    const bulletEnd = content.indexOf("\n", speedDeltaIdx + 400);
+    const bullet = content.slice(
+      speedDeltaIdx,
+      bulletEnd === -1 ? content.length : bulletEnd,
+    );
+    expect(bullet).toMatch(/aggregate/i);
+    expect(bullet).toMatch(/budget/i);
+  });
+
+  it("includes per-layer p95 only when Tier 2 was actually triggered", () => {
+    const speedDeltaIdx = content.indexOf("**Speed delta**");
+    const bulletEnd = content.indexOf("\n\n", speedDeltaIdx);
+    const bullet = content.slice(
+      speedDeltaIdx,
+      bulletEnd === -1 ? content.length : bulletEnd,
+    );
+    expect(bullet).toMatch(/Tier 2|Tier-2/);
+    expect(bullet).toMatch(/triggered/i);
+  });
+});
+
+describe("SKILL.md — Mandatory M1 task rescoped to the Tier-1-breach gate", () => {
+  it("has a Mandatory M1 task bullet about carried-forward measurement-only items", () => {
+    const hasBullet =
+      /Mandatory M1 task/i.test(content) &&
+      /carried forward/i.test(content) &&
+      /measurement-only/i.test(content);
+    expect(hasBullet).toBe(true);
+  });
+
+  it("gates the mandatory M1 escalation on an actual Tier-1 budget breach via speed-budgets' escalation formula", () => {
+    const bulletIdx = content.indexOf(
+      "Mandatory M1 task — carried-forward measurement-only items",
+    );
+    expect(bulletIdx).toBeGreaterThan(-1);
+    const section = content.slice(bulletIdx, bulletIdx + 800);
+    expect(section).toMatch(/Tier[\s-]?1/i);
+    expect(section).toMatch(/budget breach/i);
+    expect(section).toContain("speed-budgets");
+    expect(section).toMatch(/escalation formula/i);
+  });
+
+  it("does not gate mandatory M1 escalation on a bare 3-or-more-cycles count", () => {
+    const bulletIdx = content.indexOf(
+      "Mandatory M1 task — carried-forward measurement-only items",
+    );
+    const section = content.slice(bulletIdx, bulletIdx + 800);
+    const hasBareCycleCountGate =
+      /\b3\b[^.]*consecutive|\bconsecutive\b[^.]*\b3\b/i.test(section);
+    expect(hasBareCycleCountGate).toBe(false);
+  });
+});

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -47,7 +47,12 @@ The concrete diff between sections 1 and 2:
 - Wrong-layer tests (count and severity)
 - External-only deps with no local substitute (blockers)
 - Canary suite size vs. target
-- **Speed delta** — current per-layer p95 vs. target, expressed as ratio or time-to-close
+- **Speed delta** — leads with the aggregate-vs-budget number: the Tier 1 aggregate wall-clock
+  pulled in test-migration Step 4a vs. the <15 min Full PR pipeline budget from
+  `speed-budgets/SKILL.md`, expressed as ratio or time-to-close. Per-layer p95 numbers are
+  included only when Tier 2 was actually triggered by a prior `/test-migration` pass (i.e. the
+  aggregate breached speed-budgets' escalation formula and a per-layer breakdown exists) — do
+  not fabricate per-layer numbers when only the Tier 1 aggregate is available.
 
 ### 4. Roadmap — five milestones
 
@@ -73,7 +78,7 @@ This task covers:
    - **bun test `--filter`** — use path-based filters that respect the naming convention
 3. **Verification** — run each entry point in isolation and confirm it picks up only its layer's files (e.g., `bun test --filter integration` finds zero unit files).
 
-**Mandatory M1 task — carried-forward measurement-only items:** if Phase 3's `test-migration.md` flags a measurement-only item (not a test file) as carried forward unactioned across 3 or more consecutive cycles, Milestone 1 must include it as the first task, by construction — do not rely on noticing the streak in prose when assembling the task list.
+**Mandatory M1 task — carried-forward measurement-only items:** if Phase 3's `test-migration.md` flags a measurement-only item (not a test file) as carried forward unactioned, gate the mandatory-M1 trigger on the same Tier-1-breach gate `test-migration/SKILL.md` uses — a Tier 1 budget breach, not a bare cycle count. Only when the aggregate wall-clock has tripped `speed-budgets/SKILL.md`'s escalation formula (aggregate exceeds 50% of the <15 min budget, sustained across 2 consecutive measurements) and the resulting item remains carried forward unactioned does Milestone 1 need to include it as the first task, by construction — do not rely on noticing the streak in prose when assembling the task list. A carried-forward item that exists only because Tier 2 infra was never exercised on an otherwise-in-budget suite is not, by itself, grounds for mandatory M1 escalation.
 
 #### Milestone 2: Critical-path coverage
 Write or rebuild every `critical` tier test across all layers.

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -27,7 +27,7 @@ Distilled from Phase 3:
 - Layer coverage map (counts: how many tests at each layer, how many ought to be there)
 - Local-runnable status: % of tests that run locally with no network
 - Canary status: size of current canary suite vs. target (from Phase 2 critical-path roster)
-- Speed status: current p95 per layer vs. budget
+- Speed status: Tier 1 aggregate wall-clock vs. budget; per-layer p95 only if Tier 2 was triggered
 - "Rebuild" debt: count by layer and effort
 - "Delete (redundant)" count and what it implies about false-confidence coverage
 


### PR DESCRIPTION
## Summary
- Rewrites `speed-budgets/SKILL.md`'s "Measuring speed" section to lead with a two-tier model: Tier 1 (default, always-on) pulls the aggregate full-suite wall-clock from the most recent green CI run of the `lint / typecheck / test` job; Tier 2 (conditional per-layer breakdown) only triggers when Tier 1's aggregate exceeds 50% of the <15min Full-PR-pipeline budget, sustained across 2 consecutive measurements.
- Splits `test-migration/SKILL.md` Step 4 into 4a (always: CI aggregate pull, no local Postgres needed) and 4b (conditional: per-layer breakdown gated on the Tier-2 trigger), and rescopes the "carried-forward measurement-only item" Failure-modes bullet so mandatory Milestone-1 escalation requires an actual Tier-1 budget breach rather than mere Tier-2 infra unavailability.
- Updates `test-roadmap/SKILL.md`'s "Speed delta" section to lead with aggregate-vs-budget (per-layer p95 only when Tier 2 was actually triggered) and rescopes its "Mandatory M1 task" rule to the same Tier-1-breach gate.

This closes the root cause of `test-t-074-shipwright` being stuck across 5 consecutive `/test-migration` cycles — the old policy unconditionally escalated to Milestone 1 after 3 carried-forward cycles even when the only blocker was missing local Postgres in the audit sandbox, not an actual speed problem. A CI run pulled during scoping (run 30323307262, main, commit ac6f7cf) showed 5598 tests / 249 files / 35.17s wall-clock — 2.9% of the 15min budget — demonstrating the aggregate is trivially obtainable and the suite is comfortably in budget.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | speed-budgets/SKILL.md documents the two-tier model + explicit escalation formula, leads with CI-aggregate pull | MET |
| 2 | test-migration/SKILL.md Step 4 split into 4a/4b; failure-modes bullet rescoped to Tier-1 breach gate | MET |
| 3 | test-roadmap/SKILL.md Speed delta leads with aggregate-vs-budget; Mandatory M1 rule uses same Tier-1-breach gate | MET |
| 4 | test-migration content test's bare-cycle-count assertion rewritten; new Tier-1-gate assertions added to test-roadmap content test | MET |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/skills/speed-budgets plugins/shipwright/skills/test-migration plugins/shipwright/skills/test-roadmap` — 30 pass, 0 fail
- `bunx biome lint` on both modified content test files — clean
- `task check-strings` — no banned strings
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
