### PR TITLE
docs: refresh configuration.md for auto_post_reviews default flip

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,7 +219,7 @@ This is the write side (services reporting into Sentry). For the read side — t
 
 ## Policy Config
 
-Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file with a YAML front-matter block, automatically seeded from a template when the workspace is provisioned. Edit it directly to change review posting, merge permissions, and autonomy levels without reconfiguring crons or restarting the agent. Conservative defaults (e.g., `auto_post_reviews: false`) are set for safety on initial provisioning.
+Agent behavior is controlled by `state/agent-policy.md`. This is a Markdown file with a YAML front-matter block, automatically seeded from a template when the workspace is provisioned. Edit it directly to change review posting, merge permissions, and autonomy levels without reconfiguring crons or restarting the agent. `auto_post_reviews` defaults to `true` (reviews post to GitHub automatically) on initial provisioning; set it to `false` to stage reviews locally for owner approval instead.
 
 ### Fields
 


### PR DESCRIPTION
## Summary

Scheduled docs-freshness pass (auto mode, Steps A3-A8) over source changes since anchor `9c7a500d`. Most changed files (the `reviewedCommitSha` field, `check-review.ts`'s staged-guard change, the `hitl.ts` auto-clone/plugin-install additions) already carried their own doc updates in the same PRs that introduced them (#2356, #2361, #2375), so `docs/task-store.md` and `docs/agent.md` were already current and required no edit.

One real staleness found: `feat: default auto_post_reviews to true across template and docs (#2367)` flipped `agent/workspace/state/agent-policy.md.template`'s `auto_post_reviews` default to `true` and updated the Fields table in `docs/configuration.md`, but left a leftover prose sentence in the Policy Config intro claiming "Conservative defaults (e.g., `auto_post_reviews: false`) are set for safety" — directly contradicting the table two lines below it and the actual template. Fixed the sentence to describe the current default correctly.

## What was checked but left alone

- `docs/task-store.md`, `docs/agent.md` — `reviewedCommitSha`/`commitSha` dedup semantics, PATCH-allowed-fields list, and the staged-review guard description are already accurate against current `task-store/src/routes/prs.ts` and `agent/src/check-review.ts` (updated in the same source PRs).
- `docs/configuration.md` — `SHIPWRIGHT_HITL_REPOS` auto-clone description already matches `scripts/hitl.ts`'s `computeMissingClones()`; `installPlugins()` addition to hitl preflight is an internal sequencing detail not documented step-by-step anywhere, so nothing went stale there.
- `docs/architecture.md` — already lists `merge` among commands (that command shipped in an earlier commit, predating this range).
- `docs/migration.md` — correctly has no entry for `reviewedCommitSha` (additive/nullable column, not a breaking change).
- Chart/package/plugin version bumps (`Chart.yaml`, `values.yaml`, `version.txt`, `package.json` files, `bun.lock`, `marketplace.json`) — routine auto-bumps; no doc hardcodes these version numbers.
- `plugins/shipwright/commands/*.md`, `plugins/shipwright/references/toolchain-patterns.md`, `plugins/shipwright/references/reviews-schema.md` — plugin-internal reference docs, out of scope for `docs/*.md` (research-docs only audits `docs/`).
- Slack-post-step removal from `/shipwright:review` (#2376) — no `docs/*.md` file described that behavior, so nothing to update.

No modules found with missing doc coverage; no `CLAUDE.md` reference changes needed (no doc created or removed, no scope change).

## Test plan

- [x] Read the current `agent-policy.md.template` and `docs/configuration.md`'s Fields table to confirm the fix matches actual default behavior
- [x] Verified `docs/test-readiness/` was untouched (out of scope, read-only)
- N/A — docs-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)