### PR TITLE
feat(plugin): support multi-layer test commands in toolchain cache

### DIFF
--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -269,6 +269,32 @@ describe("dev-task.md 0b — docs-first toolchain discovery + per-repo cache (TD
   it("does not reference the old single shared cache file", () => {
     expect(content).not.toContain("state/toolchain-cache.json");
   });
+
+  it("stores a tests object for multi-layer test commands alongside the single test command", () => {
+    const stepIdx = content.indexOf("### 0b. Detect Project Toolchain");
+    const section = content.slice(stepIdx, stepIdx + 2000);
+    expect(section).toMatch(/\*\*tests\*\*/i);
+    expect(section).toMatch(/optional.*object.*layer/i);
+  });
+});
+
+describe("toolchain-patterns.md — cache schema includes tests object for multi-layer test commands", () => {
+  it("defines a tests field in the cache schema", () => {
+    const referencesPath = join(import.meta.dir, "..", "references", "toolchain-patterns.md");
+    const referencesContent = readFileSync(referencesPath, "utf-8");
+
+    const schemaIdx = referencesContent.indexOf('"commands"');
+    expect(schemaIdx).toBeGreaterThan(-1);
+    const schemaSection = referencesContent.slice(schemaIdx, schemaIdx + 500);
+    expect(schemaSection).toContain('"tests"');
+  });
+
+  it("documents multi-layer test detection", () => {
+    const referencesPath = join(import.meta.dir, "..", "references", "toolchain-patterns.md");
+    const referencesContent = readFileSync(referencesPath, "utf-8");
+    expect(referencesContent).toContain("### Multi-Layer Test Detection");
+    expect(referencesContent).toMatch(/keys are free-form/i);
+  });
 });
 
 describe("toolchain-patterns.md — fingerprint path list covers task-runner/version-manager config (CPF-review-2242)", () => {

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -183,7 +183,8 @@ Auto-detect the project toolchain (run once, reuse throughout), checking the cro
 
 4. **Store and cache.** Store the detected commands:
    - **validate**: Full validation command (e.g., `pnpm validate`, `cargo clippy && cargo test`, `make check`)
-   - **test**: Test command (e.g., `pnpm test`, `cargo test`, `go test ./...`, `pytest`)
+   - **test**: Fast default test command for TDD cycles (e.g., `pnpm test`, `cargo test`, `go test ./...`, `pytest`)
+   - **tests**: Optional object mapping layer names to commands when the project has distinct test layers (e.g., `{"unit": "pytest tests/unit", "integration": "pytest tests/integration", "e2e": "npx playwright test"}`). Keys are free-form — use whatever the project calls its layers. Omit when only one test command exists.
    - **lint**: Lint command (e.g., `pnpm lint`, `cargo clippy`, `golangci-lint run`, `ruff check`)
    - **typecheck**: Type check command if applicable (e.g., `pnpm -r check`, `tsc --noEmit`)
    - **build**: Build command (e.g., `pnpm build`, `cargo build`, `go build ./...`)
@@ -455,6 +456,7 @@ PROJECT CONVENTIONS (from CLAUDE.md):
 
 TOOLCHAIN:
   Test command:     {test command from Step 0}
+  Test layers:      {if tests from Step 0 is non-empty, list each as "layer: command"; otherwise "none — test command covers all layers"}
   Validate command: {validate command from Step 0}
   Typecheck:        {typecheck command from Step 0, or "none"}
 
@@ -663,7 +665,7 @@ Stop.
 
 ## Step 8: Pre-Ship Checks
 
-Run the detected validation commands from Step 0. For multi-ecosystem projects, run all applicable commands.
+Run the detected validation commands from Step 0. For multi-ecosystem projects, run all applicable commands. If `tests` was populated in Step 0 (multiple test layers), run each layer's command — not just the fast default `test` command.
 
 Examples based on detected toolchain:
 - Node.js: `{manager} validate` (or `{manager} lint && {manager} test && {manager} build`)
@@ -671,6 +673,7 @@ Examples based on detected toolchain:
 - Go: `go vet ./... && go test ./...`
 - Python: `pytest` (or `poetry run pytest`, `uv run pytest`)
 - Ruby: `bundle exec rspec` (or `bundle exec rake test`)
+- Multi-layer: run `{test command}`, then each additional entry in `{tests}` (e.g., `npx playwright test` for e2e alongside the default `pytest` for unit/integration)
 
 ### Coverage Gate
 

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1102,6 +1102,18 @@ describe("patch.md — docs-first toolchain discovery + per-repo cache (TDF-1.1)
   it("does not reference the old single shared cache file", () => {
     expect(content).not.toContain("state/toolchain-cache.json");
   });
+
+  it("stores a tests object for multi-layer test commands at each detection site", () => {
+    function checkTestsField(step: string, next: string) {
+      const stepIdx = content.indexOf(step);
+      const nextIdx = content.indexOf(next, stepIdx);
+      const section = content.slice(stepIdx, nextIdx);
+      expect(section).toMatch(/\{tests\}/i);
+    }
+    checkTestsField("### Step 4a.5: Detect Project Toolchain", "### Step 4a.6");
+    checkTestsField("### Step 5a.5: Detect Project Toolchain", "### Step 5a.6");
+    checkTestsField("### Step 6a.5: Detect Project Toolchain", "### Step 6b");
+  });
 });
 
 describe("patch.md — Step 2.5/Step 3 opening prose reflects single-PR scope (PCG-1.1)", () => {

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -353,11 +353,12 @@ git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTR
 
 Check the cache before any fresh detection, then fall back to docs-first discovery and config-file scanning — see `references/toolchain-patterns.md`'s "Caching Across Runs" and "Docs-First Discovery" sections for the exact protocol:
 
-1. Compute the fingerprint against `{worktree-path}` and read `state/toolchain-cache/{repo}.json`. If the file exists and its fingerprint matches, reuse the cached **lint**/**test** commands and skip to Step 4a.6.
+1. Compute the fingerprint against `{worktree-path}` and read `state/toolchain-cache/{repo}.json`. If the file exists and its fingerprint matches, reuse the cached **lint**/**test**/**tests** commands and skip to Step 4a.6.
 2. Otherwise, read `CLAUDE.md` + `docs/*.md`/`ai-docs/*.md` for explicit lint/test commands first (authoritative if found), then fall back to the config-file lookup table in `references/toolchain-patterns.md` to fill any gaps.
 3. Store detected commands:
    - **{lint command}**: e.g., `bun run lint`, `cargo clippy`, `golangci-lint run`
    - **{test command}**: e.g., `bun test`, `cargo test`, `go test ./...`, `pytest`
+   - **{tests}**: optional object of additional test layers (e.g., `{"integration": "pytest tests/integration", "e2e": "npx playwright test"}`) — omit when only one test command exists
 4. On a cache miss, overwrite `state/toolchain-cache/{repo}.json` with the new fingerprint + commands.
 
 ### Step 4a.6: Claim PR Record (pre-work lock)
@@ -438,6 +439,7 @@ Worktree: {worktree-path}
 TOOLCHAIN:
   Lint command: {lint command}
   Test command: {test command}
+  Test layers:  {if tests is non-empty, list each as "layer: command"; otherwise "none"}
 
 INSTRUCTIONS — follow in order:
 
@@ -596,11 +598,12 @@ All subsequent steps for this PR run from `~/worktrees/{repo}-{branch-slug}/`.
 
 Check the cache before any fresh detection, then fall back to docs-first discovery and config-file scanning — see `references/toolchain-patterns.md`'s "Caching Across Runs" and "Docs-First Discovery" sections for the exact protocol:
 
-1. Compute the fingerprint against `{worktree-path}` and read `state/toolchain-cache/{repo}.json`. If the file exists and its fingerprint matches, reuse the cached **lint**/**test** commands and skip to the diff collection below.
+1. Compute the fingerprint against `{worktree-path}` and read `state/toolchain-cache/{repo}.json`. If the file exists and its fingerprint matches, reuse the cached **lint**/**test**/**tests** commands and skip to the diff collection below.
 2. Otherwise, read `CLAUDE.md` + `docs/*.md`/`ai-docs/*.md` for explicit lint/test commands first (authoritative if found), then fall back to the config-file lookup table in `references/toolchain-patterns.md` to fill any gaps.
 3. Store detected commands:
    - **{lint command}**: e.g., `bun run lint`, `cargo clippy`, `golangci-lint run`
    - **{test command}**: e.g., `bun test`, `cargo test`, `go test ./...`, `pytest`
+   - **{tests}**: optional object of additional test layers (e.g., `{"integration": "pytest tests/integration", "e2e": "npx playwright test"}`) — omit when only one test command exists
 4. On a cache miss, overwrite `state/toolchain-cache/{repo}.json` with the new fingerprint + commands.
 
 From inside the worktree, collect the full picture of what needs fixing:
@@ -852,6 +855,7 @@ Worktree: {worktree-path}
 TOOLCHAIN:
   Lint command: {lint command}
   Test command: {test command}
+  Test layers:  {if tests is non-empty, list each as "layer: command"; otherwise "none"}
 
 REVIEW FINDINGS TO ADDRESS:
 
@@ -1201,11 +1205,12 @@ git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTR
 
 Check the cache before any fresh detection, then fall back to docs-first discovery and config-file scanning — see `references/toolchain-patterns.md`'s "Caching Across Runs" and "Docs-First Discovery" sections for the exact protocol:
 
-1. Compute the fingerprint against `{worktree-path}` and read `state/toolchain-cache/{repo}.json`. If the file exists and its fingerprint matches, reuse the cached **lint**/**test** commands and skip to Step 6b.
+1. Compute the fingerprint against `{worktree-path}` and read `state/toolchain-cache/{repo}.json`. If the file exists and its fingerprint matches, reuse the cached **lint**/**test**/**tests** commands and skip to Step 6b.
 2. Otherwise, read `CLAUDE.md` + `docs/*.md`/`ai-docs/*.md` for explicit lint/test commands first (authoritative if found), then fall back to the config-file lookup table in `references/toolchain-patterns.md` to fill any gaps.
 3. Store detected commands:
    - **{lint command}**: e.g., `bun run lint`, `cargo clippy`, `golangci-lint run`
    - **{test command}**: e.g., `bun test`, `cargo test`, `go test ./...`, `pytest`
+   - **{tests}**: optional object of additional test layers (e.g., `{"integration": "pytest tests/integration", "e2e": "npx playwright test"}`) — omit when only one test command exists
 4. On a cache miss, overwrite `state/toolchain-cache/{repo}.json` with the new fingerprint + commands.
 
 ### Step 6b: Collect CI Failure Output
@@ -1351,6 +1356,7 @@ Worktree: {worktree-path}
 TOOLCHAIN:
   Lint command: {lint command}
   Test command: {test command}
+  Test layers:  {if tests is non-empty, list each as "layer: command"; otherwise "none"}
 
 CI FAILURE OUTPUT (last 200 lines):
 {log output from Step 6b}

--- a/plugins/shipwright/commands/spc-3.1.unit.test.ts
+++ b/plugins/shipwright/commands/spc-3.1.unit.test.ts
@@ -69,6 +69,11 @@ describe("patch.md — Step 5b subagent prompt: no hardcoded bun commands", () =
     const section = extractSection(patch, "### Step 5b:", "### Step 5c:");
     expect(section).toContain("{test command}");
   });
+
+  it("includes Test layers in Step 5b TOOLCHAIN block", () => {
+    const section = extractSection(patch, "### Step 5b:", "### Step 5c:");
+    expect(section).toContain("Test layers:");
+  });
 });
 
 describe("patch.md — Step 6c subagent prompt: no hardcoded bun commands", () => {
@@ -95,5 +100,10 @@ describe("patch.md — Step 6c subagent prompt: no hardcoded bun commands", () =
   it("uses {test command} placeholder in Step 6c [C] Validate", () => {
     const section = extractSection(patch, "### Step 6c:", "### Step 6d:");
     expect(section).toContain("{test command}");
+  });
+
+  it("includes Test layers in Step 6c TOOLCHAIN block", () => {
+    const section = extractSection(patch, "### Step 6c:", "### Step 6d:");
+    expect(section).toContain("Test layers:");
   });
 });

--- a/plugins/shipwright/references/toolchain-patterns.md
+++ b/plugins/shipwright/references/toolchain-patterns.md
@@ -13,6 +13,21 @@ Before scanning config files, check whether the project's own docs already say h
 
 A project with no `CLAUDE.md`/`docs/`/`ai-docs/` just falls straight through to config-file detection — this step costs nothing extra in that case beyond checking those paths exist.
 
+### Multi-Layer Test Detection
+
+Many projects have more than one test command — unit, integration, smoke, e2e, schema-conformance, contract, acceptance, etc. During detection, populate `tests` when distinct test layers are discovered:
+
+**Docs-first signals:** CLAUDE.md or docs mentioning multiple test commands, test suffixes, or separate test scripts (e.g., "run `pytest tests/unit` for unit tests, `pytest tests/integration` for integration tests").
+
+**Config-file signals:**
+- **Node.js:** `package.json` scripts prefixed with `test:` (e.g., `test:unit`, `test:integration`, `test:e2e`, `test:schema`). Each becomes a `tests` entry keyed by the suffix.
+- **Java/Gradle:** `sourceSets` blocks (`integrationTest`, `acceptanceTest`), or `src/integrationTest/`, `src/acceptanceTest/` directories. Maven profiles (`-Pintegration`, `-Pit`).
+- **Python:** multiple test directories (`tests/unit/`, `tests/integration/`), or tox environments.
+- **Rust:** `cargo test` vs `cargo test --test <name>` for specific test binaries.
+- **Mixed-ecosystem:** a project with both `cargo test` and `npm test` (e.g., Rust backend + JS e2e) — each is a separate layer.
+
+Set `test` to the fastest/default layer (usually unit or the project's main test runner). If only one test command exists, omit `tests` — `test` alone covers everything.
+
 ## Caching Across Runs
 
 Toolchain detection (docs-first + config-file fallback) is redundant to redo on every single command invocation — most projects don't change their toolchain often. Cache the result **one level up from the repo checkout** (same tier as `state/error-patrol-ledger.json`), **one file per repo**, so `/dev-task` and `/patch` share one cache instead of each redetecting independently:
@@ -26,10 +41,18 @@ state/toolchain-cache/{repo}.json
   "fingerprint": "<git commit sha>",
   "detectedAt": "<ISO timestamp>",
   "commands": {
-    "validate": "...", "test": "...", "lint": "...", "typecheck": "...", "build": "..."
+    "validate": "...",
+    "test": "...",
+    "tests": { "<layer>": "<command>", ... },
+    "lint": "...",
+    "typecheck": "...",
+    "build": "..."
   }
 }
 ```
+
+- **`test`** — the fast default test command for TDD cycles (unit tests, or the project's main test runner). Always populated.
+- **`tests`** — optional object mapping layer names to commands, populated when the project has distinct test commands per layer. Keys are free-form (e.g., `unit`, `integration`, `smoke`, `e2e`, `schema-conformance`, `contract` — whatever the project calls them). When present, `test` should match one of these entries (typically the fastest layer). When absent or empty, `test` alone covers everything.
 
 One file per repo (not one shared file keyed by repo) — a shared file read-modify-written from multiple concurrent processes is not atomic: two agents updating *different* repos' entries at the same time can each read the whole file and clobber the other's addition on write, even though they touched different keys. Splitting by repo removes that cross-repo collision entirely. A same-repo collision (two runs racing on the same repo) can still happen, but it's benign — both would compute the same commands from the same repo state, so a lost update just costs a redundant re-detection next time, not data loss.
 
@@ -41,7 +64,7 @@ git -C {repo-dir} log -1 --format=%H -- CLAUDE.md docs ai-docs package.json pack
 
 `{repo-dir}` is whichever checkout is live at the point detection runs — `${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo}` for dev-task's pre-worktree detection (Step 1/0b runs before the worktree exists); the active `{worktree-path}` for patch, which always operates on an already-existing branch.
 
-1. Read `state/toolchain-cache/{repo}.json`. If it exists and its `fingerprint` matches the value above, reuse the cached `commands` and skip both Docs-First Discovery and config-file scanning entirely.
+1. Read `state/toolchain-cache/{repo}.json`. If it exists and its `fingerprint` matches the value above, reuse the cached `commands` (including `tests` if present) and skip both Docs-First Discovery and config-file scanning entirely.
 2. Otherwise — file missing, or a fingerprint mismatch (first run, or a toolchain-relevant file changed since the last detection) — run Docs-First Discovery above, then the config-file fallback tables below, and overwrite `state/toolchain-cache/{repo}.json` with the new fingerprint + commands (a whole-file write — no cross-repo merge needed, since this file only ever holds this one repo's data).
 
 A missing or stale cache never blocks progress — worst case is a cache miss, which costs exactly what a full detection would cost with no cache at all.


### PR DESCRIPTION
## Summary

- Adds an optional `tests` object to the toolchain cache schema, keyed by free-form layer names (e.g., `unit`, `integration`, `e2e`, `schema-conformance`) so projects with distinct test commands per layer are fully supported
- The existing `test` field remains as the fast default for TDD cycles; `tests` entries are exercised during pre-ship validation (Step 8) and surfaced in subagent TOOLCHAIN blocks as `Test layers:`
- Updates all three patch.md detection sites and subagent prompts to cache/restore/inject test layers
- Adds multi-layer test detection guidance to `toolchain-patterns.md` covering Node.js, Java, Python, Rust, and mixed-ecosystem signals

## Test plan

- [x] All 450 command tests pass (content + unit across 13 files)
- [ ] Verify toolchain cache round-trip: a project with multiple `test:*` scripts in `package.json` populates `tests` on cache miss and reuses it on cache hit
- [ ] Verify dev-task subagent receives `Test layers:` in its TOOLCHAIN block
- [ ] Verify pre-ship checks (Step 8) runs each `tests` entry, not just the fast default

🤖 Generated with [Claude Code](https://claude.com/claude-code)