### PR TITLE
feat(chart): generate the inter-service token mesh so a fresh install needs no Secrets

### DIFF
--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -824,3 +824,101 @@ describe("combined server — regression guard: runtime middleware must not bloc
     expect(body.repos).toEqual([]);
   });
 });
+
+// ─── Deployment-wide default agent env ────────────────────────────────────────
+//
+// A Helm install supplies one set of Claude credentials for the whole deployment
+// (agent.credentials.*) instead of an operator pasting a token into every agent.
+// Admin merges those defaults UNDERNEATH each agent's own env rows when serving
+// the config bundle, so a per-agent value always wins. These tests pin that
+// precedence — getting it backwards would let a deployment-wide credential
+// silently override a deliberately-scoped per-agent one.
+
+describe("defaultAgentEnv merging in GET /:id/config", () => {
+  const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+  const ADMIN_KEY = "sk_default_env_admin";
+
+  function buildApp(opts: {
+    bundleEnv?: Record<string, string>;
+    defaultAgentEnv?: Record<string, string>;
+  }) {
+    return createAgentRuntimeApp({
+      agentEnvService: {
+        async getConfigBundle() {
+          return {
+            agentId: AGENT_ID,
+            env: opts.bundleEnv ?? {},
+            allowedTools: [],
+          };
+        },
+      },
+      agentCronJobService: {
+        async list() {
+          return [];
+        },
+        async listWithRunSummary() {
+          return [];
+        },
+      },
+      agentService: {
+        async getById() {
+          return {
+            id: AGENT_ID,
+            name: "Test Agent",
+            repos: [],
+            authorAllowlist: [],
+          };
+        },
+      },
+      agentPluginService: {
+        async listEnabled() {
+          return [];
+        },
+      },
+      adminApiKeys: parseAdminApiKeys(`admin:${ADMIN_KEY}:*`),
+      agentTokenService: { validate: async () => null },
+      sessionSecret: SESSION_SECRET,
+      defaultAgentEnv: opts.defaultAgentEnv,
+    });
+  }
+
+  async function fetchEnv(app: ReturnType<typeof buildApp>) {
+    const res = await app.request(`/${AGENT_ID}/config`, {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()).env as Record<string, string>;
+  }
+
+  test("an agent with no env rows inherits the deployment-wide default", async () => {
+    const env = await fetchEnv(
+      buildApp({ defaultAgentEnv: { ANTHROPIC_API_KEY: "deployment-wide" } }),
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe("deployment-wide");
+  });
+
+  test("a per-agent value OVERRIDES the deployment-wide default", async () => {
+    const env = await fetchEnv(
+      buildApp({
+        bundleEnv: { ANTHROPIC_API_KEY: "per-agent" },
+        defaultAgentEnv: { ANTHROPIC_API_KEY: "deployment-wide" },
+      }),
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe("per-agent");
+  });
+
+  test("defaults and per-agent rows for different keys are unioned", async () => {
+    const env = await fetchEnv(
+      buildApp({
+        bundleEnv: { AGENT_ONLY: "a" },
+        defaultAgentEnv: { CLAUDE_CODE_OAUTH_TOKEN: "d" },
+      }),
+    );
+    expect(env).toEqual({ AGENT_ONLY: "a", CLAUDE_CODE_OAUTH_TOKEN: "d" });
+  });
+
+  test("omitting defaultAgentEnv leaves the bundle env untouched", async () => {
+    const env = await fetchEnv(buildApp({ bundleEnv: { ONLY: "x" } }));
+    expect(env).toEqual({ ONLY: "x" });
+  });
+});

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -88,6 +88,15 @@ export interface AgentRuntimeDeps {
   adminApiKeys?: Map<string, AdminApiKey>;
   /** Token service for per-agent bearer token validation. */
   agentTokenService: Pick<AgentTokenService, "validate">;
+  /**
+   * Deployment-wide default env merged UNDERNEATH each agent's own env rows, so
+   * every agent inherits shared credentials (e.g. ANTHROPIC_API_KEY) without an
+   * operator pasting them per agent.
+   *
+   * Per-agent rows always win — this is a floor, never an override. Agents pick
+   * defaults up on their next config sync, with no pod restart or re-provision.
+   */
+  defaultAgentEnv?: Record<string, string>;
 }
 
 // ─── Route definitions ────────────────────────────────────────────────────────
@@ -157,6 +166,7 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     agentCronJobService,
     agentService,
     agentPluginService,
+    defaultAgentEnv,
   } = deps;
 
   const app = new OpenAPIHono();
@@ -190,7 +200,8 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     ]);
 
     const response: AgentConfigResponse = {
-      env: bundle?.env ?? {},
+      // Deployment-wide defaults first so per-agent rows override them.
+      env: { ...(defaultAgentEnv ?? {}), ...(bundle?.env ?? {}) },
       allowedTools: bundle?.allowedTools ?? [],
       plugins: plugins.map((p) => {
         // The stored name is the canonical Claude plugin spec — exactly what

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -313,6 +313,40 @@ export function resolvePublicRepo(
   return env.SHIPWRIGHT_ADMIN_PUBLIC_REPO?.trim() || undefined;
 }
 
+/**
+ * Deployment-wide default env handed to EVERY agent's config bundle, merged
+ * underneath that agent's own env rows (per-agent values always win).
+ *
+ * This is what lets a Helm install supply one set of Claude credentials for the
+ * whole deployment instead of an operator pasting a token into each agent
+ * through the admin UI. Agents pick these up on their next config sync — no pod
+ * restart and no re-provision, so it also reaches already-running agents.
+ *
+ * Deliberately read from SHIPWRIGHT_AGENT_DEFAULT_-prefixed vars rather than
+ * bare ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN: the admin process must never
+ * hand out a credential it happens to hold for its own use. Opting in is
+ * explicit.
+ *
+ * Blank/whitespace values are treated as unset so an empty Helm value (the
+ * default) doesn't inject an empty credential that would mask a working
+ * per-agent one.
+ */
+export function resolveDefaultAgentEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  const mapping: Record<string, string> = {
+    SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "ANTHROPIC_API_KEY",
+    SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "CLAUDE_CODE_OAUTH_TOKEN",
+  };
+
+  const defaults: Record<string, string> = {};
+  for (const [source, target] of Object.entries(mapping)) {
+    const value = env[source]?.trim();
+    if (value) defaults[target] = value;
+  }
+  return defaults;
+}
+
 // startServer() is the process entrypoint: it runs the real migration
 // preflight, constructs a real PrismaClient (live DB connection), calls
 // Bun.serve to bind an actual socket, and mounts every sub-app. This is
@@ -427,6 +461,7 @@ async function startServer(): Promise<void> {
     sessionSecret,
     adminApiKeys,
     agentTokenService,
+    defaultAgentEnv: resolveDefaultAgentEnv(process.env),
   });
 
   root.route("/agents", runtimeApp);

--- a/admin/src/main.unit.test.ts
+++ b/admin/src/main.unit.test.ts
@@ -11,6 +11,7 @@ import type { AgentTokenService } from "./agent-tokens.ts";
 import {
   buildProvisioner,
   checkDbReady,
+  resolveDefaultAgentEnv,
   resolvePublicRepo,
   resolveTaskStoreBaseUrl,
   runMigrations,
@@ -296,5 +297,68 @@ describe("checkDbReady", () => {
       },
     };
     await expect(checkDbReady(prisma)).resolves.toBe(false);
+  });
+});
+
+// resolveDefaultAgentEnv is the pure env rule behind the chart's
+// agent.credentials.* values: it turns SHIPWRIGHT_AGENT_DEFAULT_-prefixed vars
+// into the deployment-wide default env admin merges underneath each agent's own
+// rows when serving GET /agents/:id/config.
+//
+// The prefix is the security boundary — admin must never hand out a bare
+// ANTHROPIC_API_KEY it happens to hold for its own use.
+describe("resolveDefaultAgentEnv", () => {
+  it("maps the prefixed vars to the names the agent actually reads", () => {
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "sk-ant-xxx",
+        SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy",
+      }),
+    ).toEqual({
+      ANTHROPIC_API_KEY: "sk-ant-xxx",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy",
+    });
+  });
+
+  it("returns an empty object when nothing is set", () => {
+    expect(resolveDefaultAgentEnv({})).toEqual({});
+  });
+
+  it("ignores blank and whitespace-only values", () => {
+    // An unset Helm value renders as "". Injecting an empty credential would
+    // mask a working per-agent one, so blank must behave exactly like unset.
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "",
+        SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "   ",
+      }),
+    ).toEqual({});
+  });
+
+  it("trims surrounding whitespace from a real value", () => {
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "  sk-ant-xxx\n",
+      }),
+    ).toEqual({ ANTHROPIC_API_KEY: "sk-ant-xxx" });
+  });
+
+  it("supports supplying only one of the two credentials", () => {
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy",
+      }),
+    ).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy" });
+  });
+
+  it("does NOT pick up bare ANTHROPIC_API_KEY from the admin process env", () => {
+    // The security boundary: admin holding a credential for its own use must
+    // never cause that credential to be handed to every agent.
+    expect(
+      resolveDefaultAgentEnv({
+        ANTHROPIC_API_KEY: "admins-own-key",
+        CLAUDE_CODE_OAUTH_TOKEN: "admins-own-token",
+      }),
+    ).toEqual({});
   });
 });

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,61 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.9.0] - 2026-08-07
+
+### Added
+
+- **Inter-service token mesh.** The chart now generates the three tokens that let
+  the services authenticate to each other, so a fresh install needs **zero**
+  hand-created Secrets:
+
+  | Token | Produced by | Consumed by |
+  |---|---|---|
+  | `TASK_STORE_ADMIN_TOKEN` | task-store (`TASK_STORE_SEED_ADMIN_TOKEN`) | admin, metrics |
+  | `CHAT_ADMIN_TOKEN` | chat (`CHAT_SEED_ADMIN_TOKEN`) | admin |
+  | `INTERNAL_API_KEY` | admin (inside `SHIPWRIGHT_ADMIN_API_KEYS`) | metrics, task-store, chat |
+
+  Generated once in `templates/internal-secret.yaml` and referenced everywhere
+  else by `secretKeyRef` — Helm evaluates templates independently, so generating
+  in more than one place would produce mismatched values. Reused across
+  `helm upgrade` via the same `lookup` idiom as the admin session keys.
+- Admin now receives `SHIPWRIGHT_TASK_STORE_URL` / `SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN`
+  (when task-store is enabled) and `SHIPWRIGHT_ADMIN_API_KEYS`. Task-store and chat
+  receive their seed tokens and their `*_AGENTS_URL` / `*_AGENTS_API_KEY`
+  scope-resolver pairs. None of these were previously rendered at all.
+- **Metrics URL auto-defaulting.** `METRICS_ADMIN_URL` and `METRICS_TASK_STORE_URL`
+  now fall back to the in-cluster Service DNS names. This is load-bearing: without
+  `METRICS_TASK_STORE_URL` the provider selector falls through to SQLite, which has
+  no writable path in the published image and crashes on boot (`SQLITE_CANTOPEN`).
+  An explicit `metrics.provider.*Url` still wins.
+- `admin.apiKeys.extra` — additional `name:token:scope` entries merged into
+  `SHIPWRIGHT_ADMIN_API_KEYS`.
+- `internal.enabled` / `internal.existingSecret` — disable the mesh entirely, or
+  point every consumer at a caller-managed Secret.
+
+### Changed
+
+- **Enabling chat no longer requires `chat.adminToken.existingSecret`.** Previously
+  the admin console's Chat tab stayed unwired unless you pre-created a Secret; the
+  chart now generates the token. `chat.adminToken.existingSecret` still wins when set.
+
+### Compatibility
+
+- Every generated value is a **fallback**. A service-specific `existingSecret`
+  (`chat.adminToken`, `metrics.provider.taskStoreToken`,
+  `metrics.provider.internalKey`) always wins, and `extraEnv` — which still renders
+  **last** — wins over everything.
+- ⚠️ **If you hand-wire `SHIPWRIGHT_ADMIN_API_KEYS` through `admin.extraEnv`**, that
+  override shadows the composed value, leaving the chart-generated internal key out
+  of admin's accepted set — metrics, task-store and chat will then **401** whenever
+  they fall back to it. Move those entries to `admin.apiKeys.extra`, or set
+  `internal.enabled=false` to keep the pre-1.9 behaviour exactly.
+- ⚠️ `helm template | kubectl apply` does not execute `lookup`, so that flow would
+  **rotate all three tokens on every apply**. Use `internal.existingSecret` if you
+  deploy that way. Same hazard class as the admin session/encryption keys.
+- Token rotation does not revoke: the task-store and chat seeds are idempotent
+  upserts, so a rotated token leaves the previous hashed row behind.
+
 ## [1.8.3] - 2026-08-07
 
 ### Changed
