### PR TITLE
feat: add end-of-run CI verification gate to patch.md

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1103,3 +1103,151 @@ describe("patch.md — docs-first toolchain discovery + per-repo cache (TDF-1.1)
     expect(content).not.toContain("state/toolchain-cache.json");
   });
 });
+
+describe("patch.md — Step 2.5/Step 3 opening prose reflects single-PR scope (PCG-1.1)", () => {
+  function getStep2_5Section() {
+    const step2_5Idx = content.indexOf("## Step 2.5: Handle DIRTY PRs (Auto-Rebase Attempt)");
+    const step3Idx = content.indexOf("## Step 3: Classify PRs into Three Lists");
+    expect(step2_5Idx).toBeGreaterThan(-1);
+    expect(step3Idx).toBeGreaterThan(-1);
+    return content.slice(step2_5Idx, step3Idx);
+  }
+
+  function getStep3OpeningSection() {
+    const step3Idx = content.indexOf("## Step 3: Classify PRs into Three Lists");
+    const step3aIdx = content.indexOf("### Step 3a: Check for Unaddressed Review Findings");
+    expect(step3Idx).toBeGreaterThan(-1);
+    expect(step3aIdx).toBeGreaterThan(-1);
+    return content.slice(step3Idx, step3aIdx);
+  }
+
+  it("Step 2.5's opening line no longer describes 'each PR discovered in Step 2'", () => {
+    const section = getStep2_5Section();
+    expect(section).not.toContain("For each PR discovered in Step 2");
+  });
+
+  it("Step 2.5's opening line reflects the single target PR resolved in Step 2", () => {
+    const section = getStep2_5Section();
+    const openingLine =
+      section
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .find((line) => !line.trim().startsWith("#")) ?? "";
+    expect(openingLine).toMatch(/the (target )?PR resolved in Step 2/i);
+  });
+
+  it("Step 3's opening prose no longer says 'each PR' or 'all PRs'", () => {
+    const section = getStep3OpeningSection();
+    expect(section).not.toContain("each PR");
+    expect(section).not.toContain("all PRs");
+    expect(section).not.toContain("Work through all PRs before continuing");
+  });
+
+  it("Step 3's opening prose reflects checking the single target PR against all three conditions", () => {
+    const section = getStep3OpeningSection();
+    expect(section).toMatch(/the (target )?PR against all three conditions/i);
+  });
+
+  it("Step 3's List A/C/D labels and multi-list membership note are unchanged", () => {
+    const section = getStep3OpeningSection();
+    expect(section).toContain("**List A** — PRs with unresolved review or PR comments");
+    expect(section).toContain("**List C** — PRs with merge conflicts (DIRTY)");
+    expect(section).toContain("**List D** — PRs with failing CI");
+    expect(section).toMatch(/appear in multiple lists/);
+    expect(section).toContain("processed in the order the steps execute (C → A → D)");
+  });
+
+  it("does not touch the 'move to the next PR in List X' fallback phrasing deeper in Steps 4-6", () => {
+    expect(content).toContain("Move to the next candidate PR in List C");
+    expect(content).toContain("Move to the next qualifying PR in List A");
+    expect(content).toContain("Move to the next PR in List D");
+  });
+
+  it("does not touch the List A/C/D classification labels used later in Steps 3a-3c", () => {
+    expect(content).toContain("add it to **List A**");
+    expect(content).toContain("add to **List C**");
+    expect(content).toContain("add the PR to **List D**");
+  });
+});
+
+describe("patch.md — end-of-run CI verification gate (PCG-1.1)", () => {
+  function getStep6_5Section() {
+    const step6_5Idx = content.indexOf("## Step 6.5: Verify CI After Patch");
+    const step7Idx = content.indexOf("## Step 7: Report");
+    expect(step6_5Idx).toBeGreaterThan(-1);
+    expect(step7Idx).toBeGreaterThan(-1);
+    return content.slice(step6_5Idx, step7Idx);
+  }
+
+  it("Step 6.5 exists between Step 6e (cleanup) and Step 7 (report)", () => {
+    const step6eIdx = content.indexOf("### Step 6e: Cleanup Worktree");
+    const step6_5Idx = content.indexOf("## Step 6.5: Verify CI After Patch");
+    const step7Idx = content.indexOf("## Step 7: Report");
+    expect(step6eIdx).toBeGreaterThan(-1);
+    expect(step6_5Idx).toBeGreaterThan(step6eIdx);
+    expect(step7Idx).toBeGreaterThan(step6_5Idx);
+  });
+
+  it("fires only when at least one of Steps 4/5/6 pushed a commit this cycle, and skips cleanly with a one-line message otherwise", () => {
+    const section = getStep6_5Section();
+    expect(section).toMatch(/Step 4.{0,20}Step 5.{0,20}Step 6|Steps 4[/,].{0,10}5[/,].{0,10}6/is);
+    expect(section.toLowerCase()).toContain("pushed");
+    expect(section).toMatch(/skip/i);
+    // The skip message is a one-liner, not a multi-paragraph explanation.
+    const skipLineMatch = section.match(/^.*no.*push.*$/im);
+    expect(skipLineMatch).not.toBeNull();
+  });
+
+  it("polls the GitHub Actions API for the final HEAD SHA at a bounded cadence (30s interval, ~5 min cap)", () => {
+    const section = getStep6_5Section();
+    expect(section).toContain("repos/$REPO/actions/runs?head_sha=$HEAD_SHA");
+    expect(section).toMatch(/30[\s-]?second|30s/i);
+    expect(section).toMatch(/5[\s-]?min/i);
+  });
+
+  it("renews the PR claim's heartbeat on every poll iteration", () => {
+    const section = getStep6_5Section();
+    expect(section).toContain("/prs/$PR_RECORD_ID/heartbeat");
+    expect(section).toMatch(/each (poll|iteration)|every (poll|iteration)/i);
+  });
+
+  it("skips cleanly if no CI runs are configured for the repo, mirroring the existing no-CI-configured skip pattern", () => {
+    const section = getStep6_5Section();
+    expect(section.toLowerCase()).toContain("no ci");
+    expect(section).toMatch(/skip/i);
+  });
+
+  it("on green (or no CI configured), proceeds to the existing Step 7 report unchanged", () => {
+    const section = getStep6_5Section();
+    expect(section).toContain("Step 7");
+  });
+
+  it("on still-red after the poll window, reuses Step 6c's prompt template verbatim instead of duplicating it", () => {
+    const section = getStep6_5Section();
+    expect(section).toContain("Step 6c");
+    expect(section.toLowerCase()).toMatch(/same prompt template|exact same prompt|reus\w* .{0,40}step 6c/i);
+    // Must not duplicate Step 6c's actual prompt body text in Step 6.5.
+    expect(section).not.toContain("You are fixing failing CI on a pull request");
+    expect(section).not.toContain("[A] Diagnose the failures");
+  });
+
+  it("dispatches exactly one bonus CI-fix subagent and pushes once, with no re-poll or retry", () => {
+    const section = getStep6_5Section();
+    expect(section).toMatch(/one|single/i);
+    expect(section).toMatch(/no.{0,20}(re-poll|retry|further)/i);
+  });
+
+  it("on BLOCKED from the bonus subagent, reuses Step 6d's existing HITL-escalation branch instead of a new escalation path", () => {
+    const section = getStep6_5Section();
+    expect(section).toContain("Step 6d");
+    expect(section.toLowerCase()).toMatch(/same (hitl|escalation)|reus\w* .{0,40}step 6d/i);
+    // Must not duplicate Step 6d's escalation procedure text in Step 6.5.
+    expect(section).not.toContain("PATCH the linked task to `hitl: true`");
+    expect(section).not.toContain("shipwright-patch-blocked-6d-{pr}.txt");
+  });
+
+  it("uses the same PATCH-hitl/PR-comment/release convention referenced from Step 6d, not a bespoke mechanism", () => {
+    const section = getStep6_5Section();
+    expect(section).toMatch(/hitl/i);
+  });
+});

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -133,9 +133,9 @@ PR_TASK_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 
 ## Step 2.5: Handle DIRTY PRs (Auto-Rebase Attempt)
 
