### PR TITLE
feat: add gitleaksignore promotion step to /shipwright:hitl

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -57,6 +57,7 @@ Manual test scenarios for each command across different project types.
 | 40 | `/dev-task` Step 8.5 | Any | Unparseable agent result is recorded, not silent | Agent returns no/garbled `AUTO_DOCS_METRICS` block; `⚠ ... agent_error` printed; metrics record has `skipped_reason:"agent_error"`, `updated:false`; pipeline continues |
 | 41 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (admin app base URL configured) | Plan viz link after markdown write | `PLAN.md`/`PRODUCT-SPEC.md` written unchanged, then a `${SHIPWRIGHT_ADMIN_APP_BASE_URL}/admin/sessions/{session}` link is constructed and a `Plan viz: {url}` line is surfaced in the confirmation block |
 | 42 | `/plan-session` Step 6a / `/prd` Phase 4 | Any (admin app base URL unset) | Plan viz graceful skip | `⏭ Plan viz skipped — SHIPWRIGHT_ADMIN_APP_BASE_URL unset.` printed; markdown still written; no `Plan viz:` line; command never blocks |
+| 44 | `/shipwright:hitl` Step 6a | Any (gitleaks-secret/hardcoded-credential HITL task) | Gitleaksignore suppression sub-step | Two distinct questions asked (false-positive vs. rotated); suppression never offered for rotated findings; confirmed findings flow through worktree → `.gitleaksignore` append → commit → push → PR; declining suppression still reaches Step 6b mark-done |
 
 ---
 
@@ -1154,6 +1155,63 @@ As `agent-A`, invoke `/shipwright:dev-task`
 
 ### Related — task-store API
 - [ ] `GET /tasks?status=in_progress&assignee={own-agent-id}` on a repo-scoped token now actually narrows results to that assignee (previously silently ignored the query param) — see `task-store/src/api.smoke.test.ts` and `tasks.integration.test.ts`
