### PR TITLE
fix(task-store): require active claim for legacy review-conflict guard

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -299,8 +299,8 @@ Body:
 Claim semantics:
 - No existing record → creates and returns `201`
 - Same `commitSha`, same `phase`, and already claimed by another agent → returns `409` (phase already locked)
-- Same `commitSha` and `reviewState !== pending` (review phase only) → returns `409` (already reviewed at this commit)
-- Different `commitSha` or `reviewState === pending` → updates and returns `200` (new cycle)
+- Already claimed (claimedBy !== null) AND same `commitSha` AND `reviewState !== pending` (review phase only) → returns `409` (already reviewed at this commit)
+- Not claimed, OR different `commitSha`, OR `reviewState === pending` → updates and returns `200` (new cycle)
 
 The `taskId` field is optional and does not trigger any side effects on the Task table — it is stored as metadata on the PR record only for reference.
 

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -5,8 +5,9 @@
  *
  * claim() is atomic via a Prisma $transaction:
  *   1. Find existing record by @@unique([repo, prNumber])
- *   2. Same commitSha AND reviewState !== 'pending' → ConflictError(409)
- *   3. Different commitSha OR reviewState === 'pending' → update (200)
+ *   2. Already claimed (claimedBy !== null) AND same commitSha AND
+ *      reviewState !== 'pending' → ConflictError(409)
+ *   3. Not claimed, OR different commitSha, OR reviewState === 'pending' → update (200)
  *   4. No record → create (201)
  *
  * Timestamp fields are stored as ISO strings to match the application contract;
@@ -374,7 +375,8 @@ export class PullRequestService implements PullRequestServiceLike {
    *     the existing claim's heartbeat is never checked inline here — a stale claim
    *     still blocks; only the reaper (a separate process) adjudicates staleness and
    *     clears stale claims asynchronously.
-   *   - Legacy review path: same commitSha AND reviewState !== 'pending' → 409
+   *   - Legacy review path: claimedBy IS NOT NULL AND same commitSha AND
+   *     reviewState !== 'pending' → 409
    */
   async claim(
     repo: string,
@@ -406,10 +408,15 @@ export class PullRequestService implements PullRequestServiceLike {
           );
         }
 
-        // Legacy review conflict: same commitSha and reviewState is not pending
-        // (covers the case where phase was not set yet)
+        // Legacy review conflict: already claimed, same commitSha, and
+        // reviewState is not pending (covers the case where phase was not
+        // set yet). The claimedBy check keeps this guard from firing while
+        // the PR is idle (claimedBy: null) — e.g. after release()/complete()
+        // clear the claim — so a legitimate re-claim (such as the
+        // fresh-author-reply re-candidacy case) is not permanently blocked.
         if (
           phase === "review" &&
+          existing.claimedBy !== null &&
           existing.commitSha === commitSha &&
           existing.reviewState !== "pending"
         ) {

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -515,6 +515,44 @@ describeOrSkip("PullRequestService.claim() phase support (integration)", () => {
     }
     expect(threw).toBe(true);
   });
+
+  it("claim(phase=review) at unchanged commitSha with reviewState=posted and claimedBy=null succeeds (idle re-claim / fresh-author-reply case)", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 706;
+    const commitSha = "sha-idle-reclaim";
+
+    // First claim creates the record and reviews it.
+    const first = await service.claim(repo, prNumber, commitSha, "agent-a");
+    expect(first.status).toBe(201);
+
+    // Simulate the review flow completing: reviewState -> posted, claim
+    // released (mirrors complete()/release()'s real behavior — claimedBy,
+    // claimedAt, heartbeatAt, and phase are all cleared).
+    await service.complete(first.record.id);
+
+    const idle = await prisma.pullRequest.findUnique({
+      where: { id: first.record.id },
+    });
+    expect(idle?.reviewState).toBe("posted");
+    expect(idle?.claimedBy).toBeNull();
+    expect(idle?.phase).toBeNull();
+
+    // A fresh-author-reply re-candidacy claim attempt at the SAME commitSha
+    // for phase=review must succeed (200), not 409 — nobody actually holds
+    // the claim, so the legacy guard must not block it.
+    const result = await service.claim(
+      repo,
+      prNumber,
+      commitSha,
+      "agent-b",
+      undefined,
+      "review",
+    );
+    expect(result.status).toBe(200);
+    expect(result.record.claimedBy).toBe("agent-b");
+    expect(result.record.reviewState).toBe("in_progress");
+    expect(result.record.phase).toBe("review");
+  });
 });
 
 // ─── claim() prCreatedAt wiring ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `PullRequestService.claim()`'s "legacy review conflict" guard 409'd purely on `commitSha` match + `reviewState !== 'pending'`, without checking `claimedBy` — so it blocked re-claiming an idle (unclaimed) PR whenever its review had already advanced past `pending` at the same commit.
- This defeated the fresh-author-reply re-candidacy exception in `agent/src/check-review.ts`'s `getReviewCandidates()` (#2450, #2461): a PR correctly re-queued for review after its author replied at an unchanged commit would still get 409'd on every claim attempt, permanently. Reproduced live on shipwright#2382 — stuck 45+ minutes across dozens of loop ticks, and (as later discovered) fully starving the whole dispatch loop, since #2382's age made it win FIFO selection every tick while never being excluded after its silent 409.
- Investigated whether the guard is dead code safe to delete outright — it isn't: `phase` is nullable and normally `null` while a PR is idle (reset on every `release()`/`complete()`), so the *primary* guard (which requires `phase` equality) can never catch a genuine concurrent double-claim during that idle window. The legacy guard is the only protection for that case. Fix: add `existing.claimedBy !== null` to it, matching the primary guard's condition — preserves real concurrent-claim protection, stops blocking re-claims when nobody actually holds the claim.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Legacy guard only throws `ConflictError` when `existing.claimedBy !== null` | MET |
| 2 | New integration test: claim() at unchanged commitSha with `reviewState !== 'pending'` and `claimedBy: null` succeeds (200), not 409 | MET |
| 3 | Existing "already claimed" conflict tests pass unmodified | MET |
| 4 | No unit test changes needed (integration-layer logic per repo convention) | MET |

## Test Plan
- New integration test added to `task-store/src/pull-request.integration.test.ts` (idle re-claim / fresh-author-reply case), verified RED (fails against pre-fix code) then GREEN.
- Full `pull-request.integration.test.ts` (69 tests) passes against a real local Postgres instance, including all existing concurrent-claim conflict tests unmodified.
- Full `task-store` package test suite: 607 pass, 0 fail.
- `task typecheck` and `task lint` clean across all workspaces.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
