### PR TITLE
feat: capture and report CI failure signature in patch.md

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1274,3 +1274,70 @@ describe("patch.md — drop stale review-patch reference from claim-release step
     expect(matches.length).toBe(3);
   });
 });
+
+describe("patch.md — capture and report CI failure signature (CSD-1.2)", () => {
+  function getStep6bSection() {
+    const step6bIdx = content.indexOf("### Step 6b: Collect CI Failure Output");
+    const step6b5Idx = content.indexOf("### Step 6b.5:");
+    expect(step6bIdx).toBeGreaterThan(-1);
+    expect(step6b5Idx).toBeGreaterThan(step6bIdx);
+    return content.slice(step6bIdx, step6b5Idx);
+  }
+
+  function getStep6d5Section() {
+    const step6d5Idx = content.indexOf("### Step 6d.5: Upsert PR Record");
+    const step6eIdx = content.indexOf("### Step 6e:");
+    expect(step6d5Idx).toBeGreaterThan(-1);
+    expect(step6eIdx).toBeGreaterThan(step6d5Idx);
+    return content.slice(step6d5Idx, step6eIdx);
+  }
+
+  it("Step 6b computes the failing-job-name signature via gh run view --json jobs --jq, sorted and comma-joined", () => {
+    const section = getStep6bSection();
+    expect(section).toContain('gh run view "$RUN_ID" --json jobs');
+    expect(section).toContain("--jq");
+    expect(section).toContain('select(.conclusion=="failure")');
+    expect(section).toContain(".name");
+    expect(section).toContain("sort");
+    expect(section).toContain('join(",")');
+  });
+
+  it("Step 6b stores the computed signature in a CI_FAILURE_SIGNATURE variable", () => {
+    const section = getStep6bSection();
+    expect(section).toMatch(/CI_FAILURE_SIGNATURE=/);
+  });
+
+  it("Step 6b's signature computation runs after the existing RUN_ID/log-collection block", () => {
+    const section = getStep6bSection();
+    const runIdIdx = section.indexOf("RUN_ID=$(gh run list");
+    const logsIdx = section.indexOf("gh run view \"$RUN_ID\" --log --failed");
+    const signatureIdx = section.indexOf("CI_FAILURE_SIGNATURE=");
+    expect(runIdIdx).toBeGreaterThan(-1);
+    expect(logsIdx).toBeGreaterThan(runIdIdx);
+    expect(signatureIdx).toBeGreaterThan(logsIdx);
+  });
+
+  it("Step 6d.5's POST /prs/:id/patch payload conditionally includes ciFailureSignature when CI_FAILURE_SIGNATURE is set", () => {
+    const section = getStep6d5Section();
+    // Existing unconditional heartbeat + commitSha patch call remains.
+    expect(section).toContain("/prs/$PR_RECORD_ID/heartbeat");
+    expect(section).toContain("/prs/$PR_RECORD_ID/patch");
+    expect(section).toContain("commitSha");
+    // New conditional inclusion of ciFailureSignature.
+    expect(section).toContain("ciFailureSignature");
+    expect(section).toContain("CI_FAILURE_SIGNATURE");
+    // Must be gated by a condition (guarding Steps 4/5's reuse of this same block, which
+    // never populate CI_FAILURE_SIGNATURE), not unconditionally appended.
+    const codeBlockIdx = section.indexOf("```bash");
+    const sigIdx = section.indexOf("ciFailureSignature", codeBlockIdx);
+    expect(sigIdx).toBeGreaterThan(-1);
+    const before = section.slice(codeBlockIdx, sigIdx);
+    expect(before).toMatch(/if\s*\[\s*-n\s*"\$CI_FAILURE_SIGNATURE"/);
+  });
+
+  it("Step 6d.5's guard on CI_FAILURE_SIGNATURE mirrors the existing PR_RECORD_ID '-n' guard pattern", () => {
+    const section = getStep6d5Section();
+    expect(section).toMatch(/if\s*\[\s*-n\s*"\$PR_RECORD_ID"\s*\]/);
+    expect(section).toMatch(/if\s*\[\s*-n\s*"\$CI_FAILURE_SIGNATURE"\s*\]/);
+  });
+});

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1229,6 +1229,18 @@ gh run view "$RUN_ID" --log --failed --repo {org}/{repo} 2>&1 | tail -200
 
 Store the log output for use in the subagent prompt.
 
+Compute a stable failure signature from the failing job names — sorted and comma-joined so
+the same set of failing jobs always produces the same signature regardless of job-completion
+order, matching Step 6d.5's already-existing `ciFailureSignature` field on the task store's
+`POST /prs/:id/patch` (CSD-1.1):
+
+```bash
+CI_FAILURE_SIGNATURE=$(gh run view "$RUN_ID" --json jobs \
+  --jq '[.jobs[] | select(.conclusion=="failure") | .name] | sort | join(",")')
+```
+
+Store `CI_FAILURE_SIGNATURE` for use in Step 6d.5's PR record upsert.
+
 ### Step 6b.5: Claim PR Record (pre-work lock)
 
 The fix subagent dispatched next can run long enough to overlap with another patch run
@@ -1477,6 +1489,12 @@ The record was already claimed pre-work in Step 6b.5 — `PR_RECORD_ID` is alrea
 this renews the claim's heartbeat and increments `patchCycles` rather than re-claiming.
 Warn and continue on any failure — do not stop.
 
+This is the only site among Steps 4c.5/5c.5/6d.5 where a CI failure signature is available
+— Step 6b computed `CI_FAILURE_SIGNATURE` above, but Steps 4 (merge conflicts) and 5 (review
+findings) never run Step 6b, so they have no signature to report. Build the `patch` payload
+body conditionally so this step only sends `ciFailureSignature` when one was actually
+computed this cycle:
+
 ```bash
 if [ -n "$PR_RECORD_ID" ]; then
   curl -s -o /dev/null -X POST \
@@ -1484,11 +1502,16 @@ if [ -n "$PR_RECORD_ID" ]; then
     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat" || \
     echo "⚠ heartbeat renewal failed — continuing"
   HEAD_SHA_POST_PATCH=$(git -C ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} rev-parse HEAD)
+  if [ -n "$CI_FAILURE_SIGNATURE" ]; then
+    PATCH_BODY="{\"commitSha\": \"$HEAD_SHA_POST_PATCH\", \"ciFailureSignature\": \"$CI_FAILURE_SIGNATURE\"}"
+  else
+    PATCH_BODY="{\"commitSha\": \"$HEAD_SHA_POST_PATCH\"}"
+  fi
   curl -sf -X POST \
     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
     -H "Content-Type: application/json" \
     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" \
-    -d "{\"commitSha\": \"$HEAD_SHA_POST_PATCH\"}" > /dev/null 2>&1 || \
+    -d "$PATCH_BODY" > /dev/null 2>&1 || \
     echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
 else
   echo "⚠ no PR_RECORD_ID from pre-work claim — skipping PR record update"


### PR DESCRIPTION
## Summary
- Step 6b computes a stable, sorted, comma-joined failing-job-name signature via `gh run view $RUN_ID --json jobs` before the fix subagent is dispatched, storing it in `CI_FAILURE_SIGNATURE`.
- Step 6d.5's `POST /prs/:id/patch` payload conditionally includes `ciFailureSignature` when a signature was computed this cycle (Steps 4/5 reuse the same upsert block without running Step 6b, so they never populate it).
- `docs/task-store.md` already documents `lastCiFailureSignature`/`consecutiveCiFailureCount` and the auto-block behavior from CSD-1.1 — no additional doc changes needed.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 6b computes and stores the failing-job-name signature before the fix subagent is dispatched | MET |
| 2 | Step 6d.5's POST /prs/:id/patch payload includes ciFailureSignature | MET |
| 3 | docs/task-store.md documents lastCiFailureSignature/consecutiveCiFailureCount and the auto-block behavior | MET (pre-existing from CSD-1.1) |
| 4 | Test decision: patch.content.test.ts assertions for signature computation + payload field (content-test layer, no unit/integration I/O) | MET |

## Test Plan
- [x] `plugins/shipwright/commands/patch.content.test.ts` — 5 new assertions covering Step 6b's signature computation and Step 6d.5's conditional payload inclusion (118 tests pass in file)
- [x] `task lint`, `task typecheck`, `task check-strings`, `task check-config-docs`, `task check-version-sync` all pass
- [x] Pre-commit checks passing (one unrelated, pre-existing `claude.unit.test.ts` failure caused by nested-worktree glob pollution, reproduced identically on `main`)

Generated with [Claude Code](https://claude.com/claude-code)