+
+---
+
+## Scenario 44: /shipwright:hitl — Gitleaksignore Suppression Sub-Step
+
+Covers the fix for a real gap: once a human confirms a `gitleaks-secret` or
+`hardcoded-credential` HITL finding is a false positive and closes the task via
+`/shipwright:hitl`, nothing previously recorded that decision anywhere gitleaks itself
+respects — the same full-history scan re-detected the identical commits every subsequent
+ISO week and `security-fix` re-filed an identical task (this happened for real on a
+downstream repo and had to be backfilled manually). Step 6a now offers to permanently
+suppress confirmed false positives via `.gitleaksignore`, while never conflating that with
+a rotated-credential closure.
+
+### Setup
+1. A HITL task in the task store whose `description` ends with a trailer line
+   `Rule: gitleaks-secret | Severity: high | Tier: 1 | HITL: true | requires-credential-action: true`
+   and a findings list of 2 entries, e.g.:
+   ```
+   Findings (2 total):
+   - config/settings.example.py:14 — placeholder-looking API key literal
+   - scripts/legacy-deploy.sh:22 — hardcoded token string
+   ```
+2. A target repo cloned at `repos/{repo}` with no existing `.gitleaksignore`.
+
+### Run
+Invoke `/shipwright:hitl {task-id}`. When prompted at Step 6, tell the agent: finding 1
+(`config/settings.example.py:14`) is a confirmed false positive (a template placeholder);
+finding 2 (`scripts/legacy-deploy.sh:22`) was closed because the credential was rotated.
+
+### Verify
+- [ ] Step 6a is triggered (task's `Rule:` line matches `gitleaks-secret`)
+- [ ] The agent asks two distinct questions — which findings are confirmed false positives
+      to suppress, and which were closed via rotation — not a single combined prompt
+- [ ] Suppression is **never offered** for finding 2 (the rotated one) — no
+      `.gitleaksignore` entry is proposed or written for it
+- [ ] For finding 1, the agent asks for (or derives) the full gitleaks fingerprint
+      (`commit:file:rule:startLine`), since `TASK_DESC` only has `file:line`
+- [ ] A worktree is created for the target repo following the standard convention
+      (`git -C repos/{repo} pull`, `git -C repos/{repo} worktree add {absolute-path} origin/main -b {branch}`)
+- [ ] `.gitleaksignore` is created at the repo root (it didn't exist) with the confirmed
+      fingerprint appended, preceded by a comment citing the HITL task ID and today's date
+- [ ] A commit (`fix:` or `docs:` prefix per the target repo's convention), push, and PR
+      are produced for the `.gitleaksignore` change
+- [ ] After the suppression flow completes, Step 6b's `PATCH /tasks/{id}` with
+      `"status": "done"` still runs unchanged, and the `HITL TASK COMPLETE` banner prints
+
+### Negative case — decline / all-rotated
+Repeat with a task where every finding is closed via rotation (no false positives).
+- [ ] The agent does not propose any `.gitleaksignore` entry or worktree
+- [ ] Step 6b's mark-done PATCH runs immediately, unaffected
+
+### Negative case — non-security-fix HITL task
+Repeat with a HITL task whose `description` has no `Rule:` trailer line at all (e.g. a
+manually-filed infra task).
+- [ ] Step 6a is skipped entirely — no suppression questions asked
+- [ ] Step 6b's mark-done flow behaves exactly as it did before this change
 
 ---
 

--- a/plugins/shipwright/commands/hitl.content.test.ts
+++ b/plugins/shipwright/commands/hitl.content.test.ts
@@ -1,0 +1,152 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const HITL_MD_PATH = join(import.meta.dir, "hitl.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(HITL_MD_PATH, "utf-8");
+});
+
+function extractStep6Section(md: string): string {
+  const match = md.match(/## Step 6[\s\S]*$/);
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
+function extractSuppressionSubStep(md: string): string {
+  const match = md.match(
+    /### 6a\. Offer Gitleaksignore Suppression[\s\S]*?(?=\n### 6b\.)/,
+  );
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
+describe("hitl.md — gitleaksignore suppression sub-step exists (GLB-2.2 AC1)", () => {
+  it("contains a Step 6a suppression sub-step section", () => {
+    expect(content).toContain("### 6a. Offer Gitleaksignore Suppression");
+  });
+
+  it("is gated on parsing Rule: gitleaks-secret or Rule: hardcoded-credential out of TASK_DESC", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain("gitleaks-secret");
+    expect(section).toContain("hardcoded-credential");
+    expect(section).toContain("Rule:");
+  });
+
+  it("skips the sub-step entirely when TASK_DESC has no Rule: line (non-security-fix HITL task)", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("no `rule:` line");
+    expect(lower).toContain("skip");
+  });
+});
+
+describe("hitl.md — rotation vs. false-positive are two distinct questions (GLB-2.2 AC1)", () => {
+  it("asks which findings are confirmed false positives to suppress, distinct from which were rotated", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("false positive");
+    expect(lower).toContain("rotat");
+  });
+
+  it("never offers suppression for a finding closed via rotation", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    const hasGuardrail =
+      /never (offer(ed)?|suppress(ed)?)[^.]*rotat/.test(lower) ||
+      lower.includes("never for rotated credentials") ||
+      lower.includes("never for a finding closed via rotation");
+    expect(hasGuardrail).toBe(true);
+  });
+
+  it("only asks about findings confirmed as false positives as candidates for .gitleaksignore, even when some findings are rotated", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("only the false-positive");
+  });
+});
+
+describe("hitl.md — fingerprint resolution (GLB-2.2)", () => {
+  it("documents the gitleaks fingerprint format commit:file:rule:startLine", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain("commit:file:rule:startLine");
+  });
+
+  it("handles the case where TASK_DESC already breaks out fingerprints directly", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("already");
+    expect(lower).toContain("fingerprint");
+  });
+
+  it("otherwise asks the human to supply file:line and derive/look up the fingerprint via git blame/git log or the security report", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    const mentionsLookup =
+      lower.includes("git blame") || lower.includes("git log");
+    expect(mentionsLookup).toBe(true);
+    expect(lower).toContain("security-report.md");
+  });
+});
+
+describe("hitl.md — worktree → .gitleaksignore → commit → push → PR flow (GLB-2.2 AC2)", () => {
+  it("creates a worktree following the standard convention (pull, worktree add, absolute path)", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain("git -C repos/");
+    expect(section).toContain("pull");
+    expect(section).toContain("worktree add");
+    expect(section.toLowerCase()).toContain("absolute");
+  });
+
+  it("appends confirmed fingerprint lines to the target repo's root .gitleaksignore, creating it if absent", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain(".gitleaksignore");
+    const lower = section.toLowerCase();
+    expect(lower).toContain("create");
+    expect(lower).toContain("append");
+  });
+
+  it("each appended line carries a comment citing the HITL task ID and date", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain("TASK_ID");
+    const lower = section.toLowerCase();
+    expect(lower).toContain("date");
+    expect(section).toContain("#");
+  });
+
+  it("commits with a fix:/docs: prefix per the target repo's own convention", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain("fix:");
+    expect(section).toContain("docs:");
+  });
+
+  it("pushes and opens a PR", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("git push");
+    const hasPrOpen =
+      section.includes("gh pr create") || lower.includes("open a pr");
+    expect(hasPrOpen).toBe(true);
+  });
+});
+
+describe("hitl.md — suppression is additive, not required (GLB-2.2)", () => {
+  it("declining suppression still proceeds to mark the task done as normal", () => {
+    const section = extractSuppressionSubStep(content);
+    const lower = section.toLowerCase();
+    const hasDeclineLanguage =
+      lower.includes("decline") || lower.includes("still deciding");
+    expect(hasDeclineLanguage).toBe(true);
+    expect(lower).toContain("skip");
+    expect(section).toContain("Step 6");
+  });
+
+  it("does not remove or restructure the existing mark-done PATCH/print logic in Step 6", () => {
+    const step6Section = extractStep6Section(content);
+    expect(step6Section).toContain('\\"status\\": \\"done\\"');
+    expect(step6Section).toContain("HITL TASK COMPLETE");
+  });
+});

