### PR TITLE
chore(chart): bump chart version to 1.11.4

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.4] - 2026-08-08
+
+### Changed
+
+- auto-bump to chart v1.11.4 triggered by release tag(s): `task-store-v1.45.1`
+
 ## [1.11.3] - 2026-08-08
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.3
+version: 1.11.4
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,15 +30,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.11.3 triggered by release tag admin-v1.66.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.3 triggered by release tag agent-v1.130.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.3 triggered by release tag chat-v1.28.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.3 triggered by release tag metrics-v1.31.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.3 triggered by release tag task-store-v1.45.0"
+      description: "auto-bump to chart v1.11.4 triggered by release tag task-store-v1.45.1"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -563,7 +563,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.45.0
+    tag: task-store-v1.45.1
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.11.3 → 1.11.4

**Triggering tags:**
- `task-store-v1.45.1`

**New chart version:** `1.11.4`

**Pinned in values.yaml:**
- `taskStore.image.tag`: `task-store-v1.45.1`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.11.4 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._