@@ -27,6 +82,7 @@ independent of `appVersion`. CI enforces this with
 ### Changed
 
 - chart version bump to 1.8.1 — rebase past main's chart v1.8.0 (originally targeted 1.7.196, superseded by an intervening chart release)
+
 
 ## [1.8.0] - 2026-08-07
 

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,36 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.10.0] - 2026-08-07
+
+### Added
+
+- **`agent.credentials.*` — deployment-wide Claude credentials for every agent.**
+  There is no agent Deployment in this chart; agents are provisioned at runtime by
+  the admin service and fetch their credentials from `GET /agents/:id/config` on
+  each config sync. Previously the only way to give an agent a Claude token was to
+  paste one into every agent through the admin UI, so a `helm install` could never
+  produce a working agent on its own.
+
+  Supply `agent.credentials.anthropicApiKey` or `.claudeCodeOauthToken` (or point
+  `.existingSecret` at your own Secret) and admin merges them **underneath** each
+  agent's own env rows — a per-agent value always wins. Changes reach
+  already-running agents on their next sync, with no restart or re-provision.
+
+  Credentials are injected into admin under `SHIPWRIGHT_AGENT_DEFAULT_`-prefixed
+  names, never as a bare `ANTHROPIC_API_KEY`. That prefix is a security boundary:
+  admin must not hand out a credential it happens to hold for its own use.
+
+### Fixed
+
+- **Provisioned agents silently requested 40Gi PVCs.** `agent.provisioning.pvc.size`
+  was documented as "not injected", and indeed nothing ever rendered
+  `SHIPWRIGHT_AGENT_PVC_STORAGE_GI` — so `agent-provisioner.ts` fell back to its own
+  40Gi default for every agent, regardless of the configured value. Now injected
+  (with the `Gi` suffix stripped), and the stale `values.yaml` comment corrected.
+  **Upgrade note:** existing agents keep their current PVCs; the new size applies to
+  agents provisioned from here on.
+
 ## [1.9.0] - 2026-08-07
 
 ### Added

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -63,10 +63,13 @@ independent of `appVersion`. CI enforces this with
   receive their seed tokens and their `*_AGENTS_URL` / `*_AGENTS_API_KEY`
   scope-resolver pairs. None of these were previously rendered at all.
 - **Metrics URL auto-defaulting.** `METRICS_ADMIN_URL` and `METRICS_TASK_STORE_URL`
