### PR TITLE
feat: seed agent-policy.md during HITL workspace provisioning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,7 +219,7 @@ This is the write side (services reporting into Sentry). For the read side — t
 
 ## Policy Config
 
-Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file with a YAML front-matter block. Edit it directly to change review posting, merge permissions, and autonomy levels without reconfiguring crons or restarting the agent.
+Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file with a YAML front-matter block, automatically seeded from a template when the workspace is provisioned. Edit it directly to change review posting, merge permissions, and autonomy levels without reconfiguring crons or restarting the agent. Conservative defaults (e.g., `auto_post_reviews: false`) are set for safety on initial provisioning.
 
 ### Fields
 

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -182,20 +182,35 @@ const HITL_TEMPLATE = join(
   "CLAUDE-HITL.md.template",
 );
 
+const AGENT_POLICY_TEMPLATE = join(
+  REPO_ROOT,
+  "agent",
+  "workspace",
+  "state",
+  "agent-policy.md.template",
+);
+
 /**
  * Pure planning step for provisionWorkspace(): given the set of dirs the
  * workspace needs and an injectable existence check, report which dirs are
- * missing and whether CLAUDE.md still needs to be seeded. Kept side-effect
- * free so it's unit-testable without touching the real filesystem.
+ * missing and whether CLAUDE.md and agent-policy.md still need to be seeded.
+ * Kept side-effect free so it's unit-testable without touching the real
+ * filesystem.
  */
 export function computeProvisionPlan(
   dirs: string[],
   claudeMdPath: string,
+  agentPolicyPath: string,
   exists: (path: string) => boolean,
-): { missingDirs: string[]; needsClaudeMd: boolean } {
+): {
+  missingDirs: string[];
+  needsClaudeMd: boolean;
+  needsAgentPolicy: boolean;
+} {
   return {
     missingDirs: dirs.filter((dir) => !exists(dir)),
     needsClaudeMd: !exists(claudeMdPath),
+    needsAgentPolicy: !exists(agentPolicyPath),
   };
 }
 
@@ -208,8 +223,9 @@ function provisionWorkspace(): void {
     join(WORKSPACE, ".claude"),
   ];
   const claudeMd = join(WORKSPACE, "CLAUDE.md");
+  const agentPolicy = join(WORKSPACE, "state", "agent-policy.md");
 
