### PR TITLE
docs: document branch-exclusivity in plan-session's Bundles section

### DIFF
--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -215,6 +215,8 @@ Tasks that are tightly coupled — where splitting into separate PRs would produ
 
 **⚠ `allow_auto_merge` bypasses the bundle gate.** GitHub's `allow_auto_merge` causes a PR to merge automatically as soon as checks pass — before the deploy cron runs its bundle-completeness check. Repos that use bundles **must keep `allow_auto_merge` disabled** (the repository default). If you need auto-merge for a specific flow (e.g., automated changelog PRs driven by a dedicated workflow), use a PAT-driven merge step scoped to that workflow only, not a repo-wide setting. On 2026-06-16 a bundle shipped with an incomplete sibling because `allow_auto_merge` was temporarily enabled on the repo; the bundle gate never fired.
 
+**Same-branch scheduling exclusivity is automatic — no dependency edge needed.** Bundle-mate tasks that share a `branch` but have no `dependencies` edge between them still never dispatch concurrently: `task-store/src/ready.ts`'s ready-filter excludes a pending task from the ready set whenever another task on the same branch is `in_progress` with a fresh claim, serializing same-branch siblings automatically. This means the Dependency Map (Step 5's summary table) can legitimately show no edge between two bundle-mates even though they still execute one at a time — don't read a missing edge as a scheduling bug. The complementary backstop for the explicit-task-id dispatch path (which bypasses the ready-filter entirely, since it targets a task id directly rather than pulling from the ready set) is `dev-task.md`'s Same-Branch Sibling Check — the two mechanisms cover different dispatch paths and are not redundant with each other.
+
 ### Dependency Map
 
 Present the map in two forms:


### PR DESCRIPTION
## Summary
- Documents that same-branch bundle-mate tasks serialize automatically via the ready-filter's branch-exclusivity guard (`task-store/src/ready.ts`, landed in BBE-1.1), even with no `dependencies` edge between them.
- Clarifies that this is why the Dependency Map may show no edge between such siblings despite them never dispatching concurrently — not a scheduling bug.
- Cross-references `dev-task.md`'s Same-Branch Sibling Check as the complementary backstop for the explicit-task-id dispatch path, which bypasses the ready-filter entirely.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | plan-session.md's Bundles section gains a paragraph documenting automatic same-branch serialization via ready.ts's guard (BBE-1.1) | MET | New paragraph added after the `allow_auto_merge` warning in the Bundles section |
| 2 | Paragraph cross-references dev-task.md's Same-Branch Sibling Check as the complementary backstop | MET | Paragraph explicitly names `dev-task.md`'s Same-Branch Sibling Check and explains the two mechanisms cover different dispatch paths |
| 3 | No test change — pure documentation addition, no existing `*.content.test.ts` covers plan-session.md's prose | MET | Confirmed no `plan-session*content.test.ts` exists in the repo |

## Test Plan
- Verified no `*.content.test.ts` exists for `plan-session.md` (consistent with the repo's convention of only adding content tests where one already exists for the file)
- `task lint` passes
- `task ci`'s single failure (`prs.openapi.smoke.test.ts`) is a pre-existing failure on `main`, unrelated to this doc-only change (verified by running the same test against `main`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
