### PR TITLE
fix: clear hitl flag and guard against silent PR in Step 6b

### DIFF
--- a/plugins/shipwright/commands/hitl.content.test.ts
+++ b/plugins/shipwright/commands/hitl.content.test.ts
@@ -24,6 +24,12 @@ function extractSuppressionSubStep(md: string): string {
   return match?.[0] ?? "";
 }
 
+function extractMarkTaskDoneSubStep(md: string): string {
+  const match = md.match(/### 6b\. Mark Task Done[\s\S]*$/);
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
 describe("hitl.md — gitleaksignore suppression sub-step exists (GLB-2.2 AC1)", () => {
   it("contains a Step 6a suppression sub-step section", () => {
     expect(content).toContain("### 6a. Offer Gitleaksignore Suppression");
@@ -155,5 +161,73 @@ describe("hitl.md — suppression is additive, not required (GLB-2.2)", () => {
     const step6Section = extractStep6Section(content);
     expect(step6Section).toContain('\\"status\\": \\"done\\"');
     expect(step6Section).toContain("HITL TASK COMPLETE");
+  });
+});
+
+describe("hitl.md — clear hitl flag when marking done (HSR-2.1 AC1)", () => {
+  it("Step 6b PATCHes hitl:false alongside status:done in the code block", () => {
+    const section = extractMarkTaskDoneSubStep(content);
+    // Check that both status:done and hitl:false appear in the section
+    expect(section).toContain("hitl");
+    expect(section).toContain("false");
+    expect(section).toContain("status");
+    expect(section).toContain("done");
+    // Both should appear in the code block
+    const codeBlock = section.match(/```bash[\s\S]*?```/);
+    expect(codeBlock).not.toBeNull();
+    const code = codeBlock?.[0] ?? "";
+    expect(code).toContain("hitl");
+    expect(code).toContain("status");
+  });
+
+  it("Step 6b includes hitl:false in multiple branches (with and without OUTCOME_NOTE)", () => {
+    const section = extractMarkTaskDoneSubStep(content);
+    // Count occurrences of hitl to ensure both branches are covered
+    const hitlCount = (section.match(/hitl/g) || []).length;
+    expect(hitlCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("hitl.md — guard against silent PR in HITL session (HSR-2.1 AC2)", () => {
+  it("Step 6 documents a guard: if a PR is set, warn the human instead of marking done", () => {
+    const section = extractStep6Section(content);
+    const lower = section.toLowerCase();
+    // Should check for PR existence
+    const hasPrCheck =
+      lower.includes("task_pr") ||
+      lower.includes("task pr") ||
+      lower.includes("resulted") ||
+      lower.includes("pr was created");
+    expect(hasPrCheck).toBe(true);
+    // Should warn the human
+    expect(lower).toContain("warn");
+  });
+
+  it("Step 6 clarifies that when a PR exists, only hitl:false is cleared, status is left unchanged", () => {
+    const section = extractStep6Section(content);
+    const lower = section.toLowerCase();
+    // When PR exists, should mention not marking status done
+    const hasStatusGuard =
+      lower.includes("do not mark") ||
+      lower.includes("skip") ||
+      lower.includes("leave") ||
+      lower.includes("leave status");
+    expect(hasStatusGuard).toBe(true);
+    // Should mention only clearing hitl
+    expect(lower).toContain("hitl");
+    expect(lower).toContain("false");
+  });
+
+  it("Step 6 explains that leaving status unchanged allows the task to re-enter normal candidacy for review/patch/deploy", () => {
+    const section = extractStep6Section(content);
+    const lower = section.toLowerCase();
+    // Should explain that PR flows through the normal lifecycle
+    const hasNormalFlow =
+      lower.includes("review") ||
+      lower.includes("normal") ||
+      lower.includes("candidacy") ||
+      lower.includes("deploy") ||
+      lower.includes("lifecycle");
+    expect(hasNormalFlow).toBe(true);
   });
 });

--- a/plugins/shipwright/commands/hitl.md
+++ b/plugins/shipwright/commands/hitl.md
@@ -56,6 +56,7 @@ TASK_STATUS=$(echo "$TASK_JSON" | jq -r '.status // empty')
 TASK_HITL=$(echo "$TASK_JSON" | jq -r '.hitl // empty')
 TASK_LAYER=$(echo "$TASK_JSON" | jq -r '.layer // empty')
 TASK_AC=$(echo "$TASK_JSON" | jq -r '.acceptanceCriteria // empty | if type == "array" then .[] else . end')
+TASK_PR=$(echo "$TASK_JSON" | jq -r '.pr // empty')
 ```
 
 ---
@@ -140,6 +141,21 @@ If the human asks for help with a step, provide the relevant commands and contex
 
 When the human confirms the task is complete (e.g. says "done", "finished", "all good",
 "mark it done", or similar):
+
+**First, check if a PR resulted from this HITL session.** If `TASK_PR` is set (a non-empty
+PR number/URL), a PR was created during this session and needs the normal review/patch/deploy
+lifecycle — do not mark the task `done`. Instead, warn the human:
+
+```
+⚠ A PR resulted from this HITL task (pr: {TASK_PR}) — it needs the normal review/patch/deploy
+  lifecycle, not a direct "done" mark. We'll clear the hitl flag so the PR can flow through
+  candidacy, but we'll leave the task status as-is so it re-enters the queue.
+```
+
+Then proceed to Step 6b below, but **only PATCH `hitl: false`** (skip the status:"done"
+update — leave status as-is). The task will re-enter normal candidacy once hitl is cleared.
+
+If `TASK_PR` is empty (purely standalone infra work), proceed normally with both steps below.
 
 1. First run **Step 6a** below if it applies to this task.
 2. Then mark the task done in the task store as described further down (**Step 6b**), which
@@ -239,24 +255,44 @@ Ask a brief optional follow-up: "Any outcome note for the record (e.g. 'fixed', 
 positive — no change needed')? Press enter to skip." If the human provides one, capture it
 as `OUTCOME_NOTE`; otherwise leave it empty.
 
-Mark the task done in the task store, including `note: OUTCOME_NOTE` only when one was
-given (omit the field entirely when skipped — do not send an empty string):
+Mark the task done in the task store (or clear the hitl flag if a PR was created), including
+`note: OUTCOME_NOTE` only when one was given (omit the field entirely when skipped — do not
+send an empty string). Always include `hitl: false` to clear the hitl flag:
 
 ```bash
 COMPLETED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-if [ -n "$OUTCOME_NOTE" ]; then
-  curl -sf -X PATCH \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    -H "Content-Type: application/json" \
-    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-    -d "$(jq -n --arg note "$OUTCOME_NOTE" --arg completedAt "$COMPLETED_AT" \
-      '{status: "done", completedAt: $completedAt, note: $note}')" | jq .
+if [ -n "$TASK_PR" ]; then
+  # PR exists: only clear hitl, leave status unchanged
+  if [ -n "$OUTCOME_NOTE" ]; then
+    curl -sf -X PATCH \
+      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+      -d "$(jq -n --arg note "$OUTCOME_NOTE" \
+        '{hitl: false, note: $note}')" | jq .
+  else
+    curl -sf -X PATCH \
+      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+      -d '{"hitl": false}' | jq .
+  fi
 else
-  curl -sf -X PATCH \
-    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    -H "Content-Type: application/json" \
-    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
-    -d "{\"status\": \"done\", \"completedAt\": \"$COMPLETED_AT\"}" | jq .
+  # No PR: mark done and clear hitl
+  if [ -n "$OUTCOME_NOTE" ]; then
+    curl -sf -X PATCH \
+      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+      -d "$(jq -n --arg note "$OUTCOME_NOTE" --arg completedAt "$COMPLETED_AT" \
+        '{status: "done", completedAt: $completedAt, hitl: false, note: $note}')" | jq .
+  else
+    curl -sf -X PATCH \
+      -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+      -d "{\"status\": \"done\", \"completedAt\": \"$COMPLETED_AT\", \"hitl\": false}" | jq .
+  fi
 fi
 ```
 


### PR DESCRIPTION
## Summary
- Fix `/shipwright:hitl` Step 6b to always PATCH `hitl: false` alongside `status: "done"` when marking a task done, so completed HITL tasks stop showing `hitl: true` forever (proven live: RBV-V.1 is `merged` and fully shipped but still `hitl: true`).
- Add a guard: if `task.pr` is already set when Step 6 runs (a PR resulted from the HITL session), warn the human and skip the done-marking PATCH entirely — only clear `hitl` so the task re-enters normal review/patch/deploy candidacy instead of being silently marked done with an unmerged PR attached.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 6b PATCHes hitl:false whenever it marks the task done | ✅ MET |
| 2 | If task.pr is set, warn and don't mark status:'done' — only clear hitl | ✅ MET |
| 3 | Extend hitl.content.test.ts to assert the hitl:false PATCH and task.pr guard language | ✅ MET |

## Test Plan
- Extended `hitl.content.test.ts` with 5 new tests (2 describe blocks) asserting the Step 6b markdown includes `hitl: false` in the done-marking PATCH, and Step 6 documents the `task.pr` guard/warning/status-unchanged behavior.
- `bun test plugins/shipwright/commands/hitl.content.test.ts` — 22/22 pass.
- `task typecheck` — all workspaces pass.
- `task ci` — full suite passes except one pre-existing, diff-unrelated sandbox flake (`agent/src/claude.unit.test.ts` extraAllowedTools), confirmed to also fail on clean main.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
