### PR TITLE
feat: install shipwright plugin during hitl preflight

### DIFF
--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -52,12 +52,13 @@ import {
   buildProductionDeps as buildReviewDeps,
   getReviewCandidates,
 } from "../agent/src/check-review.ts";
+import { FLOOR_TOOLS } from "../agent/src/claude.ts";
+import { installPlugins } from "../agent/src/setup.ts";
 import {
   type WorkPrCandidate,
   type WorkTaskCandidate,
   selectNextWorkItem,
 } from "../agent/src/work-selector.ts";
-import { FLOOR_TOOLS } from "../agent/src/claude.ts";
 
 // ---------------------------------------------------------------------------
 // Allowed tools — FLOOR_TOOLS + web access, minus Bash/Agent (both can
@@ -254,6 +255,9 @@ function provisionWorkspace(): void {
 
 async function runPreflight(): Promise<void> {
   provisionWorkspace();
+
+  log("installing shipwright plugin...");
+  await installPlugins();
 
   log("running task-store prisma generate + migrate...");
   const tsGen = Bun.spawnSync(


### PR DESCRIPTION
## Summary
- Import `installPlugins` from `agent/src/setup.ts` into `scripts/hitl.ts`
- Call it (default args) inside `runPreflight()`, immediately after `provisionWorkspace()` and before the task-store/admin prisma steps, with a matching `log(...)` line
- Ensures a fresh `task hitl` run on a machine without a manually-installed shipwright plugin still has working `/shipwright:*` commands when it spawns `claude`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | runPreflight() calls installPlugins() before runLoop() begins spawning claude processes | MET | hitl.ts:259-260 — installPlugins() called inside runPreflight() right after provisionWorkspace(); main flow calls runPreflight() (line 806) before runLoop() (line 823) |
| 2 | Manual verify: task hitl on clean checkout shows shipwright installed via claude plugin list after preflight | UNVERIFIABLE (manual/operational — not runnable in sandbox) | Code path is correct: installPlugins() awaited with default args, matching agent/src/index.ts:200's proven pattern |
| 3 | Test decision: no new automated test for the call site, per established hitl.unit.test.ts precedent | MET | Diff touches only scripts/hitl.ts (import + 2-line call site); no test file added/modified; existing hitl.unit.test.ts (40 tests) still passes |

## Test Plan
- `bun test scripts/hitl.unit.test.ts` — all 40 existing tests pass, no regressions
- `task typecheck` — passes across all workspaces
- `task lint`, `task check-strings`, `task check-config-docs`, `task check-version-sync`, `task secret-scan` — all pass
- `task test:coverage` — blocked by a pre-existing, unrelated flake in `agent/src/claude.unit.test.ts` (confirmed reproducing identically on clean `main`); all other suites pass (5496 pass / 1 pre-existing fail / 380 skip)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
