### PR TITLE
fix: write reviewedCommitSha from review.md

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -33,19 +33,22 @@ Applies to: **review**, **deploy**, **patch**, **dev-task**
 ### 2. Task Store PR Record Is the Dedup Source
 
 The task store `PullRequest` record (accessible via `GET /prs?repo=X`) is the source of
-truth for review deduplication. `commitSha` on the record is compared to the current
+truth for review deduplication. `reviewedCommitSha` on the record is compared to the current
 `headRefOid` from GitHub to detect "new commits since last review" without re-fetching
-history. Skills must not fail or behave incorrectly when no PR record exists — a missing
-record means the PR has not been reviewed yet and should be treated as eligible.
+history. `commitSha` is a separate claim-lock field — it is overwritten on every claim
+(including by later `patch`/`deploy` claims on the same PR) and is not safe to use for
+review dedup. Skills must not fail or behave incorrectly when no PR record exists — a
+missing record means the PR has not been reviewed yet and should be treated as eligible.
 
 Local files (`state/reviews/PR_REVIEW_{pr}.md`, `state/reviews/pr_review_{pr}.json`) hold
 the review narrative (findings, verdict, inline comments) for posting to GitHub. They are
 written by `/shipwright:review` and consumed by `/shipwright:review-staged`. They are not
 dedup state — the task store record owns that.
 
-Applies to: **review** (dedup by `commitSha`), **review-staged** (stale check via `commitSha`
-vs current `headRefOid`), **deploy** (falls back to `gh pr view --json reviewDecision`
-when no task store APPROVE record exists)
+Applies to: **review** (dedup by `reviewedCommitSha`), **review-staged** (stale check via
+`commitSha` vs current `headRefOid` — pending a follow-up to migrate to `reviewedCommitSha`),
+**deploy** (falls back to `gh pr view --json reviewDecision` when no task store APPROVE
+record exists)
 
 ### 3. A PR Created Outside Shipwright Is Fully Serviceable
 

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -422,3 +422,76 @@ describe("review.md — Step 14 live-review pre-check (RVD-1.2)", () => {
     expect(section.toLowerCase()).toContain("stop");
   });
 });
