### PR TITLE
feat: render sessionId in the admin cron-logs table

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -202,6 +202,11 @@ export interface CronRunItem {
   itemType?: string | null;
   itemId?: string | null;
   /**
+   * The Claude session id for this cron run. Present when the run was
+   * dispatched with a session context; null/absent for runs with no session.
+   */
+  sessionId?: string | null;
+  /**
    * The owning cron's id/name/schedule — present on cross-cron listings (e.g.
    * renderCronLogsPage's per-agent table) so the Cron column can be rendered
    * without an N+1 lookup. Absent on single-cron listings.
@@ -3194,6 +3199,13 @@ export function renderCronLogsPage(opts: {
           }</span>`
         : "—";
 
+    // Session cell: render truncated sessionId (first 8 chars) with full id
+    // in a title= tooltip, em-dash when null/undefined/empty string. Follows
+    // the same monospace styling convention as other id cells.
+    const sessionCell = r.sessionId?.trim()
+      ? `<span class="mono" style="font-size:12px" title="${escapeHtml(r.sessionId)}">${escapeHtml(r.sessionId.substring(0, 8))}</span>`
+      : "—";
+
     // Detail cell: mirrors badgeTitle's priority above — skipReason wins whenever
     // the run is skipped (even if error is also set), then falls back to error,
     // else renders an em-dash. Multi-line/long error text is truncated for
@@ -3220,13 +3232,14 @@ export function renderCronLogsPage(opts: {
       <td class="col-model" style="font-size:12px">${modelCell}</td>
       <td style="font-size:12px">${phaseCell}</td>
       <td style="font-size:12px">${itemCell}</td>
+      <td style="font-size:12px">${sessionCell}</td>
       <td style="font-size:12px;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${detailCell}</td>
     </tr>`;
   }
 
   const bodyRows =
     runs.length === 0
-      ? `<tr><td colspan="9" class="empty-state">No runs match the selected filters.</td></tr>`
+      ? `<tr><td colspan="10" class="empty-state">No runs match the selected filters.</td></tr>`
       : runs.map(row).join("\n");
 
   // Filter form
@@ -3323,6 +3336,7 @@ export function renderCronLogsPage(opts: {
               <th class="col-model">Model</th>
               <th>Phase</th>
               <th>Item</th>
+              <th>Session</th>
               <th>Detail</th>
             </tr>
           </thead>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -4052,6 +4052,7 @@ describe("renderCronLogsPage", () => {
     expect(html).toContain("Model");
     expect(html).toContain("<th>Phase</th>");
     expect(html).toContain("<th>Item</th>");
+    expect(html).toContain("<th>Session</th>");
     expect(html).toContain("<th>Detail</th>");
     // Cost is shown inline within the Model column's badges, not as its own column.
     expect(html).not.toContain("<th>Cost</th>");
@@ -4297,7 +4298,9 @@ describe("renderCronLogsPage", () => {
       }),
     ]);
     // The outcome badge (first title attribute in the row) should show skipReason.
-    const badgeMatch = html.match(/<span class="badge"[^>]*title="([^"]*)"[^>]*>([^<]*)<\/span>/);
+    const badgeMatch = html.match(
+      /<span class="badge"[^>]*title="([^"]*)"[^>]*>([^<]*)<\/span>/,
+    );
     expect(badgeMatch).not.toBeNull();
     expect(badgeMatch?.[1]).toBe("Rate limit exceeded");
   });
@@ -4451,9 +4454,73 @@ describe("renderCronLogsPage", () => {
     expect(html).toContain(`<span title="${longError}">${longError}</span>`);
   });
 
-  test("empty-state colspan updates from 8 to 9 for the new Detail column", () => {
+  test("empty-state colspan updates from 9 to 10 for the new Session column", () => {
     const html = render([]);
-    expect(html).toContain('colspan="9"');
+    expect(html).toContain('colspan="10"');
+  });
+
+  // ─── Session column ────────────────────────────────────────────────────────────
+
+  test("renders the Session column header", () => {
+    const html = render([makeRun()]);
+    expect(html).toContain("<th>Session</th>");
+  });
+
+  test("renders a truncated sessionId (first 8 chars) with the full id in a title= tooltip", () => {
+    const html = render([makeRun({ sessionId: "session-123456789abcdef" })]);
+    // Should render first 8 chars: "session-"
+    expect(html).toContain('title="session-123456789abcdef"');
+    // Must have a monospace cell with truncated value
+    expect(html).toMatch(
+      /<span[^>]*class="[^"]*mono[^"]*"[^>]*title="session-123456789abcdef"[^>]*>session-<\/span>/,
+    );
+  });
+
+  test("renders an em-dash when sessionId is null", () => {
+    const html = render([makeRun({ sessionId: null })]);
+    // Extract the session cell from the tbody
+    const bodyRowMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/);
+    expect(bodyRowMatch).not.toBeNull();
+    // Check that the row contains an em-dash (should have 9 columns as per the new table)
+    expect(bodyRowMatch?.[1]).toContain("—");
+  });
+
+  test("renders an em-dash when sessionId is undefined", () => {
+    const html = render([makeRun({ sessionId: undefined })]);
+    // Extract the session cell from the tbody
+    const bodyRowMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/);
+    expect(bodyRowMatch).not.toBeNull();
+    // Check that the row contains an em-dash
+    expect(bodyRowMatch?.[1]).toContain("—");
+  });
+
+  test("renders an em-dash when sessionId is an empty string", () => {
+    const html = render([makeRun({ sessionId: "" })]);
+    // Extract the session cell from the tbody
+    const bodyRowMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/);
+    expect(bodyRowMatch).not.toBeNull();
+    // Check that the row contains an em-dash
+    expect(bodyRowMatch?.[1]).toContain("—");
+  });
+
+  test("table has a Session column header in the table header row", () => {
+    const html = render([makeRun()]);
+    // Extract the table header row
+    const theadMatch = html.match(/<thead>([\s\S]*?)<\/thead>/);
+    expect(theadMatch).not.toBeNull();
+    // Count <th> elements within the thead
+    const headers = theadMatch?.[1].match(/<th[^>]*>/g);
+    expect(headers?.length).toBe(10);
+  });
+
+  test("escapes XSS in sessionId within the title attribute", () => {
+    const html = render([
+      makeRun({
+        sessionId: '"><script>alert(99)</script>',
+      }),
+    ]);
+    expect(html).not.toContain("<script>alert(99)</script>");
+    expect(html).toContain("&lt;script&gt;");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `sessionId?: string | null` to the `CronRunItem` interface in `admin/src/admin-ui-pages.ts`
- Render a truncated (first 8 chars), monospace session id in the per-agent cron-logs table, with the full id in a `title=` tooltip — em-dash when null/undefined/empty, matching the existing started-at cell convention
- No changes required in `admin-ui.ts` — `sessionId` flows through automatically once the interface and row renderer are updated

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | CronRunItem interface gains sessionId?: string \| null | MET |
| 2 | row() renders truncated monospace session id with title= tooltip, em-dash when null | MET |
| 3 | No changes required in admin-ui.ts | MET |
| 4 | Extend existing test to cover run with/without sessionId | MET |

## Test Plan
- Extended `admin/src/admin-ui-pages.unit.test.ts` with new cases: Session column header, truncated value + tooltip, em-dash for null/undefined/empty sessionId, column count, XSS escaping in the title attribute
- `bun test src/admin-ui-pages.unit.test.ts` — 540 pass, 0 fail
- `task lint` / `task typecheck` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