-  now fall back to the in-cluster Service DNS names. This is load-bearing: without
-  `METRICS_TASK_STORE_URL` the provider selector falls through to SQLite, which has
-  no writable path in the published image and crashes on boot (`SQLITE_CANTOPEN`).
-  An explicit `metrics.provider.*Url` still wins.
+  now fall back to the in-cluster Service DNS names whenever the token mesh is
+  wired (`internal.enabled=true`, the default) — mirroring the gate on their
+  paired tokens, so `internal.enabled=false` doesn't leave metrics with a URL but
+  no credential. This is load-bearing: without `METRICS_TASK_STORE_URL` the
+  provider selector falls through to SQLite, which has no writable path in the
+  published image and crashes on boot (`SQLITE_CANTOPEN`). An explicit
+  `metrics.provider.*Url` still wins regardless of `internal.enabled`.
 - `admin.apiKeys.extra` — additional `name:token:scope` entries merged into
   `SHIPWRIGHT_ADMIN_API_KEYS`.
 - `internal.enabled` / `internal.existingSecret` — disable the mesh entirely, or

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.9.0
+version: 1.10.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,11 +30,9 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "inter-service token mesh: the chart now generates the task-store, chat and internal API tokens so a fresh install needs zero hand-created Secrets"
-    - kind: added
-      description: "metrics auto-defaults METRICS_ADMIN_URL and METRICS_TASK_STORE_URL to the in-cluster Services, avoiding the SQLITE_CANTOPEN crash-on-boot"
-    - kind: added
-      description: "admin.apiKeys.extra merges caller-supplied entries into SHIPWRIGHT_ADMIN_API_KEYS (migration path off hand-wiring it via extraEnv)"
+      description: "agent.credentials.* supplies deployment-wide Claude credentials to every provisioned agent, merged under each agent's own env rows"
+    - kind: fixed
+      description: "agent.provisioning.pvc.size is now injected as SHIPWRIGHT_AGENT_PVC_STORAGE_GI; it was never rendered, so every provisioned agent silently requested the provisioner's 40Gi default"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.8.3
+version: 1.9.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,12 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.8.3 triggered by release tag agent-v1.129.0"
+    - kind: added
+      description: "inter-service token mesh: the chart now generates the task-store, chat and internal API tokens so a fresh install needs zero hand-created Secrets"
+    - kind: added
+      description: "metrics auto-defaults METRICS_ADMIN_URL and METRICS_TASK_STORE_URL to the in-cluster Services, avoiding the SQLITE_CANTOPEN crash-on-boot"
+    - kind: added
+      description: "admin.apiKeys.extra merges caller-supplied entries into SHIPWRIGHT_ADMIN_API_KEYS (migration path off hand-wiring it via extraEnv)"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -208,6 +208,27 @@ app.kubernetes.io/component: agent
 {{- end }}
 
 {{/*
+Name of the chart-managed Secret holding the deployment-wide Claude credentials
+handed to every provisioned agent.
+*/}}
+{{- define "shipwright.agent.credentialsSecretName" -}}
+{{- printf "%s-agent-credentials" (include "shipwright.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret name the admin Deployment should reference for agent credentials: the
+caller-managed agent.credentials.existingSecret when set, otherwise the
+chart-managed Secret.
+*/}}
+{{- define "shipwright.agent.effectiveCredentialsSecretName" -}}
+{{- if .Values.agent.credentials.existingSecret }}
+{{- .Values.agent.credentials.existingSecret }}
+{{- else }}
+{{- include "shipwright.agent.credentialsSecretName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Name of the ServiceAccount provisioned agent pods run as (SEPARATE from the admin
 SA). Defaults to "<fullname>-agent" when create=true and no name override.
 */}}

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -136,6 +136,63 @@ assembled DATABASE_URL when the bundled PostgreSQL subchart is used).
 {{- end }}
 
 {{/*
+Name of the chart-managed internal Secret holding the tokens that wire the
+Shipwright services to each other (task-store admin token, chat admin token,
+internal API key, and the composed SHIPWRIGHT_ADMIN_API_KEYS).
+
+Generation happens in exactly ONE template (internal-secret.yaml) and every
+consumer references these keys by secretKeyRef. That is forced, not a
+preference: Helm evaluates templates independently, so calling randAlphaNum in
+a producer template and again in a consumer template would yield two DIFFERENT
+values and the services would never authenticate to each other.
+*/}}
+{{- define "shipwright.internal.secretName" -}}
+{{- printf "%s-internal" (include "shipwright.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret name consumers should reference for the mesh tokens: the caller-managed
+internal.existingSecret when set, otherwise the chart-managed Secret.
+*/}}
+{{- define "shipwright.internal.effectiveSecretName" -}}
+{{- if .Values.internal.existingSecret }}
+{{- .Values.internal.existingSecret }}
+{{- else }}
+{{- include "shipwright.internal.secretName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Whether the chart-managed token mesh is available to wire into Deployments.
+False when internal.enabled=false, in which case no mesh env is injected at all
+and the operator is expected to hand-wire via extraEnv (the pre-1.8 behaviour).
+*/}}
+{{- define "shipwright.internal.wired" -}}
+{{- if .Values.internal.enabled }}true{{- end }}
+{{- end }}
+
+{{/*
+In-cluster base URL of the admin Service ("http://<fullname>-admin:<port>").
+*/}}
+{{- define "shipwright.admin.serviceUrl" -}}
+{{- printf "http://%s:%v" (include "shipwright.admin.fullname" .) .Values.admin.service.port }}
+{{- end }}
+
+{{/*
+In-cluster base URL of the task-store Service.
+*/}}
+{{- define "shipwright.taskStore.serviceUrl" -}}
+{{- printf "http://%s:%v" (include "shipwright.taskStore.fullname" .) .Values.taskStore.service.port }}
+{{- end }}
+
+{{/*
+In-cluster base URL of the chat Service.
+*/}}
+{{- define "shipwright.chat.serviceUrl" -}}
+{{- printf "http://%s:%v" (include "shipwright.chat.fullname" .) .Values.chat.service.port }}
+{{- end }}
+
+{{/*
 Agent component fullname: "<fullname>-agent".
 */}}
 {{- define "shipwright.agent.fullname" -}}

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -219,12 +219,53 @@ spec:
             # agent.provisioning.apiUrl for an external gateway.
             - name: SHIPWRIGHT_API_URL
               value: {{ .Values.agent.provisioning.apiUrl | default (printf "http://%s:%v" (include "shipwright.admin.fullname" .) .Values.admin.service.port) | quote }}
+            # Size of the workspace PVC the provisioner creates per agent. Without
+            # this the provisioner falls back to its own 40Gi default, which is far
+            # too large for a laptop cluster and silently over-requests everywhere.
+            - name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+              value: {{ .Values.agent.provisioning.pvc.size | trimSuffix "Gi" | quote }}
             {{- with .Values.agent.provisioning.pvcNameTemplate }}
             # PVC name template: when set, the provisioner substitutes {name} with
             # the agent's human-readable name (slug) to derive the PVC name. Used
             # when migrating from static agents with fixed naming conventions.
             - name: SHIPWRIGHT_AGENT_PVC_NAME_TEMPLATE
               value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.agent.credentials.enabled }}
+            {{- /* Deployment-wide agent credentials. Admin merges these under each
+                   agent's own env rows when serving GET /agents/:id/config, so a
+                   per-agent value always wins. Prefixed so admin never hands out
+                   a credential it holds for its own use — see
+                   resolveDefaultAgentEnv in admin/src/main.ts. */}}
+            {{- if .Values.agent.credentials.existingSecret }}
+            - name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agent.credentials.existingSecret }}
+                  key: {{ .Values.agent.credentials.anthropicApiKeyRef }}
+                  optional: true
+            - name: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agent.credentials.existingSecret }}
+                  key: {{ .Values.agent.credentials.claudeCodeOauthTokenRef }}
+                  optional: true
+            {{- else }}
+            {{- with .Values.agent.credentials.anthropicApiKey }}
+            - name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.agent.credentialsSecretName" $ }}
+                  key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            {{- end }}
+            {{- with .Values.agent.credentials.claudeCodeOauthToken }}
+            - name: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.agent.credentialsSecretName" $ }}
+                  key: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if .Values.agent.voice.enabled }}

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -114,6 +114,29 @@ spec:
             - name: SHIPWRIGHT_ADMIN_APP_BASE_URL
               value: {{ .Values.admin.appBaseUrl | quote }}
             {{- end }}
+            {{- if include "shipwright.internal.wired" . }}
+            # ── Inter-service token mesh ──────────────────────────────────────
+            # SHIPWRIGHT_ADMIN_API_KEYS is composed in the internal Secret (it
+            # embeds the raw internal key) and is what lets metrics, task-store
+            # and chat authenticate to this service. See internal-secret.yaml.
+            - name: SHIPWRIGHT_ADMIN_API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: SHIPWRIGHT_ADMIN_API_KEYS
+            {{- if .Values.taskStore.enabled }}
+            # Admin's own in-cluster task-store calls. The token is the same raw
+            # value task-store seeds at boot via TASK_STORE_SEED_ADMIN_TOKEN, so
+            # the pair works with no manual token minting.
+            - name: SHIPWRIGHT_TASK_STORE_URL
+              value: {{ include "shipwright.taskStore.serviceUrl" . | quote }}
+            - name: SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: TASK_STORE_ADMIN_TOKEN
+            {{- end }}
+            {{- end }}
             {{- if .Values.admin.taskStorePublicUrl }}
             # admin.taskStorePublicUrl: externally-reachable task-store base URL
             # advertised in the mint-token env block (e.g. https://<host>/task-store
@@ -240,7 +263,7 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
-            {{- if and .Values.chat.enabled .Values.chat.adminToken.existingSecret }}
+            {{- if and .Values.chat.enabled (or .Values.chat.adminToken.existingSecret (include "shipwright.internal.wired" .)) }}
             # ── Chat-service wiring ───────────────────────────────────────────
             # Enables the admin console's Chat tab (/admin/chat) and per-agent
             # chat-token minting during provisioning. The URL is the in-cluster
@@ -249,12 +272,18 @@ spec:
             # the box. Override the URL via admin.extraEnv if needed (extraEnv
             # is appended last and wins).
             - name: SHIPWRIGHT_CHAT_SERVICE_URL
-              value: {{ printf "http://%s:%v" (include "shipwright.chat.fullname" .) .Values.chat.service.port | quote }}
+              value: {{ include "shipwright.chat.serviceUrl" . | quote }}
             - name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.chat.adminToken.existingSecret }}
