### PR TITLE
feat: add periodic chart-drift-check workflow

### DIFF
--- a/.github/workflows/check-chart-drift.yml
+++ b/.github/workflows/check-chart-drift.yml
@@ -1,0 +1,99 @@
+name: Chart Drift Check
+
+# Periodic drift-check: catches a future recurrence of chart-pin drift (from a
+# race condition in auto-bump-chart.yml's debounce/burst handling, or any
+# other cause) between the highest-semver release tag for each Shipwright
+# service and what's actually pinned in charts/shipwright/values.yaml, without
+# requiring manual git archaeology to discover it.
+#
+# For each service (admin, metrics, agent, task-store, chat) this workflow:
+#   1. Finds the highest-semver `{service}-v*` git tag.
+#   2. Reads the tag currently pinned at that service's values.yaml path(s).
+#   3. Compares them. Any mismatch fails the job — the job failure IS the
+#      alert (visible in the Actions tab / a red X on the default branch).
+#      No new notification infra, no new secrets: only the default
+#      GITHUB_TOKEN read scope (contents: read) already used elsewhere in
+#      this repo's workflows.
+#
+# Reuses the SAME service_for_tag / values_paths_for_service /
+# highest_semver_tag logic that auto-bump-chart.yml uses to pin tags in the
+# first place — extracted to .github/workflows/lib/chart-tag-utils.sh so both
+# workflows share one implementation instead of drifting apart themselves.
+#
+# Deliberately does NOT source .github/workflows/test-auto-bump-chart.sh
+# directly: that file has no `if [[ "${BASH_SOURCE[0]}" == "$0" ]]`
+# main-guard, so sourcing it would run its entire existing assertion suite as
+# a side effect and its trailing `exit 1` (on failure) would kill this step's
+# shell outright even on unrelated failures. lib/chart-tag-utils.sh instead
+# holds ONLY the function definitions, extracted verbatim, safe to source.
+#
+# Logic tests live in .github/workflows/test-check-chart-drift.sh.
+# Run locally: bash .github/workflows/test-check-chart-drift.sh
+
+on:
+  schedule:
+    # Daily at 09:00 UTC.
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check-drift:
+    name: check chart pins against latest release tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compare pinned tags against latest release tags
+        run: |
+          set -uo pipefail
+
+          source .github/workflows/lib/chart-tag-utils.sh
+          source .github/workflows/lib/chart-drift-check.sh
+
+          VALUES_YAML="charts/shipwright/values.yaml"
+          SERVICES=(admin metrics agent task-store chat)
+
+          # Resolve the highest-semver `{service}-v*` git tag for each
+          # service into "service=tag" lines, mirroring how
+          # auto-bump-chart.yml's select_pinned_tags() groups tags by
+          # service before picking the winner with highest_semver_tag().
+          LATEST_BY_SERVICE=""
+          MISSING_SERVICES=()
+          for service in "${SERVICES[@]}"; do
+            TAGS=$(git tag -l "${service}-v*")
+            if [ -z "$TAGS" ]; then
+              MISSING_SERVICES+=("$service")
+              continue
+            fi
+            LATEST=$(highest_semver_tag $TAGS)
+            LATEST_BY_SERVICE="${LATEST_BY_SERVICE}${service}=${LATEST}
+          "
+          done
+
+          if [ ${#MISSING_SERVICES[@]} -gt 0 ]; then
+            echo "No git tags found for: ${MISSING_SERVICES[*]} — skipping drift check for these services (nothing to compare against)."
+          fi
+
+          echo "Latest release tag per service:"
+          echo "$LATEST_BY_SERVICE"
+
+          MISMATCHES=$(compute_drift "$VALUES_YAML" "$LATEST_BY_SERVICE")
+
+          if [ -n "$MISMATCHES" ]; then
+            echo ""
+            echo "Chart drift detected — values.yaml is not pinned to the latest release tag(s):"
+            echo "$MISMATCHES"
+            echo ""
+            echo "Fix: update the listed path(s) in ${VALUES_YAML} to the expected tag(s) above (or investigate why auto-bump-chart.yml did not pin them)."
+            exit 1
+          fi
+
+          echo ""
+          echo "No chart drift detected — all pinned tags match their latest release tags."

--- a/.github/workflows/lib/chart-drift-check.sh
+++ b/.github/workflows/lib/chart-drift-check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# .github/workflows/lib/chart-drift-check.sh
+#
+# Drift-comparison logic for check-chart-drift.yml: reading the currently
+# pinned tag at a values.yaml dot-path, and computing mismatches between the
+# highest-semver git release tag per service and what's actually pinned.
+#
+# Depends on chart-tag-utils.sh (service_for_tag / values_paths_for_service)
+# being sourced first for values_paths_for_service; source both together:
+#   source .github/workflows/lib/chart-tag-utils.sh
+#   source .github/workflows/lib/chart-drift-check.sh
+#
+# Read-only — unlike auto-bump-chart.yml's update_values_tag (which WRITES a
+# new tag into values.yaml and needs python3 for safe indentation-scoped
+# editing), these functions only ever read, so a simple awk state-machine
+# scoped by indentation is sufficient and keeps this dependency-free (no
+# python3, no yq).
+#
+# This file is sourced only — running it directly does nothing useful.
+#
+set -uo pipefail
+
+# Reads the value pinned at `dot_path` (e.g. "agent.provisioning.image.tag")
+# inside `values_yaml`. Walks the key chain top-down using 2-space-indent
+# scoping — identical structural assumption to auto-bump-chart.yml's
+# update_values_tag() — so agent.image.tag and agent.provisioning.image.tag
+# resolve independently even though both lines read "tag: agent-v...".
+# Prints nothing (empty string) if the path isn't found.
+read_pinned_tag() {
+  local values_yaml="$1"
+  local dot_path="$2"
+  awk -v dot_path="$dot_path" '
+    BEGIN {
+      n = split(dot_path, keys, ".")
+      depth = 0
+      target_indent = 0
+      in_scope = 1
+    }
+    {
+      line = $0
+      # Compute leading-space indentation.
+      indent = 0
+      while (substr(line, indent + 1, 1) == " ") indent++
+      stripped = line
+      sub(/^ +/, "", stripped)
+
+      if (in_scope == 0) next
+
+      # Once we have matched all keys but the last, we are inside the final
+      # blocks scope; look for the last key at target_indent.
+      if (depth == n - 1) {
+        if (indent < target_indent) { in_scope = 0; next }
+        if (indent != target_indent) next
+        key = keys[depth + 1]
+        if (stripped == key ":" || index(stripped, key ":") == 1) {
+          val = stripped
+          sub("^" key ":[ ]*", "", val)
+          print val
+          exit
+        }
+        next
+      }
+
+      # Still matching an intermediate key: must appear at target_indent.
+      if (indent < target_indent) { in_scope = 0; next }
+      if (indent != target_indent) next
+      key = keys[depth + 1]
+      if (stripped == key ":" || index(stripped, key ":") == 1) {
+        depth++
+        target_indent += 2
+      }
+    }
+  ' "$values_yaml"
+}
+
+# Given the path to a values.yaml and a newline-separated list of
+# "service=latest-tag" pairs (e.g. the output of highest_semver_tag applied
+# per service against live git tags), computes every path where the
+# currently-pinned tag differs from the latest tag. Emits one line per
+# mismatch in the form:
+#   MISMATCH: service={service} path={path} expected={tag-from-git} actual={tag-in-values-yaml}
+# Emits nothing (empty string) when everything is in sync. Never fails fast —
+# every service/path combination is checked and all mismatches are collected.
+compute_drift() {
+  local values_yaml="$1"
+  local latest_by_service="$2"
+  local service latest_tag path pinned_tag
+
+  while IFS='=' read -r service latest_tag; do
+    [ -z "$service" ] && continue
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      pinned_tag=$(read_pinned_tag "$values_yaml" "$path")
+      if [ "$pinned_tag" != "$latest_tag" ]; then
+        echo "MISMATCH: service=${service} path=${path} expected=${latest_tag} actual=${pinned_tag}"
+      fi
+    done < <(values_paths_for_service "$service")
+  done <<< "$latest_by_service"
+}

--- a/.github/workflows/lib/chart-tag-utils.sh
+++ b/.github/workflows/lib/chart-tag-utils.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# .github/workflows/lib/chart-tag-utils.sh
+#
+# Shared tag-parsing logic used by both auto-bump-chart.yml (writes release
+# tags into charts/shipwright/values.yaml on tag push) and
+# check-chart-drift.yml (reads them back and compares against the latest git
+# tags on a schedule). Extracted here — rather than having check-chart-drift.yml
+# source test-auto-bump-chart.sh directly — because that test file has no
+# `if [[ "${BASH_SOURCE[0]}" == "$0" ]]` main-guard: it runs its entire
+# assertion suite unconditionally top-to-bottom and calls `exit 1` on failure
+# at the very bottom. Sourcing it from a production workflow step would (a)
+# run the whole existing test suite as an unwanted side effect, and (b) the
+# trailing `exit` would kill the parent shell even on success. This file
+# contains ONLY function definitions — sourcing it has no side effects.
+#
+# Function bodies here are verbatim copies of the ones inlined in
+# auto-bump-chart.yml's "Pin released tags into values.yaml" step (and
+# mirrored in test-auto-bump-chart.sh). Keep all three copies in sync.
+#
+# This file is sourced only — running it directly does nothing useful.
+#
+set -uo pipefail
+
+# Maps a release tag prefix to its service key.
+service_for_tag() {
+  local tag="$1"
+  case "$tag" in
+    admin-v*) echo "admin" ;;
+    metrics-v*) echo "metrics" ;;
+    agent-v*) echo "agent" ;;
+    task-store-v*) echo "task-store" ;;
+    chat-v*) echo "chat" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Maps a service key to the values.yaml dot-paths that must be pinned to its
+# released tag, one path per line. The agent service pins two paths from the
+# same agent-v* tag: the top-level agent image and the admin-provisioned
+# agent image nested under agent.provisioning.
+values_paths_for_service() {
+  local service="$1"
+  case "$service" in
+    admin) printf '%s\n' "admin.image.tag" ;;
+    metrics) printf '%s\n' "metrics.image.tag" ;;
+    agent) printf '%s\n' "agent.image.tag" "agent.provisioning.image.tag" ;;
+    task-store) printf '%s\n' "taskStore.image.tag" ;;
+    chat) printf '%s\n' "chat.image.tag" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Returns the highest-semver tag among the given tags (space-separated, all
+# sharing the same prefix). Strips the non-numeric prefix so `sort -V`
+# compares the bare X.Y.Z portion, then re-attaches the winning original tag.
+# A single-tag input is a no-op — the sole tag always "wins".
+highest_semver_tag() {
+  local tag
+  for tag in "$@"; do
+    printf '%s %s\n' "${tag##*-v}" "$tag"
+  done | sort -V | tail -n1 | cut -d' ' -f2-
+}

--- a/.github/workflows/test-check-chart-drift.sh
+++ b/.github/workflows/test-check-chart-drift.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+#
+# .github/workflows/test-check-chart-drift.sh
+#
+# Unit-tests the logic behind check-chart-drift.yml: the shared
+# service_for_tag / values_paths_for_service / highest_semver_tag functions
+# (sourced from .github/workflows/lib/chart-tag-utils.sh) plus the
+# drift-specific "read pinned tag from values.yaml" and "compute mismatches"
+# logic (sourced from .github/workflows/lib/chart-drift-check.sh).
+#
+# Tests pure bash logic — no GitHub Actions, no network, no yq/python3
+# required.
+#
+# Run: bash .github/workflows/test-check-chart-drift.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() { echo "  PASS: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo "  FAIL: $1 — expected '$2', got '$3'"; FAIL=$(( FAIL + 1 )); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "$expected" "$actual"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Source the shared libs under test. Sourcing must be side-effect free (no
+# assertions run, no top-level `exit`) — that's the whole point of extracting
+# these into lib/ instead of sourcing test-auto-bump-chart.sh directly (see
+# check-chart-drift.yml's header comment for why sourcing that test file
+# would be unsafe: no main-guard, runs its whole suite, and calls `exit`
+# unconditionally at the bottom which would kill this script too).
+# ---------------------------------------------------------------------------
+
+# shellcheck source=lib/chart-tag-utils.sh
+source "$SCRIPT_DIR/lib/chart-tag-utils.sh"
+# shellcheck source=lib/chart-drift-check.sh
+source "$SCRIPT_DIR/lib/chart-drift-check.sh"
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Fixture mirroring the shape of charts/shipwright/values.yaml's five
+# image-tag-bearing service blocks (admin, metrics, agent + nested
+# provisioning.image, taskStore, chat). Same shape as test-auto-bump-chart.sh's
+# make_values_yaml fixture, with tags overridable per-block so drift/no-drift
+# scenarios are easy to construct.
+make_values_yaml() {
+  local admin_tag="${1:-admin-v1.50.0}"
+  local metrics_tag="${2:-metrics-v1.21.0}"
+  local agent_tag="${3:-agent-v1.107.0}"
+  local agent_prov_tag="${4:-agent-v1.107.0}"
+  local task_store_tag="${5:-task-store-v1.28.0}"
+  local chat_tag="${6:-chat-v1.19.0}"
+  local path="$TMPDIR_TEST/values-$$-${RANDOM}.yaml"
+  cat > "$path" <<EOF
+admin:
+  enabled: true
+  image:
+    repository: ghcr.io/app-vitals/shipwright-admin
+    tag: ${admin_tag}
+    pullPolicy: ""
+  replicas: 1
+metrics:
+  enabled: true
+  image:
+    repository: ghcr.io/app-vitals/shipwright-metrics
+    tag: ${metrics_tag}
+    pullPolicy: ""
+agent:
+  enabled: true
+  image:
+    repository: ghcr.io/app-vitals/shipwright-agent
+    tag: ${agent_tag}
+    pullPolicy: ""
+  provisioning:
+    enabled: false
+    namespace: ""
+    image:
+      repository: ghcr.io/app-vitals/shipwright-agent
+      tag: ${agent_prov_tag}
+    replicas: 1
+taskStore:
+  enabled: false
+  image:
+    repository: ghcr.io/app-vitals/shipwright-task-store
+    tag: ${task_store_tag}
+    pullPolicy: ""
+chat:
+  enabled: false
+  image:
+    repository: ghcr.io/app-vitals/shipwright-chat
+    tag: ${chat_tag}
+    pullPolicy: ""
+EOF
+  echo "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: shared lib (chart-tag-utils.sh) sourced standalone
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== chart-tag-utils.sh: service_for_tag tests ==="
+
+assert_eq "admin-v0.188.0 → admin" "admin" "$(service_for_tag 'admin-v0.188.0')"
+assert_eq "metrics-v0.150.0 → metrics" "metrics" "$(service_for_tag 'metrics-v0.150.0')"
+assert_eq "agent-v0.172.0 → agent" "agent" "$(service_for_tag 'agent-v0.172.0')"
+assert_eq "task-store-v0.86.0 → task-store" "task-store" "$(service_for_tag 'task-store-v0.86.0')"
+assert_eq "chat-v0.38.0 → chat" "chat" "$(service_for_tag 'chat-v0.38.0')"
+assert_eq "unrecognized prefix → empty" "" "$(service_for_tag 'unknown-v1.0.0')"
+
+echo ""
+echo "=== chart-tag-utils.sh: values_paths_for_service tests ==="
+
+assert_eq "admin → single path" "admin.image.tag" "$(values_paths_for_service 'admin' | paste -sd, -)"
+assert_eq "metrics → single path" "metrics.image.tag" "$(values_paths_for_service 'metrics' | paste -sd, -)"
+assert_eq "task-store → taskStore.image.tag" "taskStore.image.tag" "$(values_paths_for_service 'task-store' | paste -sd, -)"
+assert_eq "chat → single path" "chat.image.tag" "$(values_paths_for_service 'chat' | paste -sd, -)"
+assert_eq "agent → dual path (image.tag AND provisioning.image.tag)" \
+  "agent.image.tag,agent.provisioning.image.tag" \
+  "$(values_paths_for_service 'agent' | paste -sd, -)"
+
+echo ""
+echo "=== chart-tag-utils.sh: highest_semver_tag tests ==="
+
+assert_eq "single tag is a no-op" "agent-v1.107.0" "$(highest_semver_tag 'agent-v1.107.0')"
+assert_eq "picks higher patch" "admin-v1.50.1" "$(highest_semver_tag 'admin-v1.50.0' 'admin-v1.50.1')"
+assert_eq "picks higher patch regardless of arg order" "admin-v1.50.1" "$(highest_semver_tag 'admin-v1.50.1' 'admin-v1.50.0')"
+assert_eq "picks higher minor" "metrics-v1.22.0" "$(highest_semver_tag 'metrics-v1.21.9' 'metrics-v1.22.0')"
+assert_eq "picks higher major" "chat-v2.0.0" "$(highest_semver_tag 'chat-v1.19.9' 'chat-v2.0.0')"
+assert_eq "double-digit patch beats single-digit (not lexicographic)" "agent-v1.107.10" "$(highest_semver_tag 'agent-v1.107.2' 'agent-v1.107.10')"
+assert_eq "three-way batch picks the max" "task-store-v1.28.2" "$(highest_semver_tag 'task-store-v1.28.0' 'task-store-v1.28.2' 'task-store-v1.28.1')"
+
+# ---------------------------------------------------------------------------
+# Tests: read_pinned_tag (chart-drift-check.sh)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== read_pinned_tag tests ==="
+
+v1=$(make_values_yaml)
+assert_eq "reads admin.image.tag" "admin-v1.50.0" "$(read_pinned_tag "$v1" "admin.image.tag")"
+assert_eq "reads metrics.image.tag" "metrics-v1.21.0" "$(read_pinned_tag "$v1" "metrics.image.tag")"
+assert_eq "reads agent.image.tag (top-level, not the nested one)" "agent-v1.107.0" "$(read_pinned_tag "$v1" "agent.image.tag")"
+assert_eq "reads agent.provisioning.image.tag (nested case)" "agent-v1.107.0" "$(read_pinned_tag "$v1" "agent.provisioning.image.tag")"
+assert_eq "reads taskStore.image.tag" "task-store-v1.28.0" "$(read_pinned_tag "$v1" "taskStore.image.tag")"
+assert_eq "reads chat.image.tag" "chat-v1.19.0" "$(read_pinned_tag "$v1" "chat.image.tag")"
+
+# Distinct values at agent.image.tag vs agent.provisioning.image.tag — proves
+# the reader is indentation/path-scoped, not a blind grep for the first "tag:"
+# match under an "agent:" heading.
+v2=$(make_values_yaml "admin-v1.50.0" "metrics-v1.21.0" "agent-v1.107.0" "agent-v1.99.0")
+assert_eq "agent.image.tag independent of provisioning nested tag" "agent-v1.107.0" "$(read_pinned_tag "$v2" "agent.image.tag")"
+assert_eq "agent.provisioning.image.tag independent of top-level tag" "agent-v1.99.0" "$(read_pinned_tag "$v2" "agent.provisioning.image.tag")"
+
+# ---------------------------------------------------------------------------
+# Tests: compute_drift (chart-drift-check.sh)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== compute_drift tests: no mismatches ==="
+
+v3=$(make_values_yaml)
+LATEST_IN_SYNC="admin=admin-v1.50.0
+metrics=metrics-v1.21.0
+agent=agent-v1.107.0
+task-store=task-store-v1.28.0
+chat=chat-v1.19.0"
+
+MISMATCHES_NONE=$(compute_drift "$v3" "$LATEST_IN_SYNC")
+assert_eq "fully in sync → no mismatches" "" "$MISMATCHES_NONE"
+
+echo ""
+echo "=== compute_drift tests: single mismatch ==="
+
+v4=$(make_values_yaml "admin-v1.49.0")
+LATEST_ADMIN_AHEAD="admin=admin-v1.50.0
+metrics=metrics-v1.21.0
+agent=agent-v1.107.0
+task-store=task-store-v1.28.0
+chat=chat-v1.19.0"
+
+MISMATCHES_ONE=$(compute_drift "$v4" "$LATEST_ADMIN_AHEAD")
+assert_eq "one line reported for one mismatch" "1" "$(echo "$MISMATCHES_ONE" | grep -c '^MISMATCH:')"
+if echo "$MISMATCHES_ONE" | grep -qF "MISMATCH: service=admin path=admin.image.tag expected=admin-v1.50.0 actual=admin-v1.49.0"; then
+  pass "mismatch line has expected format and values"
+else
+  fail "mismatch line has expected format and values" "MISMATCH: service=admin path=admin.image.tag expected=admin-v1.50.0 actual=admin-v1.49.0" "$MISMATCHES_ONE"
+fi
+
+echo ""
+echo "=== compute_drift tests: multiple mismatches across multiple services (no fail-fast) ==="
+
+v5=$(make_values_yaml "admin-v1.49.0" "metrics-v1.21.0" "agent-v1.106.0" "agent-v1.106.0" "task-store-v1.27.0")
+LATEST_MULTI="admin=admin-v1.50.0
+metrics=metrics-v1.21.0
+agent=agent-v1.107.0
+task-store=task-store-v1.28.0
+chat=chat-v1.19.0"
+
+MISMATCHES_MULTI=$(compute_drift "$v5" "$LATEST_MULTI")
+# admin (1) + agent (2 paths) + task-store (1) = 4 mismatch lines; metrics and
+# chat stay in sync and must NOT appear.
+assert_eq "collects all mismatches, not just the first" "4" "$(echo "$MISMATCHES_MULTI" | grep -c '^MISMATCH:')"
+
+if echo "$MISMATCHES_MULTI" | grep -qF "service=admin path=admin.image.tag expected=admin-v1.50.0 actual=admin-v1.49.0"; then
+  pass "multi: admin mismatch present"
+else
+  fail "multi: admin mismatch present" "admin mismatch line" "$MISMATCHES_MULTI"
+fi
+
+if echo "$MISMATCHES_MULTI" | grep -qF "service=agent path=agent.image.tag expected=agent-v1.107.0 actual=agent-v1.106.0"; then
+  pass "multi: agent top-level mismatch present"
+else
+  fail "multi: agent top-level mismatch present" "agent.image.tag mismatch line" "$MISMATCHES_MULTI"
+fi
+
+if echo "$MISMATCHES_MULTI" | grep -qF "service=agent path=agent.provisioning.image.tag expected=agent-v1.107.0 actual=agent-v1.106.0"; then
+  pass "multi: agent provisioning-nested mismatch present"
+else
+  fail "multi: agent provisioning-nested mismatch present" "agent.provisioning.image.tag mismatch line" "$MISMATCHES_MULTI"
+fi
+
+if echo "$MISMATCHES_MULTI" | grep -qF "service=task-store path=taskStore.image.tag expected=task-store-v1.28.0 actual=task-store-v1.27.0"; then
+  pass "multi: task-store mismatch present"
+else
+  fail "multi: task-store mismatch present" "taskStore.image.tag mismatch line" "$MISMATCHES_MULTI"
+fi
+
+if echo "$MISMATCHES_MULTI" | grep -q 'service=metrics'; then
+  fail "multi: metrics (in sync) must NOT be reported" "no metrics line" "$MISMATCHES_MULTI"
+else
+  pass "multi: metrics (in sync) not reported"
+fi
+
+if echo "$MISMATCHES_MULTI" | grep -q 'service=chat'; then
+  fail "multi: chat (in sync) must NOT be reported" "no chat line" "$MISMATCHES_MULTI"
+else
+  pass "multi: chat (in sync) not reported"
+fi
+
+echo ""
+echo "=== compute_drift tests: agent's two paths can drift independently ==="
+
+# Top-level agent.image.tag matches latest but the nested provisioning tag
+# lags — must report exactly the provisioning path, not the top-level one.
+v6=$(make_values_yaml "admin-v1.50.0" "metrics-v1.21.0" "agent-v1.107.0" "agent-v1.106.0")
+LATEST_AGENT_ONLY="admin=admin-v1.50.0
+metrics=metrics-v1.21.0
+agent=agent-v1.107.0
+task-store=task-store-v1.28.0
+chat=chat-v1.19.0"
+
+MISMATCHES_AGENT=$(compute_drift "$v6" "$LATEST_AGENT_ONLY")
+assert_eq "only the nested provisioning path is reported" "1" "$(echo "$MISMATCHES_AGENT" | grep -c '^MISMATCH:')"
+if echo "$MISMATCHES_AGENT" | grep -qF "service=agent path=agent.provisioning.image.tag expected=agent-v1.107.0 actual=agent-v1.106.0"; then
+  pass "nested provisioning mismatch correctly isolated from top-level"
+else
+  fail "nested provisioning mismatch correctly isolated from top-level" "provisioning-only mismatch" "$MISMATCHES_AGENT"
+fi
+
+# ---------------------------------------------------------------------------
+# Tests: highest_semver_tag drives "latest tag" selection from a git-tag list
+# (mirrors how the workflow step will pick the winner among `git tag -l`
+# output for a given service prefix before calling compute_drift).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== git-tag-derived latest tag tests ==="
+
+GIT_TEST_DIR="$TMPDIR_TEST/git-tags-test"
+mkdir -p "$GIT_TEST_DIR"
+(
+  cd "$GIT_TEST_DIR"
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "test"
+  echo hi > README.md
+  git add -A
+  git commit -q -m "init"
+  git tag admin-v1.50.0
+  git tag admin-v1.50.2
+  git tag admin-v1.50.1
+  git tag metrics-v1.21.0
+)
+
+ADMIN_TAGS=$(cd "$GIT_TEST_DIR" && git tag -l 'admin-v*')
+LATEST_ADMIN=$(highest_semver_tag $ADMIN_TAGS)
+assert_eq "highest_semver_tag picks v1.50.2 among 3 git tags" "admin-v1.50.2" "$LATEST_ADMIN"
+
+METRICS_TAGS=$(cd "$GIT_TEST_DIR" && git tag -l 'metrics-v*')
+LATEST_METRICS=$(highest_semver_tag $METRICS_TAGS)
+assert_eq "highest_semver_tag single-tag case from git" "metrics-v1.21.0" "$LATEST_METRICS"
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "================================"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/check-chart-drift.yml`, a daily-scheduled (+ `workflow_dispatch`) workflow that catches chart-pin drift: for each service (admin, metrics, agent, task-store, chat) it finds the highest-semver `{service}-v*` git tag and compares it against the tag currently pinned at that service's path(s) in `charts/shipwright/values.yaml`, failing the job (with a `MISMATCH: service=... path=... expected=... actual=...` line per drifted path) if anything is out of sync.
- Extracts the `service_for_tag` / `values_paths_for_service` / `highest_semver_tag` logic — previously inlined separately in `auto-bump-chart.yml` and mirrored in `test-auto-bump-chart.sh` — verbatim into a new shared, sourceable file: `.github/workflows/lib/chart-tag-utils.sh`.
- Adds `.github/workflows/lib/chart-drift-check.sh` with the new, read-only drift-comparison logic (`read_pinned_tag`, `compute_drift`), and `.github/workflows/test-check-chart-drift.sh` — a new companion pure-bash test file (40 assertions, no network/no yq/no python3) following the exact same pattern as `test-auto-bump-chart.sh`.

**Why a new shared-lib file instead of sourcing `test-auto-bump-chart.sh` directly:** `test-auto-bump-chart.sh` has no `if [[ "${BASH_SOURCE[0]}" == "$0" ]]` main-guard — it runs its entire assertion suite unconditionally top-to-bottom and calls `exit 1` at the bottom on failure. Sourcing it from a production workflow step would (a) run the whole existing test suite as an unwanted side effect and (b) its trailing `exit` would kill the parent shell outright, even on success. `lib/chart-tag-utils.sh` instead holds only the three function definitions, verbatim, with no side effects when sourced. `auto-bump-chart.yml` and `test-auto-bump-chart.sh` are left completely untouched — this PR only adds new files.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New workflow runs daily + on `workflow_dispatch`; compares highest-semver `{service}-v*` tag vs. values.yaml pin per service | MET | `check-chart-drift.yml`: `schedule` (daily 09:00 UTC) + `workflow_dispatch`, loops over all 5 services |
| 2 | Job fails non-zero with service/expected/actual message; no new notification infra | MET | `exit 1` with one `MISMATCH:` line per drifted path; failure is visible natively in the Actions tab |
| 3 | Reuses existing tag-parsing logic rather than re-implementing | MET | `service_for_tag`/`values_paths_for_service`/`highest_semver_tag` extracted verbatim into `lib/chart-tag-utils.sh`, sourced by the new workflow |
| 4 | Test coverage for the new comparison logic, pure-bash pattern | MET | `test-check-chart-drift.sh`, 40 assertions, all passing |
| 5 | No new `${{ secrets.* }}` reference; default `GITHUB_TOKEN` read scope only | MET | `permissions: contents: read` only; no `secrets.*` anywhere in the new workflow |

## Test Plan
- `bash .github/workflows/test-check-chart-drift.sh` — 40/40 assertions pass
- `task check-strings` — no banned strings
- `task ci` — passes except one **pre-existing, unrelated** failure in `agent/src/claude.unit.test.ts` ("empty extraAllowedTools produces identical args") caused by an `AGENT_ALLOWED_TOOLS` env var leaking into that unit test in this sandbox; reproduced identically against an unrelated worktree on `main` with no changes from this PR. This PR touches no bun-managed package, so it has no effect on the coverage gate.
- Manually verified the new workflow's YAML parses correctly and its comparison logic correctly flags real, pre-existing drift already present on `main` today (several services' `values.yaml` pins currently lag their latest release tags) — confirming the detection logic works, though fixing that pre-existing drift is out of scope for this task.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
