### PR TITLE
feat: add /shipwright:unblock command for HITL triage (HSR-2.5)

### DIFF
--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -42,6 +42,7 @@ Every feature moves through the same stages. One `planning/{folder}/` directory 
 | `/dev-task {task-id} --merge` | Same as above, but auto-merges after review (used by dev-loop) |
 | `/dev-loop {folder?}` | Autonomous continuous dev — picks next task, runs dev-task --merge in a loop |
 | `/hitl {task-id}` | Execute a human-in-the-loop task — loads task context, assists with infra execution, marks done on exit |
+| `/unblock [repo ...]` | Interactive triage for blocked tasks/PRs — discovers escalations, infers origin phase, lets you retry, redirect, or abandon each one |
 | `/metrics {project?}` | Analyze pipeline metrics — fix cascade trends, quality rates, and recommendations |
 | `/refresh-plan {folder}` | Syncs planning doc against current codebase state |
 | `/review` | Auto-detecting multi-agent code review for the current branch |

--- a/plugins/shipwright/commands/unblock.content.test.ts
+++ b/plugins/shipwright/commands/unblock.content.test.ts
@@ -1,0 +1,203 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const UNBLOCK_MD_PATH = join(import.meta.dir, "unblock.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(UNBLOCK_MD_PATH, "utf-8");
+});
+
+describe("unblock.md — frontmatter and interactive contract (HSR-2.5)", () => {
+  it("has a description and argument-hint in frontmatter", () => {
+    const frontmatterEnd = content.indexOf("---", 3);
+    const frontmatter = content.slice(0, frontmatterEnd);
+    expect(frontmatter).toContain("description:");
+    expect(frontmatter).toContain("argument-hint:");
+  });
+
+  it("states the command runs interactively, not autonomously", () => {
+    expect(content).toContain("This command runs interactively");
+  });
+
+  it("points to /shipwright:task-store for setup when env vars are missing", () => {
+    expect(content).toContain("SHIPWRIGHT_TASK_STORE_URL");
+    expect(content).toContain("SHIPWRIGHT_TASK_STORE_TOKEN");
+    expect(content).toContain("/shipwright:task-store");
+  });
+
+  it("does not self-run as an autonomous shipwright-loop phase (no candidate-provider integration)", () => {
+    const lower = content.toLowerCase();
+    expect(lower).not.toContain("loop-orchestrator");
+    expect(lower).not.toContain("candidate provider");
+  });
+});
+
+describe("unblock.md — discovery (AC1)", () => {
+  it("queries GET /tasks?state=blocked", () => {
+    expect(content).toContain("/tasks?state=blocked");
+  });
+
+  it("queries GET /prs?blocked=true", () => {
+    expect(content).toContain("/prs?blocked=true");
+  });
+
+  it("documents that an omitted repo filter discovers across all repos in the token's scope", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("repo");
+    const hasScopeLanguage =
+      lower.includes("token's scope") ||
+      lower.includes("token scope") ||
+      lower.includes("all repos");
+    expect(hasScopeLanguage).toBe(true);
+  });
+
+  it("notes blockedBy is dependency-blocking context, distinct from escalation blockedReason", () => {
+    expect(content).toContain("blockedBy");
+    const lower = content.toLowerCase();
+    expect(lower).toContain("dependency");
+  });
+});
+
+describe("unblock.md — phase inference (AC2)", () => {
+  const devTaskReasons = [
+    "implementation_blocked_after_model_escalation",
+    "requirements_not_met",
+    "pr_creation_failed",
+    "ci_max_retries_exhausted",
+  ];
+  const patchReasons = [
+    "merge-conflict",
+    "second-round disagreement",
+    "review-finding fix blocked",
+    "CI-fix blocked",
+  ];
+  const deployReasons = [
+    "Post-merge CI failed",
+    "Deploy stage failed",
+    "canary_blocked",
+    "Pipeline timeout",
+    "Canary failed after deploy",
+  ];
+
+  it("mentions every dev-task.md blockedReason pattern", () => {
+    for (const reason of devTaskReasons) {
+      expect(content).toContain(reason);
+    }
+  });
+
+  it("mentions every patch.md blockedReason pattern", () => {
+    for (const reason of patchReasons) {
+      expect(content).toContain(reason);
+    }
+  });
+
+  it("mentions every deploy.md blockedReason pattern", () => {
+    for (const reason of deployReasons) {
+      expect(content).toContain(reason);
+    }
+  });
+
+  it("mentions the recordSkip auto-block pattern (Auto-blocked after)", () => {
+    expect(content).toContain("Auto-blocked after");
+  });
+
+  it("attributes dev-task reasons to the dev-task phase, patch reasons to patch, deploy reasons to deploy", () => {
+    expect(content).toMatch(/dev-task/);
+    expect(content).toMatch(/patch/);
+    expect(content).toMatch(/deploy/);
+  });
+
+  it("handles an unrecognized blockedReason as unknown origin phase rather than guessing", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("unknown");
+  });
+});
+
+describe("unblock.md — retry logic (AC3)", () => {
+  it("distinguishes task.pr-having tasks (status:pr_open) from no-PR tasks (status:pending via release)", () => {
+    expect(content).toContain("pr_open");
+    expect(content).toContain("/release");
+  });
+
+  it("uses POST /tasks/:id/release for the no-PR retry case, not a raw PATCH status:pending", () => {
+    expect(content).toContain("/release");
+    // The raw-PATCH-to-pending path must be called out as disallowed for agent tokens.
+    const lower = content.toLowerCase();
+    expect(lower).toContain("agent token");
+    expect(lower).toContain("cannot");
+  });
+
+  it("PATCHes status:pr_open directly (not release) when task.pr is set", () => {
+    expect(content).toMatch(/status.{0,20}pr_open/s);
+  });
+
+  it("clears blockedReason and blockedAt on retry", () => {
+    expect(content).toContain("blockedReason");
+    expect(content).toContain("blockedAt");
+    const lower = content.toLowerCase();
+    expect(lower).toContain("clear");
+  });
+
+  it("resets skipCount to 0 via POST /tasks/:id/skip/reset when blockedReason indicates spin-detection", () => {
+    expect(content).toContain("/skip/reset");
+    expect(content).toContain("Auto-blocked after");
+  });
+
+  it("retries PR-only records (no linked task) via PATCH /prs/:id with blocked:false", () => {
+    expect(content).toMatch(/PATCH.{0,200}\/prs\/(\{|\$)/s);
+    expect(content).toContain("blocked");
+    expect(content).toMatch(/blocked.{0,20}false/s);
+  });
+
+  it("distinguishes the three retry destinations explicitly: pr_open, pending via release, and PR blocked:false", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("pr_open");
+    expect(lower).toContain("no pr");
+    expect(lower).toContain("pr-only");
+  });
+});
+
+describe("unblock.md — redirect (AC5 workflow)", () => {
+  it("describes editing description/acceptanceCriteria before retrying", () => {
+    expect(content).toContain("description");
+    expect(content).toContain("acceptanceCriteria");
+    const lower = content.toLowerCase();
+    expect(lower).toContain("redirect");
+    expect(lower).toContain("retry");
+  });
+});
+
+describe("unblock.md — abandon (AC4)", () => {
+  it("sets status:cancelled on abandon", () => {
+    expect(content).toMatch(/status.{0,20}cancelled/s);
+  });
+
+  it("preserves blockedReason as a historical note rather than clearing it", () => {
+    const lower = content.toLowerCase();
+    const hasPreserveLanguage =
+      lower.includes("preserve") ||
+      lower.includes("do not clear") ||
+      lower.includes("historical note") ||
+      lower.includes("not cleared");
+    expect(hasPreserveLanguage).toBe(true);
+  });
+});
+
+describe("unblock.md — edge cases", () => {
+  it("prints a clean message and stops when no blocked items are found", () => {
+    const lower = content.toLowerCase();
+    const hasNothingLanguage =
+      lower.includes("nothing to triage") || lower.includes("no blocked items");
+    expect(hasNothingLanguage).toBe(true);
+  });
+
+  it("human choice menu offers retry, redirect, and abandon", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("retry");
+    expect(lower).toContain("redirect");
+    expect(lower).toContain("abandon");
+  });
+});

