### PR TITLE
fix: use origin/$base in review/patch diff commands to avoid stale local refs

### DIFF
--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -608,7 +608,7 @@ From inside the worktree, collect the full picture of what needs fixing:
 1. **PR diff against base**:
    ```bash
    base=$(gh pr view {pr} --repo {org}/{repo} --json baseRefName -q '.baseRefName')
-   git diff "$base"...HEAD
+   git diff "origin/$base"...HEAD
    ```
 
 2. **Unresolved inline threads** (from Step 3a — already fetched, reuse):

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -203,10 +203,10 @@ describe("review.md — state/reviews/ paths survive worktree checkout (RSP-1.1)
     const section = content.slice(step10Idx, step11Idx);
 
     expect(section).toContain("**Diff-line mapping**");
-    expect(section).toContain("git diff {base}...HEAD -- {file}");
+    expect(section).toContain("git diff origin/{base}...HEAD -- {file}");
     // This must NOT be qualified with WORKSPACE_ROOT -- it correctly runs from
     // inside the worktree, unlike the file-write paths above.
-    const diffLineIdx = section.indexOf("git diff {base}...HEAD -- {file}");
+    const diffLineIdx = section.indexOf("git diff origin/{base}...HEAD -- {file}");
     const surrounding = section.slice(Math.max(0, diffLineIdx - 100), diffLineIdx);
     expect(surrounding).not.toContain("WORKSPACE_ROOT");
   });

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -185,10 +185,23 @@ back to `'sonnet'`.
 2. **Diff against the correct base branch** (not always main):
    ```bash
    base=$(gh pr view {pr} --repo {org}/{repo} --json baseRefName -q '.baseRefName')
-   git diff "$base"...HEAD
+   git diff "origin/$base"...HEAD
    ```
 
+   **Always use `origin/$base`, not bare `$base`.** The worktree is created from a
+   remote-tracking ref (`origin/{branch}`) and Step 4 runs `fetch origin`, so
+   `origin/main` is always fresh. But the local `main` branch is never updated — it
+   can be hundreds of commits behind, producing a diff that includes unrelated changes
+   from other merged PRs.
+
 3. **Changed files**: extract from the diff
+
+   **Sanity check**: compare the number of files in the diff against the PR metadata's
+   `changedFiles` count. If the diff contains significantly more files (e.g. 2x+), the
+   merge-base is likely wrong — the diff is picking up commits from other merged PRs.
+   Stop and diagnose: verify `origin/$base` resolves to the expected commit, check
+   whether `git merge-base origin/$base HEAD` matches what GitHub shows, and re-run
+   `git fetch origin` if needed. Do not proceed with a review based on a wrong diff.
 
 4. **CI status** via Actions API (not `gh pr checks` -- broken with PATs):
    ```bash
@@ -298,7 +311,7 @@ falling back to `'sonnet'` when no task is linked or the lookup failed), and pas
 a single prompt block containing:
 
 - **PR metadata** — `number`, `title`, `author`, `headRefName`, `baseRefName`, `headRefOid`
-- **Full diff** — the `git diff "$base"...HEAD` output from Step 5.2
+- **Full diff** — the `git diff "origin/$base"...HEAD` output from Step 5.2
 - **Changed files** — the list extracted in Step 5.3
 - **CLAUDE.md contents** — root CLAUDE.md + any CLAUDE.md in directories containing
   changed files (from Step 5.6). Include each as a labeled block so the subagent knows
@@ -490,7 +503,7 @@ For a COMMENT verdict, the `body` follows the same convention, e.g.
 `"body": "Verdict: COMMENT — {one-line summary of the most important finding}"`.
 
 **Diff-line mapping**: for each finding with a `file:line` reference, check if the
-line is in the diff (`git diff {base}...HEAD -- {file}`). Only lines within diff
+line is in the diff (`git diff origin/{base}...HEAD -- {file}`). Only lines within diff
 hunks are valid for inline comments. Move others to the review body.
 
 **Event selection** (from policy `allowed_events`):
@@ -823,7 +836,7 @@ These rules are non-negotiable regardless of policy settings:
 
 - **Verify before flagging**: check actual code, not just the diff. Confirm library
   versions, check if both branches of a conditional do the same thing.
-- **Check scope**: `git show {base}:{file}` -- if the issue exists on the base branch,
+- **Check scope**: `git show origin/{base}:{file}` -- if the issue exists on the base branch,
   it's out of scope.
 - **Don't echo CI**: don't call out failing tests unless confident your findings are
   the cause.

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -7,11 +7,13 @@ How to build and submit a GitHub review with inline comments. Referenced by
 
 ## Diff Against the Correct Base Branch
 
-Always diff against the PR's actual base branch, not main:
+Always diff against the PR's actual base branch, not main. Use `origin/$base`
+(the remote-tracking ref) — the local branch may be stale since worktrees only
+`fetch origin`, never `pull`:
 
 ```bash
 base=$(gh pr view <number> --repo <org/repo> --json baseRefName -q '.baseRefName')
-git diff "$base"...HEAD
+git diff "origin/$base"...HEAD
 ```
 
 PRs targeting feature branches will show wrong diffs if compared to main.
@@ -24,7 +26,7 @@ GitHub's reviews API only accepts `line` numbers for lines that appear in the di
 
 For each finding with a `file:line` reference:
 
-1. Get the file-specific diff: `git diff <base>...HEAD -- <file>`
+1. Get the file-specific diff: `git diff origin/<base>...HEAD -- <file>`
 2. Check if the line number falls within a diff hunk
 3. If yes: include as an inline comment with `path`, `line`, `side: "RIGHT"`
 4. If no: move the comment to the review body instead


### PR DESCRIPTION
## Summary

- The review and patch commands diff against `$base` (the bare branch name from GitHub's `baseRefName`), but worktrees only run `git fetch origin` — the local `main` branch is never updated. When it falls behind, `git merge-base main HEAD` picks a stale merge-base, producing a diff that includes unrelated commits from other merged PRs.
- Observed in production: a PR with 4 changed files produced a 68-file, 6.5k-line diff, causing the reviewer to approve based on the wrong diff.
- All `git diff`/`git show` commands now use `origin/$base` so the merge-base is always computed against the freshly-fetched remote-tracking ref.
- Added a sanity check in Step 5.3 that compares the diff file count against the PR metadata's `changedFiles` and stops if they diverge significantly.

## Test plan

- [x] `bun test commands/review.content.test.ts` — 33/33 pass
- [ ] Run `/shipwright:review` against a PR and verify the diff file count matches the PR metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)