### PR TITLE
fix: retry bump-chart on branch collision instead of silent skip (CBR-2.1)

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -28,6 +28,22 @@ name: Auto-Bump Chart Version
 # accepted tradeoff — release cadence here is a handful of tags a day, not a
 # continuous stream. If that changes, add a max-wait fallback.
 #
+# Collision retry: debounce collapses bursts down to one bump-chart run per
+# burst, but two *separate* bursts (triggered by different service release
+# tags landing close together but more than DEBOUNCE_SECONDS apart) can still
+# compute the same next chart version from the same starting Chart.yaml —
+# both are reading main before either has pushed its bump commit. The
+# "Resolve chart version bump" step detects this via a branch-name collision
+# (`chore/chart-v{version}` already exists on the remote) and, instead of
+# silently skipping and dropping its whole tag batch, fetches fresh main and
+# recomputes its batch/version/branch from that new state — collect_batch_tags
+# naturally excludes tags credited by the concurrent run that landed first,
+# since that run's own chart-bump commit becomes the new "since" cutoff. This
+# retries up to a fixed number of attempts with a brief backoff between each.
+# If every attempt still collides, the step fails the job outright, naming
+# the release tag(s) that could not be pinned — no more silent green runs
+# that quietly drop a batch of release tags.
+#
 # Flow:
 #   tag push (agent-v* / admin-v* / metrics-v* / task-store-v* / chat-v*)
 #     → debounce job: sleep DEBOUNCE_SECONDS
@@ -36,6 +52,9 @@ name: Auto-Bump Chart Version
 #     → bump-chart job
 #       → collect every release tag pushed since the last chart-bump commit
 #       → bump patch version in Chart.yaml once for the whole batch
+#       → on branch-name collision with a concurrent run: fetch fresh main,
+#         re-derive the batch/version, and retry (bounded attempts); fail
+#         loudly (naming the un-pinned tags) if every attempt collides
 #       → pin each batched tag's highest semver into its values.yaml
 #         image.tag path(s) (admin/metrics/agent+provisioning/taskStore/chat)
 #       → open PR (chore/chart-v{new_version}) crediting all batched tags and
@@ -62,6 +81,35 @@ name: Auto-Bump Chart Version
 #      exactly once.
 #   6. Delete the dummy tags to clean up:
 #        git push origin --delete agent-v9.9.8 admin-v9.9.9
+#
+# Manual test plan — collision retry (also cannot be fully exercised in CI
+# without real concurrent tag pushes + secrets):
+#   1. Note the current chart version in charts/shipwright/Chart.yaml, e.g.
+#      X.Y.Z, and manually pre-create + push the branch the *next* bump would
+#      use, simulating a concurrent run that already landed:
+#        git checkout -b chore/chart-vX.Y.(Z+1)
+#        git push origin chore/chart-vX.Y.(Z+1)
+#        git checkout main
+#   2. Push a dummy tag to trigger a real run:
+#        git tag agent-v9.9.7 && git push origin agent-v9.9.7
+#   3. In the "Resolve chart version bump (retry on branch collision)" step's
+#      logs, confirm it detects the collision on attempt 1 ("Branch ... already
+#      exists on remote"), fetches fresh main, and recomputes — since no
+#      matching chart-bump commit actually landed on main in this manual
+#      simulation, the *same* version will collide again; either delete the
+#      dummy pre-created branch partway through to let a later attempt
+#      succeed (confirming the retry recomputes and proceeds), or let all
+#      5 attempts exhaust to exercise the failure path below.
+#   4. If all attempts exhaust: confirm the job fails (non-zero exit) and the
+#      step's log contains a line starting with "ERROR: exhausted 5 attempts"
+#      that names the release tag(s) (e.g. agent-v9.9.7) that could not be
+#      pinned — this must surface as a real failed GitHub Actions run, not a
+#      silent success.
+#   5. If a later attempt succeeds (branch deleted mid-retry): confirm the PR
+#      that opens targets the *recomputed* version/branch (not the one that
+#      collided) and still credits agent-v9.9.7.
+#   6. Clean up the dummy tag and any leftover branches:
+#        git push origin --delete agent-v9.9.7 chore/chart-vX.Y.(Z+1)
 #
 # Logic tests live in .github/workflows/test-auto-bump-chart.sh.
 # Run locally: bash .github/workflows/test-auto-bump-chart.sh