+                  # Caller-managed Secret always wins over the chart-generated one.
                   name: {{ .Values.chat.adminToken.existingSecret }}
                   key: {{ .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+                  {{- else }}
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: CHAT_ADMIN_TOKEN
+                  {{- end }}
             {{- end }}
             {{- if .Values.admin.sentry.dsn.existingSecret }}
             - name: SENTRY_DSN

--- a/charts/shipwright/templates/agent-credentials-secret.yaml
+++ b/charts/shipwright/templates/agent-credentials-secret.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.agent.credentials.enabled (not .Values.agent.credentials.existingSecret) (or .Values.agent.credentials.anthropicApiKey .Values.agent.credentials.claudeCodeOauthToken) }}
+{{- /*
+  Chart-managed Secret holding the deployment-wide Claude credentials handed to
+  EVERY provisioned agent.
+
+  There is no agent Deployment template — agents are provisioned at runtime by
+  the admin service. An agent fetches its credentials on each config sync via
+  GET /agents/:id/config, and admin merges this deployment-wide default
+  UNDERNEATH that agent's own env rows (per-agent values always win). So this is
+  a floor, not an override, and it reaches already-running agents on their next
+  sync without a restart or re-provision.
+
+  Rendered only when a credential is actually supplied — an empty value (the
+  default) must not inject an empty credential that would mask a working
+  per-agent one. Skipped entirely when agent.credentials.existingSecret is set;
+  the admin Deployment then references the caller's Secret directly.
+
+  These land in the admin Deployment as SHIPWRIGHT_AGENT_DEFAULT_-prefixed vars,
+  NOT as bare ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN. That prefix is
+  deliberate: the admin process must never hand out a credential it happens to
+  hold for its own use — opting in has to be explicit.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "shipwright.agent.credentialsSecretName" . }}
+  labels:
+    {{- include "shipwright.agent.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- with .Values.agent.credentials.anthropicApiKey }}
+  SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: {{ . | b64enc | quote }}
+{{- end }}
+{{- with .Values.agent.credentials.claudeCodeOauthToken }}
+  SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: {{ . | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/shipwright/templates/chat-deployment.yaml
+++ b/charts/shipwright/templates/chat-deployment.yaml
@@ -74,7 +74,7 @@ spec:
             {{- else }}
             {{- fail "chat.database.existingSecret is required when postgresql.enabled=false" }}
             {{- end }}
-            {{- if .Values.chat.adminToken.existingSecret }}
+            {{- if or .Values.chat.adminToken.existingSecret (include "shipwright.internal.wired" .) }}
             # Seed the admin token (stored hashed) at boot so the admin console
             # can authenticate without manual token minting. Idempotent upsert —
             # the same raw value is injected into the admin Deployment as
@@ -82,8 +82,24 @@ spec:
             - name: CHAT_SEED_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.chat.adminToken.existingSecret }}
+                  # Caller-managed Secret always wins over the chart-generated one.
                   name: {{ .Values.chat.adminToken.existingSecret }}
                   key: {{ .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+                  {{- else }}
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: CHAT_ADMIN_TOKEN
+                  {{- end }}
+            {{- end }}
+            {{- if and (include "shipwright.internal.wired" .) .Values.admin.enabled }}
+            # Scope resolver: chat calls admin to resolve an agent token's scope.
+            - name: SHIPWRIGHT_CHAT_AGENTS_URL
+              value: {{ include "shipwright.admin.serviceUrl" . | quote }}
+            - name: SHIPWRIGHT_CHAT_AGENTS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: INTERNAL_API_KEY
             {{- end }}
             {{- with .Values.chat.extraEnv }}
             # chat.extraEnv: caller-supplied env vars appended last so they can

--- a/charts/shipwright/templates/internal-secret.yaml
+++ b/charts/shipwright/templates/internal-secret.yaml
@@ -1,0 +1,103 @@
+{{- if and .Values.internal.enabled (not .Values.internal.existingSecret) }}
+{{- /*
+  Chart-managed internal Secret — the shared tokens that wire the Shipwright
+  services to each other, so a fresh install needs ZERO hand-created Secrets.
+
+  A zero-touch install needs exactly three generated values:
+
+    TASK_STORE_ADMIN_TOKEN
+      produced by  task-store  as TASK_STORE_SEED_ADMIN_TOKEN (upserted hashed at
+                   boot, agentId=null → admin scope)
+      consumed by  admin       as SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN
+                   metrics     as METRICS_TASK_STORE_TOKEN
+      (one token serves both consumers — the seeded token is admin-scoped.)
+
+    CHAT_ADMIN_TOKEN
+      produced by  chat        as CHAT_SEED_ADMIN_TOKEN
+      consumed by  admin       as SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+    INTERNAL_API_KEY
+      produced by  admin       inside SHIPWRIGHT_ADMIN_API_KEYS
+      consumed by  metrics     as METRICS_INTERNAL_API_KEY
+                   task-store  as SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY
+                   chat        as SHIPWRIGHT_CHAT_AGENTS_API_KEY
+
+  WHY ONE TEMPLATE: Helm evaluates every template independently, so randAlphaNum
+  called in a producer template and again in a consumer template yields two
+  different strings. Generation must happen exactly once, here, with every
+  consumer referencing these keys by secretKeyRef. This is a Helm constraint, not
+  a style choice.
+
+  SHIPWRIGHT_ADMIN_API_KEYS is composed HERE rather than in the admin Deployment
+  because the format embeds the raw key. Per admin/src/api-auth.ts parseAdminApiKeys
+  it is comma-separated "name:token:scope" — first segment is the name, LAST is
+  the scope, everything between is the token (so tokens may contain colons, but
+  never commas). Scope is "*" because no agent exists at install time, so a
+  per-agent scope is impossible to know here.
+
+  PERSISTENCE IDIOM (survives `helm upgrade`): look up the already-installed
+  Secret and reuse its (already base64-encoded) values; generate fresh random
+  material only on first install. Because producer and consumer both read the
+  SAME key by reference, upgrade stability is automatic — there is no
+  "both sides must regenerate identically" problem to solve.
+
+  CAVEAT — `helm template | kubectl apply` (GitOps): `helm template` and
+  helm-unittest do NOT execute `lookup`, so they always take the generate branch
+  and every apply would ROTATE all three tokens. Use internal.existingSecret to
+  pin them if you deploy that way. Same hazard class as the admin session /
+  encryption keys.
+
+  CAVEAT — rotation leaves stale rows: the task-store and chat seeds are
+  idempotent UPSERTS, never deletes, so a rotated token leaves the previous
+  hashed row behind. Harmless, but it means rotation does not revoke.
+*/}}
+{{- $secretName := include "shipwright.internal.secretName" . }}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+
+{{- /* Reuse-or-generate each token. Values stay base64-encoded end to end when
+       reused; freshly generated ones are encoded at the point of use. */}}
+{{- $taskStoreToken := "" }}
+{{- if and $existing $existing.data (index $existing.data "TASK_STORE_ADMIN_TOKEN") }}
+{{- $taskStoreToken = index $existing.data "TASK_STORE_ADMIN_TOKEN" }}
+{{- else }}
+{{- $taskStoreToken = (randAlphaNum 40 | b64enc) }}
+{{- end }}
+
+{{- $chatToken := "" }}
+{{- if and $existing $existing.data (index $existing.data "CHAT_ADMIN_TOKEN") }}
+{{- $chatToken = index $existing.data "CHAT_ADMIN_TOKEN" }}
+{{- else }}
+{{- $chatToken = (randAlphaNum 40 | b64enc) }}
+{{- end }}
+
+{{- $internalKey := "" }}
+{{- if and $existing $existing.data (index $existing.data "INTERNAL_API_KEY") }}
+{{- $internalKey = index $existing.data "INTERNAL_API_KEY" }}
+{{- else }}
+{{- $internalKey = (randAlphaNum 40 | b64enc) }}
+{{- end }}
+
+{{- /* Compose SHIPWRIGHT_ADMIN_API_KEYS from the RAW internal key plus any
+       caller-supplied entries. admin.apiKeys.extra is the supported migration
+       path off hand-wiring this var through admin.extraEnv — an extraEnv
+       override would shadow this value entirely and the chart-generated key
+       would then be rejected by admin, 401ing every consumer that falls back
+       to it. */}}
+{{- $apiKeys := printf "internal:%s:*" ($internalKey | b64dec) }}
+{{- range .Values.admin.apiKeys.extra }}
+{{- $apiKeys = printf "%s,%s" $apiKeys . }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: internal
+type: Opaque
+data:
+  TASK_STORE_ADMIN_TOKEN: {{ $taskStoreToken | quote }}
+  CHAT_ADMIN_TOKEN: {{ $chatToken | quote }}
+  INTERNAL_API_KEY: {{ $internalKey | quote }}
+  SHIPWRIGHT_ADMIN_API_KEYS: {{ $apiKeys | b64enc | quote }}
+{{- end }}

--- a/charts/shipwright/templates/metrics-deployment.yaml
+++ b/charts/shipwright/templates/metrics-deployment.yaml
@@ -87,9 +87,16 @@ spec:
                   name: {{ include "shipwright.metrics.secretName" . }}
                   key: METRICS_DATABASE_URL
             {{- end }}
-            {{- if .Values.metrics.provider.adminUrl }}
+            {{- /* Falls back to the in-cluster admin Service DNS name so a
+                   full-stack install needs no hand-written URLs. An explicit
+                   metrics.provider.adminUrl still wins (external admin). */}}
+            {{- $adminUrl := .Values.metrics.provider.adminUrl }}
+            {{- if and (not $adminUrl) .Values.admin.enabled }}
+            {{- $adminUrl = include "shipwright.admin.serviceUrl" . }}
+            {{- end }}
+            {{- if $adminUrl }}
             - name: METRICS_ADMIN_URL
-              value: {{ .Values.metrics.provider.adminUrl | quote }}
+              value: {{ $adminUrl | quote }}
             {{- end }}
             # Task-store mode: when taskStoreUrl is set alongside adminUrl, the
             # metrics service selects TASKSTORE mode (TaskStoreProvider over the
@@ -97,9 +104,18 @@ spec:
             # the local SQLite store, which has no writable path in this image and
             # crashes on boot (SQLITE_CANTOPEN). The token authenticates the
             # task-store HTTP client (METRICS_TASK_STORE_TOKEN).
-            {{- if .Values.metrics.provider.taskStoreUrl }}
+            {{- /* Falls back to the in-cluster task-store Service DNS name when
+                   that service is part of this release. This is load-bearing:
+                   without METRICS_TASK_STORE_URL the provider selector falls
+                   through to SQLite, which has no writable path in the published
+                   image and crashes on boot with SQLITE_CANTOPEN. */}}
+            {{- $taskStoreUrl := .Values.metrics.provider.taskStoreUrl }}
+            {{- if and (not $taskStoreUrl) .Values.taskStore.enabled }}
+            {{- $taskStoreUrl = include "shipwright.taskStore.serviceUrl" . }}
+            {{- end }}
+            {{- if $taskStoreUrl }}
             - name: METRICS_TASK_STORE_URL
-              value: {{ .Values.metrics.provider.taskStoreUrl | quote }}
+              value: {{ $taskStoreUrl | quote }}
             {{- end }}
             {{- if .Values.metrics.provider.taskStoreToken.existingSecret }}
             - name: METRICS_TASK_STORE_TOKEN
@@ -107,6 +123,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.metrics.provider.taskStoreToken.existingSecret }}
                   key: {{ .Values.metrics.provider.taskStoreToken.key }}
