### PR TITLE
docs: refresh stale references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Key surfaces (see `plugins/shipwright/README.md` and `plugins/shipwright/CLAUDE.
 - **Commands** (`commands/`) — `prd`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, the five-phase test-readiness pipeline (`test-inventory` → `test-design` → `test-migration` → `test-roadmap` → `test-fix`), `metrics`, `research`, `research-docs`, and more.
 - **Skills** (`skills/`) — autonomous behaviors including `pull-requests`, `review-staged`, `consolidation-scan`, `consolidation-fix`, `entropy-scan`, `entropy-fix`, `security-scan`, `security-fix`, `agent-admin`, `investigate-cron`, `learning-capture`, `task-store`, `test-readiness`, `test-debt`, `triage-dependabot-pr`, and `triage-dependabot-prs`.
 - **Scripts** (`scripts/`) — the task-store adapters, precheck scripts for each cron (`check-docs-freshness.ts`, `check-learn-dream.ts`, etc.), and supporting tooling.
-- **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `task-store.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, …).
+- **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, `principles.md`, …).
 
 `dev-task`, `review`, `patch`, and `deploy` are item-addressed executors, not self-discovering
 standalone crons: each requires an explicit target (a task id for `dev-task`; an

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -79,7 +79,7 @@ List tasks
 - **Method:** GET
 - **Path:** `/tasks`
 - **Has body:** No
-- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `hitl` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query), `updatedSince` (query)
+- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query), `updatedSince` (query)
 
 ## `tasks_update`
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,7 +24,7 @@ When `SENTRY_DSN` is set, a service reports:
 
 - **Request headers** — `Authorization` and `Cookie` header **values** are unconditionally redacted to `[Filtered]` in every event before it leaves the process, regardless of whether any secret env var is set. (The header keys remain; only the values are scrubbed.)
 - **Request bodies** — request/response bodies are never attached to Sentry events.
-- **Secret values** — any currently-set value of a secret-shaped env var (`ANTHROPIC_API_KEY`, `GH_TOKEN`, `SHIPWRIGHT_SESSION_SECRET`, etc. — see `SECRET_ENV_VARS` in `lib/sentry.ts` for the full list) is redacted to `[Filtered]` wherever it appears in an event or log, including nested inside longer strings. This scrub runs on both error events (`scrubEvent`) and console-derived logs (`scrubLog`).
+- **Secret values** — any currently-set value of a secret-shaped env var (`ANTHROPIC_API_KEY`, `GH_TOKEN`, `SHIPWRIGHT_SESSION_SECRET`, etc. — see `SECRET_ENV_VARS` in `lib/secret-env-vars.ts` for the full list) is redacted to `[Filtered]` wherever it appears in an event or log, including nested inside longer strings. This scrub runs on both error events (`scrubEvent`) and console-derived logs (`scrubLog`).
 
 ## Disabling Sentry
 


### PR DESCRIPTION
## Summary

Auto-mode doc-refresh pass over the shipwright docs candidates listed for this cycle. Verified every extracted reference (file paths, symbols, generated content) against current source in this worktree; three docs had genuine drift, the rest checked out current.

**Updated:**

- **`docs/architecture.md`** — the References bullet listed `task-store.md` as living under `plugins/shipwright/references/`, but that file doesn't exist there (task-store docs are actually at `docs/task-store.md`, a different top-level doc). Swapped the example for `principles.md`, which does exist under `plugins/shipwright/references/`.
- **`docs/mcp-tools.md`** — this is a generated file (`bun run generate:mcp-docs`, sourced from `mcp-server/src/generated-tools.ts` ← `task-store/openapi.json`). The committed version still listed a `hitl` query param on `tasks_list` that `generated-tools.ts` no longer has (already regenerated on `main` at some point without the doc following). Regenerated it via the real generator script — the diff is exactly the stale `hitl` entry being dropped.
- **`docs/observability.md`** — pointed readers at `SECRET_ENV_VARS` "in `lib/sentry.ts`", but that constant is actually defined in `lib/secret-env-vars.ts` and only imported into `sentry.ts`. Fixed the file pointer.

**Checked, current, left untouched:** `docs/agent-types.md`, `docs/agent.md`, `docs/chat.md`, `docs/configuration.md`, `docs/helm-repo.md`, `docs/metrics.md`, `docs/migration.md`, `docs/task-store.md`, `docs/testing.md` (test-system.md mtime special-case does not trigger — testing.md is the newer of the two).

`docs/test-readiness/` was not touched (read-only, owned by a different plugin). `CLAUDE.md`'s Reference section already has accurate entries for every doc touched here — no scope changes warranted an update there.

## Test plan

- [x] Every changed line verified against live source in this worktree (file existence via `Glob`/`test -f`, symbol/const location via `Grep`)
- [x] `docs/mcp-tools.md` diff produced by running the actual generator (`bun run generate:mcp-docs`), not hand-edited
- [x] No changes under `docs/test-readiness/`
- [x] `git diff --stat` shows only the 3 intended files, 3 lines total

🤖 Generated with [Claude Code](https://claude.com/claude-code)