### PR TITLE
docs: restructure speed-baseline docs to two-tier aggregate/breakdown model

### DIFF
--- a/docs/test-readiness/speed-baseline.md
+++ b/docs/test-readiness/speed-baseline.md
@@ -13,6 +13,24 @@ speed-delta table") do not. This doc stands alone rather than filling in a table
 doesn't exist yet; once `test-readiness-plan.md` lands, its Section 3 can point here
 or copy these numbers in.
 
+## Aggregate (Tier 1)
+
+Per the two-tier measurement model in
+[`speed-budgets/SKILL.md`](../../plugins/shipwright/skills/speed-budgets/SKILL.md#two-tier-measurement-model),
+this is the primary, continuously-tracked number — pulled fresh from the most recent
+green run of the `lint / typecheck / test` CI job, the same way this doc's e2e/site
+rows below source their numbers from CI:
+
+- **Run:** [30415213982](https://github.com/app-vitals/shipwright/actions/runs/30415213982)
+  (2026-07-29T01:50:45Z), commit `1a6a085d0ccb91db5c29f0899b686c21dd060ece`
+- **Job wall-clock:** 2m01s (`lint / typecheck / test`, 01:50:59Z–01:53:00Z) — of which
+  the `Test` step (`task test:coverage`) itself ran 35.82s
+- **Tests:** 5762 pass / 1 skip / 0 fail — 5763 tests across 258 files
+- **vs. budget:** 2m01s against the <15 min Full-PR-pipeline budget — **13% of budget,
+  well within.** The escalation formula (aggregate wall-clock >7.5 min, sustained across
+  2 consecutive measurements) is nowhere near tripped, so no Tier 2 re-measurement is
+  warranted by this reading.
+
 ## Methodology
 
 - **unit / integration / smoke / content** — measured locally via
@@ -32,7 +50,16 @@ or copy these numbers in.
   Postgres in this sandbox) — skip counts are noted per row. This does not affect the
   measured wall-clock of the tests that did run.
 
-## Section 3: Speed-delta table
+## Section 3: Speed-delta table — Tier-2 breakdown
+
+**Last produced 2026-07-15.** This is the conditional per-package/per-layer breakdown
+from the two-tier model — it does not refresh on a fixed cadence. Per
+[`speed-budgets/SKILL.md`](../../plugins/shipwright/skills/speed-budgets/SKILL.md#two-tier-measurement-model)'s
+escalation formula, it is only re-produced when the Tier 1 aggregate above trips the
+escalation trigger (wall-clock >7.5 min, sustained across 2 consecutive measurements).
+The Tier 1 aggregate is currently at 13% of budget, nowhere near that trigger, so this
+table remains supplementary/on-demand context rather than something requiring
+perpetual refreshing.
 
 ### Plugin (`@shipwright/plugin`)
 
@@ -79,21 +106,10 @@ here for completeness since it carries real unit/integration/smoke/e2e layers to
 
 ## Full suite
 
-Verification command run at the repo root, exactly as specified in the T-002 task:
-
-```
-$ NODE_ENV=test bun test --coverage --coverage-reporter=lcov 2>&1 | tail -20
-
- 3842 pass
- 242 skip
- 0 fail
- 5 snapshots, 7873 expect() calls
-Ran 4084 tests across 198 files. [34.23s]
-```
-
-34.23s wall-clock, well within the `<2 min` full-suite budget documented in
-`test-system.md`. The 242 skips are the DB-gated agent/admin/task-store integration
-tests noted above — expected in a sandbox with no Postgres, not a regression.
+Superseded by the [Aggregate (Tier 1)](#aggregate-tier-1) section at the top of this
+doc, which now carries the continuously-tracked full-suite number (pulled from live CI
+against the current `<15 min` Full-PR-pipeline budget) in place of the one-off local
+`bun test` run this section previously cited.
 
 ## Summary
 

--- a/docs/test-readiness/test-system.md
+++ b/docs/test-readiness/test-system.md
@@ -367,15 +367,17 @@ introduce a reason to.
   (budget miss) is the trigger to revisit, not a fixed test-count threshold. This
   cycle's ~4-file net delta is not, on its own, that trigger.
 
-**Measured baseline (carried forward from T-067/T-002):** real per-layer numbers exist
-in [`speed-baseline.md`](./speed-baseline.md), measured across all five workspaces
-(plugin, metrics dashboard, agent, admin, site). Every measured layer falls comfortably
-within budget — unit 1.05s–2.50s per package, integration 0.15s–5.35s per package,
-smoke 3.24s–4.62s per package, E2E 4s–40s via CI, full suite 34.23s wall-clock (3842
-pass, 242 skip, 4084 tests across 198 files). This baseline predates this cycle's small
-source delta; the delta is not large enough to warrant a re-measurement before the next
-scheduled one. See `speed-baseline.md` for the full per-package breakdown and
-methodology.
+**Measured baseline (aggregate-first, per the two-tier model in `speed-budgets/SKILL.md`):**
+the primary, continuously-tracked number is the Tier 1 aggregate in
+[`speed-baseline.md`](./speed-baseline.md#aggregate-tier-1) — pulled fresh from the most
+recent green `lint / typecheck / test` CI run: [run 30415213982](https://github.com/app-vitals/shipwright/actions/runs/30415213982)
+(2026-07-29, commit `1a6a085d`), job wall-clock 2m01s against the <15 min Full-PR-pipeline
+budget (13% of budget, well within — no escalation triggered). `speed-baseline.md`'s
+Section 3 table is the Tier-2 per-package/per-layer breakdown (unit 1.05s–2.50s per
+package, integration 0.15s–5.35s per package, smoke 3.24s–4.62s per package, E2E 4s–40s
+via CI, across plugin/metrics/agent/admin/site) — last produced 2026-07-15, supplementary
+and on-demand: it refreshes only when the Tier 1 aggregate trips the escalation formula,
+not on a fixed cadence. See `speed-baseline.md` for the full breakdown and methodology.
 
 ## Shared helpers / utilities to build
 


### PR DESCRIPTION
## Summary
- Add a top-of-doc "Aggregate (Tier 1)" section to `docs/test-readiness/speed-baseline.md`, citing a fresh green CI run (run id/link, commit, date, pass/skip/fail counts, wall-clock) against the `<15 min` Full-PR-pipeline budget, sourced the same way the doc's existing e2e/site rows source from CI.
- Relabel the existing per-package/per-layer table as the "Tier-2 breakdown", adding a "last produced" date and a note that it refreshes only when Tier 1 trips the escalation trigger defined in `speed-budgets/SKILL.md` — not on a fixed cadence. Retired the stale "Full suite" section that cited an outdated `<2 min` budget in favor of pointing at the new Tier 1 section.
- Update `test-system.md`'s "Speed budgets" section (the "Measured baseline" paragraph) to cite the refreshed Tier 1 aggregate as the primary, continuously-tracked number, cross-referencing the Tier-2 table as supplementary/on-demand.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | speed-baseline.md has a new top-of-doc Aggregate section citing a live CI run vs. the <15min budget | MET |
| 2 | Existing per-package/per-layer table retained, relabeled as Tier-2 breakdown with "last produced" date + escalation-gated refresh note | MET |
| 3 | test-system.md's Measured baseline paragraph updated to cite the aggregate as primary, Tier-2 as supplementary | MET |
| 4 | Test decision: docs-only, no *.content.test.ts exists or is needed for docs/test-readiness/*.md | MET |

## Test Plan
- [x] `task lint` passing
- [x] `task typecheck` passing
- [x] `task check-config-docs` passing
- [x] `task check-strings` passing
- [x] Docs-only change — no test files needed (consistent with repo convention of content-testing only plugin SKILL.md files, not doc artifacts)

Generated with [Claude Code](https://claude.com/claude-code)
