### PR TITLE
feat: default auto_post_reviews to true across template and docs

### DIFF
--- a/agent/workspace/state/agent-policy.md.template
+++ b/agent/workspace/state/agent-policy.md.template
@@ -10,10 +10,11 @@ Conservative defaults are set for safety. Relax them as trust grows.
 ## Review Policy
 
 ### Posting
-- **auto_post_reviews**: false
-  When false, reviews are staged to `state/reviews/` and a Slack message is
-  sent to the owner. The owner must explicitly approve before the review is
-  posted to GitHub. When true, reviews are posted automatically.
+- **auto_post_reviews**: true
+  When true (the default), reviews are posted to GitHub automatically. When
+  false, reviews are staged to `state/reviews/` and a Slack message is sent
+  to the owner instead — the owner must explicitly approve before the review
+  is posted to GitHub.
 
 ### Event Type
 - **allowed_events**: [COMMENT, APPROVE]
@@ -26,8 +27,8 @@ Conservative defaults are set for safety. Relax them as trust grows.
   Review PRs created by this agent (from the task store with status pr_open).
 
 - **review_external_prs**: true
-  Review open PRs not created by this agent. Safe with auto_post_reviews off
-  since reviews are staged for owner confirmation before posting.
+  Review open PRs not created by this agent. Set `auto_post_reviews: false`
+  if you'd rather stage these reviews for owner confirmation before posting.
 
 - **allow_self_review**: false
   Review own open PRs. GitHub blocks self-APPROVE, so own PRs are always posted

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,7 +225,7 @@ Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `auto_post_reviews` | `bool` | `false` | Post review comments to GitHub automatically without manual approval. |
+| `auto_post_reviews` | `bool` | `true` | Post review comments to GitHub automatically without manual approval. Set to `false` to stage reviews locally for owner approval instead. |
 | `allowed_events` | `string[]` | `["COMMENT", "APPROVE"]` | GitHub review event types the agent may emit. |
 | `review_external_prs` | `bool` | `true` | Currently unused — `/shipwright:review` always targets a single explicit PR (no repo-wide scan to filter), and no other command reads this field. |
 | `allow_self_review` | `bool` | `true` | Read by `agent/src/check-review.ts`'s `getReviewCandidates()` (the `shipwright-loop` cron's in-process review candidate provider) to decide whether the agent's own open PRs are review candidates. Set to `false` to require a human reviewer on agent-authored PRs. |
@@ -238,7 +238,7 @@ Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file
 
 ```markdown
 ---
-auto_post_reviews: false
+auto_post_reviews: true
 allowed_events: [COMMENT, APPROVE]
 allow_self_review: true
 min_confidence: 75

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -65,7 +65,7 @@ Read `state/agent-policy.md`. If the file doesn't exist, use these conservative 
 
 | Setting | Default |
 |---------|---------|
-| `auto_post_reviews` | false |
+| `auto_post_reviews` | true |
 | `allowed_events` | [COMMENT, APPROVE] |
 | `allow_self_review` | true |
 | `min_confidence` | 75 |
@@ -521,7 +521,7 @@ should be held; the inline comments convey the specific feedback to the author.
 
 ## Step 11: Post or Stage
 
-### If `auto_post_reviews` is true (policy):
+### If `auto_post_reviews` is true (default):
 
 1. Submit via GitHub API, writing the response to a temp file (NOT a shell variable —
    the response JSON contains embedded newlines that corrupt `echo "$var" | jq` parsing):
@@ -556,7 +556,7 @@ should be held; the inline comments convey the specific feedback to the author.
 5. Print: `Posted review for #{pr}: {REVIEW_URL}`
 6. Post Slack message (see below)
 
-### If `auto_post_reviews` is false (default):
+### If `auto_post_reviews` is false (staged):
 
 1. Mark the PR record staged, persisting the verdict so the APPROVE-first sort in
    `/shipwright:review-staged` works correctly. Both branches also release the claim
@@ -616,7 +616,7 @@ Use the Slack MCP tool if available. If no Slack integration is configured, prin
 
 ## Step 11b: Mark PullRequest Record Posted
 
