### PR TITLE
fix: wait for required checks before merge-poll handoff in plugin-sync workflows

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -53,9 +53,14 @@ name: Auto-Bump Chart Version
 #      only the second run's `debounce` job completes and proceeds.
 #   3. Observe `bump-chart` opens exactly one PR, and its body/CHANGELOG entry
 #      credits both agent-v9.9.8 and admin-v9.9.9.
-#   4. Verify the PR merges once checks pass, and chart-release.yml fires
+#   4. In the "Wait for checks and merge" step's logs, confirm the initial
+#      poll waits specifically for a required check to register — even if a
+#      non-required check (e.g. "Detect changed paths") registers first, the
+#      step must keep polling rather than handing off to `--watch --required`
+#      early and failing with "no required checks reported".
+#   5. Verify the PR merges once checks pass, and chart-release.yml fires
 #      exactly once.
-#   5. Delete the dummy tags to clean up:
+#   6. Delete the dummy tags to clean up:
 #        git push origin --delete agent-v9.9.8 admin-v9.9.9
 #
 # Logic tests live in .github/workflows/test-auto-bump-chart.sh.
@@ -579,14 +584,18 @@ jobs:
         run: |
           PR_URL="${{ steps.pr.outputs.pr_url }}"
 
-          # `gh pr checks --watch` fails fast with "no checks reported" if it
-          # runs before GitHub has registered any check runs on the new
-          # commit — the check-triggering workflows haven't started yet
-          # immediately after `gh pr create`. Poll until at least one check
-          # appears before handing off to --watch.
-          echo "Waiting for checks to register on ${PR_URL}..."
+          # `gh pr checks --watch --required` fails fast with "no required
+          # checks reported" if it runs before GitHub has registered any
+          # *required* check run on the new commit. A non-required check
+          # (e.g. "Detect changed paths") commonly registers first — polling
+          # for ANY check (no --required filter) let this loop exit early on
+          # that non-required check, before a required check had appeared,
+          # handing off to --watch --required prematurely and failing
+          # instantly. Poll specifically for a required check to register
+          # before handing off to --watch --required below.
+          echo "Waiting for required checks to register on ${PR_URL}..."
           for _ in $(seq 1 30); do
-            CHECK_COUNT=$(gh pr checks "$PR_URL" --json name -q 'length' 2>/dev/null || echo 0)
+            CHECK_COUNT=$(gh pr checks "$PR_URL" --required --json name -q 'length' 2>/dev/null || echo 0)
             [ "$CHECK_COUNT" -gt 0 ] && break
             sleep 2
           done

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -58,9 +58,14 @@ name: Sync Plugin Version
 #   2. Observe this workflow runs, creates branch chore/plugin-version-v9.9.9,
 #      opens a PR, and enables auto-merge.
 #   3. Verify the PR's squash-merge subject includes "[skip ci]".
-#   4. After merge, confirm none of the five build-*.yml workflows fired for
+#   4. In the "Wait for checks and merge" step's logs, confirm the initial
+#      poll waits specifically for a required check to register — even if a
+#      non-required check (e.g. "Detect changed paths") registers first, the
+#      step must keep polling rather than handing off to `--watch --required`
+#      early and failing with "no required checks reported".
+#   5. After merge, confirm none of the five build-*.yml workflows fired for
 #      that merge commit.
-#   5. Delete the dummy tag to clean up:
+#   6. Delete the dummy tag to clean up:
 #        git push origin --delete agent-v9.9.9
 #
 # Logic tests live in .github/workflows/test-sync-plugin-version.sh.
@@ -258,14 +263,18 @@ jobs:
           PR_URL="${{ steps.pr.outputs.pr_url }}"
           VERSION="${{ steps.version.outputs.version }}"
 
-          # `gh pr checks --watch` fails fast with "no checks reported" if it
-          # runs before GitHub has registered any check runs on the new
-          # commit — the check-triggering workflows haven't started yet
-          # immediately after `gh pr create`. Poll until at least one check
-          # appears before handing off to --watch.
-          echo "Waiting for checks to register on ${PR_URL}..."
+          # `gh pr checks --watch --required` fails fast with "no required
+          # checks reported" if it runs before GitHub has registered any
+          # *required* check run on the new commit. A non-required check
+          # (e.g. "Detect changed paths") commonly registers first — polling
+          # for ANY check (no --required filter) let this loop exit early on
+          # that non-required check, before a required check had appeared,
+          # handing off to --watch --required prematurely and failing
+          # instantly. Poll specifically for a required check to register
+          # before handing off to --watch --required below.
+          echo "Waiting for required checks to register on ${PR_URL}..."
           for _ in $(seq 1 30); do
-            CHECK_COUNT=$(gh pr checks "$PR_URL" --json name -q 'length' 2>/dev/null || echo 0)
+            CHECK_COUNT=$(gh pr checks "$PR_URL" --required --json name -q 'length' 2>/dev/null || echo 0)
             [ "$CHECK_COUNT" -gt 0 ] && break
             sleep 2
           done


### PR DESCRIPTION
## Summary
- Fix a race in `sync-plugin-version.yml` and `auto-bump-chart.yml`'s "Wait for checks and merge" step: the initial polling loop waited for ANY check to register (`gh pr checks "$PR_URL" --json name -q 'length'`), including non-required checks like "Detect changed paths". If a non-required check registered before any required check, the loop exited early and handed off to `gh pr checks --watch --required`, which failed instantly with "no required checks reported" — orphaning the auto-generated version-bump PR.
- Both workflows now poll with `--required` (`gh pr checks "$PR_URL" --required --json name -q 'length'`), so the loop only exits once a required check has actually registered, matching what the subsequent `--watch --required` handoff expects.
- Updated the surrounding comments and each workflow's "Manual test plan" section to describe the fixed behavior and add a verification step for it.

Confirmed occurrences (2026-07-28): `sync-plugin-version.yml` failed for agent-v1.94.2, agent-v1.95.0, agent-v1.98.0, agent-v1.99.0 (PRs #2307, #2310, #2316, #2317); `auto-bump-chart.yml` failed once for agent-v1.94.0 (PR #2305). Manual cleanup for those was already done same day.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | sync-plugin-version.yml's poll uses `--required --json name -q 'length'` | MET |
| 2 | auto-bump-chart.yml gets the identical fix | MET |
| 3 | Comments + manual test plan sections updated in both workflows | MET |
| 4 | No new automated test added — verification stays manual (no unit-testable seam) | MET |

## Test Plan
- No automated test added — the polling loop only exercises live GitHub Actions/API state, mirroring existing `test-sync-plugin-version.sh`/`test-auto-bump-chart.sh` coverage (which only test `is_stale_base_error` and the idempotency guard, never this loop).
- Verification is manual per each workflow's already-documented dummy-tag test plan (push `agent-v9.9.9` / a service tag, observe the PR self-merges even if a non-required check registers first, delete the tag).
- [x] `task lint` passing
- [x] `task typecheck` passing
- [x] `task test:coverage` — 5367 pass, 1 pre-existing failure (`agent/src/claude.unit.test.ts`) confirmed identical on `main`, unrelated to this change
- [x] YAML validity of both modified files confirmed

Generated with [Claude Code](https://claude.com/claude-code)
