### PR TITLE
chore(chart): bump chart version to 1.7.149

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.7.149] - 2026-07-28
+
+### Changed
+
+- auto-bump to chart v1.7.149 triggered by release tag(s): `metrics-v1.21.0`
+
 ## [1.7.148] - 2026-07-28
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.7.148
+version: 1.7.149
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,13 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.7.148 triggered by release tag admin-v1.50.0"
-    - kind: changed
-      description: "auto-bump to chart v1.7.148 triggered by release tag chat-v1.19.0"
-    - kind: changed
-      description: "auto-bump to chart v1.7.148 triggered by release tag metrics-v1.21.0"
-    - kind: changed
-      description: "auto-bump to chart v1.7.148 triggered by release tag task-store-v1.28.0"
+      description: "auto-bump to chart v1.7.149 triggered by release tag metrics-v1.21.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer


### PR DESCRIPTION
## Chart version bump: 1.7.148 → 1.7.149

**Triggering tags:**
- `metrics-v1.21.0`

**New chart version:** `1.7.149`

**Pinned in values.yaml:**
- `metrics.image.tag`: `metrics-v1.21.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.7.149 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._