### PR TITLE
feat: add reviewedCommitSha field to task-store (RCS-1.1)

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -304,7 +304,7 @@ Returns `404` if not found.
 PATCH /prs/:id
 ```
 
-Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`, `reviewState`, `phase`, `readyForReviewAt`, `readyForPatchAt`, `readyForDeployAt`, `hitl`, `hitlNotifiedAt`, `blockedReason`. All other fields are managed by lifecycle endpoints. Returns `400` if no writable fields are provided.
+Writable fields: `staged`, `commitSha`, `reviewedCommitSha`, `taskId`, `agentId`, `state`, `mergedAt`, `reviewState`, `phase`, `readyForReviewAt`, `readyForPatchAt`, `readyForDeployAt`, `hitl`, `hitlNotifiedAt`, `blockedReason`. All other fields are managed by lifecycle endpoints. Returns `400` if no writable fields are provided.
 
 **Side effect:** When `state` is set to `merged` or `closed`, the claim fields (`claimedBy`, `claimedAt`, `heartbeatAt`, `phase`) are automatically cleared. This ensures that merged or closed PRs are no longer held by an agent claim.
 
@@ -340,6 +340,8 @@ Writable fields: `staged`, `commitSha`, `taskId`, `agentId`, `state`, `mergedAt`
 `skipCount`: integer (default `0`) — consecutive count of times this PR has been dispatched but produced no visible outcome ([silent] dispatch). Incremented by `POST /prs/:id/skip`; reset by `POST /prs/:id/skip/reset`. When it crosses the threshold (3, matching `SPIN_DETECTION_THRESHOLD`), the service auto-sets `hitl=true` and `blockedReason="Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)"` to prevent infinite spin loops.
 
 `lastSkippedAt`: optional ISO timestamp — records when the most recent skip was recorded. Updated by `POST /prs/:id/skip`, cleared by `POST /prs/:id/skip/reset`.
+
+`reviewedCommitSha`: optional string — the review pipeline's exclusive commit-tracking field, separate from the shared `commitSha` field written by claim()/patch()/deploy for their own multi-phase bookkeeping. Set via `PATCH /prs/:id`. Used by the review phase to independently track the commit at which a review was conducted, allowing review state to persist across pipeline transitions without interference from concurrent patch/deploy phase operations updating `commitSha`.
 
 #### PR timestamp fields
 

