### PR TITLE
feat: plan-session.md 3-way HITL classification (HSR-2.2)

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -47,7 +47,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `hitl !== true` (Type A HITL tasks excluded; Type B tasks with `requiresHumanApproval=true` remain included), no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string, repeatable | Filter by repo (`org/repo` format). Repeat the param to match any repo in the list (e.g. `?repo=org/a&repo=org/b`). A single `?repo=` behaves identically to before (exact match). |
@@ -57,6 +57,7 @@ Query params:
 | `pr` | number | Filter by PR number |
 | `branch` | string | Filter by branch name |
 | `hitl` | `true` or `false` | Filter by HITL (human-in-the-loop) flag: return tasks with or without the flag set |
+| `requiresHumanApproval` | `true` or `false` | Filter by approval-gate flag (Type B classification): return tasks that do or do not require human review/approval before merge. Unlike `hitl`, tasks with `requiresHumanApproval=true` are not excluded from the ready set — they ship through `dev-task` normally and are subject to a separate merge-gate check later. |
 | `limit` | number | Page size. Defaults to `50` when omitted. |
 | `offset` | number | Page offset. Defaults to `0` when omitted. |
 | `sort` | string | `asc` (default) or `desc` — orders results by `createdAt`. Default preserves existing ascending order for all callers. |
@@ -452,7 +453,7 @@ If `GET /tasks?ready=true` returns `{ tasks: [], total: 0 }` even though tasks e
 
 1. **No tasks assigned to this agent** — repo-pool visibility means an unfiltered query can still exclude tasks assigned elsewhere. Use an admin token, or drop the `?assignee=` filter, to see all ready tasks in scope.
 
-2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. Clear the flag once the human action is complete.
+2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. This is the Type A classification — the task cannot be completed autonomously because it requires a human to execute it directly (no code/acceptance-criteria diff). Clear the flag once the human action is complete. (Note: tasks with `requiresHumanApproval=true` are Type B and remain included in the ready set — they are not a ready-filter obstacle.)
 
 3. **Same-branch sibling in progress** — query `?status=in_progress` to check whether another task shares the pending task's `branch` with an active claim. If so, that task holds the exclusivity lock on the branch. Wait for it to complete, fail, or release. If the sibling's claim looks stale (more than 65 minutes old with no heartbeat, by default), it will be reaped automatically; verify via the stale-claim-reaper logs in the meanwhile.
 

