### PR TITLE
feat: use admin API sessionId for direct transcript lookup in investigate-cron

### DIFF
--- a/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
@@ -399,6 +399,34 @@ describe("SKILL.md — Step 4: Sentry cross-check (IC-1.3)", () => {
   });
 });
 
+describe("SKILL.md — Step 1c: direct sessionId-based transcript lookup (CSI-4.1)", () => {
+  it("documents the direct $TRANSCRIPT_DIR/$SESSION_ID.jsonl lookup path used when sessionId is non-null", () => {
+    expect(content).toContain("$TRANSCRIPT_DIR/$SESSION_ID.jsonl");
+  });
+
+  it("Step 1c gates the direct lookup on sessionId being non-null, falling back to 3b's mtime window when null", () => {
+    const step1cBlock = content.slice(
+      content.indexOf("### 1c. From the resolved run to a transcript"),
+      content.indexOf("## Step 2: Ground-truth snapshot"),
+    );
+    expect(step1cBlock).toContain("sessionId");
+    expect(step1cBlock).toContain("null");
+  });
+
+  it("Step 5's synthesis note says session id comes directly from the admin API record when available", () => {
+    const step5Block = content.slice(
+      content.indexOf("## Step 5: Synthesize the explanation"),
+      content.indexOf("**Output format (name+time mode):**"),
+    );
+    expect(step5Block).toContain("sessionId");
+  });
+
+  it("Notes section states the admin API is now the exact source for session id, not just startedAt", () => {
+    const notesBlock = content.slice(content.indexOf("## Notes"));
+    expect(notesBlock).toContain("sessionId");
+  });
+});
+
 describe("SKILL.md — Step 1b populates ITEM_ARG in name+time mode (review fix)", () => {
   it("assigns ITEM_ARG from BEST_RUN's itemId in the name+time branch", () => {
     // Must appear in the BEST_RUN resolution block, not just anywhere in the doc.

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -184,11 +184,36 @@ otherwise report that no dispatch history exists.
 
 ### 1c. From the resolved run to a transcript
 
-Once you have the run's exact `startedAt` (name+time mode: `RUN_STARTED_AT`;
-item mode: each entry in `ITEM_RUNS`), use it as a **tight window** — a few
-minutes, not ±90 — around the transcript directory's file mtimes in 3b,
-since this is now a known exact event time rather than a guess. The transcript
-directory itself is still resolved the same way (see 3b).
+Once you have the resolved run (name+time mode: `BEST_RUN`; item mode: each
+entry in `ITEM_RUNS`), check its `sessionId` field first — this is the exact
+Claude session id the run recorded, not a guess:
+
+```bash
+SESSION_ID=$(echo "$BEST_RUN" | jq -r '.sessionId // empty')  # or per-entry in ITEM_RUNS
+```
+
+**If `sessionId` is non-null**, skip the mtime-window search entirely and
+construct the transcript path directly — no scanning or matching required:
+
+```bash
+TRANSCRIPT_PATH="$TRANSCRIPT_DIR/$SESSION_ID.jsonl"
+if [ -f "$TRANSCRIPT_PATH" ]; then
+  echo "Transcript resolved directly via sessionId: $TRANSCRIPT_PATH"
+else
+  echo "Run has sessionId=$SESSION_ID but no matching .jsonl file exists at $TRANSCRIPT_PATH — the transcript may have been pruned. Fall back to the mtime-window search (3b) as a best-effort recovery."
+fi
+```
+
+`$TRANSCRIPT_DIR` is derived from the CWD exactly as described in 3b — that
+derivation is shared by both this direct path and the fallback below, so run
+it once regardless of which path you end up taking.
+
+**If `sessionId` is null** — the run predates CSI-3.1 (session-id recording),
+or the CLI produced no stdout at all for that invocation — fall back to Step
+3b's existing tight mtime-window search around the run's exact `startedAt`
+(name+time mode: `RUN_STARTED_AT`; item mode: the entry's own `startedAt`).
+That fallback logic is unchanged; see **"When sessionId is null: mtime-window
+fallback"** in 3b.
 
 ---
 
@@ -431,10 +456,15 @@ If the directory doesn't exist or contains no `.jsonl` files, it means this
 workspace has no Claude Code session history at this path. Verify the CWD is
 the agent workspace root.
 
-**With an admin-API run resolved (preferred path):** you have an exact
-`startedAt` for the run (Step 1c). Use a tight window (e.g. ±5 minutes) around
-that timestamp against the `.jsonl` file mtimes to find the matching transcript
-— this is a precision narrowing step now, not the primary matching mechanism.
+**When `sessionId` is null: mtime-window fallback.** Step 1c's direct
+`$TRANSCRIPT_DIR/$SESSION_ID.jsonl` lookup is the preferred path whenever the
+resolved run carries a non-null `sessionId` — this section only applies when
+it doesn't (runs that predate CSI-3.1, or a CLI invocation that produced no
+stdout). In that case you still have an exact `startedAt` for the run (Step
+1c). Use a tight window (e.g. ±5 minutes) around that timestamp against the
+`.jsonl` file mtimes to find the matching transcript — this is a precision
+narrowing step, not an exact match, which is why it's the fallback rather than
+the primary matching mechanism now that `sessionId` is available.
 `startedAt` is ISO 8601 (e.g. `2026-07-21T01:11:46.391Z`) — convert it to epoch
 seconds first (in item mode, repeat this per entry in `ITEM_RUNS`):
 
@@ -740,7 +770,10 @@ Produce a plain-language explanation covering:
    mode, list every phase that dispatched against the item
 2. **Time** — when the session fired (from the resolved run's `startedAt`, or the
    JSONL mtime/first entry timestamp when using the fallback path)
-3. **Session ID** — the JSONL filename (without `.jsonl`), for cross-referencing logs
+3. **Session ID** — the resolved run's `sessionId` field from the admin API record when
+   available (Step 1c's direct lookup), falling back to the JSONL filename (without
+   `.jsonl`) matched via the mtime window when `sessionId` is null — either way, this is
+   for cross-referencing logs
 4. **What it did** — summarize the bash commands and assistant reasoning in 2–5 sentences
 5. **Conclusion** — what the cron decided and why (approved, skipped, silenced, errored)
 6. **Why (if unexpected)** — if the behavior was surprising, explain the root cause
@@ -819,6 +852,11 @@ grep -i "precheck\|pre-check\|cron" logs/bodhi.log | tail -50
 - Prefer the admin-API path (Step 1) over the fallback whenever the admin API is
   reachable and returns run records — it gives an exact `startedAt` instead of a guess,
   and item mode is only possible through it.
+- The admin API is now the exact source for session id too, not just `startedAt`: a
+  resolved run's `sessionId` field (when non-null) points directly at
+  `$TRANSCRIPT_DIR/$SESSION_ID.jsonl` (Step 1c) — no mtime-window search needed. The
+  ±5 minute mtime-window match in 3b is now only a fallback for runs where `sessionId`
+  is null (pre-CSI-3.1 runs, or a CLI invocation with no stdout).
 - Prefer the ground-truth snapshot (Step 2) over transcript extraction whenever it alone
   answers the question — it's cheaper and doesn't require a matching session to exist at
   all. Fall through to Steps 3–5 only when live state is inconclusive.


### PR DESCRIPTION
## Summary
- `investigate-cron`'s Step 1c now checks the resolved run's `sessionId` field first (populated by CSI-2.2/CSI-2.3/CSI-3.2) and, when non-null, constructs the transcript path directly as `$TRANSCRIPT_DIR/$SESSION_ID.jsonl` — no mtime-window scanning needed.
- Step 3b's existing ±5min mtime-window search is preserved unmodified and reframed as the fallback used only when `sessionId` is null (pre-CSI-3.1 runs, or a CLI invocation with no stdout).
- Step 5's synthesis note and the Notes section updated to reflect that session id now comes directly from the admin API record, not a mtime-match guess.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 1c documents the direct `$TRANSCRIPT_DIR/$SESSION_ID.jsonl` lookup path used when the resolved run has a non-null sessionId | MET |
| 2 | Step 3b's mtime-window logic is preserved unmodified as the fallback for `sessionId === null` | MET |
| 3 | Step 5's synthesis note updated: Session ID now comes directly from the admin API record, not the mtime-match | MET |
| 4 | Notes section updated to state the admin API is now the exact source for session id, not just startedAt | MET |
| 5 | `SKILL.content.test.ts` extended with assertions for the direct sessionId-based lookup; existing mtime/fallback assertions retained unmodified | MET |

## Test Plan
- Extended `plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts` with 4 new assertions (RED confirmed against unmodified SKILL.md, GREEN after the edit)
- `NODE_ENV=test bun test plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts` — 63/63 pass (all pre-existing assertions retained and passing)
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- `task ci` — lint/check-strings/typecheck pass; 2 pre-existing test failures (`task-store/src/routes/prs.openapi.smoke.test.ts`, `metrics/src/lib/errors.unit.test.ts`) confirmed to reproduce identically with this branch's changes stashed (pre-existing flakiness, unrelated to this docs-only change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
