### PR TITLE
chore(chart): bump chart version to 1.11.3

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.3] - 2026-08-08
+
+### Changed
+
+- auto-bump to chart v1.11.3 triggered by release tag(s): `admin-v1.66.0`, `agent-v1.130.0`, `chat-v1.28.0`, `metrics-v1.31.0`, `task-store-v1.45.0`
+
 ## [1.11.2] - 2026-08-08
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.2
+version: 1.11.3
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,12 +29,16 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "examples/values-minikube.yaml — full local stack (admin, metrics, task-store, chat, PostgreSQL, agent provisioning) with no hand-created Secrets"
-    - kind: added
-      description: "helm test now checks task-store and chat /health, proving the chart-managed database wiring actually works"
     - kind: changed
-      description: "NOTES/README corrected: agents are provisioned at runtime by admin, not rendered as a chart Deployment"
+      description: "auto-bump to chart v1.11.3 triggered by release tag admin-v1.66.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.3 triggered by release tag agent-v1.130.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.3 triggered by release tag chat-v1.28.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.3 triggered by release tag metrics-v1.31.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.3 triggered by release tag task-store-v1.45.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -117,7 +117,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.65.1
+    tag: admin-v1.66.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -185,7 +185,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v1.29.0
+    tag: metrics-v1.31.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -301,7 +301,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.129.0
+    tag: agent-v1.130.0
     pullPolicy: ""
   service:
     port: 3000
@@ -324,7 +324,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.129.0
+      tag: agent-v1.130.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).
@@ -563,7 +563,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.44.0
+    tag: task-store-v1.45.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -652,7 +652,7 @@ chat:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-chat
-    tag: chat-v1.26.0
+    tag: chat-v1.28.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.11.2 → 1.11.3

**Triggering tags:**
- `admin-v1.66.0`
- `agent-v1.130.0`
- `chat-v1.28.0`
- `metrics-v1.31.0`
- `task-store-v1.45.0`

**New chart version:** `1.11.3`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.66.0`
- `agent.image.tag`: `agent-v1.130.0`
- `agent.provisioning.image.tag`: `agent-v1.130.0`
- `chat.image.tag`: `chat-v1.28.0`
- `metrics.image.tag`: `metrics-v1.31.0`
- `taskStore.image.tag`: `task-store-v1.45.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.11.3 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._