+            {{- else if and (include "shipwright.internal.wired" .) .Values.taskStore.enabled }}
+            # Same raw value task-store seeds at boot (admin-scoped token).
+            - name: METRICS_TASK_STORE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: TASK_STORE_ADMIN_TOKEN
             {{- end }}
             {{- if .Values.metrics.provider.basePath }}
             - name: METRICS_BASE_PATH
@@ -126,6 +149,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.metrics.provider.internalKey.existingSecret }}
                   key: {{ .Values.metrics.provider.internalKey.key }}
+            {{- else if and (include "shipwright.internal.wired" .) .Values.admin.enabled }}
+            # Bearer key metrics presents to admin. Accepted because the SAME raw
+            # value is embedded in admin's SHIPWRIGHT_ADMIN_API_KEYS with scope "*".
+            - name: METRICS_INTERNAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: INTERNAL_API_KEY
             {{- end }}
             {{- if .Values.metrics.public.enabled }}
             # Public read-only proof surface: mount the unauthenticated, repo-scoped

--- a/charts/shipwright/templates/metrics-deployment.yaml
+++ b/charts/shipwright/templates/metrics-deployment.yaml
@@ -91,7 +91,7 @@ spec:
                    full-stack install needs no hand-written URLs. An explicit
                    metrics.provider.adminUrl still wins (external admin). */}}
             {{- $adminUrl := .Values.metrics.provider.adminUrl }}
-            {{- if and (not $adminUrl) .Values.admin.enabled }}
+            {{- if and (not $adminUrl) .Values.admin.enabled (include "shipwright.internal.wired" .) }}
             {{- $adminUrl = include "shipwright.admin.serviceUrl" . }}
             {{- end }}
             {{- if $adminUrl }}
@@ -110,7 +110,7 @@ spec:
                    through to SQLite, which has no writable path in the published
                    image and crashes on boot with SQLITE_CANTOPEN. */}}
             {{- $taskStoreUrl := .Values.metrics.provider.taskStoreUrl }}
-            {{- if and (not $taskStoreUrl) .Values.taskStore.enabled }}
+            {{- if and (not $taskStoreUrl) .Values.taskStore.enabled (include "shipwright.internal.wired" .) }}
             {{- $taskStoreUrl = include "shipwright.taskStore.serviceUrl" . }}
             {{- end }}
             {{- if $taskStoreUrl }}

--- a/charts/shipwright/templates/task-store-deployment.yaml
+++ b/charts/shipwright/templates/task-store-deployment.yaml
@@ -74,6 +74,29 @@ spec:
             {{- else }}
             {{- fail "taskStore.database.existingSecret is required when postgresql.enabled=false" }}
             {{- end }}
+            {{- if include "shipwright.internal.wired" . }}
+            # ── Inter-service token mesh ──────────────────────────────────────
+            # Seeded (hashed, idempotent upsert) at boot as the admin-scoped
+            # token, agentId=null. The SAME raw value is injected into admin as
+            # SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN and into metrics as
+            # METRICS_TASK_STORE_TOKEN — one token, three references.
+            - name: TASK_STORE_SEED_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: TASK_STORE_ADMIN_TOKEN
+            {{- if .Values.admin.enabled }}
+            # Scope resolver: task-store calls admin to resolve an agent token's
+            # scope. Without this pair, agent-scoped tokens cannot be validated.
+            - name: SHIPWRIGHT_TASK_STORE_AGENTS_URL
+              value: {{ include "shipwright.admin.serviceUrl" . | quote }}
+            - name: SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.internal.effectiveSecretName" . }}
+                  key: INTERNAL_API_KEY
+            {{- end }}
+            {{- end }}
             {{- if .Values.taskStore.sentry.dsn.existingSecret }}
             - name: SENTRY_DSN
               valueFrom:

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -377,10 +377,38 @@ tests:
             name: SHIPWRIGHT_CHAT_SERVICE_URL
             value: http://r-shipwright-chat:3000
 
-  - it: does not inject chat-service env when chat.enabled but adminToken unset
+  - it: injects chat-service env from the chart-generated token when adminToken is unset
+    # BEHAVIOUR CHANGE (chart 1.8.0): this previously injected nothing, because
+    # the only source of a chat admin token was a hand-created Secret. The chart
+    # now generates one (see internal-secret.yaml), so enabling chat is enough to
+    # wire the admin console's Chat tab — that is the point of the token mesh.
     template: templates/admin-deployment.yaml
     set:
       chat.enabled: true
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_URL
+            value: http://r-shipwright-chat:3000
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: CHAT_ADMIN_TOKEN
+
+  - it: injects NO chat-service env when the token mesh is disabled and adminToken is unset
+    # The pre-1.8 behaviour, preserved behind internal.enabled=false for
+    # operators who hand-wire the mesh through extraEnv.
+    template: templates/admin-deployment.yaml
+    set:
+      chat.enabled: true
+      internal.enabled: false
     release:
       name: r
     asserts:

