### PR TITLE
fix: resolve zizmor-lint GitHub Actions workflow findings

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -123,9 +123,10 @@ on:
       - "task-store-v*"
       - "chat-v*"
 
+# Least privilege at the workflow level; the bump-chart job widens to
+# contents:write / pull-requests:write.
 permissions:
-  contents: write      # push branch + commit
-  pull-requests: write # open PR + enable auto-merge
+  contents: read
 
 jobs:
   # Absorbs bursts of near-simultaneous release tags into a single downstream
@@ -155,6 +156,9 @@ jobs:
     name: bump chart version
     needs: debounce
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # push branch + commit
+      pull-requests: write # open PR + enable auto-merge
     # Separate from the debounce group and still queued (not cancelled): once
     # we're doing real repo mutation, a run must always finish rather than be
     # cancelled mid-PR/mid-merge. This is only a safety net for the rare case
@@ -166,6 +170,11 @@ jobs:
     steps:
       # Check out main (not the tag's commit) so we always bump from the
       # latest chart version on main rather than whatever state the tag points at.
+      #
+      # persist-credentials left at its default (true) intentionally: the
+      # "git push -u origin $BRANCH" step further below pushes from this
+      # checkout's working directory and relies on the token persisted into
+      # its local git config to authenticate that push.
       - name: Checkout main
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -303,7 +312,7 @@ jobs:
       # avoids inadvertently touching appVersion or dependency versions.
       - name: Update Chart.yaml version
         run: |
-          NEW_VERSION="${{ steps.resolve.outputs.version }}"
+          NEW_VERSION="${STEPS_RESOLVE_OUTPUTS_VERSION}"
           python3 - charts/shipwright/Chart.yaml "$NEW_VERSION" <<'PYEOF'
           import sys, re
           path, new_ver = sys.argv[1], sys.argv[2]
@@ -313,14 +322,16 @@ jobs:
           with open(path, 'w') as f:
               f.write(content)
           PYEOF
+        env:
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
 
       # Record every batched release tag in the Artifact Hub change log
       # annotation — one "changed" entry per tag, so a burst-collapsed bump
       # still surfaces exactly which releases it contains.
       - name: Update artifacthub.io/changes annotation
         run: |
-          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
-          NEW_VERSION="${{ steps.resolve.outputs.version }}"
+          TAGS_CSV="${STEPS_RESOLVE_OUTPUTS_TAGS}"
+          NEW_VERSION="${STEPS_RESOLVE_OUTPUTS_VERSION}"
           python3 - charts/shipwright/Chart.yaml "$TAGS_CSV" "$NEW_VERSION" <<'PYEOF'
           import sys, re
           path, tags_csv, ver = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -341,13 +352,16 @@ jobs:
           with open(path, 'w') as f:
               f.write(content)
           PYEOF
+        env:
+          STEPS_RESOLVE_OUTPUTS_TAGS: ${{ steps.resolve.outputs.tags }}
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
 
       # Prepend a new entry to CHANGELOG.md so it stays in sync with Chart.yaml.
       # Chart.yaml line 28-29 requires the two to mirror each other on every bump.
       - name: Update CHANGELOG.md
         run: |
-          NEW_VERSION="${{ steps.resolve.outputs.version }}"
-          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
+          NEW_VERSION="${STEPS_RESOLVE_OUTPUTS_VERSION}"
+          TAGS_CSV="${STEPS_RESOLVE_OUTPUTS_TAGS}"
           TAGS_LIST=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/`/; s/$/`/' | paste -sd, - | sed 's/,/, /g')
           DATE=$(date -u +%Y-%m-%d)
           ENTRY="## [${NEW_VERSION}] - ${DATE}\n\n### Changed\n\n- auto-bump to chart v${NEW_VERSION} triggered by release tag(s): ${TAGS_LIST}\n"
@@ -367,6 +381,9 @@ jobs:
           with open(path, 'w') as f:
               f.write(content)
           PYEOF
+        env:
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
+          STEPS_RESOLVE_OUTPUTS_TAGS: ${{ steps.resolve.outputs.tags }}
 
       # Pin every batched release tag into its values.yaml default(s) — the
       # chart's GHCR image defaults (values.yaml's admin/metrics/agent/
