### PR TITLE
feat: replace timestamp-only second-round escalation with content-correlation judgment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.88.0",
+      "version": "1.88.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -99,7 +99,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.88.0",
+      "version": "1.88.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -117,7 +117,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.88.0",
+      "version": "1.88.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -636,6 +636,70 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
     expect(section).toContain("do not reset");
     expect(section).toContain("reviewState");
   });
+
+  it("requires an explicit SAME_FINDING/DIFFERENT_FINDING judgment with justification for each candidate reply before escalating", () => {
+    const section = getStep5a7Section();
+    expect(section).toContain("SAME_FINDING");
+    expect(section).toContain("DIFFERENT_FINDING");
+    expect(section.toLowerCase()).toContain("justification");
+    // The judgment must be printed/decided before the escalation branch runs, not after.
+    const judgmentIdx = section.indexOf("SAME_FINDING");
+    const escalationBranchIdx = section.indexOf(
+      "**If any qualifying review has an author-reply comment",
+    );
+    expect(escalationBranchIdx).toBe(-1); // old unconditional-timestamp escalation framing must be gone
+    const ifEscalateIdx = section.search(/\*\*If.{0,80}SAME_FINDING/is);
+    expect(ifEscalateIdx).toBeGreaterThan(-1);
+    expect(judgmentIdx).toBeLessThan(ifEscalateIdx);
+  });
+
+  it("states the anti-pattern explicitly: a reply predating the review is not sufficient by itself to escalate", () => {
+    const section = getStep5a7Section();
+    expect(section.toLowerCase()).toContain("anti-pattern");
+    expect(section).toMatch(
+      /predat(e|ing|es) the review.{0,200}(not sufficient|is not enough|alone is not)/is,
+    );
+    expect(section.toLowerCase()).toContain("content must be verified");
+  });
+
+  it("gates escalation on at least one candidate reply judged SAME_FINDING, not on timestamp precedence alone", () => {
+    const section = getStep5a7Section();
+    expect(section).toMatch(/at least one.{0,40}candidate.{0,60}SAME_FINDING/is);
+    expect(section).not.toContain(
+      "If any qualifying review has an author-reply comment dated before its `submittedAt`",
+    );
+  });
+
+  it("the no-escalation path covers both no-candidate-replies and all-candidates-judged-DIFFERENT_FINDING, proceeding to Step 5b as a first-round finding", () => {
+    const section = getStep5a7Section();
+    const otherwiseIdx = section.indexOf("**Otherwise**");
+    expect(otherwiseIdx).toBeGreaterThan(-1);
+    const otherwiseSection = section.slice(otherwiseIdx);
+    expect(otherwiseSection).toContain("proceed normally to Step 5b");
+    expect(otherwiseSection.toLowerCase()).toContain("first-round finding");
+    expect(otherwiseSection).toMatch(/no candidate replies|no candidates/i);
+    expect(otherwiseSection).toContain("DIFFERENT_FINDING");
+  });
+
+  it("prefers inline-thread anchors (stable path/line) over freeform PR-comment text matching when the finding came from a thread", () => {
+    const section = getStep5a7Section();
+    expect(section.toLowerCase()).toContain("inline-thread anchor");
+    expect(section).toContain("path");
+    expect(section).toContain("line");
+    expect(section.toLowerCase()).toMatch(/freeform (pr-comment )?text matching/);
+  });
+
+  it("frames the timestamp check as a shared pre-filter with check-patch.ts, and explains why the extra correlation judgment is needed here but not there", () => {
+    const section = getStep5a7Section();
+    expect(section).toContain("isAddressedByAuthorReply");
+    expect(section.toLowerCase()).toContain("pre-filter");
+    // Must no longer imply timestamp-order alone is sufficient signal for this step's decision.
+    expect(section).not.toContain(
+      "a reply dated *before* the\ncurrent review means we already rebutted once, the reviewer looked at that\nrebuttal, and\nstill raised a finding this round.",
+    );
+    // Should explain reply-after-review is inherently a stronger signal than reply-before-review.
+    expect(section).toMatch(/after a review.{0,120}(stronger|inherent)/is);
+  });
 });
 
 describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation already exists (CFE-1.1)", () => {

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -679,19 +679,69 @@ resolve. Before dispatching the fix subagent (which is where RPF-1.1's rebuttal-
 lives, in Step 5b Instructions [D]), check whether this PR's List A finding is a *second*
 round of the same disagreement.
 
