### PR TITLE
feat: exclude tasks with fresh same-branch in_progress sibling (BBE-1.1)

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -47,7 +47,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string, repeatable | Filter by repo (`org/repo` format). Repeat the param to match any repo in the list (e.g. `?repo=org/a&repo=org/b`). A single `?repo=` behaves identically to before (exact match). |
@@ -239,6 +239,18 @@ When `GET /tasks?ready=true` evaluates whether a task is eligible to run, it che
 3. **Cross-branch merged PR** — the dependency has `status = pr_open` AND its `pr` field is set (not null) AND the referenced GitHub PR number is merged in the repository. This indicates a dependency from another branch whose work has landed.
 
 4. **Any other status is not satisfied.** If a dependency does not match one of the three rules above (e.g., it has `status = pending`, `status = blocked`, or is `pr_open` on a different branch with no PR link), the task cannot run — the dependency is unsatisfied and the task is excluded from `?ready=true` results.
+
+### Same-branch exclusivity guard
+
+A pending task is excluded from the ready set if another task shares its non-null/non-empty `branch` field and is `in_progress` with a fresh claim. This "same-branch exclusivity guard" prevents multiple agents from simultaneously executing tasks bound to the same feature branch — a real dev-task session is likely mid-flight on that shared git branch.
+
+**Freshness definition:** A claim is considered fresh if its `heartbeatAt` (or `claimedAt` if heartbeat is absent) is within `DEFAULT_CLAIM_TTL_MS` (default: 10 minutes) of now. This mirrors the stale-claim-reaper's exact freshness formula, ensuring a genuinely crashed or abandoned sibling task (one whose agent failed to heartbeat) does not permanently starve pending bundled tasks on the same branch.
+
+**Example:** If two tasks share `branch=feat/foo` and the first is `in_progress` with a fresh claim, the second remains excluded from `?ready=true` until either:
+- The first task completes, fails, or is released (no longer `in_progress`)
+- The first task's claim becomes stale (more than 10 minutes without heartbeat) and is reaped
+
+This rule only applies when `branch` is set. Tasks with `branch=null` or `branch=""` are not subject to the exclusivity check.
 
 ### PR tracking
 
@@ -444,9 +456,11 @@ If `GET /tasks?ready=true` returns `{ tasks: [], total: 0 }` even though tasks e
 
 2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. Clear the flag once the human action is complete.
 
-3. **Dependencies not satisfied** — query `?status=pending` to find pending tasks, then check each task's `dependencies` array against the [dependency satisfaction rules](#dependency-satisfaction-rules) (terminal status, same-branch `pr_open`/`approved`, or a merged cross-branch PR).
+3. **Same-branch sibling in progress** — query `?status=in_progress` to check whether another task shares the pending task's `branch` with an active claim. If so, that task holds the exclusivity lock on the branch. Wait for it to complete, fail, or release. If the sibling's claim looks stale (more than 10 minutes old with no heartbeat), it will be reaped automatically; verify via the stale-claim-reaper logs in the meanwhile.
 
-4. **Queue empty** — no pending tasks exist at all. Confirm with `?status=pending`.
+4. **Dependencies not satisfied** — query `?status=pending` to find pending tasks, then check each task's `dependencies` array against the [dependency satisfaction rules](#dependency-satisfaction-rules) (terminal status, same-branch `pr_open`/`approved`, or a merged cross-branch PR).
+
+5. **Queue empty** — no pending tasks exist at all. Confirm with `?status=pending`.
 
 ### 401 Unauthorized
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -244,11 +244,11 @@ When `GET /tasks?ready=true` evaluates whether a task is eligible to run, it che
 
 A pending task is excluded from the ready set if another task shares its non-null/non-empty `branch` field and is `in_progress` with a fresh claim. This "same-branch exclusivity guard" prevents multiple agents from simultaneously executing tasks bound to the same feature branch — a real dev-task session is likely mid-flight on that shared git branch.
 
