### PR TITLE
feat: add org and repo multiselect filters to admin Task Store page

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1641,6 +1641,62 @@ function statusBadgeClass(s: string): string {
   return "badge-gray";
 }
 
+/**
+ * Normalize a filter value that may be a single string (legacy/bookmarked
+ * URL, e.g. `?repo=org/repo`) or an array of strings (repeated query params,
+ * e.g. `?repo=a&repo=b`) into an array. Absent values normalize to `[]`.
+ */
+function toFilterArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Shared org/repo multiselect filter fields, used by the Tasks page filter
+ * form (and, eventually, the PRs page — ORF-2.2). Renders two native
+ * `<select multiple>` elements — Org and Repo — populated from
+ * `suggestions.orgs` / `suggestions.repos`, with `<option selected>` for any
+ * value present in the currently-active filters. A native multiselect
+ * submits repeated query params on GET with no client JS required.
+ *
+ * Any active filter value not present in the suggestions list is still
+ * rendered as a selected option, so a value from a stale/edited-by-hand URL
+ * isn't silently dropped from the visible selection.
+ */
+export function renderRepoOrgFilterFields(
+  filters: { org?: string | string[]; repo?: string | string[] },
+  suggestions?: { orgs?: string[]; repos?: string[] },
+): string {
+  const activeOrgs = new Set(toFilterArray(filters.org));
+  const activeRepos = new Set(toFilterArray(filters.repo));
+
+  const orgOptionValues = new Set([
+    ...(suggestions?.orgs ?? []),
+    ...activeOrgs,
+  ]);
+  const repoOptionValues = new Set([
+    ...(suggestions?.repos ?? []),
+    ...activeRepos,
+  ]);
+
+  const renderOptions = (values: Set<string>, active: Set<string>) =>
+    [...values]
+      .map((v) => {
+        const selected = active.has(v) ? " selected" : "";
+        return `<option value="${escapeHtml(v)}"${selected}>${escapeHtml(v)}</option>`;
+      })
+      .join("");
+
+  return `<div class="form-group" style="margin-bottom:0">
+          <label class="form-label" style="font-size:11px">Org</label>
+          <select name="org" multiple class="form-input" style="font-size:12px;padding:4px 8px">${renderOptions(orgOptionValues, activeOrgs)}</select>
+        </div>
+        <div class="form-group" style="margin-bottom:0">
+          <label class="form-label" style="font-size:11px">Repo</label>
+          <select name="repo" multiple class="form-input" style="font-size:12px;padding:4px 8px">${renderOptions(repoOptionValues, activeRepos)}</select>
+        </div>`;
+}
+
 // ─── Tasks page ──────────────────────────────────────────────────────────────
 
 export function renderTasksPage(
@@ -1649,7 +1705,8 @@ export function renderTasksPage(
     status?: string;
     state?: "ready" | "in_progress" | "blocked" | "closed";
     session?: string;
-    repo?: string;
+    repo?: string | string[];
+    org?: string | string[];
     source?: string;
     agent?: string;
     hitl?: "true" | "false";
@@ -1663,7 +1720,12 @@ export function renderTasksPage(
     page: 1,
   },
   opts?: { error?: string; agentFilterActive?: boolean },
-  suggestions?: { sessions?: string[]; repos?: string[]; agents?: string[] },
+  suggestions?: {
+    sessions?: string[];
+    repos?: string[];
+    orgs?: string[];
+    agents?: string[];
+  },
   readOnly = false,
   timezone = "America/Los_Angeles",
 ): string {
@@ -1705,7 +1767,8 @@ export function renderTasksPage(
     if (filters.status) params.set("status", filters.status);
     else if (filters.state) params.set("state", filters.state);
     if (filters.session) params.set("session", filters.session);
-    if (filters.repo) params.set("repo", filters.repo);
+    for (const r of toFilterArray(filters.repo)) params.append("repo", r);
+    for (const o of toFilterArray(filters.org)) params.append("org", o);
     if (filters.source) params.set("source", filters.source);
     if (filters.agent) params.set("agent", filters.agent);
     if (filters.hitl) params.set("hitl", filters.hitl);
@@ -1794,7 +1857,8 @@ export function renderTasksPage(
     const p = new URLSearchParams();
     p.set("state", newState);
     if (filters.session) p.set("session", filters.session);
-    if (filters.repo) p.set("repo", filters.repo);
+    for (const r of toFilterArray(filters.repo)) p.append("repo", r);
+    for (const o of toFilterArray(filters.org)) p.append("org", o);
     if (filters.source) p.set("source", filters.source);
     if (filters.agent) p.set("agent", filters.agent);
     if (filters.hitl) p.set("hitl", filters.hitl);
@@ -1908,10 +1972,10 @@ export function renderTasksPage(
           <label class="form-label" style="font-size:11px">Session</label>
           <input name="session" type="text" class="form-input" style="font-size:12px;padding:4px 8px" value="${escapeHtml(filters.session ?? "")}" placeholder="session-id"${suggestions?.sessions?.length ? ' list="sessions-list"' : ""} />
         </div>
-        <div class="form-group" style="margin-bottom:0">
-          <label class="form-label" style="font-size:11px">Repo</label>
-          <input name="repo" type="text" class="form-input" style="font-size:12px;padding:4px 8px" value="${escapeHtml(filters.repo ?? "")}" placeholder="org/repo"${suggestions?.repos?.length ? ' list="repos-list"' : ""} />
-        </div>
+        ${renderRepoOrgFilterFields(
+          { org: filters.org, repo: filters.repo },
+          { orgs: suggestions?.orgs, repos: suggestions?.repos },
+        )}
         <div class="form-group" style="margin-bottom:0">
           <label class="form-label" style="font-size:11px">Source</label>
           <input name="source" type="text" class="form-input" style="font-size:12px;padding:4px 8px" value="${escapeHtml(filters.source ?? "")}" placeholder="source" />
@@ -1923,7 +1987,6 @@ export function renderTasksPage(
         <button type="submit" class="btn btn-secondary" style="font-size:12px">Filter</button>
         <a href="/admin/tasks" class="btn btn-secondary" style="font-size:12px">Reset</a>
         ${suggestions?.sessions?.length ? `<datalist id="sessions-list">${suggestions.sessions.map((s) => `<option value="${escapeHtml(s)}">`).join("")}</datalist>` : ""}
-        ${suggestions?.repos?.length ? `<datalist id="repos-list">${suggestions.repos.map((r) => `<option value="${escapeHtml(r)}">`).join("")}</datalist>` : ""}
         ${suggestions?.agents?.length ? `<datalist id="agents-list">${suggestions.agents.map((a) => `<option value="${escapeHtml(a)}">`).join("")}</datalist>` : ""}
       </form>
     </div>`

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2098,22 +2098,6 @@ describe("renderTasksPage — datalist autocomplete", () => {
     expect(html).toContain('list="sessions-list"');
   });
 
-  test("renderTasksPage with repos suggestions renders repo datalist", () => {
-    const html = renderTasksPage(
-      [],
-      {},
-      false,
-      "user@test.com",
-      {},
-      pagination,
-      undefined,
-      { repos: ["org/repo-a", "org/repo-b"] },
-    );
-    expect(html).toContain('<datalist id="repos-list">');
-    expect(html).toContain('<option value="org/repo-a">');
-    expect(html).toContain('list="repos-list"');
-  });
-
   test("renderTasksPage with agents suggestions renders agent datalist", () => {
     const html = renderTasksPage(
       [],
@@ -2130,7 +2114,7 @@ describe("renderTasksPage — datalist autocomplete", () => {
     expect(html).toContain('list="agents-list"');
   });
 
-  test("renderTasksPage without suggestions renders plain text inputs (no datalists)", () => {
+  test("renderTasksPage without suggestions renders plain text session input (no datalist)", () => {
     const html = renderTasksPage(
       [],
       {},
@@ -2141,9 +2125,7 @@ describe("renderTasksPage — datalist autocomplete", () => {
       undefined,
       undefined,
     );
-    expect(html).not.toContain("<datalist");
     expect(html).not.toContain('list="sessions-list"');
-    expect(html).not.toContain('list="repos-list"');
     expect(html).not.toContain('list="agents-list"');
   });
 
@@ -2157,6 +2139,178 @@ describe("renderTasksPage — datalist autocomplete", () => {
       pagination,
       undefined,
       { sessions: ['<script>alert("xss")</script>'] },
+    );
+    expect(html).not.toContain('<script>alert("xss")</script>');
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+// ─── renderTasksPage — org/repo multiselect filters (ORF-2.1) ────────────────
+
+describe("renderTasksPage — org/repo multiselect filters", () => {
+  const pagination = { total: 0, limit: 50, page: 1 };
+
+  test("renders both an Org and a Repo select-multiple element", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals", "other-org"], repos: ["app-vitals/repo-a"] },
+    );
+    expect(html).toContain('<select name="org" multiple');
+    expect(html).toContain('<select name="repo" multiple');
+  });
+
+  test("populates Org options from suggestions.orgs", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals", "other-org"] },
+    );
+    expect(html).toContain('<option value="app-vitals">');
+    expect(html).toContain('<option value="other-org">');
+  });
+
+  test("populates Repo options from suggestions.repos", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { repos: ["app-vitals/repo-a", "app-vitals/repo-b"] },
+    );
+    expect(html).toContain('<option value="app-vitals/repo-a">');
+    expect(html).toContain('<option value="app-vitals/repo-b">');
+  });
+
+  test("marks currently-active repo filter values as selected (array)", () => {
+    const html = renderTasksPage(
+      [],
+      { repo: ["app-vitals/repo-a", "app-vitals/repo-b"] },
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      {
+        repos: ["app-vitals/repo-a", "app-vitals/repo-b", "app-vitals/repo-c"],
+      },
+    );
+    expect(html).toContain(
+      '<option value="app-vitals/repo-a" selected>app-vitals/repo-a</option>',
+    );
+    expect(html).toContain(
+      '<option value="app-vitals/repo-b" selected>app-vitals/repo-b</option>',
+    );
+    expect(html).toContain(
+      '<option value="app-vitals/repo-c">app-vitals/repo-c</option>',
+    );
+  });
+
+  test("marks currently-active org filter values as selected (array)", () => {
+    const html = renderTasksPage(
+      [],
+      { org: ["app-vitals"] },
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals", "other-org"] },
+    );
+    expect(html).toContain(
+      '<option value="app-vitals" selected>app-vitals</option>',
+    );
+    expect(html).toContain('<option value="other-org">other-org</option>');
+  });
+
+  test("backward compat: a single-value repo filter (string, not array) is still marked selected", () => {
+    const html = renderTasksPage(
+      [],
+      { repo: "app-vitals/repo-a" },
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { repos: ["app-vitals/repo-a", "app-vitals/repo-b"] },
+    );
+    expect(html).toContain(
+      '<option value="app-vitals/repo-a" selected>app-vitals/repo-a</option>',
+    );
+    expect(html).toContain(
+      '<option value="app-vitals/repo-b">app-vitals/repo-b</option>',
+    );
+  });
+
+  test("an active filter value not present in suggestions still renders as a selected option", () => {
+    const html = renderTasksPage(
+      [],
+      { repo: ["app-vitals/stale-repo"] },
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { repos: ["app-vitals/repo-a"] },
+    );
+    expect(html).toContain(
+      '<option value="app-vitals/stale-repo" selected>app-vitals/stale-repo</option>',
+    );
+  });
+
+  test("no repo/org filter active renders no selected options", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals"], repos: ["app-vitals/repo-a"] },
+    );
+    expect(html).not.toContain("selected>");
+  });
+
+  test("removes the legacy single-value repo <input>+<datalist> markup", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { repos: ["app-vitals/repo-a"] },
+    );
+    expect(html).not.toContain('name="repo" type="text"');
+    expect(html).not.toContain('<datalist id="repos-list">');
+    expect(html).not.toContain('list="repos-list"');
+  });
+
+  test("escapes org/repo suggestion and filter values to prevent XSS", () => {
+    const html = renderTasksPage(
+      [],
+      { org: ['<script>alert("xss")</script>'] },
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ['<script>alert("xss")</script>'] },
     );
     expect(html).not.toContain('<script>alert("xss")</script>');
     expect(html).toContain("&lt;script&gt;");
@@ -2495,6 +2649,87 @@ describe("renderTasksPage — source filter", () => {
     );
     expect(html).toContain(
       `href="/admin/tasks?state=in_progress&source=entropy-fix"`,
+    );
+  });
+
+  test("makePageUrl carries multi-value filters.repo as repeated repo= params into pagination links, not comma-joined", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { repo: ["app-vitals/repo-a", "app-vitals/repo-b"] },
+      false,
+      USER_NAME,
+      {},
+      { total: 100, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain(
+      'href="/admin/tasks?repo=app-vitals%2Frepo-a&repo=app-vitals%2Frepo-b&page=2"',
+    );
+    expect(html).not.toContain("app-vitals/repo-a,app-vitals/repo-b");
+  });
+
+  test("makePageUrl carries multi-value filters.org as repeated org= params into pagination links", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { org: ["app-vitals", "other-org"] },
+      false,
+      USER_NAME,
+      {},
+      { total: 100, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain(
+      'href="/admin/tasks?org=app-vitals&org=other-org&page=2"',
+    );
+  });
+
+  test("makeStateParams carries multi-value filters.repo as repeated repo= params into state-tab links", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { state: "ready", repo: ["app-vitals/repo-a", "app-vitals/repo-b"] },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain(
+      'href="/admin/tasks?state=in_progress&repo=app-vitals%2Frepo-a&repo=app-vitals%2Frepo-b"',
+    );
+  });
+
+  test("makeStateParams carries multi-value filters.org as repeated org= params into state-tab links", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { state: "ready", org: ["app-vitals", "other-org"] },
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain(
+      'href="/admin/tasks?state=in_progress&org=app-vitals&org=other-org"',
+    );
+  });
+
+  test("makePageUrl backward-compat: a single-value (string) filters.repo still round-trips as one repo= param", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      { repo: "app-vitals/repo-a" },
+      false,
+      USER_NAME,
+      {},
+      { total: 100, limit: 50, page: 1 },
+      undefined,
+      undefined,
+    );
+    expect(html).toContain(
+      'href="/admin/tasks?repo=app-vitals%2Frepo-a&page=2"',
     );
   });
 });

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -4003,6 +4003,84 @@ describe("admin UI — tasks page", () => {
     expect(capturedParams[0].get("source")).toBe("entropy-fix");
   });
 
+  it("GET /admin/tasks?repo=a&repo=b&org=app-vitals forwards repeated repo and org params to the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks?repo=a&repo=b&org=app-vitals", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].getAll("repo")).toEqual(["a", "b"]);
+    expect(capturedParams[0].getAll("org")).toEqual(["app-vitals"]);
+  });
+
+  it("GET /admin/tasks?repo=org/repo (single value) still forwards a single repo param (backward compat)", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks?repo=org%2Frepo", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].getAll("repo")).toEqual(["org/repo"]);
+  });
+
+  it("GET /admin/tasks with no repo/org params forwards neither to the task store", async () => {
+    const capturedParams: URLSearchParams[] = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async (params) => {
+          capturedParams.push(params);
+          return { tasks: [], total: 0, limit: 50, offset: 0 };
+        },
+      }),
+    );
+    await app.request("/admin/tasks", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0].has("repo")).toBe(false);
+    expect(capturedParams[0].has("org")).toBe(false);
+  });
+
+  it("GET /admin/tasks?repo=a&repo=b renders both selected repo options in the multiselect", async () => {
+    const app = createAdminUIApp(
+      makeMockDeps({
+        fetchTaskStoreTasks: async () => ({
+          tasks: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        }),
+        fetchDistinctTaskValues: async () => ({
+          sessions: [],
+          repos: ["a", "b", "c"],
+          orgs: [],
+        }),
+      }),
+    );
+    const res = await app.request("/admin/tasks?repo=a&repo=b", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    const html = await res.text();
+    expect(html).toContain('<option value="a" selected>a</option>');
+    expect(html).toContain('<option value="b" selected>b</option>');
+    expect(html).toContain('<option value="c">c</option>');
+  });
+
   it("GET /admin/tasks with no source param forwards no source to the task store", async () => {
     const capturedParams: URLSearchParams[] = [];
     const app = createAdminUIApp(
@@ -4194,6 +4272,7 @@ describe("admin UI — tasks page", () => {
         fetchDistinctTaskValues: async () => ({
           sessions: [],
           repos: [],
+          orgs: [],
         }),
       }),
     );

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -299,6 +299,7 @@ export interface AdminUIDeps {
   fetchDistinctTaskValues?: () => Promise<{
     sessions: string[];
     repos: string[];
+    orgs: string[];
   }>;
   /**
    * IANA timezone name for date/time display in the admin UI.
@@ -2085,7 +2086,12 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
           ? stateRaw
           : undefined;
     const session = c.req.query("session") ?? undefined;
-    const repo = c.req.query("repo") ?? undefined;
+    // c.req.query("repo") only returns the first value when the query string
+    // repeats the key (?repo=a&repo=b) — use queries() to get all values, so
+    // both a bookmarked single-value URL and a multiselect submission with
+    // several selections round-trip correctly.
+    const repo = c.req.queries("repo");
+    const org = c.req.queries("org");
     const source = c.req.query("source") ?? undefined;
     const agent = c.req.query("agent") ?? undefined;
     const hitlRaw = c.req.query("hitl");
@@ -2108,7 +2114,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     let tasks: TaskItem[] = [];
     let total = 0;
     let degraded = false;
-    let distinctValues: { sessions: string[]; repos: string[] } | null = null;
+    let distinctValues: {
+      sessions: string[];
+      repos: string[];
+      orgs: string[];
+    } | null = null;
 
     if (!fetchTaskStoreTasks) {
       degraded = true;
@@ -2117,7 +2127,8 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       if (status) params.set("status", status);
       if (state) params.set("state", state);
       if (session) params.set("session", session);
-      if (repo) params.set("repo", repo);
+      for (const r of repo ?? []) params.append("repo", r);
+      for (const o of org ?? []) params.append("org", o);
       if (source) params.set("source", source);
       if (hitl) params.set("hitl", hitl);
       // Agent-name filtering is done client-side, so we fetch a larger slice
@@ -2171,6 +2182,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         ? {
             sessions: distinctValues.sessions,
             repos: distinctValues.repos,
+            orgs: distinctValues.orgs,
             agents: (await agentService.listOptions()).map((a) => a.name),
           }
         : undefined;
@@ -2178,7 +2190,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     return html(
       renderTasksPage(
         tasks,
-        { status, state, session, repo, source, agent, hitl },
+        { status, state, session, repo, org, source, agent, hitl },
         degraded,
         c.var.userEmail,
         agentNames,

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -501,6 +501,7 @@ async function startServer(): Promise<void> {
             return res.json() as Promise<{
               sessions: string[];
               repos: string[];
+              orgs: string[];
             }>;
           },
           fetchTaskStorePr: async (taskId: string) => {


### PR DESCRIPTION
## Summary
- Replaces the Task Store page's single-value repo `<input>` + `<datalist>` with two native `<select multiple>` dropdowns — Org and Repo — sourced from the `/tasks/distinct` endpoint's `orgs`/`repos` suggestions
- Extracts a shared `renderRepoOrgFilterFields(filters, suggestions)` helper in `admin/src/admin-ui-pages.ts` so a future task (ORF-2.2) can reuse the same markup on the PRs page
- Updates the `/admin/tasks` route handler to read repeated `repo=`/`org=` query params via `c.req.queries()` and forward them as arrays to the task-store fetch, and updates `makePageUrl`/`makeStateParams` to serialize multi-value filters as repeated params so they round-trip through pagination and state-tab navigation

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Task Store page renders both Org and Repo `<select multiple>` with active values pre-selected | MET | `renderRepoOrgFilterFields` renders both selects with `<option selected>` markers |
| 2 | Multi-value round-trips through pagination/state-tab links | MET | `makePageUrl`/`makeStateParams` loop `params.append()` per value |
| 3 | Backward compat with single-value `?repo=org/repo` URL | MET | `toFilterArray()` normalizes string→array |
| 4 | Unit test for multiselect rendering + selected markers | MET | New `renderTasksPage — org/repo multiselect filters` test suite |
| 5 | Smoke test for array-valued forwarding | MET | New smoke tests assert `getAll("repo")`/`getAll("org")` |
| 6 | Replace old datalist assertions, add new cases | MET | Old repo-datalist test removed; new multiselect + round-trip suites added |

## Test Plan
- `bun test admin/src/admin-ui-pages.unit.test.ts admin/src/admin-ui.smoke.test.ts` — 741 pass, 0 fail
- `task typecheck` — clean
- `task lint` — clean
- `task test:coverage` gate — 82.42% lines / 87.16% functions (threshold 80%/80%); changed files at 97.8% (admin-ui-pages.ts) / 88.9% (admin-ui.ts)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
