### PR TITLE
chore(chart): bump chart version to 1.7.182

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.7.182] - 2026-07-31
+
+### Changed
+
+- auto-bump to chart v1.7.182 triggered by release tag(s): `admin-v1.61.0`
+
 ## [1.7.181] - 2026-07-31
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.7.181
+version: 1.7.182
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,13 +29,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.7.181 triggered by release tag admin-v1.60.0"
-    - kind: changed
-      description: "auto-bump to chart v1.7.181 triggered by release tag chat-v1.25.0"
-    - kind: changed
-      description: "auto-bump to chart v1.7.181 triggered by release tag metrics-v1.27.0"
-    - kind: changed
-      description: "auto-bump to chart v1.7.181 triggered by release tag task-store-v1.41.0"
+      description: "auto-bump to chart v1.7.182 triggered by release tag admin-v1.61.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -114,7 +114,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.60.0
+    tag: admin-v1.61.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.7.181 → 1.7.182

**Triggering tags:**
- `admin-v1.61.0`

**New chart version:** `1.7.182`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.61.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.7.182 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._