@@ -506,7 +523,7 @@ jobs:
           PYEOF
           }
 
-          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
+          TAGS_CSV="${STEPS_RESOLVE_OUTPUTS_TAGS}"
           PINNED=$(select_pinned_tags "$TAGS_CSV")
 
           # Rendered alongside the values.yaml writes below (same
@@ -538,15 +555,17 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Pinned tags for this bump:"
           echo "$PINNED"
+        env:
+          STEPS_RESOLVE_OUTPUTS_TAGS: ${{ steps.resolve.outputs.tags }}
 
       # Create a dedicated branch, commit the Chart.yaml + CHANGELOG.md +
       # values.yaml changes, and push.
       - name: Commit and push bump branch
         id: commit-push
         run: |
-          BRANCH="${{ steps.resolve.outputs.branch }}"
-          NEW_VERSION="${{ steps.resolve.outputs.version }}"
-          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
+          BRANCH="${STEPS_RESOLVE_OUTPUTS_BRANCH}"
+          NEW_VERSION="${STEPS_RESOLVE_OUTPUTS_VERSION}"
+          TAGS_CSV="${STEPS_RESOLVE_OUTPUTS_TAGS}"
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/  - /')
 
           git checkout -b "$BRANCH"
@@ -570,6 +589,10 @@ jobs:
           # re-run the workflow (which will re-derive against main as it
           # then stands).
           git push -u origin "$BRANCH"
+        env:
+          STEPS_RESOLVE_OUTPUTS_BRANCH: ${{ steps.resolve.outputs.branch }}
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
+          STEPS_RESOLVE_OUTPUTS_TAGS: ${{ steps.resolve.outputs.tags }}
 
       # Open the PR targeting main. The title triggers chart-testing CI (helm.yml)
       # and the merge will trigger chart-release.yml (which watches charts/**).
@@ -590,12 +613,16 @@ jobs:
           # is a single parameter expansion — bash does not re-scan an
           # expanded value for further substitution.
           PINNED_LINES: ${{ steps.pin.outputs.pinned_lines }}
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
+          STEPS_RESOLVE_OUTPUTS_CURRENT_VERSION: ${{ steps.resolve.outputs.current_version }}
+          STEPS_RESOLVE_OUTPUTS_TAGS: ${{ steps.resolve.outputs.tags }}
+          STEPS_RESOLVE_OUTPUTS_BRANCH: ${{ steps.resolve.outputs.branch }}
         run: |
-          NEW_VERSION="${{ steps.resolve.outputs.version }}"
-          CURRENT_VERSION="${{ steps.resolve.outputs.current_version }}"
-          TAGS_CSV="${{ steps.resolve.outputs.tags }}"
+          NEW_VERSION="${STEPS_RESOLVE_OUTPUTS_VERSION}"
+          CURRENT_VERSION="${STEPS_RESOLVE_OUTPUTS_CURRENT_VERSION}"
+          TAGS_CSV="${STEPS_RESOLVE_OUTPUTS_TAGS}"
           TAGS_LINES=$(echo "$TAGS_CSV" | tr ',' '\n' | sed 's/^/- `/; s/$/`/')