--- a/charts/shipwright/tests/agent_credentials_test.yaml
+++ b/charts/shipwright/tests/agent_credentials_test.yaml
@@ -1,0 +1,190 @@
+suite: deployment-wide agent credentials + provisioned PVC sizing
+# There is no agent Deployment template — agents are provisioned at runtime by the
+# admin service, and they fetch credentials from admin's GET /agents/:id/config on
+# each config sync. So "give every agent a Claude token" is wired by injecting a
+# deployment-wide default into the ADMIN Deployment, which admin then merges
+# underneath each agent's own env rows (per-agent always wins).
+#
+# The SHIPWRIGHT_AGENT_DEFAULT_ prefix is a security boundary, not decoration:
+# admin must never hand out a bare ANTHROPIC_API_KEY it holds for its own use.
+# See resolveDefaultAgentEnv in admin/src/main.ts.
+release:
+  name: r
+  namespace: shipwright
+tests:
+  # ── chart-managed Secret ──────────────────────────────────────────────────
+
+  - it: renders no credentials Secret when neither credential is supplied
+    # An empty Helm value must not inject an empty credential that would mask a
+    # working per-agent one.
+    template: templates/agent-credentials-secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a Secret holding the inline Anthropic API key
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: r-shipwright-agent-credentials
+      - equal:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+          value: c2stYW50LXRlc3QxMjM=
+      - notExists:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+
+  - it: renders a Secret holding the inline OAuth token
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.claudeCodeOauthToken: oauth-test456
+    asserts:
+      - matchRegex:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+          decodeBase64: true
+          pattern: "^oauth-test456$"
+      - notExists:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  - it: renders no chart Secret when the caller supplies existingSecret
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.existingSecret: my-claude-creds
+      agent.credentials.anthropicApiKey: sk-ant-ignored
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no chart Secret when credentials are disabled
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.enabled: false
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── admin Deployment wiring ───────────────────────────────────────────────
+
+  - it: injects nothing into admin when no credential is supplied
+    template: templates/admin-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-agent-credentials
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  - it: references the chart Secret from admin when a credential is inline
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-agent-credentials
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  - it: references the caller's Secret when existingSecret is set
+    # optional:true so a Secret carrying only one of the two keys still starts.
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.existingSecret: my-claude-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-claude-creds
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-claude-creds
+                key: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+                optional: true
+
+  - it: honors custom key names in the caller's Secret
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.existingSecret: my-claude-creds
+      agent.credentials.anthropicApiKeyRef: MY_ANTHROPIC_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-claude-creds
+                key: MY_ANTHROPIC_KEY
+                optional: true
+
+  - it: never injects a BARE ANTHROPIC_API_KEY into the admin container
+    # The security boundary. A bare var would be admin's own credential; the
+    # prefixed one is explicitly "hand this to agents".
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-agent-credentials
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  # ── provisioned agent PVC sizing (regression) ─────────────────────────────
+
+  - it: injects SHIPWRIGHT_AGENT_PVC_STORAGE_GI from agent.provisioning.pvc.size
+    # Regression guard: this var was never rendered, so the provisioner fell back
+    # to its own 40Gi default and every provisioned agent silently over-requested.
+    template: templates/admin-deployment.yaml
+    set:
+      agent.provisioning.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+            value: "2"
+
+  - it: tracks a custom PVC size and strips the Gi suffix
+    template: templates/admin-deployment.yaml
+    set:
+      agent.provisioning.enabled: true
+      agent.provisioning.pvc.size: 10Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+            value: "10"
+
+  - it: omits the PVC size when provisioning is disabled
+    template: templates/admin-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+            value: "2"

--- a/charts/shipwright/tests/internal_secret_test.yaml
+++ b/charts/shipwright/tests/internal_secret_test.yaml
@@ -1,0 +1,103 @@
+suite: internal Secret — inter-service token generation and SHIPWRIGHT_ADMIN_API_KEYS composition
+# The single template that GENERATES the shared mesh tokens. Generation must
+# happen exactly once: Helm evaluates templates independently, so randAlphaNum
+# called in a producer and again in a consumer would yield two different values.
+# Every consumer therefore references these keys by secretKeyRef.
+#
+# NOTE: helm-unittest does NOT execute `lookup`, so these always exercise the
+# GENERATE branch. The reuse-on-upgrade branch is only observable on a live
+# cluster — see the end-to-end validation step (helm upgrade twice, tokens must
+# be byte-identical before and after).
+templates:
+  - templates/internal-secret.yaml
+release:
+  name: r
+  namespace: shipwright
+tests:
+  - it: renders by default with all four keys
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: r-shipwright-internal
+      - equal:
+          path: type
+          value: Opaque
+      - exists:
+          path: data.TASK_STORE_ADMIN_TOKEN
+      - exists:
+          path: data.CHAT_ADMIN_TOKEN
+      - exists:
+          path: data.INTERNAL_API_KEY
+      - exists:
+          path: data.SHIPWRIGHT_ADMIN_API_KEYS
+
+  - it: generates 40-character alphanumeric tokens
+    asserts:
+      - matchRegex:
+          path: data.TASK_STORE_ADMIN_TOKEN
+          decodeBase64: true
+          pattern: "^[A-Za-z0-9]{40}$"
+      - matchRegex:
+          path: data.CHAT_ADMIN_TOKEN
+          decodeBase64: true
+          pattern: "^[A-Za-z0-9]{40}$"
+      - matchRegex:
+          path: data.INTERNAL_API_KEY
+          decodeBase64: true
+          pattern: "^[A-Za-z0-9]{40}$"
+
+  - it: composes SHIPWRIGHT_ADMIN_API_KEYS as name:token:scope with scope "*"
+    # Format per admin/src/api-auth.ts parseAdminApiKeys: first segment is the
+    # name, LAST is the scope, everything between is the token. Scope must be "*"
+    # because no agent exists at install time.
+    asserts:
+      - matchRegex:
+          path: data.SHIPWRIGHT_ADMIN_API_KEYS
+          decodeBase64: true
+          pattern: "^internal:[A-Za-z0-9]{40}:\\*$"
+
+  - it: appends admin.apiKeys.extra entries comma-separated after the internal key
+    set:
+      admin.apiKeys.extra:
+        - "ci:sk_ci_abc123:*"
+        - "scoped:sk_xyz:agent-7"
+    asserts:
+      - matchRegex:
+          path: data.SHIPWRIGHT_ADMIN_API_KEYS
+          decodeBase64: true
+          pattern: "^internal:[A-Za-z0-9]{40}:\\*,ci:sk_ci_abc123:\\*,scoped:sk_xyz:agent-7$"
+
+  - it: still leads with the internal key when extras are supplied
+    # The chart-generated key must never be dropped — every consumer falls back
+    # to it, and losing it would 401 metrics, task-store and chat.
+    set:
+      admin.apiKeys.extra:
+        - "ci:sk_ci_abc123:*"
+    asserts:
+      - matchRegex:
+          path: data.SHIPWRIGHT_ADMIN_API_KEYS
+          decodeBase64: true
+          pattern: "^internal:"
+
+  - it: carries the internal component label
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: internal
+
+  - it: renders nothing when internal.enabled=false
+    set:
+      internal.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when the caller supplies internal.existingSecret
+    # Consumers reference the caller's Secret instead — see service_mesh_env_test.
+    set:
+      internal.existingSecret: my-mesh-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/tests/service_mesh_env_test.yaml
+++ b/charts/shipwright/tests/service_mesh_env_test.yaml
@@ -510,6 +510,30 @@ tests:
                 name: r-shipwright-internal
                 key: INTERNAL_API_KEY
 
+  - it: internal.enabled=false also omits the metrics URL auto-defaults (no half-wired pod)
+    # The URL auto-default is paired with the token above — both must be gated
+    # on the same condition, otherwise internal.enabled=false leaves metrics with
+    # METRICS_TASK_STORE_URL set but no METRICS_TASK_STORE_TOKEN, which flips the
+    # provider selector into TASKSTORE mode with no credential instead of the
+    # documented pre-1.9 no-op.
+    template: templates/metrics-deployment.yaml
+    set:
+      internal.enabled: false
+      metrics.enabled: true
+      admin.enabled: true
+      taskStore.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_ADMIN_URL
+            value: "http://r-shipwright-admin:3001"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_URL
+            value: "http://r-shipwright-task-store:3000"
+
   - it: extraEnv still renders LAST so hand-wired overrides beat the mesh
     # Kubernetes resolves duplicate env names to the LAST occurrence. Production
     # hand-wires these vars, so this ordering is what keeps it working.

