### PR TITLE
fix: exclude worktrees/node_modules artifacts from security-scan Tier 1 targets

### DIFF
--- a/plugins/shipwright/skills/security-scan/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/security-scan/SKILL.content.test.ts
@@ -189,6 +189,65 @@ describe("SKILL.md — Tier 3 posture checks", () => {
   });
 });
 
+describe("SKILL.md — environment-artifact noise filtering (Tier 1 scan targets)", () => {
+  it("excludes node_modules from grype's scan target via --exclude", () => {
+    const grypeSection = content.slice(
+      content.indexOf("### 3.3 grype"),
+      content.indexOf("### 3.4 syft"),
+    );
+    expect(grypeSection).toContain("--exclude");
+    expect(grypeSection).toContain("node_modules");
+  });
+
+  it("excludes worktrees from grype's scan target via --exclude", () => {
+    const grypeSection = content.slice(
+      content.indexOf("### 3.3 grype"),
+      content.indexOf("### 3.4 syft"),
+    );
+    expect(grypeSection).toContain("--exclude");
+    expect(grypeSection).toContain("worktrees");
+  });
+
+  it("excludes node_modules and worktrees from syft's scan target via --exclude", () => {
+    const syftSection = content.slice(
+      content.indexOf("### 3.4 syft"),
+      content.indexOf("### 3.5 zizmor"),
+    );
+    expect(syftSection).toContain("--exclude");
+    expect(syftSection).toContain("node_modules");
+    expect(syftSection).toContain("worktrees");
+  });
+
+  it("documents that osv-scanner has no --exclude flag and uses .git/info/exclude instead", () => {
+    const osvSection = content.slice(
+      content.indexOf("### 3.2 osv-scanner"),
+      content.indexOf("### 3.3 grype"),
+    );
+    expect(osvSection).toContain(".git/info/exclude");
+    expect(osvSection).toContain("worktrees");
+  });
+
+  it("clarifies .git/info/exclude writes are not tracked-file changes or git operations", () => {
+    expect(content).toContain(".git/info/exclude");
+    const text = content.toLowerCase();
+    const hasClarification =
+      text.includes("not a git operation") ||
+      text.includes("never the tracked .gitignore") ||
+      text.includes("not the tracked .gitignore");
+    expect(hasClarification).toBe(true);
+  });
+
+  it("explains the rationale: leftover worktree/node_modules artifacts causing false-positive noise", () => {
+    const text = content.toLowerCase();
+    const hasRationale =
+      text.includes("false-positive") || text.includes("false positive");
+    const mentionsArtifacts =
+      text.includes("environment artifact") || text.includes("scan-environment noise");
+    expect(hasRationale).toBe(true);
+    expect(mentionsArtifacts).toBe(true);
+  });
+});
+
 describe("SKILL.md — ledger classification with repo-namespaced keys", () => {
   it("references the security-patrol ledger location", () => {
     expect(content).toContain("state/security-patrol-ledger.json");

--- a/plugins/shipwright/skills/security-scan/SKILL.md
+++ b/plugins/shipwright/skills/security-scan/SKILL.md
@@ -116,6 +116,41 @@ verified.
 > plausible-looking but unverified hash. If a tool's checksum cannot be verified, treat that
 > tool as unavailable and use its per-tool fallback rather than shipping a fake hash.
 
+### 3.0 Exclude Scan-Environment Noise (before running any tool below)
+
+Two non-codebase environment artifacts have repeatedly caused **false-positive** grype-cve /
+osv-cve noise across weekly scans: a stale `node_modules/` left over from a previously-fixed
+dependency pin, and a leftover `worktrees/` side-checkout nested inside the repo root (e.g.
+from a worktree created with a relative instead of absolute target path). Neither is
+codebase content — both must be excluded from every Tier 1 scan target so environment
+staleness never masquerades as a new/regressed finding:
+
+- **grype and syft** (`dir:` mode) do not respect `.gitignore` at all — they walk the full
+  filesystem tree under the given path. Both accept repeatable `--exclude <glob>` flags
+  (verified independently by running each tool against a fixture with a lockfile nested
+  under `node_modules/` and `worktrees/` — the flag suppresses matches from both without
+  affecting real source paths). Always pass:
+  ```
+  --exclude './node_modules/**' --exclude './worktrees/**'
+  ```
+- **osv-scanner** has no `--exclude`/path-scoping flag. It does, however, respect git's
+  ignore rules by default (no `--no-ignore` passed) — but only for paths git itself
+  considers ignored, and a target repo's own tracked `.gitignore` may not cover `worktrees/`
+  (confirmed: vitals-os's `.gitignore` only excludes `.claude/worktrees/`, not a top-level
+  `worktrees/`). Rather than depend on the target repo's own `.gitignore` contents, add
+  scan-local entries to `.git/info/exclude` — git's per-checkout, untracked ignore file —
+  before running osv-scanner:
+  ```bash
+  grep -qxF 'node_modules/' .git/info/exclude 2>/dev/null || echo 'node_modules/' >> .git/info/exclude
+  grep -qxF 'worktrees/' .git/info/exclude 2>/dev/null || echo 'worktrees/' >> .git/info/exclude
+  ```
+  This is **not the tracked `.gitignore`** and **not a git operation** in the sense of this
+  skill's "no git operations" constraint below — it writes local, untracked git metadata,
+  not a commit, branch, or staged change, and never touches the working tree or history.
+- **gitleaks** is unaffected: its full-history scan (Step 3.1) walks committed git objects,
+  not the working tree, so untracked `node_modules/`/`worktrees/` directories never appear
+  in its results.
+
 ### 3.1 gitleaks — secret scan (full history)
 
 Unlike `ci.yml` (which runs `--no-git` on the working tree), this skill runs a **full-history**
@@ -144,6 +179,9 @@ osv-scanner ships a bare linux amd64 binary named `osv-scanner_linux_amd64` (no 
 the filename) plus a `osv-scanner_SHA256SUMS` manifest per release.
 
 ```bash
+grep -qxF 'node_modules/' .git/info/exclude 2>/dev/null || echo 'node_modules/' >> .git/info/exclude
+grep -qxF 'worktrees/' .git/info/exclude 2>/dev/null || echo 'worktrees/' >> .git/info/exclude
+
 curl -sSfL "https://github.com/google/osv-scanner/releases/download/v2.0.2/osv-scanner_linux_amd64" -o osv-scanner
 echo "3abcfd7126c453a00421487e721b296e0cb68085bd431d6cef60872774170fc8  osv-scanner" | sha256sum -c
 chmod +x osv-scanner
@@ -159,7 +197,7 @@ Anchore projects publish `grype_{version}_linux_amd64.tar.gz` plus a
 curl -sSfL "https://github.com/anchore/grype/releases/download/v0.116.0/grype_0.116.0_linux_amd64.tar.gz" -o grype.tar.gz
 echo "40aff724297312f91ea390d003bed8d8651c74cc7f5b26732db80b3a408d2fc5  grype.tar.gz" | sha256sum -c
 tar -xz -f grype.tar.gz grype
-./grype dir:. -o json --file grype-report.json
+./grype dir:. --exclude './node_modules/**' --exclude './worktrees/**' -o json --file grype-report.json
 ```
 
 ### 3.4 syft — SBOM generation
@@ -172,7 +210,7 @@ feeds Tier 3's SBOM-presence posture check.
 curl -sSfL "https://github.com/anchore/syft/releases/download/v1.27.1/syft_1.27.1_linux_amd64.tar.gz" -o syft.tar.gz
 echo "c2cb5867a238baf41adf15f7e01e28cbd886378859eed81e52c080ca0346eefe  syft.tar.gz" | sha256sum -c
 tar -xz -f syft.tar.gz syft
-./syft dir:. -o cyclonedx-json=sbom.cyclonedx.json
+./syft dir:. --exclude './node_modules/**' --exclude './worktrees/**' -o cyclonedx-json=sbom.cyclonedx.json
 ```
 
 The generated `sbom.cyclonedx.json` is the SBOM artifact Tier 3 checks for.
@@ -435,7 +473,9 @@ SECURITY SCAN COMPLETE
   checkouts) — plus transient tool report artifacts (`gitleaks-report.json`, `osv-report.json`,
   `grype-report.json`, `sbom.cyclonedx.json`, `zizmor-report.json`) which are scan byproducts,
   never committed. Neither the report nor the ledger is written in `--dry-run` mode.
-- **No git operations.** Do not commit, branch, or stage anything.
+- **No git operations.** Do not commit, branch, or stage anything. Writing scan-local
+  entries to `.git/info/exclude` (Step 3.0) is exempt — it is untracked, per-checkout git
+  metadata, not the tracked `.gitignore`, and involves no commit, branch, or staged change.
 - **No PR creation.** `security-scan` never creates PRs or tasks — queueing findings as
   task-store tasks belongs to `/security-fix`.
 - **No tool aborts the scan.** Every Tier 1 tool has a per-tool fallback: a failed download or

--- a/plugins/shipwright/skills/security-scan/SKILL.md
+++ b/plugins/shipwright/skills/security-scan/SKILL.md
@@ -135,11 +135,11 @@ staleness never masquerades as a new/regressed finding:
   ```
 - **osv-scanner** has no `--exclude`/path-scoping flag. It does, however, respect git's
   ignore rules by default (no `--no-ignore` passed) — but only for paths git itself
-  considers ignored, and a target repo's own tracked `.gitignore` may not cover `worktrees/`
-  (confirmed: vitals-os's `.gitignore` only excludes `.claude/worktrees/`, not a top-level
-  `worktrees/`). Rather than depend on the target repo's own `.gitignore` contents, add
-  scan-local entries to `.git/info/exclude` — git's per-checkout, untracked ignore file —
-  before running osv-scanner:
+  considers ignored, and a target repo's own tracked `.gitignore` may not cover a top-level
+  `worktrees/` directory (a repo's `.gitignore` may only cover a nested worktree convention
+  path, missing the top-level one). Rather than depend on the target repo's own `.gitignore`
+  contents, add scan-local entries to `.git/info/exclude` — git's per-checkout, untracked
+  ignore file — before running osv-scanner:
   ```bash
   grep -qxF 'node_modules/' .git/info/exclude 2>/dev/null || echo 'node_modules/' >> .git/info/exclude
   grep -qxF 'worktrees/' .git/info/exclude 2>/dev/null || echo 'worktrees/' >> .git/info/exclude


### PR DESCRIPTION
## Summary
- Add `--exclude './node_modules/**' --exclude './worktrees/**'` to grype and syft's Tier 1 `dir:` scan invocations in `security-scan`'s `SKILL.md` — neither tool respects `.gitignore`, so a stale `node_modules/` or a nested `worktrees/` checkout was inflating grype-cve/osv-cve results.
- Since osv-scanner has no `--exclude` flag, add scan-local entries to `.git/info/exclude` (git's untracked, per-checkout ignore file — never the tracked `.gitignore`) before running it, so `worktrees/` is skipped even when a target repo's own `.gitignore` doesn't cover it.
- Document why gitleaks is unaffected (full-history scan walks committed git objects, not the working tree) and why the `.git/info/exclude` write doesn't violate this skill's "no git operations" constraint.
- Add content tests covering the new exclusion flags/rationale.

## Acceptance Criteria
(None recorded on the task — verified against the task's fix guidance directly.)

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | grype's Tier 1 invocation excludes `worktrees/`/`node_modules/` | MET | `SKILL.md` grype step now passes `--exclude` twice |
| 2 | osv-scanner's Tier 1 invocation excludes `worktrees/`/`node_modules/` | MET | `.git/info/exclude` entries added before the osv-scanner invocation |
| 3 | gitleaks addressed (excluded or documented as unaffected) | MET | New "3.0" section explains gitleaks scans git history, not the working tree |
| 4 | Fix scoped to the security-scan skill itself | MET | Only `plugins/shipwright/skills/security-scan/` touched |
| 5 | Rationale documented per tool | MET | New "3.0 Exclude Scan-Environment Noise" section |

## Test Plan
- [x] `bun test plugins/shipwright/skills/security-scan/` — 47 pass (6 new tests added, verified RED before the fix and GREEN after)
- [x] `task lint` — pass
- [x] `task typecheck` — pass
- [x] `task check-strings` — pass (caught and fixed one target-repo-name leak during review)
- [x] `task check-config-docs` / `task check-version-sync` — pass
- [x] Verified `--exclude` glob behavior empirically against real `grype`/`syft` binaries with fixture lockfiles nested under `node_modules/`/`worktrees/`
- [x] Verified `.git/info/exclude` suppresses `osv-scanner` findings for an untracked directory not covered by the repo's own `.gitignore`
- [x] Full `bun test` run: 1 pre-existing failure (`extraAllowedTools` in `agent/src/claude.unit.test.ts`), reproduces identically on clean `main`, unrelated to this diff

Generated with [Claude Code](https://claude.com/claude-code)
