### PR TITLE
feat: wire GET /prs route for repeated repo/org params

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -249,11 +249,11 @@ The `/prs` surface tracks GitHub PRs through the review → patch → deploy pip
 GET /prs
 ```
 
-Query params: `repo`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`, `ready`, `blocked`, `sort`, `updatedSince`.
+Query params: `repo`, `org`, `prNumber`, `taskId`, `state`, `reviewState`, `staged`, `limit`, `offset`, `ready`, `blocked`, `sort`, `updatedSince`.
 
-`repo=org/repo` (single string) — exact-match on a single repository. This is currently the only repo-scoping the `/prs` HTTP endpoint supports.
+`repo` — repeatable query param (`?repo=a&repo=b`). Matches PRs whose `repo` field equals any of the provided repos (string exact-match, OR logic). Omit to search across all repos in scope.
 
-**Note:** `PullRequestService.list()` (the service layer backing this route) also accepts a `repo` array and an `org` filter — `repo: string[]` matches any of the listed repos, and `org` matches any repo under that org prefix (`repo: { startsWith: "<org>/" }`), combined via **AND/intersection** when both are supplied (see `buildRepoOrgWhere` in `task-store/src/lib/repo-org-filter.ts`). These are not yet wired up as HTTP query params on `/prs` — `PrListQuerySchema` and the route handler still only read a single scalar `repo` string.
+`org` — repeatable query param (`?org=x&org=y`). Matches PRs whose `repo` field starts with any of the provided org prefixes (`repo.startsWith("<org>/")`), OR logic. Omit to search across all repos in scope. When both `repo` and `org` are supplied, they compose via AND — only PRs matching the repo set AND at least one org prefix are returned (see `buildRepoOrgWhere` in `task-store/src/lib/repo-org-filter.ts`).
 
 `ready=true` returns only unclaimed PRs (`claimedBy IS NULL`) — mirrors `/tasks?ready=true`'s semantics for tasks. It composes with the other filters (e.g. `?ready=true&repo=org/repo`) rather than hardcoding `claim-next`'s `state=open AND reviewState IN (pending, posted, approved)` eligibility rules; claim staleness itself is handled entirely by the `StaleClaimReaper` background job, not by this filter.
 

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -545,7 +545,22 @@ export const PrIdParamSchema = z
 
 export const PrListQuerySchema = z
   .object({
-    repo: z.string().optional().openapi({ example: "org/repo" }),
+    repo: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .openapi({
+        example: "org/repo",
+        description:
+          "Filter by repo. Repeatable (?repo=a&repo=b) to match any of several repos.",
+      }),
+    org: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .openapi({
+        example: "org",
+        description:
+          "Filter by org — matches repos whose 'org/repo' starts with '<org>/'. Repeatable (?org=a&org=b) to match any of several orgs. Composable with repo (AND).",
+      }),
     prNumber: z
       .string()
       .optional()

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -174,7 +174,21 @@ function fakePrService(
       if (filters?.taskId) prs = prs.filter((p) => p.taskId === filters.taskId);
       if (filters?.reviewState)
         prs = prs.filter((p) => p.reviewState === filters.reviewState);
-      if (filters?.repo) prs = prs.filter((p) => p.repo === filters.repo);
+      // Mirrors pull-request-service.ts's list()/buildRepoOrgWhere semantics:
+      // repo array is OR-membership, org array is OR-prefix-match, and repo +
+      // org together combine via AND.
+      if (filters?.repo !== undefined) {
+        const repos = Array.isArray(filters.repo)
+          ? filters.repo
+          : [filters.repo];
+        prs = prs.filter((p) => repos.includes(p.repo));
+      }
+      if (filters?.org !== undefined) {
+        const orgs = Array.isArray(filters.org) ? filters.org : [filters.org];
+        prs = prs.filter((p) =>
+          orgs.some((org) => p.repo.startsWith(`${org}/`)),
+        );
+      }
       if (filters?.staged !== undefined)
         prs = prs.filter((p) => p.staged === filters.staged);
       return {
@@ -733,6 +747,91 @@ describe("/prs routes (smoke)", () => {
     const body = (await res.json()) as PullRequestListResult;
     expect(body.prs).toHaveLength(1);
     expect(body.prs[0].taskId).toBe("task-42");
+  });
+
+  it("GET /prs?repo=... (single) returns records matching that repo only", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", repo: "org-a/a" }));
+    store.set("pr-2", makePr({ id: "pr-2", repo: "org-a/b" }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs?repo=org-a%2Fa", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs).toHaveLength(1);
+    expect(body.prs[0].repo).toBe("org-a/a");
+  });
+
+  it("GET /prs?repo=org/a&repo=org/b returns PRs matching either repo", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", repo: "org/a" }));
+    store.set("pr-2", makePr({ id: "pr-2", repo: "org/b" }));
+    store.set("pr-3", makePr({ id: "pr-3", repo: "org/c" }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs?repo=org%2Fa&repo=org%2Fb", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs.map((p) => p.repo).sort()).toEqual(["org/a", "org/b"]);
+  });
+
+  it("GET /prs?org=app-vitals returns PRs whose repo starts with app-vitals/", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", repo: "app-vitals/shipwright" }));
+    store.set("pr-2", makePr({ id: "pr-2", repo: "app-vitals/metrics" }));
+    store.set("pr-3", makePr({ id: "pr-3", repo: "acme-inc/backend-api" }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs?org=app-vitals", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs.map((p) => p.repo).sort()).toEqual([
+      "app-vitals/metrics",
+      "app-vitals/shipwright",
+    ]);
+  });
+
+  it("GET /prs?org=org-a&org=org-b returns PRs matching either org prefix", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1", repo: "org-a/x" }));
+    store.set("pr-2", makePr({ id: "pr-2", repo: "org-b/y" }));
+    store.set("pr-3", makePr({ id: "pr-3", repo: "org-c/z" }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs?org=org-a&org=org-b", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequestListResult;
+    expect(body.prs.map((p) => p.repo).sort()).toEqual(["org-a/x", "org-b/y"]);
+  });
+
+  it("GET /prs without repo/org leaves both filters undefined (not empty arrays)", async () => {
+    let capturedFilters: PullRequestListFilters | undefined;
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const baseFake = fakePrService({ store });
+    const prServiceWithCapture: PullRequestServiceLike = {
+      ...baseFake,
+      async list(
+        filters?: PullRequestListFilters,
+      ): Promise<PullRequestListResult> {
+        capturedFilters = filters;
+        return baseFake.list(filters);
+      },
+    };
+    const app = makeApp({ prService: prServiceWithCapture });
+
+    const res = await app.request("/prs", { headers: adminAuth() });
+    expect(res.status).toBe(200);
+    expect(capturedFilters?.repo).toBeUndefined();
+    expect(capturedFilters?.org).toBeUndefined();
   });
 
   it("GET /prs?reviewState=posted returns filtered set", async () => {

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -10,7 +10,8 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /prs               list (?repo, ?prNumber, ?taskId, ?state, ?reviewState, ?staged, ?ready, ?blocked, ?sort)
+ *   GET    /prs               list (?repo, ?org, ?prNumber, ?taskId, ?state, ?reviewState, ?staged, ?ready, ?blocked, ?sort)
+ *                              — ?repo and ?org accept repeated query params (e.g. ?repo=a&repo=b)
  *   POST   /prs/claim         atomic claim (201 new, 200 update, 409 conflict)
  *   POST   /prs/claim-next    atomic find-and-claim oldest eligible PR (200+{pr,phase} or 204)
  *   GET    /prs/:id           fetch one (404 when missing)
@@ -26,6 +27,7 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, NotFoundError } from "../errors.ts";
+import type { PullRequest } from "../index.ts";
 import {
   ClaimNextBodySchema,
   ClaimNextResponseSchema,
@@ -38,7 +40,6 @@ import {
   PullRequestSchema,
   UpdatePrBodySchema,
 } from "../openapi-schemas.ts";
-import type { PullRequest } from "../index.ts";
 import type { PullRequestServiceLike } from "../pull-request-service.ts";
 import { isOrgRepo } from "../validate.ts";
 
@@ -336,7 +337,8 @@ export function createPrsRoutes(
     const sort = c.req.query("sort") === "desc" ? "desc" : undefined;
 
     const result = await prService.list({
-      repo: c.req.query("repo"),
+      repo: c.req.queries("repo"),
+      org: c.req.queries("org"),
       prNumber:
         prNumberRaw !== undefined
           ? Number.parseInt(prNumberRaw, 10)


### PR DESCRIPTION
## Summary
- `GET /prs` now reads `repo` and `org` as repeated query params (`c.req.queries()`) and forwards them as arrays into `pullRequestService.list()` (landed in ORF-1.3), enabling OR-across-repos and OR-across-org-prefix filtering, composable via AND when both are supplied.
- Updated `PrListQuerySchema` in the OpenAPI schema to document `repo`/`org` as repeatable params.
- Single-value `?repo=x` requests keep working identically — no behavior change for existing callers.
- Refreshed `docs/task-store.md` to document the new repeatable `repo`/`org` params and their OR/AND semantics.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Smoke test: GET /prs?repo=org/a&repo=org/b returns PRs matching either repo | MET |
| 2 | Smoke test: GET /prs?org=app-vitals returns PRs whose repo starts with app-vitals/ | MET |
| 3 | Existing single-repo GET /prs?repo=... smoke test cases still pass unmodified | MET |
| 4 | Test decision: extends the prs route's openapi smoke test file with the new multi-value and org cases; no existing smoke tests are retired | MET |

## Test Plan
- Extended `task-store/src/prs.smoke.test.ts`'s in-memory `fakePrService.list()` to perform real repo-array (OR-membership) and org-array (OR-prefix-match) filtering, mirroring `pull-request-service.ts`/`buildRepoOrgWhere` semantics.
- Added 5 new smoke tests: single-repo unchanged, multi-repo OR, org prefix match, multi-org OR, absent-params-stay-undefined.
- All 57 tests in `task-store/src/prs.smoke.test.ts` pass; full `task-store/` suite passes.
- `bun run typecheck` (task-store) passes; `bunx biome lint` clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
