### PR TITLE
fix: strip SENTRY_DSN from Claude Code session spawn env

### DIFF
--- a/agent/src/claude.ts
+++ b/agent/src/claude.ts
@@ -394,9 +394,16 @@ export function createRunClaude(
     args: string[],
     perCallOnProgress?: ProgressCallback,
   ): Promise<ClaudeRunResult> {
+    // Strip SENTRY_DSN so a spawned Claude Code session (and any `bun test`
+    // it runs internally) can never construct a real Sentry client from
+    // ambient env — this is not the agent's own operational Sentry
+    // reporting (see the reportCronFailure / captureException call sites),
+    // which runs in this parent process against its own client, unaffected
+    // by the child's env.
+    const { SENTRY_DSN: _sentryDsn, ...spawnEnv } = process.env;
     const proc = spawner(["claude", ...args], {
       cwd: workspace,
-      env: process.env,
+      env: spawnEnv,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/agent/src/claude.unit.test.ts
+++ b/agent/src/claude.unit.test.ts
@@ -309,6 +309,27 @@ describe("runClaude", () => {
     expect(opts.stderr).toBe("pipe");
   });
 
+  test("strips SENTRY_DSN from the spawned child's env but keeps unrelated vars", async () => {
+    const priorSentryDsn = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://fake@sentry.example/123";
+    try {
+      await runClaude("test");
+      const [, opts] = mockSpawn.mock.calls[0] as [
+        string[],
+        { env: Record<string, string | undefined> },
+      ];
+      expect(opts.env.SENTRY_DSN).toBeUndefined();
+      expect(opts.env.PATH).toBe(process.env.PATH);
+    } finally {
+      if (priorSentryDsn === undefined) {
+        // biome-ignore lint/performance/noDelete: process.env deletion is intentional — assignment stringifies to "undefined"
+        delete process.env.SENTRY_DSN;
+      } else {
+        process.env.SENTRY_DSN = priorSentryDsn;
+      }
+    }
+  });
+
   test("passes message as last arg without identity injection", async () => {
     await runClaude("my prompt");
     const [cmd] = mockSpawn.mock.calls[0] as [string[]];


### PR DESCRIPTION
## Summary
- `_spawn()` in `agent/src/claude.ts` now builds the child process env by destructuring `SENTRY_DSN` out of `process.env` instead of passing `process.env` straight through, so spawned Claude Code sessions (and any `bun test` run inside them) can never construct a real Sentry client from ambient env.
- This is the root-cause fix for shipwright agent containers leaking real error events to production Sentry from test runs. The agent's own operational Sentry reporting (`reportCronFailure`, session-failure capture in `claude.ts:539`) is untouched — it runs in the parent process against its own already-initialized client, not inside the spawned child's env.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `_spawn()` constructs its env as `{ ...process.env }` with `SENTRY_DSN` deleted/omitted, instead of passing `process.env` directly, before calling `spawner()`. | MET | `claude.ts:403` destructures `SENTRY_DSN` out via rest spread; `claude.ts:406` passes `env: spawnEnv` instead of `env: process.env` |
| 2 | New unit test in `claude.unit.test.ts` using the existing injected-spawner pattern; sets `SENTRY_DSN`, asserts it's omitted from the spawned env while an unrelated key (`PATH`) is retained; net-new coverage, no existing tests retired. | MET | `claude.unit.test.ts:312-331` — new test added (64 tests total, 63 pre-existing + 1 new); asserts `opts.env.SENTRY_DSN` is `undefined` and `opts.env.PATH` matches `process.env.PATH`; restores/deletes `SENTRY_DSN` in a `finally` block to avoid leaking into sibling tests |

## Test Plan
- `NODE_ENV=test bun test agent/src/claude.unit.test.ts` — 64/64 pass
- New test verified RED (failed against unfixed `env: process.env`) before the fix, GREEN after
- `bunx biome lint` on changed files — clean
- `bun run --filter='@shipwright/agent' typecheck` — clean
- Coverage on `agent/src/claude.ts`: 100% lines
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
