### PR TITLE
fix: patch.md migrate escalation sites off hitl

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -47,7 +47,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `status != blocked`, no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string, repeatable | Filter by repo (`org/repo` format). Repeat the param to match any repo in the list (e.g. `?repo=org/a&repo=org/b`). A single `?repo=` behaves identically to before (exact match). |
@@ -452,7 +452,7 @@ If `GET /tasks?ready=true` returns `{ tasks: [], total: 0 }` even though tasks e
 
 1. **No tasks assigned to this agent** — repo-pool visibility means an unfiltered query can still exclude tasks assigned elsewhere. Use an admin token, or drop the `?assignee=` filter, to see all ready tasks in scope.
 
-2. **Task blocked** — query `?state=blocked` to check whether tasks have `status='blocked'`. Clear the flag once the human action is complete via `/tasks/:id/release` or `PATCH /tasks/:id` with `status=pending` (admin only).
+2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. Clear the flag once the human action is complete.
 
 3. **Same-branch sibling in progress** — query `?status=in_progress` to check whether another task shares the pending task's `branch` with an active claim. If so, that task holds the exclusivity lock on the branch. Wait for it to complete, fail, or release. If the sibling's claim looks stale (more than 65 minutes old with no heartbeat, by default), it will be reaped automatically; verify via the stale-claim-reaper logs in the meanwhile.
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -47,7 +47,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, no `hitl`, no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `status != blocked`, no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string, repeatable | Filter by repo (`org/repo` format). Repeat the param to match any repo in the list (e.g. `?repo=org/a&repo=org/b`). A single `?repo=` behaves identically to before (exact match). |
@@ -452,7 +452,7 @@ If `GET /tasks?ready=true` returns `{ tasks: [], total: 0 }` even though tasks e
 
 1. **No tasks assigned to this agent** — repo-pool visibility means an unfiltered query can still exclude tasks assigned elsewhere. Use an admin token, or drop the `?assignee=` filter, to see all ready tasks in scope.
 
-2. **HITL flag set** — query `?status=pending` to check whether tasks have `"hitl": true`. Clear the flag once the human action is complete.
+2. **Task blocked** — query `?state=blocked` to check whether tasks have `status='blocked'`. Clear the flag once the human action is complete via `/tasks/:id/release` or `PATCH /tasks/:id` with `status=pending` (admin only).
 
 3. **Same-branch sibling in progress** — query `?status=in_progress` to check whether another task shares the pending task's `branch` with an active claim. If so, that task holds the exclusivity lock on the branch. Wait for it to complete, fail, or release. If the sibling's claim looks stale (more than 65 minutes old with no heartbeat, by default), it will be reaped automatically; verify via the stale-claim-reaper logs in the meanwhile.
 

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -561,7 +561,7 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
     expect(section).toContain("reply dated *before* the");
   });
 
