### PR TITLE
fix: regenerate mcp-server/src/generated-tools.ts from task-store openapi.json

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -25,7 +25,7 @@ List pull requests
 - **Method:** GET
 - **Path:** `/prs`
 - **Has body:** No
-- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query), `updatedSince` (query)
+- **Parameters:** `repo` (query), `prNumber` (query), `taskId` (query), `state` (query), `reviewState` (query), `staged` (query), `limit` (query), `offset` (query), `ready` (query), `blocked` (query), `sort` (query), `updatedSince` (query)
 
 ## `prs_update`
 
@@ -79,7 +79,7 @@ List tasks
 - **Method:** GET
 - **Path:** `/tasks`
 - **Has body:** No
-- **Parameters:** `status` (query), `state` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `sort` (query), `updatedSince` (query)
+- **Parameters:** `status` (query), `state` (query), `source` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `hitl` (query), `sort` (query), `updatedSince` (query)
 
 ## `tasks_update`
 

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -47,6 +47,10 @@ export const generatedTools: GeneratedTool[] = [
           enum: ["open", "closed", "in_progress", "ready", "blocked"],
           example: "open",
         },
+        source: {
+          type: "string",
+          example: "entropy-fix",
+        },
         session: {
           type: "string",
           example: "session-123",
@@ -84,6 +88,11 @@ export const generatedTools: GeneratedTool[] = [
           enum: ["true", "false"],
           example: "true",
         },
+        hitl: {
+          type: "string",
+          enum: ["true", "false"],
+          example: "true",
+        },
         sort: {
           type: "string",
           enum: ["asc", "desc"],
@@ -104,6 +113,7 @@ export const generatedTools: GeneratedTool[] = [
     queryParams: [
       "status",
       "state",
+      "source",
       "session",
       "repo",
       "assignee",
@@ -113,6 +123,7 @@ export const generatedTools: GeneratedTool[] = [
       "limit",
       "offset",
       "ready",
+      "hitl",
       "sort",
       "updatedSince",
     ],
@@ -419,6 +430,47 @@ export const generatedTools: GeneratedTool[] = [
     hasBody: false,
   },
   {
+    name: "tasks_skip",
+    description:
+      "Record a skip — increments skipCount, auto-blocks at threshold",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/skip",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "tasks_reset",
+    description: "Reset skip tracking — skipCount back to 0",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx1234567890",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/tasks/{id}/skip/reset",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
     name: "tokens_list",
     description: "List all tokens",
     inputSchema: {
@@ -557,6 +609,13 @@ export const generatedTools: GeneratedTool[] = [
             "When true, return only unclaimed PRs (claimedBy IS NULL) — mirrors /tasks?ready=true. Composable with other filters (repo, state, reviewState); does not itself apply state/reviewState eligibility rules the way claim-next does.",
           example: "true",
         },
+        blocked: {
+          type: "string",
+          enum: ["true", "false"],
+          description:
+            "When true, return only PRs considered blocked: pr.hitl===true OR (linked task exists AND (task.hitl===true OR task.status==='blocked')). Composable with other filters (e.g. state=open).",
+          example: "true",
+        },
         sort: {
           type: "string",
           enum: ["asc", "desc"],
@@ -586,6 +645,7 @@ export const generatedTools: GeneratedTool[] = [
       "limit",
       "offset",
       "ready",
+      "blocked",
       "sort",
       "updatedSince",
     ],
@@ -796,6 +856,47 @@ export const generatedTools: GeneratedTool[] = [
     },
     method: "POST",
     pathTemplate: "/prs/{id}/release",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_skip",
+    description:
+      "Record a skip — increments skipCount, auto-blocks at threshold",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/{id}/skip",
+    queryParams: [],
+    pathParams: ["id"],
+    hasBody: false,
+  },
+  {
+    name: "prs_reset",
+    description: "Reset skip tracking — skipCount back to 0",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          example: "clx0987654321",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    method: "POST",
+    pathTemplate: "/prs/{id}/skip/reset",
     queryParams: [],
     pathParams: ["id"],
     hasBody: false,

--- a/mcp-server/src/generated-tools.unit.test.ts
+++ b/mcp-server/src/generated-tools.unit.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { generatedTools } from "./generated-tools.ts";
 
 describe("generatedTools", () => {
-  it("emits one tool per OpenAPI operation (25 total)", () => {
-    expect(generatedTools).toHaveLength(25);
+  it("emits one tool per OpenAPI operation (29 total)", () => {
+    expect(generatedTools).toHaveLength(29);
   });
 
   it("has unique tool names", () => {

--- a/mcp-server/src/tool-allowlist.ts
+++ b/mcp-server/src/tool-allowlist.ts
@@ -16,11 +16,11 @@ import type { GeneratedTool } from "./generated-tools.ts";
  *
  * Excluded categories:
  * - Pipeline-internal lifecycle ops: tasks_claim, tasks_heartbeat, tasks_complete,
- *   tasks_fail, tasks_release
+ *   tasks_fail, tasks_release, tasks_skip, tasks_reset
  * - Destructive ops: tasks_delete
  * - Token-management routes: tokens_list, tokens_create, tokens_update, tokens_delete
  * - PR lifecycle ops: prs_claim, prs_claim_next, prs_heartbeat, prs_complete,
- *   prs_patch, prs_release
+ *   prs_patch, prs_release, prs_skip, prs_reset
  */
 export const EXCLUDED_TOOLS: readonly string[] = [
   // tasks: pipeline-internal lifecycle
@@ -29,6 +29,8 @@ export const EXCLUDED_TOOLS: readonly string[] = [
   "tasks_complete",
   "tasks_fail",
   "tasks_release",
+  "tasks_skip",
+  "tasks_reset",
   // tasks: destructive
   "tasks_delete",
   // tokens: all token-management
@@ -43,6 +45,8 @@ export const EXCLUDED_TOOLS: readonly string[] = [
   "prs_complete",
   "prs_patch",
   "prs_release",
+  "prs_skip",
+  "prs_reset",
 ] as const;
 
 /**

--- a/mcp-server/src/tool-allowlist.unit.test.ts
+++ b/mcp-server/src/tool-allowlist.unit.test.ts
@@ -31,10 +31,10 @@ describe("allowedTools", () => {
     }
   });
 
-  it("stays stable across regeneration — given all 25 generatedTools, only 9 come back", () => {
+  it("stays stable across regeneration — given all 29 generatedTools, only 9 come back", () => {
     // This is the "across regeneration" invariant:
-    // even if generate:mcp-tools emits all 25 ops, only the 9 allowed ones are exposed.
-    expect(generatedTools).toHaveLength(25);
+    // even if generate:mcp-tools emits all 29 ops, only the 9 allowed ones are exposed.
+    expect(generatedTools).toHaveLength(29);
     const result = allowedTools(generatedTools);
     expect(result).toHaveLength(9);
     const resultNames = result.map((t) => t.name);


### PR DESCRIPTION
## Summary
- Regenerated `mcp-server/src/generated-tools.ts` from `task-store/openapi.json` — it hadn't been regenerated since commit 44d2e791 (2026-07-16) and was missing two schema drift updates: commit 0ebde3d1 (`hitl`/`scopeDegraded`) and later additions (`source` filter on `/tasks`, `blocked` filter on `/prs`, and new `/tasks/{id}/skip(/reset)` + `/prs/{id}/skip(/reset)` endpoints). Tool count went from 25 → 29.
- Regenerated `docs/mcp-tools.md` via `bun run generate:mcp-docs` to match.
- Added the four newly-generated pipeline-internal ops (`tasks_skip`, `tasks_reset`, `prs_skip`, `prs_reset`) to `mcp-server/src/tool-allowlist.ts`'s `EXCLUDED_TOOLS` — without this, regeneration would have silently exposed pipeline-internal skip-tracking ops on the public 9-tool MCP surface, alongside the existing `tasks_claim`/`tasks_release`-style exclusions.
- Updated the two test files that hardcoded the prior 25-tool count.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `generated-tools.ts` matches `bun run generate:mcp-tools` output (empty diff) | MET | Re-ran generator; `git diff --stat -- mcp-server/src/generated-tools.ts` empty |
| 2 | `docs/mcp-tools.md` regenerated via `generate:mcp-docs` | MET | Re-ran generator; `git diff --stat -- docs/mcp-tools.md` empty |
| 3 | Existing mcp-server tests still pass | MET | `bun test mcp-server/src` → 45 pass, 0 fail |

## Test Plan
- [x] `bun run generate:mcp-tools` run twice — idempotent, empty diff
- [x] `bun run generate:mcp-docs` run twice — idempotent, empty diff
- [x] `bun test mcp-server/src` — 45 pass, 0 fail
- [x] `task typecheck` — all packages pass
- [x] `task lint`, `task check-strings`, `task check-config-docs`, `task check-version-sync` — all pass
- [x] `task ci`'s `test:coverage` step shows one pre-existing failure (`agent/src/claude.unit.test.ts` `extraAllowedTools`), confirmed to reproduce identically on clean `main` — unrelated to this diff

Generated with [Claude Code](https://claude.com/claude-code)
