### PR TITLE
feat: add /shipwright:merge command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.102.0",
+      "version": "1.110.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -100,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.102.0",
+      "version": "1.110.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.102.0",
+      "version": "1.110.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,19 +21,19 @@ The plugin drives the delivery loop: **spec → plan → execute → review → 
 
 Key surfaces (see `plugins/shipwright/README.md` and `plugins/shipwright/CLAUDE.md` for the full command/skill catalog):
 
-- **Commands** (`commands/`) — `prd`, `plan-session`, `dev-task`, `review`, `patch`, `deploy`, the five-phase test-readiness pipeline (`test-inventory` → `test-design` → `test-migration` → `test-roadmap` → `test-fix`), `metrics`, `research`, `research-docs`, and more.
+- **Commands** (`commands/`) — `prd`, `plan-session`, `dev-task`, `review`, `patch`, `merge`, `deploy`, the five-phase test-readiness pipeline (`test-inventory` → `test-design` → `test-migration` → `test-roadmap` → `test-fix`), `metrics`, `research`, `research-docs`, and more.
 - **Skills** (`skills/`) — autonomous behaviors including `pull-requests`, `review-staged`, `consolidation-scan`, `consolidation-fix`, `entropy-scan`, `entropy-fix`, `security-scan`, `security-fix`, `agent-admin`, `investigate-cron`, `learning-capture`, `task-store`, `test-readiness`, `test-debt`, `triage-dependabot-pr`, and `triage-dependabot-prs`.
 - **Scripts** (`scripts/`) — the task-store adapters, precheck scripts for each cron (`check-docs-freshness.ts`, `check-learn-dream.ts`, etc.), and supporting tooling.
 - **References** (`references/`) — schemas and recipes (`metrics-schema.md`, `doc-refresh-recipe.md`, `reviews-schema.md`, `principles.md`, …).
 
-`dev-task`, `review`, `patch`, and `deploy` are item-addressed executors, not self-discovering
+`dev-task`, `review`, `patch`, `merge`, and `deploy` are item-addressed executors, not self-discovering
 standalone crons: each requires an explicit target (a task id for `dev-task`; an
-`org/repo#number` PR for the other three) and does no candidate scanning of its own.
-Candidate selection happens once, upstream, in the Shipwright agent's `shipwright-loop`
+`org/repo#number` PR for the other four) and does no candidate scanning of its own.
+Candidate selection for the four loop-driven phases happens once, upstream, in the Shipwright agent's `shipwright-loop`
 cron (artifact **C** — see [agent.md](./agent.md)), which is the sole supported driver for
 these four phases; it merges candidates from `agent/src`'s per-phase qualification
 functions and dispatches the winning item's command with its id/PR embedded directly in the
-prompt. A human can still invoke any of the four directly with an explicit target.
+prompt. `merge` is currently human-invoked only. A human can invoke any of the five directly with an explicit target.
 
 The plugin is pure TypeScript with **no server, no database, and no external HTTP in production code** — only `unit` and `integration` test layers apply.
 

--- a/plugins/shipwright/.claude-plugin/plugin.json
+++ b/plugins/shipwright/.claude-plugin/plugin.json
@@ -21,6 +21,7 @@
     "test-readiness",
     "canary",
     "coverage",
-    "deploy"
+    "deploy",
+    "merge"
   ]
 }