--- a/task-store/prisma/migrations/20260729000000_add_reviewed_commit_sha_to_pull_request/migration.sql
+++ b/task-store/prisma/migrations/20260729000000_add_reviewed_commit_sha_to_pull_request/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: add reviewedCommitSha to PullRequest
+-- Additive, nullable column — no data loss, defaults to NULL for existing rows.
+-- This field is the review pipeline's exclusive commit-tracking field, separate
+-- from the shared commitSha field written by claim()/patch()/deploy for their
+-- own multi-phase bookkeeping.
+ALTER TABLE "PullRequest" ADD COLUMN "reviewedCommitSha" TEXT;

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -154,17 +154,18 @@ enum PrPhase {
 // tracks which phase of the full review→patch→deploy cycle the PR is in.
 
 model PullRequest {
-  id          String        @id @default(cuid())
-  repo        String        // org/repo format
-  prNumber    Int
-  taskId      String?
-  staged      Boolean       @default(false) // true = review written but not yet posted
-  state       PrState       @default(open)
-  reviewState PrReviewState @default(pending) // workflow phase within the review cycle
-  commitSha    String?
-  patchCycles  Int           @default(0)
-  reviewCycles Int           @default(0)
-  agentId      String?
+  id                String        @id @default(cuid())
+  repo              String // org/repo format
+  prNumber          Int
+  taskId            String?
+  staged            Boolean       @default(false) // true = review written but not yet posted
+  state             PrState       @default(open)
+  reviewState       PrReviewState @default(pending) // workflow phase within the review cycle
+  commitSha         String?
+  reviewedCommitSha String? // exclusive commit-tracking field for the review pipeline, separate from the shared commitSha written by claim()/patch()/deploy
+  patchCycles       Int           @default(0)
+  reviewCycles      Int           @default(0)
+  agentId           String?
   reviewedAt        String?
   patchedAt         String?
   mergedAt          String?

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -276,6 +276,11 @@ export const PullRequestSchema = z
       .nullable()
       .optional()
       .openapi({ example: "abc123def456" }),
+    reviewedCommitSha: z.string().nullable().optional().openapi({
+      example: "abc123def456",
+      description:
+        "The review pipeline's exclusive commit-tracking field, separate from the shared commitSha field written by claim()/patch()/deploy for their own multi-phase bookkeeping.",
+    }),
     patchCycles: z.number().int().default(0).openapi({ example: 1 }),
     reviewCycles: z.number().int().default(0).openapi({ example: 0 }),
     agentId: z

--- a/task-store/src/openapi-schemas.unit.test.ts
+++ b/task-store/src/openapi-schemas.unit.test.ts
@@ -87,6 +87,7 @@ const validPullRequest = {
   state: "open",
   reviewState: "pending",
   commitSha: "abc123def456",
+  reviewedCommitSha: "abc123def456",
   patchCycles: 1,
   reviewCycles: 0,
   agentId: "agent-id-123",
@@ -303,6 +304,40 @@ describe("PullRequestSchema", () => {
     };
     const result = PullRequestSchema.safeParse(withNulls);
     expect(result.success).toBe(true);
+  });
+
+  test("parses pull request with reviewedCommitSha set", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      reviewedCommitSha: "def456abc123",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.reviewedCommitSha).toBe("def456abc123");
+    }
+  });
+
+  test("parses pull request with null reviewedCommitSha", () => {
+    const result = PullRequestSchema.safeParse({
+      ...validPullRequest,
+      reviewedCommitSha: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.reviewedCommitSha).toBeNull();
+    }
+  });
+
+  test("parses pull request without reviewedCommitSha (optional field)", () => {
+    const { reviewedCommitSha: _, ...withoutField } = {
+      ...validPullRequest,
+      reviewedCommitSha: "unused",
+    };
+    const result = PullRequestSchema.safeParse(withoutField);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.reviewedCommitSha).toBeUndefined();
+    }
   });
 
   test("accepts all valid PrState enum values", () => {

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -49,6 +49,7 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     state: "open",
     reviewState: "pending",
     commitSha: null,
+    reviewedCommitSha: null,
     patchCycles: 0,
     reviewCycles: 0,
     agentId: null,
@@ -1126,6 +1127,21 @@ describe("/prs routes (smoke)", () => {
     expect(body.hitl).toBe(true);
     expect(body.hitlNotifiedAt).toBe(notifiedAt);
     expect(body.blockedReason).toBe("no linked task");
+  });
+
+  it("PATCH /prs/:id can set and read back reviewedCommitSha", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", reviewedCommitSha: null }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs/pr-1", {
+      method: "PATCH",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({ reviewedCommitSha: "abc123def456" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequest;
+    expect(body.reviewedCommitSha).toBe("abc123def456");
   });
 
   it("PATCH /prs/:id returns 400 for agent token with out-of-scope repo", async () => {

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -61,6 +61,7 @@ describeOrSkip("PullRequest model (integration)", () => {
     expect(read.staged).toBe(false);
     expect(read.taskId).toBeNull();
     expect(read.commitSha).toBeNull();
+    expect(read.reviewedCommitSha).toBeNull();
     expect(read.agentId).toBeNull();
     expect(read.reviewedAt).toBeNull();
     expect(read.patchedAt).toBeNull();
@@ -150,6 +151,27 @@ describeOrSkip("PullRequest model (integration)", () => {
     if (!read) return;
 
     expect(read.prCreatedAt).toBe(prCreatedAt);
+  });
+
+  it("round-trips reviewedCommitSha", async () => {
+    const reviewedCommitSha = "abc123def456";
+
+    const created = await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 56,
+        reviewedCommitSha,
+      },
+    });
+
+    const read = await prisma.pullRequest.findUnique({
+      where: { id: created.id },
+    });
+
+    expect(read).not.toBeNull();
+    if (!read) return;
+
+    expect(read.reviewedCommitSha).toBe(reviewedCommitSha);
   });
 
   it("rejects duplicate (repo, prNumber)", async () => {

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -495,6 +495,7 @@ export function createPrsRoutes(
   const PATCH_ALLOWED_FIELDS: Array<keyof PullRequest> = [
     "staged",
     "commitSha",
+    "reviewedCommitSha",
     "taskId",
     "agentId",
     "state",


### PR DESCRIPTION
## Summary
- Add nullable `reviewedCommitSha String?` field to the `PullRequest` model in task-store, via an additive Prisma migration
- Expose the field in `PullRequestSchema` (openapi-schemas.ts) and add it to `PATCH_ALLOWED_FIELDS` so `PATCH /prs/:id` can write it
- This becomes the review pipeline's exclusive commit-tracking field, separate from the shared `commitSha` field written by claim()/patch()/deploy for their own multi-phase bookkeeping

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | reviewedCommitSha String? in schema.prisma, additive migration | MET | schema.prisma + migrations/20260729000000_.../migration.sql (ALTER TABLE ADD COLUMN, nullable) |
| 2 | reviewedCommitSha added to PullRequestSchema (openapi-schemas.ts) | MET | z.string().nullable().optional() field added with openapi() metadata |
| 3 | reviewedCommitSha added to PATCH_ALLOWED_FIELDS (routes/prs.ts) | MET | Added to the allowlist array |
| 4 | Integration + smoke + unit test coverage, no existing tests retired | MET | pull-request.integration.test.ts (default-null + round-trip), prs.smoke.test.ts (PATCH set/read-back), openapi-schemas.unit.test.ts (3 new parse cases) |

## Test Plan
- `NODE_ENV=test bun test task-store` — 485 pass, 132 skip (integration suite skipped locally due to no reachable Postgres, gated via `describeOrSkip`), 0 fail
- `bun run --filter='@shipwright/task-store' typecheck` — passes
- `bunx biome lint` on changed files — no issues
- Coverage on changed files: `openapi-schemas.ts` 100% lines, `routes/prs.ts` 98.2% lines
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
