### PR TITLE
feat: extend TaskService list and distinct for multi-repo and org filters

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,19 +4,23 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
-## New: `GET /tasks` `?org` filter and distinct `orgs` field
+## New: `TaskService.list()` multi-repo/org filters and distinct `orgs` field
 
 **Version**: next (ORF-1.2)
 
-The task-store API now supports filtering tasks by organization prefix and returns distinct organizations in the distinct endpoint:
+`TaskService.list()` now accepts `repo` as `string | string[]` and a new `org: string | string[]`
+filter (repo prefix match, e.g. `"app-vitals"` matches any `repo` starting with `"app-vitals/"`).
+`TaskService.distinct()` now also returns a third field, `orgs: string[]` — the distinct
+organization prefixes extracted from the `repos` it already returns.
 
-- **`GET /tasks?org=<org>`** — filters tasks to only those whose `repo` field starts with `"<org>/"`. Combines with an existing `?repo=` filter as an AND condition (both narrow the result).
-- **`GET /tasks/distinct`** — now returns a third field `orgs: string[]`, containing the distinct organization prefixes extracted from all visible `repo` values (the `org` part of each `org/repo`).
-- **`GET /tasks?ready=true`** and **`GET /tasks?state=blocked`** — support the same `?org` filter as the regular list endpoint.
+- These filters are available today to in-process callers of `TaskService.list()`. The public
+  `GET /tasks` HTTP route is unchanged in this version — it still only wires through the
+  single-string `?repo=` query param; `?org=` is not yet an HTTP-exposed filter.
+- **`GET /tasks/distinct`** — now returns a third field `orgs: string[]`, containing the distinct organization prefixes extracted from all visible `repo` values (the `org` part of each `org/repo`). This IS live over HTTP, since the route passes `TaskService.distinct()`'s result straight through.
 
-**For API callers**: The `?org` filter is purely additive. Existing queries without `?org` behave identically. The new `orgs` field in distinct responses is safe to ignore if your UI doesn't need it.
+**For API callers**: `GET /tasks/distinct` responses gain a new `orgs` field — safe to ignore if your UI doesn't need it. No other HTTP-visible behavior changes.
 