-          BRANCH="${{ steps.resolve.outputs.branch }}"
+          BRANCH="${STEPS_RESOLVE_OUTPUTS_BRANCH}"
 
           PR_URL=$(gh pr create \
             --base main \
@@ -657,8 +684,9 @@ jobs:
         timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          STEPS_PR_OUTPUTS_PR_URL: ${{ steps.pr.outputs.pr_url }}
         run: |
-          PR_URL="${{ steps.pr.outputs.pr_url }}"
+          PR_URL="${STEPS_PR_OUTPUTS_PR_URL}"
 
           # `gh pr checks --watch --required` fails fast with "no required
           # checks reported" if it runs before GitHub has registered any

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -81,8 +81,10 @@ jobs:
       - name: Parse bare version from tag
         id: version
         run: |
-          TAG="${{ steps.tag.outputs.new_tag }}"
+          TAG="${STEPS_TAG_OUTPUTS_NEW_TAG}"
           echo "version=${TAG#agent-v}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_TAG_OUTPUTS_NEW_TAG: ${{ steps.tag.outputs.new_tag }}
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0

--- a/.github/workflows/check-chart-drift.yml
+++ b/.github/workflows/check-chart-drift.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Compare pinned tags against latest release tags
         run: |

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -38,8 +38,6 @@ jobs:
       # checkout to authenticate its push to gh-pages.
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -38,6 +38,8 @@ jobs:
       # checkout to authenticate its push to gh-pages.
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -111,6 +111,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.x"
+          no-cache: true
 
       - name: Configure Git identity
         run: |
@@ -137,8 +138,9 @@ jobs:
         id: idempotency
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          STEPS_VERSION_OUTPUTS_BRANCH: ${{ steps.version.outputs.branch }}
         run: |
-          BRANCH="${{ steps.version.outputs.branch }}"
+          BRANCH="${STEPS_VERSION_OUTPUTS_BRANCH}"
           if git ls-remote --heads origin "$BRANCH" | grep -q .; then
             echo "Branch ${BRANCH} already exists on remote — skipping (burst-collapse)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -148,7 +150,9 @@ jobs:
 
       - name: Sync version files
         if: steps.idempotency.outputs.skip != 'true'
-        run: bun run scripts/sync-version.ts "${{ steps.version.outputs.version }}"
+        run: bun run scripts/sync-version.ts "${STEPS_VERSION_OUTPUTS_VERSION}"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       # No-op guard: if the version files already matched (e.g. a prior sync
       # cycle already landed this exact version), there's nothing to commit.
@@ -157,11 +161,13 @@ jobs:
         if: steps.idempotency.outputs.skip != 'true'
         run: |
           if git diff --quiet; then
-            echo "No version drift — files already match ${{ steps.version.outputs.version }}."
+            echo "No version drift — files already match ${STEPS_VERSION_OUTPUTS_VERSION}."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Commit and push sync branch
         id: commit-push
@@ -259,9 +265,11 @@ jobs:
         timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          STEPS_PR_OUTPUTS_PR_URL: ${{ steps.pr.outputs.pr_url }}
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          PR_URL="${{ steps.pr.outputs.pr_url }}"
-          VERSION="${{ steps.version.outputs.version }}"
+          PR_URL="${STEPS_PR_OUTPUTS_PR_URL}"
+          VERSION="${STEPS_VERSION_OUTPUTS_VERSION}"
 
           # `gh pr checks --watch --required` fails fast with "no required
           # checks reported" if it runs before GitHub has registered any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,6 +9,7 @@ rules:
     ignore:
       - auto-bump-chart.yml:178 # "Checkout main" — pushed from by `git push -u origin "$BRANCH"`
       - chart-release.yml:71 # "Checkout gh-pages" — pushed from by "Commit and push to gh-pages"
+      - deploy-site.yml:39 # "Checkout" — pushed from by JamesIves/github-pages-deploy-action below
       - sync-plugin-version.yml:104 # "Checkout main" — pushed from by "Commit and push sync branch"
 
   # workflow_run always trips this audit (zizmor has no exception for it,

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,30 @@
+rules:
+  # These checkout steps intentionally leave persist-credentials at its
+  # default (true) because a later step in the same job pushes from that
+  # checkout's working directory and relies on the token persisted into its
+  # local git config to authenticate the push. Setting persist-credentials:
+  # false here would break the push. Each site also carries an inline
+  # comment explaining the same thing.
+  artipacked:
+    ignore:
+      - auto-bump-chart.yml:178 # "Checkout main" — pushed from by `git push -u origin "$BRANCH"`
+      - chart-release.yml:71 # "Checkout gh-pages" — pushed from by "Commit and push to gh-pages"
+      - sync-plugin-version.yml:104 # "Checkout main" — pushed from by "Commit and push sync branch"
+
+  # workflow_run always trips this audit (zizmor has no exception for it,
+  # unlike its labeler carve-out for pull_request_target — see
+  # dangerous_triggers.rs upstream). Each of these six build-*.yml workflows
+  # gates its jobs on `github.event.workflow_run.head_branch == 'main'`, so
+  # they only ever act on a completed CI run that itself ran on main —
+  # equivalent to a push-to-main trigger, not attacker-controlled PR state.
+  # A workflow_run-free redesign (e.g. driving builds from CI's own final
+  # step via workflow_dispatch) is a larger architectural change tracked as
+  # a follow-up, not a mechanical lint fix.
+  dangerous-triggers:
+    ignore:
+      - build-admin.yml:3
+      - build-agent.yml:3
+      - build-chat.yml:3
+      - build-mcp-server.yml:3
+      - build-metrics.yml:3
+      - build-task-store.yml:3


### PR DESCRIPTION
## Summary
- Fixed all 20 informational `template-injection` findings (auto-bump-chart.yml, build-agent.yml, sync-plugin-version.yml) by routing `${{ steps.*.outputs.* }}` expansions through `env:` instead of splicing them straight into `run:` script bodies
- Fixed the `cache-poisoning` finding in sync-plugin-version.yml by disabling `oven-sh/setup-bun`'s default caching (`no-cache: true`) on the job that publishes runtime artifacts
- Fixed 2 of 6 `artipacked` findings (`check-chart-drift.yml`, `release.yml`) by setting `persist-credentials: false` on checkouts that don't push
- Fixed both `excessive-permissions` findings in `auto-bump-chart.yml` by moving `contents: write` / `pull-requests: write` from the workflow level down to the one job (`bump-chart`) that actually needs them
- Added `.github/zizmor.yml` documenting 10 findings left as accepted risk (see below)

## Findings left as accepted risk (documented in `.github/zizmor.yml`)

**4 of 6 `artipacked` findings — checkouts that intentionally persist credentials for a same-job push:**
`auto-bump-chart.yml`, `chart-release.yml`, `deploy-site.yml`, and `sync-plugin-version.yml` each have a checkout step whose credential is consumed by a later `git push` (or, for `deploy-site.yml`, by `JamesIves/github-pages-deploy-action`, which isn't passed an explicit token) from the same job's working directory. Each of these four already carried an inline comment explaining this before this PR — zizmor's own `--fix=all` mode blindly applied `persist-credentials: false` to all of them regardless, which I caught by re-reading each job's later steps and reverted before it broke every automated push/deploy workflow in the repo (chart bumps, chart releases, site deploys, and plugin-version sync). Listed under `artipacked.ignore` in `.github/zizmor.yml`.

**6 `dangerous-triggers` findings — `workflow_run` on the 6 `build-*.yml` workflows:**
Zizmor flags any `workflow_run` trigger unconditionally (`dangerous_triggers.rs` upstream has a carve-out for `pull_request_target` + `actions/labeler` but none for `workflow_run`). Each of these six jobs is gated on `github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'`, so they only ever act on a CI run that itself ran on `main` — equivalent in trust level to a push-to-main trigger, not attacker-controlled PR state. Redesigning this away from `workflow_run` (e.g. having CI's own final step call `workflow_dispatch`) is a real architectural change, not a mechanical lint fix — listed here as a follow-up if the maintainers want it.

## Test Plan
- [x] `zizmor .` reports zero findings (10 ignored via `.github/zizmor.yml`, 43 pre-existing suppressions)
- [x] `task lint` passes
- [x] `task typecheck` passes
- [x] `task check-config-docs` / `task check-version-sync` pass
- [x] `task test:coverage` — same result as unmodified `main`: 5653 pass / 1 pre-existing failure in `task-store/src/routes/prs.openapi.smoke.test.ts` (`repos.includes` on undefined `repos`), unrelated to this PR (only `.github/workflows/*.yml` and `.github/zizmor.yml` changed — no TypeScript touched)
- No CI-wired test scripts (`test-auto-bump-chart.sh` / `test-sync-plugin-version.sh` are manual-only, per their own header comments) exercise the changed workflow logic; the template-injection rewrites are string-for-string equivalent (GHA expression → `env:` var → same bash variable), and the persist-credentials / permissions changes were verified by hand against each job's actual push/API-call sites

Generated with [Claude Code](https://claude.com/claude-code)
