### PR TITLE
fix: use constant-time comparison for dashboardToken in metrics auth

### DIFF
--- a/metrics/src/api.ts
+++ b/metrics/src/api.ts
@@ -22,7 +22,12 @@ import {
   wrapResponse,
 } from "./formatters.ts";
 import type { AccountsClient } from "./lib/accounts-client.ts";
-import type { AppHandler, AuthEnv, Caller } from "./lib/api-auth.ts";
+import {
+  type AppHandler,
+  type AuthEnv,
+  type Caller,
+  constantTimeEqual,
+} from "./lib/api-auth.ts";
 import { ErrorSchema } from "./lib/api-schemas.ts";
 import { registerWithAuthz } from "./lib/api-utils.ts";
 import { makeOnError } from "./lib/errors.ts";
@@ -1276,7 +1281,7 @@ function createCombinedAuthMiddleware(
     const header = c.req.header("Authorization")?.trim();
     const token = header?.startsWith("Bearer ") ? header.slice(7) : undefined;
     if (token) {
-      if (dashboardToken && token === dashboardToken) {
+      if (dashboardToken && constantTimeEqual(token, dashboardToken)) {
         c.set("caller", { name: "dashboard-token", scope: "*" });
         return next();
       }

--- a/metrics/src/lib/api-auth.ts
+++ b/metrics/src/lib/api-auth.ts
@@ -15,6 +15,7 @@
  * that no route ships without a declared policy.
  */
 
+import { timingSafeEqual } from "node:crypto";
 import type { RouteConfig, RouteHandler } from "@hono/zod-openapi";
 import type { Caller } from "@shipwright/lib/request-context";
 import type { Context } from "hono";
@@ -28,6 +29,17 @@ export type { Caller };
 
 // Hono env type for routes that use the auth middleware
 export type AuthEnv = { Variables: { caller: Caller } };
+
+/**
+ * Constant-time string comparison for secret tokens — avoids leaking secret
+ * content via response-time side channels (mirrors mcp-server/src/auth.ts).
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
 
 /**
  * Handler type that gets input types from a route's Zod schemas.

--- a/metrics/src/lib/api-auth.unit.test.ts
+++ b/metrics/src/lib/api-auth.unit.test.ts
@@ -10,6 +10,7 @@ import {
   type AuthEnv,
   type AuthzPolicy,
   type Caller,
+  constantTimeEqual,
   enforceAuthz,
   parseApiKeys,
 } from "./api-auth.ts";
@@ -70,6 +71,32 @@ describe("parseApiKeys", () => {
   test("ignores blank comma-separated segments", () => {
     const m = parseApiKeys("bodhi:sk_x:*,,sully:sk_y:eng");
     expect(m.size).toBe(2);
+  });
+});
+
+// ─── constantTimeEqual ─────────────────────────────────────────────────────────
+
+describe("constantTimeEqual", () => {
+  test("returns true for matching strings", () => {
+    expect(constantTimeEqual("dt_secret_token", "dt_secret_token")).toBe(true);
+  });
+
+  test("returns false for a same-length mismatch", () => {
+    expect(constantTimeEqual("dt_secret_token", "dt_secret_tokeX")).toBe(
+      false,
+    );
+  });
+
+  test("returns false without throwing when lengths differ (shorter)", () => {
+    expect(constantTimeEqual("short", "dt_secret_token")).toBe(false);
+  });
+
+  test("returns false without throwing when lengths differ (longer)", () => {
+    expect(constantTimeEqual("dt_secret_token", "short")).toBe(false);
+  });
+
+  test("returns false for empty vs non-empty", () => {
+    expect(constantTimeEqual("", "dt_secret_token")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Security patrol finding (`secret-weak-compare`, medium, tier 2): `createCombinedAuthMiddleware`'s bearer-token check compared `token === dashboardToken` directly, leaking the secret's content via response-time side channels.
- Swaps the `===` comparison for a length-checked `crypto.timingSafeEqual`, mirroring the existing `constantTimeEqual` precedent in `mcp-server/src/auth.ts` (Buffer.from both sides, length-check short-circuit, then `timingSafeEqual`).
- Adds `constantTimeEqual` to `metrics/src/lib/api-auth.ts` alongside the other shared auth helpers, with new unit tests covering match/mismatch/length-difference cases.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `metrics/src/api.ts`'s dashboardToken comparison uses a constant-time compare instead of `===` | MET | `metrics/src/api.ts` now calls `constantTimeEqual(token, dashboardToken)` |
| 2 | Mirrors the `mcp-server/src/auth.ts` `constantTimeEqual` pattern exactly | MET | Same Buffer.from + length-check + `timingSafeEqual` shape |

## Test Plan
- Added unit tests for `constantTimeEqual` (match, same-length mismatch, shorter/longer length mismatch, empty vs non-empty) — confirms no exception is thrown on length mismatch and behavior parity with the old `===` check for matching/non-matching tokens.
- Existing `METRICS_DASHBOARD_TOKEN gate` integration tests (correct/wrong/unset token) still pass unchanged.
- Full metrics suite: 354 pass, 0 fail.
- [x] Lint, typecheck, and metrics test suite passing

Generated with [Claude Code](https://claude.com/claude-code)
