### PR TITLE
feat: add stale-worktree age sweep background module (WTR-1.2)

### DIFF
--- a/agent/src/worktree-reaper.ts
+++ b/agent/src/worktree-reaper.ts
@@ -69,12 +69,12 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
  * Resolve the scoped repo that owns a worktree dirname via longest-prefix
- * match. Repo names can themselves contain dashes (e.g. "vitals-os"), so a
+ * match. Repo names can themselves contain dashes (e.g. "example-repo"), so a
  * naive first-dash split is unsafe — instead, every scoped repo is checked
  * as a candidate prefix (`dirname === repo` or `dirname.startsWith(repo +
  * "-")`, so a match only counts at a "-" boundary, never mid-word) and the
- * LONGEST matching repo name wins (so "vitals-os" wins over a hypothetical
- * shorter false-positive prefix like "vitals").
+ * LONGEST matching repo name wins (so "example-repo" wins over a hypothetical
+ * shorter false-positive prefix like "example").
  *
  * Returns null when no scoped repo's name is a prefix of dirname.
  */

--- a/agent/src/worktree-reaper.ts
+++ b/agent/src/worktree-reaper.ts
@@ -1,0 +1,198 @@
+/**
+ * agent/src/worktree-reaper.ts
+ *
+ * Stale-worktree age sweep (WTR-1.2) — a pure-filesystem background pass
+ * that force-removes `worktrees/<repo>-<branch>` directories that have gone
+ * stale (older than the agent-policy.md-configured cleanup_after_days),
+ * mirroring the workspace CLAUDE.md instruction that worktrees older than 14
+ * days are removed automatically.
+ *
+ * Unlike pr-state-reconciler.ts, this module makes NO GitHub or task-store
+ * calls — it only reads agent-policy.md, lists the worktrees/ directory,
+ * checks mtimes against an injected clock, and runs `git worktree remove
+ * --force` for stale matches. It reuses WTR-1.1's parseCleanupMergedWorktrees
+ * / parseCleanupAfterDays (check-helpers.ts) rather than reimplementing
+ * policy parsing.
+ *
+ * Shape mirrors pr-state-reconciler.ts: an injected-deps interface, a pure
+ * `reconcileStaleWorktrees(deps)` core function, per-directory try/catch
+ * error isolation (console.error, not console.warn — matches
+ * reconcilePrState's per-record loop) so one bad directory can't abort the
+ * rest of the batch, and a `buildProductionDeps()` factory wiring real
+ * fs/git calls at the bottom.
+ *
+ * Not wired into agent/src/index.ts's setInterval registration — that's
+ * out of scope for this task (WTR-1.2 covers only the module + its unit
+ * tests).
+ */
+
+import { execFile } from "node:child_process";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+  parseCleanupAfterDays,
+  parseCleanupMergedWorktrees,
+  resolveWorkspacePath,
+} from "./check-helpers.ts";
+import type { Clock } from "./clock.ts";
+import { SystemClock } from "./clock.ts";
+
+const execFileAsync = promisify(execFile);
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** A single `removeWorktree(repo, dirname)` invocation — exported for test-fixture typing. */
+export interface RemoveWorktreeCall {
+  repo: string;
+  dirname: string;
+}
+
+export interface WorktreeReaperDeps {
+  /** Reads agent-policy.md content. */
+  readAgentPolicy: () => string;
+  /** Lists dirnames directly under worktrees/ (not full paths). */
+  listWorktreeDirs: () => string[];
+  /** The list of repo names to prefix-match worktree dirnames against. */
+  scopedRepos: string[];
+  /** mtime lookup for a given worktree dirname. */
+  statMtime: (dirname: string) => Date;
+  /** Force-removes a worktree: `git -C repos/{repo} worktree remove worktrees/{dirname} --force`. */
+  removeWorktree: (repo: string, dirname: string) => Promise<void>;
+  /** Injected time source — never call Date.now()/new Date() directly. */
+  clock: Clock;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the scoped repo that owns a worktree dirname via longest-prefix
+ * match. Repo names can themselves contain dashes (e.g. "vitals-os"), so a
+ * naive first-dash split is unsafe — instead, every scoped repo is checked
+ * as a candidate prefix (`dirname === repo` or `dirname.startsWith(repo +
+ * "-")`, so a match only counts at a "-" boundary, never mid-word) and the
+ * LONGEST matching repo name wins (so "vitals-os" wins over a hypothetical
+ * shorter false-positive prefix like "vitals").
+ *
+ * Returns null when no scoped repo's name is a prefix of dirname.
+ */
+function resolveOwningRepo(
+  dirname: string,
+  scopedRepos: string[],
+): string | null {
+  let best: string | null = null;
+  for (const repo of scopedRepos) {
+    const isMatch = dirname === repo || dirname.startsWith(`${repo}-`);
+    if (!isMatch) continue;
+    if (best === null || repo.length > best.length) best = repo;
+  }
+  return best;
+}
+
+/** True when `mtime` is older than `cleanupAfterDays` days before `now`. */
+function isStale(mtime: Date, now: Date, cleanupAfterDays: number): boolean {
+  const cutoff = now.getTime() - cleanupAfterDays * MS_PER_DAY;
+  return mtime.getTime() < cutoff;
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Scan worktrees/ for directories that have gone stale (older than the
+ * policy's cleanup_after_days) and force-remove each one via the injected
+ * removeWorktree dep. No-ops entirely (zero fs/git calls beyond reading the
+ * policy) when cleanup_merged_worktrees parses to false.
+ *
+ * A dirname whose prefix matches no scoped repo is skipped defensively
+ * (logged, not fatal). A single directory's removeWorktree failure is
+ * caught and logged; it does not abort processing of the remaining
+ * directories — mirrors pr-state-reconciler.ts's reconcilePrState per-record
+ * continue-on-error isolation.
+ */
+export async function reconcileStaleWorktrees(
+  deps: WorktreeReaperDeps,
+): Promise<void> {
+  const policyContent = deps.readAgentPolicy();
+  if (!parseCleanupMergedWorktrees(policyContent)) return; // disabled — no fs/git calls at all
+
+  const cleanupAfterDays = parseCleanupAfterDays(policyContent);
+  const now = deps.clock.now();
+
+  const dirs = deps.listWorktreeDirs();
+
+  for (const dirname of dirs) {
+    const repo = resolveOwningRepo(dirname, deps.scopedRepos);
+    if (repo === null) {
+      console.error(
+        `[worktree-reaper] skipping ${dirname} — no scoped repo matches this worktree dirname's prefix`,
+      );
+      continue;
+    }
+
+    try {
+      const mtime = deps.statMtime(dirname);
+      if (!isStale(mtime, now, cleanupAfterDays)) continue; // still fresh — leave untouched
+
+      await deps.removeWorktree(repo, dirname);
+    } catch (err) {
+      console.error(
+        `[worktree-reaper] failed to reconcile worktree ${dirname}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+/**
+ * Production deps for `reconcileStaleWorktrees()`. Reads agent-policy.md and
+ * worktrees/ from the resolved workspace path, and shells out to `git
+ * worktree remove --force` for the actual removal.
+ */
+export function buildProductionDeps(opts?: {
+  clock?: Clock;
+  scopedRepos?: string[];
+}): WorktreeReaperDeps {
+  const workspacePath = resolveWorkspacePath();
+
+  return {
+    readAgentPolicy: () => {
+      try {
+        return readFileSync(
+          join(workspacePath, "state", "agent-policy.md"),
+          "utf-8",
+        );
+      } catch {
+        return ""; // missing policy file — parseCleanupMergedWorktrees defaults to true, parseCleanupAfterDays to 14
+      }
+    },
+    listWorktreeDirs: () => {
+      try {
+        return readdirSync(join(workspacePath, "worktrees"), {
+          withFileTypes: true,
+        })
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => entry.name);
+      } catch {
+        return [];
+      }
+    },
+    scopedRepos: opts?.scopedRepos ?? [],
+    statMtime: (dirname: string) =>
+      statSync(join(workspacePath, "worktrees", dirname)).mtime,
+    removeWorktree: async (repo: string, dirname: string) => {
+      await execFileAsync("git", [
+        "-C",
+        join(workspacePath, "repos", repo),
+        "worktree",
+        "remove",
+        join(workspacePath, "worktrees", dirname),
+        "--force",
+      ]);
+    },
+    clock: opts?.clock ?? SystemClock(),
+  };
+}

--- a/agent/src/worktree-reaper.unit.test.ts
+++ b/agent/src/worktree-reaper.unit.test.ts
@@ -77,15 +77,15 @@ describe("reconcileStaleWorktrees", () => {
     // 20 days old, threshold 14 — stale.
     const oldMtime = new Date("2026-07-08T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      dirs: ["vitals-os-feat-foo"],
-      scopedRepos: ["vitals-os"],
-      mtimes: { "vitals-os-feat-foo": oldMtime },
+      dirs: ["example-repo-feat-foo"],
+      scopedRepos: ["example-repo"],
+      mtimes: { "example-repo-feat-foo": oldMtime },
     });
 
     await reconcileStaleWorktrees(deps);
 
     expect(removeCalls).toEqual([
-      { repo: "vitals-os", dirname: "vitals-os-feat-foo" },
+      { repo: "example-repo", dirname: "example-repo-feat-foo" },
     ]);
   });
 
@@ -93,9 +93,9 @@ describe("reconcileStaleWorktrees", () => {
     // 2 days old, threshold 14 — not stale.
     const recentMtime = new Date("2026-07-26T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      dirs: ["vitals-os-feat-foo"],
-      scopedRepos: ["vitals-os"],
-      mtimes: { "vitals-os-feat-foo": recentMtime },
+      dirs: ["example-repo-feat-foo"],
+      scopedRepos: ["example-repo"],
+      mtimes: { "example-repo-feat-foo": recentMtime },
     });
 
     await reconcileStaleWorktrees(deps);
@@ -108,9 +108,9 @@ describe("reconcileStaleWorktrees", () => {
     let statCalled = false;
     const { deps, removeCalls } = makeDeps({
       policyContent: "- **cleanup_merged_worktrees**: false\n",
-      dirs: ["vitals-os-feat-foo"],
-      scopedRepos: ["vitals-os"],
-      mtimes: { "vitals-os-feat-foo": new Date("2020-01-01T00:00:00.000Z") },
+      dirs: ["example-repo-feat-foo"],
+      scopedRepos: ["example-repo"],
+      mtimes: { "example-repo-feat-foo": new Date("2020-01-01T00:00:00.000Z") },
     });
     const wrappedDeps: WorktreeReaperDeps = {
       ...deps,
@@ -135,7 +135,7 @@ describe("reconcileStaleWorktrees", () => {
     const oldMtime = new Date("2026-07-08T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
       dirs: ["unknown-repo-feat-foo"],
-      scopedRepos: ["vitals-os", "shipwright"],
+      scopedRepos: ["example-repo", "shipwright"],
       mtimes: { "unknown-repo-feat-foo": oldMtime },
     });
 
@@ -146,21 +146,21 @@ describe("reconcileStaleWorktrees", () => {
   test("AC5: a single directory's removeWorktree failure is caught and logged; remaining directories still processed", async () => {
     const oldMtime = new Date("2026-07-08T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      dirs: ["vitals-os-feat-broken", "shipwright-feat-fine"],
-      scopedRepos: ["vitals-os", "shipwright"],
+      dirs: ["example-repo-feat-broken", "shipwright-feat-fine"],
+      scopedRepos: ["example-repo", "shipwright"],
       mtimes: {
-        "vitals-os-feat-broken": oldMtime,
+        "example-repo-feat-broken": oldMtime,
         "shipwright-feat-fine": oldMtime,
       },
       removeErrors: {
-        "vitals-os-feat-broken": new Error("git worktree remove failed"),
+        "example-repo-feat-broken": new Error("git worktree remove failed"),
       },
     });
 
     await expect(reconcileStaleWorktrees(deps)).resolves.toBeUndefined();
 
     expect(removeCalls).toEqual([
-      { repo: "vitals-os", dirname: "vitals-os-feat-broken" },
+      { repo: "example-repo", dirname: "example-repo-feat-broken" },
       { repo: "shipwright", dirname: "shipwright-feat-fine" },
     ]);
   });
@@ -168,40 +168,40 @@ describe("reconcileStaleWorktrees", () => {
   test("longest-prefix match: dashed repo names don't false-positive against a shorter prefix", async () => {
     const oldMtime = new Date("2026-07-08T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      dirs: ["vitals-os-feat-foo"],
-      // "vitals" is a false-positive shorter prefix; "vitals-os" is the real, longer match.
-      scopedRepos: ["vitals", "vitals-os"],
-      mtimes: { "vitals-os-feat-foo": oldMtime },
+      dirs: ["example-repo-feat-foo"],
+      // "example" is a false-positive shorter prefix; "example-repo" is the real, longer match.
+      scopedRepos: ["example", "example-repo"],
+      mtimes: { "example-repo-feat-foo": oldMtime },
     });
 
     await reconcileStaleWorktrees(deps);
 
     expect(removeCalls).toEqual([
-      { repo: "vitals-os", dirname: "vitals-os-feat-foo" },
+      { repo: "example-repo", dirname: "example-repo-feat-foo" },
     ]);
   });
 
   test("dirname exactly equal to a scoped repo name matches", async () => {
     const oldMtime = new Date("2026-07-08T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      dirs: ["vitals-os"],
-      scopedRepos: ["vitals-os"],
-      mtimes: { "vitals-os": oldMtime },
+      dirs: ["example-repo"],
+      scopedRepos: ["example-repo"],
+      mtimes: { "example-repo": oldMtime },
     });
 
     await reconcileStaleWorktrees(deps);
 
-    expect(removeCalls).toEqual([{ repo: "vitals-os", dirname: "vitals-os" }]);
+    expect(removeCalls).toEqual([{ repo: "example-repo", dirname: "example-repo" }]);
   });
 
   test("a dirname that merely starts with a repo name's characters but not at a '-' boundary does not match", async () => {
     const oldMtime = new Date("2026-07-08T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      // "vitals-osprey-feat-x" should NOT match scoped repo "vitals-os" —
+      // "example-repository-feat-x" should NOT match scoped repo "example-repo" —
       // the character after the prefix must be a "-" boundary (or nothing).
-      dirs: ["vitals-osprey-feat-x"],
-      scopedRepos: ["vitals-os"],
-      mtimes: { "vitals-osprey-feat-x": oldMtime },
+      dirs: ["example-repository-feat-x"],
+      scopedRepos: ["example-repo"],
+      mtimes: { "example-repository-feat-x": oldMtime },
     });
 
     await reconcileStaleWorktrees(deps);
@@ -214,36 +214,36 @@ describe("reconcileStaleWorktrees", () => {
     const staleUnderDefault = new Date("2026-07-13T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
       policyContent: "- **cleanup_merged_worktrees**: true\n",
-      dirs: ["vitals-os-feat-foo"],
-      scopedRepos: ["vitals-os"],
-      mtimes: { "vitals-os-feat-foo": staleUnderDefault },
+      dirs: ["example-repo-feat-foo"],
+      scopedRepos: ["example-repo"],
+      mtimes: { "example-repo-feat-foo": staleUnderDefault },
     });
 
     await reconcileStaleWorktrees(deps);
 
     expect(removeCalls).toEqual([
-      { repo: "vitals-os", dirname: "vitals-os-feat-foo" },
+      { repo: "example-repo", dirname: "example-repo-feat-foo" },
     ]);
   });
 
   test("multiple stale directories across different repos are all removed", async () => {
     const oldMtime = new Date("2026-07-01T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
-      dirs: ["vitals-os-feat-a", "shipwright-feat-b", "vitals-os-fix-c"],
-      scopedRepos: ["vitals-os", "shipwright"],
+      dirs: ["example-repo-feat-a", "shipwright-feat-b", "example-repo-fix-c"],
+      scopedRepos: ["example-repo", "shipwright"],
       mtimes: {
-        "vitals-os-feat-a": oldMtime,
+        "example-repo-feat-a": oldMtime,
         "shipwright-feat-b": oldMtime,
-        "vitals-os-fix-c": oldMtime,
+        "example-repo-fix-c": oldMtime,
       },
     });
 
     await reconcileStaleWorktrees(deps);
 
     expect(removeCalls).toEqual([
-      { repo: "vitals-os", dirname: "vitals-os-feat-a" },
+      { repo: "example-repo", dirname: "example-repo-feat-a" },
       { repo: "shipwright", dirname: "shipwright-feat-b" },
-      { repo: "vitals-os", dirname: "vitals-os-fix-c" },
+      { repo: "example-repo", dirname: "example-repo-fix-c" },
     ]);
   });
 
@@ -252,14 +252,14 @@ describe("reconcileStaleWorktrees", () => {
     const recentMtime = new Date("2026-07-27T00:00:00.000Z");
     const { deps, removeCalls } = makeDeps({
       dirs: [
-        "vitals-os-feat-stale",
-        "vitals-os-feat-fresh",
+        "example-repo-feat-stale",
+        "example-repo-feat-fresh",
         "ghost-repo-feat-x",
       ],
-      scopedRepos: ["vitals-os"],
+      scopedRepos: ["example-repo"],
       mtimes: {
-        "vitals-os-feat-stale": oldMtime,
-        "vitals-os-feat-fresh": recentMtime,
+        "example-repo-feat-stale": oldMtime,
+        "example-repo-feat-fresh": recentMtime,
         "ghost-repo-feat-x": oldMtime,
       },
     });
@@ -267,7 +267,7 @@ describe("reconcileStaleWorktrees", () => {
     await reconcileStaleWorktrees(deps);
 
     expect(removeCalls).toEqual([
-      { repo: "vitals-os", dirname: "vitals-os-feat-stale" },
+      { repo: "example-repo", dirname: "example-repo-feat-stale" },
     ]);
   });
 });

--- a/agent/src/worktree-reaper.unit.test.ts
+++ b/agent/src/worktree-reaper.unit.test.ts
@@ -1,0 +1,273 @@
+/**
+ * agent/src/worktree-reaper.unit.test.ts
+ *
+ * Unit tests for reconcileStaleWorktrees() — a pure-filesystem background
+ * pass (WTR-1.2) that force-removes worktrees/ directories older than the
+ * agent-policy.md-configured cleanup_after_days threshold.
+ *
+ * Uses fully injected fs/git-exec/clock doubles — no real filesystem or git
+ * calls, no global.fetch/global.* overrides, time injected via FixedClock —
+ * per this repo's unit-test isolation contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { FixedClock } from "./clock.ts";
+import {
+  type RemoveWorktreeCall,
+  type WorktreeReaperDeps,
+  reconcileStaleWorktrees,
+} from "./worktree-reaper.ts";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────────
+
+const FAKE_NOW = new Date("2026-07-28T00:00:00.000Z");
+
+interface MakeDepsOptions {
+  policyContent?: string;
+  dirs?: string[];
+  scopedRepos?: string[];
+  /** dirname -> mtime. Any dirname not present here throws (defensive — every test must configure the dirs it lists). */
+  mtimes?: Record<string, Date>;
+  /** dirname -> Error to throw from removeWorktree, if configured. */
+  removeErrors?: Record<string, Error>;
+  now?: Date;
+}
+
+function makeDeps(opts: MakeDepsOptions = {}): {
+  deps: WorktreeReaperDeps;
+  removeCalls: RemoveWorktreeCall[];
+} {
+  const {
+    policyContent = "- **cleanup_merged_worktrees**: true\n- **cleanup_after_days**: 14\n",
+    dirs = [],
+    scopedRepos = [],
+    mtimes = {},
+    removeErrors = {},
+    now = FAKE_NOW,
+  } = opts;
+
+  const removeCalls: RemoveWorktreeCall[] = [];
+
+  const deps: WorktreeReaperDeps = {
+    readAgentPolicy: () => policyContent,
+    listWorktreeDirs: () => dirs,
+    scopedRepos,
+    statMtime: (dirname: string) => {
+      const mtime = mtimes[dirname];
+      if (!mtime) {
+        throw new Error(`test fixture missing mtime for dirname: ${dirname}`);
+      }
+      return mtime;
+    },
+    removeWorktree: async (repo: string, dirname: string) => {
+      removeCalls.push({ repo, dirname });
+      const err = removeErrors[dirname];
+      if (err) throw err;
+    },
+    clock: FixedClock(now),
+  };
+
+  return { deps, removeCalls };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("reconcileStaleWorktrees", () => {
+  test("AC1: removes a worktree older than cleanup_after_days whose name's prefix matches a scoped repo", async () => {
+    // 20 days old, threshold 14 — stale.
+    const oldMtime = new Date("2026-07-08T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["vitals-os-feat-foo"],
+      scopedRepos: ["vitals-os"],
+      mtimes: { "vitals-os-feat-foo": oldMtime },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([
+      { repo: "vitals-os", dirname: "vitals-os-feat-foo" },
+    ]);
+  });
+
+  test("AC2: leaves a worktree younger than the threshold untouched", async () => {
+    // 2 days old, threshold 14 — not stale.
+    const recentMtime = new Date("2026-07-26T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["vitals-os-feat-foo"],
+      scopedRepos: ["vitals-os"],
+      mtimes: { "vitals-os-feat-foo": recentMtime },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([]);
+  });
+
+  test("AC3: cleanup_merged_worktrees false — no directories scanned or removed", async () => {
+    let listCalled = false;
+    let statCalled = false;
+    const { deps, removeCalls } = makeDeps({
+      policyContent: "- **cleanup_merged_worktrees**: false\n",
+      dirs: ["vitals-os-feat-foo"],
+      scopedRepos: ["vitals-os"],
+      mtimes: { "vitals-os-feat-foo": new Date("2020-01-01T00:00:00.000Z") },
+    });
+    const wrappedDeps: WorktreeReaperDeps = {
+      ...deps,
+      listWorktreeDirs: () => {
+        listCalled = true;
+        return deps.listWorktreeDirs();
+      },
+      statMtime: (dirname: string) => {
+        statCalled = true;
+        return deps.statMtime(dirname);
+      },
+    };
+
+    await reconcileStaleWorktrees(wrappedDeps);
+
+    expect(listCalled).toBe(false);
+    expect(statCalled).toBe(false);
+    expect(removeCalls).toEqual([]);
+  });
+
+  test("AC4: dirname whose prefix matches no scoped repo is skipped defensively", async () => {
+    const oldMtime = new Date("2026-07-08T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["unknown-repo-feat-foo"],
+      scopedRepos: ["vitals-os", "shipwright"],
+      mtimes: { "unknown-repo-feat-foo": oldMtime },
+    });
+
+    await expect(reconcileStaleWorktrees(deps)).resolves.toBeUndefined();
+    expect(removeCalls).toEqual([]);
+  });
+
+  test("AC5: a single directory's removeWorktree failure is caught and logged; remaining directories still processed", async () => {
+    const oldMtime = new Date("2026-07-08T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["vitals-os-feat-broken", "shipwright-feat-fine"],
+      scopedRepos: ["vitals-os", "shipwright"],
+      mtimes: {
+        "vitals-os-feat-broken": oldMtime,
+        "shipwright-feat-fine": oldMtime,
+      },
+      removeErrors: {
+        "vitals-os-feat-broken": new Error("git worktree remove failed"),
+      },
+    });
+
+    await expect(reconcileStaleWorktrees(deps)).resolves.toBeUndefined();
+
+    expect(removeCalls).toEqual([
+      { repo: "vitals-os", dirname: "vitals-os-feat-broken" },
+      { repo: "shipwright", dirname: "shipwright-feat-fine" },
+    ]);
+  });
+
+  test("longest-prefix match: dashed repo names don't false-positive against a shorter prefix", async () => {
+    const oldMtime = new Date("2026-07-08T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["vitals-os-feat-foo"],
+      // "vitals" is a false-positive shorter prefix; "vitals-os" is the real, longer match.
+      scopedRepos: ["vitals", "vitals-os"],
+      mtimes: { "vitals-os-feat-foo": oldMtime },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([
+      { repo: "vitals-os", dirname: "vitals-os-feat-foo" },
+    ]);
+  });
+
+  test("dirname exactly equal to a scoped repo name matches", async () => {
+    const oldMtime = new Date("2026-07-08T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["vitals-os"],
+      scopedRepos: ["vitals-os"],
+      mtimes: { "vitals-os": oldMtime },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([{ repo: "vitals-os", dirname: "vitals-os" }]);
+  });
+
+  test("a dirname that merely starts with a repo name's characters but not at a '-' boundary does not match", async () => {
+    const oldMtime = new Date("2026-07-08T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      // "vitals-osprey-feat-x" should NOT match scoped repo "vitals-os" —
+      // the character after the prefix must be a "-" boundary (or nothing).
+      dirs: ["vitals-osprey-feat-x"],
+      scopedRepos: ["vitals-os"],
+      mtimes: { "vitals-osprey-feat-x": oldMtime },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([]);
+  });
+
+  test("uses the default cleanup_after_days (14) when unset in policy content", async () => {
+    // 15 days old — stale under the 14-day default.
+    const staleUnderDefault = new Date("2026-07-13T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      policyContent: "- **cleanup_merged_worktrees**: true\n",
+      dirs: ["vitals-os-feat-foo"],
+      scopedRepos: ["vitals-os"],
+      mtimes: { "vitals-os-feat-foo": staleUnderDefault },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([
+      { repo: "vitals-os", dirname: "vitals-os-feat-foo" },
+    ]);
+  });
+
+  test("multiple stale directories across different repos are all removed", async () => {
+    const oldMtime = new Date("2026-07-01T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: ["vitals-os-feat-a", "shipwright-feat-b", "vitals-os-fix-c"],
+      scopedRepos: ["vitals-os", "shipwright"],
+      mtimes: {
+        "vitals-os-feat-a": oldMtime,
+        "shipwright-feat-b": oldMtime,
+        "vitals-os-fix-c": oldMtime,
+      },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([
+      { repo: "vitals-os", dirname: "vitals-os-feat-a" },
+      { repo: "shipwright", dirname: "shipwright-feat-b" },
+      { repo: "vitals-os", dirname: "vitals-os-fix-c" },
+    ]);
+  });
+
+  test("a mix of stale, fresh, and unmatched directories only removes the stale+matched one", async () => {
+    const oldMtime = new Date("2026-07-01T00:00:00.000Z");
+    const recentMtime = new Date("2026-07-27T00:00:00.000Z");
+    const { deps, removeCalls } = makeDeps({
+      dirs: [
+        "vitals-os-feat-stale",
+        "vitals-os-feat-fresh",
+        "ghost-repo-feat-x",
+      ],
+      scopedRepos: ["vitals-os"],
+      mtimes: {
+        "vitals-os-feat-stale": oldMtime,
+        "vitals-os-feat-fresh": recentMtime,
+        "ghost-repo-feat-x": oldMtime,
+      },
+    });
+
+    await reconcileStaleWorktrees(deps);
+
+    expect(removeCalls).toEqual([
+      { repo: "vitals-os", dirname: "vitals-os-feat-stale" },
+    ]);
+  });
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,8 +230,8 @@ Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file
 | `allow_self_review` | `bool` | `true` | Read by `agent/src/check-review.ts`'s `getReviewCandidates()` (the `shipwright-loop` cron's in-process review candidate provider) to decide whether the agent's own open PRs are review candidates. Set to `false` to require a human reviewer on agent-authored PRs. |
 | `min_confidence` | `number` | `75` | Minimum confidence score (0–100) for a finding to be included in a review. |
 | `max_findings` | `number` | `5` | Maximum number of findings to include in a single review. |
-| `cleanup_merged_worktrees` | `bool` | `true` | Automatically remove worktrees for merged branches. |
-| `cleanup_after_days` | `number` | `14` | Age threshold (days) before a merged-branch worktree is eligible for cleanup. |
+| `cleanup_merged_worktrees` | `bool` | `true` | Automatically remove stale worktrees older than `cleanup_after_days`. |
+| `cleanup_after_days` | `number` | `14` | Age threshold (days) before a worktree is eligible for automatic cleanup via `reconcileStaleWorktrees()`. |
 
 ### Example
 


### PR DESCRIPTION
## Summary
- Adds `agent/src/worktree-reaper.ts` implementing `reconcileStaleWorktrees(deps)`, a pure-filesystem background pass that force-removes stale `worktrees/<repo>-<branch>` directories once they exceed the `agent-policy.md`-configured `cleanup_after_days` threshold.
- Resolves each worktree dirname's owning repo via longest-prefix match against the scoped-repos list (handles dashed repo names like `vitals-os` safely, matching only at a `-` boundary).
- Mirrors `pr-state-reconciler.ts`'s per-item continue-on-error isolation — a single directory's `removeWorktree` failure is caught/logged without aborting the rest of the batch.
- Not wired into `agent/src/index.ts`'s `setInterval` registration — out of scope for this task (module + unit tests only).
- Refreshes `docs/configuration.md`'s `cleanup_merged_worktrees`/`cleanup_after_days` descriptions to reflect the actual age-based (not merge-based) cleanup behavior.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Stale worktree dir + matching scoped repo prefix → `removeWorktree(repo, dirname)` called | MET |
| 2 | Younger-than-threshold worktree left untouched | MET |
| 3 | `cleanup_merged_worktrees` parses to false → no directories scanned or removed | MET |
| 4 | Unmatched dirname prefix skipped defensively (logged, not fatal) | MET |
| 5 | Single `removeWorktree` failure caught/logged, remaining directories still processed | MET |
| 6 | New `agent/src/worktree-reaper.unit.test.ts` — fully injected fs/git-exec/clock doubles, no real fs/git calls, no `global.*` overrides, time via `Clock` | MET |

## Test Plan
- `NODE_ENV=test bun test agent/src/worktree-reaper.unit.test.ts` — 11/11 passing
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- Coverage gate: 80.76% lines / 81.63% functions (threshold 80%) — passing
- Note: `agent/src/claude.unit.test.ts` has 2 pre-existing failures on `main` (unrelated `runClaude`/`extraAllowedTools` cases) — confirmed present on `main` HEAD prior to this branch, not introduced here.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
