### PR TITLE
refactor: consolidate admin provisioning client onto generated task-store types

### DIFF
--- a/admin/src/task-store-provisioning-client.ts
+++ b/admin/src/task-store-provisioning-client.ts
@@ -9,6 +9,8 @@
  * omitting the client from KubernetesAgentProvisionerConfig).
  */
 
+import type { components } from "@shipwright/lib/task-store-types";
+
 // ─── Interface ───────────────────────────────────────────────────────────────
 
 export interface TaskStoreProvisioningClient {
@@ -72,20 +74,25 @@ export class HttpTaskStoreProvisioningClient
     label: string,
     agentId?: string,
   ): Promise<{ id: string; rawToken: string }> {
+    const tokenBody: components["schemas"]["TokenBody"] = {
+      label,
+      ...(agentId ? { agentId } : {}),
+    };
     const res = await this.fetchFn(`${this.baseUrl}/tokens`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.adminToken}`,
       },
-      body: JSON.stringify({ label, ...(agentId ? { agentId } : {}) }),
+      body: JSON.stringify(tokenBody),
     });
     if (!res.ok) {
       throw new Error(
         `task-store POST /tokens failed: ${res.status} ${res.statusText}`,
       );
     }
-    const body = (await res.json()) as { id: string; rawToken: string };
+    const body =
+      (await res.json()) as components["schemas"]["TaskTokenWithRaw"];
     return { id: body.id, rawToken: body.rawToken };
   }
 
@@ -115,7 +122,8 @@ export class HttpTaskStoreProvisioningClient
         `task-store GET /tokens failed: ${res.status} ${res.statusText}`,
       );
     }
-    const tokens = (await res.json()) as { id: string; agentId?: string | null }[];
+    const tokens =
+      (await res.json()) as components["schemas"]["TaskToken"][];
     return tokens
       .filter((token) => token.agentId === agentId)
       .map((token) => ({ id: token.id }));


### PR DESCRIPTION
## Summary
- Repoints `HttpTaskStoreProvisioningClient.mintToken`'s response cast onto `components["schemas"]["TaskTokenWithRaw"]` and its request body onto `components["schemas"]["TokenBody"]`, both imported from `@shipwright/lib/task-store-types`.
- Repoints `listTokensForAgent`'s response cast onto `components["schemas"]["TaskToken"][]`.
- Type-source swap only — no behavior change; public `TaskStoreProvisioningClient` interface and both implementations' exported method signatures are unchanged.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `mintToken`'s `res.json()` cast uses `TaskTokenWithRaw`; `listTokensForAgent`'s uses `TaskToken[]`, both from `@shipwright/lib/task-store-types` | MET |
| 2 | `mintToken`'s request body still matches `TokenBody` shape | MET |
| 3 | Public interface + exported method signatures unchanged; no changes to `agent-provisioner.ts`, `agent-deletion.ts`, `main.ts` | MET |
| 4 | No new tests (type-only refactor); existing tests continue to pass unmodified | MET |

## Test Plan
- `bun test` on `task-store-provisioning-client.integration.test.ts`, `agent-provisioner.unit.test.ts`, `agent-deletion.unit.test.ts`, and related suites — all pass, unmodified.
- `bun run typecheck` (admin package) — clean.
- `task ci` — passes except one pre-existing, unrelated flake (`agent/src/claude.unit.test.ts`, `extraAllowedTools` test) that reproduces identically on clean `main`; coverage gate passes (80.84% lines / 81.61% functions, threshold 80%).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
