### PR TITLE
feat: review.md: add [silent] + deferred-tagged skip-reason to RVD-1.2 precheck and Step 14.3 dedup

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -555,6 +555,75 @@ describe("review.md — Step 14 live-review pre-check (RVD-1.2)", () => {
   });
 });
 
+describe("review.md — RVD-1.2 terminal-review skip emits [silent] + skip-reason marker (STD-1.5)", () => {
+  it("the terminal-review skip block contains the skip-reason marker before [silent], exempting it from the HITL auto-block skip counter", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    expect(preCheckIdx).toBeGreaterThan(-1);
+    expect(fastPathIdx).toBeGreaterThan(preCheckIdx);
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain(
+      "[skip-reason:review:deferred:already-reviewed-at-head:{pr}]",
+    );
+    const skipReasonIdx = section.indexOf(
+      "[skip-reason:review:deferred:already-reviewed-at-head:{pr}]",
+    );
+    const silentIdx = section.indexOf("[silent]");
+    expect(silentIdx).toBeGreaterThan(-1);
+    expect(skipReasonIdx).toBeLessThan(silentIdx);
+  });
+
+  it("still stops with no claim, no checkout after emitting the markers", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("Stop.");
+    expect(section).toContain("No claim, no checkout");
+  });
+});
+
+describe("review.md — Step 14.3 already-reviewed-at-commit skip emits [silent] + skip-reason marker (STD-1.5)", () => {
+  it("the already-reviewed-at-commit skip block contains the skip-reason marker before [silent], exempting it from the HITL auto-block skip counter", () => {
+    const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");
+    const endIdx = content.indexOf("## Review Quality Rules", step14Idx);
+    expect(step14Idx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(step14Idx);
+    const section = content.slice(step14Idx, endIdx);
+
+    const dedupIdx = section.indexOf(
+      "**Check if the PR was already reviewed at the current commit**",
+    );
+    expect(dedupIdx).toBeGreaterThan(-1);
+    const dedupSection = section.slice(dedupIdx);
+
+    expect(dedupSection).toContain(
+      "[skip-reason:review:deferred:already-reviewed-at-head:{pr}]",
+    );
+    const skipReasonIdx = dedupSection.indexOf(
+      "[skip-reason:review:deferred:already-reviewed-at-head:{pr}]",
+    );
+    const silentIdx = dedupSection.indexOf("[silent]");
+    expect(silentIdx).toBeGreaterThan(-1);
+    expect(skipReasonIdx).toBeLessThan(silentIdx);
+  });
+
+  it("still stops after emitting the markers", () => {
+    const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");
+    const endIdx = content.indexOf("## Review Quality Rules", step14Idx);
+    const section = content.slice(step14Idx, endIdx);
+
+    const dedupIdx = section.indexOf(
+      "**Check if the PR was already reviewed at the current commit**",
+    );
+    expect(dedupIdx).toBeGreaterThan(-1);
+    const dedupSection = section.slice(dedupIdx);
+
+    expect(dedupSection).toContain("Stop.");
+  });
+});
+
 describe("review.md — reviewedCommitSha written/read for dedup (RCS-1.2)", () => {
   it("Step 5's Unresolved Comment Check PATCH call also sets reviewedCommitSha alongside commitSha", () => {
     const step5Idx = content.indexOf("## Step 5: Gather Context");

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -873,7 +873,13 @@ Then print:
 Skipping #{pr} — a review already exists at this commit (${headRefOid:0:7}) on GitHub (cross-task-store check), nothing to do.
 ```
 
-Stop. No claim, no checkout (no worktree checkout happens).
+Emit `[skip-reason:review:deferred:already-reviewed-at-head:{pr}]` immediately before the
+following `[silent]` marker (interpolating `{pr}` from the value above) — this defer is a
+legitimate backstop, not a genuine no-op, and without the tagged reason the loop
+orchestrator's generic `[silent]` handling would count it toward `SKIP_BLOCK_THRESHOLD`,
+risking a false HITL auto-block (see `agent/src/loop-orchestrator.ts`).
+
+Respond `[silent]`. Stop. No claim, no checkout (no worktree checkout happens).
 
 **If `$terminal` is `false`**: continue to the Pre-Claim Fast Path subsection immediately
 below, unchanged.
@@ -967,7 +973,13 @@ gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid'
      ```
      Skipping #{pr} — already reviewed at this commit ({headRefOid[0..7]}), nothing to do.
      ```
-   - Stop.
+   - Emit `[skip-reason:review:deferred:already-reviewed-at-head:{pr}]` immediately before
+     the following `[silent]` marker (interpolating `{pr}` from the value above) — this
+     defer is a legitimate backstop, not a genuine no-op, and without the tagged reason the
+     loop orchestrator's generic `[silent]` handling would count it toward
+     `SKIP_BLOCK_THRESHOLD`, risking a false HITL auto-block (see
+     `agent/src/loop-orchestrator.ts`).
+   - Respond `[silent]`. Stop.
 
    If no record exists (first review), or `record.reviewState` is `pending` (claimed but
    never completed — never actually reviewed), or `headRefOid` differs from


### PR DESCRIPTION
## Summary
- Adds an explicit `[silent]` marker to review.md's two "already-handled PR" skip paths — the RVD-1.2 terminal-review pre-check and Step 14.3's already-reviewed-at-commit dedup — which previously said "Stop." with no marker at all, unlike every other guard in this file.
- Pairs `[silent]` with `[skip-reason:review:deferred:already-reviewed-at-head:{pr}]`, following the existing convention used at the Step 5 unresolved-feedback skip site, so both defers are exempt from `SKIP_BLOCK_THRESHOLD` counting instead of silently starting to count toward it.
- No change to the underlying dedup/terminal-check logic — prose-only insertion immediately before each site's existing Stop instruction.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | RVD-1.2's terminal-review skip path emits both `[silent]` and `[skip-reason:review:deferred:already-reviewed-at-head:{pr}]` together | MET |
| 2 | Step 14.3's already-reviewed-at-commit dedup skip path emits both markers together | MET |
| 3 | No behavior change to the underlying dedup logic (RPG-1.1's fresh-author-reply exception untouched) | MET |
| 4 | review.content.test.ts extended to assert both sections contain `[silent]` and the skip-reason marker | MET |

## Test Plan
- Extended `plugins/shipwright/commands/review.content.test.ts` with 2 new describe blocks (4 tests) asserting marker presence/ordering and preserved "Stop." language in both target sections.
- `bun test plugins/shipwright/commands/review.content.test.ts` — 72/72 pass.
- `task typecheck` — clean.
- `task ci` — clean except a pre-existing, unrelated flake (`agent/src/claude.unit.test.ts` → `extraAllowedTools`), confirmed to reproduce identically on clean `main`.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