+
+describe("review.md — reviewedCommitSha written/read for dedup (RCS-1.2)", () => {
+  it("Step 5's Unresolved Comment Check PATCH call also sets reviewedCommitSha alongside commitSha", () => {
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const step6Idx = content.indexOf("## Step 6: Classify Changes by Domain");
+    const section = content.slice(step5Idx, step6Idx);
+    const patchIdx = section.indexOf("PATCH");
+    expect(patchIdx).toBeGreaterThan(-1);
+
+    const patchBlock = section.slice(patchIdx, patchIdx + 500);
+    expect(patchBlock).toContain("commitSha");
+    expect(patchBlock).toContain("reviewedCommitSha");
+  });
+
+  it("Step 11's APPROVE staging PATCH call sets reviewedCommitSha", () => {
+    const step11Idx = content.indexOf("## Step 11: Post or Stage");
+    const step11bIdx = content.indexOf("## Step 11b: Mark PullRequest Record Posted");
+    expect(step11Idx).toBeGreaterThan(-1);
+    expect(step11bIdx).toBeGreaterThan(step11Idx);
+    const section = content.slice(step11Idx, step11bIdx);
+
+    const approveIdx = section.indexOf('"reviewState": "approved"');
+    expect(approveIdx).toBeGreaterThan(-1);
+    const approveBlock = section.slice(approveIdx - 200, approveIdx + 200);
+    expect(approveBlock).toContain("reviewedCommitSha");
+  });
+
+  it("Step 11's COMMENT staging PATCH call sets reviewedCommitSha", () => {
+    const step11Idx = content.indexOf("## Step 11: Post or Stage");
+    const step11bIdx = content.indexOf("## Step 11b: Mark PullRequest Record Posted");
+    const section = content.slice(step11Idx, step11bIdx);
+
+    const commentIdx = section.indexOf('"reviewState": "posted"');
+    expect(commentIdx).toBeGreaterThan(-1);
+    const commentBlock = section.slice(commentIdx - 200, commentIdx + 200);
+    expect(commentBlock).toContain("reviewedCommitSha");
+  });
+
+  it("Step 14's stale-staged-review detection captures reviewedCommitSha (not commitSha) as lastReviewedCommit", () => {
+    const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");
+    const endIdx = content.indexOf("## Review Quality Rules", step14Idx);
+    expect(step14Idx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(step14Idx);
+    const section = content.slice(step14Idx, endIdx);
+
+    expect(section).toContain(
+      "Capture the record's `id` as `PR_RECORD_ID` and `reviewedCommitSha` as `lastReviewedCommit`.",
+    );
+  });
+
+  it("Step 14's stale-staged-review comparisons reference record.reviewedCommitSha, not record.commitSha", () => {
+    const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");
+    const endIdx = content.indexOf("## Review Quality Rules", step14Idx);
+    const section = content.slice(step14Idx, endIdx);
+
+    // The staged-record comparison and the defense-in-depth dedup comparison
+    // must both read the dedicated reviewedCommitSha field.
+    expect(section).toContain("record.reviewedCommitSha");
+    expect(section).not.toContain("record.commitSha");
+  });
+
+  it("the initial /prs/claim call's commitSha argument is unchanged (claim-lock field, not reviewedCommitSha)", () => {
+    const step4Idx = content.indexOf("## Step 4: Checkout into Worktree");
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    expect(step4Idx).toBeGreaterThan(-1);
+    expect(step5Idx).toBeGreaterThan(step4Idx);
+    const section = content.slice(step4Idx, step5Idx);
+
+    expect(section).toContain(
+      '-d "{\\"repo\\": \\"{org}/{repo}\\", \\"prNumber\\": {pr}, \\"commitSha\\": \\"{headRefOid}\\"',
+    );
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -219,7 +219,8 @@ back to `'sonnet'`.
 7. **Test-readiness context** (optional): try to read `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}/docs/test-readiness/test-system.md`. If absent, note that no repo-specific test-readiness doc exists. When the changed files include any path that looks like a test file — by common conventions across languages (e.g. files named or located in a way that signals they contain tests, such as files in `test/`, `tests/`, `spec/`, or `__tests__/` directories, or files whose names follow typical test-naming conventions for the project's language), also extract the "## Testing" section from the root CLAUDE.md (if present). Use the project's language and toolchain (visible from the diff and CLAUDE.md) to recognise test files — do not apply a fixed set of glob patterns. Combine both pieces into `testReadinessContext`. If neither produces content, `testReadinessContext` is absent — omit it entirely from the subagent prompt.
 
 `lastReviewedCommit` is the `LAST_REVIEWED_COMMIT` value saved from the pre-claim record in
-Step 14 (the record's `commitSha` before the claim overwrote it).
+Step 14 (the record's `reviewedCommitSha`, captured before the claim call — which only
+overwrites the separate `commitSha` lock field).
 
 #### Unresolved Comment Check
 
@@ -251,7 +252,7 @@ curl -sf -X PATCH \
   -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_TASK_STORE_URL/prs/{PR_RECORD_ID}" \
-  -d '{"reviewState": "posted", "commitSha": "{headRefOid}"}' >/dev/null
+  -d '{"reviewState": "posted", "commitSha": "{headRefOid}", "reviewedCommitSha": "{headRefOid}"}' >/dev/null
 ```
 Note: `staged` is NOT set here, so this does not interact with `/shipwright:review-staged`'s
 staged-record flow — this is purely a commit-level dedup to prevent re-review at the same head
@@ -569,7 +570,7 @@ should be held; the inline comments convey the specific feedback to the author.
      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      -H "Content-Type: application/json" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
-     -d '{"staged": true, "reviewState": "approved", "claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null}' >/dev/null
+     -d '{"staged": true, "reviewState": "approved", "reviewedCommitSha": "{headRefOid}", "claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null}' >/dev/null
    ```
 
    If `{verdict}` is `COMMENT`:
@@ -578,7 +579,7 @@ should be held; the inline comments convey the specific feedback to the author.
      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      -H "Content-Type: application/json" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
-     -d '{"staged": true, "reviewState": "posted", "claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null}' >/dev/null
+     -d '{"staged": true, "reviewState": "posted", "reviewedCommitSha": "{headRefOid}", "claimedBy": null, "claimedAt": null, "heartbeatAt": null, "phase": null}' >/dev/null
    ```
 
    (`PR_RECORD_ID` is the claim response `.id` from Step 4.)
@@ -759,7 +760,7 @@ headRefOid=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefO
    curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" | jq -c '.prs[0] // empty'
    ```
-   Capture the record's `id` as `PR_RECORD_ID` and `commitSha` as `lastReviewedCommit`.
+   Capture the record's `id` as `PR_RECORD_ID` and `reviewedCommitSha` as `lastReviewedCommit`.
 
 **This command never posts a staged review — posting a staged review is owned exclusively
 by `/shipwright:review-staged`.** `/shipwright:review` only ever produces or refreshes
@@ -768,12 +769,12 @@ is refresh it if it's gone stale — nothing more.
 
 **If a record exists with `staged: true`**:
 
-Fetch the current head commit and compare to `record.commitSha` (`lastReviewedCommit`):
+Fetch the current head commit and compare to `record.reviewedCommitSha` (`lastReviewedCommit`):
 ```bash
 gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
 ```
 
-- **`headRefOid == record.commitSha`** (no new commits — the staged review is still
+- **`headRefOid == record.reviewedCommitSha`** (no new commits — the staged review is still
   current, nothing to refresh). Translate `record.reviewState` to a verdict the same way
   `/shipwright:review-staged` does (`approved` → APPROVE, `posted`/`in_progress` → COMMENT),
   then print:
@@ -782,7 +783,7 @@ gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
   Run /shipwright:review-staged to post, skip, or discuss it.
   ```
   Stop.
-- **`headRefOid != record.commitSha`** (author pushed new commits since staging — the
+- **`headRefOid != record.reviewedCommitSha`** (author pushed new commits since staging — the
   staged review is stale and needs a refresh). Re-claim the record at the new head to
   flip it to `in_progress`:
   ```bash
@@ -794,7 +795,7 @@ gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
   ```
   Print:
   ```
-  Staged review is stale — {pr} has new commits since the review was written ({record.commitSha[0..7]} → {headRefOid[0..7]}).
+  Staged review is stale — {pr} has new commits since the review was written ({record.reviewedCommitSha[0..7]} → {headRefOid[0..7]}).
   Re-reviewing now.
   ```
   Continue from **Step 4** (checkout into worktree) with this PR as the target. The
@@ -814,7 +815,7 @@ gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
    ```bash
    gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
    ```
-   Compare to `record.commitSha` (`lastReviewedCommit`). If `headRefOid == record.commitSha`
+   Compare to `record.reviewedCommitSha` (`lastReviewedCommit`). If `headRefOid == record.reviewedCommitSha`
    (the commit has already been reviewed and there are no new commits):
    - Print:
      ```
@@ -824,7 +825,7 @@ gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
 
    If no record exists (first review), or `record.reviewState` is `pending` (claimed but
    never completed — never actually reviewed), or `headRefOid` differs from
-   `record.commitSha` (new commits exist), proceed to Step 4 below.
+   `record.reviewedCommitSha` (new commits exist), proceed to Step 4 below.
 
 4. Go directly to Step 4 (checkout) with this specific PR as the target.
 

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -101,13 +101,13 @@ describe("review.md — WLS-3.2 explicit-target-only", () => {
     expect(content.includes("gh pr list --state open")).toBe(false);
   });
 
-  it("still contains the commitSha/headRefOid dedup check for the explicit target PR", () => {
+  it("still contains the reviewedCommitSha/headRefOid dedup check for the explicit target PR", () => {
     const dedupIdx = content.indexOf(
       "Check if the PR was already reviewed at the current commit",
     );
     expect(dedupIdx).toBeGreaterThan(-1);
     const dedupSection = content.slice(dedupIdx, dedupIdx + 1500);
-    expect(dedupSection.includes("record.commitSha")).toBe(true);
+    expect(dedupSection.includes("record.reviewedCommitSha")).toBe(true);
     expect(dedupSection.includes("headRefOid")).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- `review.md` now writes `reviewedCommitSha` (in addition to the shared claim-lock `commitSha`) at every point it records "the commit review just processed": Step 11's two staging PATCH calls and the unresolved-comment-skip PATCH.
- Step 14.2's stale-staged-review detection and defense-in-depth dedup now read/compare `record.reviewedCommitSha` instead of `record.commitSha`, so review dedup no longer collides with the claim-lock field shared across review/patch/deploy.
- The initial `/prs/claim` call's `commitSha` argument (Step 4) and the re-claim call inside the stale-refresh path are untouched — both use the shared claim-lock endpoint, which only accepts `commitSha`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 11's staging PATCH calls set reviewedCommitSha alongside staged/reviewState | MET |
| 2 | The unresolved-comment-skip PATCH sets reviewedCommitSha alongside commitSha | MET |
| 3 | Step 14.2's stale-staged-review detection reads/compares record.reviewedCommitSha instead of record.commitSha throughout | MET |
| 4 | The initial /prs/claim call's commitSha argument is unchanged | MET |
| 5 | Test decision: extend existing *.content.test.ts coverage; no existing tests retired | MET |

## Test Plan
- Extended `review.content.test.ts` with a new describe block (6 tests) asserting `reviewedCommitSha` appears in the Step 11/Step 5 PATCH payloads and that Step 14's comparisons use `record.reviewedCommitSha`, not `record.commitSha`; confirmed RED against the pre-fix file, GREEN after.
- Updated one pre-existing assertion in `review.unit.test.ts` that expected `record.commitSha` in the same dedup section this task changed.
- [x] `task ci` — all suites pass except one documented pre-existing sandbox flake (`extraAllowedTools` in `agent/src/claude.unit.test.ts`), reproduced independently of this diff on a clean checkout.

Generated with [Claude Code](https://claude.com/claude-code)