--- a/charts/shipwright/tests/service_mesh_env_test.yaml
+++ b/charts/shipwright/tests/service_mesh_env_test.yaml
@@ -1,0 +1,527 @@
+suite: inter-service token mesh — both sides of every producer/consumer pair
+# The load-bearing suite for a zero-hand-Secret install. A token is only useful
+# if the service that SEEDS it and the service that PRESENTS it resolve to the
+# same Secret name AND the same key. Each pair below asserts both sides against
+# the same literal, so a rename on one side fails here rather than silently
+# 401ing at runtime.
+#
+# Pairs:
+#   TASK_STORE_ADMIN_TOKEN  task-store seeds -> admin + metrics consume
+#   CHAT_ADMIN_TOKEN        chat seeds       -> admin consumes
+#   INTERNAL_API_KEY        admin accepts (via SHIPWRIGHT_ADMIN_API_KEYS)
+#                                            -> metrics + task-store + chat present
+release:
+  name: r
+  namespace: shipwright
+set:
+  taskStore.enabled: true
+  chat.enabled: true
+  taskStore.database.existingSecret: ""
+  chat.database.existingSecret: ""
+  postgresql.auth.password: testpw
+tests:
+  # ── pair 1: task-store admin token ────────────────────────────────────────
+
+  - it: task-store SEEDS the task-store admin token from the internal Secret
+    template: templates/task-store-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TASK_STORE_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: TASK_STORE_ADMIN_TOKEN
+
+  - it: admin CONSUMES the same task-store admin token
+    template: templates/admin-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: TASK_STORE_ADMIN_TOKEN
+
+  - it: metrics CONSUMES the same task-store admin token
+    # One token serves both consumers — the seeded token is admin-scoped
+    # (agentId=null), so metrics does not need a separate credential.
+    template: templates/metrics-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: TASK_STORE_ADMIN_TOKEN
+
+  # ── pair 2: chat admin token ──────────────────────────────────────────────
+
+  - it: chat SEEDS the chat admin token from the internal Secret
+    template: templates/chat-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: CHAT_ADMIN_TOKEN
+
+  - it: admin CONSUMES the same chat admin token
+    template: templates/admin-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: CHAT_ADMIN_TOKEN
+
+  # ── pair 3: internal API key ──────────────────────────────────────────────
+
+  - it: admin ACCEPTS the internal key via the composed SHIPWRIGHT_ADMIN_API_KEYS
+    template: templates/admin-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_API_KEYS
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: SHIPWRIGHT_ADMIN_API_KEYS
+
+  - it: metrics PRESENTS the same internal key
+    template: templates/metrics-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_INTERNAL_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  - it: task-store PRESENTS the same internal key to the admin scope resolver
+    template: templates/task-store-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  - it: chat PRESENTS the same internal key to the admin scope resolver
+    template: templates/chat-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  # ── in-cluster service URLs ───────────────────────────────────────────────
+
+  - it: admin points at the in-cluster task-store Service
+    template: templates/admin-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_URL
+            value: "http://r-shipwright-task-store:3000"
+
+  - it: admin points at the in-cluster chat Service
+    template: templates/admin-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_URL
+            value: "http://r-shipwright-chat:3000"
+
+  - it: task-store points its scope resolver at the in-cluster admin Service
+    template: templates/task-store-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_AGENTS_URL
+            value: "http://r-shipwright-admin:3001"
+
+  - it: chat points its scope resolver at the in-cluster admin Service
+    template: templates/chat-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_AGENTS_URL
+            value: "http://r-shipwright-admin:3001"
+
+  - it: metrics auto-defaults its admin and task-store URLs to in-cluster Services
+    # Load-bearing: without METRICS_TASK_STORE_URL the provider selector falls
+    # through to SQLite, which has no writable path in the published image and
+    # crashes on boot with SQLITE_CANTOPEN.
+    template: templates/metrics-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_ADMIN_URL
+            value: "http://r-shipwright-admin:3001"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_URL
+            value: "http://r-shipwright-task-store:3000"
+
+  - it: an explicit metrics.provider URL still wins over the auto-default
+    template: templates/metrics-deployment.yaml
+    set:
+      metrics.provider.adminUrl: https://admin.example.com
+      metrics.provider.taskStoreUrl: https://ts.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_ADMIN_URL
+            value: https://admin.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_URL
+            value: https://ts.example.com
+
+  # ── gating: mesh is only wired where the peer exists ──────────────────────
+
+  - it: omits task-store wiring from admin when task-store is disabled
+    template: templates/admin-deployment.yaml
+    set:
+      taskStore.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_URL
+            value: "http://r-shipwright-task-store:3000"
+      # ...but admin still accepts the internal key for metrics/chat.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_API_KEYS
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: SHIPWRIGHT_ADMIN_API_KEYS
+
+  - it: omits the metrics task-store token when task-store is disabled
+    template: templates/metrics-deployment.yaml
+    set:
+      taskStore.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: TASK_STORE_ADMIN_TOKEN
+
+  - it: omits task-store scope-resolver wiring when admin is disabled
+    template: templates/task-store-deployment.yaml
+    set:
+      admin.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_AGENTS_URL
+            value: "http://r-shipwright-admin:3001"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  - it: omits chat scope-resolver wiring when admin is disabled
+    template: templates/chat-deployment.yaml
+    set:
+      admin.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_AGENTS_URL
+            value: "http://r-shipwright-admin:3001"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  # ── caller overrides always win ───────────────────────────────────────────
+
+  - it: internal.existingSecret redirects admin's mesh refs to the caller's Secret
+    template: templates/admin-deployment.yaml
+    set:
+      internal.existingSecret: my-mesh-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_API_KEYS
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: SHIPWRIGHT_ADMIN_API_KEYS
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: TASK_STORE_ADMIN_TOKEN
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_API_KEYS
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: SHIPWRIGHT_ADMIN_API_KEYS
+
+  - it: internal.existingSecret redirects the task-store seed and resolver key
+    template: templates/task-store-deployment.yaml
+    set:
+      internal.existingSecret: my-mesh-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TASK_STORE_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: TASK_STORE_ADMIN_TOKEN
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: INTERNAL_API_KEY
+
+  - it: internal.existingSecret redirects the chat seed and resolver key
+    template: templates/chat-deployment.yaml
+    set:
+      internal.existingSecret: my-mesh-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: CHAT_ADMIN_TOKEN
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: INTERNAL_API_KEY
+
+  - it: internal.existingSecret redirects the metrics consumer keys
+    template: templates/metrics-deployment.yaml
+    set:
+      internal.existingSecret: my-mesh-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: TASK_STORE_ADMIN_TOKEN
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_INTERNAL_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-mesh-secret
+                key: INTERNAL_API_KEY
+
+  - it: chat.adminToken.existingSecret wins on the chat seeding side
+    template: templates/chat-deployment.yaml
+    set:
+      chat.adminToken.existingSecret: my-chat-tokens
+      chat.adminToken.key: CHAT_ADMIN_RAW
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-chat-tokens
+                key: CHAT_ADMIN_RAW
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: CHAT_ADMIN_TOKEN
+
+  - it: chat.adminToken.existingSecret wins on the admin consuming side
+    template: templates/admin-deployment.yaml
+    set:
+      chat.adminToken.existingSecret: my-chat-tokens
+      chat.adminToken.key: CHAT_ADMIN_RAW
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-chat-tokens
+                key: CHAT_ADMIN_RAW
+
+  - it: metrics token existingSecrets win over the chart-generated ones
+    template: templates/metrics-deployment.yaml
+    set:
+      metrics.provider.taskStoreToken.existingSecret: my-ts-token
+      metrics.provider.internalKey.existingSecret: my-internal-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-ts-token
+                key: METRICS_TASK_STORE_TOKEN
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_INTERNAL_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-internal-key
+                key: METRICS_INTERNAL_API_KEY
+
+  - it: internal.enabled=false injects no mesh env into admin (pre-1.8 behaviour)
+    # The escape hatch for operators who hand-wire the mesh through extraEnv.
+    template: templates/admin-deployment.yaml
+    set:
+      internal.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_API_KEYS
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: SHIPWRIGHT_ADMIN_API_KEYS
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: TASK_STORE_ADMIN_TOKEN
+
+  - it: internal.enabled=false injects no mesh env into task-store
+    template: templates/task-store-deployment.yaml
+    set:
+      internal.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TASK_STORE_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: TASK_STORE_ADMIN_TOKEN
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  - it: internal.enabled=false injects no mesh env into chat or metrics
+    templates:
+      - templates/chat-deployment.yaml
+      - templates/metrics-deployment.yaml
+    set:
+      internal.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHAT_SEED_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: CHAT_ADMIN_TOKEN
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_INTERNAL_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-internal
+                key: INTERNAL_API_KEY
+
+  - it: extraEnv still renders LAST so hand-wired overrides beat the mesh
+    # Kubernetes resolves duplicate env names to the LAST occurrence. Production
+    # hand-wires these vars, so this ordering is what keeps it working.
+    template: templates/admin-deployment.yaml
+    set:
+      admin.extraEnv:
+        - name: SHIPWRIGHT_TASK_STORE_URL
+          value: "http://external-task-store:9999"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].name
+          value: SHIPWRIGHT_TASK_STORE_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].value
+          value: "http://external-task-store:9999"

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -145,6 +145,23 @@ admin:
   # without this generates random keys that cannot decrypt existing agent env
   # (caused the 2026-06-16 prod outage). Leave empty to use the chart-managed
   # Secret (generate on first install, reuse on upgrade via lookup).
+  # -- Additional entries merged into SHIPWRIGHT_ADMIN_API_KEYS alongside the
+  # chart-generated internal key.
+  #
+  # Format per entry (admin/src/api-auth.ts parseAdminApiKeys): "name:token:scope".
+  # First segment is the name, LAST is the scope, everything between is the token
+  # (tokens may contain colons, never commas). Scope "*" grants full admin;
+  # a scope of "<agentId>" restricts the key to that agent.
+  #
+  # MIGRATION: if you currently hand-wire SHIPWRIGHT_ADMIN_API_KEYS through
+  # admin.extraEnv, move those entries here. extraEnv renders LAST and therefore
+  # SHADOWS the composed value — which would leave the chart-generated internal
+  # key out of admin's accepted set, so metrics / task-store / chat would get a
+  # 401 whenever they fall back to it.
+  #
+  # Example: ["ci:sk_ci_abc123:*", "scoped:sk_xyz:agent-7"]
+  apiKeys:
+    extra: []
   encryptionKeys:
     existingSecret: ""
     # -- Key in existingSecret that holds SHIPWRIGHT_ENCRYPTION_KEY.