-  const plan = computeProvisionPlan(dirs, claudeMd, existsSync);
+  const plan = computeProvisionPlan(dirs, claudeMd, agentPolicy, existsSync);
 
   for (const dir of plan.missingDirs) {
     mkdirSync(dir, { recursive: true });
@@ -219,6 +235,12 @@ function provisionWorkspace(): void {
     const template = readFileSync(HITL_TEMPLATE, "utf8");
     writeFileSync(claudeMd, template, { flag: "wx" });
     log("seeded CLAUDE.md");
+  }
+
+  if (plan.needsAgentPolicy) {
+    const template = readFileSync(AGENT_POLICY_TEMPLATE, "utf8");
+    writeFileSync(agentPolicy, template, { flag: "wx" });
+    log("seeded agent-policy.md");
   }
 
   if (plan.missingDirs.length > 0) {

--- a/scripts/hitl.unit.test.ts
+++ b/scripts/hitl.unit.test.ts
@@ -152,18 +152,6 @@ describe("computeProvisionPlan", () => {
     expect(plan.needsAgentPolicy).toBe(true);
   });
 
-  test("agent-policy.md need is independent of dir existence", () => {
-    const plan = computeProvisionPlan(
-      ["/ws"],
-      "/ws/CLAUDE.md",
-      "/ws/state/agent-policy.md",
-      (path) => path === "/ws",
-    );
-    expect(plan.missingDirs).toEqual([]);
-    expect(plan.needsClaudeMd).toBe(true);
-    expect(plan.needsAgentPolicy).toBe(true);
-  });
-
   test("agent-policy.md need is independent of CLAUDE.md need", () => {
     const existing = new Set(["/ws", "/ws/CLAUDE.md"]);
     const plan = computeProvisionPlan(

--- a/scripts/hitl.unit.test.ts
+++ b/scripts/hitl.unit.test.ts
@@ -107,20 +107,24 @@ describe("computeProvisionPlan", () => {
     const plan = computeProvisionPlan(
       ["/ws", "/ws/repos", "/ws/worktrees"],
       "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
       () => false,
     );
     expect(plan.missingDirs).toEqual(["/ws", "/ws/repos", "/ws/worktrees"]);
     expect(plan.needsClaudeMd).toBe(true);
+    expect(plan.needsAgentPolicy).toBe(true);
   });
 
   test("reports nothing missing when everything already exists", () => {
     const plan = computeProvisionPlan(
       ["/ws", "/ws/repos"],
       "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
       () => true,
     );
     expect(plan.missingDirs).toEqual([]);
     expect(plan.needsClaudeMd).toBe(false);
+    expect(plan.needsAgentPolicy).toBe(false);
   });
 
   test("reports only the dirs that don't yet exist", () => {
@@ -128,20 +132,66 @@ describe("computeProvisionPlan", () => {
     const plan = computeProvisionPlan(
       ["/ws", "/ws/repos", "/ws/worktrees"],
       "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
       (path) => existing.has(path),
     );
     expect(plan.missingDirs).toEqual(["/ws/repos", "/ws/worktrees"]);
     expect(plan.needsClaudeMd).toBe(true);
+    expect(plan.needsAgentPolicy).toBe(true);
   });
 
   test("CLAUDE.md need is independent of dir existence", () => {
     const plan = computeProvisionPlan(
       ["/ws"],
       "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
       (path) => path === "/ws",
     );
     expect(plan.missingDirs).toEqual([]);
     expect(plan.needsClaudeMd).toBe(true);
+    expect(plan.needsAgentPolicy).toBe(true);
+  });
+
+  test("agent-policy.md need is independent of dir existence", () => {
+    const plan = computeProvisionPlan(
+      ["/ws"],
+      "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
+      (path) => path === "/ws",
+    );
+    expect(plan.missingDirs).toEqual([]);
+    expect(plan.needsClaudeMd).toBe(true);
+    expect(plan.needsAgentPolicy).toBe(true);
+  });
+
+  test("agent-policy.md need is independent of CLAUDE.md need", () => {
+    const existing = new Set(["/ws", "/ws/CLAUDE.md"]);
+    const plan = computeProvisionPlan(
+      ["/ws"],
+      "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
+      (path) => existing.has(path),
+    );
+    expect(plan.missingDirs).toEqual([]);
+    expect(plan.needsClaudeMd).toBe(false);
+    expect(plan.needsAgentPolicy).toBe(true);
+  });
+
+  test("agent-policy.md not needed when it already exists", () => {
+    const existing = new Set([
+      "/ws",
+      "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
+    ]);
+    const plan = computeProvisionPlan(
+      ["/ws"],
+      "/ws/CLAUDE.md",
+      "/ws/state/agent-policy.md",
+      (path) => existing.has(path),
+    );
+    expect(plan.missingDirs).toEqual([]);
+    expect(plan.needsClaudeMd).toBe(false);
+    expect(plan.needsAgentPolicy).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Extend `scripts/hitl.ts`'s `provisionWorkspace()` to seed `workspace/state/agent-policy.md` from `agent/workspace/state/agent-policy.md.template`, mirroring the existing `CLAUDE-HITL.md.template` wx-seed pattern
- `computeProvisionPlan()` gains a `needsAgentPolicy` field computed the same way as `needsClaudeMd`, via the injectable `exists()` check
- HITL-run sessions now get the same policy defaults real agents get via `ensureAgentHome()`
- Refreshed `docs/configuration.md` to note that `state/agent-policy.md` is automatically seeded from a template on workspace provisioning

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | computeProvisionPlan() gains needsAgentPolicy field via injectable exists() check | MET | new `agentPolicyPath` param + `needsAgentPolicy: !exists(agentPolicyPath)` computed identically to `needsClaudeMd` |
| 2 | provisionWorkspace() writes state/agent-policy.md via wx semantics when needed, logs 'seeded agent-policy.md' | MET | new block reads `AGENT_POLICY_TEMPLATE`, `writeFileSync` with `{ flag: "wx" }`, logs `"seeded agent-policy.md"`, mirroring the CLAUDE.md block |
| 3 | Unit tests extend computeProvisionPlan describe block, additive, cover present/absent cases | MET | 4 existing tests updated non-destructively + 2 new tests covering independence and already-exists cases |

## Test Plan
- `bun test scripts/hitl.unit.test.ts` — 40 pass, 0 fail
- `task typecheck` — all workspaces pass
- `task ci` — passes except one pre-existing, unrelated failure in `metrics/src/lib/errors.unit.test.ts` (confirmed failing identically on `main`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
