### PR TITLE
feat: remove review.md's worktree cleanup step now that the background reaper is live

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,8 +230,8 @@ Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file
 | `allow_self_review` | `bool` | `true` | Read by `agent/src/check-review.ts`'s `getReviewCandidates()` (the `shipwright-loop` cron's in-process review candidate provider) to decide whether the agent's own open PRs are review candidates. Set to `false` to require a human reviewer on agent-authored PRs. |
 | `min_confidence` | `number` | `75` | Minimum confidence score (0–100) for a finding to be included in a review. |
 | `max_findings` | `number` | `5` | Maximum number of findings to include in a single review. |
-| `cleanup_merged_worktrees` | `bool` | `true` | Automatically remove stale worktrees older than `cleanup_after_days`. |
-| `cleanup_after_days` | `number` | `14` | Age threshold (days) before a worktree is eligible for automatic cleanup via `reconcileStaleWorktrees()`. |
+| `cleanup_merged_worktrees` | `bool` | `true` | Read by the agent's background worktree reconciler to decide whether merged-PR worktrees are automatically removed (`agent/src/pr-state-reconciler.ts`'s `reconcileRecord()`). Not read by `/shipwright:review`. |
+| `cleanup_after_days` | `number` | `14` | Age threshold (days) before a worktree is eligible for automatic cleanup via `reconcileStaleWorktrees()` (`agent/src/worktree-reaper.ts`, run on the same background interval as `agent/src/pr-state-reconciler.ts`). Not read by `/shipwright:review`. |
 
 ### Example
 

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -146,10 +146,10 @@ describe("review.md — task model tier passed to code-reviewer subagent (MTR-1.
 describe("review.md — state/reviews/ paths survive worktree checkout (RSP-1.1)", () => {
   it("Step 1 captures WORKSPACE_ROOT before the Step 4 worktree checkout", () => {
     const step1Idx = content.indexOf("## Step 1: Load Policy");
-    const step2Idx = content.indexOf("## Step 2: Clean Up Worktrees");
+    const step3Idx = content.indexOf("## Step 3: Resolve Current User and Target");
     expect(step1Idx).toBeGreaterThan(-1);
-    expect(step2Idx).toBeGreaterThan(-1);
-    const section = content.slice(step1Idx, step2Idx);
+    expect(step3Idx).toBeGreaterThan(-1);
+    const section = content.slice(step1Idx, step3Idx);
 
     expect(section).toContain("WORKSPACE_ROOT=$(pwd)");
     expect(section).toContain("state/reviews/");

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -70,44 +70,11 @@ Read `state/agent-policy.md`. If the file doesn't exist, use these conservative 
 | `allow_self_review` | true |
 | `min_confidence` | 75 |
 | `max_findings` | 5 |
-| `cleanup_merged_worktrees` | true |
-| `cleanup_after_days` | 14 |
 
 Print a one-line policy summary:
 ```
 Policy: {staging|auto-posting} reviews
 ```
-
----
-
-## Step 2: Clean Up Worktrees
-
-If `cleanup_merged_worktrees` is true:
-
-1. List PR records for each configured repo:
-   ```bash
-   curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-     "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}" | jq -c '.prs[]'
-   ```
-2. For each record whose `reviewState` is `in_progress`, `posted`, or `approved`:
-   - Check if the PR is merged or closed: `gh pr view {pr} --repo {org}/{repo} --json state -q '.state'`
-   - If `MERGED` or `CLOSED`:
-     - Remove the worktree if it exists: `git -C repos/{repo} worktree remove worktrees/{repo}-{branch-slug} --force 2>/dev/null`
-     - Mark the record terminal in one PATCH:
-       ```bash
-       curl -sf -X PATCH \
-         -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-         -H "Content-Type: application/json" \
-         "$SHIPWRIGHT_TASK_STORE_URL/prs/{record.id}" \
-         -d "{\"state\": \"merged\", \"mergedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >/dev/null
-       ```
-       `state: "merged"` is the terminal state — no further status progression is needed.
-3. Remove stale worktrees older than `cleanup_after_days`:
-   ```bash
-   find worktrees/ -maxdepth 1 -type d -mtime +{cleanup_after_days} -exec basename {} \;
-   ```
-   For each, remove via `git worktree remove`.
-4. If any cleaned: print `Cleaned {N} worktrees`
 
 ---
 


### PR DESCRIPTION
## Summary
- Delete `plugins/shipwright/commands/review.md`'s `## Step 2: Clean Up Worktrees` section and its `cleanup_merged_worktrees`/`cleanup_after_days` rows from Step 1's policy defaults table — the background worktree reconciler (`agent/src/worktree-reaper.ts` + `agent/src/pr-state-reconciler.ts`) now owns this cleanup, making the inline review-time cleanup redundant.
- Update `review.content.test.ts`'s WORKSPACE_ROOT-capture test to slice Step 1's content using the new `## Step 3: Resolve Current User and Target` boundary instead of the removed Step 2 heading.
- Update `docs/configuration.md`'s field-table rows for both settings to attribute them to the background reconciler rather than `/shipwright:review`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `review.md` no longer contains a 'Clean Up Worktrees' step; Step 1's policy table no longer lists the two settings | MET |
| 2 | `review.content.test.ts`'s WORKSPACE_ROOT test slices using the new Step 3 boundary and passes | MET |
| 3 | `docs/configuration.md` rows attribute both settings to the background reconciler | MET |
| 4 | The one existing boundary assertion is retired/replaced, not duplicated | MET |

## Test Plan
- `bun test plugins/shipwright/commands/review.content.test.ts` — 33/33 pass
- `task ci` — full suite passes except one pre-existing, unrelated flake (`agent/src/claude.unit.test.ts`'s `extraAllowedTools` test), confirmed to fail identically on unmodified `main`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
