### PR TITLE
docs: regenerate mcp-tools.md for tasks_list org filter

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -79,7 +79,7 @@ List tasks
 - **Method:** GET
 - **Path:** `/tasks`
 - **Has body:** No
-- **Parameters:** `status` (query), `state` (query), `source` (query), `session` (query), `repo` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `hitl` (query), `sort` (query), `updatedSince` (query)
+- **Parameters:** `status` (query), `state` (query), `source` (query), `session` (query), `repo` (query), `org` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `hitl` (query), `sort` (query), `updatedSince` (query)
 
 ## `tasks_update`
 


### PR DESCRIPTION
## Summary
- Scheduled docs-freshness pass over anchor `dcec6196`..HEAD.
- `GET /tasks` gained a repeatable `org` query param (`task-store/src/lib/repo-org-filter.ts`, landed in #2403) but the generated MCP tool reference doc (`docs/mcp-tools.md`) was never regenerated afterward, so `tasks_list`'s parameter list was missing `org`.
- Ran `bun run generate:mcp-docs` to bring the doc back in sync with `task-store/openapi.json` / `mcp-server/src/generated-tools.ts`. No hand edits.

## Test plan
- [x] Regenerated via the project's own generator script (`bun run generate:mcp-docs`) — deterministic, diff-stable output.
- [x] Confirmed `org` is a real, wired, OpenAPI-spec'd param (not WIP) via `task-store/openapi.json` and `task-store/src/routes/tasks.ts`.
- [x] Cross-checked `docs/task-store.md` (hand-maintained) already documents `org` correctly — only the generated doc lagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)