-Run this step immediately after posting a review. The only place this command posts is Step 11's `auto_post_reviews: true` path; `/shipwright:review-staged`'s `post it` action also runs this step (after its own staged-flag clear, which is the one thing this step doesn't do) since posting-then-completing is identical either way. Skip this step when the review is staged (not posted).
+Run this step immediately after posting a review. The only place this command posts is Step 11's `auto_post_reviews: true` (default) path; `/shipwright:review-staged`'s `post it` action also runs this step (after its own staged-flag clear, which is the one thing this step doesn't do) since posting-then-completing is identical either way. Skip this step when the review is staged (not posted).
 
 Use `{verdict}` and `PR_RECORD_ID` — from Step 10 and the claim in Step 4 respectively when called from this command; `record.reviewState == "approved" ? APPROVE : COMMENT` and `record.id` respectively when called from `/shipwright:review-staged`.
 

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -133,8 +133,8 @@ describe("review.md — RPF-1.4 verify review post before complete", () => {
   let autoPostSection: string;
 
   beforeAll(() => {
-    const startIdx = content.indexOf("### If `auto_post_reviews` is true (policy):");
-    const endIdx = content.indexOf("### If `auto_post_reviews` is false (default):");
+    const startIdx = content.indexOf("### If `auto_post_reviews` is true (default):");
+    const endIdx = content.indexOf("### If `auto_post_reviews` is false (staged):");
     expect(startIdx).toBeGreaterThan(-1);
     expect(endIdx).toBeGreaterThan(startIdx);
     autoPostSection = content.slice(startIdx, endIdx);

--- a/plugins/shipwright/references/reviews-schema.md
+++ b/plugins/shipwright/references/reviews-schema.md
@@ -112,9 +112,9 @@ curl -X POST -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   during claim in Step 4). Comparing it to the current GitHub head detects "new commits since
   last review" without re-fetching history. Compare against `gh pr view --json headRefOid`.
 
-- **`staged` flag**: when `auto_post_reviews` is false (default), reviews are staged. Set `staged: true`
-  on Step 11 (before posting). Explicit `/shipwright:review {org}/{repo}#{pr}` invocation
-  posts a staged review (owner confirmation).
+- **`staged` flag**: when `auto_post_reviews` is false (opt-out from the default), reviews are staged.
+  Set `staged: true` on Step 11 (before posting). Explicit `/shipwright:review {org}/{repo}#{pr}`
+  invocation posts a staged review (owner confirmation).
 
 - **Workflow phases**: `review.md` is explicit-target-only — it always operates on the one
   PR named in `$ARGUMENTS`, not a self-scanned/ranked queue. `reviewState` still governs

--- a/site/src/content/docs/configuring-autonomy.mdx
+++ b/site/src/content/docs/configuring-autonomy.mdx
@@ -51,7 +51,7 @@ You still control merging.
 | `shipwright-deploy` | off |
 
 At this stage, `auto_post_reviews` in `state/agent-policy.md` determines whether the agent
-posts reviews to GitHub immediately or holds them for your approval. See
+posts reviews to GitHub immediately (the default) or holds them for your approval. See
 [Staged reviews](#staged-reviews) below.
 
 ### Stage 3 — Full autonomous loop
@@ -87,13 +87,14 @@ dev-task  ✓  patch  ✓  review  ✗  deploy  ✗
 
 ### Staged reviews
 
-You want the agent to review PRs but prefer to read and approve each review before it goes to
-GitHub. Set `auto_post_reviews: false` in `state/agent-policy.md`. Enable `shipwright-review`
-(and `shipwright-patch` if you also want findings addressed automatically).
+By default, the agent posts reviews to GitHub immediately (`auto_post_reviews: true`). If you'd
+rather read and approve each review before it goes to GitHub, set `auto_post_reviews: false` in
+`state/agent-policy.md`. Enable `shipwright-review` (and `shipwright-patch` if you also want
+findings addressed automatically).
 
-The agent runs its review pass and writes the findings to a local review file. Nothing is posted
-to GitHub until you approve it. Once you've confirmed the review looks right, post it manually
-or set `auto_post_reviews: true` to have the agent send it.
+With staging on, the agent runs its review pass and writes the findings to a local review file.
+Nothing is posted to GitHub until you approve it. Once you've confirmed the review looks right,
+post it manually, or set `auto_post_reviews: true` again to go back to automatic posting.
 
 ```
 dev-task  ✓  review  ✓  patch  ✓  deploy  ✗   (auto_post_reviews: false)
@@ -128,7 +129,7 @@ Ask your agent to change the policy settings in `state/agent-policy.md` — no r
 
 | Setting | Value | Notes |
 |---------|-------|-------|
-| `auto_post_reviews` | false | Stage reviews locally; do not post to GitHub automatically. |
+| `auto_post_reviews` | true | Post reviews to GitHub automatically. Set to `false` to stage reviews locally instead. |
 | `allowed_events` | [COMMENT, APPROVE] | Never REQUEST_CHANGES |
 | `review_external_prs` | true | Review externally-opened PRs |
 | `allow_self_review` | true | Review own PRs |
@@ -145,7 +146,7 @@ Ask your agent to change the policy settings in `state/agent-policy.md` — no r
 
 | Field | Default | What it controls |
 |-------|---------|-----------------|
-| `auto_post_reviews` | `false` | Post review comments to GitHub immediately. When `false`, reviews are staged locally. |
+| `auto_post_reviews` | `true` | Post review comments to GitHub immediately. When `false`, reviews are staged locally. |
 | `allowed_events` | `[COMMENT, APPROVE]` | GitHub review event types the agent may emit. Remove `APPROVE` to prevent agent approvals. |
 | `review_external_prs` | `true` | Review PRs opened by users other than the agent. Set `false` to review only the agent's own PRs. |
 | `allow_self_review` | `true` | Allow the agent to review PRs it opened. Set `false` to require a human reviewer on agent-authored PRs. |

--- a/site/src/content/docs/reference.mdx
+++ b/site/src/content/docs/reference.mdx
@@ -125,7 +125,7 @@ Agent behavior is controlled by `state/agent-policy.md`. Ask your agent to chang
 
 ```yaml
 ---
-auto_post_reviews: false
+auto_post_reviews: true
 allowed_events: [COMMENT, APPROVE]
 review_external_prs: true
 allow_self_review: true

--- a/site/src/data/config-vars.ts
+++ b/site/src/data/config-vars.ts
@@ -115,7 +115,7 @@ export const agentProvisioningVars: ConfigVar[] = [
 ];
 
 export const policyFields: ConfigVar[] = [
-  { name: "auto_post_reviews", type: "bool", def: "false", desc: "Post review comments to GitHub automatically without manual approval." },
+  { name: "auto_post_reviews", type: "bool", def: "true", desc: "Post review comments to GitHub automatically without manual approval. Set to false to stage reviews locally for owner approval instead." },
   { name: "allowed_events", type: "string[]", def: '["COMMENT", "APPROVE"]', desc: "GitHub review event types the agent may emit." },
   { name: "review_external_prs", type: "bool", def: "true", desc: "Review PRs opened by users other than the agent." },
   { name: "allow_self_review", type: "bool", def: "true", desc: "Allow the agent to review its own PRs. Set to false to require a human reviewer on agent-authored PRs." },


### PR DESCRIPTION
## Summary
- Flips the default review-posting policy from staged/manual to auto-post-to-GitHub: `agent/workspace/state/agent-policy.md.template` now sets `auto_post_reviews: true`
- Updates every doc surface that documents this default so behavior and docs stay in sync: `docs/configuration.md`, `site/src/data/config-vars.ts`, `site/src/content/docs/configuring-autonomy.mdx`, `site/src/content/docs/reference.mdx`
- Relabels `plugins/shipwright/commands/review.md`'s Step 11 headers and `plugins/shipwright/references/reviews-schema.md`'s prose so `true` is now `(default)` and `false` is `(staged)`/opt-out; updates `review.unit.test.ts`'s two `content.indexOf(...)` assertions to match

Not a breaking change — `seedFile()` uses write-once (`wx`) semantics, so existing `state/agent-policy.md` files on already-running agents are untouched. This only changes what newly-provisioned workspaces get seeded with.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | template:13 sets `auto_post_reviews: true`; prose updated | MET |
| 2 | 4 docs/site files reflect `true` as default | MET |
| 3 | review.md + reviews-schema.md relabel default/opt-in | MET |
| 4 | review.unit.test.ts assertions updated to match | MET |

## Test Plan
- [x] `review.unit.test.ts` (93/93 relevant tests) pass with swapped header strings
- [x] `agent/src/setup.integration.test.ts`'s conservative-defaults test still passes unchanged (asserts `allow_self_review: false`, unaffected by this change)
- [x] `task typecheck` — all 7 workspaces pass
- [x] `task ci` — lint, check-strings, typecheck, check-config-docs, check-version-sync all pass; `test:coverage` fails only on a pre-existing, unrelated flake (`agent/src/claude.unit.test.ts` > `extraAllowedTools`), reproduces identically on clean `main`

Generated with [Claude Code](https://claude.com/claude-code)