-**For TaskService implementations**: The `distinct()` method's return type has changed from `{ sessions: string[]; repos: string[] }` to `{ sessions: string[]; repos: string[]; orgs: string[] }`. If you override `distinct()`, update your implementation to compute and return the `orgs` array (extract unique organization prefixes from the `repos` array).
+**For TaskService implementations**: The `distinct()` method's return type has changed from `{ sessions: string[]; repos: string[] }` to `{ sessions: string[]; repos: string[]; orgs: string[] }`. If you override `distinct()`, update your implementation to compute and return the `orgs` array (extract unique organization prefixes from the `repos` array). The `list()` filters type gained `repo?: string | string[]` (single string keeps the old exact-match shape) and `org?: string | string[]`.
 
 ---
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,22 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
+## New: `GET /tasks` `?org` filter and distinct `orgs` field
+
+**Version**: next (ORF-1.2)
+
+The task-store API now supports filtering tasks by organization prefix and returns distinct organizations in the distinct endpoint:
+
+- **`GET /tasks?org=<org>`** — filters tasks to only those whose `repo` field starts with `"<org>/"`. Combines with an existing `?repo=` filter as an AND condition (both narrow the result).
+- **`GET /tasks/distinct`** — now returns a third field `orgs: string[]`, containing the distinct organization prefixes extracted from all visible `repo` values (the `org` part of each `org/repo`).
+- **`GET /tasks?ready=true`** and **`GET /tasks?state=blocked`** — support the same `?org` filter as the regular list endpoint.
+
+**For API callers**: The `?org` filter is purely additive. Existing queries without `?org` behave identically. The new `orgs` field in distinct responses is safe to ignore if your UI doesn't need it.
+
+**For TaskService implementations**: The `distinct()` method's return type has changed from `{ sessions: string[]; repos: string[] }` to `{ sessions: string[]; repos: string[]; orgs: string[] }`. If you override `distinct()`, update your implementation to compute and return the `orgs` array (extract unique organization prefixes from the `repos` array).
+
+---
+
 ## Breaking: `dev-task`/`review`/`patch`/`deploy` require `shipwright-loop` (or an explicit target)
 
 **Version**: next (WLS-6.1)

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -50,8 +50,7 @@ Query params:
 | `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
-| `repo` | string | Filter by repo (`org/repo` format) or list of repos (when combined with org filter). A single string preserves exact-match behavior; multiple repos via array notation in internal calls |
-| `org` | string | Filter by organization — matches any repo whose `org/repo` string starts with `"<org>/"`. Combines with `repo` filter as an AND condition (both narrow the result). Multiple orgs supported in internal calls. |
+| `repo` | string | Filter by repo (`org/repo` format) |
 | `assignee` | string | Filter by assignee (admin tokens only; agent tokens without repo scope see only their own tasks). When used with repo-scoped agent tokens under `agentScope`, acts as an additional AND filter narrowing the visible set. |
 | `claimedBy` | string | Filter by claiming agent |
 | `pr` | number | Filter by PR number |
@@ -61,6 +60,12 @@ Query params:
 | `offset` | number | Page offset. Defaults to `0` when omitted. |
 | `sort` | string | `asc` (default) or `desc` — orders results by `createdAt`. Default preserves existing ascending order for all callers. |
 | `updatedSince` | string | ISO timestamp. Only return tasks with `updatedAt >= this value`. A conservative pre-filter (not a precise sync anchor). Omitting it preserves current (unfiltered) behavior. |
+
+The underlying `TaskService.list()` also accepts `repo` as a `string[]` (matches any repo in
+the list) and a separate `org`/`org[]` filter (matches any repo whose `org/repo` string starts
+with `"<org>/"`), available today to in-process callers. These are not yet exposed as query
+params on this HTTP route; only the single-string `?repo=` filter above is wired through
+`GET /tasks`.
 
 Returns `{ tasks: Task[], total: number, limit: number, offset: number, scopeDegraded: boolean }`. 
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -50,8 +50,9 @@ Query params:
 | `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
-| `repo` | string | Filter by repo (`org/repo` format) |
-| `assignee` | string | Filter by assignee (admin tokens only; agent tokens see only their own tasks) |
+| `repo` | string | Filter by repo (`org/repo` format) or list of repos (when combined with org filter). A single string preserves exact-match behavior; multiple repos via array notation in internal calls |
+| `org` | string | Filter by organization — matches any repo whose `org/repo` string starts with `"<org>/"`. Combines with `repo` filter as an AND condition (both narrow the result). Multiple orgs supported in internal calls. |
+| `assignee` | string | Filter by assignee (admin tokens only; agent tokens without repo scope see only their own tasks). When used with repo-scoped agent tokens under `agentScope`, acts as an additional AND filter narrowing the visible set. |
 | `claimedBy` | string | Filter by claiming agent |
 | `pr` | number | Filter by PR number |
 | `branch` | string | Filter by branch name |
@@ -88,7 +89,12 @@ is simply `tasks.length`; `limit`/`offset` query params have no effect on these 
 `?sort` parameter applies to `?state=blocked` (sort by `createdAt`; default `asc`), but is not
 supported with `?ready=true`.
 
