### PR TITLE
fix: release orphaned pre-claim on RVD-1.2's terminal-review skip path

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -421,6 +421,54 @@ describe("review.md — Step 14 live-review pre-check (RVD-1.2)", () => {
     expect(section).toContain("cross-task-store");
     expect(section.toLowerCase()).toContain("stop");
   });
+
+  it("when a pre-claim marker was present, the skip branch releases the orphaned claim before stopping", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    // The section must contain a conditional release call referencing PRECLAIM_RECORD_ID
+    expect(section).toContain("/prs/");
+    expect(section).toContain("/release");
+    expect(section).toContain("PRECLAIM_RECORD_ID");
+  });
+
+  it("the pre-claim release call appears before the 'Skipping' message", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    const releaseIdx = section.indexOf("/release");
+    const skippingIdx = section.indexOf("Skipping #{pr}");
+
+    expect(releaseIdx).toBeGreaterThan(-1);
+    expect(skippingIdx).toBeGreaterThan(-1);
+    expect(releaseIdx).toBeLessThan(skippingIdx);
+  });
+
+  it("the release call is conditional on PRECLAIM_RECORD_ID being non-empty", () => {
+    const preCheckIdx = step14Section.indexOf(
+      "### Live-Review Pre-Check (RVD-1.2)",
+    );
+    const fastPathIdx = step14Section.indexOf(
+      "### Pre-Claim Fast Path (CBD-1.4)",
+    );
+    const section = step14Section.slice(preCheckIdx, fastPathIdx);
+
+    // Should reference checking if PRECLAIM_RECORD_ID is set
+    const releaseIdx = section.indexOf("/release");
+    const releaseBlock = section.slice(Math.max(0, releaseIdx - 300), releaseIdx + 100);
+
+    expect(releaseBlock).toMatch(/if.*PRECLAIM_RECORD_ID|PRECLAIM_RECORD_ID.*if|-z.*PRECLAIM_RECORD_ID|-n.*PRECLAIM_RECORD_ID/i);
+  });
 });
 
 describe("review.md — reviewedCommitSha written/read for dedup (RCS-1.2)", () => {

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -829,10 +829,23 @@ a literal `Verdict:` label match rather than the fuller thread/finding-body anal
 label match is sufficient to detect "already reviewed, terminal" at this commit. There is
 no author filtering — a review from any identity counts, not just self-authored ones.
 
-**If `$terminal` is `true`** (a terminal review already exists at head on GitHub): print
+**If `$terminal` is `true`** (a terminal review already exists at head on GitHub):
+
+If a pre-claim marker was present (`PRECLAIM_RECORD_ID` is non-empty), release the
+inherited claim first so the PR re-enters the candidate pool:
+```bash
+if [ -n "$PRECLAIM_RECORD_ID" ]; then
+  curl -s -o /dev/null -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/${PRECLAIM_RECORD_ID}/release"
+fi
+```
+
+Then print:
 ```
 Skipping #{pr} — a review already exists at this commit (${headRefOid:0:7}) on GitHub (cross-task-store check), nothing to do.
 ```
+
 Stop. No claim, no checkout (no worktree checkout happens).
 
 **If `$terminal` is `false`**: continue to the Pre-Claim Fast Path subsection immediately


### PR DESCRIPTION
## Summary
- Fixes RVD-1.2's terminal-review skip path in `review.md` to release an inherited pre-claim (`PRECLAIM_RECORD_ID`) before stopping, so a legitimately-skipped PR immediately re-enters candidate selection instead of sitting orphaned until the StaleClaimReaper's 65-minute TTL expires.
- The release call is conditional — only fires when a pre-claim marker was present (`PRECLAIM_RECORD_ID` non-empty); a human/manual invocation with no pre-claim marker behaves exactly as before.
- Extends `review.content.test.ts` with 3 new assertions in the existing RVD-1.2 test block covering: presence of the conditional release call, its ordering before the "Skipping..." message, and its conditionality on `PRECLAIM_RECORD_ID`.

Confirmed live on PR #2466 (app-vitals/shipwright): an orphaned claim from a review-cron dispatch left a PR record's `claimedBy` set for 50+ minutes after a legitimate skip, excluding it from all future review candidacy per `check-review.ts`'s exclusion rule.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | RVD-1.2's skip branch calls POST /prs/{PRECLAIM_RECORD_ID}/release before stopping, whenever PRECLAIM_RECORD_ID was set | MET | New bash block in review.md's terminal-review skip branch |
| 2 | When no pre-claim marker present, skip branch behaves exactly as today | MET | Guarded by `if [ -n "$PRECLAIM_RECORD_ID" ]` — no-op when unset |
| 3 | Release call happens before "Skipping #{pr}..." print and "Stop." | MET | Release block precedes the print/stop in the diff |
| 4 | review.content.test.ts extended with conditional-release assertions | MET | 3 new tests added to the existing RVD-1.2 describe block |

## Test Plan
- [x] `bun test plugins/shipwright/commands/review.content.test.ts` — 62/62 pass, including 3 new tests
- [x] `task lint` — clean
- [x] `task typecheck` — clean
- [x] Full `bun test` — 1 pre-existing failure (`agent/src/claude.unit.test.ts` extraAllowedTools), unrelated to this diff, reproduces on main

Generated with [Claude Code](https://claude.com/claude-code)
