### PR TITLE
feat: add shared repo/org where-clause builder helper

### DIFF
--- a/task-store/src/lib/repo-org-filter.ts
+++ b/task-store/src/lib/repo-org-filter.ts
@@ -1,0 +1,66 @@
+/**
+ * task-store/src/lib/repo-org-filter.ts
+ *
+ * Pure helper: buildRepoOrgWhere({ orgs, repos }) → a Prisma-compatible where
+ * fragment for filtering by org and/or by a list of repos.
+ *
+ * `repo` is stored as a single `"org/repo"` string on both the `Task` and
+ * `PullRequest` models — there's no dedicated org column — so org matching is
+ * done via `repo: { startsWith: "<org>/" }`. This mirrors the existing
+ * `{ repo: { in: repos } }` pattern used for agent-scoped filtering in
+ * task-service.ts and the raw-SQL `= ANY(...)` pattern in
+ * pull-request-service.ts's claimNext(), extracted here as a shared,
+ * testable building block for both services.
+ */
+
+/** Input filters: repos and/or orgs to scope a query to. */
+export interface RepoOrgFilter {
+  orgs?: string[];
+  repos?: string[];
+}
+
+/** A single repo-matching clause: exact membership. */
+export interface RepoInClause {
+  repo: { in: string[] };
+}
+
+/** A single org-matching clause: repo prefix match. */
+export interface RepoStartsWithClause {
+  repo: { startsWith: string };
+}
+
+/** The shape returned by buildRepoOrgWhere — usable as a fragment of
+ * Prisma.TaskWhereInput or Prisma.PullRequestWhereInput. */
+export type RepoOrgWhere =
+  | Record<string, never>
+  | RepoInClause
+  | { OR: RepoStartsWithClause[] }
+  | { AND: [RepoInClause, { OR: RepoStartsWithClause[] }] };
+
+/**
+ * Builds a Prisma-compatible where fragment from `{ orgs?, repos? }`:
+ *   - repos only -> { repo: { in: repos } }
+ *   - orgs only  -> { OR: orgs.map(o => ({ repo: { startsWith: `${o}/` } })) }
+ *   - both       -> { AND: [the repos clause, the orgs OR clause] }
+ *   - neither    -> {}
+ *
+ * Empty arrays are treated the same as absent.
+ */
+export function buildRepoOrgWhere(
+  filter: RepoOrgFilter = {},
+): RepoOrgWhere {
+  const orgs = filter.orgs?.length ? filter.orgs : undefined;
+  const repos = filter.repos?.length ? filter.repos : undefined;
+
+  const repoClause: RepoInClause | undefined = repos
+    ? { repo: { in: repos } }
+    : undefined;
+  const orgClause: { OR: RepoStartsWithClause[] } | undefined = orgs
+    ? { OR: orgs.map((org) => ({ repo: { startsWith: `${org}/` } })) }
+    : undefined;
+
+  if (repoClause && orgClause) return { AND: [repoClause, orgClause] };
+  if (repoClause) return repoClause;
+  if (orgClause) return orgClause;
+  return {};
+}

--- a/task-store/src/lib/repo-org-filter.unit.test.ts
+++ b/task-store/src/lib/repo-org-filter.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { buildRepoOrgWhere } from "./repo-org-filter.ts";
+
+describe("buildRepoOrgWhere", () => {
+  it("returns a repo `in` clause when only repos is given", () => {
+    const where = buildRepoOrgWhere({ repos: ["acme/foo", "acme/bar"] });
+    expect(where).toEqual({ repo: { in: ["acme/foo", "acme/bar"] } });
+  });
+
+  it("returns an OR of repo `startsWith` clauses when only orgs is given", () => {
+    const where = buildRepoOrgWhere({ orgs: ["acme", "other"] });
+    expect(where).toEqual({
+      OR: [
+        { repo: { startsWith: "acme/" } },
+        { repo: { startsWith: "other/" } },
+      ],
+    });
+  });
+
+  it("returns an AND combining both clauses when both orgs and repos are given", () => {
+    const where = buildRepoOrgWhere({
+      orgs: ["acme"],
+      repos: ["acme/foo", "other/bar"],
+    });
+    expect(where).toEqual({
+      AND: [
+        { repo: { in: ["acme/foo", "other/bar"] } },
+        { OR: [{ repo: { startsWith: "acme/" } }] },
+      ],
+    });
+  });
+
+  it("returns an empty object when neither orgs nor repos is given", () => {
+    expect(buildRepoOrgWhere({})).toEqual({});
+    expect(buildRepoOrgWhere({ orgs: [], repos: [] })).toEqual({});
+    expect(buildRepoOrgWhere()).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `buildRepoOrgWhere({ orgs, repos })` in `task-store/src/lib/repo-org-filter.ts` — a pure helper that builds a Prisma-compatible where fragment for filtering by org and/or by a list of repos.
- Org filtering matches via `repo: { startsWith: "${org}/" }` since `repo` is stored as a single `"org/repo"` string with no dedicated org column.
- Standalone helper only — not yet wired into `TaskService` or `PullRequestService` (reserved for ORF-1.2/1.3).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Returns `{ repo: { in: [...] } }` when only repos given | MET | `repo-org-filter.ts`; test covers this branch |
| 2 | Returns `{ OR: [{ repo: { startsWith: 'org/' } }, ...] }` when only orgs given | MET | `repo-org-filter.ts`; test covers this branch |
| 3 | Returns `{ AND: [...] }` combining both when both given | MET | `repo-org-filter.ts`; test covers this branch |
| 4 | Returns `{}` when neither given | MET | `repo-org-filter.ts`; test covers this branch (incl. empty arrays) |
| 5 | New unit-test file covering all four branches | MET | `task-store/src/lib/repo-org-filter.unit.test.ts` |

## Test Plan
- `NODE_ENV=test bun test task-store/src/lib/repo-org-filter.unit.test.ts` — 4/4 pass, 100% line/function coverage on the new file
- [x] Lint (Biome) clean on new files
- [x] Typecheck clean (task-store)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