-**Freshness definition:** A claim is considered fresh if its `heartbeatAt` (or `claimedAt` if heartbeat is absent) is within `DEFAULT_CLAIM_TTL_MS` (default: 10 minutes) of now. This mirrors the stale-claim-reaper's exact freshness formula, ensuring a genuinely crashed or abandoned sibling task (one whose agent failed to heartbeat) does not permanently starve pending bundled tasks on the same branch.
+**Freshness definition:** A claim is considered fresh if its `heartbeatAt` (or `claimedAt` if heartbeat is absent) is within `DEFAULT_CLAIM_TTL_MS` (default: 65 minutes — `DEFAULT_CLAUDE_TIMEOUT_MS` + `CLAIM_TTL_BUFFER_MS`, overridable via `SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS`) of now. This mirrors the stale-claim-reaper's exact freshness formula, ensuring a genuinely crashed or abandoned sibling task (one whose agent failed to heartbeat) does not permanently starve pending bundled tasks on the same branch.
 
 **Example:** If two tasks share `branch=feat/foo` and the first is `in_progress` with a fresh claim, the second remains excluded from `?ready=true` until either:
 - The first task completes, fails, or is released (no longer `in_progress`)
-- The first task's claim becomes stale (more than 10 minutes without heartbeat) and is reaped
+- The first task's claim becomes stale (more than 65 minutes without heartbeat) and is reaped
 
 This rule only applies when `branch` is set. Tasks with `branch=null` or `branch=""` are not subject to the exclusivity check.
 
@@ -456,7 +456,7 @@ If `GET /tasks?ready=true` returns `{ tasks: [], total: 0 }` even though tasks e
 
 2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. Clear the flag once the human action is complete.
 
-3. **Same-branch sibling in progress** — query `?status=in_progress` to check whether another task shares the pending task's `branch` with an active claim. If so, that task holds the exclusivity lock on the branch. Wait for it to complete, fail, or release. If the sibling's claim looks stale (more than 10 minutes old with no heartbeat), it will be reaped automatically; verify via the stale-claim-reaper logs in the meanwhile.
+3. **Same-branch sibling in progress** — query `?status=in_progress` to check whether another task shares the pending task's `branch` with an active claim. If so, that task holds the exclusivity lock on the branch. Wait for it to complete, fail, or release. If the sibling's claim looks stale (more than 65 minutes old with no heartbeat, by default), it will be reaped automatically; verify via the stale-claim-reaper logs in the meanwhile.
 
 4. **Dependencies not satisfied** — query `?status=pending` to find pending tasks, then check each task's `dependencies` array against the [dependency satisfaction rules](#dependency-satisfaction-rules) (terminal status, same-branch `pr_open`/`approved`, or a merged cross-branch PR).
 

--- a/task-store/src/ready.ts
+++ b/task-store/src/ready.ts
@@ -6,6 +6,7 @@
  * A task is "ready" to execute when:
  *   - task.status === "pending"
  *   - task.hitl !== true
+ *   - it has no fresh same-branch in_progress sibling (exclusivity guard, see below)
  *   - every dependency ID resolves to a known task whose status satisfies the
  *     dependency-satisfied rules below
  *
@@ -15,9 +16,19 @@
  *   3. cross-branch dep with status === pr_open AND dep.pr set AND isPrMerged(pr)
  *   4. anything else → not satisfied
  *
+ * Same-branch exclusivity guard: a pending task is excluded from the ready set
+ * if another task shares its non-null/non-empty `branch` and is `in_progress`
+ * with a fresh claim — a real dev-task session is likely mid-flight on that
+ * shared git branch. "Fresh" mirrors stale-claim-reaper.ts's exact two-case
+ * freshness formula (heartbeatAt, falling back to claimedAt) against
+ * DEFAULT_CLAIM_TTL_MS, so a genuinely crashed/stale sibling does not
+ * permanently starve the rest of the bundle.
+ *
  * Operates on the Prisma `Task` shape (nullable fields) rather than the store.ts
  * interface — the dependency semantics are identical.
  */
