### PR TITLE
docs: document adding an MCP server on the-agent page

### DIFF
--- a/site/src/content/docs/the-agent.mdx
+++ b/site/src/content/docs/the-agent.mdx
@@ -122,6 +122,42 @@ spends a Claude turn when there is real work ready.
 See [configuration.md](https://github.com/app-vitals/shipwright/blob/main/docs/configuration.md)
 for the full environment variable reference.
 
+## Adding an MCP server
+
+Register an MCP server on a Shipwright agent the same way you would in any Claude Code session:
+
+```bash
+claude mcp add <name> <command> [args...]
+# or, for an HTTP/SSE server:
+claude mcp add --transport http <name> <url>
+```
+
+This writes the registration into `~/.claude.json`. On a Shipwright agent, `~/.claude.json`
+is not a real file — it's a symlink to `$AGENT_HOME/claude.json`, created by
+`ensureDotClaudeSymlink()` in `agent/src/setup.ts` at every agent startup. The same function
+also symlinks `~/.claude` → `$AGENT_HOME/dot-claude`. Both live on the agent's persistent
+volume (PVC), which survives pod restarts; the container's ephemeral filesystem does not.
+
+This matters because `~/.claude.json` is where MCP server registrations live — **outside**
+`~/.claude/` as a sibling file — so it needs its own symlink to persist across pod restarts.
+Without it, a server you register with `claude mcp add` would be written into the ephemeral
+image copy and silently vanish the next time the pod restarts. Claude Code would then read
+the fresh image copy instead of the PVC's persisted registration.
+
+### Troubleshooting: MCP server "disappeared"
+
+If a registered MCP server vanishes after a pod restart:
+
+1. Confirm that `~/.claude.json` is actually a symlink: `ls -la ~/.claude.json`
+2. Verify it points to `$AGENT_HOME/claude.json` and that the target file exists
+3. Check that the target file contains your MCP server registration: `cat $AGENT_HOME/claude.json`
+
+### Security note
+
+Avoid putting secrets directly in an MCP server registration command line if possible —
+prefer an environment variable reference instead. This prevents the secret from appearing
+in `claude mcp list` output or process listings.
+
 ## Kubernetes provisioning
 
 When `SHIPWRIGHT_K8S_PROVISIONING=enabled`, the admin service acts as a Kubernetes provisioner.


### PR DESCRIPTION
## Summary
- Adds an "Adding an MCP server" section to `site/src/content/docs/the-agent.mdx`, documenting `claude mcp add` and how MCP server registrations persist across pod restarts
- Content is verified against `ensureDotClaudeSymlink()` in `agent/src/setup.ts` — the actual `~/.claude.json` → `$AGENT_HOME/claude.json` symlink mechanism, not guessed
- Closes the one genuine content gap found nowhere in `docs/` or `site/`, giving UGD-1.1's "read more" link a real target

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New section added to the-agent.mdx documenting MCP server addition, verified against setup.ts's actual symlink mechanism | MET | New section cross-checked line-by-line against `ensureDotClaudeSymlink()` in `agent/src/setup.ts` |
| 2 | No existing Playwright spec covers the-agent.mdx — state explicitly, don't add a spec unprompted | MET | Confirmed no `docs-the-agent.spec.ts` exists; none added |

## Test Plan
- Docs-only change — no test framework applies to this file (no existing `docs-the-agent.spec.ts`, unlike sibling docs pages)
- [x] `task typecheck` passes clean across all workspaces
- [x] `task ci` test suite passes except one pre-existing, unrelated failure (`task-store/src/routes/prs.openapi.smoke.test.ts` — a `validateRepo` null-repos bug), confirmed to reproduce identically on unmodified `main`

Generated with [Claude Code](https://claude.com/claude-code)