-For each PR discovered in Step 2, use the `mergeStateStatus` field (already fetched in Step 2) to identify DIRTY PRs.
+Using the `mergeStateStatus` field already fetched for the target PR resolved in Step 2, check whether it is DIRTY.
 
-For each DIRTY PR, attempt an automatic rebase via GitHub:
+If the target PR is DIRTY, attempt an automatic rebase via GitHub:
 ```bash
 gh pr update-branch --rebase {number} --repo {org}/{repo}
 ```
@@ -151,13 +151,13 @@ gh pr update-branch --rebase {number} --repo {org}/{repo}
 
 ## Step 3: Classify PRs into Three Lists
 
-Check each PR against all three conditions independently. A PR may appear in multiple lists.
+Check the target PR against all three conditions independently. It may appear in multiple lists.
 
 - **List A** — PRs with unresolved review or PR comments
 - **List C** — PRs with merge conflicts (DIRTY)
 - **List D** — PRs with failing CI
 
-Work through all PRs before continuing. When a PR appears in multiple lists, all applicable fixes run — processed in the order the steps execute (C → A → D).
+When the target PR appears in multiple lists, all applicable fixes run — processed in the order the steps execute (C → A → D).
 
 **This command does not read `state/reviews.json`.** All data comes from GitHub directly.
 
