### PR TITLE
feat: accept and return sessionId on the admin cron-runs API

### DIFF
--- a/admin/openapi.json
+++ b/admin/openapi.json
@@ -903,6 +903,14 @@
             ],
             "example": 10
           },
+          "sessionId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Agent session id this run was executed under. Null for runs with no recorded session.",
+            "example": "session-abc-123"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -932,6 +940,7 @@
           "outputTokens",
           "cacheReadTokens",
           "cacheCreationTokens",
+          "sessionId",
           "createdAt"
         ]
       },
@@ -1119,6 +1128,14 @@
               "null"
             ],
             "example": 10
+          },
+          "sessionId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Agent session id this run was executed under.",
+            "example": "session-abc-123"
           },
           "modelBreakdown": {
             "type": "array",

--- a/admin/src/agent-cron-runs.integration.test.ts
+++ b/admin/src/agent-cron-runs.integration.test.ts
@@ -465,6 +465,61 @@ describeOrSkip("AgentCronRunService (integration)", () => {
     ).rejects.toBeInstanceOf(NotFoundError);
   });
 
+  it("patch() round-trips a sessionId field", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run = await runService.create(cronId, agentId, {
+      startedAt: new Date(),
+      skipped: false,
+    });
+    expect(run.sessionId).toBeNull();
+
+    const updated = await runService.patch(run.id, agentId, cronId, {
+      sessionId: "session-abc-123",
+    });
+
+    expect(updated.sessionId).toBe("session-abc-123");
+  });
+
+  it("patch() clears sessionId when explicitly set to null", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run = await runService.create(cronId, agentId, {
+      startedAt: new Date(),
+      skipped: false,
+    });
+
+    await runService.patch(run.id, agentId, cronId, {
+      sessionId: "session-to-be-cleared",
+    });
+    const cleared = await runService.patch(run.id, agentId, cronId, {
+      sessionId: null,
+    });
+
+    expect(cleared.sessionId).toBeNull();
+  });
+
+  it("patch() leaves sessionId untouched when omitted from the input", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    const run = await runService.create(cronId, agentId, {
+      startedAt: new Date(),
+      skipped: false,
+    });
+
+    await runService.patch(run.id, agentId, cronId, {
+      sessionId: "session-should-persist",
+    });
+    const updated = await runService.patch(run.id, agentId, cronId, {
+      outcome: "success",
+    });
+
+    expect(updated.sessionId).toBe("session-should-persist");
+  });
+
   // ─── listWithRunSummary ─────────────────────────────────────────────────────
 
   it("listWithRunSummary() returns lastRun null when no runs exist", async () => {

--- a/admin/src/agent-cron-runs.ts
+++ b/admin/src/agent-cron-runs.ts
@@ -67,6 +67,8 @@ export interface PatchAgentCronRunInput {
   outputTokens?: number | null;
   cacheReadTokens?: number | null;
   cacheCreationTokens?: number | null;
+  /** Agent session id this run was executed under. Null clears it. */
+  sessionId?: string | null;
   modelBreakdown?: ModelBreakdownEntry[];
 }
 
@@ -180,6 +182,7 @@ export class AgentCronRunService {
       ...(input.error !== undefined && { error: input.error }),
       ...(input.skipped !== undefined && { skipped: input.skipped }),
       ...(input.skipReason !== undefined && { skipReason: input.skipReason }),
+      ...(input.sessionId !== undefined && { sessionId: input.sessionId }),
     };
 
     if (input.modelBreakdown && input.modelBreakdown.length > 0) {

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -3233,6 +3233,34 @@ describe("admin API — cron runs", () => {
     expect(res.status).toBe(400);
   });
 
+  it("PATCH then GET /agents/:id/crons/:cronId/runs/:runId round trips sessionId", async () => {
+    const deps = makeMockDepsWithStatefulRunService();
+    const app = createAdminApp(deps);
+
+    const patchRes = await app.request(
+      `/agents/${AGENT_ID}/crons/${CRON_ID}/runs/${RUN_ID}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ sessionId: "session-abc-123" }),
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `admin_session=${cookie}`,
+        },
+      },
+    );
+    expect(patchRes.status).toBe(200);
+    const patchBody = await patchRes.json();
+    expect(patchBody.run.sessionId).toBe("session-abc-123");
+
+    const listRes = await app.request(
+      `/agents/${AGENT_ID}/crons/${CRON_ID}/runs`,
+      { headers: { Cookie: `admin_session=${cookie}` } },
+    );
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.items[0].sessionId).toBe("session-abc-123");
+  });
+
   it("GET /agents/:id/crons/summary response includes lastRun and runCountToday", async () => {
     const deps = makeMockDepsWithRunSummary();
     const app = createAdminApp(deps);
@@ -3409,6 +3437,59 @@ function makeMockDepsWithRunService(opts?: {
                 },
               ],
             }),
+    },
+  };
+}
+
+/**
+ * Like makeMockDepsWithRunService, but patch()/list() share a mutable
+ * in-memory run record so a PATCH followed by a GET reflects the write —
+ * used to exercise round-trip behavior (e.g. sessionId persistence) that a
+ * fixed-return mock can't verify.
+ */
+function makeMockDepsWithStatefulRunService(): AdminDeps {
+  const state: { run: Record<string, unknown> } = {
+    run: {
+      id: RUN_ID,
+      cronId: CRON_ID,
+      agentId: AGENT_ID,
+      startedAt: new Date("2026-01-01T08:00:00.000Z"),
+      completedAt: null,
+      skipped: false,
+      skipReason: null,
+      outcome: "success",
+      error: null,
+      itemType: null,
+      itemId: null,
+      sessionId: null,
+      phaseId: null,
+      createdAt: new Date("2026-01-01T08:00:00.000Z"),
+      modelBreakdown: [],
+    },
+  };
+
+  const base = makeMockDeps();
+  return {
+    ...base,
+    agentCronRunService: {
+      create: async () => state.run as never,
+      list: async () => ({
+        items: [state.run as never],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      }),
+      patch: async (
+        _runId: string,
+        _agentId: string,
+        _cronId: string,
+        input: { sessionId?: string | null },
+      ) => {
+        if (input.sessionId !== undefined) {
+          state.run = { ...state.run, sessionId: input.sessionId };
+        }
+        return state.run as never;
+      },
     },
   };
 }

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -1361,6 +1361,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       ...(body.cacheCreationTokens !== undefined && {
         cacheCreationTokens: body.cacheCreationTokens,
       }),
+      ...(body.sessionId !== undefined && { sessionId: body.sessionId }),
       ...(body.modelBreakdown !== undefined && {
         modelBreakdown: body.modelBreakdown,
       }),
@@ -1641,6 +1642,7 @@ function serializeCronRun(run: {
   phaseId: string | null;
   itemType: string | null;
   itemId: string | null;
+  sessionId: string | null;
   createdAt: Date;
   modelBreakdown?: ModelBreakdownEntry[];
 }): z.infer<typeof AgentCronRunSchema> {
@@ -1682,6 +1684,7 @@ function serializeCronRun(run: {
     phaseId: run.phaseId,
     itemType: run.itemType,
     itemId: run.itemId,
+    sessionId: run.sessionId,
     ...tokenTotals,
     createdAt: run.createdAt.toISOString(),
     ...(run.modelBreakdown !== undefined && {

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -309,6 +309,11 @@ export const AgentCronRunSchema = z
     outputTokens: z.number().int().nullable().openapi({ example: 567 }),
     cacheReadTokens: z.number().int().nullable().openapi({ example: 89 }),
     cacheCreationTokens: z.number().int().nullable().openapi({ example: 10 }),
+    sessionId: z.string().nullable().openapi({
+      example: "session-abc-123",
+      description:
+        "Agent session id this run was executed under. Null for runs with no recorded session.",
+    }),
     createdAt: z
       .string()
       .datetime()
@@ -412,6 +417,10 @@ export const PatchAgentCronRunBodySchema = z
       .nullable()
       .optional()
       .openapi({ example: 10 }),
+    sessionId: z.string().nullable().optional().openapi({
+      example: "session-abc-123",
+      description: "Agent session id this run was executed under.",
+    }),
     modelBreakdown: z
       .array(ModelBreakdownEntrySchema)
       .optional()

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -309,7 +309,7 @@ Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`,
 PATCH /agents/:id/crons/:cronId/runs/:runId
 ```
 
-Used to record completion data after a run finishes. Updatable fields: `completedAt`, `outcome`, `error`, `skipped`, `skipReason`, `modelBreakdown` (array of `{ model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd }` — upserted per `[cronRunId, model]`). The legacy top-level `inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`/`model` fields are still accepted for backward compatibility with older agent builds but are silently ignored (not persisted) — send `modelBreakdown` instead. Returns the updated run.
+Used to record completion data after a run finishes. Updatable fields: `completedAt`, `outcome`, `error`, `skipped`, `skipReason`, `sessionId`, `modelBreakdown` (array of `{ model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd }` — upserted per `[cronRunId, model]`). The legacy top-level `inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`/`model` fields are still accepted for backward compatibility with older agent builds but are silently ignored (not persisted) — send `modelBreakdown` instead. Returns the updated run.
 
 ### Cron run stats
 


### PR DESCRIPTION
## Summary
- Extended the admin cron-runs API to carry the `sessionId` column (added by CSI-3.1) through PATCH and GET
- `AgentCronRunSchema` and `PatchAgentCronRunBodySchema` in `openapi-schemas.ts` now include a nullable `sessionId` field
- `serializeCronRun()` maps `sessionId` through on every response; the PATCH handler forwards `body.sessionId` into `agentCronRunService.patch()`; `PatchAgentCronRunInput`/`patch()`'s `runData` in `agent-cron-runs.ts` include it

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `AgentCronRunSchema` and `PatchAgentCronRunBodySchema` include `sessionId` | MET |
| 2 | `serializeCronRun()` maps `sessionId` through on every response | MET |
| 3 | PATCH handler forwards `body.sessionId` into `agentCronRunService.patch()` | MET |
| 4 | `PatchAgentCronRunInput` and `patch()`'s `runData` include `sessionId` | MET |
| 5 | Test decision: smoke PATCH-then-GET round trip + integration `patch()` tests, no retirements | MET |

## Test Plan
- `admin/src/agent-cron-runs.integration.test.ts`: `patch()` round-trips a `sessionId`, clears it on explicit `null`, and leaves it untouched when omitted
- `admin/src/agents-api.smoke.test.ts`: PATCH-then-GET round trip asserting `sessionId` persists and serializes correctly
- `admin/openapi.json` regenerated to reflect the schema changes
- [x] `task lint` — clean
- [x] `task typecheck` — clean across all workspaces
- [x] `bun test admin/` — 1498 pass, 0 fail
- [x] Full-repo `bun test`: 5531 pass, 1 pre-existing unrelated failure (`agent/src/claude.unit.test.ts`, confirmed failing on `main` too)

Generated with [Claude Code](https://claude.com/claude-code)