@@ -130,101 +178,132 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Credit every release tag that landed since the last chart-bump commit,
-      # not just the tag that happened to trigger this run — that's everything
-      # the debounce window batched together. Falls back to the triggering tag
-      # alone if no prior bump commit exists (e.g. first-ever bump).
-      - name: Collect release tags in this batch
-        id: batch
-        run: |
-          PATTERNS=("agent-v*" "admin-v*" "metrics-v*" "task-store-v*" "chat-v*")
-
-          LAST_BUMP_SHA=$(git log -1 --format=%H --grep='^chore(chart): bump chart version' -- charts/shipwright/Chart.yaml || true)
-
-          SINCE=""
-          if [ -n "$LAST_BUMP_SHA" ]; then
-            SINCE=$(git log -1 --format=%cI "$LAST_BUMP_SHA")
-          fi
-
-          TAGS=()
-          if [ -n "$SINCE" ]; then
-            for PATTERN in "${PATTERNS[@]}"; do
-              while IFS= read -r LINE; do
-                [ -z "$LINE" ] && continue
-                TAGS+=("$LINE")
-              done < <(git for-each-ref "refs/tags/${PATTERN}" \
-                --format='%(creatordate:iso-strict)|%(refname:short)' \
-                | awk -F'|' -v since="$SINCE" '$1 > since { print $2 }')
-            done
-          fi
-
-          # Always include the triggering tag even if it fell outside the
-          # window (clock skew, first-ever bump) — never silently drop the
-          # tag that fired this run.
-          TRIGGER="${GITHUB_REF_NAME}"
-          FOUND=false
-          for T in "${TAGS[@]:-}"; do
-            [ "$T" = "$TRIGGER" ] && FOUND=true
-          done
-          if [ "$FOUND" = "false" ]; then
-            TAGS+=("$TRIGGER")
-          fi
-
-          TAGS_CSV=$(printf '%s\n' "${TAGS[@]}" | sort -u | paste -sd, -)
-
-          echo "tags=${TAGS_CSV}" >> "$GITHUB_OUTPUT"
-          echo "Batched tags for this bump: ${TAGS_CSV}"
-
-      # Read the current chart version using grep+sed — avoids a yq dependency.
-      # The version line in Chart.yaml is always "version: X.Y.Z" (no spaces
-      # before the key, plain value — no quoting).
-      - name: Read current chart version
-        id: current
-        run: |
-          VERSION=$(grep '^version:' charts/shipwright/Chart.yaml | sed 's/^version: //')
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Current chart version: ${VERSION}"
-
-      # Increment the patch component only. Chart version bumps are always
-      # patch-level here — minor/major bumps remain a manual step. One bump
-      # covers the whole batch of tags collected above, however many landed.
-      - name: Compute new chart version
-        id: new
-        run: |
-          CURRENT="${{ steps.current.outputs.version }}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          PATCH=$(( PATCH + 1 ))
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          BRANCH="chore/chart-v${NEW_VERSION}"
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "branch=${BRANCH}"       >> "$GITHUB_OUTPUT"
-          echo "New chart version: ${NEW_VERSION} (branch: ${BRANCH})"
-
-      # Idempotency guard: if the branch for this exact chart version already
-      # exists on the remote, a prior run already opened the bump PR — skip.
-      # With debounce collapsing bursts into a single bump-chart run, this is
-      # now only a safety net for the rare case of two debounce windows
-      # resolving close together, not the common path.
-      - name: Check for existing bump branch
-        id: idempotency
+      # Collect this run's tag batch, compute the next chart version/branch,
+      # and resolve any branch-name collision against a *fresh* main — all
+      # in one step, since a collision means re-deriving every one of these
+      # values from scratch (not just picking a new version number).
+      #
+      # Credit every release tag that landed since the last chart-bump
+      # commit, not just the tag that happened to trigger this run — that's
+      # everything the debounce window batched together. Falls back to the
+      # triggering tag alone if no prior bump commit exists (e.g. first-ever
+      # bump). Same tag-collection logic as
+      # .github/workflows/test-auto-bump-chart.sh's collect_batch_tags() —
+      # keep both copies in sync.
+      #
+      # Collision handling: two concurrent bump-chart runs (triggered by
+      # different service release tags landing close together but outside
+      # the debounce window) can compute the *same* next chart version from
+      # the same starting Chart.yaml. The loser used to just skip silently,
+      # dropping its entire tag batch (including values.yaml pins) with no
+      # error. Instead: on collision, fetch fresh main, re-derive the batch
+      # and version from that new state (collect_batch_tags naturally
+      # excludes tags that landed before the concurrent run's own chart-bump
+      # commit, since that commit's timestamp becomes the new `since`
+      # cutoff), and retry — bounded to MAX_ATTEMPTS with a brief backoff.
+      # If every attempt collides, fail loudly naming the tags that could
+      # not be pinned rather than exiting 0 having silently dropped them.
+      # Mirrors .github/workflows/test-auto-bump-chart.sh's
+      # compute_batch_and_version() / branch_exists_on_remote() /
+      # resolve_batch_with_retry() — keep both copies in sync.
+      - name: Resolve chart version bump (retry on branch collision)
+        id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="${{ steps.new.outputs.branch }}"
-          if git ls-remote --heads origin "$BRANCH" | grep -q .; then
-            echo "Branch ${BRANCH} already exists on remote — skipping bump (burst-collapse)."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          MAX_ATTEMPTS=5
+          BACKOFF_SECONDS=15
+          TRIGGER="${GITHUB_REF_NAME}"
+
+          collect_batch_tags() {
+            local trigger_tag="$1"
+            local patterns=("agent-v*" "admin-v*" "metrics-v*" "task-store-v*" "chat-v*")
+
+            local last_bump_sha
+            last_bump_sha=$(git log -1 --format=%H --grep='^chore(chart): bump chart version' -- charts/shipwright/Chart.yaml || true)
+
+            local since=""
+            if [ -n "$last_bump_sha" ]; then
+              since=$(git log -1 --format=%cI "$last_bump_sha")
+            fi
+
+            local tags=()
+            if [ -n "$since" ]; then
+              for pattern in "${patterns[@]}"; do
+                while IFS= read -r line; do
+                  [ -z "$line" ] && continue
+                  tags+=("$line")
+                done < <(git for-each-ref "refs/tags/${pattern}" \
+                  --format='%(creatordate:iso-strict)|%(refname:short)' \
+                  | awk -F'|' -v since="$since" '$1 > since { print $2 }')
+              done
+            fi
+
+            local found=false
+            for t in "${tags[@]:-}"; do
+              [ "$t" = "$trigger_tag" ] && found=true
+            done
+            if [ "$found" = "false" ]; then
+              tags+=("$trigger_tag")
+            fi
+
+            printf '%s\n' "${tags[@]}" | sort -u | paste -sd, -
+          }
+
+          compute_batch_and_version() {
+            local trigger_tag="$1"
+            local tags_csv
+            tags_csv=$(collect_batch_tags "$trigger_tag")
+
+            local current_version new_version branch
+            current_version=$(grep '^version:' charts/shipwright/Chart.yaml | sed 's/^version: //')
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$current_version"
+            PATCH=$(( PATCH + 1 ))
+            new_version="${MAJOR}.${MINOR}.${PATCH}"
+            branch="chore/chart-v${new_version}"
+
+            printf '%s|%s|%s|%s\n' "$tags_csv" "$current_version" "$new_version" "$branch"
+          }
+
+          for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
+            RESULT=$(compute_batch_and_version "$TRIGGER")
+            TAGS_CSV="${RESULT%%|*}"
+            REST="${RESULT#*|}"
+            CURRENT_VERSION="${REST%%|*}"
+            REST="${REST#*|}"
+            NEW_VERSION="${REST%%|*}"
+            BRANCH="${REST#*|}"
+
+            if ! git ls-remote --heads origin "$BRANCH" | grep -q .; then
+              echo "tags=${TAGS_CSV}" >> "$GITHUB_OUTPUT"
+              echo "current_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+              echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+              echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+              echo "Resolved chart bump: ${CURRENT_VERSION} -> ${NEW_VERSION} (branch: ${BRANCH}), tags: ${TAGS_CSV}"
+              exit 0
+            fi
+
+            echo "Branch ${BRANCH} already exists on remote (attempt ${attempt}/${MAX_ATTEMPTS}) — someone else's batch landed first."
+
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Fetching fresh main and retrying in ${BACKOFF_SECONDS}s..."
+              sleep "$BACKOFF_SECONDS"
+              git fetch origin main
+              git checkout main
+              git reset --hard origin/main
+              git fetch origin --tags --force
+            fi
+          done
+
+          echo "ERROR: exhausted ${MAX_ATTEMPTS} attempts to bump the chart version — branch ${BRANCH} still collides after re-deriving from fresh main each time. Release tag(s) that could NOT be pinned: ${TAGS_CSV}" >&2
+          exit 1
 
       # Update the version field in Chart.yaml using python3 (available on all
       # GitHub-hosted runners). Regex substitution on the 'version:' line only
       # avoids inadvertently touching appVersion or dependency versions.
       - name: Update Chart.yaml version
