### PR TITLE
feat: remove Slack post step from /shipwright:review

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -297,7 +297,7 @@ Before reading individual files, build a structural picture of what kind of work
 - **Breaking changes**: Any changes that break backwards compatibility — removed endpoints, changed request/response shapes, renamed fields, dropped columns, changed auth semantics, changed event contracts. Assume rolling deployments; clients and servers don't update atomically.
 - **Testing changes**: Classify whether the PR is "test-touching" (modifies or adds test files) or "untested logic" (adds production code with no corresponding test additions). Identify test files using the project's language and toolchain — look at the diff context, the CLAUDE.md stack description, and common conventions for that language rather than applying a fixed set of filename patterns. Note which test files were added, modified, or removed. If neither applies (pure refactor of existing tested code, docs-only, etc.), note "none".
 
-Note which categories are present (even if "none") — this drives review focus and the Slack summary.
+Note which categories are present (even if "none") — this drives review focus.
 
 ---
 
@@ -539,7 +539,7 @@ should be held; the inline comments convey the specific feedback to the author.
    REVIEW_URL=$(jq -r '.html_url // empty' "/tmp/pr_post_{pr}.json")
    ```
 3. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `REVIEW_URL` both count as failure:
-   - **Success** (`POST_EXIT == 0` and `REVIEW_URL` present): continue to steps 4-6 below.
+   - **Success** (`POST_EXIT == 0` and `REVIEW_URL` present): continue to steps 4-5 below.
    - **Failure**: the GitHub post did not land, so nothing was actually reviewed at HEAD.
      Do not run Step 11b — marking the record posted here would let
      `check-review.ts`'s `commitSha`/`reviewState` dedup permanently hide this PR from
@@ -551,10 +551,9 @@ should be held; the inline comments convey the specific feedback to the author.
           "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/release"
         ```
      2. Print a warning: `Warning: review post for #{pr} failed (exit {POST_EXIT}) — released claim, will retry next pass.`
-     3. Stop — do not proceed to Step 11b or the Slack message below.
+     3. Stop — do not proceed to Step 11b.
 4. Run Step 11b to mark the PR record posted.
 5. Print: `Posted review for #{pr}: {REVIEW_URL}`
-6. Post Slack message (see below)
 
 ### If `auto_post_reviews` is false (staged):
 
@@ -583,34 +582,7 @@ should be held; the inline comments convey the specific feedback to the author.
    ```
 
    (`PR_RECORD_ID` is the claim response `.id` from Step 4.)
-2. Post Slack message to the configured channel (see below)
-3. Print: `Review staged for #{pr}. Slack notification sent.`
-
-### Slack Message (both paths)
-
-Send to the configured engineering channel:
-
-```
-*PR #{pr}: {title}*
-{url}
-
-*Why:* {motivation from Change Summary}
-
-*What changed:*
-{high-level summary from Change Summary}
-
-*View changes:* {value or "none"}
-*API changes:* {value or "none"}
-*Database changes:* {value or "none"}
-*Architecture changes:* {value or "none"}
-*Breaking changes:* {value or "none"}
-*Testing changes:* {value or "none"}
-
-*Verdict:* {APPROVE|COMMENT} — {one-line reasoning}
-{if staged: Post with: /shipwright:review {org}/{repo}#{pr}}
-```
-
-Use the Slack MCP tool if available. If no Slack integration is configured, print the formatted message.
+2. Print: `Review staged for #{pr}.`
 
 ---
 

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -65,11 +65,6 @@ describe("review.md — CPF-2.2 verdict phrase requirement", () => {
         jsonBlock.includes("Verdict: COMMENT"),
     ).toBe(true);
   });
-
-  it("Slack message template has a *Verdict:* placeholder line", () => {
-    const slackVerdictLine = content.includes("*Verdict:* {APPROVE|COMMENT}");
-    expect(slackVerdictLine).toBe(true);
-  });
 });
 
 describe("review.md — WLS-3.2 explicit-target-only", () => {


### PR DESCRIPTION
## Summary
- Removes the composed Slack-message step from `/shipwright:review` (both the `auto_post_reviews: true` auto-post path and the staged path)
- Deletes the "### Slack Message (both paths)" section (template + Slack MCP instruction) and cleans up two dangling prose references
- Removes the now-obsolete unit test asserting the Slack `*Verdict:*` placeholder line

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Auto-post path no longer has "Post Slack message" step | MET | Step 6 removed, path ends at "Print: Posted review..." |
| 2 | Staged path no longer posts Slack / no "Slack notification sent." print | MET | Step 2 replaced with "Print: Review staged for #{pr}." |
| 3 | "### Slack Message (both paths)" section fully removed | MET | Section + template + MCP instruction deleted |
| 4 | Lines 300/554 prose no longer reference Slack | MET | Both lines edited to remove dangling references |
| 5 | Obsolete unit test removed, other tests still pass | MET | Test deleted; 60/60 pass post-edit |

## Test Plan
- `bun test commands/review.unit.test.ts commands/review.content.test.ts` — 60 pass, 0 fail (was 61 pass before the deletion)
- `task lint` — clean
- `task typecheck` — clean across all workspaces
- Repo-wide grep confirms zero remaining "Slack" references in `review.md` or `review.unit.test.ts`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
