### PR TITLE
feat: link architecture pages from the docs sidebar

### DIFF
--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -52,3 +52,17 @@ export const PRIMARY_NAV_LINKS: NavLink[] = [
   { href: "/agent-model", label: "Agent Model" },
   { href: "/story", label: "Story" },
 ];
+
+/**
+ * Hardcoded architecture page links for the DocsLayout sidebar.
+ *
+ * /agent-model and /service-architecture are standalone BaseLayout pages
+ * outside the docs content collection. These links render in the sidebar's
+ * Reference section, allowing readers to navigate from docs content to the
+ * architecture pages. Single source of truth ensures the sidebar links stay
+ * in sync with the actual routes.
+ */
+export const DOCS_SIDEBAR_SUPPLEMENTAL_LINKS: NavLink[] = [
+  { href: "/agent-model", label: "Agent Model" },
+  { href: "/service-architecture", label: "Service Architecture" },
+];

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -10,7 +10,12 @@ import "../styles/brand.css";
 import Analytics from "../components/Analytics.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SiteHeader from "../components/SiteHeader.astro";
-import { BOOKING_URL, PRIMARY_NAV_LINKS, REPO_URL } from "../consts";
+import {
+  BOOKING_URL,
+  DOCS_SIDEBAR_SUPPLEMENTAL_LINKS,
+  PRIMARY_NAV_LINKS,
+  REPO_URL,
+} from "../consts";
 
 interface Heading {
   depth: number;
@@ -356,6 +361,14 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
                         </li>
                       );
                     })}
+                    {sectionName === "Reference" &&
+                      DOCS_SIDEBAR_SUPPLEMENTAL_LINKS.map((link) => (
+                        <li>
+                          <a href={link.href} class="docs-sidebar-link">
+                            {link.label}
+                          </a>
+                        </li>
+                      ))}
                   </ul>
                 </div>
               ))

--- a/site/tests/docs-nav.spec.ts
+++ b/site/tests/docs-nav.spec.ts
@@ -67,3 +67,22 @@ test("docs footer does not include Compare or Docs links", async ({
   );
   await expect(footer.getByRole("link", { name: /^Docs$/i })).toHaveCount(0);
 });
+
+test("docs sidebar includes links to Agent Model and Service Architecture in Reference section", async ({
+  page,
+}) => {
+  // UGD-3.2: /agent-model and /service-architecture are standalone BaseLayout
+  // pages outside the docs content collection. These hardcoded links should
+  // render in the docs sidebar's Reference section, allowing readers to
+  // navigate from docs content to the architecture pages (AC#1).
+  // Note: aria-current is explicitly out of scope for these links (AC#2) —
+  // they lead to BaseLayout pages that never render the sidebar.
+  await page.goto("/docs/getting-started");
+  const docsNav = page.getByRole("navigation", { name: "Docs navigation" });
+  await expect(
+    docsNav.getByRole("link", { name: /Agent Model/i }),
+  ).toHaveAttribute("href", "/agent-model");
+  await expect(
+    docsNav.getByRole("link", { name: /Service Architecture/i }),
+  ).toHaveAttribute("href", "/service-architecture");
+});


### PR DESCRIPTION
## Summary
- Add `DOCS_SIDEBAR_SUPPLEMENTAL_LINKS` in `site/src/consts.ts` — a hardcoded set of links to the standalone `/agent-model` and `/service-architecture` BaseLayout pages, which live outside the `docs` content collection and therefore don't appear in the auto-generated sidebar.
- Render these links in `DocsLayout.astro`'s sidebar under the existing "Reference" section, which is present on every `/docs/*` page since sidebar sections are derived from the full docs collection, not the current page alone.
- `aria-current="page"` active-state behavior is intentionally not implemented for these two links, since they navigate to BaseLayout pages that never render the docs sidebar.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Docs sidebar shows links to both /agent-model and /service-architecture on every /docs/* page | MET | Links render inside the always-present "Reference" section block |
| 2 | aria-current active-state explicitly scoped out | MET | New links omit aria-current entirely, documented in code/commit |
| 3 | Test extends site/tests/docs-nav.spec.ts confirming both links render | MET | New Playwright test added and passing |

## Test Plan
- [x] `npx playwright test tests/docs-nav.spec.ts` — 5/5 passing, including new sidebar link assertion
- [x] `task lint` / `task typecheck` passing
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