+
+import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 
 /** The minimal Task shape resolveReadyTasks needs. */
 export interface ReadyTaskLike {
@@ -29,18 +40,46 @@ export interface ReadyTaskLike {
   hitl?: boolean | null;
   /** ISO timestamp set when HITL notification was sent; null while awaiting. */
   hitlNotifiedAt?: string | null;
+  /** ISO timestamp when claimed. */
+  claimedAt?: string | null;
+  /** ISO timestamp of last heartbeat (liveness check). */
+  heartbeatAt?: string | null;
+}
+
+/**
+ * Mirrors stale-claim-reaper.ts's exact freshness formula: prefer
+ * heartbeatAt when present, else fall back to claimedAt; a claim with
+ * neither set is never fresh.
+ */
+function hasFreshClaim(task: ReadyTaskLike, nowMs: number): boolean {
+  const effectiveTimestamp = task.heartbeatAt ?? task.claimedAt;
+  if (!effectiveTimestamp) return false;
+  return nowMs - new Date(effectiveTimestamp).getTime() < DEFAULT_CLAIM_TTL_MS;
 }
 
 export async function resolveReadyTasks<T extends ReadyTaskLike>(
   tasks: T[],
   isPrMerged: (prNumber: number) => Promise<boolean>,
+  now: () => Date = () => new Date(),
 ): Promise<T[]> {
   const byId = new Map(tasks.map((t) => [t.id, t]));
   const results: T[] = [];
+  const nowMs = now().getTime();
 
   for (const task of tasks) {
     if (task.status !== "pending") continue;
     if (task.hitl === true) continue;
+
+    if (task.branch) {
+      const hasFreshInProgressSibling = tasks.some(
+        (other) =>
+          other.id !== task.id &&
+          other.branch === task.branch &&
+          other.status === "in_progress" &&
+          hasFreshClaim(other, nowMs),
+      );
+      if (hasFreshInProgressSibling) continue;
+    }
 
     let ready = true;
     for (const depId of task.dependencies ?? []) {

--- a/task-store/src/ready.ts
+++ b/task-store/src/ready.ts
@@ -20,9 +20,12 @@
  * if another task shares its non-null/non-empty `branch` and is `in_progress`
  * with a fresh claim — a real dev-task session is likely mid-flight on that
  * shared git branch. "Fresh" mirrors stale-claim-reaper.ts's exact two-case
- * freshness formula (heartbeatAt, falling back to claimedAt) against
- * DEFAULT_CLAIM_TTL_MS, so a genuinely crashed/stale sibling does not
- * permanently starve the rest of the bundle.
+ * freshness formula (heartbeatAt, falling back to claimedAt) against the
+ * resolved claim TTL — `process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS ??
+ * DEFAULT_CLAIM_TTL_MS`, the same operator-overridable formula used by
+ * stale-claim-reaper.ts and pull-request-service.ts's claimNext — so a
+ * genuinely crashed/stale sibling does not permanently starve the rest of
+ * the bundle.
  *
  * Operates on the Prisma `Task` shape (nullable fields) rather than the store.ts
  * interface — the dependency semantics are identical.
@@ -49,12 +52,18 @@ export interface ReadyTaskLike {
 /**
  * Mirrors stale-claim-reaper.ts's exact freshness formula: prefer
  * heartbeatAt when present, else fall back to claimedAt; a claim with
- * neither set is never fresh.
+ * neither set is never fresh. The TTL itself mirrors stale-claim-reaper.ts
+ * and pull-request-service.ts's claimNext: the operator-overridable
+ * SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS env var, falling back to
+ * DEFAULT_CLAIM_TTL_MS.
  */
 function hasFreshClaim(task: ReadyTaskLike, nowMs: number): boolean {
   const effectiveTimestamp = task.heartbeatAt ?? task.claimedAt;
   if (!effectiveTimestamp) return false;
-  return nowMs - new Date(effectiveTimestamp).getTime() < DEFAULT_CLAIM_TTL_MS;
+  const ttlMs = Number(
+    process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS ?? DEFAULT_CLAIM_TTL_MS,
+  );
+  return nowMs - new Date(effectiveTimestamp).getTime() < ttlMs;
 }
 
 export async function resolveReadyTasks<T extends ReadyTaskLike>(

--- a/task-store/src/ready.unit.test.ts
+++ b/task-store/src/ready.unit.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { type ReadyTaskLike, resolveReadyTasks } from "./ready.ts";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -303,6 +303,60 @@ describe("resolveReadyTasks", () => {
       const task = makeTask({ id: "t1", branch: "feat/shared" });
       const result = await resolveReadyTasks([task], isPrMergedShouldNotBeCalled);
       expect(result).toEqual([task]);
+    });
+
+    describe("SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS override", () => {
+      const ENV_KEY = "SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS";
+      const originalValue = process.env[ENV_KEY];
+
+      afterEach(() => {
+        if (originalValue === undefined) {
+          delete process.env[ENV_KEY];
+        } else {
+          process.env[ENV_KEY] = originalValue;
+        }
+      });
+
+      it("excludes a sibling that is fresh under a custom (longer) TTL but would be stale under the default", async () => {
+        process.env[ENV_KEY] = String(DEFAULT_CLAIM_TTL_MS * 2);
+        const sibling = makeTask({
+          id: "sibling",
+          status: "in_progress",
+          branch: "feat/shared",
+          heartbeatAt: new Date(
+            FIXED_NOW.getTime() - DEFAULT_CLAIM_TTL_MS - 1_000,
+          ).toISOString(),
+        });
+        const task = makeTask({ id: "t1", branch: "feat/shared" });
+        const result = await resolveReadyTasks(
+          [task, sibling],
+          isPrMergedShouldNotBeCalled,
+          fixedNow,
+        );
+        // Under the default TTL this sibling's claim is stale (excluded from
+        // the guard); under the custom, longer TTL it's still fresh, so t1
+        // stays blocked.
+        expect(result).toEqual([]);
+      });
+
+      it("does not exclude a sibling that is stale under a custom (shorter) TTL even though it would be fresh under the default", async () => {
+        process.env[ENV_KEY] = String(30_000);
+        const sibling = makeTask({
+          id: "sibling",
+          status: "in_progress",
+          branch: "feat/shared",
+          heartbeatAt: new Date(FIXED_NOW.getTime() - 60_000).toISOString(),
+        });
+        const task = makeTask({ id: "t1", branch: "feat/shared" });
+        const result = await resolveReadyTasks(
+          [task, sibling],
+          isPrMergedShouldNotBeCalled,
+          fixedNow,
+        );
+        // Under the default TTL (65min) this sibling would still be fresh;
+        // under the custom, shorter 30s TTL, it's stale, so t1 is unblocked.
+        expect(result).toEqual([task]);
+      });
     });
   });
 });

--- a/task-store/src/ready.unit.test.ts
+++ b/task-store/src/ready.unit.test.ts
@@ -6,6 +6,7 @@
  * (dependency injection, not a global/module mock).
  */
 
+import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import { describe, expect, it } from "bun:test";
 import { type ReadyTaskLike, resolveReadyTasks } from "./ready.ts";
 
@@ -20,9 +21,14 @@ function makeTask(overrides: Partial<ReadyTaskLike> = {}): ReadyTaskLike {
     pr: null,
     hitl: null,
     hitlNotifiedAt: null,
+    claimedAt: null,
+    heartbeatAt: null,
     ...overrides,
   };
 }
+
+const FIXED_NOW = new Date("2026-08-05T00:00:00.000Z");
+const fixedNow = () => FIXED_NOW;
 
 /** isPrMerged stub that always throws — use when the test asserts it must
  * never be called (e.g. dep.pr is null so the check should short-circuit). */
@@ -192,5 +198,111 @@ describe("resolveReadyTasks", () => {
       isPrMergedShouldNotBeCalled,
     );
     expect(result).toEqual([task]);
+  });
+
+  describe("same-branch exclusivity", () => {
+    it("excludes a pending task when a fresh in_progress sibling shares its branch (heartbeatAt)", async () => {
+      const sibling = makeTask({
+        id: "sibling",
+        status: "in_progress",
+        branch: "feat/shared",
+        heartbeatAt: new Date(FIXED_NOW.getTime() - 1_000).toISOString(),
+      });
+      const task = makeTask({ id: "t1", branch: "feat/shared" });
+      const result = await resolveReadyTasks(
+        [task, sibling],
+        isPrMergedShouldNotBeCalled,
+        fixedNow,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("excludes a pending task when a fresh in_progress sibling shares its branch (claimedAt, no heartbeatAt)", async () => {
+      const sibling = makeTask({
+        id: "sibling",
+        status: "in_progress",
+        branch: "feat/shared",
+        claimedAt: new Date(FIXED_NOW.getTime() - 1_000).toISOString(),
+        heartbeatAt: null,
+      });
+      const task = makeTask({ id: "t1", branch: "feat/shared" });
+      const result = await resolveReadyTasks(
+        [task, sibling],
+        isPrMergedShouldNotBeCalled,
+        fixedNow,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("does not exclude a pending task when the in_progress sibling's claim is stale (older than DEFAULT_CLAIM_TTL_MS)", async () => {
+      const sibling = makeTask({
+        id: "sibling",
+        status: "in_progress",
+        branch: "feat/shared",
+        heartbeatAt: new Date(
+          FIXED_NOW.getTime() - DEFAULT_CLAIM_TTL_MS - 1_000,
+        ).toISOString(),
+      });
+      const task = makeTask({ id: "t1", branch: "feat/shared" });
+      const result = await resolveReadyTasks(
+        [task, sibling],
+        isPrMergedShouldNotBeCalled,
+        fixedNow,
+      );
+      expect(result).toEqual([task]);
+    });
+
+    it("does not exclude a pending task when the in_progress sibling is on a different branch", async () => {
+      const sibling = makeTask({
+        id: "sibling",
+        status: "in_progress",
+        branch: "feat/other",
+        heartbeatAt: new Date(FIXED_NOW.getTime() - 1_000).toISOString(),
+      });
+      const task = makeTask({ id: "t1", branch: "feat/shared" });
+      const result = await resolveReadyTasks(
+        [task, sibling],
+        isPrMergedShouldNotBeCalled,
+        fixedNow,
+      );
+      expect(result).toEqual([task]);
+    });
+
+    it("does not exclude a pending task with no branch set", async () => {
+      const sibling = makeTask({
+        id: "sibling",
+        status: "in_progress",
+        branch: null,
+        heartbeatAt: new Date(FIXED_NOW.getTime() - 1_000).toISOString(),
+      });
+      const task = makeTask({ id: "t1", branch: null });
+      const result = await resolveReadyTasks(
+        [task, sibling],
+        isPrMergedShouldNotBeCalled,
+        fixedNow,
+      );
+      expect(result).toEqual([task]);
+    });
+
+    it("does not exclude a task from being blocked by itself when it happens to be in_progress-like in the list (self is skipped as a sibling)", async () => {
+      // Only the task itself is present with a shared branch — since a task
+      // can never be its own sibling, and this record is 'pending' (not
+      // in_progress) anyway, it must be included.
+      const task = makeTask({ id: "t1", branch: "feat/solo" });
+      const result = await resolveReadyTasks(
+        [task],
+        isPrMergedShouldNotBeCalled,
+        fixedNow,
+      );
+      expect(result).toEqual([task]);
+    });
+
+    it("uses the default now() when no now function is injected (production default, real time)", async () => {
+      // No in_progress siblings at all — this exercises the default
+      // `now: () => new Date()` parameter path without needing determinism.
+      const task = makeTask({ id: "t1", branch: "feat/shared" });
+      const result = await resolveReadyTasks([task], isPrMergedShouldNotBeCalled);
+      expect(result).toEqual([task]);
+    });
   });
 });

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -262,7 +262,11 @@ export class TaskService implements TaskServiceLike {
     const tasks = await this.prisma.task.findMany({
       orderBy: { createdAt: "asc" },
     });
-    const ready = await resolveReadyTasks(tasks, async () => false);
+    const ready = await resolveReadyTasks(
+      tasks,
+      async () => false,
+      () => this.clock.now(),
+    );
     if (agentId) {
       return ready.filter(
         (t) =>


### PR DESCRIPTION
## Summary
- Add a same-branch exclusivity guard to `resolveReadyTasks()`: a pending task is now excluded from the ready set when another task shares its non-null `branch` and is `in_progress` with a fresh claim.
- Freshness mirrors `stale-claim-reaper.ts`'s exact two-case formula (`heartbeatAt`, falling back to `claimedAt`) against `DEFAULT_CLAIM_TTL_MS`, so a genuinely crashed/stale sibling never permanently starves the rest of a bundle.
- Threads a `now: () => Date` parameter through `resolveReadyTasks()` (defaulted to real time) and wires `listReady()` in `task-service.ts` to the service's existing injected `Clock`.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Excludes pending task when a same-branch sibling is `in_progress` with a fresh claim | MET | `hasFreshInProgressSibling` check in `ready.ts` |
| 2 | Stale in_progress sibling does not block readiness | MET | `hasFreshClaim()` staleness math matches `stale-claim-reaper.ts`; unit test covers it |
| 3 | No-branch / no-sibling tasks unaffected | MET | `if (task.branch)` guard; existing dependency logic untouched |
| 4 | Unit tests: fresh same-branch exclusion, stale non-exclusion, different-branch non-exclusion, no-branch non-exclusion | MET | All 4 required cases + 3 bonus cases added to `ready.unit.test.ts` |

## Test Plan
- `task-store/src/ready.unit.test.ts`: 7 new unit tests covering fresh/stale claims, cross-branch isolation, no-branch tasks, self-exclusion safety, and the default `now()` path.
- [x] `task typecheck` — clean across all 7 workspaces
- [x] `task test` (full suite) — 5684 pass / 1 pre-existing unrelated failure (`agent/src/claude.unit.test.ts` extraAllowedTools flake, reproduces identically on clean `main`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
