### PR TITLE
feat: sort blocked tasks by createdAt to match other tabs

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -84,7 +84,9 @@ and this agent truly has zero accessible repos."
 `?ready=true` (or `?state=ready`) and `?state=blocked` are unpaginated convenience endpoints —
 they compute over the entire task graph (dependency resolution needs every task, not a
 `limit`/`offset` slice) and always return every matching task in one response. Their `total`
-is simply `tasks.length`; `limit`/`offset` query params have no effect on these two branches.
+is simply `tasks.length`; `limit`/`offset` query params have no effect on these two branches. The
+`?sort` parameter applies to `?state=blocked` (sort by `createdAt`; default `asc`), but is not
+supported with `?ready=true`.
 
 Agent tokens with a repo scope return tasks where `assignee === agentId` OR `repo` is in the agent's scope (pool tasks). Agent tokens without a repo scope see only tasks where `assignee === agentId`.
 

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -566,6 +566,7 @@ export function createTasksRoutes(
       const tasks = await taskService.listBlocked(
         agentId ?? undefined,
         repos !== null ? repos : undefined,
+        c.req.query("sort") === "desc" ? "desc" : undefined,
       );
       return c.json({ tasks, total: tasks.length, scopeDegraded }, 200);
     }

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -107,6 +107,7 @@ function fakeTaskService(opts: {
   capturedListReadyArgs?: Array<string | undefined>;
   capturedListBlockedCalls?: number[];
   capturedListBlockedArgs?: Array<string | undefined>;
+  capturedListBlockedSortArgs?: Array<"asc" | "desc" | undefined>;
 }): TaskServiceLike {
   return {
     async list(filters?: TaskListFilters) {
@@ -125,10 +126,16 @@ function fakeTaskService(opts: {
       if (opts.capturedListReadyArgs) opts.capturedListReadyArgs.push(agentId);
       return opts.listReadyResult ?? [];
     },
-    async listBlocked(agentId?: string) {
+    async listBlocked(
+      agentId?: string,
+      _repos?: string[],
+      sort?: "asc" | "desc",
+    ) {
       if (opts.capturedListBlockedCalls) opts.capturedListBlockedCalls.push(1);
       if (opts.capturedListBlockedArgs)
         opts.capturedListBlockedArgs.push(agentId);
+      if (opts.capturedListBlockedSortArgs)
+        opts.capturedListBlockedSortArgs.push(sort);
       return (opts.listBlockedResult ?? []).map((t) => withBlockedBy(t));
     },
     async get(id: string) {
@@ -353,7 +360,10 @@ describe("GET /tasks state filter (smoke)", () => {
     const taskService = fakeTaskService({ listBlockedResult: [blockedTask] });
     const app = makeApp(taskService);
     const res = await app.request("/tasks?state=blocked", { headers: auth() });
-    const body = (await res.json()) as { tasks: TaskWithBlockedBy[]; total: number };
+    const body = (await res.json()) as {
+      tasks: TaskWithBlockedBy[];
+      total: number;
+    };
     expect(Array.isArray(body.tasks)).toBe(true);
     expect(typeof body.total).toBe("number");
   });
@@ -372,7 +382,10 @@ describe("GET /tasks state filter (smoke)", () => {
     const taskService = fakeTaskService({ listBlockedResult: [b1, b2] });
     const app = makeApp(taskService);
     const res = await app.request("/tasks?state=blocked", { headers: auth() });
-    const body = (await res.json()) as { tasks: TaskWithBlockedBy[]; total: number };
+    const body = (await res.json()) as {
+      tasks: TaskWithBlockedBy[];
+      total: number;
+    };
     expect(body.tasks).toHaveLength(2);
     expect(body.tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
     expect(body.total).toBe(2);
@@ -382,7 +395,10 @@ describe("GET /tasks state filter (smoke)", () => {
     const taskService = fakeTaskService({ listBlockedResult: [] });
     const app = makeApp(taskService);
     const res = await app.request("/tasks?state=blocked", { headers: auth() });
-    const body = (await res.json()) as { tasks: TaskWithBlockedBy[]; total: number };
+    const body = (await res.json()) as {
+      tasks: TaskWithBlockedBy[];
+      total: number;
+    };
     expect(Array.isArray(body.tasks)).toBe(true);
     expect(body.tasks).toHaveLength(0);
     expect(body.total).toBe(0);
@@ -393,7 +409,10 @@ describe("GET /tasks state filter (smoke)", () => {
     const taskService = fakeTaskService({ listBlockedResult: [blockedTask] });
     const app = makeApp(taskService);
     const res = await app.request("/tasks?state=blocked", { headers: auth() });
-    const body = (await res.json()) as { tasks: TaskWithBlockedBy[]; total: number };
+    const body = (await res.json()) as {
+      tasks: TaskWithBlockedBy[];
+      total: number;
+    };
     expect(Array.isArray(body.tasks[0].blockedBy)).toBe(true);
   });
 
@@ -415,5 +434,81 @@ describe("GET /tasks state filter (smoke)", () => {
     await app.request("/tasks?state=blocked", { headers: auth() });
     expect(capturedListBlockedArgs).toHaveLength(1);
     expect(capturedListBlockedArgs[0]).toBeUndefined();
+  });
+
+  // ─── sort param for state=blocked ──────────────────────────────────────────
+
+  it("GET /tasks?state=blocked&sort=desc forwards sort='desc' to listBlocked()", async () => {
+    const capturedListBlockedSortArgs: Array<"asc" | "desc" | undefined> = [];
+    const taskService = fakeTaskService({ capturedListBlockedSortArgs });
+    const app = makeApp(taskService);
+    await app.request("/tasks?state=blocked&sort=desc", { headers: auth() });
+    expect(capturedListBlockedSortArgs).toHaveLength(1);
+    expect(capturedListBlockedSortArgs[0]).toBe("desc");
+  });
+
+  it("GET /tasks?state=blocked without ?sort forwards undefined to listBlocked() (default asc)", async () => {
+    const capturedListBlockedSortArgs: Array<"asc" | "desc" | undefined> = [];
+    const taskService = fakeTaskService({ capturedListBlockedSortArgs });
+    const app = makeApp(taskService);
+    await app.request("/tasks?state=blocked", { headers: auth() });
+    expect(capturedListBlockedSortArgs).toHaveLength(1);
+    expect(capturedListBlockedSortArgs[0]).toBeUndefined();
+  });
+
+  it("GET /tasks?state=blocked&sort=desc returns tasks newest-first", async () => {
+    // fakeTaskService's listBlocked() doesn't itself sort — apply the
+    // route's sort filter here to model what the real Prisma-backed
+    // service does, so this test exercises the query-param → service →
+    // response round trip (mirrors the GET /prs?sort=desc round-trip test
+    // in prs.smoke.test.ts).
+    const oldest = makeTask({
+      id: "t-oldest",
+      status: "blocked",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const middle = makeTask({
+      id: "t-middle",
+      status: "blocked",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    const newest = makeTask({
+      id: "t-newest",
+      status: "blocked",
+      createdAt: new Date("2026-01-03T00:00:00.000Z"),
+    });
+    const baseFake = fakeTaskService({
+      listBlockedResult: [oldest, middle, newest],
+    });
+    const taskServiceWithSort: TaskServiceLike = {
+      ...baseFake,
+      async listBlocked(
+        agentId?: string,
+        repos?: string[],
+        sort?: "asc" | "desc",
+      ) {
+        const tasks = await baseFake.listBlocked(agentId, repos, sort);
+        const sorted = [...tasks].sort((a, b) => {
+          const diff = a.createdAt.getTime() - b.createdAt.getTime();
+          return sort === "desc" ? -diff : diff;
+        });
+        return sorted;
+      },
+    };
+    const app = makeApp(taskServiceWithSort);
+
+    const res = await app.request("/tasks?state=blocked&sort=desc", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tasks: TaskWithBlockedBy[];
+      total: number;
+    };
+    expect(body.tasks.map((t) => t.id)).toEqual([
+      "t-newest",
+      "t-middle",
+      "t-oldest",
+    ]);
   });
 });

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -98,7 +98,11 @@ export interface TaskListResult {
 export interface TaskServiceLike {
   list(filters?: TaskListFilters): Promise<TaskListResult>;
   listReady(agentId?: string, repos?: string[]): Promise<Task[]>;
-  listBlocked(agentId?: string, repos?: string[]): Promise<TaskWithBlockedBy[]>;
+  listBlocked(
+    agentId?: string,
+    repos?: string[],
+    sort?: "asc" | "desc",
+  ): Promise<TaskWithBlockedBy[]>;
   distinct(
     agentId?: string,
     scopeRepos?: string[],
@@ -254,8 +258,11 @@ export class TaskService implements TaskServiceLike {
   async listBlocked(
     agentId?: string,
     repos?: string[],
+    sort?: "asc" | "desc",
   ): Promise<TaskWithBlockedBy[]> {
-    const allTasks = await this.prisma.task.findMany();
+    const allTasks = await this.prisma.task.findMany({
+      orderBy: { createdAt: sort ?? "asc" },
+    });
     const useRepoScope =
       agentId !== undefined && repos !== undefined && repos.length > 0;
     const closedStatuses = new Set<string>(CLOSED_STATUSES);

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -365,6 +365,131 @@ describe("listBlocked logic (unit)", () => {
   });
 });
 
+// ─── TaskService.listBlocked() sort ─────────────────────────────────────────
+
+describe("TaskService.listBlocked() sort (unit)", () => {
+  /**
+   * Prisma double for listBlocked(): captures the findMany args (in
+   * particular orderBy) passed by the service, mirroring the
+   * PullRequestService.list() sort unit test pattern
+   * (pull-request-service.unit.test.ts). Returns tasks in the order given
+   * regardless of orderBy — real ordering is Postgres's job; this double
+   * only lets us assert the service *requests* the right orderBy and that
+   * the array order it's fed survives listBlocked()'s .map()/.filter().
+   */
+  function makeListBlockedPrismaDouble(tasks: Task[]) {
+    const findManyCalls: Array<{ orderBy?: unknown }> = [];
+
+    const prisma = {
+      task: {
+        findMany(args: { orderBy?: unknown } = {}) {
+          findManyCalls.push(args);
+          return Promise.resolve(tasks);
+        },
+      },
+      _findManyCalls: findManyCalls,
+    };
+
+    return prisma as unknown as PrismaClient & {
+      _findManyCalls: Array<{ orderBy?: unknown }>;
+    };
+  }
+
+  function makeBlockedTask(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "task-1",
+      title: "A task",
+      status: "blocked",
+      source: null,
+      session: null,
+      repo: null,
+      description: null,
+      acceptanceCriteria: [],
+      layer: null,
+      branch: null,
+      dependencies: [],
+      pr: null,
+      hours: null,
+      addedAt: null,
+      startedAt: null,
+      prCreatedAt: null,
+      mergedAt: null,
+      blockedAt: null,
+      blockedReason: null,
+      note: null,
+      type: null,
+      priority: null,
+      cancelledAt: null,
+      completedAt: null,
+      deployingAt: null,
+      ciFixAttempts: null,
+      mergeCommit: null,
+      prUrl: null,
+      assignee: null,
+      issue: null,
+      model: null,
+      complexity: null,
+      hitl: null,
+      hitlNotifiedAt: null,
+      claimedBy: null,
+      agentHint: null,
+      claimedAt: null,
+      heartbeatAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      ...overrides,
+    } as Task;
+  }
+
+  it("listBlocked({ sort: 'desc' }) requests orderBy: { createdAt: 'desc' } from Prisma", async () => {
+    const prisma = makeListBlockedPrismaDouble([]);
+    const service = new TaskService(prisma);
+
+    await service.listBlocked(undefined, undefined, "desc");
+
+    expect(prisma._findManyCalls).toHaveLength(1);
+    expect(prisma._findManyCalls[0].orderBy).toEqual({ createdAt: "desc" });
+  });
+
+  it("listBlocked() with no sort defaults to orderBy: { createdAt: 'asc' } (current behavior)", async () => {
+    const prisma = makeListBlockedPrismaDouble([]);
+    const service = new TaskService(prisma);
+
+    await service.listBlocked();
+
+    expect(prisma._findManyCalls).toHaveLength(1);
+    expect(prisma._findManyCalls[0].orderBy).toEqual({ createdAt: "asc" });
+  });
+
+  it("listBlocked({ sort: 'desc' }) returns tasks ordered by createdAt descending", async () => {
+    // Simulate Postgres honoring orderBy: desc — the double returns tasks
+    // pre-sorted newest-first, proving order survives listBlocked()'s
+    // subsequent .map()/.filter() calls (both preserve array order in JS).
+    const oldest = makeBlockedTask({
+      id: "t-oldest",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const middle = makeBlockedTask({
+      id: "t-middle",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    const newest = makeBlockedTask({
+      id: "t-newest",
+      createdAt: new Date("2026-01-03T00:00:00.000Z"),
+    });
+    const prisma = makeListBlockedPrismaDouble([newest, middle, oldest]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listBlocked(undefined, undefined, "desc");
+
+    expect(result.map((t) => t.id)).toEqual([
+      "t-newest",
+      "t-middle",
+      "t-oldest",
+    ]);
+  });
+});
+
 // ─── TaskService.bulk() ─────────────────────────────────────────────────────
 
 describe("TaskService.bulk (unit)", () => {


### PR DESCRIPTION
## Summary
- `TaskService.listBlocked()` now accepts an optional `sort?: "asc" | "desc"` param and applies `orderBy: { createdAt: sort ?? "asc" }` in its Prisma `findMany()` call, mirroring the existing `list()` method's sort handling.
- `routes/tasks.ts`'s `?state=blocked` branch now forwards the `sort` query param into `listBlocked()`, mirroring the existing forwarding for the normal `list()` path — so `GET /admin/tasks?state=blocked` (which always requests `sort=desc`) now returns newest-first, matching every other status tab.
- `TaskServiceLike` interface signature updated to match; existing test fakes are unaffected since they ignore extra args.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | listBlocked() accepts sort param, applies orderBy: { createdAt: sort ?? "asc" } | MET | task-service.ts findMany() now passes orderBy: { createdAt: sort ?? "asc" } |
| 2 | routes/tasks.ts forwards sort query param mirroring list() path | MET | routes/tasks.ts: c.req.query("sort") === "desc" ? "desc" : undefined passed as 3rd arg |
| 3 | TaskServiceLike interface updated | MET | interface signature updated with sort?: "asc" \| "desc" |
| 4 | Unit test (desc order) + smoke test (route round-trip), no existing tests removed | MET | 3 new unit tests, 3 new smoke tests added; no existing tests removed |

## Test Plan
- New unit tests in `task-service.unit.test.ts` asserting `listBlocked()` requests the correct Prisma `orderBy` and that order survives the `.map()`/`.filter()` pipeline.
- New smoke tests in `state-filter.smoke.test.ts` asserting `GET /tasks?state=blocked&sort=desc` forwards `sort` to the service and returns tasks newest-first.
- Docs refreshed (`docs/task-store.md`) to note `?sort` support on the blocked tasks endpoint.
- [x] Pre-commit checks passing (`task typecheck`, `task lint`, full `bun test` suite — 5510 pass, 1 pre-existing unrelated failure in `agent/src/claude.unit.test.ts` confirmed failing identically on `main`, coverage gate passes at 80.99%/81.85% aggregate)

Generated with [Claude Code](https://claude.com/claude-code)
