### PR TITLE
feat(chart): supply deployment-wide Claude credentials to provisioned agents

### DIFF
--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -824,3 +824,101 @@ describe("combined server — regression guard: runtime middleware must not bloc
     expect(body.repos).toEqual([]);
   });
 });
+
+// ─── Deployment-wide default agent env ────────────────────────────────────────
+//
+// A Helm install supplies one set of Claude credentials for the whole deployment
+// (agent.credentials.*) instead of an operator pasting a token into every agent.
+// Admin merges those defaults UNDERNEATH each agent's own env rows when serving
+// the config bundle, so a per-agent value always wins. These tests pin that
+// precedence — getting it backwards would let a deployment-wide credential
+// silently override a deliberately-scoped per-agent one.
+
+describe("defaultAgentEnv merging in GET /:id/config", () => {
+  const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+  const ADMIN_KEY = "sk_default_env_admin";
+
+  function buildApp(opts: {
+    bundleEnv?: Record<string, string>;
+    defaultAgentEnv?: Record<string, string>;
+  }) {
+    return createAgentRuntimeApp({
+      agentEnvService: {
+        async getConfigBundle() {
+          return {
+            agentId: AGENT_ID,
+            env: opts.bundleEnv ?? {},
+            allowedTools: [],
+          };
+        },
+      },
+      agentCronJobService: {
+        async list() {
+          return [];
+        },
+        async listWithRunSummary() {
+          return [];
+        },
+      },
+      agentService: {
+        async getById() {
+          return {
+            id: AGENT_ID,
+            name: "Test Agent",
+            repos: [],
+            authorAllowlist: [],
+          };
+        },
+      },
+      agentPluginService: {
+        async listEnabled() {
+          return [];
+        },
+      },
+      adminApiKeys: parseAdminApiKeys(`admin:${ADMIN_KEY}:*`),
+      agentTokenService: { validate: async () => null },
+      sessionSecret: SESSION_SECRET,
+      defaultAgentEnv: opts.defaultAgentEnv,
+    });
+  }
+
+  async function fetchEnv(app: ReturnType<typeof buildApp>) {
+    const res = await app.request(`/${AGENT_ID}/config`, {
+      headers: { Authorization: `Bearer ${ADMIN_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()).env as Record<string, string>;
+  }
+
+  test("an agent with no env rows inherits the deployment-wide default", async () => {
+    const env = await fetchEnv(
+      buildApp({ defaultAgentEnv: { ANTHROPIC_API_KEY: "deployment-wide" } }),
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe("deployment-wide");
+  });
+
+  test("a per-agent value OVERRIDES the deployment-wide default", async () => {
+    const env = await fetchEnv(
+      buildApp({
+        bundleEnv: { ANTHROPIC_API_KEY: "per-agent" },
+        defaultAgentEnv: { ANTHROPIC_API_KEY: "deployment-wide" },
+      }),
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe("per-agent");
+  });
+
+  test("defaults and per-agent rows for different keys are unioned", async () => {
+    const env = await fetchEnv(
+      buildApp({
+        bundleEnv: { AGENT_ONLY: "a" },
+        defaultAgentEnv: { CLAUDE_CODE_OAUTH_TOKEN: "d" },
+      }),
+    );
+    expect(env).toEqual({ AGENT_ONLY: "a", CLAUDE_CODE_OAUTH_TOKEN: "d" });
+  });
+
+  test("omitting defaultAgentEnv leaves the bundle env untouched", async () => {
+    const env = await fetchEnv(buildApp({ bundleEnv: { ONLY: "x" } }));
+    expect(env).toEqual({ ONLY: "x" });
+  });
+});

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -88,6 +88,15 @@ export interface AgentRuntimeDeps {
   adminApiKeys?: Map<string, AdminApiKey>;
   /** Token service for per-agent bearer token validation. */
   agentTokenService: Pick<AgentTokenService, "validate">;
+  /**
+   * Deployment-wide default env merged UNDERNEATH each agent's own env rows, so
+   * every agent inherits shared credentials (e.g. ANTHROPIC_API_KEY) without an
+   * operator pasting them per agent.
+   *
+   * Per-agent rows always win — this is a floor, never an override. Agents pick
+   * defaults up on their next config sync, with no pod restart or re-provision.
+   */
+  defaultAgentEnv?: Record<string, string>;
 }
 
 // ─── Route definitions ────────────────────────────────────────────────────────
@@ -157,6 +166,7 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     agentCronJobService,
     agentService,
     agentPluginService,
+    defaultAgentEnv,
   } = deps;
 
   const app = new OpenAPIHono();
@@ -190,7 +200,8 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
     ]);
 
     const response: AgentConfigResponse = {
-      env: bundle?.env ?? {},
+      // Deployment-wide defaults first so per-agent rows override them.
+      env: { ...(defaultAgentEnv ?? {}), ...(bundle?.env ?? {}) },
       allowedTools: bundle?.allowedTools ?? [],
       plugins: plugins.map((p) => {
         // The stored name is the canonical Claude plugin spec — exactly what

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -313,6 +313,40 @@ export function resolvePublicRepo(
   return env.SHIPWRIGHT_ADMIN_PUBLIC_REPO?.trim() || undefined;
 }
 
+/**
+ * Deployment-wide default env handed to EVERY agent's config bundle, merged
+ * underneath that agent's own env rows (per-agent values always win).
+ *
+ * This is what lets a Helm install supply one set of Claude credentials for the
+ * whole deployment instead of an operator pasting a token into each agent
+ * through the admin UI. Agents pick these up on their next config sync — no pod
+ * restart and no re-provision, so it also reaches already-running agents.
+ *
+ * Deliberately read from SHIPWRIGHT_AGENT_DEFAULT_-prefixed vars rather than
+ * bare ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN: the admin process must never
+ * hand out a credential it happens to hold for its own use. Opting in is
+ * explicit.
+ *
+ * Blank/whitespace values are treated as unset so an empty Helm value (the
+ * default) doesn't inject an empty credential that would mask a working
+ * per-agent one.
+ */
+export function resolveDefaultAgentEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  const mapping: Record<string, string> = {
+    SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "ANTHROPIC_API_KEY",
+    SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "CLAUDE_CODE_OAUTH_TOKEN",
+  };
+
+  const defaults: Record<string, string> = {};
+  for (const [source, target] of Object.entries(mapping)) {
+    const value = env[source]?.trim();
+    if (value) defaults[target] = value;
+  }
+  return defaults;
+}
+
 // startServer() is the process entrypoint: it runs the real migration
 // preflight, constructs a real PrismaClient (live DB connection), calls
 // Bun.serve to bind an actual socket, and mounts every sub-app. This is
@@ -427,6 +461,7 @@ async function startServer(): Promise<void> {
     sessionSecret,
     adminApiKeys,
     agentTokenService,
+    defaultAgentEnv: resolveDefaultAgentEnv(process.env),
   });
 
   root.route("/agents", runtimeApp);

--- a/admin/src/main.unit.test.ts
+++ b/admin/src/main.unit.test.ts
@@ -11,6 +11,7 @@ import type { AgentTokenService } from "./agent-tokens.ts";
 import {
   buildProvisioner,
   checkDbReady,
+  resolveDefaultAgentEnv,
   resolvePublicRepo,
   resolveTaskStoreBaseUrl,
   runMigrations,
@@ -296,5 +297,68 @@ describe("checkDbReady", () => {
       },
     };
     await expect(checkDbReady(prisma)).resolves.toBe(false);
+  });
+});
+
+// resolveDefaultAgentEnv is the pure env rule behind the chart's
+// agent.credentials.* values: it turns SHIPWRIGHT_AGENT_DEFAULT_-prefixed vars
+// into the deployment-wide default env admin merges underneath each agent's own
+// rows when serving GET /agents/:id/config.
+//
+// The prefix is the security boundary — admin must never hand out a bare
+// ANTHROPIC_API_KEY it happens to hold for its own use.
+describe("resolveDefaultAgentEnv", () => {
+  it("maps the prefixed vars to the names the agent actually reads", () => {
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "sk-ant-xxx",
+        SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy",
+      }),
+    ).toEqual({
+      ANTHROPIC_API_KEY: "sk-ant-xxx",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy",
+    });
+  });
+
+  it("returns an empty object when nothing is set", () => {
+    expect(resolveDefaultAgentEnv({})).toEqual({});
+  });
+
+  it("ignores blank and whitespace-only values", () => {
+    // An unset Helm value renders as "". Injecting an empty credential would
+    // mask a working per-agent one, so blank must behave exactly like unset.
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "",
+        SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "   ",
+      }),
+    ).toEqual({});
+  });
+
+  it("trims surrounding whitespace from a real value", () => {
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: "  sk-ant-xxx\n",
+      }),
+    ).toEqual({ ANTHROPIC_API_KEY: "sk-ant-xxx" });
+  });
+
+  it("supports supplying only one of the two credentials", () => {
+    expect(
+      resolveDefaultAgentEnv({
+        SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy",
+      }),
+    ).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "oauth-yyy" });
+  });
+
+  it("does NOT pick up bare ANTHROPIC_API_KEY from the admin process env", () => {
+    // The security boundary: admin holding a credential for its own use must
+    // never cause that credential to be handed to every agent.
+    expect(
+      resolveDefaultAgentEnv({
+        ANTHROPIC_API_KEY: "admins-own-key",
+        CLAUDE_CODE_OAUTH_TOKEN: "admins-own-token",
+      }),
+    ).toEqual({});
   });
 });

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,36 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.10.0] - 2026-08-07
+
+### Added
+
+- **`agent.credentials.*` — deployment-wide Claude credentials for every agent.**
+  There is no agent Deployment in this chart; agents are provisioned at runtime by
+  the admin service and fetch their credentials from `GET /agents/:id/config` on
+  each config sync. Previously the only way to give an agent a Claude token was to
+  paste one into every agent through the admin UI, so a `helm install` could never
+  produce a working agent on its own.
+
+  Supply `agent.credentials.anthropicApiKey` or `.claudeCodeOauthToken` (or point
+  `.existingSecret` at your own Secret) and admin merges them **underneath** each
+  agent's own env rows — a per-agent value always wins. Changes reach
+  already-running agents on their next sync, with no restart or re-provision.
+
+  Credentials are injected into admin under `SHIPWRIGHT_AGENT_DEFAULT_`-prefixed
+  names, never as a bare `ANTHROPIC_API_KEY`. That prefix is a security boundary:
+  admin must not hand out a credential it happens to hold for its own use.
+
+### Fixed
+
+- **Provisioned agents silently requested 40Gi PVCs.** `agent.provisioning.pvc.size`
+  was documented as "not injected", and indeed nothing ever rendered
+  `SHIPWRIGHT_AGENT_PVC_STORAGE_GI` — so `agent-provisioner.ts` fell back to its own
+  40Gi default for every agent, regardless of the configured value. Now injected
+  (with the `Gi` suffix stripped), and the stale `values.yaml` comment corrected.
+  **Upgrade note:** existing agents keep their current PVCs; the new size applies to
+  agents provisioned from here on.
+
 ## [1.9.0] - 2026-08-07
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.9.0
+version: 1.10.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,11 +30,9 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "inter-service token mesh: the chart now generates the task-store, chat and internal API tokens so a fresh install needs zero hand-created Secrets"
-    - kind: added
-      description: "metrics auto-defaults METRICS_ADMIN_URL and METRICS_TASK_STORE_URL to the in-cluster Services, avoiding the SQLITE_CANTOPEN crash-on-boot"
-    - kind: added
-      description: "admin.apiKeys.extra merges caller-supplied entries into SHIPWRIGHT_ADMIN_API_KEYS (migration path off hand-wiring it via extraEnv)"
+      description: "agent.credentials.* supplies deployment-wide Claude credentials to every provisioned agent, merged under each agent's own env rows"
+    - kind: fixed
+      description: "agent.provisioning.pvc.size is now injected as SHIPWRIGHT_AGENT_PVC_STORAGE_GI; it was never rendered, so every provisioned agent silently requested the provisioner's 40Gi default"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -208,6 +208,27 @@ app.kubernetes.io/component: agent
 {{- end }}
 
 {{/*
+Name of the chart-managed Secret holding the deployment-wide Claude credentials
+handed to every provisioned agent.
+*/}}
+{{- define "shipwright.agent.credentialsSecretName" -}}
+{{- printf "%s-agent-credentials" (include "shipwright.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret name the admin Deployment should reference for agent credentials: the
+caller-managed agent.credentials.existingSecret when set, otherwise the
+chart-managed Secret.
+*/}}
+{{- define "shipwright.agent.effectiveCredentialsSecretName" -}}
+{{- if .Values.agent.credentials.existingSecret }}
+{{- .Values.agent.credentials.existingSecret }}
+{{- else }}
+{{- include "shipwright.agent.credentialsSecretName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Name of the ServiceAccount provisioned agent pods run as (SEPARATE from the admin
 SA). Defaults to "<fullname>-agent" when create=true and no name override.
 */}}

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -219,12 +219,53 @@ spec:
             # agent.provisioning.apiUrl for an external gateway.
             - name: SHIPWRIGHT_API_URL
               value: {{ .Values.agent.provisioning.apiUrl | default (printf "http://%s:%v" (include "shipwright.admin.fullname" .) .Values.admin.service.port) | quote }}
+            # Size of the workspace PVC the provisioner creates per agent. Without
+            # this the provisioner falls back to its own 40Gi default, which is far
+            # too large for a laptop cluster and silently over-requests everywhere.
+            - name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+              value: {{ .Values.agent.provisioning.pvc.size | trimSuffix "Gi" | quote }}
             {{- with .Values.agent.provisioning.pvcNameTemplate }}
             # PVC name template: when set, the provisioner substitutes {name} with
             # the agent's human-readable name (slug) to derive the PVC name. Used
             # when migrating from static agents with fixed naming conventions.
             - name: SHIPWRIGHT_AGENT_PVC_NAME_TEMPLATE
               value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.agent.credentials.enabled }}
+            {{- /* Deployment-wide agent credentials. Admin merges these under each
+                   agent's own env rows when serving GET /agents/:id/config, so a
+                   per-agent value always wins. Prefixed so admin never hands out
+                   a credential it holds for its own use — see
+                   resolveDefaultAgentEnv in admin/src/main.ts. */}}
+            {{- if .Values.agent.credentials.existingSecret }}
+            - name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agent.credentials.existingSecret }}
+                  key: {{ .Values.agent.credentials.anthropicApiKeyRef }}
+                  optional: true
+            - name: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agent.credentials.existingSecret }}
+                  key: {{ .Values.agent.credentials.claudeCodeOauthTokenRef }}
+                  optional: true
+            {{- else }}
+            {{- with .Values.agent.credentials.anthropicApiKey }}
+            - name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.agent.credentialsSecretName" $ }}
+                  key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            {{- end }}
+            {{- with .Values.agent.credentials.claudeCodeOauthToken }}
+            - name: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.agent.credentialsSecretName" $ }}
+                  key: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if .Values.agent.voice.enabled }}

--- a/charts/shipwright/templates/agent-credentials-secret.yaml
+++ b/charts/shipwright/templates/agent-credentials-secret.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.agent.credentials.enabled (not .Values.agent.credentials.existingSecret) (or .Values.agent.credentials.anthropicApiKey .Values.agent.credentials.claudeCodeOauthToken) }}
+{{- /*
+  Chart-managed Secret holding the deployment-wide Claude credentials handed to
+  EVERY provisioned agent.
+
+  There is no agent Deployment template — agents are provisioned at runtime by
+  the admin service. An agent fetches its credentials on each config sync via
+  GET /agents/:id/config, and admin merges this deployment-wide default
+  UNDERNEATH that agent's own env rows (per-agent values always win). So this is
+  a floor, not an override, and it reaches already-running agents on their next
+  sync without a restart or re-provision.
+
+  Rendered only when a credential is actually supplied — an empty value (the
+  default) must not inject an empty credential that would mask a working
+  per-agent one. Skipped entirely when agent.credentials.existingSecret is set;
+  the admin Deployment then references the caller's Secret directly.
+
+  These land in the admin Deployment as SHIPWRIGHT_AGENT_DEFAULT_-prefixed vars,
+  NOT as bare ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN. That prefix is
+  deliberate: the admin process must never hand out a credential it happens to
+  hold for its own use — opting in has to be explicit.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "shipwright.agent.credentialsSecretName" . }}
+  labels:
+    {{- include "shipwright.agent.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- with .Values.agent.credentials.anthropicApiKey }}
+  SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY: {{ . | b64enc | quote }}
+{{- end }}
+{{- with .Values.agent.credentials.claudeCodeOauthToken }}
+  SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN: {{ . | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/shipwright/tests/agent_credentials_test.yaml
+++ b/charts/shipwright/tests/agent_credentials_test.yaml
@@ -1,0 +1,190 @@
+suite: deployment-wide agent credentials + provisioned PVC sizing
+# There is no agent Deployment template — agents are provisioned at runtime by the
+# admin service, and they fetch credentials from admin's GET /agents/:id/config on
+# each config sync. So "give every agent a Claude token" is wired by injecting a
+# deployment-wide default into the ADMIN Deployment, which admin then merges
+# underneath each agent's own env rows (per-agent always wins).
+#
+# The SHIPWRIGHT_AGENT_DEFAULT_ prefix is a security boundary, not decoration:
+# admin must never hand out a bare ANTHROPIC_API_KEY it holds for its own use.
+# See resolveDefaultAgentEnv in admin/src/main.ts.
+release:
+  name: r
+  namespace: shipwright
+tests:
+  # ── chart-managed Secret ──────────────────────────────────────────────────
+
+  - it: renders no credentials Secret when neither credential is supplied
+    # An empty Helm value must not inject an empty credential that would mask a
+    # working per-agent one.
+    template: templates/agent-credentials-secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a Secret holding the inline Anthropic API key
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: r-shipwright-agent-credentials
+      - equal:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+          value: c2stYW50LXRlc3QxMjM=
+      - notExists:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+
+  - it: renders a Secret holding the inline OAuth token
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.claudeCodeOauthToken: oauth-test456
+    asserts:
+      - matchRegex:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+          decodeBase64: true
+          pattern: "^oauth-test456$"
+      - notExists:
+          path: data.SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  - it: renders no chart Secret when the caller supplies existingSecret
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.existingSecret: my-claude-creds
+      agent.credentials.anthropicApiKey: sk-ant-ignored
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no chart Secret when credentials are disabled
+    template: templates/agent-credentials-secret.yaml
+    set:
+      agent.credentials.enabled: false
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── admin Deployment wiring ───────────────────────────────────────────────
+
+  - it: injects nothing into admin when no credential is supplied
+    template: templates/admin-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-agent-credentials
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  - it: references the chart Secret from admin when a credential is inline
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-agent-credentials
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  - it: references the caller's Secret when existingSecret is set
+    # optional:true so a Secret carrying only one of the two keys still starts.
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.existingSecret: my-claude-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-claude-creds
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-claude-creds
+                key: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+                optional: true
+
+  - it: honors custom key names in the caller's Secret
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.existingSecret: my-claude-creds
+      agent.credentials.anthropicApiKeyRef: MY_ANTHROPIC_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-claude-creds
+                key: MY_ANTHROPIC_KEY
+                optional: true
+
+  - it: never injects a BARE ANTHROPIC_API_KEY into the admin container
+    # The security boundary. A bare var would be admin's own credential; the
+    # prefixed one is explicitly "hand this to agents".
+    template: templates/admin-deployment.yaml
+    set:
+      agent.credentials.anthropicApiKey: sk-ant-test123
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-agent-credentials
+                key: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+
+  # ── provisioned agent PVC sizing (regression) ─────────────────────────────
+
+  - it: injects SHIPWRIGHT_AGENT_PVC_STORAGE_GI from agent.provisioning.pvc.size
+    # Regression guard: this var was never rendered, so the provisioner fell back
+    # to its own 40Gi default and every provisioned agent silently over-requested.
+    template: templates/admin-deployment.yaml
+    set:
+      agent.provisioning.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+            value: "2"
+
+  - it: tracks a custom PVC size and strips the Gi suffix
+    template: templates/admin-deployment.yaml
+    set:
+      agent.provisioning.enabled: true
+      agent.provisioning.pvc.size: 10Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+            value: "10"
+
+  - it: omits the PVC size when provisioning is disabled
+    template: templates/admin-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_AGENT_PVC_STORAGE_GI
+            value: "2"

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -320,6 +320,39 @@ agent:
   service:
     port: 3000
   replicas: 1
+  # -- Deployment-wide Claude credentials handed to EVERY provisioned agent.
+  #
+  # Agents fetch credentials from the admin service on each config sync. The
+  # admin merges these defaults UNDERNEATH each agent's own env rows, so a
+  # per-agent value set through the admin UI always wins — this is a floor, not
+  # an override. Changes reach already-running agents on their next sync, with no
+  # pod restart and no re-provision.
+  #
+  # Without this, every agent needs its Claude token pasted in by hand through
+  # the admin UI before it can do any work.
+  #
+  # Supply exactly one of anthropicApiKey / claudeCodeOauthToken (an OAuth token
+  # from `claude /oauth-token` is the usual choice for personal use). Leave both
+  # empty to keep credentials strictly per-agent.
+  #
+  # SECURITY: inline values land in a chart-managed Secret, which means they sit
+  # in your values file and in Helm release history. Prefer existingSecret for
+  # anything beyond local development.
+  credentials:
+    # -- Whether to wire deployment-wide agent credentials at all.
+    enabled: true
+    # -- Source the credentials from a caller-managed Secret instead of the
+    # inline values below. Must supply the keys named by anthropicApiKeyRef /
+    # claudeCodeOauthTokenRef.
+    existingSecret: ""
+    # -- Key in existingSecret holding the Anthropic API key.
+    anthropicApiKeyRef: SHIPWRIGHT_AGENT_DEFAULT_ANTHROPIC_API_KEY
+    # -- Key in existingSecret holding the Claude Code OAuth token.
+    claudeCodeOauthTokenRef: SHIPWRIGHT_AGENT_DEFAULT_CLAUDE_CODE_OAUTH_TOKEN
+    # -- Inline Anthropic API key (chart-managed Secret). Local dev only.
+    anthropicApiKey: ""
+    # -- Inline Claude Code OAuth token (chart-managed Secret). Local dev only.
+    claudeCodeOauthToken: ""
   # -- Provisioning controls for the agent's persistent home / workspace.
   provisioning:
     # -- Whether the admin service provisions agent workloads at runtime. OFF by
@@ -360,9 +393,9 @@ agent:
     # When empty (the default), PVCs are named `{sanitizedAgentId}-home`.
     pvcNameTemplate: ""
     # -- Provisioned workspace PVCs: created per-agent when the provisioner spins
-    # up a new agent pod. These settings are surfaced for the agent manifest
-    # builder's future use. NOTE: buildProvisioner does not read these as env
-    # today, so they are NOT injected into the admin Deployment.
+    # up a new agent pod. `size` is injected into the admin Deployment as
+    # SHIPWRIGHT_AGENT_PVC_STORAGE_GI; leaving it unset makes the provisioner fall
+    # back to its own 40Gi default. Must be a whole number of Gi.
     pvc:
       size: 2Gi
       # -- StorageClass for provisioned agent PVCs. Empty uses the cluster default.


### PR DESCRIPTION
Third of four PRs toward a full `helm install` of the whole Shipwright stack on Minikube.

**Stacked on #2484** (which is stacked on #2483). Review those first.

## Why

This chart renders no agent Deployment by design — agents are provisioned at runtime by the admin service, and they fetch credentials from `GET /agents/:id/config` on each config sync. The only way to give an agent a Claude token was to paste one into every agent through the admin UI, so `helm install` could never produce a *working* agent on its own.

## How

The cheapest correct hook is a defaults merge in the config-bundle handler, not the manifest builder:

- `admin/src/api.ts` — `env: { ...defaultAgentEnv, ...bundle.env }`, so **per-agent rows always win**. This is a floor, not an override.
- `admin/src/main.ts` — new pure `resolveDefaultAgentEnv(env)`.
- Chart — `agent.credentials.*` → `agent-credentials-secret.yaml` → `secretKeyRef` into the admin Deployment.

~15 lines of app code. Because it flows through the config bundle, it also reaches **already-running** agents on their next sync — no pod restart, no re-provision. (Injecting into the pod manifest instead would only apply on re-provision, and `syncConfig`'s `Object.assign` would override it anyway.)

### Security boundary

Credentials are read from `SHIPWRIGHT_AGENT_DEFAULT_`-prefixed vars, never bare `ANTHROPIC_API_KEY`. Admin must not hand out a credential it happens to hold for its own use, so opting in is explicit. There's a test asserting a bare `ANTHROPIC_API_KEY` in admin's env is *not* picked up, and another asserting no bare var is injected into the container.

Blank values are treated as unset — an empty Helm value (the default) must not inject an empty credential that would mask a working per-agent one.

Inline values land in a chart-managed Secret and therefore sit in your values file and Helm release history; `existingSecret` is documented as the choice for anything beyond local dev.

## Bug fix: provisioned agents silently requested 40Gi PVCs

`values.yaml` claimed `agent.provisioning.pvc.size` was "not injected", and nothing ever rendered `SHIPWRIGHT_AGENT_PVC_STORAGE_GI` — so `agent-provisioner.ts:517` fell back to its **40Gi** default for every agent regardless of the configured value. Now injected (with `Gi` stripped); stale comment corrected.

*Upgrade note:* existing agents keep their current PVCs; the new size applies to agents provisioned from here on.

## Tests

- **Chart:** 345 passing, up from 332. New `agent_credentials_test` covers the Secret gating (inline / existingSecret / disabled / neither), admin wiring, custom key names, the no-bare-var boundary, and the PVC-size regression.
- **App:** 4 new smoke tests pin the merge precedence both ways (default inherited, per-agent wins, keys unioned, no-defaults passthrough); 6 new unit tests on `resolveDefaultAgentEnv` including blank/whitespace handling and the bare-var boundary.
- Full admin suite green: 1551 pass / 0 fail. `helm lint` + kubeconform 23/23. `task lint` + admin typecheck clean.

⚠️ Not yet validated against a real cluster — that lands with the Minikube profile PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019U7YiXDtDkvhXtPrWtT1ib