-For each qualifying review from Step 3a (`state == "COMMENTED"` or `"CHANGES_REQUESTED"`,
-contributing to this PR's List A membership), check the PR-level
-comments already fetched in Step 3a (`comments.nodes`) for an author reply: a comment whose
-`author.login == CURRENT_USER` with `createdAt` **before** that review's `submittedAt`. This
-mirrors `check-patch.ts`'s `isAddressedByAuthorReply` (an author reply *after* a review marks
-that review addressed) but checks the opposite direction — a reply dated *before* the
-current review means we already rebutted once, the reviewer looked at that rebuttal, and
-still raised a finding this round.
+**Step 1 — cheap timestamp pre-filter to find candidate prior replies.** This stays a cheap
+pre-filter, not the final gate — see Step 2 below for the decisive judgment. For each
+qualifying review from Step 3a (`state == "COMMENTED"` or `"CHANGES_REQUESTED"`, contributing
+to this PR's List A membership), check the PR-level comments already fetched in Step 3a
+(`comments.nodes`) for an author reply: a comment whose `author.login == CURRENT_USER` with
+`createdAt` **before** that review's `submittedAt`. This mirrors `check-patch.ts`'s
+`isAddressedByAuthorReply` (an author reply *after* a review marks that review addressed) as
+a shared timestamp-comparison mechanism, but checks the opposite direction — a reply dated
+*before* the current review is only a **candidate** signal that we already rebutted once and
+the reviewer looked at that rebuttal before still raising a finding this round; unlike
+`isAddressedByAuthorReply`, this direction is not treated as sufficient signal on its own.
+A reply dated *after a review* is inherently a stronger, self-sufficient signal already — a
+reply posted after a review is reasonably a response to that review, so timestamp order alone
+is enough for `isAddressedByAuthorReply`. A reply dated *before* the review has no such
+inherent connection: an earlier reply could be about a completely different, unrelated
+finding that simply happens to predate this review's timestamp. That's exactly why this step
+needs an extra layer `isAddressedByAuthorReply` doesn't: the content-correlation judgment in
+Step 2 below, before a candidate can justify escalating.
 
-**If any qualifying review has an author-reply comment dated before its `submittedAt`**
-(second round on the same disagreement): escalate instead of looping. Skip the rest of Step
-5 for this PR entirely — do not dispatch the fix subagent, do not post another rebuttal, and
-do not reset `reviewState`.
+**Anti-pattern:** a reply predating the review is not sufficient by itself to classify this
+as a second round, and it is not sufficient by itself to escalate. Timestamp precedence only
+narrows down which prior replies are worth reading — content must be verified before any
+escalation decision is made. This is exactly the bug that motivated this step's rewrite
+(RPF-1.5): PR #2153 had an unrelated earlier rebuttal comment (about a different, already-
+fixed finding) that happened to predate a brand-new finding's review, and a timestamp-only
+check escalated to HITL instead of ever attempting a fix — repeating the same false
+escalation days later when the HITL flag was cleared, because nothing about the *content* had
+actually recurred.
+
+**Step 2 — content-correlation judgment for each candidate.** For each candidate reply found
+in Step 1, read the reply's `body` and the current finding's text, then print an explicit
+judgment before deciding anything:
+
+```
+Candidate reply ({createdAt}): "{reply body, or a representative excerpt}"
+Current finding ({review submittedAt}): "{finding text, or a representative excerpt}"
+Judgment: SAME_FINDING | DIFFERENT_FINDING
+Justification: {one or two sentences — what specifically makes this the same issue
+  recurring, or a different issue that happens to share a timestamp ordering}
+```
+
+The "current finding's text" depends on where the finding came from:
+- **Review body** — use the qualifying review's `body` from Step 3a directly.
+- **Inline thread** — when the finding originated from one of Step 3a's
+  `reviewThreads.nodes[]` rather than (or in addition to) the review body, prefer that
+  thread's inline-thread anchor — its first comment's stable `path` and `line`, plus its
+  `body` — over freeform PR-comment text matching. A thread's `path`/`line` pinpoints the
+  exact code location a finding is about; matching on freeform comment prose alone is
+  comparatively unreliable prose-similarity guessing at what a comment refers to, especially
+  across differently-worded restatements of the same underlying issue. If the candidate
+  reply is itself a reply to that specific thread (an inline thread reply, not a PR-level
+  comment), correlate against the thread's `path`/`line` first and its text second.
+
+`SAME_FINDING` means the candidate reply is a rebuttal of the same underlying issue the
+current review/finding is raising again — the reviewer read that rebuttal and is still
+unconvinced. `DIFFERENT_FINDING` means the reply addresses a different issue that merely
+happens to predate this review's timestamp (the PR #2153 case) — unrelated content, no real
+second round.
+
+**If at least one candidate reply is judged `SAME_FINDING`** (a genuine second round on the
+same disagreement): escalate instead of looping. Skip the rest of Step 5 for this PR
+entirely — do not dispatch the fix subagent, do not post another rebuttal, and do not reset
+`reviewState`.
 
 1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. (Step 2.1
    fetched `GET /prs?repo={org}/{repo}&prNumber={pr}` and captured `.prs[0].taskId` right
@@ -766,9 +816,13 @@ do not reset `reviewState`.
    ```
 7. Move to the next qualifying PR in List A. If no candidates remain, continue to Step 6.
 
-**Otherwise** (no qualifying review has an author-reply comment dated before its
-`submittedAt` — a first-round rebuttal, or no rebuttal history at all): this is unaffected
-by RPF-1.3 — proceed normally to Step 5b, and RPF-1.1/1.2 behavior applies as before.
+**Otherwise** — either no candidate replies were found at all in Step 1 (a first-round
+rebuttal, or no rebuttal history at all), or candidates were found but every one was judged
+`DIFFERENT_FINDING` in Step 2 (timestamp precedence matched, but content correlation ruled
+out a real second round, as in the PR #2153 incident): this is unaffected by RPF-1.3. Treat
+it as a first-round finding and proceed normally to Step 5b.
+
+RPF-1.1/1.2 behavior applies as before.
 
 ### Step 5b: Dispatch Fix Subagent
 


### PR DESCRIPTION
## Summary
- Rewrites `patch.md` Step 5a.7 so the escalate-vs-fix decision requires an explicit `SAME_FINDING`/`DIFFERENT_FINDING` content-correlation judgment (with justification) instead of relying on reply-timestamp ordering alone.
- Keeps the timestamp comparison as a cheap pre-filter for candidate prior replies, states the anti-pattern explicitly ("a reply predating the review is not sufficient by itself to escalate"), and prefers inline-thread anchors (stable `path`/`line`) over freeform PR-comment text matching when the finding came from a thread.
- Root-caused via a real incident on PR #2153 (app-vitals/shipwright): an unrelated earlier rebuttal (about a different, already-fixed finding) happened to predate a brand-new finding's review, causing a false escalation to HITL that repeated after the flag was cleared.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | SAME_FINDING/DIFFERENT_FINDING judgment with justification printed before escalating | MET | patch.md Step 5a.7 Step 2 block |
| 2 | Anti-pattern stated: reply predating review not sufficient alone | MET | patch.md "Anti-pattern" callout with PR #2153 rationale |
| 3 | Escalation gated on ≥1 SAME_FINDING; otherwise proceed to Step 5b as first-round | MET | patch.md escalation gate + "Otherwise" branch |
| 4 | Test updates in existing RPF-1.3 describe block, no regression, no runtime tests added | MET | patch.content.test.ts, 5 new content assertions, 93/93 pass |
| 5 | check-patch.ts unchanged | MET | zero diff on agent/src/check-patch.ts |

## Test Plan
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 93/93 pass
- `task lint` — clean
- `task typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