--- a/plugins/shipwright/commands/hitl.content.test.ts
+++ b/plugins/shipwright/commands/hitl.content.test.ts
@@ -101,6 +101,13 @@ describe("hitl.md — worktree → .gitleaksignore → commit → push → PR fl
     expect(section.toLowerCase()).toContain("absolute");
   });
 
+  it("defines an explicit branch name for the suppression worktree, distinct from the original task's branch", () => {
+    const section = extractSuppressionSubStep(content);
+    expect(section).toContain("chore/gitleaksignore-suppress-{TASK_ID}");
+    const lower = section.toLowerCase();
+    expect(lower).toContain("do not reuse that task's branch");
+  });
+
   it("appends confirmed fingerprint lines to the target repo's root .gitleaksignore, creating it if absent", () => {
     const section = extractSuppressionSubStep(content);
     expect(section).toContain(".gitleaksignore");

--- a/plugins/shipwright/commands/hitl.md
+++ b/plugins/shipwright/commands/hitl.md
@@ -139,7 +139,100 @@ If the human asks for help with a step, provide the relevant commands and contex
 ## Step 6: Mark Task Done
 
 When the human confirms the task is complete (e.g. says "done", "finished", "all good",
-"mark it done", or similar), mark the task done in the task store:
+"mark it done", or similar):
+
+1. First run **Step 6a** below if it applies to this task.
+2. Then mark the task done in the task store as described further down.
+
+### 6a. Offer Gitleaksignore Suppression
+
+**Gate:** parse `TASK_DESC` for a trailer line of the form
+`Rule: {rule} | Severity: {severity} | Tier: {tier} | HITL: true | requires-credential-action: true`
+(this is the exact format `security-fix/SKILL.md` Step 6q.5 writes for credential-rotation
+tasks). Extract `{rule}`.
+
+- If `TASK_DESC` has **no `Rule:` line** at all (this HITL task did not originate from
+  `/shipwright:security-fix`), **skip this sub-step entirely** and proceed straight to
+  marking the task done, unchanged from today.
+- If `{rule}` is **not** `gitleaks-secret` or `hardcoded-credential`, skip this sub-step
+  entirely and proceed straight to marking the task done.
+- Otherwise ({rule} is `gitleaks-secret` or `hardcoded-credential`), continue below.
+
+**Why this exists:** a committed secret's exposure can't be undone by a code edit — the
+gitleaks full-history scan will keep re-detecting the same commits every subsequent scan
+unless the human's disposition is recorded somewhere gitleaks itself respects
+(`.gitleaksignore`). Without this, a human closing the task as a false positive today gets
+an identical task re-filed next week.
+
+**Ask the human two distinct questions — do not conflate them:**
+
+1. "Which of the findings listed above (if any) are **confirmed false positives** you want
+   to permanently suppress via `.gitleaksignore`?"
+2. "Which of the findings (if any) were closed because the **credential was rotated/revoked**?"
+
+These are separate human answers. Suppression is **never offered for rotated credentials** —
+never for a finding closed via rotation. An old fingerprint from a rotated secret is
+harmless to leave undetected, but suppression must only ever be applied to findings the
+human explicitly confirms as false positives. If a finding is rotated, it needs no
+`.gitleaksignore` entry at all; just let it be. Only the false-positive-confirmed findings
+are candidates for `.gitleaksignore` — even when the same task has a mix of some findings
+rotated and some false-positive, ask about suppression only for the false-positive subset.
+
+If the human is still deciding, or all findings in this task were closed via rotation (no
+false positives to suppress), **skip suppression** and go straight to marking the task done
+— this sub-step is additive, not required.
+
+**If the human confirms one or more findings for suppression:**
+
+1. **Resolve each confirmed finding to a gitleaks fingerprint.** The gitleaks fingerprint
+   format is `commit:file:rule:startLine` (verified against gitleaks v8.27.2).
+   - If `TASK_DESC` already breaks out full fingerprints for its findings (e.g. a backfill
+     task written directly in that format), use those fingerprints directly — no further
+     lookup needed.
+   - Otherwise, `TASK_DESC`'s findings list is plain `- {file}:{line} — {finding_description}`
+     (per `security-fix/SKILL.md` Step 6q.5) with no commit SHA. Ask the human to supply the
+     full fingerprint for each confirmed finding, since that is what gitleaks actually
+     matches on. If they only have `file:line`, tell them to look up the commit SHA via
+     `git blame`/`git log` on that file/line, or via the original `security-report.md` that
+     generated the task (security-scan writes the commit SHA per finding there).
+
+2. **Create a worktree for the target repo**, following the standard convention:
+   ```bash
+   git -C repos/{repo} pull
+   git -C repos/{repo} worktree add /absolute/path/to/worktrees/{repo}-{branch} origin/main -b {branch}
+   ```
+   Use an absolute path for the worktree (naming: `{repo}-{branch}`, no timestamps, no
+   nesting) per the standard worktree convention.
+
+3. **Append the confirmed fingerprint lines to that repo's root `.gitleaksignore`**,
+   creating the file if it doesn't exist. Each appended line carries a comment citing the
+   HITL task ID and today's date:
+   ```
+   # Suppressed via HITL task {TASK_ID} on {YYYY-MM-DD} — confirmed false positive
+   {fingerprint}
+   ```
+
+4. **Commit, push, and open a PR** in that worktree, using a `fix:` or `docs:` prefix per
+   the target repo's own commit-message convention (`fix:` if the repo treats a
+   `.gitleaksignore` entry as suppressing a would-be finding/check failure; `docs:` if the
+   repo treats it as a non-functional record-keeping change):
+   ```bash
+   git add .gitleaksignore
+   git commit -m "fix: suppress confirmed false-positive gitleaks finding ({TASK_ID})"
+   git push -u origin {branch}
+   gh pr create --title "fix: suppress confirmed false-positive gitleaks finding ({TASK_ID})" \
+     --body "Confirmed false positive during HITL review of {TASK_ID}. See task for finding detail."
+   ```
+
+5. Then proceed to mark the task done as normal (below).
+
+**If the human declines suppression** (still deciding, or all findings were rotated rather
+than false-positive), skip straight to marking the task done — do not block on this
+sub-step.
+
+### 6b. Mark Task Done
+
+Mark the task done in the task store:
 
 ```bash
 COMPLETED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/shipwright/commands/hitl.md
+++ b/plugins/shipwright/commands/hitl.md
@@ -196,7 +196,9 @@ false positives to suppress), **skip suppression** and go straight to marking th
      `git blame`/`git log` on that file/line, or via the original `security-report.md` that
      generated the task (security-scan writes the commit SHA per finding there).
 
-2. **Create a worktree for the target repo**, following the standard convention:
+2. **Create a worktree for the target repo**, following the standard convention. Use branch
+   name `chore/gitleaksignore-suppress-{TASK_ID}` for this suppression PR (a new, distinct
+   change from the original credential-rotation task — do not reuse that task's branch):
    ```bash
    git -C repos/{repo} pull
    git -C repos/{repo} worktree add /absolute/path/to/worktrees/{repo}-{branch} origin/main -b {branch}