-        if: steps.idempotency.outputs.skip != 'true'
         run: |
-          NEW_VERSION="${{ steps.new.outputs.version }}"
+          NEW_VERSION="${{ steps.resolve.outputs.version }}"
           python3 - charts/shipwright/Chart.yaml "$NEW_VERSION" <<'PYEOF'
           import sys, re
           path, new_ver = sys.argv[1], sys.argv[2]
@@ -239,10 +318,9 @@ jobs:
       # annotation — one "changed" entry per tag, so a burst-collapsed bump
       # still surfaces exactly which releases it contains.
       - name: Update artifacthub.io/changes annotation
-        if: steps.idempotency.outputs.skip != 'true'
         run: |
-          TAGS_CSV="${{ steps.batch.outputs.tags }}"
-          NEW_VERSION="${{ steps.new.outputs.version }}"
+          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
+          NEW_VERSION="${{ steps.resolve.outputs.version }}"
           python3 - charts/shipwright/Chart.yaml "$TAGS_CSV" "$NEW_VERSION" <<'PYEOF'
           import sys, re
           path, tags_csv, ver = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -267,10 +345,9 @@ jobs:
       # Prepend a new entry to CHANGELOG.md so it stays in sync with Chart.yaml.
       # Chart.yaml line 28-29 requires the two to mirror each other on every bump.
       - name: Update CHANGELOG.md
-        if: steps.idempotency.outputs.skip != 'true'
         run: |
-          NEW_VERSION="${{ steps.new.outputs.version }}"
-          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          NEW_VERSION="${{ steps.resolve.outputs.version }}"
+          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
           TAGS_LIST=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/`/; s/$/`/' | paste -sd, - | sed 's/,/, /g')
           DATE=$(date -u +%Y-%m-%d)
           ENTRY="## [${NEW_VERSION}] - ${DATE}\n\n### Changed\n\n- auto-bump to chart v${NEW_VERSION} triggered by release tag(s): ${TAGS_LIST}\n"
@@ -300,7 +377,6 @@ jobs:
       # select_pinned_tags / update_values_tag — keep both copies in sync.
       - name: Pin released tags into values.yaml
         id: pin
-        if: steps.idempotency.outputs.skip != 'true'
         run: |
           # Maps a release tag prefix to its service key.
           service_for_tag() {
@@ -430,7 +506,7 @@ jobs:
           PYEOF
           }
 
-          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
           PINNED=$(select_pinned_tags "$TAGS_CSV")
 
           # Rendered alongside the values.yaml writes below (same
@@ -467,11 +543,10 @@ jobs:
       # values.yaml changes, and push.
       - name: Commit and push bump branch
         id: commit-push
-        if: steps.idempotency.outputs.skip != 'true'
         run: |
-          BRANCH="${{ steps.new.outputs.branch }}"
-          NEW_VERSION="${{ steps.new.outputs.version }}"
-          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          BRANCH="${{ steps.resolve.outputs.branch }}"
+          NEW_VERSION="${{ steps.resolve.outputs.version }}"
+          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/  - /')
 
           git checkout -b "$BRANCH"
