### PR TITLE
docs: document .gitleaksignore auto-discovery in security-scan

### DIFF
--- a/plugins/shipwright/skills/security-scan/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/security-scan/SKILL.content.test.ts
@@ -98,6 +98,28 @@ describe("SKILL.md — Tier 1 pinned-version + sha256 download steps", () => {
   });
 });
 
+describe("SKILL.md — Step 3.1 gitleaks .gitleaksignore auto-discovery", () => {
+  it("documents that .gitleaksignore is auto-discovered at the scan source root", () => {
+    expect(content).toContain(".gitleaksignore");
+  });
+
+  it("documents the fingerprint format commit:file:rule:startLine", () => {
+    expect(content).toContain("commit:file:rule:startLine");
+  });
+
+  it("documents that suppression entries are added only via human HITL confirmation", () => {
+    const text = content.toLowerCase();
+    const hasHITL =
+      text.includes("hitl") || text.includes("human") || text.includes("closing");
+    const hasNeverAuto =
+      text.includes("never automatically") ||
+      text.includes("not automatically") ||
+      text.includes("human confirming") ||
+      text.includes("only");
+    expect(hasHITL && hasNeverAuto).toBe(true);
+  });
+});
+
 describe("SKILL.md — per-tool fallback behavior", () => {
   it("documents that a failed tool download is skipped, not fatal", () => {
     const hasFallback =

--- a/plugins/shipwright/skills/security-scan/SKILL.md
+++ b/plugins/shipwright/skills/security-scan/SKILL.md
@@ -131,6 +131,13 @@ tar -xz -f gitleaks.tar.gz gitleaks
 (Full-history mode: run `gitleaks detect` **without** `--no-git` so it walks the git log.)
 Record each finding in the common finding-record shape (Step 6).
 
+> **Suppression via `.gitleaksignore`.** This invocation auto-discovers and respects a
+> `.gitleaksignore` file at the scan source root (gitleaks natively defaults
+> `-i`/`--gitleaks-ignore-path` to `.` — no flag change is needed). Entries in
+> `.gitleaksignore` use the fingerprint format `commit:file:rule:startLine`. Suppression
+> entries are only added when a human confirms a false-positive finding while closing a HITL
+> task via `/shipwright:hitl` (see GLB-2.2), never automatically.
+
 ### 3.2 osv-scanner — lockfile / dependency CVEs
 
 osv-scanner ships a bare linux amd64 binary named `osv-scanner_linux_amd64` (no version in


### PR DESCRIPTION
## Summary
- Documents that `gitleaks detect --source .` (Step 3.1 of `security-scan`) already auto-discovers a repo-root `.gitleaksignore` (gitleaks defaults `-i`/`--gitleaks-ignore-path` to `.`) — no flag change needed, previously undocumented and easy to silently regress
- Documents the `.gitleaksignore` fingerprint format (`commit:file:rule:startLine`) and that suppression entries are only ever added via a human confirming a false positive when closing a HITL task through `/shipwright:hitl` (see GLB-2.2), never automatically
- Docs-only change — no functional/executable behavior changes

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 3.1 gains a note documenting `.gitleaksignore` auto-discovery, fingerprint format, and human-only HITL suppression | MET |
| 2 | `SKILL.content.test.ts` extended with content-layer assertions for `.gitleaksignore` and the fingerprint format string | MET |
| 3 | No functional/executable behavior changes | MET |

## Test Plan
- [x] New content-layer tests in `SKILL.content.test.ts` (41/41 pass)
- [x] `bunx biome lint .` clean
- [x] `docs:` commit prefix — no version bump (per marketplace-dev's Version Ownership table)

Generated with [Claude Code](https://claude.com/claude-code)
