### PR TITLE
feat: add browser launch helper and CI sandbox verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           bunx prisma migrate deploy --schema=chat/prisma/schema.prisma
 
       - name: Install Playwright chromium-headless-shell
-        run: bunx playwright install --with-deps chromium-headless-shell
+        run: ./agent/node_modules/.bin/playwright install --with-deps chromium-headless-shell
 
       - name: Test
         run: task test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,27 @@ jobs:
       - name: Build agent Docker image
         run: docker build -f agent/Dockerfile -t shipwright-agent:ci .
 
+      # Load-bearing check, not a build smoke test: a green `bun test` run in
+      # CI's normal (unrestricted) process does not prove Chromium can launch
+      # under the pod's actual restricted securityContext (runAsNonRoot,
+      # allowPrivilegeEscalation: false, no sudo) — only running the already
+      # -built image with matching restrictions does. --user 1000 mirrors the
+      # image's baked-in non-root runtime user; --security-opt=no-new-privileges
+      # mirrors allowPrivilegeEscalation: false. No new CI secrets — this runs
+      # the image already built above, entirely locally within this job.
+      #
+      # The image's ENTRYPOINT is exec-form (`bun run
+      # /app/agent/src/entrypoint-main.ts`), not CMD, so `docker run <image>
+      # <args>` would just append those args to the entrypoint's fixed command
+      # rather than replacing it. --entrypoint overrides it explicitly so the
+      # container runs the verify script instead of the full agent startup
+      # sequence.
+      - name: Verify browser launch under sandbox restrictions
+        run: |
+          docker run --rm --user 1000 --security-opt=no-new-privileges \
+            --entrypoint bun shipwright-agent:ci \
+            run agent/scripts/verify-browser-launch.ts
+
   metrics-docker-build:
     name: metrics docker build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
           bunx prisma migrate deploy --schema=task-store/prisma/schema.prisma
           bunx prisma migrate deploy --schema=chat/prisma/schema.prisma
 
+      - name: Install Playwright chromium-headless-shell
+        run: bunx playwright install --with-deps chromium-headless-shell
+
       - name: Test
         run: task test:coverage
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -175,7 +175,10 @@ RUN bun run scripts/sync-version.ts "${AGENT_VERSION}"
 # succeeding is not proof the image runs — this bundles the whole agent/src
 # tree (not just entrypoint-main.ts's reachable graph) so an import missed
 # by that one entry point, like the lib/ omission above, still gets caught.
-RUN find agent/src -name "*.ts" | xargs bun build --target=bun --outdir=/tmp/module-check
+# playwright/playwright-core are externalized: bun's bundler eagerly resolves
+# playwright-core's internal optional chromium-bidi requires, which aren't
+# actually installed or used by our CDP-based launch path.
+RUN find agent/src -name "*.ts" | xargs bun build --target=bun --external playwright --external playwright-core --outdir=/tmp/module-check
 
 # ─── Runtime stage (non-root) ─────────────────────────────────────────────────
 

