### PR TITLE
chore: increase HITL poll interval default from 15s to 60s

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,7 +203,7 @@ On Kubernetes these env vars are a deploy-time option of the Helm chart rather t
 | `SHIPWRIGHT_HITL_HOST` | `string` | `localhost` | Hostname for service URLs in the HITL runner. Used to construct URLs for task-store and admin services (e.g. `http://localhost:3002` for task-store). |
 | `SHIPWRIGHT_HITL_REPOS` | `string` | — | Comma-separated list of `org/repo` strings assigned to the HITL agent record. Controls which task-store tasks the HITL agent token can claim via repo-scoped ownership (e.g. `app-vitals/shipwright`). |
 | `SHIPWRIGHT_HITL_AUTHORS` | `string` | — | Comma-separated list of GitHub login strings; when set, restricts review candidates to PRs authored by one of these users (default: none, unfiltered). Equivalent to the agent's `authorAllowlist` config field; `hitl.ts` syncs this value onto the persisted hitl agent record via `PATCH /agents/:id`. |
-| `SHIPWRIGHT_HITL_POLL_INTERVAL` | `number` | `15` | Polling interval in seconds for the HITL runner's task fetch loop. When no ready tasks are found, the runner waits this many seconds before retrying. |
+| `SHIPWRIGHT_HITL_POLL_INTERVAL` | `number` | `60` | Polling interval in seconds for the HITL runner's task fetch loop. When no ready tasks are found, the runner waits this many seconds before retrying. |
 
 ---
 

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -21,7 +21,7 @@
  *   SHIPWRIGHT_HITL_HOST          — hostname for service URLs (default: "localhost")
  *   SHIPWRIGHT_HITL_REPOS         — comma-separated org/repo list for the hitl agent (default: none)
  *   SHIPWRIGHT_HITL_AUTHORS       — comma-separated GitHub usernames; when set, restricts review candidates to PRs authored by one of these logins (default: none, unfiltered). hitl.ts's local equivalent of the agent's authorAllowlist config field, kept in sync on the persisted hitl agent record via PATCH.
- *   SHIPWRIGHT_HITL_POLL_INTERVAL — seconds between empty-queue polls (default: 15)
+ *   SHIPWRIGHT_HITL_POLL_INTERVAL — seconds between empty-queue polls (default: 60)
  */
 
 import {
@@ -130,7 +130,7 @@ export function parseHitlAuthors(raw: string | undefined): string[] {
 
 const HITL_AUTHORS = parseHitlAuthors(process.env.SHIPWRIGHT_HITL_AUTHORS);
 const POLL_INTERVAL_S = Number(
-  process.env.SHIPWRIGHT_HITL_POLL_INTERVAL ?? "15",
+  process.env.SHIPWRIGHT_HITL_POLL_INTERVAL ?? "60",
 );
 
 const DEV_DB_USER = process.env.USER ?? "";


### PR DESCRIPTION
## Summary
- Changes the default `SHIPWRIGHT_HITL_POLL_INTERVAL` from 15 seconds to 60 seconds to reduce unnecessary polling when the task queue is empty.
- The interval remains overridable via the env var.

## Test plan
- [ ] Verify `task hitl` polls at ~60s intervals with no env var override
- [ ] Verify `SHIPWRIGHT_HITL_POLL_INTERVAL=10` still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)