### PR DESCRIPTION
## Summary
- Adds a new Step 6a to `/shipwright:hitl` (`plugins/shipwright/commands/hitl.md`): for a task whose source rule is `gitleaks-secret` or `hardcoded-credential`, asks the human which findings are confirmed false positives to permanently suppress via `.gitleaksignore`, as a distinct question from which findings were closed via credential rotation — suppression is never offered/applied for rotation-closed findings.
- When the human confirms findings for suppression, documents the worktree-create → append-to-`.gitleaksignore` → commit → push → open-PR flow (reusing the standard worktree/PR convention), before falling through to the existing mark-done logic (now Step 6b).
- Declining suppression, or a HITL task with no `Rule:` trailer line (non-security-fix origin), skips straight to mark-done unchanged — this is additive, not required.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | hitl.md Step 6 gains a new sub-step, gated on the task's rule being gitleaks-secret or hardcoded-credential, that asks which findings to suppress and never offers suppression for rotation-closed findings | MET |
| 2 | hitl.md documents the worktree-create → append-to-.gitleaksignore → commit → push → open-PR flow, reusing the standard worktree/PR convention | MET |
| 3 | `plugins/shipwright/commands/hitl.content.test.ts` added, asserting the guardrail text and worktree/PR flow are present in the command body | MET |
| 4 | `plugins/shipwright/TESTING.md` gains a manual-walkthrough scenario (Scenario 44) for the new interactive sub-step | MET |

## Test Plan
- [x] `NODE_ENV=test bun test plugins/shipwright/commands/hitl.content.test.ts` — 16/16 passing
- [x] `task ci` — lint, check-strings, typecheck, check-config-docs, check-version-sync, test:coverage all green (5262/5262 tests passing); `secret-scan` skips locally (gitleaks not installed in this sandbox) — enforced in CI
- [x] Independent spec-compliance review confirmed all 4 acceptance criteria MET

Generated with [Claude Code](https://claude.com/claude-code)
