### PR TITLE
feat: add Service Architecture page, rename Architecture to Agent Model

### DIFF
--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -41,7 +41,7 @@ export interface NavLink {
  *
  * Single source of truth — was hand-rolled separately in BaseLayout and
  * DocsLayout, which let DocsLayout's copies drift and silently drop the
- * "vs Devin" and "Architecture" links. Centralized here so every nav surface
+ * "vs Devin" and "Agent Model" links. Centralized here so every nav surface
  * renders the same list. D10-designated link (brand/MESSAGING.md D10) — one
  * "vs Devin" entry only, no additional claim text.
  */
@@ -49,6 +49,6 @@ export const PRIMARY_NAV_LINKS: NavLink[] = [
   { href: "/docs", label: "Docs" },
   { href: "/compare", label: "Compare" },
   { href: "/vs/devin", label: "vs Devin" },
-  { href: "/architecture", label: "Architecture" },
+  { href: "/agent-model", label: "Agent Model" },
   { href: "/story", label: "Story" },
 ];

--- a/site/src/pages/agent-model.astro
+++ b/site/src/pages/agent-model.astro
@@ -235,6 +235,10 @@ const components = [
       ))}
     </div>
 
+    <p class="arch-crosslink">
+      Looking for the service-level diagram? See <a href="/service-architecture">Service Architecture →</a>
+    </p>
+
   </section>
 </BaseLayout>
 