--- a/plugins/shipwright/commands/unblock.content.test.ts
+++ b/plugins/shipwright/commands/unblock.content.test.ts
@@ -159,6 +159,15 @@ describe("unblock.md — retry logic (AC3)", () => {
     expect(content).toContain("Auto-blocked after");
   });
 
+  it("also resets skipCount via POST /prs/:id/skip/reset for a PR-only record hit by the skip-count spin-detection variant", () => {
+    expect(content).toMatch(/\/prs\/(\{|\$)[A-Za-z0-9_]*\}?\/skip\/reset/);
+    const lower = content.toLowerCase();
+    // The skip-count row/step must not be described as task-only, since PullRequest
+    // carries its own skipCount/lastSkippedAt and recordSkip() produces the identical
+    // blockedReason string on a PR-only record.
+    expect(lower).not.toContain("task-only, tracked via `skipcount`");
+  });
+
   it("retries PR-only records (no linked task) via PATCH /prs/:id with blocked:false", () => {
     expect(content).toMatch(/PATCH.{0,200}\/prs\/(\{|\$)/s);
     expect(content).toContain("blocked");

--- a/plugins/shipwright/commands/unblock.content.test.ts
+++ b/plugins/shipwright/commands/unblock.content.test.ts
@@ -80,6 +80,7 @@ describe("unblock.md — phase inference (AC2)", () => {
     "canary_blocked",
     "Pipeline timeout",
     "Canary failed after deploy",
+    "Post-merge CI still pending after 10 minutes",
   ];
 
   it("mentions every dev-task.md blockedReason pattern", () => {
@@ -102,6 +103,18 @@ describe("unblock.md — phase inference (AC2)", () => {
 
   it("mentions the recordSkip auto-block pattern (Auto-blocked after)", () => {
     expect(content).toContain("Auto-blocked after");
+  });
+
+  it("distinguishes the task-side skip-count spin-detection variant from the PR-side CI-failure-streak variant", () => {
+    expect(content).toContain("consecutive skips");
+    expect(content).toContain("consecutive patch cycles hitting the same CI failure");
+    expect(content).toContain("consecutiveCiFailureCount");
+    expect(content).toContain("skipCount");
+  });
+
+  it("notes there is no dedicated reset endpoint for the PR-side consecutiveCiFailureCount streak", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("no dedicated reset");
   });
 
   it("attributes dev-task reasons to the dev-task phase, patch reasons to patch, deploy reasons to deploy", () => {

--- a/plugins/shipwright/commands/unblock.md
+++ b/plugins/shipwright/commands/unblock.md
@@ -1,0 +1,271 @@
+---
+description: Human-facing triage tool for blocked tasks and PRs — discovers escalations, infers which phase raised them, and lets you retry, redirect, or abandon each one
+argument-hint: "[repo ...]"
+---
+
+# Unblock
+
+Discover every `status: 'blocked'` task and `blocked: true` PR in the task store, infer
+which pipeline phase escalated each one from its `blockedReason` text, and walk through
+them one at a time so a human can decide: **retry**, **redirect**, or **abandon**.
+
+Unlike `dev-task`/`review`/`patch`/`deploy`, this command is **not** dispatched by the
+`shipwright-loop` cron and is exempt from the Candidate Selection Contract (see
+`plugins/shipwright/CLAUDE.md`) — it self-discovers its own targets because it is a
+human-facing triage tool, not an autonomous pipeline phase. It never runs unattended.
+
+**This command runs interactively. Present each blocked item and wait for the human's
+decision before acting on it — do not batch-act or assume a default choice.**
+
+> **Task store setup:** This command reads and updates tasks/PRs in the Shipwright task
+> store. If `SHIPWRIGHT_TASK_STORE_URL` or `SHIPWRIGHT_TASK_STORE_TOKEN` is missing, invoke
+> `/shipwright:task-store` for setup instructions.
+
+---
+
+## Step 1: Parse Arguments
+
+`$ARGUMENTS` is an optional, space-separated list of `org/repo` filters:
+
+```bash
+read -ra REPO_ARGS <<< "$ARGUMENTS"
+```
+
+If `REPO_ARGS` is empty, **do not filter by repo** — discover across every repo the
+token's scope allows (an admin token sees all repos; an agent token is limited to its own
+repo scope server-side, same as every other list endpoint in this plugin). If one or more
+repos are given, pass each as a repeated `?repo=` query param (both `GET /tasks` and
+`GET /prs` accept `?repo=` repeatably per `TaskListQuerySchema`/`PrListQuerySchema` — a
+single repo behaves as an exact match, multiple repos match any of the list).
+
+Build a reusable query-string suffix:
+
+```bash
+REPO_QS=""
+for r in "${REPO_ARGS[@]}"; do
+  REPO_QS="$REPO_QS&repo=$r"
+done
+```
+
+---
+
+## Step 2: Discover Blocked Tasks
+
+```bash
+BLOCKED_TASKS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?state=blocked${REPO_QS}")
+BLOCKED_TASKS=$(echo "$BLOCKED_TASKS_JSON" | jq -c '.tasks[]')
+```
+
+`GET /tasks?state=blocked` delegates to `listBlocked()`, which returns tasks where
+`status === 'blocked'` **OR** the task is open with a non-empty `blockedBy` dependency
+array. **`blockedBy` is dependency-blocking context (which sibling tasks this one depends
+on that aren't done yet) — it is unrelated to escalation blocking and must not be
+confused with `blockedReason`.** Only surface an item in this command's triage list when
+its `status === 'blocked'` (i.e. it actually carries a `blockedReason` from an escalation);
+skip tasks that are merely dependency-blocked (`status` still open, `blockedBy.length > 0`,
+no `blockedReason`) — those aren't triage-able here, they resolve themselves once their
+dependency completes.
+
+---
+
+## Step 3: Discover Blocked PRs
+
+```bash
+BLOCKED_PRS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs?blocked=true${REPO_QS}")
+BLOCKED_PRS=$(echo "$BLOCKED_PRS_JSON" | jq -c '.prs[]')
+```
+
+`GET /prs?blocked=true` returns PRs where `pr.blocked === true` **OR** the PR has a linked
+task whose `task.status === 'blocked'`. That means a PR with a linked blocked task can
+appear in **both** this list and the blocked-tasks list from Step 2 — dedupe on the
+task/PR pairing: when a blocked PR's `taskId` is non-null and that task also came back from
+Step 2, triage it once as a task-with-PR item (Step 5's task.pr-having path), not twice.
+Only PRs with **no linked task** (`taskId` is null) are genuinely PR-only records.
+
+If both `BLOCKED_TASKS` and `BLOCKED_PRS` are empty after dedup, print and stop:
+
+```
+✓ Nothing to triage — no blocked tasks or PRs found.
+```
+
+---
+
+## Step 4: Infer Origin Phase
+
+For each item, parse `blockedReason` (tasks: `.blockedReason`; PR-only records:
+`.blockedReason` on the PR) against the known patterns below. Match on substring
+containment, not exact equality — several patterns include a dynamic suffix (a run ID, a
+subagent's own detail) after a fixed prefix.
+
+| Origin phase | `blockedReason` pattern (substring match) |
+|---|---|
+| **dev-task** | `implementation_blocked_after_model_escalation` |
+| **dev-task** | `requirements_not_met` |
+| **dev-task** | `pr_creation_failed` |
+| **dev-task** | `ci_max_retries_exhausted` |
+| **patch** | `merge-conflict` (resolution blocked) |
+| **patch** | `second-round disagreement` (reviewer vs. automated fix, escalated to HITL) |
+| **patch** | `review-finding fix blocked` |
+| **patch** | `CI-fix blocked` |
+| **deploy** | `Post-merge CI failed` |
+| **deploy** | `Deploy stage failed` |
+| **deploy** | `canary_blocked` |
+| **deploy** | `Pipeline timeout` |
+| **deploy** | `Canary failed after deploy` |
+| **spin-detection** (`recordSkip`) | starts with `Auto-blocked after` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` |
+
+If `blockedReason` doesn't match any pattern above (empty, or genuinely unrecognized text),
+present it as **unknown origin phase** — do not guess which phase set it. Never crash on an
+unmatched reason.
+
+---
+
+## Step 5: Present Each Blocked Item
+
+For each blocked task or PR-only record (in the order returned), print:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+BLOCKED: {task-id or org/repo#pr}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Title:         {title}
+Repo:          {repo}
+Origin phase:  {dev-task | patch | deploy | spin-detection | unknown origin phase}
+Blocked at:    {blockedAt}
+Blocked reason: {blockedReason}
+PR:            {task.pr or "(none)"}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Then ask the human to choose one of:
+- **retry** — clear the block and return the item to the pipeline
+- **redirect** — edit the description/acceptance criteria first, then retry
+- **abandon** — cancel the item, leaving `blockedReason` as a historical record
+
+Wait for the human's answer before acting. Skip an item entirely if the human says so (no
+action taken, move to the next).
+
+---
+
+## Step 6: Act on the Human's Choice
+
+There are three retry destinations, chosen per item:
+
+- **task.pr is set** (escalation happened mid-review/patch/deploy, after a PR already
+  existed) → PATCH the task directly to `status: 'pr_open'`. Do **not** use `/release` here
+  — `/release` resets to `'pending'`, which would let `dev-task` open a duplicate PR.
+- **task.pr is empty** (no PR exists yet) → agent tokens **cannot** PATCH a task's status
+  to `'pending'` directly (`assertNoLifecycleFieldWrite()` in `task-store/src/routes/tasks.ts`
+  throws 400 for agent tokens attempting this). Use `POST /tasks/:id/release` instead —
+  it atomically sets `status:'pending', claimedBy:null, claimedAt:null, heartbeatAt:null` —
+  then a follow-up `PATCH /tasks/:id` to clear `blockedReason`/`blockedAt` (release() does
+  not touch those fields).
+- **PR-only record** (no linked task) → `PATCH /prs/:id` with `blocked: false` (and clear
+  `blockedReason`). No task-side call needed.
+
+### 6a. Retry — task.pr is set
+
+```bash
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+  -d '{"status": "pr_open", "blockedReason": null, "blockedAt": null}' | jq .
+```
+
+### 6b. Retry — task.pr is empty (no PR yet)
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID/release" | jq .
+
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+  -d '{"blockedReason": null, "blockedAt": null}' | jq .
+```
+
+### 6c. Retry — PR-only record (no linked task)
+
+```bash
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_ID" \
+  -d '{"blocked": false, "blockedReason": null}' | jq .
+```
+
+### 6d. Spin-detection skipCount reset
+
+In addition to whichever retry path (6a/6b/6c) applies, if `blockedReason` starts with
+`Auto-blocked after` (the `recordSkip()` spin-detection pattern), also reset `skipCount` via
+the purpose-built endpoint — prefer this over a raw PATCH of `skipCount`:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID/skip/reset" | jq .
+```
+
+(`resetSkip()` sets `skipCount: 0, lastSkippedAt: null`.) This step is task-only — PR-only
+records don't carry `skipCount`.
+
+### 6e. Redirect
+
+Ask the human what to change in the description and/or acceptance criteria. PATCH those
+fields first:
+
+```bash
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+  -d "$(jq -n --arg desc "$NEW_DESC" --argjson ac "$NEW_AC_JSON" \
+    '{description: $desc, acceptanceCriteria: $ac}')" | jq .
+```
+
+Then run the **same retry logic as above** (6a/6b as applicable, plus 6d if spin-detected)
+against the now-updated task. Redirect has no PR-only variant — a PR-only blocked record
+has no description/acceptanceCriteria to edit; offer only retry/abandon for those.
+
+### 6f. Abandon
+
+Task-only (PR-only records have no `status` field to cancel — abandon a PR-only record via
+its linked repo/PR directly on GitHub, or simply leave it blocked; this command does not
+force an action). Set `status: 'cancelled'`. **Preserve `blockedReason` as-is — do not
+clear it.** It becomes a historical note of why the item was abandoned.
+
+```bash
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID" \
+  -d '{"status": "cancelled"}' | jq .
+```
+
+---
+
+## Step 7: Confirm
+
+After acting on an item, print a one-line confirmation and move to the next item:
+
+```
+✓ {task-id or org/repo#pr}: {retried → pr_open | retried → pending | retried → unblocked | redirected → retried | abandoned}
+```
+
+Once every discovered item has been triaged (or explicitly skipped), print a final summary:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+UNBLOCK TRIAGE COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Retried:    {n}
+Redirected: {n}
+Abandoned:  {n}
+Skipped:    {n}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/plugins/shipwright/commands/unblock.md
+++ b/plugins/shipwright/commands/unblock.md
@@ -114,7 +114,9 @@ subagent's own detail) after a fixed prefix.
 | **deploy** | `canary_blocked` |
 | **deploy** | `Pipeline timeout` |
 | **deploy** | `Canary failed after deploy` |
-| **spin-detection** (`recordSkip`) | starts with `Auto-blocked after` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` |
+| **deploy** | `Post-merge CI still pending after 10 minutes` (post-merge CI budget timed out with runs still pending — PR-only, set by `deploy.md`'s Step 5a) |
+| **spin-detection — task skip (`recordSkip`)** | starts with `Auto-blocked after` and contains `consecutive skips` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` — task-only, tracked via `skipCount` |
+| **spin-detection — PR CI-failure streak (`patch()`/`ciFailureSignature`)** | starts with `Auto-blocked after` and contains `consecutive patch cycles hitting the same CI failure` — exact format is `` Auto-blocked after ${N} consecutive patch cycles hitting the same CI failure (${signature}) `` — PR-only, tracked via `consecutiveCiFailureCount` on the PR record (a distinct counter from task-side `skipCount`); **no dedicated reset endpoint exists today** — Step 6d's `/tasks/:id/skip/reset` doesn't apply (task-only, wrong counter), so a 6c retry clears `blocked`/`blockedReason` but leaves the streak elevated and one more matching CI failure re-blocks the PR immediately |
 
 If `blockedReason` doesn't match any pattern above (empty, or genuinely unrecognized text),
 present it as **unknown origin phase** — do not guess which phase set it. Never crash on an
@@ -132,7 +134,7 @@ BLOCKED: {task-id or org/repo#pr}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Title:         {title}
 Repo:          {repo}
-Origin phase:  {dev-task | patch | deploy | spin-detection | unknown origin phase}
+Origin phase:  {dev-task | patch | deploy | spin-detection — task skip | spin-detection — PR CI-failure streak | unknown origin phase}
 Blocked at:    {blockedAt}
 Blocked reason: {blockedReason}
 PR:            {task.pr or "(none)"}
@@ -201,9 +203,10 @@ curl -sf -X PATCH \
 
 ### 6d. Spin-detection skipCount reset
 
-In addition to whichever retry path (6a/6b/6c) applies, if `blockedReason` starts with
-`Auto-blocked after` (the `recordSkip()` spin-detection pattern), also reset `skipCount` via
-the purpose-built endpoint — prefer this over a raw PATCH of `skipCount`:
+In addition to whichever retry path (6a/6b/6c) applies, if `blockedReason` matches the
+**task skip** spin-detection variant (starts with `Auto-blocked after` and contains
+`consecutive skips` — the `recordSkip()` pattern), also reset `skipCount` via the
+purpose-built endpoint — prefer this over a raw PATCH of `skipCount`:
 
 ```bash
 curl -sf -X POST \
@@ -213,6 +216,15 @@ curl -sf -X POST \
 
 (`resetSkip()` sets `skipCount: 0, lastSkippedAt: null`.) This step is task-only — PR-only
 records don't carry `skipCount`.
+
+**Does not apply to the PR CI-failure-streak variant.** If `blockedReason` instead matches
+the **PR CI-failure streak** spin-detection variant (contains `consecutive patch cycles
+hitting the same CI failure` — the `consecutiveCiFailureCount` pattern), there is no
+reset endpoint for that counter today — `/tasks/:id/skip/reset` is task-only and resets the
+wrong field entirely. A 6c retry clears `blocked`/`blockedReason`, but `consecutiveCiFailureCount`
+stays elevated, so one more patch cycle hitting the same CI failure signature re-blocks the
+PR immediately. Tell the human this before retrying so they aren't surprised by an
+immediate re-block.
 
 ### 6e. Redirect
 

--- a/plugins/shipwright/commands/unblock.md
+++ b/plugins/shipwright/commands/unblock.md
@@ -94,31 +94,40 @@ If both `BLOCKED_TASKS` and `BLOCKED_PRS` are empty after dedup, print and stop:
 
 ## Step 4: Infer Origin Phase
 
-For each item, parse `blockedReason` (tasks: `.blockedReason`; PR-only records:
-`.blockedReason` on the PR) against the known patterns below. Match on substring
+For each item, parse the reason text against the known patterns below. Match on substring
 containment, not exact equality — several patterns include a dynamic suffix (a run ID, a
 subagent's own detail) after a fixed prefix.
 
-| Origin phase | `blockedReason` pattern (substring match) |
-|---|---|
-| **dev-task** | `implementation_blocked_after_model_escalation` |
-| **dev-task** | `requirements_not_met` |
-| **dev-task** | `pr_creation_failed` |
-| **dev-task** | `ci_max_retries_exhausted` |
-| **patch** | `merge-conflict` (resolution blocked) |
-| **patch** | `second-round disagreement` (reviewer vs. automated fix, escalated to HITL) |
-| **patch** | `review-finding fix blocked` |
-| **patch** | `CI-fix blocked` |
-| **deploy** | `Post-merge CI failed` |
-| **deploy** | `Deploy stage failed` |
-| **deploy** | `canary_blocked` |
-| **deploy** | `Pipeline timeout` |
-| **deploy** | `Canary failed after deploy` |
-| **deploy** | `Post-merge CI still pending after 10 minutes` (post-merge CI budget timed out with runs still pending — PR-only, set by `deploy.md`'s Step 5a) |
-| **spin-detection — skip-count (`recordSkip`)** | starts with `Auto-blocked after` and contains `consecutive skips` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` — tracked via `skipCount`; **not task-only** — `Task` and `PullRequest` each carry their own `skipCount`/`lastSkippedAt` (`task-store/prisma/schema.prisma`) and `PullRequestService.recordSkip()` produces this identical blockedReason string on a PR-only record (no linked task), just like `TaskService.recordSkip()` does on a task — distinct from (though similarly named to) the PR CI-failure-streak variant below |
-| **spin-detection — PR CI-failure streak (`patch()`/`ciFailureSignature`)** | starts with `Auto-blocked after` and contains `consecutive patch cycles hitting the same CI failure` — exact format is `` Auto-blocked after ${N} consecutive patch cycles hitting the same CI failure (${signature}) `` — PR-only, tracked via `consecutiveCiFailureCount` on the PR record (a distinct counter from task-side `skipCount`); **no dedicated reset endpoint exists today** — Step 6d's `/tasks/:id/skip/reset` doesn't apply (task-only, wrong counter), so a 6c retry clears `blocked`/`blockedReason` but leaves the streak elevated and one more matching CI failure re-blocks the PR immediately |
+- **PR-only records:** parse `.blockedReason` on the PR.
+- **Tasks:** parse `.blockedReason` first. If it's empty, also check `.note` — `deploy.md`
+  writes its five escalation strings (`Post-merge CI failed`, `Deploy stage failed`,
+  `canary_blocked`, `Pipeline timeout`, `Canary failed after deploy`) into the task's `note`
+  field when a task is linked (`$TASK_ID` set), not `blockedReason`; `blockedReason` on a
+  task-linked deploy escalation stays `null`. `blockedReason` is only populated for these
+  five deploy patterns in the PR-only branch (`$PR_RECORD_ID`, no linked task). All other
+  phases (dev-task, patch, spin-detection) write to `blockedReason` on tasks as usual — the
+  `.note` fallback only matters for deploy-originated task escalations.
 
-If `blockedReason` doesn't match any pattern above (empty, or genuinely unrecognized text),
+| Origin phase | pattern (substring match) | field(s) to check |
+|---|---|---|
+| **dev-task** | `implementation_blocked_after_model_escalation` | task: `blockedReason` |
+| **dev-task** | `requirements_not_met` | task: `blockedReason` |
+| **dev-task** | `pr_creation_failed` | task: `blockedReason` |
+| **dev-task** | `ci_max_retries_exhausted` | task: `blockedReason` |
+| **patch** | `merge-conflict` (resolution blocked) | task: `blockedReason` |
+| **patch** | `second-round disagreement` (reviewer vs. automated fix, escalated to HITL) | task: `blockedReason` |
+| **patch** | `review-finding fix blocked` | task: `blockedReason` |
+| **patch** | `CI-fix blocked` | task: `blockedReason` |
+| **deploy** | `Post-merge CI failed` | task: `blockedReason`, fallback `note`; PR: `blockedReason` |
+| **deploy** | `Deploy stage failed` | task: `blockedReason`, fallback `note`; PR: `blockedReason` |
+| **deploy** | `canary_blocked` | task: `blockedReason`, fallback `note`; PR: `blockedReason` |
+| **deploy** | `Pipeline timeout` | task: `blockedReason`, fallback `note`; PR: `blockedReason` |
+| **deploy** | `Canary failed after deploy` | task: `blockedReason`, fallback `note`; PR: `blockedReason` |
+| **deploy** | `Post-merge CI still pending after 10 minutes` (post-merge CI budget timed out with runs still pending — PR-only, set by `deploy.md`'s Step 5a; the task-linked branch of that same step sets `status=deployed` with no note/blockedReason at all, so this pattern never appears on a task) | PR: `blockedReason` only |
+| **spin-detection — skip-count (`recordSkip`)** | starts with `Auto-blocked after` and contains `consecutive skips` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` — tracked via `skipCount`; **not task-only** — `Task` and `PullRequest` each carry their own `skipCount`/`lastSkippedAt` (`task-store/prisma/schema.prisma`) and `PullRequestService.recordSkip()` produces this identical blockedReason string on a PR-only record (no linked task), just like `TaskService.recordSkip()` does on a task — distinct from (though similarly named to) the PR CI-failure-streak variant below | task: `blockedReason`; PR: `blockedReason` |
+| **spin-detection — PR CI-failure streak (`patch()`/`ciFailureSignature`)** | starts with `Auto-blocked after` and contains `consecutive patch cycles hitting the same CI failure` — exact format is `` Auto-blocked after ${N} consecutive patch cycles hitting the same CI failure (${signature}) `` — PR-only, tracked via `consecutiveCiFailureCount` on the PR record (a distinct counter from task-side `skipCount`); **no dedicated reset endpoint exists today** — Step 6d's `/tasks/:id/skip/reset` doesn't apply (task-only, wrong counter), so a 6c retry clears `blocked`/`blockedReason` but leaves the streak elevated and one more matching CI failure re-blocks the PR immediately | PR: `blockedReason` only |
+
+If neither field matches any pattern above (both empty, or genuinely unrecognized text),
 present it as **unknown origin phase** — do not guess which phase set it. Never crash on an
 unmatched reason.
 
@@ -136,7 +145,7 @@ Title:         {title}
 Repo:          {repo}
 Origin phase:  {dev-task | patch | deploy | spin-detection — skip-count | spin-detection — PR CI-failure streak | unknown origin phase}
 Blocked at:    {blockedAt}
-Blocked reason: {blockedReason}
+Blocked reason: {blockedReason, or task.note when blockedReason is empty (deploy escalations on a linked task)}
 PR:            {task.pr or "(none)"}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```

--- a/plugins/shipwright/commands/unblock.md
+++ b/plugins/shipwright/commands/unblock.md
@@ -115,7 +115,7 @@ subagent's own detail) after a fixed prefix.
 | **deploy** | `Pipeline timeout` |
 | **deploy** | `Canary failed after deploy` |
 | **deploy** | `Post-merge CI still pending after 10 minutes` (post-merge CI budget timed out with runs still pending — PR-only, set by `deploy.md`'s Step 5a) |
-| **spin-detection — task skip (`recordSkip`)** | starts with `Auto-blocked after` and contains `consecutive skips` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` — task-only, tracked via `skipCount` |
+| **spin-detection — skip-count (`recordSkip`)** | starts with `Auto-blocked after` and contains `consecutive skips` — exact format is `` Auto-blocked after ${N} consecutive skips (dispatched but found nothing to do) `` — tracked via `skipCount`; **not task-only** — `Task` and `PullRequest` each carry their own `skipCount`/`lastSkippedAt` (`task-store/prisma/schema.prisma`) and `PullRequestService.recordSkip()` produces this identical blockedReason string on a PR-only record (no linked task), just like `TaskService.recordSkip()` does on a task — distinct from (though similarly named to) the PR CI-failure-streak variant below |
 | **spin-detection — PR CI-failure streak (`patch()`/`ciFailureSignature`)** | starts with `Auto-blocked after` and contains `consecutive patch cycles hitting the same CI failure` — exact format is `` Auto-blocked after ${N} consecutive patch cycles hitting the same CI failure (${signature}) `` — PR-only, tracked via `consecutiveCiFailureCount` on the PR record (a distinct counter from task-side `skipCount`); **no dedicated reset endpoint exists today** — Step 6d's `/tasks/:id/skip/reset` doesn't apply (task-only, wrong counter), so a 6c retry clears `blocked`/`blockedReason` but leaves the streak elevated and one more matching CI failure re-blocks the PR immediately |
 
 If `blockedReason` doesn't match any pattern above (empty, or genuinely unrecognized text),
@@ -134,7 +134,7 @@ BLOCKED: {task-id or org/repo#pr}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Title:         {title}
 Repo:          {repo}
-Origin phase:  {dev-task | patch | deploy | spin-detection — task skip | spin-detection — PR CI-failure streak | unknown origin phase}
+Origin phase:  {dev-task | patch | deploy | spin-detection — skip-count | spin-detection — PR CI-failure streak | unknown origin phase}
 Blocked at:    {blockedAt}
 Blocked reason: {blockedReason}
 PR:            {task.pr or "(none)"}
@@ -204,9 +204,13 @@ curl -sf -X PATCH \
 ### 6d. Spin-detection skipCount reset
 
 In addition to whichever retry path (6a/6b/6c) applies, if `blockedReason` matches the
-**task skip** spin-detection variant (starts with `Auto-blocked after` and contains
+**skip-count** spin-detection variant (starts with `Auto-blocked after` and contains
 `consecutive skips` — the `recordSkip()` pattern), also reset `skipCount` via the
-purpose-built endpoint — prefer this over a raw PATCH of `skipCount`:
+purpose-built endpoint — prefer this over a raw PATCH of `skipCount`. This applies to
+**both** tasks and PR-only records — `Task` and `PullRequest` each carry their own
+`skipCount`/`lastSkippedAt`, and each has its own reset endpoint:
+
+Task record:
 
 ```bash
 curl -sf -X POST \
@@ -214,17 +218,26 @@ curl -sf -X POST \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID/skip/reset" | jq .
 ```
 
-(`resetSkip()` sets `skipCount: 0, lastSkippedAt: null`.) This step is task-only — PR-only
-records don't carry `skipCount`.
+PR-only record (no linked task):
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_ID/skip/reset" | jq .
+```
+
+(Both `resetSkip()` implementations set `skipCount: 0, lastSkippedAt: null` on their
+respective record.) Without this step, a PR-only record blocked by this exact reason
+re-blocks on its very next skip — its elevated `skipCount` is untouched by a 6c retry.
 
 **Does not apply to the PR CI-failure-streak variant.** If `blockedReason` instead matches
 the **PR CI-failure streak** spin-detection variant (contains `consecutive patch cycles
 hitting the same CI failure` — the `consecutiveCiFailureCount` pattern), there is no
-reset endpoint for that counter today — `/tasks/:id/skip/reset` is task-only and resets the
-wrong field entirely. A 6c retry clears `blocked`/`blockedReason`, but `consecutiveCiFailureCount`
-stays elevated, so one more patch cycle hitting the same CI failure signature re-blocks the
-PR immediately. Tell the human this before retrying so they aren't surprised by an
-immediate re-block.
+reset endpoint for that counter today — neither `/tasks/:id/skip/reset` nor
+`/prs/:id/skip/reset` touches it, since both reset `skipCount`, a different field entirely.
+A 6c retry clears `blocked`/`blockedReason`, but `consecutiveCiFailureCount` stays elevated,
+so one more patch cycle hitting the same CI failure signature re-blocks the PR immediately.
+Tell the human this before retrying so they aren't surprised by an immediate re-block.
 
 ### 6e. Redirect
 


### PR DESCRIPTION
## Summary
- Adds `/shipwright:unblock` — a human-facing, interactive triage command that discovers `status:'blocked'` tasks (`GET /tasks?state=blocked`) and `blocked:true` PRs (`GET /prs?blocked=true`) across the caller's repo scope.
- Infers which pipeline phase (dev-task, patch, deploy, or spin-detection) raised each escalation by matching `blockedReason` text against the known prefixes from each phase's escalation sites, and walks the human through retry, redirect, or abandon per item.
- Retry correctly branches three ways: task-with-PR → `status:'pr_open'` (avoids a duplicate PR from dev-task); no-PR task → `POST /tasks/:id/release` (agent tokens can't PATCH `status:'pending'` directly) followed by clearing `blockedReason`/`blockedAt`; PR-only record → `PATCH /prs/:id` with `blocked:false`. Spin-detected blocks additionally reset `skipCount` via `POST /tasks/:id/skip/reset`. Abandon sets `status:'cancelled'` while explicitly preserving `blockedReason` as a historical note.
- Exempt from the Candidate Selection Contract (`plugins/shipwright/CLAUDE.md`) by design — it self-discovers because it's a standalone human tool, not a `shipwright-loop`-dispatched phase.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Discovers all status:'blocked' tasks and blocked:true PRs across target repo(s) | MET |
| 2 | Correctly infers origin phase for each blockedReason pattern | MET |
| 3 | Retry restores task.pr-having tasks to pr_open (not pending), PR-only records to blocked:false | MET |
| 4 | Abandon sets status:'cancelled' with blockedReason preserved | MET |
| 5 | New unblock.content.test.ts covering discovery, phase-inference, retry/redirect/abandon | MET |

## Test Plan
- `unblock.content.test.ts` — 26 tests covering discovery, phase-inference table, all three retry destinations, redirect, abandon, and edge cases (nothing-to-triage, unknown blockedReason).
- `task ci` — lint, check-strings, typecheck, check-config-docs, check-version-sync, coverage gate (81.35%/82.21% vs 80/80 threshold) all pass. One pre-existing unrelated failure (`agent/src/claude.unit.test.ts`'s `extraAllowedTools` test) reproduces identically on clean main with `agent/` untouched by this diff — a known environment gap, not caused by this change.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