@@ -483,20 +558,22 @@ jobs:
 
           After merge, chart-release.yml will publish chart v${NEW_VERSION}."
 
-          # Fault-tolerant push: if a concurrent run slips through the
-          # idempotency check (ls-remote and push are non-atomic), the second
-          # push will fail because the branch already exists. Treat that as a
-          # clean skip rather than a noisy workflow failure.
-          git push -u origin "$BRANCH" || {
-            echo "Branch ${BRANCH} already pushed by a concurrent run — skipping."
-            echo "push_skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
+          # The "Resolve chart version bump" step above already retried
+          # against fresh main up to MAX_ATTEMPTS times to clear any branch
+          # collision, so a push failure here means an even narrower
+          # concurrent-push race slipped through in the moments between that
+          # step's final collision check and this push (ls-remote and push
+          # are non-atomic). That's still a batch of release tags
+          # (${TAGS_CSV}) that would go unpinned — fail loudly rather than
+          # silently skipping, per the same no-silent-drop rule as the
+          # retry loop above. A human/on-call sees a real failure and can
+          # re-run the workflow (which will re-derive against main as it
+          # then stands).
+          git push -u origin "$BRANCH"
 
       # Open the PR targeting main. The title triggers chart-testing CI (helm.yml)
       # and the merge will trigger chart-release.yml (which watches charts/**).
       - name: Open bump PR
-        if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         id: pr
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -514,11 +591,11 @@ jobs:
           # expanded value for further substitution.
           PINNED_LINES: ${{ steps.pin.outputs.pinned_lines }}
         run: |
-          NEW_VERSION="${{ steps.new.outputs.version }}"
-          CURRENT_VERSION="${{ steps.current.outputs.version }}"
-          TAGS_CSV="${{ steps.batch.outputs.tags }}"
+          NEW_VERSION="${{ steps.resolve.outputs.version }}"
+          CURRENT_VERSION="${{ steps.resolve.outputs.current_version }}"
+          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/- `/; s/$/`/')
-          BRANCH="${{ steps.new.outputs.branch }}"
+          BRANCH="${{ steps.resolve.outputs.branch }}"
 
           PR_URL=$(gh pr create \
             --base main \
@@ -577,7 +654,6 @@ jobs:
       # past all retries, the step still ultimately fails for the same
       # reason.
       - name: Wait for checks and merge
-        if: steps.idempotency.outputs.skip != 'true' && steps.commit-push.outputs.push_skipped != 'true'
         timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/test-auto-bump-chart.sh
+++ b/.github/workflows/test-auto-bump-chart.sh
@@ -345,12 +345,16 @@ collect_batch_tags() {
 # instead of returning success having dropped them.
 # ---------------------------------------------------------------------------
 
-# Computes the {tags_csv, new_version, branch} triple from the current
-# working-directory repo state. Mirrors chaining the "Collect release tags
-# in this batch" + "Read current chart version" + "Compute new chart
-# version" steps into one reusable unit, so the retry loop below can re-run
-# it wholesale after re-syncing to fresh main. Emits "tags_csv|version|branch"
-# on stdout (single line — tag values and versions never contain '|').
+# Computes the {tags_csv, current_version, new_version, branch} quadruple
+# from the current working-directory repo state. Mirrors chaining the
+# "Collect release tags in this batch" + "Read current chart version" +
+# "Compute new chart version" steps into one reusable unit, so the retry
+# loop below can re-run it wholesale after re-syncing to fresh main. Emits
+# "tags_csv|current_version|new_version|branch" on stdout (single line — tag
+# values and versions never contain '|'). Matches the real workflow's
+# compute_batch_and_version() 4-field output shape exactly (auto-bump-chart.yml)
+# — steps.resolve.outputs.current_version is consumed downstream by the
+# "Open bump PR" step's PR body.
 compute_batch_and_version() {
   local trigger_tag="$1"
   local chart_yaml="${2:-charts/shipwright/Chart.yaml}"
@@ -363,7 +367,7 @@ compute_batch_and_version() {
   new_version=$(bump_patch "$current_version")
   branch="chore/chart-v${new_version}"
 
-  printf '%s|%s|%s\n' "$tags_csv" "$new_version" "$branch"
+  printf '%s|%s|%s|%s\n' "$tags_csv" "$current_version" "$new_version" "$branch"
 }
 
 # Checks whether `branch` exists as a head ref in `remote_dir` (a bare or
@@ -386,12 +390,16 @@ branch_exists_on_remote() {
 # exactly when/how the "fresh main" state changes between attempts, without
 # this function needing to know about network/CI specifics.
 #
-# On success, prints "tags_csv|version|branch" on stdout and returns 0.
-# On exhaustion (every attempt collided), prints nothing on stdout, prints
-# an explicit, greppable error to stderr naming the release tags that could
-# not be pinned (from the final attempt's batch), and returns 1 — the
-# caller (the real workflow step) must let that failure propagate as a
-# non-zero exit, not swallow it.
+# On success, prints "tags_csv|current_version|new_version|branch" on stdout
+# and returns 0. On exhaustion (every attempt collided), prints nothing on
+# stdout, prints an explicit, greppable error to stderr naming the release
+# tags that could not be pinned (from the final attempt's batch), and
+# returns 1 — the caller (the real workflow step) must let that failure
+# propagate as a non-zero exit, not swallow it. current_version isn't
+# needed by the retry/collision logic itself (only tags_csv appears in the
+# exhausted-error message) — it's threaded through solely so the 4-field
+# shape survives to the caller, matching the real workflow's
+# steps.resolve.outputs.current_version.
 resolve_batch_with_retry() {
   local trigger_tag="$1"
   local work_dir="$2"
@@ -400,11 +408,13 @@ resolve_batch_with_retry() {
   local max_attempts="${5:-5}"
   local backoff_seconds="${6:-10}"
 
-  local attempt result tags_csv new_version branch
+  local attempt result tags_csv current_version new_version branch
   for (( attempt=1; attempt<=max_attempts; attempt++ )); do
     result=$(cd "$work_dir" && compute_batch_and_version "$trigger_tag")
     tags_csv="${result%%|*}"
     local rest="${result#*|}"
+    current_version="${rest%%|*}"
+    rest="${rest#*|}"
     new_version="${rest%%|*}"
     branch="${rest#*|}"
 
@@ -867,8 +877,8 @@ echo ""
 echo "=== compute_batch_and_version tests ==="
 
 CBV_RESULT=$(cd "$GIT_TEST_DIR" && compute_batch_and_version "agent-v0.144.0")
-assert_eq "compute_batch_and_version: tags|version|branch shape" \
-  "admin-v0.156.0,agent-v0.144.0|1.6.285|chore/chart-v1.6.285" \
+assert_eq "compute_batch_and_version: tags|current_version|new_version|branch shape" \
+  "admin-v0.156.0,agent-v0.144.0|1.6.284|1.6.285|chore/chart-v1.6.285" \
   "$CBV_RESULT"
 
 # ---------------------------------------------------------------------------
@@ -1010,7 +1020,7 @@ RETRY_STATUS=$?
 
 assert_eq "resolve_batch_with_retry: succeeds after one collision" "0" "$RETRY_STATUS"
 assert_eq "resolve_batch_with_retry: recomputes non-colliding version 1.6.286" \
-  "task-store-v0.9.0|1.6.286|chore/chart-v1.6.286" \
+  "task-store-v0.9.0|1.6.285|1.6.286|chore/chart-v1.6.286" \
   "$RETRY_RESULT"
 
 # --- resolve_batch_with_retry: 3(b) exhausted-retries path exits non-zero

--- a/.github/workflows/test-auto-bump-chart.sh
+++ b/.github/workflows/test-auto-bump-chart.sh
@@ -326,6 +326,108 @@ collect_batch_tags() {
 }
 
 # ---------------------------------------------------------------------------
+# Branch-collision retry logic (mirrors the consolidated "Collect release
+# tags in this batch" + "Read current chart version" + "Compute new chart
+# version" + "Check for existing bump branch" step)
+#
+# Two concurrent bump-chart runs (triggered by different service release
+# tags landing close together but outside the debounce window) can compute
+# the *same* next chart version from the same starting Chart.yaml — the
+# first run to push its branch wins, and the loser used to just set
+# skip=true and silently drop its entire tag batch (including values.yaml
+# pins) with no error, exiting success. That silently loses real release
+# tags from ever being pinned/credited.
+#
+# The fix: on branch collision, re-derive state from fresh main (a new
+# chart-bump commit may have just landed) and retry — bounded to a fixed
+# number of attempts with a brief backoff between attempts. If every
+# attempt collides, fail loudly naming the tags that could not be pinned,
+# instead of returning success having dropped them.
+# ---------------------------------------------------------------------------
+
+# Computes the {tags_csv, new_version, branch} triple from the current
+# working-directory repo state. Mirrors chaining the "Collect release tags
+# in this batch" + "Read current chart version" + "Compute new chart
+# version" steps into one reusable unit, so the retry loop below can re-run
+# it wholesale after re-syncing to fresh main. Emits "tags_csv|version|branch"
+# on stdout (single line — tag values and versions never contain '|').
+compute_batch_and_version() {
+  local trigger_tag="$1"
+  local chart_yaml="${2:-charts/shipwright/Chart.yaml}"
+
+  local tags_csv
+  tags_csv=$(collect_batch_tags "$trigger_tag")
+
+  local current_version new_version branch
+  current_version=$(read_chart_version "$chart_yaml")
+  new_version=$(bump_patch "$current_version")
+  branch="chore/chart-v${new_version}"
+
+  printf '%s|%s|%s\n' "$tags_csv" "$new_version" "$branch"
+}
+
+# Checks whether `branch` exists as a head ref in `remote_dir` (a bare or
+# non-bare git repo used as the "origin" fixture in tests). Mirrors the
+# "Check for existing bump branch" step's `git ls-remote --heads origin
+# "$BRANCH" | grep -q .` check.
+branch_exists_on_remote() {
+  local branch="$1"
+  local remote_dir="$2"
+  git ls-remote --heads "$remote_dir" "$branch" | grep -q .
+}
+
+# Bounded retry loop around branch-collision resolution. Mirrors what the
+# consolidated workflow step does: compute the batch/version/branch, check
+# for a remote collision, and if one exists, re-sync `work_dir` to fresh
+# main and recompute — up to `max_attempts` times, with `backoff_seconds`
+# between attempts. `resync_fn` is the name of a function (no args) that
+# re-syncs `work_dir` to fresh main (e.g. simulating `git fetch origin main
+# && git reset --hard origin/main`); it's injected so tests can drive
+# exactly when/how the "fresh main" state changes between attempts, without
+# this function needing to know about network/CI specifics.
+#
+# On success, prints "tags_csv|version|branch" on stdout and returns 0.
+# On exhaustion (every attempt collided), prints nothing on stdout, prints
+# an explicit, greppable error to stderr naming the release tags that could
+# not be pinned (from the final attempt's batch), and returns 1 — the
+# caller (the real workflow step) must let that failure propagate as a
+# non-zero exit, not swallow it.
+resolve_batch_with_retry() {
+  local trigger_tag="$1"
+  local work_dir="$2"
+  local remote_dir="$3"
+  local resync_fn="$4"
+  local max_attempts="${5:-5}"
+  local backoff_seconds="${6:-10}"
+
+  local attempt result tags_csv new_version branch
+  for (( attempt=1; attempt<=max_attempts; attempt++ )); do
+    result=$(cd "$work_dir" && compute_batch_and_version "$trigger_tag")
+    tags_csv="${result%%|*}"
+    local rest="${result#*|}"
+    new_version="${rest%%|*}"
+    branch="${rest#*|}"
+
+    if ! branch_exists_on_remote "$branch" "$remote_dir"; then
+      printf '%s\n' "$result"
+      return 0
+    fi
+
+    echo "Branch ${branch} already exists on remote (attempt ${attempt}/${max_attempts}) — someone else's batch landed first." >&2
+
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      echo "Re-syncing to fresh main and retrying in ${backoff_seconds}s..." >&2
+      sleep "$backoff_seconds"
+      "$resync_fn"
+      continue
+    fi
+  done
+
+  echo "ERROR: exhausted ${max_attempts} attempts to bump the chart version — branch ${branch} still collides after re-deriving from fresh main each time. Release tag(s) that could NOT be pinned: ${tags_csv}" >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # Stale-base merge-retry logic (mirrors the "Wait for checks and merge" step)
 #
 # gh pr merge --admin can fail with a transient GraphQL error when a
@@ -756,6 +858,200 @@ mkdir -p "$GIT_TEST_DIR2"
 
 FALLBACK=$(cd "$GIT_TEST_DIR2" && collect_batch_tags "metrics-v1.0.0")
 assert_eq "falls back to triggering tag with no prior bump commit" "metrics-v1.0.0" "$FALLBACK"
+
+# ---------------------------------------------------------------------------
+# Tests: compute_batch_and_version
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== compute_batch_and_version tests ==="
+
+CBV_RESULT=$(cd "$GIT_TEST_DIR" && compute_batch_and_version "agent-v0.144.0")
+assert_eq "compute_batch_and_version: tags|version|branch shape" \
+  "admin-v0.156.0,agent-v0.144.0|1.6.285|chore/chart-v1.6.285" \
+  "$CBV_RESULT"
+
+# ---------------------------------------------------------------------------
+# Tests: branch_exists_on_remote / resolve_batch_with_retry
+#
+# Fixture: a bare "remote" repo (simulating `origin`) plus a "work_dir" repo
+# (simulating the runner's checkout of main) that pushes to it. The
+# `resync_fn` callback simulates the "fetch fresh main / reset --hard
+# origin/main" step the real workflow performs after a collision — in these
+# tests it's just `git -C work_dir fetch/reset` against the shared remote.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== branch_exists_on_remote / resolve_batch_with_retry tests ==="
+
+make_retry_fixture() {
+  local fixture_name="$1"
+  local remote_dir="$TMPDIR_TEST/remote-${fixture_name}.git"
+  local work_dir="$TMPDIR_TEST/work-${fixture_name}"
+
+  git init -q --bare "$remote_dir"
+
+  mkdir -p "$work_dir/charts/shipwright"
+  (
+    cd "$work_dir"
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "test"
+    git remote add origin "$remote_dir"
+
+    cat > charts/shipwright/Chart.yaml <<'EOF'
+apiVersion: v2
+name: shipwright
+version: 1.6.284
+EOF
+    git add -A
+    GIT_AUTHOR_DATE="2026-07-06T09:00:00-07:00" GIT_COMMITTER_DATE="2026-07-06T09:00:00-07:00" \
+      git commit -q -m "chore(chart): bump chart version to 1.6.284"
+    git branch -M main
+    git push -q -u origin main
+
+    GIT_COMMITTER_DATE="2026-07-06T09:50:00-07:00" git tag -a admin-v0.156.0 -m "x"
+    GIT_COMMITTER_DATE="2026-07-06T09:52:00-07:00" git tag -a agent-v0.144.0 -m "x"
+    git push -q origin --tags
+  )
+
+  echo "$work_dir|$remote_dir"
+}
+
+# --- branch_exists_on_remote basics ---
+
+RETRY_FIXTURE_1=$(make_retry_fixture "basics")
+WORK_DIR_1="${RETRY_FIXTURE_1%%|*}"
+REMOTE_DIR_1="${RETRY_FIXTURE_1#*|}"
+
+if branch_exists_on_remote "chore/chart-v1.6.285" "$REMOTE_DIR_1"; then
+  fail "branch_exists_on_remote: false on a branch that doesn't exist yet" "false (no match)" "true (match)"
+else
+  pass "branch_exists_on_remote: false on a branch that doesn't exist yet"
+fi
+
+(
+  cd "$WORK_DIR_1"
+  git checkout -q -b chore/chart-v1.6.285
+  git push -q -u origin chore/chart-v1.6.285
+)
+
+if branch_exists_on_remote "chore/chart-v1.6.285" "$REMOTE_DIR_1"; then
+  pass "branch_exists_on_remote: true once branch is pushed to remote"
+else
+  fail "branch_exists_on_remote: true once branch is pushed to remote" "true (match)" "false (no match)"
+fi
+
+# --- resolve_batch_with_retry: 3(a) retry recomputes a non-colliding
+# version from a fresh since-timestamp, excluding already-landed tags ---
+#
+# Simulates: this run wants chore/chart-v1.6.285, but a concurrent run's
+# batch (crediting admin-v0.156.0 and agent-v0.144.0) already landed on
+# main as chart-bump commit 1.6.285 and pushed branch chore/chart-v1.6.285
+# (collision on attempt 1). On retry, resync_fn re-syncs work_dir to fresh
+# main (which now contains the 1.6.285 bump commit with a newer
+# last-bump-commit timestamp), so collect_batch_tags naturally excludes
+# admin-v0.156.0/agent-v0.144.0 (they now predate the new since-timestamp)
+# and only the *new* triggering tag (task-store-v0.9.0, landed after the
+# concurrent bump) is picked up. The recomputed version is 1.6.286 with
+# branch chore/chart-v1.6.286 — no collision — and the retry succeeds.
+
+RETRY_FIXTURE_2=$(make_retry_fixture "retry-success")
+WORK_DIR_2="${RETRY_FIXTURE_2%%|*}"
+REMOTE_DIR_2="${RETRY_FIXTURE_2#*|}"
+
+# Simulate the concurrent winning run: bumps main to 1.6.285, crediting the
+# two tags already present, and pushes the colliding branch — all directly
+# against the shared remote, independent of work_dir's checkout.
+CONCURRENT_CLONE="$TMPDIR_TEST/concurrent-winner-clone"
+git clone -q -b main "$REMOTE_DIR_2" "$CONCURRENT_CLONE"
+(
+  cd "$CONCURRENT_CLONE"
+  git config user.email "test@test.com"
+  git config user.name "test"
+  python3 - charts/shipwright/Chart.yaml <<'PYEOF'
+import re
+path = "charts/shipwright/Chart.yaml"
+with open(path) as f:
+    content = f.read()
+content = re.sub(r'^version:.*$', 'version: 1.6.285', content, flags=re.MULTILINE)
+with open(path, 'w') as f:
+    f.write(content)
+PYEOF
+  git add -A
+  GIT_AUTHOR_DATE="2026-07-06T10:10:00-07:00" GIT_COMMITTER_DATE="2026-07-06T10:10:00-07:00" \
+    git commit -q -m "chore(chart): bump chart version to 1.6.285"
+  git push -q origin main
+  git checkout -q -b chore/chart-v1.6.285
+  git push -q -u origin chore/chart-v1.6.285
+)
+
+# The new triggering tag lands on main *after* the concurrent winner's bump
+# commit — it must survive re-derivation and be the one credited by the
+# eventual, non-colliding retry.
+(
+  cd "$CONCURRENT_CLONE"
+  GIT_COMMITTER_DATE="2026-07-06T10:20:00-07:00" git tag -a task-store-v0.9.0 -m "x"
+  git push -q origin --tags
+)
+
+resync_work_dir_2() {
+  (
+    cd "$WORK_DIR_2"
+    git fetch -q origin main
+    git checkout -q main
+    git reset -q --hard origin/main
+    git fetch -q origin --tags --force
+  )
+}
+
+RETRY_RESULT=$(resolve_batch_with_retry "task-store-v0.9.0" "$WORK_DIR_2" "$REMOTE_DIR_2" resync_work_dir_2 5 0)
+RETRY_STATUS=$?
+
+assert_eq "resolve_batch_with_retry: succeeds after one collision" "0" "$RETRY_STATUS"
+assert_eq "resolve_batch_with_retry: recomputes non-colliding version 1.6.286" \
+  "task-store-v0.9.0|1.6.286|chore/chart-v1.6.286" \
+  "$RETRY_RESULT"
+
+# --- resolve_batch_with_retry: 3(b) exhausted-retries path exits non-zero
+# with an identifiable error naming the un-pinned tags ---
+#
+# Every attempt collides because resync_fn is a no-op (the branch that
+# collides is never removed and no new bump commit ever lands) — the loop
+# must give up after max_attempts and fail loudly rather than silently
+# succeed having dropped the batch.
+
+RETRY_FIXTURE_3=$(make_retry_fixture "exhausted")
+WORK_DIR_3="${RETRY_FIXTURE_3%%|*}"
+REMOTE_DIR_3="${RETRY_FIXTURE_3#*|}"
+
+(
+  cd "$WORK_DIR_3"
+  git checkout -q -b chore/chart-v1.6.285
+  git push -q -u origin chore/chart-v1.6.285
+  git checkout -q main
+)
+
+noop_resync() { :; }
+
+set +e
+EXHAUSTED_OUTPUT=$(resolve_batch_with_retry "agent-v0.144.0" "$WORK_DIR_3" "$REMOTE_DIR_3" noop_resync 3 0 2>&1)
+EXHAUSTED_STATUS=$?
+set -e
+
+assert_eq "resolve_batch_with_retry: exhausted retries exits non-zero" "1" "$EXHAUSTED_STATUS"
+
+if echo "$EXHAUSTED_OUTPUT" | grep -qi "ERROR.*exhausted"; then
+  pass "resolve_batch_with_retry: exhaustion emits a greppable ERROR message"
+else
+  fail "resolve_batch_with_retry: exhaustion emits a greppable ERROR message" "ERROR...exhausted present" "$EXHAUSTED_OUTPUT"
+fi
+
+if echo "$EXHAUSTED_OUTPUT" | grep -q "admin-v0.156.0,agent-v0.144.0"; then
+  pass "resolve_batch_with_retry: exhaustion error names the un-pinned release tags"
+else
+  fail "resolve_batch_with_retry: exhaustion error names the un-pinned release tags" "admin-v0.156.0,agent-v0.144.0 named" "$EXHAUSTED_OUTPUT"
+fi
 
 # ---------------------------------------------------------------------------
 # Tests: full pipeline (read → bump → update → verify), batched tags

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -67,6 +67,25 @@ so the batch stays fully traceable even though it's collapsed into a single
 version bump. The PR body lists exactly which `values.yaml` path(s) were
 pinned and to which tag(s).
 
+### Handling concurrent bumps (collision retry)
+
+Debounce collapses tags within a single burst, but two *separate* bursts
+(triggered by tags landing close together but outside the debounce window)
+can still compute the *same* next chart version from the same starting
+`Chart.yaml` — both runs read `main` before either has pushed its bump
+commit. When this happens, the workflow detects a branch-name collision
+(`chore/chart-v{version}` already exists on the remote) and, instead of
+silently skipping and dropping the losing run's entire tag batch, it fetches
+a fresh copy of `main`, re-derives the batch and version from that newer
+state (the winning run's chart-bump commit becomes the new baseline, so
+already-pinned tags are naturally excluded), and retries — up to 5 times
+with a 15-second backoff between attempts.
+
+If every retry attempt still collides, the workflow fails loudly, naming the
+release tag(s) that could not be pinned, rather than silently exiting
+success and dropping those tags. This ensures no release tags ever disappear
+from the chart version bump without surfacing the failure.
+
 ## How downstream consumers pick up new versions
 
 Consumption is **pull-based**, not push. `chart-release.yml` does not notify


### PR DESCRIPTION
## Summary
- Rewrites the `bump-chart` job's branch-collision handling: on a `chore/chart-v{version}` branch-name collision, the job now fetches fresh `main`, re-derives its tag batch and version, and retries — bounded to 5 attempts with a 15s backoff — instead of silently skipping and dropping the whole batch of release tags.
- If every retry attempt still collides, the job now fails loudly (non-zero exit) with an explicit error naming the release tag(s) that could not be pinned.
- Consolidates the "Collect release tags" / "Read current chart version" / "Compute new chart version" / "Check for existing bump branch" steps into a single `Resolve chart version bump (retry on branch collision)` step, and removes the `if: steps.idempotency.outputs.skip != 'true'` gating from all downstream steps (now always run once resolution succeeds).
- `test-auto-bump-chart.sh` gains `compute_batch_and_version`, `branch_exists_on_remote`, and `resolve_batch_with_retry` bash functions plus fixture-backed tests for: (a) a retry that recomputes a non-colliding version and correctly re-derives its tag batch from a fresh since-timestamp (excluding already-landed tags), and (b) the exhausted-retries path exiting non-zero with a greppable error naming the un-pinned tags. Existing `collect_batch_tags`/`select_pinned_tags`/`update_values_tag` tests and contracts are unchanged.
- `docs/helm-repo.md` refreshed to document the new collision-retry behavior.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Retry-on-collision with fresh main, bounded attempts + backoff | MET | New "Resolve chart version bump (retry on branch collision)" step, MAX_ATTEMPTS=5, BACKOFF_SECONDS=15, re-fetches/resets to origin/main and recomputes tags/version/branch each attempt |
| 2 | Fail loudly on exhaustion, naming un-pinned tags | MET | `exit 1` with `ERROR: exhausted 5 attempts... Release tag(s) that could NOT be pinned: ${TAGS_CSV}` |
| 3 | test-auto-bump-chart.sh gains coverage for retry-success and exhaustion; existing tests unchanged | MET | New `compute_batch_and_version`/`branch_exists_on_remote`/`resolve_batch_with_retry` + fixtures; 69/69 pass (61 pre-existing + 8 new) |
| 4 | PR description documents manual test plan for collision-retry | MET | See below |

## Manual Test Plan — Collision Retry

This scenario cannot be fully exercised in CI without real concurrent tag pushes + secrets — same documented limitation as the workflow's existing debounce manual-test-plan.

1. Note the current chart version in `charts/shipwright/Chart.yaml` (e.g. `X.Y.Z`), and manually pre-create + push the branch the *next* bump would use, simulating a concurrent run that already landed:
   ```
   git checkout -b chore/chart-vX.Y.(Z+1)
   git push origin chore/chart-vX.Y.(Z+1)
   git checkout main
   ```
2. Push a dummy tag to trigger a real run: `git tag agent-v9.9.7 && git push origin agent-v9.9.7`
3. In the "Resolve chart version bump (retry on branch collision)" step's logs, confirm it detects the collision on attempt 1 ("Branch ... already exists on remote"), fetches fresh main, and recomputes.
4. If all 5 attempts exhaust: confirm the job fails (non-zero exit) and the log contains a line starting with `ERROR: exhausted 5 attempts` naming the release tag(s) (e.g. `agent-v9.9.7`) that could not be pinned.
5. If a later attempt succeeds (branch deleted mid-retry): confirm the PR that opens targets the *recomputed* version/branch and still credits `agent-v9.9.7`.
6. Clean up: `git push origin --delete agent-v9.9.7 chore/chart-vX.Y.(Z+1)`

## Test Plan
- [x] `bash .github/workflows/test-auto-bump-chart.sh` — 69/69 passing (61 pre-existing + 8 new)
- [x] `bunx biome lint .` — clean
- [x] `bun run --filter='*' --sequential typecheck` — clean (no TS files touched by this PR, ran as a sanity check)
- [x] YAML validity of `auto-bump-chart.yml` confirmed via `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] One pre-existing, unrelated full-suite flake (`task-store/src/routes/prs.openapi.smoke.test.ts`) confirmed reproducing on clean `main` — not caused by this diff

Generated with [Claude Code](https://claude.com/claude-code)