--- a/plugins/shipwright/commands/plan-session.content.test.ts
+++ b/plugins/shipwright/commands/plan-session.content.test.ts
@@ -1,0 +1,159 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PLAN_SESSION_MD_PATH = join(import.meta.dir, "plan-session.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(PLAN_SESSION_MD_PATH, "utf-8");
+});
+
+function extractStep5_5Section(md: string): string {
+  const match = md.match(/## Step 5\.5: HITL Detection[\s\S]*?(?=\n## Step 6: Write to Queue)/);
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
+function extractStep6bSection(md: string): string {
+  const match = md.match(/\*\*Step 6b — Write tasks to the store:\*\*[\s\S]*$/);
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
+describe("plan-session.md — Step 5.5 introduces 3-way HITL classification (HSR-2.2)", () => {
+  it("explicitly names Type A and Type B classifications", () => {
+    const section = extractStep5_5Section(content);
+    expect(section).toContain("Type A");
+    expect(section).toContain("Type B");
+  });
+
+  it("defines Type A as no real code/acceptance-criteria diff, human executes commands directly", () => {
+    const section = extractStep5_5Section(content);
+    const typeAIdx = section.indexOf("Type A");
+    const typeBIdx = section.indexOf("Type B");
+    expect(typeAIdx).toBeGreaterThan(-1);
+    expect(typeBIdx).toBeGreaterThan(typeAIdx);
+    const typeASection = section.slice(typeAIdx, typeBIdx);
+    const lower = typeASection.toLowerCase();
+    expect(lower).toContain("no real code");
+    expect(lower).toMatch(/acceptance.criteria diff/);
+    expect(lower).toContain("human executes");
+  });
+
+  it("defines Type B as real code + acceptance criteria, but the human step is review/approve before merge", () => {
+    const section = extractStep5_5Section(content);
+    const typeBIdx = section.indexOf("Type B");
+    expect(typeBIdx).toBeGreaterThan(-1);
+    const typeBSection = section.slice(typeBIdx);
+    const lower = typeBSection.toLowerCase();
+    expect(lower).toContain("real code");
+    expect(lower).toContain("acceptance criteria");
+    expect(lower).toContain("review");
+    expect(lower).toContain("approve");
+    expect(lower).toContain("before merge");
+  });
+
+  it("Type A behavior is unchanged: still hitl:true plus Human steps injection", () => {
+    const section = extractStep5_5Section(content);
+    const typeAIdx = section.indexOf("Type A");
+    const typeBIdx = section.indexOf("Type B");
+    const typeASection = section.slice(typeAIdx, typeBIdx);
+    expect(typeASection).toContain("hitl: true");
+    expect(typeASection).toContain("## Human steps");
+    expect(typeASection.toLowerCase()).toContain("unchanged");
+  });
+
+  it("Type B sets requiresHumanApproval:true instead of hitl:true, and does NOT inject Human steps as a task replacement", () => {
+    const section = extractStep5_5Section(content);
+    const howToFlagIdx = section.indexOf("### How to Flag a Matched Task");
+    const typeBIdx = section.indexOf("Type B", howToFlagIdx);
+    const typeBSection = section.slice(typeBIdx);
+    expect(typeBSection).toContain("requiresHumanApproval: true");
+    // Type B's instructions explicitly call out *not* setting hitl:true — the negative
+    // instruction itself is expected to name the field, so assert on the "do not set hitl"
+    // phrasing rather than a bare absence of the substring.
+    expect(typeBSection).toMatch(/do\s+\*\*not\*\*\s+set\s+`hitl: true`|do not set hitl: true/);
+    const lower = typeBSection.toLowerCase();
+    expect(lower).toContain("do not");
+    expect(lower).toContain("## human steps".toLowerCase());
+  });
+
+  it("Type B tasks still ship through dev-task normally, not replaced by manual execution", () => {
+    const section = extractStep5_5Section(content);
+    const typeBIdx = section.indexOf("Type B");
+    const typeBSection = section.slice(typeBIdx);
+    const lower = typeBSection.toLowerCase();
+    expect(lower).toContain("dev-task");
+    expect(lower).toMatch(/ships? (through|via) dev-task normally|still ships? through dev-task/);
+  });
+
+  it("documents Type B tasks are NOT excluded from the dev-task ready set, since ready.ts never reads requiresHumanApproval", () => {
+    const section = extractStep5_5Section(content);
+    const typeBIdx = section.indexOf("Type B");
+    const typeBSection = section.slice(typeBIdx);
+    expect(typeBSection).toContain("ready.ts");
+    expect(typeBSection).toContain("requiresHumanApproval");
+    const lower = typeBSection.toLowerCase();
+    const hasReadySetLanguage =
+      lower.includes("ready set") || lower.includes("ready-filter") || lower.includes("dispatchable");
+    expect(hasReadySetLanguage).toBe(true);
+  });
+
+  it("documents the neither case ('Type C') as unchanged: hitl:false, no special handling", () => {
+    const section = extractStep5_5Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("neither");
+    expect(section).toContain("hitl: false");
+  });
+
+  it("How to Flag a Matched Task section covers both Type A and Type B flagging instructions distinctly", () => {
+    const section = extractStep5_5Section(content);
+    const howToFlagIdx = section.indexOf("### How to Flag a Matched Task");
+    expect(howToFlagIdx).toBeGreaterThan(-1);
+    const howToFlagSection = section.slice(howToFlagIdx);
+    expect(howToFlagSection).toContain("Type A");
+    expect(howToFlagSection).toContain("Type B");
+    expect(howToFlagSection).toContain("hitl: true");
+    expect(howToFlagSection).toContain("requiresHumanApproval: true");
+  });
+
+  it("keeps the existing Keyword Heuristics and Judgment Step subsections as Type A's detection mechanism", () => {
+    const section = extractStep5_5Section(content);
+    expect(section).toContain("### Keyword Heuristics");
+    expect(section).toContain("### Judgment Step");
+    const keywordIdx = section.indexOf("### Keyword Heuristics");
+    const judgmentIdx = section.indexOf("### Judgment Step");
+    expect(judgmentIdx).toBeGreaterThan(keywordIdx);
+  });
+});
+
+describe("plan-session.md — Step 6b template includes requiresHumanApproval (HSR-2.2)", () => {
+  it("the JSON task template code block includes a requiresHumanApproval field alongside hitl", () => {
+    const section = extractStep6bSection(content);
+    const codeBlockMatch = section.match(/```json[\s\S]*?```/);
+    expect(codeBlockMatch).not.toBeNull();
+    const codeBlock = codeBlockMatch?.[0] ?? "";
+    expect(codeBlock).toContain('"hitl": false');
+    expect(codeBlock).toContain('"requiresHumanApproval": false');
+  });
+
+  it("prose instructs setting requiresHumanApproval:true for Type B tasks, parallel to the hitl:true instruction for Type A", () => {
+    const section = extractStep6bSection(content);
+    expect(section).toContain('Set `"hitl": true`');
+    expect(section).toContain("Step 5.5");
+    expect(section).toContain('Set `"requiresHumanApproval": true`');
+    expect(section).toContain("Type B");
+  });
+
+  it("the requiresHumanApproval instruction clarifies Human steps is not injected for Type B (unlike Type A)", () => {
+    const section = extractStep6bSection(content);
+    const reqIdx = section.indexOf('Set `"requiresHumanApproval": true`');
+    expect(reqIdx).toBeGreaterThan(-1);
+    const nearby = section.slice(reqIdx, reqIdx + 400);
+    const lower = nearby.toLowerCase();
+    expect(lower).toContain("not");
+    expect(lower).toContain("human steps");
+  });
+});

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -178,7 +178,7 @@ For each task:
 - **Branch**: `feat/{id-lowered-dashes}-{first-3-words-kebab}` — or a shared branch name for bundled tasks (see below)
 - **Layer**: API | Frontend | Database | Shared | Background | CLI
 - **Hours**: rough estimate (1-8h; break tasks larger than 8h)
-- **HITL**: `⚠ HITL` if the task requires human action (see Step 5.5); omit otherwise
+- **HITL**: `⚠ HITL` if the task is Type A (human executes directly), `⚠ Approval` if the task is Type B (human reviews/approves before merge) — see Step 5.5; omit otherwise
 - **Complexity**: integer 1–5 — use the scoring table below
 - **Model**: `haiku` | `sonnet` | `opus` — derived from complexity score (see table)
 
@@ -261,9 +261,17 @@ Present the task list and dependency map as a first pass. The engineer reviews a
 
 ## Step 5.5: HITL Detection
 
-Before writing tasks to the queue, scan every task for Human-in-the-Loop requirements. A task is HITL if it cannot be completed autonomously — it requires a human to act in a UI, provision a credential, or execute a privileged command outside the automated pipeline.
+Before writing tasks to the queue, scan every task for Human-in-the-Loop requirements. Classify each task into exactly one of three buckets:
 
-### Keyword Heuristics
+- **Type A** — no real code / acceptance-criteria diff. The "task" is actually a set of manual steps: human executes commands or clicks directly (in a cloud console, provisioning a secret, running a privileged command outside the automated pipeline). This is the classic HITL case: it cannot be completed autonomously at all. Sets `hitl: true` and injects a `## Human steps` section — unchanged from today.
+- **Type B** — has real code and real acceptance criteria that `dev-task` can autonomously implement and ship as a normal PR, but the human-facing description also includes a "review/approve before merge" style step (e.g. "a human should sanity-check this before it merges," "get sign-off from X before deploying") rather than "go execute this action yourself." The code work is not blocked on a human — a human just needs to bless it before it ships. Sets `requiresHumanApproval: true` instead of setting `hitl` at all.
+- **Neither** — no HITL characteristics at all. Unchanged from today: `hitl: false`, no special handling.
+
+Type A detection (keyword heuristic + judgment step below) is largely unchanged from today — it's just now explicitly scoped to the "no real code diff, human executes commands directly" case. Type B is a new, narrower classification: real code + acceptance-criteria diff, plus a review/approve-before-merge step described somewhere in the task.
+
+**Type A vs. Type B in one line:** Type A is "a human must go execute this instead of dev-task" (`hitl: true` + `## Human steps`, unchanged from today). Type B is "dev-task executes this normally, but a human should review/approve the result before it merges" (`requiresHumanApproval: true`, no `## Human steps`, still ships through dev-task normally).
+
+### Keyword Heuristics (Type A detection)
 
 Flag a task as HITL if its title or description contains any of the following keywords (case-insensitive):
 
@@ -274,22 +282,34 @@ rollout, helm upgrade, kubectl apply, PAT, personal access token,
 provision secret, GitHub settings, branch protection, allow_auto_merge
 ```
 
-### Judgment Step
+### Judgment Step (Type A detection)
 
-Even without a keyword match, flag the task HITL if it fundamentally requires:
+Even without a keyword match, flag the task Type A HITL if it fundamentally requires:
 - A human to act in a web UI (e.g., GCP Console, GitHub Settings, DNS registrar, cloud provider dashboard)
 - Provisioning or rotating a credential, secret, or API key
 - Approving a privileged workflow that requires human authorization
 - Any action that cannot be expressed as a CLI command the agent can run
 - Reading live production data to verify something (a backfill/attribution mapping, a data shape assumption) in a repo where the dev-task agent's normal execution environment cannot reach production databases directly — check the repo's `CLAUDE.md` for a rule to this effect. The keyword scan above won't catch this on its own since the trigger words (`kubectl`, `Cloud SQL`, etc.) typically show up only in acceptance criteria, not the task title/description — apply this judgment check explicitly for any backfill/migration task.
 
-**CI workflow secret scan**: if a task adds or modifies a CI workflow file, extract every `${{ secrets.* }}` reference in the changed file and check whether each secret name already appears in other workflow files in the repo. Any secret that is net-new — not referenced anywhere else — requires a human to provision it. Flag the task HITL and list the new secret names in the `## Human steps` section.
+**CI workflow secret scan**: if a task adds or modifies a CI workflow file, extract every `${{ secrets.* }}` reference in the changed file and check whether each secret name already appears in other workflow files in the repo. Any secret that is net-new — not referenced anywhere else — requires a human to provision it. Flag the task Type A HITL and list the new secret names in the `## Human steps` section.
 
-Apply judgment: if the task description implies "someone must click approve in the console" or "create a secret in 1Password," it's HITL regardless of the keywords present.
+Apply judgment: if the task description implies "someone must click approve in the console" or "create a secret in 1Password," it's Type A HITL regardless of the keywords present.
+
+### Type B Judgment Step
+
+Apply this check separately, after Type A detection, to every task that was **not** flagged Type A (a task has real code and real acceptance criteria dev-task can autonomously implement). Flag the task Type B if its description or acceptance criteria include a step where a human should **review or approve the work before it merges** — not execute anything themselves. Signals:
+- "A human should review/sanity-check this before it merges"
+- "Get sign-off from {person/role} before deploying"
+- "Requires manual QA / approval before this ships"
+- Any phrasing that is about blessing a PR that dev-task already produced, rather than about a human performing an action dev-task cannot perform
+
+The distinguishing question: **does the human need to go execute this themselves (Type A), or does dev-task execute it and a human just needs to approve the result before merge (Type B)?** If the task is "someone must click X in a console" or "someone must run this command," that's Type A. If the task is "dev-task builds and opens the PR as normal, but get a human's sign-off before merging," that's Type B.
+
+Type B tasks are **not** excluded from the dev-task ready set. `task-store/src/ready.ts`'s ready-filter only excludes a task when `task.hitl === true` — it never reads `requiresHumanApproval`, so a Type B task with `hitl: false` and `requiresHumanApproval: true` remains fully autonomously dispatchable through `dev-task`/`review`/`patch`/`deploy` like any other task. `requiresHumanApproval` is metadata consumed later (a merge-gate decision), not an execution gate.
 
 ### How to Flag a Matched Task
 
-For each task that matches either heuristic:
+**Type A** — for each task that matches the Type A keyword heuristic or judgment step:
 
 1. **Set `hitl: true`** in its task JSON (see Step 6 templates)
 2. **Inject a `## Human steps` section** into its description naming:
@@ -298,9 +318,17 @@ For each task that matches either heuristic:
    - Any pre-requisite setup (e.g., "Must have kube-context set to production cluster")
 3. **Mark the task `⚠ HITL`** in the task table (HITL column)
 
-Non-matching tasks are unaffected — do not add a `## Human steps` section or set `hitl: true` on them.
+This is unchanged from today's behavior: the `## Human steps` section replaces what dev-task would otherwise try to autonomously execute, since there's no code to write.
 
-**Example HITL description injection:**
+**Type B** — for each task that matches the Type B judgment step:
+
+1. **Set `requiresHumanApproval: true`** in its task JSON (see Step 6 templates) — do **not** set `hitl: true` for this task.
+2. **Do not inject a `## Human steps` section.** The task's description and acceptance criteria stay exactly as designed in Step 5 — the code work still ships through `dev-task` normally, and a `## Human steps` block would incorrectly imply the human is replacing dev-task's execution rather than reviewing its output.
+3. **Mark the task `⚠ Approval` in the task table (HITL column)**, distinct from `⚠ HITL`, so the review/approve-before-merge expectation is visible without implying the task is unexecutable by dev-task.
+
+Non-matching (neither Type A nor Type B) tasks are unaffected — do not add a `## Human steps` section, and do not set `hitl: true` or `requiresHumanApproval: true` on them.
+
+**Example Type A HITL description injection:**
 ```
 {original description}
 
@@ -311,13 +339,18 @@ Action: Set the database password via Cloud SQL Studio or:
 Pre-requisite: Ensure kube-context is pointed at the production cluster before running migrations.
 ```
 
+Type B tasks get no equivalent injection — the description is left as Step 5 wrote it.
+
 After scanning, list any flagged tasks:
 ```
 HITL tasks detected: {count}
-{PREFIX}-X.Y — {title} — flagged by: {keyword match / judgment}
+{PREFIX}-X.Y — {title} — flagged by: {keyword match / judgment} (Type A)
+
+Approval-required tasks detected: {count}
+{PREFIX}-X.Y — {title} — flagged by: {review/approve-before-merge step} (Type B)
 ```
 
-If no tasks are flagged, print:
+If no tasks are flagged in either bucket, print:
 ```
 HITL scan: no tasks require human steps
 ```
@@ -387,6 +420,7 @@ Write the tasks to `/tmp/new-tasks-{session}.json`. Set `source` to `"planning/{
     "dependencies": [],
     "status": "pending",
     "hitl": false,
+    "requiresHumanApproval": false,
     "pr": null,
     "hours": 2,
     "complexity": {complexity},
@@ -395,7 +429,9 @@ Write the tasks to `/tmp/new-tasks-{session}.json`. Set `source` to `"planning/{
 ]
 ```
 
-Set `"hitl": true` (and include the `## Human steps` section in `description`) for any task flagged in Step 5.5.
+Set `"hitl": true` (and include the `## Human steps` section in `description`) for any Type A task flagged in Step 5.5.
+
+Set `"requiresHumanApproval": true` for any Type B task flagged in Step 5.5 — leave `"hitl": false` and do **not** inject a `## Human steps` section for these; the task still ships through `dev-task` normally.
 
 Post the tasks to the store:
 

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -444,6 +444,10 @@ export const TaskListQuerySchema = z.object({
   offset: z.string().optional().openapi({ example: "0" }),
   ready: z.enum(["true", "false"]).optional().openapi({ example: "true" }),
   hitl: z.enum(["true", "false"]).optional().openapi({ example: "true" }),
+  requiresHumanApproval: z
+    .enum(["true", "false"])
+    .optional()
+    .openapi({ example: "true" }),
   sort: z.enum(["asc", "desc"]).optional().openapi({ example: "asc" }),
   updatedSince: z.string().optional().openapi({
     example: "2026-01-01T00:00:00.000Z",

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -453,6 +453,77 @@ describe("createTasksRoutes — OpenAPIHono migration (TSM-1.2)", () => {
     expect(res.status).toBe(400);
   });
 
+  it("GET /?requiresHumanApproval=true passes requiresHumanApproval: true through to taskService.list()", async () => {
+    const task = makeTask({ id: "t-1", requiresHumanApproval: true });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?requiresHumanApproval=true");
+    expect(res.status).toBe(200);
+    expect(
+      (receivedFilters as { requiresHumanApproval?: boolean })
+        .requiresHumanApproval,
+    ).toBe(true);
+  });
+
+  it("GET /?requiresHumanApproval=false passes requiresHumanApproval: false through to taskService.list()", async () => {
+    const task = makeTask({ id: "t-1", requiresHumanApproval: false });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?requiresHumanApproval=false");
+    expect(res.status).toBe(200);
+    expect(
+      (receivedFilters as { requiresHumanApproval?: boolean })
+        .requiresHumanApproval,
+    ).toBe(false);
+  });
+
+  it("GET / with no requiresHumanApproval param passes requiresHumanApproval: undefined through to taskService.list() (existing behavior)", async () => {
+    const task = makeTask({ id: "t-1" });
+    let receivedFilters: unknown;
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        onList: (filters) => {
+          receivedFilters = filters;
+        },
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/");
+    expect(res.status).toBe(200);
+    expect(
+      (receivedFilters as { requiresHumanApproval?: boolean })
+        .requiresHumanApproval,
+    ).toBeUndefined();
+  });
+
+  it("GET /?requiresHumanApproval=garbage rejects with a 400 (invalid enum value, mirrors ?hitl= behavior)", async () => {
+    const app = createTasksRoutes(fakeTaskService());
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/?requiresHumanApproval=garbage");
+    expect(res.status).toBe(400);
+  });
+
   it("GET /distinct returns 200 with { sessions, repos } shape", async () => {
     const app = createTasksRoutes(fakeTaskService());
     const parent = makeAdminParent(app);

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -14,7 +14,7 @@
  * Admin tokens (agentId null) have no restrictions.
  *
  * Routes:
- *   GET    /tasks               list (?status, ?state=open|closed, ?session, ?assignee, ?pr, ?branch, ?hitl=true|false, ?limit, ?offset, ?ready=true)
+ *   GET    /tasks               list (?status, ?state=open|closed, ?session, ?assignee, ?pr, ?branch, ?hitl=true|false, ?requiresHumanApproval=true|false, ?limit, ?offset, ?ready=true)
  *                              returns { tasks, total, scopeDegraded } — scopeDegraded
  *                              mirrors the auth middleware's scopeDegraded context var
  *                              (true only when the agent's repo-scope resolver call itself
@@ -614,6 +614,12 @@ export function createTasksRoutes(
         c.req.query("hitl") === "true"
           ? true
           : c.req.query("hitl") === "false"
+            ? false
+            : undefined,
+      requiresHumanApproval:
+        c.req.query("requiresHumanApproval") === "true"
+          ? true
+          : c.req.query("requiresHumanApproval") === "false"
             ? false
             : undefined,
       limit:

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -78,6 +78,7 @@ export interface TaskListFilters {
   pr?: number;
   branch?: string;
   hitl?: boolean;
+  requiresHumanApproval?: boolean;
   limit?: number;
   offset?: number;
   /** Order results by createdAt. Defaults to "asc" (existing behavior). */
@@ -162,6 +163,8 @@ export class TaskService implements TaskServiceLike {
     if (filters.pr !== undefined) where.pr = filters.pr;
     if (filters.branch !== undefined) where.branch = filters.branch;
     if (filters.hitl !== undefined) where.hitl = filters.hitl;
+    if (filters.requiresHumanApproval !== undefined)
+      where.requiresHumanApproval = filters.requiresHumanApproval;
     if (filters.updatedSince) {
       where.updatedAt = { gte: parseUpdatedSince(filters.updatedSince) };
     }


### PR DESCRIPTION
## Summary
- Rewrites `plan-session.md` Step 5.5 (HITL Detection) from a binary hitl:true/false scan into a 3-way classification: Type A (no real code diff, human executes directly → `hitl:true` + `## Human steps` injection, unchanged), Type B (real code + acceptance criteria, but a review/approve-before-merge step → `requiresHumanApproval:true`, no `## Human steps` injection, still ships through dev-task normally), and neither (unchanged).
- Updates Step 6b's JSON task template to include `requiresHumanApproval` alongside `hitl`, with parallel prose instructing when to set it.
- Adds `plugins/shipwright/commands/plan-session.content.test.ts` (new — no prior coverage existed), mirroring the `hitl.content.test.ts`/`patch.content.test.ts` pattern.
- Docs refresh: `docs/task-store.md` updated to document the `requiresHumanApproval` filter and clarify Type A vs Type B ready-set behavior.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5.5 produces hitl:true only for genuine Type A (no code diff) tasks | MET |
| 2 | Step 5.5 produces requiresHumanApproval:true for Type B tasks, not excluded from the dev-task ready set (ready.ts never reads requiresHumanApproval) | MET |
| 3 | Step 6b's task JSON template includes requiresHumanApproval | MET |
| 4 | New plan-session.content.test.ts covering 3-way classification wording + Step 6 template | MET |

## Test Plan
- 13 new content tests in `plan-session.content.test.ts`, all passing
- `task lint`, `task typecheck` pass clean
- `task ci` full-suite run has 1 pre-existing, unrelated flake in `metrics/src/lib/errors.unit.test.ts` (test-isolation issue — passes 25/25 in isolation, fails only under full-suite run; not touched by this diff)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