--- a/agent/scripts/verify-browser-launch.ts
+++ b/agent/scripts/verify-browser-launch.ts
@@ -1,0 +1,47 @@
+/**
+ * agent/scripts/verify-browser-launch.ts
+ * CI-only smoke check: proves Chromium actually launches inside the built
+ * agent image under the pod's restricted securityContext.
+ *
+ * A green `bun test` run in CI's normal (unrestricted) process does not
+ * prove Chromium launches under Kubernetes' runAsNonRoot +
+ * allowPrivilegeEscalation: false + no-sudo securityContext — only running
+ * the built image with matching restrictions does. The `agent-docker-build`
+ * CI job invokes this script via:
+ *
+ *   docker run --rm --user 1000 --security-opt=no-new-privileges \
+ *     --entrypoint bun shipwright-agent:ci \
+ *     run agent/scripts/verify-browser-launch.ts
+ *
+ * Launches via launchBrowser() (agent/src/browser.ts), navigates a trivial
+ * data: URL, and confirms the page content is readable. Exits 0 on success,
+ * 1 with a clear stderr message on any failure.
+ */
+
+import { launchBrowser } from "../src/browser.ts";
+
+try {
+  const browser = await launchBrowser();
+  try {
+    const page = await browser.newPage();
+    await page.goto(
+      "data:text/html,<title>verify-browser-launch</title><h1>ok</h1>",
+    );
+    const title = await page.title();
+    const content = await page.content();
+    if (title !== "verify-browser-launch" || !content.includes("ok")) {
+      throw new Error(
+        `unexpected page state: title="${title}" content="${content}"`,
+      );
+    }
+    console.log("Browser launched and navigated successfully.");
+  } finally {
+    await browser.close();
+  }
+} catch (err) {
+  const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  console.error(`Error: browser failed to launch or navigate — ${msg}`);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/agent/src/browser.integration.test.ts
+++ b/agent/src/browser.integration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * agent/src/browser.integration.test.ts
+ *
+ * Integration test for launchBrowser() — a real I/O boundary (an actual
+ * Chromium process launch) with no existing coverage, so this exercises the
+ * real dependency rather than a double per docs/testing.md's integration
+ * layer definition.
+ *
+ * Verifies the browser launches under the same --no-sandbox flags the
+ * container's restricted securityContext requires (see agent/src/browser.ts)
+ * and that a trivial page can be navigated and read back.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Browser } from "playwright";
+import { launchBrowser } from "./browser.ts";
+
+describe("launchBrowser", () => {
+  let browser: Browser | undefined;
+
+  afterEach(async () => {
+    if (browser) {
+      await browser.close();
+      browser = undefined;
+    }
+  });
+
+  test("launches successfully", async () => {
+    browser = await launchBrowser();
+    expect(browser.isConnected()).toBe(true);
+  });
+
+  test("navigates a data: URL and reads back page content", async () => {
+    browser = await launchBrowser();
+    const page = await browser.newPage();
+    await page.goto(
+      "data:text/html,<title>shipwright-browser-test</title><h1>hello</h1>",
+    );
+    expect(await page.title()).toBe("shipwright-browser-test");
+    expect(await page.content()).toContain("hello");
+    await page.close();
+  });
+
+  test("navigates about:blank and reports a ready document", async () => {
+    browser = await launchBrowser();
+    const page = await browser.newPage();
+    await page.goto("about:blank");
+    const readyState = await page.evaluate(() => document.readyState);
+    expect(readyState).toBe("complete");
+    await page.close();
+  });
+});