-Agent tokens with a repo scope return tasks where `assignee === agentId` OR `repo` is in the agent's scope (pool tasks). Agent tokens without a repo scope see only tasks where `assignee === agentId`.
+**Agent token visibility:**
+- **With repo scope** (repos configured): Return tasks where `assignee === agentId` OR (`assignee === null` AND `repo` is in the agent's scope). This union of explicitly-assigned and pool tasks enables the agent to claim unassigned work from its scoped repositories.
+- **Without repo scope** (repos empty or not configured): See only tasks where `assignee === agentId` — no pool tasks visible.
+- **Admin tokens** (agentId null) have unrestricted visibility and can see any task matching the query filters.
+
+An explicit `?assignee=` filter on a repo-scoped agent token further narrows the result (acts as an AND condition on the OR union) — safe, since it only restricts visibility within an already-permitted set.
 
 #### Create task
 
@@ -113,6 +119,11 @@ GET /tasks/distinct
 ```
 
 Returns distinct values of key fields across the visible task set. Useful for populating filter dropdowns.
+
+Response: `{ sessions: string[], repos: string[], orgs: string[] }`
+- `sessions` — distinct `session` values across visible tasks
+- `repos` — distinct `repo` values (in `org/repo` format) across visible tasks
+- `orgs` — distinct organization prefixes extracted from `repo` values (the `org` part of `org/repo`)
 
 #### Get task
 

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -212,7 +212,7 @@ function fakeTaskService(
       return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct(_agentId?) {
-      return { sessions: [], repos: [] };
+      return { sessions: [], repos: [], orgs: [] };
     },
   };
 }
@@ -707,7 +707,7 @@ describe("task-store API (smoke)", () => {
       ...fakeTaskService(),
       async distinct(agentId?: string) {
         capturedAgentIds.push(agentId);
-        return { sessions: [], repos: [] };
+        return { sessions: [], repos: [], orgs: [] };
       },
     };
 
@@ -999,7 +999,7 @@ describe("task-store API (smoke)", () => {
     // even though the task is assigned to a different agent.
     expect(res.status).toBe(200);
     // Acting agent (agent-1) must NOT steal the task — assignee stays agent-2.
-    expect((await res.json() as Task).assignee).toBe("agent-2");
+    expect(((await res.json()) as Task).assignee).toBe("agent-2");
   });
 
   it("PATCH /tasks/:id with repo-scoped token for wrong repo returns 403", async () => {

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -175,7 +175,7 @@ function fakeTaskService(
       return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct(_agentId?) {
-      return { sessions: [], repos: [] };
+      return { sessions: [], repos: [], orgs: [] };
     },
   };
 }

--- a/task-store/src/generate-spec.ts
+++ b/task-store/src/generate-spec.ts
@@ -33,7 +33,7 @@ const stubTaskService: TaskServiceLike = {
     return [];
   },
   async distinct() {
-    return { sessions: [], repos: [] };
+    return { sessions: [], repos: [], orgs: [] };
   },
   async get() {
     return null;

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -517,6 +517,7 @@ export const DistinctResponseSchema = z
   .object({
     sessions: z.array(z.string()).openapi({ example: ["session-1"] }),
     repos: z.array(z.string()).openapi({ example: ["org/repo"] }),
+    orgs: z.array(z.string()).openapi({ example: ["org"] }),
   })
   .openapi("DistinctResponse");
 

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -385,7 +385,7 @@ function fakeTaskService(): TaskServiceLike {
       return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
-      return { sessions: [], repos: [] };
+      return { sessions: [], repos: [], orgs: [] };
     },
   };
 }
@@ -1203,7 +1203,10 @@ describe("/prs routes (smoke)", () => {
 
   it("POST /prs/:id/skip increments skipCount and sets lastSkippedAt", async () => {
     const store = new Map<string, PullRequest>();
-    store.set("pr-1", makePr({ id: "pr-1", skipCount: 0, lastSkippedAt: null }));
+    store.set(
+      "pr-1",
+      makePr({ id: "pr-1", skipCount: 0, lastSkippedAt: null }),
+    );
     const app = makeApp({ prService: fakePrService({ store }) });
 
     const res = await app.request("/prs/pr-1/skip", {
@@ -1220,7 +1223,11 @@ describe("/prs routes (smoke)", () => {
     const store = new Map<string, PullRequest>();
     store.set(
       "pr-1",
-      makePr({ id: "pr-1", skipCount: 2, lastSkippedAt: new Date().toISOString() }),
+      makePr({
+        id: "pr-1",
+        skipCount: 2,
+        lastSkippedAt: new Date().toISOString(),
+      }),
     );
     const app = makeApp({ prService: fakePrService({ store }) });
 

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -142,7 +142,7 @@ function fakeTaskService(
       return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
-      return { sessions: [], repos: [] };
+      return { sessions: [], repos: [], orgs: [] };
     },
   };
 }

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -175,7 +175,7 @@ function fakeTaskService(opts: {
       return { inserted: 0, updated: 0, skipped: [] };
     },
     async distinct() {
-      return { sessions: [], repos: [] };
+      return { sessions: [], repos: [], orgs: [] };
     },
   };
 }

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -16,6 +16,7 @@ import { type BlockedByEntry, computeBlockedBy } from "./blocked-by.ts";
 import { type Clock, SystemClock } from "./clock.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
 import type { Prisma, PrismaClient, Task } from "./index.ts";
+import { buildRepoOrgWhere } from "./lib/repo-org-filter.ts";
 import { resolveReadyTasks } from "./ready.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
 
@@ -59,7 +60,19 @@ export interface TaskListFilters {
   state?: "open" | "closed" | "in_progress";
   source?: string;
   session?: string;
-  repo?: string;
+  /**
+   * Repo filter. A single string preserves the original exact-match
+   * behavior (`where.repo = repo`, unchanged for back-compat); an array
+   * matches any repo in the list (`where.repo = { in: repos }` via
+   * buildRepoOrgWhere).
+   */
+  repo?: string | string[];
+  /**
+   * Org filter — matches any repo whose `org/repo` string starts with
+   * `"<org>/"`. Combines with `repo` (both narrow the same AND-scoped
+   * result) via buildRepoOrgWhere.
+   */
+  org?: string | string[];
   assignee?: string;
   claimedBy?: string;
   pr?: number;
@@ -106,7 +119,7 @@ export interface TaskServiceLike {
   distinct(
     agentId?: string,
     scopeRepos?: string[],
-  ): Promise<{ sessions: string[]; repos: string[] }>;
+  ): Promise<{ sessions: string[]; repos: string[]; orgs: string[] }>;
   get(id: string): Promise<TaskWithBlockedBy | null>;
   create(data: Prisma.TaskCreateInput): Promise<Task>;
   bulk(
@@ -166,7 +179,31 @@ export class TaskService implements TaskServiceLike {
     // condition on top of agentScope's OR — narrowing an already-visible set
     // is always safe, even though widening it (peeking at an unscoped
     // assignee) is not.
-    if (filters.repo) where.repo = filters.repo;
+    //
+    // A single-string `repo` preserves the original exact-match shape
+    // (`where.repo = "org/repo"`) for back-compat with existing callers/
+    // tests. Anything else (an array, or an `org` filter) is routed through
+    // buildRepoOrgWhere. That fragment can itself carry a top-level `OR` (org
+    // matching is `repo: { startsWith }` OR'd across orgs) — spreading it
+    // directly onto `where` would silently clobber agentScope's `where.OR`
+    // if both are present, so in that case the two OR clauses are combined
+    // under `where.AND` instead; otherwise the fragment is spread directly
+    // onto `where`, matching the plain `{ repo: { in: [...] } }` /
+    // `{ OR: [...] }` shape asserted by the unit tests.
+    if (typeof filters.repo === "string") {
+      where.repo = filters.repo;
+    } else if (filters.repo || filters.org) {
+      const repoOrgWhere = buildRepoOrgWhere({
+        repos: filters.repo,
+        orgs: typeof filters.org === "string" ? [filters.org] : filters.org,
+      });
+      if ("OR" in repoOrgWhere && where.OR) {
+        where.AND = [{ OR: where.OR }, repoOrgWhere];
+        where.OR = undefined;
+      } else {
+        Object.assign(where, repoOrgWhere);
+      }
+    }
     if (filters.assignee) where.assignee = filters.assignee;
 
     const limit = filters.limit ?? 50;
@@ -284,7 +321,7 @@ export class TaskService implements TaskServiceLike {
   async distinct(
     agentId?: string,
     scopeRepos?: string[],
-  ): Promise<{ sessions: string[]; repos: string[] }> {
+  ): Promise<{ sessions: string[]; repos: string[]; orgs: string[] }> {
     const useRepoScope =
       agentId !== undefined &&
       scopeRepos !== undefined &&
@@ -313,7 +350,17 @@ export class TaskService implements TaskServiceLike {
     ]
       .sort()
       .slice(0, 100);
-    return { sessions, repos };
+    // Derived from the same (already-capped) repos list — the "org" segment
+    // is whatever precedes the first `/` in each `org/repo` string. A repo
+    // string with no `/` has no org segment and is skipped.
+    const orgs = [
+      ...new Set(
+        repos
+          .filter((r) => r.includes("/"))
+          .map((r) => r.split("/", 1)[0] as string),
+      ),
+    ].sort();
+    return { sessions, repos, orgs };
   }
 
   async get(id: string): Promise<TaskWithBlockedBy | null> {

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -640,6 +640,70 @@ describe("TaskService.list() updatedSince/repo where clause", () => {
       | undefined;
     expect(where?.hitl).toBeUndefined();
   });
+
+  it("list({ repo: ['org/a', 'org/b'] }) sets where.repo = { in: [...] } matching both", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({ repo: ["org/a", "org/b"] });
+
+    const where = prisma._findManyCalls[0].where as
+      | { repo?: { in: string[] } }
+      | undefined;
+    expect(where?.repo).toEqual({ in: ["org/a", "org/b"] });
+  });
+
+  it("list({ org: 'app-vitals' }) sets where.repo = { startsWith: 'app-vitals/' } via an OR clause", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({ org: "app-vitals" });
+
+    const where = prisma._findManyCalls[0].where as
+      | { OR?: Array<{ repo: { startsWith: string } }> }
+      | undefined;
+    expect(where?.OR).toEqual([{ repo: { startsWith: "app-vitals/" } }]);
+  });
+
+  it("list({ org: ['app-vitals', 'acme'] }) sets where.repo OR startsWith clauses for both orgs", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({ org: ["app-vitals", "acme"] });
+
+    const where = prisma._findManyCalls[0].where as
+      | { OR?: Array<{ repo: { startsWith: string } }> }
+      | undefined;
+    expect(where?.OR).toEqual([
+      { repo: { startsWith: "app-vitals/" } },
+      { repo: { startsWith: "acme/" } },
+    ]);
+  });
+
+  it("list({ agentScope, org }) combines agentScope's OR and org's OR under AND instead of clobbering either", async () => {
+    const prisma = makeListPrismaDouble();
+    const service = new TaskService(prisma);
+
+    await service.list({
+      agentScope: { agentId: "agent-1", repos: ["acme/repo"] },
+      org: "app-vitals",
+    });
+
+    const where = prisma._findManyCalls[0].where as
+      | {
+          OR?: unknown;
+          AND?: Array<{ OR: unknown }>;
+        }
+      | undefined;
+    // agentScope's OR must not be silently dropped by the org filter's OR.
+    expect(where?.OR).toBeUndefined();
+    expect(where?.AND).toEqual([
+      {
+        OR: [{ assignee: "agent-1" }, { repo: { in: ["acme/repo"] } }],
+      },
+      { OR: [{ repo: { startsWith: "app-vitals/" } }] },
+    ]);
+  });
 });
 
 // ─── TaskService.list() blockedBy dependency lookup scoping ────────────────
@@ -802,5 +866,50 @@ describe("TaskService.list() blockedBy dependency lookup scoping", () => {
 
     const depCalls = prisma._findManyCalls.filter((call) => call.where?.id);
     expect(depCalls).toHaveLength(0);
+  });
+});
+
+// ─── TaskService.distinct() orgs derivation ────────────────────────────────
+
+describe("TaskService.distinct() orgs field (unit)", () => {
+  function makeDistinctPrismaDouble(
+    rows: Array<{ session: string | null; repo: string | null }>,
+  ) {
+    const prisma = {
+      task: {
+        findMany() {
+          return Promise.resolve(rows);
+        },
+      },
+    };
+    return prisma as unknown as PrismaClient;
+  }
+
+  it("derives orgs from the first segment of each distinct repo, deduped and sorted", async () => {
+    const prisma = makeDistinctPrismaDouble([
+      { session: "s1", repo: "app-vitals/shipwright" },
+      { session: "s2", repo: "app-vitals/other-repo" },
+      { session: "s3", repo: "acme-inc/backend-api" },
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.distinct();
+
+    expect(result.repos).toEqual([
+      "acme-inc/backend-api",
+      "app-vitals/other-repo",
+      "app-vitals/shipwright",
+    ]);
+    expect(result.orgs).toEqual(["acme-inc", "app-vitals"]);
+  });
+
+  it("returns an empty orgs array when there are no repos", async () => {
+    const prisma = makeDistinctPrismaDouble([{ session: "s1", repo: null }]);
+    const service = new TaskService(prisma);
+
+    const result = await service.distinct();
+
+    expect(result.repos).toEqual([]);
+    expect(result.orgs).toEqual([]);
   });
 });

--- a/task-store/src/tasks.execution-fields.smoke.test.ts
+++ b/task-store/src/tasks.execution-fields.smoke.test.ts
@@ -112,7 +112,9 @@ function withBlockedBy(task: Task) {
   return { ...task, blockedBy: [] };
 }
 
-function fakeTaskService(storedTasks: Map<string, Task> = new Map()): TaskServiceLike {
+function fakeTaskService(
+  storedTasks: Map<string, Task> = new Map(),
+): TaskServiceLike {
   return {
     async list() {
       return { tasks: [], total: 0, limit: 50, offset: 0 };
@@ -146,7 +148,11 @@ function fakeTaskService(storedTasks: Map<string, Task> = new Map()): TaskServic
     async claim(id: string, claimedBy: string) {
       const existing = storedTasks.get(id);
       if (!existing) throw new Error("Task not found");
-      const updated = { ...existing, status: "in_progress" as const, claimedBy };
+      const updated = {
+        ...existing,
+        status: "in_progress" as const,
+        claimedBy,
+      };
       storedTasks.set(id, updated);
       return updated;
     },
@@ -198,8 +204,12 @@ function fakeTaskService(storedTasks: Map<string, Task> = new Map()): TaskServic
     async bulk(_tasks) {
       return { inserted: 0, updated: 0, skipped: [] };
     },
-    async distinct(): Promise<{ sessions: string[]; repos: string[] }> {
-      return Promise.resolve({ sessions: [], repos: [] });
+    async distinct(): Promise<{
+      sessions: string[];
+      repos: string[];
+      orgs: string[];
+    }> {
+      return Promise.resolve({ sessions: [], repos: [], orgs: [] });
     },
   };
 }

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -1013,6 +1013,62 @@ describeOrSkip("Task store schema (integration)", () => {
     ]);
   });
 
+  // ─── TaskService.list() multi-repo + org filters ───────────────────────────
+
+  it("list({ repo: [...], org }) returns only rows intersecting both the repo list and the org", async () => {
+    const taskService = new TaskService(prisma);
+
+    // Matches: in the repo list AND in the org.
+    const matchA = await prisma.task.create({
+      data: {
+        title: "app-vitals/shipwright, in repo list",
+        status: "pending",
+        repo: "app-vitals/shipwright",
+      },
+    });
+    // Matches: in the repo list AND in the org (different repo, same org).
+    const matchB = await prisma.task.create({
+      data: {
+        title: "app-vitals/second-repo, in repo list",
+        status: "pending",
+        repo: "app-vitals/second-repo",
+      },
+    });
+    // In the repo list, but NOT in the org — excluded by the org filter.
+    await prisma.task.create({
+      data: {
+        title: "acme-inc/backend-api, in repo list but wrong org",
+        status: "pending",
+        repo: "acme-inc/backend-api",
+      },
+    });
+    // In the org, but NOT in the repo list — excluded by the repo filter.
+    await prisma.task.create({
+      data: {
+        title: "app-vitals/other-repo, in org but not in repo list",
+        status: "pending",
+        repo: "app-vitals/other-repo",
+      },
+    });
+    // Neither in the repo list nor the org.
+    await prisma.task.create({
+      data: {
+        title: "unrelated-org/unrelated-repo",
+        status: "pending",
+        repo: "unrelated-org/unrelated-repo",
+      },
+    });
+
+    const result = await taskService.list({
+      repo: ["app-vitals/shipwright", "app-vitals/second-repo"],
+      org: "app-vitals",
+    });
+
+    const ids = result.tasks.map((t) => t.id).sort();
+    expect(ids).toEqual([matchA.id, matchB.id].sort());
+    expect(result.total).toBe(2);
+  });
+
   it("resolves a same-page dependency between two tasks on the same page", async () => {
     const taskService = new TaskService(prisma);
 

--- a/task-store/src/tokens.smoke.test.ts
+++ b/task-store/src/tokens.smoke.test.ts
@@ -151,7 +151,7 @@ function fakeTaskService(): TaskServiceLike {
       return [];
     },
     async distinct() {
-      return { sessions: [], repos: [] };
+      return { sessions: [], repos: [], orgs: [] };
     },
     async get() {
       return null;

--- a/task-store/src/validate.smoke.test.ts
+++ b/task-store/src/validate.smoke.test.ts
@@ -184,8 +184,8 @@ function fakeTaskService(
     },
     async distinct(
       _agentId?: string,
-    ): Promise<{ sessions: string[]; repos: string[] }> {
-      return Promise.resolve({ sessions: [], repos: [] });
+    ): Promise<{ sessions: string[]; repos: string[]; orgs: string[] }> {
+      return Promise.resolve({ sessions: [], repos: [], orgs: [] });
     },
   };
 }


### PR DESCRIPTION
## Summary
- Generalize `TaskService.list()`'s `repo` filter from a single exact-match string to `string | string[]`, keeping the original exact-match shape for the single-string case (back-compat), and add a new `org: string | string[]` filter using the `buildRepoOrgWhere` helper from ORF-1.1.
- Extend `TaskService.distinct()` to return a new `orgs: string[]` field, derived by splitting each distinct repo string on `/`, deduping, and sorting.
- Add a unit test covering an edge case introduced by the org/agentScope interaction: when both `agentScope` and `org` produce an `OR` clause, they're merged under `where.AND` instead of one silently clobbering the other.
- **Docs note**: this task only extends `TaskService.list()`/`distinct()` at the internal layer — the public `GET /tasks` HTTP route is unchanged and does not yet parse an `?org=` query param or accept `?repo=` as a list. `docs/task-store.md` and `docs/migration.md` are updated to reflect this scope precisely (the `GET /tasks/distinct` endpoint's new `orgs` field IS live over HTTP, since that route passes the service result straight through).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Existing single-value repo exact-match unchanged, still covered | MET | `where.repo = filters.repo` preserved for string input; original test at task-service.unit.test.ts:585 still passes |
| 2 | New unit test: `list({ repo: ['org/a','org/b'] })` → `where.repo.in` matching both | MET | task-service.unit.test.ts |
| 3 | New unit test: `list({ org: 'app-vitals' })` → `where.repo.startsWith('app-vitals/')` | MET | task-service.unit.test.ts |
| 4 | New integration test seeding multi-repo/org rows, filtering repo-list + org intersecting | MET | tasks.integration.test.ts |
| 5 | New unit test: `distinct()` includes deduped/sorted `orgs` field | MET | task-service.unit.test.ts |
| 6 | Test decision: additive, no existing tests retired | MET | Only additions; 40/40 pre-existing unit tests pass |

## Test Plan
- `bun test task-store/src/task-service.unit.test.ts` — 40/40 pass
- Full monorepo `task ci`: 5520 pass / 1 pre-existing unrelated flake (`agent/src/claude.unit.test.ts` `extraAllowedTools` — untouched by this diff, documented sandbox flake) / 381 skip
- Coverage gate: 81.14% lines / 81.97% functions (threshold 80/80) — passed
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
