### PR TITLE
fix: prevent duplicate review posts when response parsing fails

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -548,14 +548,14 @@ should be held; the inline comments convey the specific feedback to the author.
    POST_EXIT=0
    gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews \
      --input $WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json \
-     > "$TMPDIR/pr_post_{pr}.json" 2>&1 || POST_EXIT=$?
+     > "/tmp/pr_post_{pr}.json" 2>&1 || POST_EXIT=$?
    ```
    **Never re-execute this POST.** If parsing fails, re-parse the temp file — do not
    re-run `gh api -X POST`, which submits a duplicate review that cannot be deleted or
    dismissed (GitHub does not allow deleting/dismissing COMMENTED reviews via the API).
 2. Capture `html_url` from the temp file:
    ```bash
-   REVIEW_URL=$(jq -r '.html_url // empty' "$TMPDIR/pr_post_{pr}.json")
+   REVIEW_URL=$(jq -r '.html_url // empty' "/tmp/pr_post_{pr}.json")
    ```
 3. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `REVIEW_URL` both count as failure:
    - **Success** (`POST_EXIT == 0` and `REVIEW_URL` present): continue to steps 4-6 below.

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -542,15 +542,23 @@ should be held; the inline comments convey the specific feedback to the author.
 
 ### If `auto_post_reviews` is true (policy):
 
-1. Submit via GitHub API, capturing both the exit status and the response body:
+1. Submit via GitHub API, writing the response to a temp file (NOT a shell variable —
+   the response JSON contains embedded newlines that corrupt `echo "$var" | jq` parsing):
    ```bash
-   POST_RESPONSE=$(gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews \
-     --input $WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json)
-   POST_EXIT=$?
+   POST_EXIT=0
+   gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews \
+     --input $WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json \
+     > "$TMPDIR/pr_post_{pr}.json" 2>&1 || POST_EXIT=$?
    ```
-2. Capture `html_url` from `$POST_RESPONSE` (e.g. `echo "$POST_RESPONSE" | jq -r '.html_url'`).
-3. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `html_url` both count as failure:
-   - **Success** (`POST_EXIT == 0` and `html_url` present): continue to steps 4-6 below.
+   **Never re-execute this POST.** If parsing fails, re-parse the temp file — do not
+   re-run `gh api -X POST`, which submits a duplicate review that cannot be deleted or
+   dismissed (GitHub does not allow deleting/dismissing COMMENTED reviews via the API).
+2. Capture `html_url` from the temp file:
+   ```bash
+   REVIEW_URL=$(jq -r '.html_url // empty' "$TMPDIR/pr_post_{pr}.json")
+   ```
+3. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `REVIEW_URL` both count as failure:
+   - **Success** (`POST_EXIT == 0` and `REVIEW_URL` present): continue to steps 4-6 below.
    - **Failure**: the GitHub post did not land, so nothing was actually reviewed at HEAD.
      Do not run Step 11b — marking the record posted here would let
      `check-review.ts`'s `commitSha`/`reviewState` dedup permanently hide this PR from
@@ -564,7 +572,7 @@ should be held; the inline comments convey the specific feedback to the author.
      2. Print a warning: `Warning: review post for #{pr} failed (exit {POST_EXIT}) — released claim, will retry next pass.`
      3. Stop — do not proceed to Step 11b or the Slack message below.
 4. Run Step 11b to mark the PR record posted.
-5. Print: `Posted review for #{pr}: {html_url}`
+5. Print: `Posted review for #{pr}: {REVIEW_URL}`
 6. Post Slack message (see below)
 
 ### If `auto_post_reviews` is false (default):

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -92,12 +92,12 @@ contains embedded newlines that break `echo "$var" | jq` parsing):
 ```bash
 gh api -X POST /repos/{org}/{repo}/pulls/{number}/reviews \
   --input state/reviews/pr_review_{number}.json \
-  > "$TMPDIR/pr_post_{number}.json" 2>&1
+  > "/tmp/pr_post_{number}.json" 2>&1
 ```
 
 Parse `html_url` from the temp file:
 ```bash
-REVIEW_URL=$(jq -r '.html_url // empty' "$TMPDIR/pr_post_{number}.json")
+REVIEW_URL=$(jq -r '.html_url // empty' "/tmp/pr_post_{number}.json")
 ```
 
 **Never re-execute the POST to fix a parse failure** — it submits a duplicate review

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -86,12 +86,22 @@ review JSON body is addressed to the PR author. Be direct -- no filler language
 
 ## Submitting the Review
 
+Write the response to a temp file — never capture in a shell variable (the response JSON
+contains embedded newlines that break `echo "$var" | jq` parsing):
+
 ```bash
 gh api -X POST /repos/{org}/{repo}/pulls/{number}/reviews \
-  --input state/reviews/pr_review_{number}.json
+  --input state/reviews/pr_review_{number}.json \
+  > "$TMPDIR/pr_post_{number}.json" 2>&1
 ```
 
-Capture `html_url` from the response to print the review link.
+Parse `html_url` from the temp file:
+```bash
+REVIEW_URL=$(jq -r '.html_url // empty' "$TMPDIR/pr_post_{number}.json")
+```
+
+**Never re-execute the POST to fix a parse failure** — it submits a duplicate review
+that cannot be deleted or dismissed via the API.
 
 ---
 


### PR DESCRIPTION
## Summary
- Write the GitHub API response to a temp file instead of capturing in a shell variable (embedded newlines in the response JSON corrupt `echo "$var" | jq` parsing)
- Parse `html_url` from the temp file with `jq` directly
- Add explicit "never re-execute this POST" warnings to both `review.md` Step 11 and `post-review-guide.md`

## Context
This has caused duplicate COMMENT reviews on multiple PRs. When the shell-variable-based parse fails, the natural "fix" is to retry the `gh api -X POST` call — which submits another review. GitHub's API does not allow deleting or dismissing COMMENTED reviews, so the duplicates are permanent.

## Test plan
- [x] All 33 content tests pass
- [x] All 21 unit tests pass
- [x] Pattern matches the existing temp-file approach used by Step 4's `/prs/claim` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)