@@ -1498,6 +1498,110 @@ After a successful push (subagent status DONE or DONE_WITH_CONCERNS with push co
 ```bash
 git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} --force
 ```
+
+---
+
+## Step 6.5: Verify CI After Patch
+
+Steps 4, 5, and 6 each fix a different condition (merge conflict, review finding, failing
+CI) and push independently. A push from any one of them can leave CI red in a way none of
+the individual steps re-checks — e.g. a conflict resolution or a review-finding fix can
+introduce a new test failure that Step 6's own CI-fix pass never ran against, since Step 6
+only fires when List D already flagged the PR *before* any of this cycle's pushes. Before
+reporting success in Step 7, verify the PR's actual, current HEAD SHA is green.
+
+**Only runs if at least one push happened this cycle.** If Step 4c/4c.5, Step 5c/5c.5, and
+Step 6d/6d.5 all completed this run with no successful push (no DONE or DONE_WITH_CONCERNS
+report reached its post-fix upsert step with a changed HEAD SHA), there is nothing new to
+verify — the PR's CI state is exactly what Step 3c already evaluated. Skip Step 6.5 entirely
+with a one-line message and proceed directly to Step 7:
+```
+⏭ No commit pushed this cycle — skipping CI verification.
+```
+
+Otherwise, proceed below.
+
+### Step 6.5a: Poll for the Final CI Result
+
+Reuse the same "poll the GitHub Actions API, dedupe by latest run per workflow, skip
+cleanly when nothing is configured" pattern as `dev-task.md`'s Step 9b.2 — same shape, a
+tighter cadence: 30-second interval, capped at **~5 minutes** (10 polls max) rather than
+Step 9b.2's 10-minute cap, since this is a final gate on a patch cycle that already ran
+fixes, not a first-attempt wait.
+
+Resolve the repo and current HEAD SHA (the worktree for whichever of Steps 4/5/6 pushed
+last has already been cleaned up in 4d/5d/6e, so re-fetch live from GitHub rather than a
+local worktree path):
+
+```bash
+REPO="{org}/{repo}"
+HEAD_SHA=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid')
+```
+
+Poll every 30 seconds, up to 10 times (~5 minutes total). On **each poll iteration**, renew
+the claim heartbeat first — this loop can run long enough on its own to threaten the claim
+TTL, same reasoning as the heartbeat renewals before every subagent dispatch in Steps
+4b/5b/6c:
+
+```bash
+curl -s -o /dev/null -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat"
+
+gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
+  --jq '[.workflow_runs[] | {id, name, workflow_id, run_number, status, conclusion}]'
+```
+
+Filter to runs where `head_sha == HEAD_SHA`. Keep polling while any run has `status` of
+`queued`, `in_progress`, or `waiting`. **Deduplicate by workflow:** evaluate only the latest
+run per workflow (highest `run_number` per `workflow_id`), same as Step 3c and `dev-task.md`
+Step 9b.2, to avoid a stale failed run being counted alongside its passing rerun.
+
+**No CI configured:** if no matching runs appear after 60 seconds (2 polls), skip the rest
+of Step 6.5 and proceed to Step 7 — mirroring `dev-task.md` Step 9b.2's identical
+no-CI-configured skip. Print:
+```
+⏭ No CI checks configured — skipping CI verification gate
+```
+
+**All checks pass:** if all latest-per-workflow runs have `conclusion == "success"`, print
+and proceed to the existing Step 7 report unchanged:
+```
+✓ CI checks passed after patch
+```
+
+**Poll window exhausted (~5 minutes) with any check still failing or pending:** treat it as
+still-red and continue to Step 6.5b.
+
+### Step 6.5b: Dispatch One Bonus CI-Fix Subagent on Still-Red
+
+If CI is still red after the poll window, collect fresh failure logs using the same
+approach as Step 6b (most recent failed run on the branch, last 200 lines):
+
+```bash
+RUN_ID=$(gh run list --branch {branch} --repo {org}/{repo} \
+  --json databaseId,conclusion \
+  --jq '[.[] | select(.conclusion == "failure")] | first | .databaseId')
+
+gh run view "$RUN_ID" --log --failed --repo {org}/{repo} 2>&1 | tail -200
+```
+
+Re-set up the worktree the same way Step 6a does (it was already removed by whichever of
+4d/5d/6e cleaned up after this cycle's push), then dispatch **exactly one** bonus CI-fix
+subagent using the exact same prompt template as Step 6c — do not restate or duplicate that
+prompt text here — substituting these freshly-collected failure logs for the `CI FAILURE
+OUTPUT` block and this same `{pr}`/`{title}`/`{org}`/`{repo}`/`{branch}`/`{worktree-path}`
+context. Pass `model: PATCH_MODEL`, same as Step 6c. This bonus dispatch pushes once if the
+subagent succeeds — do not re-poll or retry further after it reports back, regardless of
+outcome. This is a single bonus attempt, not a new fix loop.
+
+**On DONE or DONE_WITH_CONCERNS with a push:** log the fix, clean up the worktree (same
+pattern as Step 6e), and proceed to the existing Step 7 report unchanged.
+
+**On BLOCKED:** reuse the exact same HITL-escalation branch as Step 6d's BLOCKED handling —
+same `hitl` PATCH to the linked task (or the PR record when no task is linked), same PR
+comment convention, same claim release — rather than adding a new escalation path here. Log
+the blocker and proceed to the existing Step 7 report unchanged.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds "Step 6.5: Verify CI After Patch" to `patch.md` — after Steps 4/5/6 push a fix, polls the GitHub Actions API (30s interval, ~5min cap, heartbeat renewed each poll) for the final CI result before reporting success in Step 7.
- On still-red after the poll window, dispatches exactly one bonus CI-fix subagent reusing Step 6c's prompt template verbatim; a BLOCKED report reuses Step 6d's existing HITL-escalation branch — no duplicated prompt or escalation logic.
- Corrects Step 2.5's and Step 3's opening prose, which described scanning "each PR"/"all PRs" — patch.md is explicit-target-only and only ever resolves one PR (Step 2). List A/C/D labels and the "move to the next PR in List X" fallback phrasing deeper in Steps 4-6 are untouched.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 6.5 fires only when Steps 4/5/6 pushed a commit; skips with a one-line message otherwise | MET |
| 2 | Polls GitHub Actions API at 30s/~5min cadence, heartbeat renewed each poll iteration, skips cleanly on no CI configured | MET |
| 3 | On green (or no CI configured), proceeds to unchanged Step 7 | MET |
| 4 | On still-red, dispatches exactly one bonus CI-fix subagent reusing Step 6c's prompt verbatim; pushes once, no re-poll/retry; BLOCKED reuses Step 6d's HITL branch | MET |
| 5 | Step 2.5/Step 3 opening prose corrected to single-PR scope; List A/C/D labels and fallback phrasing untouched | MET |
| 6 | Content-layer test coverage added (patch.content.test.ts), no unit/integration/smoke tests (patch.md has no executable logic) | MET |

## Test Plan
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 110/110 passing (2 new describe blocks added)
- `task lint`, `task check-strings`, `task typecheck`, `task check-config-docs`, `task check-version-sync`, `task secret-scan` — all pass
- `task test` full suite — 1 pre-existing failure (`agent/src/claude.unit.test.ts` extraAllowedTools), reproduces identically on clean `main`, unrelated to this diff
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