--- a/agent/src/browser.ts
+++ b/agent/src/browser.ts
@@ -1,0 +1,34 @@
+/**
+ * agent/src/browser.ts
+ *
+ * Launches a headless Chromium browser for the agent's browser-driven tools
+ * (e.g. the PW-1.x line of work). Runs under the container's restricted
+ * securityContext (runAsNonRoot, allowPrivilegeEscalation: false, no sudo) —
+ * there is no real Linux user-namespace sandbox available, so Chromium's own
+ * OS-level sandbox must be disabled via --no-sandbox / --disable-setuid-sandbox
+ * (and Playwright's chromiumSandbox option, which wraps the same behavior).
+ *
+ * Browser resolution: chromium.launch({ headless: true }) with no explicit
+ * `channel` resolves to the chromium-headless-shell executable whenever it's
+ * installed (confirmed against playwright-core@1.61.1's actual launch-time
+ * executable resolution: BrowserType.getExecutableName() returns
+ * "chromium-headless-shell" when options.headless is true and no channel is
+ * set — see server/chromium/chromium.ts, bundled into lib/coreBundle.js).
+ * This matches Playwright's documented default headless-mode behavior since
+ * v1.49 (https://github.com/microsoft/playwright/issues/33566) — no channel
+ * string needs to be passed. agent/Dockerfile installs exactly this browser
+ * (`playwright install chromium-headless-shell`, PW-1.1), so no other
+ * Chromium variant is present in the runtime image for headless launches to
+ * fall back to.
+ */
+
+import { chromium } from "playwright";
+import type { Browser } from "playwright";
+
+export async function launchBrowser(): Promise<Browser> {
+  return chromium.launch({
+    headless: true,
+    chromiumSandbox: false,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@
 | Layer | Framework | Boundary rule | Suffix |
 |---|---|---|---|
 | **Unit** | `bun test` | Pure logic — no I/O of any kind (no filesystem, network, or subprocess). | `*.unit.test.ts` |
-| **Integration** | `bun test` + injected recorded doubles | Real dependency behavior via recorded fixtures / injected doubles, or real filesystem I/O on committed repo content — exercises the seam without a live external service. | `*.integration.test.ts` |
+| **Integration** | `bun test` + injected recorded doubles | Real dependency behavior via recorded fixtures / injected doubles, or real filesystem I/O on committed repo content — exercises the seam without a live external service. Exception: critical infrastructure like containerized browser launches where recorded fixtures would miss runtime-environment issues (e.g., securityContext sandbox compliance). | `*.integration.test.ts` |
 | **Smoke** | `bun test` + Hono `app.request()`, or `Bun.serve()` + `fetch()` | HTTP route contracts (status, shape, auth, errors). Prefer in-process `app.request()` (no real socket) for Hono apps; a real `Bun.serve()` boot with live `fetch()` is permitted when there's no in-process request seam (e.g. a bare-`Bun.serve()` server with no Hono app factory). | `*.smoke.test.ts` |
 | **E2E** | `@playwright/test` | Full browser-driven flows against a real running server. Marketing site home page (`site/*.spec.ts`); metrics dashboard (`metrics/e2e/*.e2e.ts`); admin UI (`admin/e2e/*.e2e.ts`). | `*.spec.ts` (in `site/`), `*.e2e.ts` (in `metrics/e2e/`, `admin/e2e/`) |
 | **Content** | `bun test` | Markdown/prompt-content-assertion tests — e.g. checking that a command's or skill's Markdown body contains expected sections/instructions/wording. Distinct from unit/integration/smoke: no real I/O boundary, just asserting on static content. | `*.content.test.ts` |
@@ -48,7 +48,7 @@ cd site && npm test                  # playwright (*.spec.ts)
 |---|---|---|
 | Plugin (`plugins/shipwright`) | unit, content | `bun test --filter plugins/shipwright` |
 | Metrics (`metrics`) | unit, integration, smoke, e2e | `bun test --filter metrics` (unit/integration/smoke); `task e2e` (e2e) |
-| Agent (`agent`) | unit, integration, smoke | `bun test --filter agent` |
+| Agent (`agent`) | unit, integration (real I/O), smoke | `bun test --filter agent` (Note: integration tests include real Playwright/Chromium browser launches to verify containerized execution under restricted securityContext, beyond recorded fixture coverage) |
 | Admin (`admin`) | unit, integration, smoke, e2e | `bun test --filter admin` (unit/integration/smoke); `cd admin && bunx playwright test` (e2e) |
 | Chat (`chat`) | unit, integration, smoke | `bun test --filter chat` |
 | Task Store (`task-store`) | unit, integration, smoke | `bun test --filter task-store` |


### PR DESCRIPTION
## Summary
- Add `agent/src/browser.ts` exporting `launchBrowser()`, launching headless Chromium with `--no-sandbox`/`--disable-setuid-sandbox` (and `chromiumSandbox: false`) so it works under the pod's restricted securityContext (`runAsNonRoot`, `allowPrivilegeEscalation: false`, no sudo). No explicit `channel` needed — Playwright 1.61.1 auto-resolves to the `chromium-headless-shell` executable (already installed by PW-1.1) when `headless: true` is set with no channel.
- Add `agent/src/browser.integration.test.ts` — a real integration test that launches the browser and navigates a `data:` URL and `about:blank`, asserting readable page content.
- Add `agent/scripts/verify-browser-launch.ts` — a standalone script used by the new CI step.
- Add a "Verify browser launch under sandbox restrictions" step to `.github/workflows/ci.yml`'s existing `agent-docker-build` job, running `docker run --rm --user 1000 --security-opt=no-new-privileges --entrypoint bun shipwright-agent:ci run agent/scripts/verify-browser-launch.ts` against the already-built image — this is the load-bearing check that a green `bun test` run alone can't prove (browser launch under the pod's actual restricted securityContext).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `browser.ts` exports `launchBrowser()` using `--no-sandbox`/`--disable-setuid-sandbox` and the correct Playwright API for the chromium-headless-shell channel | MET |
| 2 | `browser.integration.test.ts` launches a real browser and confirms navigation/readable content | MET |
| 3 | New CI step builds the image and runs it with `--user 1000 --security-opt=no-new-privileges`, exiting non-zero on failure | MET |
| 4 | No existing tests retired | MET |
| 5 | No new CI secrets required | MET |

## Test Plan
- `NODE_ENV=test bun test agent/src/browser.integration.test.ts` — 3/3 pass locally
- `task ci` — lint, typecheck, check-strings, check-config-docs, check-version-sync all pass; coverage gate (80/80) passes on `test:coverage`'s aggregate; 2 unrelated pre-existing flaky failures (`task-store/src/routes/prs.openapi.smoke.test.ts`, `metrics/src/lib/errors.unit.test.ts`) reproduce identically on a clean `origin/main` checkout under the same full-suite run — confirmed not caused by this change (main showed different flaky failures on a repeat run: `scripts/quickstart.smoke.test.ts`, `agent/src/claude.unit.test.ts`)
- [x] Pre-commit checks passing
- New CI step's exact `docker run --entrypoint` invocation is untested locally (no docker binary in the dev sandbox) — reasoned from the image's documented `ENTRYPOINT`/no-`CMD` semantics; this PR's own CI run is the first live validation.

Generated with [Claude Code](https://claude.com/claude-code)