-  it("escalation case reuses the shared PR_TASK_ID from Step 2.1 and PATCHes hitl: true (no fresh taskId fetch)", () => {
+  it("escalation case reuses the shared PR_TASK_ID from Step 2.1 and PATCHes status: blocked (no fresh taskId fetch)", () => {
     const section = getStep5a7Section();
     expect(section).toContain("PR_TASK_ID");
     // No independent GET .../prs/$PR_RECORD_ID fetch for taskId purposes anymore — that
@@ -572,7 +572,7 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
     expect(section).toMatch(/Step 2\.1|reuse/i);
     expect(section).toContain("-X PATCH");
     expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
-    expect(section).toContain('"hitl": true');
+    expect(section).toContain('"status": "blocked"');
   });
 
   it("escalation case with no linked task PATCHes the PR record itself with blocked: true and a blockedReason, not just a warning", () => {
@@ -735,17 +735,19 @@ describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation a
     expect(section).toContain("5a.7");
   });
 
-  it("fetches the PR record fresh and checks its hitl field", () => {
+  it("fetches the PR record fresh and checks its blocked field", () => {
     const section = getStep6b6Section();
     expect(section).toContain("GET");
     expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
-    expect(section).toContain("hitl");
+    expect(section).toContain("PR_BLOCKED");
   });
 
-  it("also checks the linked task's hitl field when taskId is present", () => {
+  it("also checks the linked task's status field when taskId is present", () => {
     const section = getStep6b6Section();
     expect(section).toContain("taskId");
     expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$');
+    expect(section).toContain("TASK_BLOCKED");
+    expect(section).toContain('.status');
   });
 
   it("true branch releases the claim, does not dispatch the fix subagent, and moves to the next PR in List D", () => {
@@ -976,11 +978,11 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
   ) {
     const blocked = getBlockedBranch(section);
 
-    // hitl PATCH to the linked task
+    // status: blocked PATCH to the linked task
     expect(blocked).toContain(opts.taskPatchSnippet);
-    expect(blocked).toContain('"hitl": true');
+    expect(blocked).toContain('"status": "blocked"');
 
-    // hitl + blockedReason PATCH fallback to the PR record
+    // blocked + blockedReason PATCH fallback to the PR record
     expect(blocked).toContain(opts.prPatchSnippet);
     expect(blocked).toContain("blockedReason");
 
@@ -988,7 +990,7 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     expect(blocked).toContain(`gh pr comment {pr} --repo {org}/{repo} --body-file ${opts.commentTmpPath}`);
     expect(blocked).toContain(`rm ${opts.commentTmpPath}`);
 
-    // Ordering: hitl PATCH + comment must occur BEFORE the release call
+    // Ordering: status PATCH + comment must occur BEFORE the release call
     const taskPatchIdx = blocked.indexOf(opts.taskPatchSnippet);
     const prPatchIdx = blocked.indexOf(opts.prPatchSnippet);
     const commentIdx = blocked.indexOf(`--body-file ${opts.commentTmpPath}`);
@@ -1061,7 +1063,7 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     expect(step5a7Section).toContain("second-round disagreement");
   });
 
-  it("Step 6d's BLOCKED escalation is consistent with Step 6b.6's pre-dispatch hitl check (same PATCH targets)", () => {
+  it("Step 6d's BLOCKED escalation is consistent with Step 6b.6's pre-dispatch status check (same PATCH targets)", () => {
     const step6b6Idx = content.indexOf("### Step 6b.6: Escalation Check (CFE-1.1)");
     const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
     const step6b6Section = content.slice(step6b6Idx, step6cIdx);

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -493,13 +493,13 @@ Parse the subagent's STATUS:
   5a.7's (RPF-1.3) escalation pattern, before releasing the claim:
 
   1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If
-     non-empty, PATCH the linked task to `hitl: true` so it's flagged for a human decision:
+     non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human decision:
      ```bash
      curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
        -H "Content-Type: application/json" \
        "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-       -d '{"hitl": true}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+       -d '{"status": "blocked", "blockedReason": "merge-conflict resolution blocked — automated conflict resolution could not complete"}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
      ```
      If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
      instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
@@ -750,14 +750,14 @@ entirely — do not dispatch the fix subagent, do not post another rebuttal, and
    fetched `GET /prs?repo={org}/{repo}&prNumber={pr}` and captured `.prs[0].taskId` right
    after Step 2 resolved this same PR, independent of any claim, so it's already available
    by the time this check runs.)
-2. If `PR_TASK_ID` is non-empty, PATCH it to `hitl: true` so the task is flagged for a human
+2. If `PR_TASK_ID` is non-empty, PATCH it to `status: 'blocked'` so the task is flagged for a human
    decision:
    ```bash
    curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      -H "Content-Type: application/json" \
      "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-     -d '{"hitl": true}' > /dev/null 2>&1 || \
-     echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+     -d '{"status": "blocked", "blockedReason": "second-round disagreement between reviewer and automated fix — escalated to HITL"}' > /dev/null 2>&1 || \
+     echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
    ```
    If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
    instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
@@ -1081,13 +1081,13 @@ Parse the subagent's STATUS:
   HITL first, mirroring Step 5a.7's escalation pattern, before releasing the claim:
 
   1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If
-     non-empty, PATCH the linked task to `hitl: true` so it's flagged for a human decision:
+     non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human decision:
      ```bash
      curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
        -H "Content-Type: application/json" \
        "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-       -d '{"hitl": true}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+       -d '{"status": "blocked", "blockedReason": "review-finding fix blocked — automated fix subagent could not complete"}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
      ```
      If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
      instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
@@ -1312,16 +1312,17 @@ already has an unresolved HITL escalation.
    PR_BLOCKED=$(echo "$PR_RECORD" | jq -r '.blocked // false')
    PR_TASK_ID=$(echo "$PR_RECORD" | jq -r '.taskId // empty')
    ```
-2. If `PR_TASK_ID` is non-empty, also fetch the linked task and check its `hitl` field:
+2. If `PR_TASK_ID` is non-empty, also fetch the linked task and check its `status` field:
    ```bash
-   TASK_HITL=false
+   TASK_BLOCKED=false
    if [ -n "$PR_TASK_ID" ]; then
-     TASK_HITL=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" | jq -r '.hitl // false')
+     TASK_STATUS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" | jq -r '.status // empty')
+     [ "$TASK_STATUS" = "blocked" ] && TASK_BLOCKED=true
    fi
    ```
 
-**If `PR_BLOCKED` is `true` OR `TASK_HITL` is `true`** (an unresolved HITL escalation already
+**If `PR_BLOCKED` is `true` OR `TASK_BLOCKED` is `true`** (an unresolved HITL escalation already
 exists — most likely from Step 5a.7 on this same PR, this cycle or a prior one): skip —
 do not dispatch the fix subagent, since doing so would silently contradict the escalation
 decision already recorded on the PR.
@@ -1340,7 +1341,7 @@ decision already recorded on the PR.
 3. Move to the next PR in List D. If no candidates remain, continue to Step 7.
 
 **Otherwise** (neither the PR record has `blocked: true` nor its linked task has
-`hitl: true`): no escalation
+`status: 'blocked'`): no escalation
 is on record for this PR — proceed normally to Step 6c.
 
 ### Step 6c: Dispatch Fix Subagent
@@ -1441,13 +1442,13 @@ Parse the subagent's STATUS:
   dispatch, this runs after a BLOCKED report; they compose without conflict):
 
   1. Reuse `PR_TASK_ID`, already resolved in Step 6b.6 — no second fetch here. If
-     non-empty, PATCH the linked task to `hitl: true` so it's flagged for a human decision:
+     non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human decision:
      ```bash
      curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
        -H "Content-Type: application/json" \
        "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-       -d '{"hitl": true}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /tasks/$PR_TASK_ID hitl flag failed — continuing"
+       -d '{"status": "blocked", "blockedReason": "CI-fix blocked — automated CI-fix subagent could not complete"}' > /dev/null 2>&1 || \
+       echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
      ```
      If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
      instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
@@ -1629,9 +1630,9 @@ outcome. This is a single bonus attempt, not a new fix loop.
 pattern as Step 6e), and proceed to the existing Step 7 report unchanged.
 
 **On BLOCKED:** reuse the exact same HITL-escalation branch as Step 6d's BLOCKED handling —
-same `hitl` PATCH to the linked task (or the PR record when no task is linked), same PR
-comment convention, same claim release — rather than adding a new escalation path here. Log
-the blocker and proceed to the existing Step 7 report unchanged.
+same `status: 'blocked'` PATCH to the linked task (or the PR record when no task is linked),
+same PR comment convention, same claim release — rather than adding a new escalation path
+here. Log the blocker and proceed to the existing Step 7 report unchanged.
 
 ---
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -488,8 +488,8 @@ Parse the subagent's STATUS:
   final report and skip Step 4c.5.
 - **BLOCKED**: A generic BLOCKED release with no escalation flag makes this PR immediately
   re-eligible for `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop`
-  tick — `claimedBy`/`hitl` are the only exclusions it checks, and releasing the claim below
-  clears the former without setting the latter. Escalate to HITL first, mirroring Step
+  tick — `claimedBy`/`blocked` are the only exclusions it checks, and releasing the claim
+  below clears the former without setting the latter. Escalate to HITL first, mirroring Step
   5a.7's (RPF-1.3) escalation pattern, before releasing the claim:
 
   1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If


### PR DESCRIPTION
## Summary
- Migrates `patch.md`'s 5 escalation sites from `hitl: true` to `status: 'blocked'` on the task-linked PATCH, reusing the exact blockedReason text already used by each site's PR-only fallback
- Updates the CFE-1.1 pre-dispatch check (Step 6b.6) to read `PR_BLOCKED`/`TASK_BLOCKED` from `.blocked`/`.status === 'blocked'` instead of `.hitl`
- Fixes one stale `hitl` reference in Step 4c's prose that described `check-patch.ts`'s exclusion fields
- Updates `patch.content.test.ts` assertions across all 5 sites and the CFE-1.1 check to match the new field names, same coverage breadth

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 5 task-linked escalation sites write status:'blocked' with unchanged blockedReason text | MET |
| 2 | All 5 PR-only escalation sites write blocked:true with unchanged blockedReason text | MET (already correct pre-task) |
| 3 | CFE-1.1 pre-dispatch check reads the new fields and still prevents CI-fix from contradicting an existing escalation | MET |
| 4 | Test decision: update patch.content.test.ts's assertions for each of the 5 escalation sites and the CFE-1.1 check to match the new field names, keeping the same coverage breadth as today | MET |

## Test Plan
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 118 pass, 0 fail
- `task typecheck` — clean across all packages
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
