### PR TITLE
chore(chart): bump chart version to 1.11.1

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.1] - 2026-08-08
+
+### Changed
+
+- auto-bump to chart v1.11.1 triggered by release tag(s): `admin-v1.65.1`
+
 ## [1.11.0] - 2026-08-08
 
 ### Removed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.0
+version: 1.11.1
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: removed
-      description: "revert the inter-service token mesh and deployment-wide Claude credentials (#2484, #2485) — broke the production Helm upgrade, see CHANGELOG"
+    - kind: changed
+      description: "auto-bump to chart v1.11.1 triggered by release tag admin-v1.65.1"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -114,7 +114,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.65.0
+    tag: admin-v1.65.1
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.11.0 → 1.11.1

**Triggering tags:**
- `admin-v1.65.1`

**New chart version:** `1.11.1`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.65.1`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.11.1 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._