### PR TITLE
feat: bake chromium-headless-shell into agent/Dockerfile

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -41,6 +41,17 @@ FROM oven/bun:1-slim AS base
 #     agent can build client code at runtime (e.g. Rust projects + OpenSSL crates).
 #     (Piper TTS for voice-out is bundled in the runtime stage below; ffmpeg /
 #     python-edge-tts stay omitted — Piper emits WAV natively.)
+#   - Chromium/chromium-headless-shell OS deps for Playwright (PW-1.1/PW-1.2 —
+#     agent/src/browser.ts, follow-up task) — installed here as root so the
+#     runtime stage's `playwright install chromium-headless-shell` (run as USER
+#     1000, no --with-deps) has everything the binary needs to actually launch.
+#     This exact package list is Playwright 1.61.1's real dependency set —
+#     verified by running `playwright install-deps --dry-run chromium-headless-shell`
+#     against an installed 1.61.1, not assumed from docs or an older version's
+#     source. That dry run confirms chromium-headless-shell needs the identical
+#     package set as full `chromium` on this OS.
+#     oven/bun:1-slim is Debian trixie (13) — see node-source stage comment above
+#     — hence the t64-suffixed package names (Debian's 64-bit time_t transition).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
@@ -50,6 +61,38 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libssl-dev \
     pkg-config \
+    fonts-freefont-ttf \
+    fonts-ipafont-gothic \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    fonts-tlwg-loma-otf \
+    fonts-unifont \
+    fonts-wqy-zenhei \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libatspi2.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libdrm2 \
+    libfontconfig1 \
+    libfreetype6 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    xfonts-scalable \
+    xvfb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI via official GitHub apt keyring
@@ -178,6 +221,22 @@ COPY --from=build --chown=1000:1000 /app/.claude-plugin ./.claude-plugin
 # Make the credential helper and gh wrapper executable
 RUN chmod +x /app/agent/scripts/bin/git-credential-shipwright.sh \
     && chmod +x /app/agent/scripts/bin/gh
+
+# ─── Playwright chromium-headless-shell (agent/src/browser.ts, PW-1.2) ────────
+# Installed as the already-active USER 1000, under /home/bun — mirrors mise's
+# non-root-first pattern above rather than Piper's root-then-chown below, so no
+# chown step is needed and nothing lands root-owned. PLAYWRIGHT_BROWSERS_PATH is
+# an ENV (not just a build-time var), so it stays set for the running container
+# too — Playwright's launch API resolves the browser path from this same var.
+# `playwright` is pinned to 1.61.1 in agent/package.json: site's @playwright/test
+# is ^1.61.1 and metrics' is ^1.49.0 — these diverge, but bun's resolver already
+# hoists metrics' range up to 1.61.1 (the newest version satisfying both ranges),
+# so 1.61.1 is the version already present in this repo's bun.lock; the agent's
+# own `playwright` runtime dep is pinned to match rather than introducing a third
+# version. No --with-deps here (that would `apt-get install` as non-root and
+# fail) — the OS-level deps were already installed as root in the base stage.
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/bun/.cache/ms-playwright
+RUN ./agent/node_modules/.bin/playwright install chromium-headless-shell
 
 # ─── Piper offline TTS (voice-out) ────────────────────────────────────────────
 # Bundle the Piper binary + the default voice so the agent can synthesize voice

--- a/agent/package.json
+++ b/agent/package.json
@@ -16,7 +16,8 @@
     "@slack/web-api": "^7.16.0",
     "hono": "^4",
     "node-cron": "^4.6.0",
-    "openapi-fetch": "^0.13"
+    "openapi-fetch": "^0.13",
+    "playwright": "1.61.1"
   },
   "devDependencies": {
     "bun-types": "^1.3.14",

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.89.0",
+      "version": "1.90.2",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -57,6 +57,7 @@
         "hono": "^4",
         "node-cron": "^4.6.0",
         "openapi-fetch": "^0.13",
+        "playwright": "1.61.1",
       },
       "devDependencies": {
         "bun-types": "^1.3.14",
@@ -99,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.89.0",
+      "version": "1.90.2",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -117,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.89.0",
+      "version": "1.90.2",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",


### PR DESCRIPTION
## Summary
- Add the full Debian trixie dependency set Playwright's `chromium-headless-shell` needs to `agent/Dockerfile`'s base-stage `apt-get` block, verified live via `playwright install-deps --dry-run chromium-headless-shell` against an installed 1.61.1 rather than assumed from docs (this caught a missing `xvfb` package)
- Pin `playwright` to `1.61.1` in `agent/package.json`/`bun.lock`, matching the version bun's resolver already hoists site's (`^1.61.1`) and metrics' (`^1.49.0`, divergent) ranges to
- Install the `chromium-headless-shell` binary in the runtime stage as `USER 1000` with `PLAYWRIGHT_BROWSERS_PATH` under `/home/bun`, so nothing lands root-owned and no chown step is needed

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | apt-get list includes full chromium-headless-shell dep set, verified against pinned version's install-deps list | MET | Live-verified via `playwright install-deps --dry-run`; caught & fixed a missing `xvfb` package |
| 2 | package.json + bun.lock pinned to a version, divergence from site/metrics @playwright/test noted explicitly | MET | Pinned to 1.61.1; divergence from metrics' ^1.49.0 documented in a Dockerfile comment |
| 3 | Browser binary installs under /home/bun (uid 1000), no chown needed | MET | `ENV PLAYWRIGHT_BROWSERS_PATH=/home/bun/.cache/ms-playwright` + install RUN placed after `USER 1000` |
| 4 | No independent tests; ships bundled with PW-1.2 | MET | No tests added by design — PW-1.2 (dependency-linked, same branch) adds the integration test + CI verification step that actually proves the install works |

## Test Plan
- This is a Dockerfile/dependency-only change with no independently-testable logic — verification is deferred to PW-1.2's integration test and CI verification step, landing on this same branch
- [x] `task lint` passing
- [x] `task typecheck` passing
- [x] Dependency list cross-checked against a live `playwright install-deps --dry-run` run, not memory/docs
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