--- a/plugins/shipwright/commands/merge.content.test.ts
+++ b/plugins/shipwright/commands/merge.content.test.ts
@@ -1,0 +1,282 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const MERGE_MD_PATH = join(import.meta.dir, "merge.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(MERGE_MD_PATH, "utf-8");
+});
+
+describe("merge.md — frontmatter", () => {
+  it("has a description and argument-hint in frontmatter", () => {
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    expect(frontmatterMatch).not.toBeNull();
+    const frontmatter = frontmatterMatch?.[1] ?? "";
+    expect(frontmatter).toContain("description:");
+    expect(frontmatter).toContain("argument-hint:");
+    expect(frontmatter).toContain("[org/repo#number | number]");
+  });
+
+  it("title is '# Merge'", () => {
+    expect(content).toContain("# Merge");
+  });
+
+  it("scopes the command to merge-only — no canary/promote", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("canary");
+    expect(lower).toContain("promote");
+    // The intro should explicitly state it does NOT run those stages.
+    expect(content).toMatch(/does not run|not run|no canary|does NOT run/i);
+  });
+
+  it("runs autonomously without pausing for user input unless pre-flight fails", () => {
+    expect(content).toContain(
+      "This command runs autonomously. Do not pause for user input unless pre-flight fails.",
+    );
+  });
+
+  it("documents task store setup blurb", () => {
+    expect(content).toContain("SHIPWRIGHT_TASK_STORE_URL");
+    expect(content).toContain("SHIPWRIGHT_TASK_STORE_TOKEN");
+    expect(content).toContain("/shipwright:task-store");
+  });
+});
+
+describe("merge.md — Arguments section (AC1)", () => {
+  function extractArgsSection(md: string): string {
+    const match = md.match(/## Arguments[\s\S]*?(?=\n---)/);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("requires $ARGUMENTS and documents org/repo#number and bare number forms", () => {
+    const section = extractArgsSection(content);
+    expect(section).toContain("$ARGUMENTS");
+    expect(section).toContain("org/repo#number");
+    expect(section).toContain("number");
+    expect(section).toContain("required");
+  });
+
+  it("infers org/repo from agent config for bare numbers, defaulting to app-vitals/shipwright", () => {
+    const section = extractArgsSection(content);
+    expect(section).toContain("SHIPWRIGHT_AGENT_API_KEY");
+    expect(section).toContain("SHIPWRIGHT_AGENT_ID");
+    expect(section).toContain("app-vitals/shipwright");
+  });
+
+  it("responds [silent] and stops with no arguments", () => {
+    const section = extractArgsSection(content);
+    expect(section).toContain("[silent]");
+  });
+
+  it("does NOT document a [preclaim:...] marker — merge has no candidate-provider wiring", () => {
+    expect(content).not.toContain("[preclaim:{recordId}:{commitSha}]");
+    expect(content).not.toContain("PRECLAIM_RECORD_ID");
+    expect(content).not.toContain("formatPreClaimMarker");
+  });
+});
+
+describe("merge.md — Step 1: Resolve Target PR (own-PRs-only + bundle gate)", () => {
+  it("looks up the task via /tasks?pr={pr}", () => {
+    expect(content).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks?pr=");
+  });
+
+  it("falls back to merge-only mode language when no task is found", () => {
+    expect(content.toLowerCase()).toContain("merge-only mode");
+  });
+
+  it("contains own GH login check (AGENT_LOGIN) and PR_AUTHOR comparison", () => {
+    expect(content).toContain("AGENT_LOGIN");
+    expect(content).toContain("PR_AUTHOR");
+    const hasSkipSilently =
+      content.includes("skip it silently") || content.includes("skip silently");
+    expect(hasSkipSilently).toBe(true);
+  });
+
+  it("prints a MERGE: header, not DEPLOY:", () => {
+    expect(content).toContain("MERGE: PR #{pr}");
+    expect(content).not.toContain("DEPLOY: PR #{pr}");
+  });
+
+  it("has a Bundle Completeness Gate section with merge-scoped skip-reason marker", () => {
+    const match = content.match(
+      /### 1b\. Bundle Completeness Gate[\s\S]*?(?=\n---|\n## )/,
+    );
+    expect(match).not.toBeNull();
+    const section = match?.[0] ?? "";
+    expect(section).toContain("[silent]");
+    expect(section).toContain("[skip-reason:merge:bundle-incomplete:{HEAD_BRANCH}]");
+    expect(section).toContain("pending");
+    expect(section).toContain("in_progress");
+    expect(section).toContain("blocked");
+  });
+});
+
+describe("merge.md — Step 2: Pre-flight Checks", () => {
+  function extractStep2Section(md: string): string {
+    const match = md.match(
+      /## Step 2: Pre-flight Checks[\s\S]*?(?=\n## Step 3)/,
+    );
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("verifies PR approval via GitHub reviewDecision or clean self-review APPROVE body", () => {
+    const section = extractStep2Section(content);
+    expect(section).toContain("reviewDecision");
+    expect(section).toContain("APPROVED");
+    expect(section).toContain("allow_self_review");
+    expect(section).toContain("agent-policy.md");
+    expect(section).toContain('startsWith("APPROVE")');
+    expect(section).toContain("Verdict: APPROVE".toLowerCase() === "verdict: approve" ? "verdict" : "verdict");
+  });
+
+  it("strips leading bold markdown markers before comparing the self-review body", () => {
+    const section = extractStep2Section(content);
+    expect(section).toContain('sub("^\\\\*+";"")');
+  });
+
+  it("verifies CI is green on the PR head commit", () => {
+    const section = extractStep2Section(content);
+    expect(section).toContain("headRefOid");
+    expect(section).toContain('.name == "CI"');
+    expect(section).toContain('conclusion == "success"');
+  });
+
+  it("has a pre-flight summary subsection", () => {
+    const section = extractStep2Section(content);
+    expect(section).toContain("Pre-flight");
+    expect(section).toContain("Pre-flight passed");
+  });
+
+  it("fails with a clear message when the PR is not approved", () => {
+    const section = extractStep2Section(content);
+    expect(section).toContain("not approved");
+  });
+
+  it("fails with a clear message when CI is not green", () => {
+    const section = extractStep2Section(content);
+    expect(section).toContain("CI is not green");
+  });
+});
+
+describe("merge.md — Step 3: Merge (claim, squash-merge, task-store update)", () => {
+  function extractStep3Section(md: string): string {
+    const match = md.match(/## Step 3: Merge[\s\S]*?(?=\n## Step 4)/);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("claims the PR record under phase: deploy (reusing the existing PrPhase enum value)", () => {
+    const section = extractStep3Section(content);
+    expect(section).toContain("/prs/claim");
+    expect(section).toContain('\\"phase\\": \\"deploy\\"');
+  });
+
+  it("does not introduce a new 'merge' PrPhase enum value in the claim body", () => {
+    const section = extractStep3Section(content);
+    expect(section).not.toContain('\\"phase\\": \\"merge\\"');
+    expect(section).not.toContain('"phase": "merge"');
+  });
+
+  it("claim call appears before the gh pr merge call", () => {
+    const claimIdx = content.indexOf("/prs/claim");
+    const mergeIdx = content.indexOf("gh pr merge {pr}");
+    expect(claimIdx).toBeGreaterThan(-1);
+    expect(mergeIdx).toBeGreaterThan(-1);
+    expect(claimIdx).toBeLessThan(mergeIdx);
+  });
+
+  it("skips the merge and does not merge when the claim returns 409", () => {
+    const section = extractStep3Section(content);
+    expect(section).toContain("409");
+    const hasSkipLanguage =
+      section.includes("do NOT merge") || section.includes("skipping");
+    expect(hasSkipLanguage).toBe(true);
+  });
+
+  it("squash-merges with --admin", () => {
+    const section = extractStep3Section(content);
+    expect(section).toContain(
+      "gh pr merge {pr} --repo {org}/{repo} --squash --admin",
+    );
+  });
+
+  it("polls for MERGED state for up to 60 seconds", () => {
+    const section = extractStep3Section(content);
+    expect(section).toContain("60 seconds");
+    expect(section).toContain("MERGED");
+  });
+
+  it("releases the pre-merge claim on a merge timeout without blocking task status", () => {
+    const section = extractStep3Section(content);
+    expect(section).toContain("/release");
+    expect(section.toLowerCase()).toContain("do not patch the task");
+    expect(section).not.toContain('"status": "blocked"');
+  });
+
+  it("PATCHes the task to status: merged with mergedAt", () => {
+    const section = extractStep3Section(content);
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID");
+    expect(section).toContain("merged");
+    expect(section).toContain("mergedAt");
+  });
+
+  it("updates the PullRequest record post-merge with state=merged, mergedAt, reviewState=approved, commitSha", () => {
+    const section = extractStep3Section(content);
+    const postMergeIdx = section.indexOf(
+      "Update PullRequest Record (post-merge)",
+    );
+    expect(postMergeIdx).toBeGreaterThan(-1);
+    const postMergeSection = section.slice(postMergeIdx, postMergeIdx + 1200);
+    expect(postMergeSection).toContain("/prs/$PR_RECORD_ID");
+    expect(postMergeSection).toContain("merged");
+    expect(postMergeSection).toContain("mergedAt");
+    expect(postMergeSection).toContain("reviewState");
+    expect(postMergeSection).toContain("approved");
+    expect(postMergeSection).toContain("SQUASH_SHA");
+    // Not a redundant claim call.
+    expect(postMergeSection.includes("/prs/claim")).toBe(false);
+  });
+
+  it("rationale for --admin bypass being safe is preserved", () => {
+    const section = extractStep3Section(content);
+    expect(section.toLowerCase()).toContain("bypass");
+  });
+});
+
+describe("merge.md — Step 4: Print Handoff", () => {
+  it("has a terminal handoff block with MERGED, PR, and SHA lines", () => {
+    const match = content.match(/## Step 4: Print Handoff[\s\S]*$/);
+    expect(match).not.toBeNull();
+    const section = match?.[0] ?? "";
+    expect(section).toContain("MERGED:");
+    expect(section).toContain("PR:");
+    expect(section).toContain("SHA:");
+  });
+});
+
+describe("merge.md — out of scope: no deploy/canary/promote pipeline logic", () => {
+  it("does not contain canary revert-PR logic", () => {
+    expect(content).not.toContain("CANARY FAILED");
+    expect(content).not.toContain("revert/canary-");
+  });
+
+  it("does not contain a health probe step", () => {
+    expect(content.toLowerCase()).not.toContain("health check");
+    expect(content).not.toContain("/health");
+  });
+
+  it("does not poll for Deploy/Canary/Promote workflow runs", () => {
+    expect(content).not.toContain("Promote to Prod");
+    expect(content).not.toContain("ARC desync");
+  });
+
+  it("does not mark the task status as deploying/deployed", () => {
+    expect(content).not.toContain('"status": "deploying"');
+    expect(content).not.toContain('"status": "deployed"');
+  });
+});

--- a/plugins/shipwright/commands/merge.md
+++ b/plugins/shipwright/commands/merge.md
@@ -1,0 +1,317 @@
+---
+description: Merge an approved, CI-green PR and mark its task-store record merged — no canary/promote
+argument-hint: "[org/repo#number | number]"
+---
+
+# Merge
+
+Merge a PR and mark its linked task-store record merged. This command does NOT run
+`/shipwright:deploy`'s Deploy → Canary → Promote pipeline — merging is its entire scope.
+It exists for setups (like a deploy-disabled configuration) where deploy stays disabled and
+a human decides when to merge; `/shipwright:merge` handles the merge sub-step without
+triggering any post-merge pipeline.
+
+**This command runs autonomously. Do not pause for user input unless pre-flight fails.**
+
+> **Task store setup:** This command updates task status in the Shipwright task store on merge completion. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke `/shipwright:task-store` for setup instructions.
+
+---
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract `org`, `repo`, and `pr` number. `$ARGUMENTS` is required —
+this command always targets an explicit PR:
+- `org/repo#number` (e.g. `app-vitals/shipwright#123`): explicit
+- `number` or `#number`: infer org/repo from the agent config (`curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.repos[0] // empty'`),
+  defaulting to `app-vitals/shipwright`.
+  **Limitation**: bare numbers only check the first configured repo (`repos[0]`). Multi-repo agents should use the full `org/repo#number` form to target a PR in any repo beyond the first.
+- _(no arguments)_: respond `[silent]` and stop — no GitHub scan across own open PRs.
+
+This command has no candidate-provider wiring yet — it is invoked explicitly by a human or
+orchestrator with a known target, so it does not accept the `[preclaim:...]` marker that
+`review`/`patch`/`deploy` do.
+
+---
+
+## Step 1: Resolve Target PR
+
+Parse `$ARGUMENTS` using the rules in the Arguments section above to extract `org`, `repo`,
+and `pr`.
+
+Look up the task via the task store:
+
+```bash
+TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?pr={pr}" | jq .)
+TASK_ID=$(echo "$TASK_JSON" | jq -r '.tasks[0].id // empty')
+TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.tasks[0].title // empty')
+TASK_STATUS=$(echo "$TASK_JSON" | jq -r '.tasks[0].status // empty')
+```
+
+If `TASK_ID` is empty or `TASK_STATUS` is not `"pr_open"`, proceed in **merge-only mode** — no
+todos update will be performed.
+
+### 1a. Own-PRs-Only Check
+
+Get the current agent's own GH login and verify the PR was authored by the agent:
+
+```bash
+AGENT_LOGIN=$(gh api user --jq '.login')
+PR_AUTHOR=$(gh pr view {pr} --repo {org}/{repo} --json author --jq '.author.login')
+```
+
+If `PR_AUTHOR != AGENT_LOGIN`, this PR was not authored by the current agent — skip it silently and stop. Only PRs we authored go through this merge command.
+
+Print:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MERGE: PR #{pr}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Repo:   {org}/{repo}
+Task:   {task_id} — {task_title}  (or "standalone merge" if no task found)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### 1b. Bundle Completeness Gate
+
+Before running pre-flight checks, verify that all tasks on this branch are `pr_open` or
+beyond (i.e., no bundle-mates are still in flight). This prevents merging a PR while
+sibling tasks on the same branch are still being developed or are blocked.
+
+```bash
+HEAD_BRANCH=$(gh pr view {pr} --repo {org}/{repo} --json headRefName --jq '.headRefName')
+BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch=$HEAD_BRANCH" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
+INCOMPLETE_TASKS=$(echo "$BRANCH_TASKS" | jq '[.tasks[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked") | {id, status}]')
+INCOMPLETE=$(echo "$INCOMPLETE_TASKS" | jq 'length')
+```
+
+**If `INCOMPLETE > 0`**: do NOT proceed to pre-flight. Print:
+```
+⏸ Bundle gate: {INCOMPLETE} task(s) on branch {HEAD_BRANCH} are still in flight:
+  {for each item in INCOMPLETE_TASKS: "  - {id} ({status})"}
+  Waiting for bundle-mates to reach pr_open before merging.
+```
+Stop here. There is no other candidate to fall back to. Emit `[skip-reason:merge:bundle-incomplete:{HEAD_BRANCH}]`
+alongside `[silent]` (interpolating `{HEAD_BRANCH}` from the value fetched above) — order
+relative to `[silent]` does not matter, both are recognized regardless of position. The
+skip-reason marker records exactly which branch's bundle gate blocked this dispatch in the
+`AgentCronRun.skipReason` field, visible in the admin cron-logs UI, instead of the generic
+`command:no-work` reason the loop orchestrator falls back to for silent dispatches that
+don't tag a specific reason (see `agent/src/loop-orchestrator.ts` and `agent/src/markers.ts`).
+
+**Otherwise** (`INCOMPLETE == 0` — no tasks tracked, or all tasks are `pr_open` or beyond):
+proceed to Step 2.
+
+---
+
+## Step 2: Pre-flight Checks (GitHub API — no local state)
+
+All pre-flight checks query GitHub directly. No worktree or local clone is needed.
+
+### 2a. Verify PR Approval
+
+Check the PR's review status from GitHub:
+
+```bash
+gh pr view {pr} --repo {org}/{repo} --json reviewDecision,reviews \
+  --jq '{decision: .reviewDecision, approvals: [.reviews[] | select(.state == "APPROVED") | .author.login]}'
+```
+
+**If `reviewDecision` is `"APPROVED"`**: Record `approval_source = "github"` and `approvers = [list]`. Proceed to Step 2b.
+
+**If `reviewDecision` is not `"APPROVED"`**: Read `allow_self_review` from
+`state/agent-policy.md` (default: true). If `allow_self_review` is true, fetch the PR's
+reviews from GitHub and check if any review has a clean APPROVE body — either a leading
+`APPROVE` (strip any leading markdown bold markers (`**`) first, since the review skill
+posts `"**APPROVE**"`) or a `Verdict: APPROVE` label anywhere in the body (the narrative
+self-review convention, case-insensitive, optional `**` around either word — mirrors
+`agent/src/check-helpers.ts`'s `isCleanApproveBody`, shared by `agent/src/check-deploy.ts`'s
+`hasSelfApproveReview` and `agent/src/check-patch.ts`'s `isSelfCleanApprove`):
+
+```bash
+gh pr view {pr} --repo {org}/{repo} --json reviews \
+  --jq '[.reviews[] | .body] | any(
+    (sub("^\\s*";"") | sub("^\\*+";"") | startswith("APPROVE"))
+    or test("verdict\\**\\s*:\\s*\\**approve\\b"; "i")
+  )'
+```
+
+A matching review is one whose stripped body `startsWith("APPROVE")` or that contains a
+`Verdict: APPROVE` label. If a matching review is found: Record `approval_source =
+"self_review"` and proceed to Step 2b.
+Print:
+```
+ℹ No GitHub approval. Proceeding on clean APPROVE review.
+```
+
+If no matching review is found (or `allow_self_review` is false), print and stop:
+```
+✗ Pre-flight failed: PR #{pr} is not approved.
+  GitHub reviewDecision: {decision}
+  No APPROVE review found on GitHub for this PR.
+  Options:
+    1. Have a human approve the PR on GitHub, or
+    2. Run /shipwright:review on the PR — once an APPROVE review is posted, re-run /shipwright:merge.
+```
+
+### 2b. Verify CI is Green
+
+Fetch the most recent CI runs on the PR's head commit:
+
+```bash
+HEAD_SHA=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid')
+REPO="{org}/{repo}"
+gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
+  --jq '[.workflow_runs[] | select(.name == "CI") | {status, conclusion}]'
+```
+
+If no CI run has `conclusion == "success"` (or no CI run exists at all), print and stop:
+```
+✗ Pre-flight failed: CI is not green on PR #{pr} head ({HEAD_SHA[0..7]}).
+  Resolve CI failures before merging.
+```
+
+### 2c. Pre-flight Summary
+
+If both checks pass:
+```
+✓ Pre-flight passed
+  Approval:    {if approval_source == "github": "GitHub — approved by: {approvers}" | if approval_source == "self_review": "Self-review — APPROVE found in GitHub review body"}
+  CI:          green ({HEAD_SHA[0..7]})
+```
+
+---
+
+## Step 3: Merge
+
+### 3a. Claim PR Record (pre-merge lock)
+
+Before merging, claim the PR record with `phase: "deploy"` — reusing the existing `deploy`
+`PrPhase` enum value (`task-store/prisma/schema.prisma`'s `PrPhase` enum has `review | patch
+| deploy`, no `merge` value, and none is added here — this command occupies the same
+pipeline slot deploy would). GitHub itself prevents a PR from being double-merged, but
+without this claim, two overlapping merge/deploy runs can both pass Step 2's approval/CI
+checks and both proceed to merge, risking duplicate work.
+
+```bash
+HEAD_SHA_PRE_MERGE=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid')
+PR_CLAIM=$(curl -s -o /tmp/pr_claim_merge.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/claim" \
+  -d "{\"repo\": \"{org}/{repo}\", \"prNumber\": {pr}, \"commitSha\": \"$HEAD_SHA_PRE_MERGE\", \"phase\": \"deploy\"}")
+PR_RECORD_ID=$(jq -r '.id // empty' /tmp/pr_claim_merge.json)
+```
+
+**If `PR_CLAIM` is `409`** (another deploy/merge run already claimed this PR at phase
+`deploy`): do NOT merge. Print:
+```
+⏸ PR #{pr} is already claimed by another deploy/merge run — skipping.
+```
+There is no other candidate to fall back to. Stop here.
+
+**Otherwise** (`200` or `201`): the claim succeeded. `PR_RECORD_ID` is reused by the
+post-merge update in Step 3c — no second claim call is needed. Proceed to Step 3b.
+
+### 3b. Squash Merge
+
+Squash merge the PR immediately with `--admin`, unconditionally — regardless of
+`approval_source` from Step 2a:
+
+```bash
+gh pr merge {pr} --repo {org}/{repo} --squash --admin
+```
+
+`--admin` bypasses branch protection (including the "require approval" rule, which GitHub
+cannot satisfy natively when the approval came from a self-review rather than a second
+GitHub user). This is safe because Step 2a (approval — GitHub or self-review) and Step 2b
+(CI green) already independently verify the safety properties branch protection exists to
+enforce here — this repo does have an active CODEOWNERS ruleset (`require_code_owner_review:
+true`, ruleset id 18495740) enforced on `main`, but both maintainer accounts are configured
+as `bypass_actors` on it, so `--admin` here is exercising an existing, already-authorized
+bypass rather than circumventing a live protection gate (no staging/prod environments either;
+see the repo's `CLAUDE.md`, "Deploy model: direct"). Queuing an auto-merge instead would only
+defer to GitHub's native branch-protection wait, which adds a fragile dependency on the
+required-status-check context name staying in sync with actual CI job names — it silently
+breaks on CI restructuring, and picking the wrong merge flag for the approval source is its
+own bug class. `--admin` avoids both.
+
+Poll for the merge to complete — check `gh pr view {pr} --json state --jq '.state'` every
+5 seconds, up to 60 seconds. When the state becomes `"MERGED"`, capture the squash SHA:
+
+```bash
+SQUASH_SHA=$(gh api "repos/{org}/{repo}/git/refs/heads/main" --jq '.object.sha')
+```
+
+If the state has not become `"MERGED"` after 60 seconds, release the pre-merge claim from
+Step 3a so a subsequent retry is not blocked by a stale `phase: "deploy"` lock — the merge
+never completed, so nothing is actually in flight:
+
+```bash
+[ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+```
+
+Then print and stop:
+```
+✗ Merge did not complete within 60 seconds (last state: {state}).
+  Check the PR on GitHub — it may require a human to resolve a merge conflict or branch protection issue.
+```
+
+**Do not PATCH the task to `status: "blocked"` here.** A merge conflict is routine and
+self-recoverable — `check-patch.ts`'s candidate logic already detects any `DIRTY` PR
+independent of task status and fixes it automatically, no human required. Marking the task
+`blocked` would hide it from candidate lists that explicitly skip PRs whose linked task is
+`blocked`, even after patch resolves the conflict, stranding it until a human notices and
+corrects the record by hand. Leave the task's status exactly as it was.
+
+Print:
+```
+✓ Merged PR #{pr} → main
+  Squash SHA: {SQUASH_SHA[0..7]}
+```
+
+Mark the task merged via the task store — skip if in merge-only mode:
+
+```bash
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+  -d "{\"status\": \"merged\", \"mergedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | jq .
+```
+
+### 3c. Update PullRequest Record (post-merge)
+
+The record was already claimed pre-merge in Step 3a — `PR_RECORD_ID` is already set, so
+this is a plain update against the existing claim, not a redundant claim call:
+
+```bash
+if [ -n "$PR_RECORD_ID" ]; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+    -d "{\"state\": \"merged\", \"mergedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"reviewState\": \"approved\", \"commitSha\": \"$SQUASH_SHA\"}" \
+    > /dev/null 2>&1 || echo "⚠ PATCH /prs/$PR_RECORD_ID failed — continuing"
+else
+  echo "⚠ Failed to upsert PullRequest record — continuing"
+fi
+```
+
+This command stops here. No post-merge CI watch, no canary, no promote, no health probe,
+no deployed-status update — that pipeline is `/shipwright:deploy`'s scope, not this
+command's.
+
+---
+
+## Step 4: Print Handoff
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MERGED: {task_id}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PR:   #{pr} — {pr_title}
+SHA:  {SQUASH_SHA[0..7]}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```


### PR DESCRIPTION
## Summary
- Adds `/shipwright:merge`, extracting deploy.md's merge sub-step (task lookup, own-PRs-only check, bundle-completeness gate, PR-approved check, CI-green check, squash-merge with `--admin`, task-store update) into a standalone command
- Merges an approved, CI-green PR and marks the linked task `merged` — does NOT run deploy's post-merge Deploy → Canary → Promote pipeline, for setups where deploy stays disabled and a human decides when to merge
- Reuses the existing `deploy` `PrPhase` enum value for the pre-merge claim lock (no schema change)
- Registers `merge` in `plugin.json`'s keywords; version bump is handled by CI's tag-driven automation via this PR's `feat:` commit, not a manual edit
- Refreshes `docs/architecture.md` to list `merge` alongside the other item-addressed executors, noting it's currently human-invoked only

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | merge.md accepts org/repo#number or bare number, `[silent]` on no args | MET |
| 2 | Reuses deploy.md's pre-flight checks as-is | MET |
| 3 | Claims under `deploy` PrPhase, squash-merge --admin, PATCH task merged, then stops | MET |
| 4 | merge.content.test.ts matching deploy/review content-test pattern | MET |
| 5 | Registered in plugin.json per checklist + version bump | MET |

## Test Plan
- [x] `bun test plugins/shipwright/commands/merge.content.test.ts` — 35/35 pass
- [x] `task typecheck` — all 7 workspaces pass
- [x] `task lint` — clean
- [x] `task check-strings`, `task check-config-docs`, `task check-version-sync` — all pass
- [x] Full `task test` — 1 pre-existing unrelated flake (`agent/src/claude.unit.test.ts` extraAllowedTools), reproduces on clean main
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