@@ -517,6 +534,32 @@ postgresql:
 # create and rotate it), and the chart-managed admin Secret assembles NO DB URL on
 # this path, so there is no duplicate/conflicting env. When postgresql.enabled=true
 # this block is ignored — the bundled subchart path wins and is unchanged.
+# -- Chart-managed inter-service token mesh.
+#
+# Generates the three shared tokens that let the Shipwright services authenticate
+# to each other, so a fresh install needs no hand-created Secrets:
+#
+#   TASK_STORE_ADMIN_TOKEN  task-store seeds it; admin and metrics consume it
+#   CHAT_ADMIN_TOKEN        chat seeds it; admin consumes it
+#   INTERNAL_API_KEY        admin accepts it; metrics, task-store and chat present it
+#
+# Generated on first install and REUSED across upgrades via the same lookup idiom
+# as the admin session/encryption keys. Every value here is a FALLBACK: a
+# service-specific `existingSecret` (e.g. chat.adminToken.existingSecret,
+# metrics.provider.internalKey.existingSecret) always wins, and `extraEnv` —
+# which renders last — wins over everything.
+#
+# CAVEAT: `helm template | kubectl apply` does not execute `lookup`, so that flow
+# would rotate all three tokens on every apply. Set existingSecret if you deploy
+# that way.
+internal:
+  # -- Whether to render the chart-managed internal Secret.
+  enabled: true
+  # -- Source the mesh tokens from a caller-managed Secret instead of generating
+  # them. Must supply the keys TASK_STORE_ADMIN_TOKEN, CHAT_ADMIN_TOKEN,
+  # INTERNAL_API_KEY and SHIPWRIGHT_ADMIN_API_KEYS.
+  existingSecret: ""
+
 # -- Post-install/post-upgrade hook Job that ensures the per-service databases
 # (metrics, task-store, chat) exist on the bundled PostgreSQL.
 #

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -320,6 +320,39 @@ agent:
   service:
     port: 3000
   replicas: 1
+  # -- Deployment-wide Claude credentials handed to EVERY provisioned agent.
+  #
+  # Agents fetch credentials from the admin service on each config sync. The
+  # admin merges these defaults UNDERNEATH each agent's own env rows, so a
+  # per-agent value set through the admin UI always wins — this is a floor, not
+  # an override. Changes reach already-running agents on their next sync, with no
+  # pod restart and no re-provision.
+  #
+  # Without this, every agent needs its Claude token pasted in by hand through
+  # the admin UI before it can do any work.
+  #
+  # Supply exactly one of anthropicApiKey / claudeCodeOauthToken (an OAuth token
+  # from `claude /oauth-token` is the usual choice for personal use). Leave both
+  # empty to keep credentials strictly per-agent.
+  #
+  # SECURITY: inline values land in a chart-managed Secret, which means they sit
+  # in your values file and in Helm release history. Prefer existingSecret for
+  # anything beyond local development.
+  credentials:
+    # -- Whether to wire deployment-wide agent credentials at all.
+    enabled: true
+    # -- Source the credentials from a caller-managed Secret instead of the
+    # inline values below. Must supply the keys named by anthropicApiKeyRef /
+    # claudeCodeOauthTokenRef.
+    existingSecret: ""
+    # -- Key in existingSecret holding the Anthropic API key.
+    anthropicApiKeyRef: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+    # -- Key in existingSecret holding the Claude Code OAuth token.
+    claudeCodeOauthTokenRef: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+    # -- Inline Anthropic API key (chart-managed Secret). Local dev only.
+    anthropicApiKey: ""
+    # -- Inline Claude Code OAuth token (chart-managed Secret). Local dev only.
+    claudeCodeOauthToken: ""
   # -- Provisioning controls for the agent's persistent home / workspace.
   provisioning:
     # -- Whether the admin service provisions agent workloads at runtime. OFF by
@@ -360,9 +393,9 @@ agent:
     # When empty (the default), PVCs are named `{sanitizedAgentId}-home`.
     pvcNameTemplate: ""
     # -- Provisioned workspace PVCs: created per-agent when the provisioner spins
-    # up a new agent pod. These settings are surfaced for the agent manifest
-    # builder's future use. NOTE: buildProvisioner does not read these as env
-    # today, so they are NOT injected into the admin Deployment.
+    # up a new agent pod. `size` is injected into the admin Deployment as
+    # SHIPWRIGHT_AGENT_PVC_STORAGE_GI; leaving it unset makes the provisioner fall
+    # back to its own 40Gi default. Must be a whole number of Gi.
     pvc:
       size: 2Gi
       # -- StorageClass for provisioned agent PVCs. Empty uses the cluster default.


### PR DESCRIPTION
Second of four PRs toward a full `helm install` of the whole Shipwright stack on Minikube.

**Stacked on #2483** — review that first; this PR targets its branch and will be retargeted to `main` once it merges.

## Why

The chart rendered *no* inter-service wiring at all. Admin never received `SHIPWRIGHT_TASK_STORE_URL`, `SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN`, or `SHIPWRIGHT_ADMIN_API_KEYS`; task-store and chat never received their seed tokens or scope-resolver credentials. Production hand-wires all of it through `extraEnv`. A fresh install could bring up pods that couldn't talk to each other.

## The three tokens

| Token | Produced by | Consumed by |
|---|---|---|
| `TASK_STORE_ADMIN_TOKEN` | task-store (`TASK_STORE_SEED_ADMIN_TOKEN`) | admin, metrics |
| `CHAT_ADMIN_TOKEN` | chat (`CHAT_SEED_ADMIN_TOKEN`) | admin |
| `INTERNAL_API_KEY` | admin (inside `SHIPWRIGHT_ADMIN_API_KEYS`) | metrics, task-store, chat |

Generated in exactly one template (`internal-secret.yaml`), referenced everywhere else by `secretKeyRef`. That's forced by Helm, not style: templates evaluate independently, so `randAlphaNum` in a producer and again in a consumer yields two different strings. Reused across upgrades via the same `lookup` idiom as the admin session keys.

`SHIPWRIGHT_ADMIN_API_KEYS` is composed in that same Secret because the format embeds the raw key — verified against `parseAdminApiKeys` in `admin/src/api-auth.ts` (`name:token:scope`, first segment name, **last** scope, middle is the token). Scope is `*` because no agent exists at install time.

## Also fixes a crash-on-boot

`METRICS_ADMIN_URL` / `METRICS_TASK_STORE_URL` now auto-default to in-cluster Service DNS. Without `METRICS_TASK_STORE_URL` the provider selector falls through to SQLite, which has no writable path in the published image and crashes with `SQLITE_CANTOPEN`.

## Compatibility

- Every generated value is a **fallback**. Service-specific `existingSecret`s always win; `extraEnv` still renders **last** and wins over everything (asserted).
- `internal.enabled=false` restores pre-1.9 behavior exactly, for operators who hand-wire the mesh.
- ⚠️ **If you hand-wire `SHIPWRIGHT_ADMIN_API_KEYS` via `admin.extraEnv`**, it shadows the composed value and the chart-generated key won't be accepted — consumers 401 on fallback. `admin.apiKeys.extra` is the migration path. Called out in CHANGELOG.
- ⚠️ `helm template | kubectl apply` doesn't execute `lookup` and would rotate all three tokens per apply. `internal.existingSecret` is the escape hatch.
- One intentional behavior change: enabling chat no longer requires `chat.adminToken.existingSecret`. The old test asserting "injects nothing" is updated, and a new case pins the old behavior under `internal.enabled=false`.

## Tests

332 passing, up from 293. New: `internal_secret_test`, `service_mesh_env_test` — the latter asserts **both sides** of every producer/consumer pair resolve to the same Secret *and* key, so a rename on one side fails here instead of 401ing at runtime.

Mutation-checked: pointing admin's chat token at a wrong key fails 2 suites; reverting restores green. (Four assertions using ambiguous `any: true` regex semantics were rewritten as explicit `contains`/`notContains` after I couldn't confirm they weren't passing vacuously.)

`helm lint` + 332 unittests + kubeconform green (default 19/19, full stack 31/31).

⚠️ Not yet validated against a real cluster — that lands with the Minikube profile PR, including a `helm upgrade`-twice check that the tokens stay byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019U7YiXDtDkvhXtPrWtT1ib