### PR TITLE
docs: harden review.md verdict convergence instructions

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -674,6 +674,69 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
   });
 });
 
+describe("review.md — Step 10 worked example distinguishes self-review-COMMENT-event from unresolved-finding-COMMENT-verdict (RVG-1.2)", () => {
+  let workedExampleSection: string;
+
+  beforeAll(() => {
+    const bodyMustContainIdx = content.indexOf(
+      "**The `body` field MUST contain the literal phrase",
+    );
+    const jsonBlockIdx = content.indexOf(
+      "Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`:",
+    );
+    expect(bodyMustContainIdx).toBeGreaterThan(-1);
+    expect(jsonBlockIdx).toBeGreaterThan(bodyMustContainIdx);
+    workedExampleSection = content.slice(bodyMustContainIdx, jsonBlockIdx);
+  });
+
+  it("references that this failure mode was observed on real production PRs (one self-authored, one not)", () => {
+    expect(workedExampleSection.toLowerCase()).toContain("production");
+    expect(workedExampleSection.toLowerCase()).toContain("self-authored, one not");
+  });
+
+  it("references the literal observed failure mode -- body said Verdict: COMMENT despite a clean narrative", () => {
+    expect(workedExampleSection).toContain("Verdict: COMMENT");
+    expect(workedExampleSection.toLowerCase()).toContain("no blocking issues");
+    expect(workedExampleSection.toLowerCase()).toContain("checks out clean");
+  });
+
+  it("Case 1 describes a self-authored PR with all findings resolved via Step 9.5's exclusions", () => {
+    const case1Idx = workedExampleSection.indexOf("**Case 1");
+    expect(case1Idx).toBeGreaterThan(-1);
+    const case1Block = workedExampleSection.slice(case1Idx, case1Idx + 700);
+
+    expect(case1Block.toLowerCase()).toContain("self-authored");
+    expect(case1Block).toContain("Step 9.5");
+    expect(case1Block).toContain('event: "COMMENT"');
+    expect(case1Block).toContain("Verdict: APPROVE");
+  });
+
+  it("Case 1 attributes the forced COMMENT event to the GitHub API self-approve restriction", () => {
+    const case1Idx = workedExampleSection.indexOf("**Case 1");
+    expect(case1Idx).toBeGreaterThan(-1);
+    const case1Block = workedExampleSection.slice(case1Idx, case1Idx + 700);
+
+    expect(case1Block.toLowerCase()).toContain("api");
+    expect(case1Block.toLowerCase()).toContain("self-approve");
+  });
+
+  it("Case 2 describes any-author PR with a genuine unresolved finding still present at head", () => {
+    const case2Idx = workedExampleSection.indexOf("**Case 2");
+    expect(case2Idx).toBeGreaterThan(-1);
+    const case2Block = workedExampleSection.slice(case2Idx, case2Idx + 700);
+
+    expect(case2Block.toLowerCase()).toContain("any-author");
+    expect(case2Block.toLowerCase()).toContain("unresolved finding");
+    expect(case2Block).toContain('event: "COMMENT"');
+    expect(case2Block).toContain("Verdict: COMMENT");
+  });
+
+  it("makes explicit that Case 1 and Case 2 share the same event but require different body verdict labels", () => {
+    expect(workedExampleSection.toLowerCase()).toContain('same `event: "comment"`');
+    expect(workedExampleSection.toLowerCase()).toContain("different");
+  });
+});
+
 describe("review.md — Review Quality Rules reflect mechanical enforcement (RUC-1.1)", () => {
   it("the 'Check for unresolved feedback first' bullet describes mechanical enforcement, not just a guideline", () => {
     const rulesIdx = content.indexOf("## Review Quality Rules");

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -585,6 +585,37 @@ treats it as an unaddressed finding forever. Always lead the body with the liter
 label, on both the initial-review and re-review paths (Steps 10/11 run identically for both;
 see Step 14's re-review flow).
 
+**Worked example — the two cases production actually confused.** This convention was not
+followed on two separate PRs in another repo in this deployment (one self-authored, one not):
+both produced review bodies reading `Verdict: COMMENT` even though the narrative was explicitly
+clean — e.g. "No blocking issues found... checks out clean." In both cases the underlying
+situation was actually Case 1 below (a clean review that should read `Verdict: APPROVE`), but it
+was written as if it were Case 2. Both cases resolve to the **same `event: "COMMENT"`** — that
+surface-level identity is exactly why they get conflated — but they MUST produce **different**
+`Verdict: ...` body labels:
+
+- **Case 1 — self-authored PR, all findings resolved via Step 9.5's exclusions.** The PR's
+  `author.login == CURRENT_USER` and Step 9.5's unaddressed-findings gate computes no
+  unaddressed findings (every review either is a clean self-APPROVE or was addressed by a
+  subsequent author reply, per the exclusions above). This is a genuinely clean approval.
+  Result: `event: "COMMENT"` (forced by the self-review override, since GitHub blocks
+  self-APPROVE via the API — not because there's anything wrong with the PR), body **must**
+  read `"Verdict: APPROVE — ..."`. Writing `Verdict: COMMENT` here is the exact bug observed
+  in production: it makes a clean PR invisible to `isSelfCleanApprove` and the patch cron
+  treats it as an unaddressed finding forever.
+- **Case 2 — any-author PR, a genuine unresolved finding still present at head.** Step 9.5's
+  gate computes real unaddressed findings (an unresolved inline thread, or a qualifying
+  `COMMENTED`/`CHANGES_REQUESTED` review body not excluded by the clean-APPROVE or
+  author-reply rules). Result: `event: "COMMENT"`, body correctly reads
+  `"Verdict: COMMENT — ..."`. This is the only case where `Verdict: COMMENT` is the right
+  label.
+
+Both cases select `event: "COMMENT"` for entirely different reasons (an API restriction on
+authorship vs. a real quality gate on content) — the `Verdict: ...` body label is the *only*
+signal that distinguishes them for downstream automation, so it must always reflect the actual
+computed verdict, never be copied from the `event` value or from generic "this went through
+COMMENT" boilerplate.
+
 Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`:
 
 ```json

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -78,6 +78,21 @@ posted as `event: COMMENT`. Free-form approval prose without the literal phrase 
 the review as an unaddressed finding forever. Always lead with the `Verdict: ...` label
 -- don't paraphrase it away.
 
+**Two cases that get confused in practice** -- both select `event: COMMENT` for entirely
+different reasons, but must carry different `Verdict: ...` labels:
+
+- **Self-authored, clean.** All findings resolved (see `review.md` Step 9.5). `event:
+  COMMENT` only because GitHub blocks self-APPROVE via the API -- the body must still say
+  `Verdict: APPROVE`.
+- **Any author, genuine unresolved finding.** A real finding remains at head. `event:
+  COMMENT`, and the body correctly says `Verdict: COMMENT`.
+
+This is the exact mix-up observed in production on two separate PRs in another repo in
+this deployment (one self-authored, one not): both posted bodies reading `Verdict: COMMENT`
+despite clean narratives ("No blocking issues found... checks out clean"), which was
+actually the first case mislabeled as the second. See `review.md` Step 10 for the full
+worked example.
+
 ### Tone
 
 The `PR_REVIEW_<number>.md` file is a draft written for the agent's owner. The


### PR DESCRIPTION
## Summary
- Adds a worked example to `review.md` Step 10 contrasting the two verdict-convergence cases that were actually confused in production (self-authored-clean vs. any-author-with-real-finding), both of which select `event: "COMMENT"` but must carry different `Verdict: ...` body labels.
- Cross-checks `post-review-guide.md` for the same convention and adds a condensed version of the same worked example, cross-referencing `review.md` Step 10.
- Extends `review.content.test.ts` with a new describe block asserting the worked-example text is present.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | review.md Step 10 includes a worked example distinguishing the two cases, referencing the literal observed failure mode | MET |
| 2 | post-review-guide.md cross-checked for the same convention and updated | MET |
| 3 | review.content.test.ts (content-test layer) extended to assert the new text is present | MET |

## Test Plan
- [x] `NODE_ENV=test bun test plugins/shipwright/commands/review.content.test.ts` — 59/59 pass
- [x] `task ci` — lint, check-strings, typecheck pass; 3 pre-existing failures in `metrics/src/lib/errors.unit.test.ts` and `agent/src` (Sentry/CLI-arg tests) are unrelated to this change (untouched files, confirmed against `main`)

Generated with [Claude Code](https://claude.com/claude-code)