@@ -610,6 +614,12 @@ const components = [
   .comp-desc {
     color: var(--sw-color-text-muted);
     line-height: 1.65;
+  }
+
+  /* ── Cross-link ── */
+  .arch-crosslink {
+    font-size: 0.875rem;
+    color: var(--sw-color-text-muted);
   }
 
   /* ── Responsive ── */

--- a/site/src/pages/service-architecture.astro
+++ b/site/src/pages/service-architecture.astro
@@ -1,0 +1,260 @@
+---
+// Service Architecture page (UGD-3.1) — a static, no-client-JS diagram of the
+// four Shipwright service clusters (Agent, Admin, Task Store, Metrics), their
+// databases (if any), and their third-party integrations. Pure CSS grid/card
+// layout — no canvas/SVG animation, no hover-only interactivity, no
+// resize-driven redraw. Grounded in the actual repo dependencies (see the
+// per-cluster `integrations` below): agent/package.json (@octokit/auth-app,
+// @slack/bolt + @slack/web-api, @sentry/bun, plus the Claude Code CLI itself),
+// admin/package.json + admin/src/kubernetes-client.ts +
+// admin/src/google-auth-client.ts (@prisma/client, KubernetesClient, Google
+// OAuth, @sentry/bun), task-store/package.json (@prisma/client, @sentry/bun),
+// and metrics/package.json (no @prisma/client — stateless, reads Task Store
+// over HTTP, @sentry/bun for error reporting).
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+interface ServiceCluster {
+  name: string;
+  dir: string;
+  summary: string;
+  db: string | null;
+  integrations: string[];
+}
+
+const clusters: ServiceCluster[] = [
+  {
+    name: "Agent",
+    dir: "agent/",
+    summary:
+      "Hono service running the autonomous execution loop — pick up a ready task, run Claude Code, ship a PR, forward metrics.",
+    db: null,
+    integrations: ["GitHub", "Claude API", "Slack", "Sentry"],
+  },
+  {
+    name: "Admin",
+    dir: "admin/",
+    summary:
+      "CRUD API + UI for agents, envs, crons, tools, and tokens. Owns agent provisioning and reconcile against the cluster.",
+    db: "Postgres (DATABASE_URL_SHIPWRIGHT_ADMIN)",
+    integrations: ["Kubernetes", "Google OAuth", "Sentry"],
+  },
+  {
+    name: "Task Store",
+    dir: "task-store/",
+    summary:
+      "The coordination layer — owns Task, PullRequest, and TaskToken state. Deduplicates work and tracks cross-agent ownership.",
+    db: "Postgres (DATABASE_URL_SHIPWRIGHT_TASK_STORE)",
+    integrations: ["Sentry"],
+  },
+  {
+    name: "Metrics",
+    dir: "metrics/",
+    summary:
+      "Stateless Hono dashboard — task-store-backed JSON endpoints plus a server-rendered UI. Holds no data of its own.",
+    db: null,
+    integrations: ["Task Store (HTTP)", "Sentry"],
+  },
+];
+---
+
+<BaseLayout title="Service Architecture — Shipwright Harness" description="The four Shipwright service clusters — Agent, Admin, Task Store, and Metrics — their databases and third-party integrations.">
+  <section class="svc-page">
+
+    <!-- Page header -->
+    <div class="svc-header">
+      <p class="svc-meta">Shipwright Harness</p>
+      <h1>Service Architecture</h1>
+      <p class="svc-subtitle">
+        Four service clusters, each with its own database (or none) and its
+        own set of third-party integrations. This is the deployment-level
+        view — for the planning/execution workflow model, see
+        <a href="/agent-model">Agent Model →</a>.
+      </p>
+    </div>
+
+    <!-- ── Service clusters ── -->
+    <div class="svc-grid">
+      {clusters.map((c) => (
+        <div class="svc-card">
+          <div class="svc-card-head">
+            <span class="svc-card-name">{c.name}</span>
+            <span class="svc-card-dir">{c.dir}</span>
+          </div>
+          <p class="svc-card-summary">{c.summary}</p>
+
+          <div class="svc-card-row">
+            <span class="svc-card-label">Database</span>
+            {c.db ? (
+              <span class="svc-badge svc-badge-db">{c.db}</span>
+            ) : (
+              <span class="svc-badge svc-badge-none">None — stateless</span>
+            )}
+          </div>
+
+          <div class="svc-card-row">
+            <span class="svc-card-label">Integrations</span>
+            <div class="svc-badges">
+              {c.integrations.map((i) => (
+                <span class="svc-badge svc-badge-integration">{i}</span>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    <p class="svc-crosslink">
+      Want the request-flow / workflow view instead? See <a href="/agent-model">Agent Model →</a>
+    </p>
+
+  </section>
+</BaseLayout>
+
+<style>
+  .svc-page {
+    padding: 3rem 0 5rem;
+    max-width: 64rem;
+  }
+
+  /* ── Header ── */
+  .svc-header {
+    margin-bottom: 2.5rem;
+  }
+
+  .svc-meta {
+    font-family: var(--sw-font-mono);
+    font-size: 0.6875rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--sw-color-text-muted);
+    margin-bottom: 1rem;
+  }
+
+  .svc-page h1 {
+    font-family: var(--sw-font-display);
+    font-size: 2.25rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--sw-color-text-heading);
+    line-height: 1.1;
+    margin-bottom: 0.75rem;
+  }
+
+  .svc-subtitle {
+    font-size: 0.9375rem;
+    color: var(--sw-color-text-muted);
+    line-height: 1.65;
+    max-width: 44rem;
+  }
+
+  .svc-subtitle a {
+    color: var(--sw-color-support-patriot-bright);
+  }
+
+  /* ── Cluster grid ── */
+  .svc-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .svc-card {
+    background: var(--sw-color-bg-raised);
+    border: 1.5px solid var(--sw-color-border-muted);
+    border-radius: var(--sw-radius-lg);
+    padding: 1.5rem;
+  }
+
+  .svc-card-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.625rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--sw-color-border-subtle);
+  }
+
+  .svc-card-name {
+    font-family: var(--sw-font-display);
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--sw-color-text-heading);
+  }
+
+  .svc-card-dir {
+    font-family: var(--sw-font-mono);
+    font-size: 0.75rem;
+    color: var(--sw-color-brand-default);
+  }
+
+  .svc-card-summary {
+    font-size: 0.8125rem;
+    color: var(--sw-color-text-body);
+    line-height: 1.6;
+    margin-bottom: 1.125rem;
+  }
+
+  .svc-card-row {
+    margin-bottom: 0.875rem;
+  }
+
+  .svc-card-row:last-child {
+    margin-bottom: 0;
+  }
+
+  .svc-card-label {
+    display: block;
+    font-family: var(--sw-font-mono);
+    font-size: 0.625rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--sw-color-text-muted);
+    margin-bottom: 0.4375rem;
+  }
+
+  .svc-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4375rem;
+  }
+
+  .svc-badge {
+    display: inline-block;
+    font-family: var(--sw-font-mono);
+    font-size: 0.6875rem;
+    padding: 0.25rem 0.625rem;
+    border-radius: var(--sw-radius-pill);
+    border: 1px solid var(--sw-color-border-muted);
+  }
+
+  .svc-badge-db {
+    color: var(--sw-color-support-patriot-bright);
+    background: var(--sw-color-support-patriot);
+    border-color: var(--sw-color-support-patriot-bright);
+  }
+
+  .svc-badge-none {
+    color: var(--sw-color-text-muted);
+    background: var(--sw-color-bg-overlay);
+  }
+
+  .svc-badge-integration {
+    color: var(--sw-color-brand-default);
+    background: var(--sw-color-brand-soft);
+    border-color: var(--sw-color-brand-default);
+  }
+
+  /* ── Cross-link ── */
+  .svc-crosslink {
+    font-size: 0.875rem;
+    color: var(--sw-color-text-muted);
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .svc-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/tests/agent-model.spec.ts
+++ b/site/tests/agent-model.spec.ts
@@ -11,15 +11,16 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
-// /architecture smoke tests — static Astro page with no logic.
+// /agent-model smoke tests — static Astro page with no logic. Formerly
+// /architecture (UGD-3.1 renamed it to make room for /service-architecture).
 
-test("architecture route responds 200", async ({ page }) => {
-  const response = await page.goto("/architecture");
+test("agent-model route responds 200", async ({ page }) => {
+  const response = await page.goto("/agent-model");
   expect(response?.status()).toBe(200);
 });
 
-test("architecture page has the correct heading", async ({ page }) => {
-  await page.goto("/architecture");
+test("agent-model page has the correct heading", async ({ page }) => {
+  await page.goto("/agent-model");
   await expect(
     page
       .getByRole("heading", { name: /Shipwright.*Agent Model|Architecture/i })
@@ -27,8 +28,8 @@ test("architecture page has the correct heading", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("architecture diagram shows all 5 sections", async ({ page }) => {
-  await page.goto("/architecture");
+test("agent-model diagram shows all 5 sections", async ({ page }) => {
+  await page.goto("/agent-model");
   const text = (await page.locator("main").textContent())?.toLowerCase() ?? "";
   expect(text).toContain("human input");
   // Maintenance Crons or "Background hygiene" (the subtitle)
@@ -41,7 +42,7 @@ test("architecture diagram shows all 5 sections", async ({ page }) => {
 });
 
 test("component reference lists all 12 components", async ({ page }) => {
-  await page.goto("/architecture");
+  await page.goto("/agent-model");
   const text = (await page.locator("main").textContent())?.toLowerCase() ?? "";
   for (const component of [
     "plan-session",
@@ -63,17 +64,17 @@ test("component reference lists all 12 components", async ({ page }) => {
   }
 });
 
-test("architecture page ships no runtime JS beyond the analytics tag", async ({
+test("agent-model page ships no runtime JS beyond the analytics tag", async ({
   page,
 }) => {
-  await page.goto("/architecture");
+  await page.goto("/agent-model");
   await expectNoRuntimeJsBeyondAnalytics(page);
 });
 
-test("architecture page links to the new operator docs pages", async ({
+test("agent-model page links to the new operator docs pages", async ({
   page,
 }) => {
-  await page.goto("/architecture");
+  await page.goto("/agent-model");
   // Core Loop section -> the-shipwright-loop
   await expect(
     page.locator('a[href="/docs/the-shipwright-loop"]'),
@@ -89,4 +90,13 @@ test("architecture page links to the new operator docs pages", async ({
   ).toHaveCount(4);
   // Task Store row reuses the existing task-store-api link target
   await expect(page.locator('a[href="/docs/task-store-api"]')).toHaveCount(1);
+});
+
+test("agent-model page cross-links to service-architecture", async ({
+  page,
+}) => {
+  await page.goto("/agent-model");
+  await expect(
+    page.locator('a[href="/service-architecture"]'),
+  ).toHaveCount(1);
 });

--- a/site/tests/booking-cta.spec.ts
+++ b/site/tests/booking-cta.spec.ts
@@ -4,12 +4,12 @@ import { BOOKING_URL } from "../src/consts";
 // The marketing pages and the docs pages render from two *different* layouts
 // (BaseLayout and DocsLayout) that each carry their own header and footer. A CTA
 // added to one does not appear in the other, so every page below is checked:
-// /, /compare and /architecture come from BaseLayout; /docs and /docs/* from
+// /, /compare and /agent-model come from BaseLayout; /docs and /docs/* from
 // DocsLayout. Losing the docs half is the regression this guards against.
 const PAGES = [
   "/",
   "/compare",
-  "/architecture",
+  "/agent-model",
   "/docs",
   "/docs/introduction",
 ];

--- a/site/tests/docs-nav.spec.ts
+++ b/site/tests/docs-nav.spec.ts
@@ -12,10 +12,10 @@ test.beforeEach(async ({ page }) => {
 
 // SWD-1.2: DocsLayout's header nav, mobile sidebar nav, and footer had
 // drifted from BaseLayout's and were silently missing the "vs Devin" and
-// "Architecture" links. SiteHeader/SiteFooter now back both layouts, so
+// "Agent Model" links. SiteHeader/SiteFooter now back both layouts, so
 // these links can no longer drift out of docs pages unnoticed.
 
-test("docs desktop header nav includes vs Devin and Architecture links", async ({
+test("docs desktop header nav includes vs Devin and Agent Model links", async ({
   page,
 }) => {
   await page.goto("/docs/getting-started");
@@ -25,11 +25,11 @@ test("docs desktop header nav includes vs Devin and Architecture links", async (
     "/vs/devin",
   );
   await expect(
-    nav.getByRole("link", { name: /Architecture/i }),
-  ).toHaveAttribute("href", "/architecture");
+    nav.getByRole("link", { name: /Agent Model/i }),
+  ).toHaveAttribute("href", "/agent-model");
 });
 
-test("docs mobile sidebar nav includes vs Devin and Architecture links", async ({
+test("docs mobile sidebar nav includes vs Devin and Agent Model links", async ({
   page,
 }) => {
   // The sidebar's mobile nav is "md:hidden" — only in the a11y tree below
@@ -42,8 +42,8 @@ test("docs mobile sidebar nav includes vs Devin and Architecture links", async (
     "/vs/devin",
   );
   await expect(
-    nav.getByRole("link", { name: /Architecture/i }),
-  ).toHaveAttribute("href", "/architecture");
+    nav.getByRole("link", { name: /Agent Model/i }),
+  ).toHaveAttribute("href", "/agent-model");
 });
 
 test("docs footer includes a vs Devin link", async ({ page }) => {

--- a/site/tests/service-architecture.spec.ts
+++ b/site/tests/service-architecture.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
+
+// Fulfill external font CDN requests immediately so the page's 'load' event
+// fires even when CI can't reach external networks.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
+    (route) =>
+      route.fulfill({ status: 200, contentType: "text/css", body: "" }),
+  );
+});
+
+// /service-architecture smoke tests — static Astro page with no logic, no
+// client JS, no hover-only interactivity, no resize-driven redraw (UGD-3.1).
+
+test("service-architecture route responds 200", async ({ page }) => {
+  const response = await page.goto("/service-architecture");
+  expect(response?.status()).toBe(200);
+});
+
+test("service-architecture page has the correct heading and eyebrow", async ({
+  page,
+}) => {
+  await page.goto("/service-architecture");
+  await expect(
+    page.getByRole("heading", { name: "Service Architecture" }).first(),
+  ).toBeVisible();
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).toContain("Shipwright Harness");
+});
+
+test("service-architecture page shows all 4 service clusters", async ({
+  page,
+}) => {
+  await page.goto("/service-architecture");
+  const text = (await page.locator("main").textContent()) ?? "";
+  for (const cluster of ["Agent", "Admin", "Task Store", "Metrics"]) {
+    expect(text, `expected cluster "${cluster}" to be visible`).toContain(
+      cluster,
+    );
+  }
+});
+
+test("service-architecture page lists key third-party integrations", async ({
+  page,
+}) => {
+  await page.goto("/service-architecture");
+  const text = (await page.locator("main").textContent()) ?? "";
+  for (const integration of [
+    "GitHub",
+    "Claude API",
+    "Slack",
+    "Sentry",
+    "Kubernetes",
+    "Google OAuth",
+  ]) {
+    expect(
+      text,
+      `expected integration "${integration}" to be visible`,
+    ).toContain(integration);
+  }
+});
+
+test("service-architecture page cross-links to agent-model", async ({
+  page,
+}) => {
+  await page.goto("/service-architecture");
+  // Scoped to <main> — the shared nav also links to /agent-model post-rename,
+  // so this asserts the page body itself carries the cross-link.
+  await expect(
+    page.locator('main a[href="/agent-model"]'),
+  ).toHaveCount(2);
+});
+
+test("service-architecture page ships no runtime JS beyond the analytics tag", async ({
+  page,
+}) => {
+  await page.goto("/service-architecture");
+  await expectNoRuntimeJsBeyondAnalytics(page);
+});

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -15,6 +15,11 @@
       "has": [{ "type": "host", "value": "www.shipwright-harness.com" }],
       "destination": "https://shipwrightharness.com/:path*",
       "statusCode": 301
+    },
+    {
+      "source": "/architecture",
+      "destination": "/agent-model",
+      "statusCode": 301
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new static `/service-architecture` page (H1 "Service Architecture", eyebrow "Shipwright Harness") showing the four service clusters (Agent, Admin, Task Store, Metrics), their databases, and their third-party integrations, grounded in actual repo dependencies (grepped `package.json`/source in `agent/`, `admin/`, `task-store/`, `metrics/` rather than an unseen mockup — see note below).
- Renames `/architecture` to `/agent-model` (content unchanged, git-detected 98% similarity), updates the primary nav entry in place (still 5 items), and adds a 301 redirect `/architecture` → `/agent-model` in `site/vercel.json`.
- Cross-links the two pages to each other.

**Note on the source diagram:** the task description referenced "the supplied HTML diagram (provided out-of-band by the requester)" as the design source, but that file could not be located anywhere in the workspace (checked planning docs, state dir, git history — nothing found). The page was designed from the acceptance criteria and verified against real repo dependencies instead. Flagging here in case there's a specific visual reference to compare against — happy to adjust the layout if so.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `/service-architecture` renders statically; `bun brand/brand-lint.ts` passes clean | ✅ MET |
| 2 | `/agent-model` serves former `/architecture` content unchanged; `/architecture` 301s to `/agent-model` | ✅ MET |
| 3 | `PRIMARY_NAV_LINKS` updated in place, still exactly 5 entries | ✅ MET |
| 4 | Both pages link to each other | ✅ MET |
| 5 | Test rename/retarget (`agent-model.spec.ts`, `docs-nav.spec.ts`, `booking-cta.spec.ts`) + new `service-architecture.spec.ts` | ✅ MET |

## Test Plan
- [x] `cd site && npx playwright test` — 227/227 passing (full suite)
- [x] `bun brand/brand-lint.ts` — clean on both new/modified page files and on the full built `dist/`
- [x] `cd site && npm run build` — succeeds, both `/agent-model` and `/service-architecture` render, no `/architecture` output remains
- [x] Verified no `<script>`, `client:*` hydration, or `:hover`-only CSS in either page (zero-JS constraint)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
