### PR TITLE
feat: add mechanical review-verdict computation gate to review.md

### DIFF
--- a/agent/src/check-patch.ts
+++ b/agent/src/check-patch.ts
@@ -248,13 +248,56 @@ function isAddressedByAuthorReply(
 }
 
 /**
+ * Returns true when a self-authored review is superseded by a LATER,
+ * genuinely clean self-review from the same identity (DRO-1.2 — mirrors
+ * patch.md's Step 3a "Self-review superseded by a later clean self-review"
+ * exclusion).
+ *
+ * review.md's Step 10/11 procedure always posts a *new* review object each
+ * pass rather than rewriting a prior one's body, so a self-authored PR that
+ * goes through N review rounds — each finding and fixing one real issue —
+ * ends up with N-1 COMMENT-bodied self-reviews on the PR even after every
+ * finding has been fixed. None of those qualifies for the clean-APPROVE
+ * exclusion (their bodies read `Verdict: COMMENT`, not `Verdict: APPROVE`),
+ * and the reply exclusion doesn't apply either (self-reviews aren't
+ * "third-party," and this PR's convention never posts a PR-level author
+ * reply) — so without this exclusion, `hasUnaddressedFindings` would return
+ * true forever and a self-authored PR could never reach a clean verdict once
+ * it has had more than one review round.
+ *
+ * Only a PRIOR self-review is superseded, and only when a later self-review
+ * (matched by `submittedAt`, same `author.login` as `currentUser`) is itself
+ * a clean verdict per `isCleanApproveBody` — a later self-review that is
+ * itself non-clean (e.g. this round found a fresh issue) does not supersede
+ * anything.
+ */
+function isSupersededBySelfReview(
+  review: Pick<ReviewNode, "author" | "submittedAt">,
+  allReviews: ReviewNode[],
+  currentUser: string,
+): boolean {
+  if (review.author.login !== currentUser) return false;
+
+  const reviewedAt = new Date(review.submittedAt).getTime();
+  return allReviews.some(
+    (r) =>
+      r.author.login === currentUser &&
+      new Date(r.submittedAt).getTime() > reviewedAt &&
+      isCleanApproveBody(r.body),
+  );
+}
+
+/**
  * Returns true if the PR has unaddressed findings:
  * - At least one COMMENTED or CHANGES_REQUESTED review posted at the current HEAD
  * - AND (has a non-empty review body OR has at least one unresolved inline thread)
  *
- * A self-authored review is excluded only when it is a clean APPROVE verdict
- * (see isSelfCleanApprove) — a self-review with a real (non-APPROVE) verdict
- * still counts as an unaddressed finding, same as any other reviewer's.
+ * A self-authored review is excluded when it is a clean APPROVE verdict (see
+ * isSelfCleanApprove) or when it is superseded by a later, genuinely clean
+ * self-review from the same identity (see isSupersededBySelfReview, DRO-1.2)
+ * — a self-review with a real (non-APPROVE) verdict that is not later
+ * superseded still counts as an unaddressed finding, same as any other
+ * reviewer's.
  *
  * A review's non-empty body is also excluded when there are no unresolved
  * threads AND the PR author has replied after the review (see
@@ -269,12 +312,14 @@ function hasUnaddressedFindings(
   const { headRefOid, reviews, reviewThreads, comments } = data;
 
   // Find qualifying reviews: state COMMENTED or CHANGES_REQUESTED at current HEAD,
-  // excluding self-authored clean-APPROVE reviews.
+  // excluding self-authored clean-APPROVE reviews and self-reviews superseded
+  // by a later clean self-review (DRO-1.2).
   const qualifyingReviews = reviews.nodes.filter(
     (r) =>
       (r.state === "COMMENTED" || r.state === "CHANGES_REQUESTED") &&
       r.commit.oid === headRefOid &&
-      !isSelfCleanApprove(r, currentUser),
+      !isSelfCleanApprove(r, currentUser) &&
+      !isSupersededBySelfReview(r, reviews.nodes, currentUser),
   );
 
   if (qualifyingReviews.length === 0) return false;

--- a/agent/src/check-patch.unit.test.ts
+++ b/agent/src/check-patch.unit.test.ts
@@ -980,6 +980,165 @@ describe("getPatchCandidates", () => {
     expect(result).toHaveLength(1);
   });
 
+  // ─── Self-review superseded by a later clean self-review (DRO-1.2) ────────
+
+  test("returns empty array when an earlier self-authored COMMENT review is superseded by a later clean self-review", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verdict: COMMENT — found a race condition in the retry logic, needs a fix before merge.",
+          },
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-27T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verified the race condition is fixed. Verdict: APPROVE",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: async () => "the-agent",
+      }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("returns a candidate when an earlier self-authored COMMENT review is followed by a LATER self-review that is itself non-clean", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verdict: COMMENT — found issue #1.",
+          },
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-27T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verdict: COMMENT — found a fresh issue #2.",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: async () => "the-agent",
+      }),
+    );
+    // Both self-reviews still count as findings: the earlier one is not
+    // superseded (the later one isn't clean), and the later one is its own
+    // real finding.
+    expect(result).toHaveLength(1);
+  });
+
+  test("does NOT supersede an earlier self-review when the clean self-review comes BEFORE it (order matters)", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verdict: APPROVE — looks good so far.",
+          },
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-27T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verdict: COMMENT — found a new issue on a later pass.",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+    });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: async () => "the-agent",
+      }),
+    );
+    // The earlier review is a clean-APPROVE itself (excluded on its own
+    // grounds), and the later non-clean self-review is a real, un-superseded
+    // finding — still one candidate.
+    expect(result).toHaveLength(1);
+  });
+
+  test("does NOT supersede a THIRD-PARTY review's finding, even when a later self-review is clean", async () => {
+    const pr = makeOwnPr();
+    const reviewData = makePrReviewData({
+      headRefOid: "current-head-sha",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "dodizzle" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-26T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Missing plugin.json/marketplace.json version bump.",
+          },
+          {
+            author: { login: "the-agent" },
+            state: "COMMENTED",
+            submittedAt: "2026-05-27T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Verdict: APPROVE",
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+      comments: { nodes: [] },
+    });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: { 10: reviewData },
+        ciStatusByPr: {},
+        mergeStatusByPr: {},
+        listPrCommits: async () => [],
+        getCurrentUser: async () => "the-agent",
+      }),
+    );
+    // The DRO-1.2 exclusion only supersedes self-authored reviews — a
+    // third-party's finding is untouched by a later self-review.
+    expect(result).toHaveLength(1);
+  });
+
   // ─── Third-party review addressed via author reply (CPF-2.3) ──────────────
 
   test("returns empty array when a third-party COMMENTED review's non-empty body is followed by a PR-author reply (mirrors PR #1432)", async () => {

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -216,13 +216,15 @@ A PR has **unaddressed findings** when ANY of the following are true:
 - At least one inline thread has `isResolved == false`
 - At least one review with `state == "COMMENTED"` or `state == "CHANGES_REQUESTED"` has a
   non-empty `body` (a review body without matching inline threads is itself a finding),
-  excluding clean-APPROVE reviews (see below) and reviews addressed via a subsequent author
-  reply (see below)
+  excluding clean-APPROVE reviews (see below), reviews addressed via a subsequent author
+  reply (see below), and self-authored reviews superseded by a later clean self-review
+  (see below)
 
 A PR has **no findings** (skip it) when ALL of the following are true:
 - All inline threads are resolved (`isResolved == true` for every thread)
 - No COMMENTED or CHANGES_REQUESTED review has a non-empty body, other than clean-APPROVE
-  reviews (see below) and reviews addressed via a subsequent author reply (see below)
+  reviews (see below), reviews addressed via a subsequent author reply (see below), and
+  self-authored reviews superseded by a later clean self-review (see below)
 
 **Clean-APPROVE exclusion**: A review is excluded from the body check above when its body is
 a clean APPROVE verdict, matched either by:
@@ -267,9 +269,32 @@ self-authored review. This exclusion still requires all inline threads to be res
 (`isResolved == true`) — an unresolved thread on the same review continues to count as a
 finding regardless of any reply.
 
+**Self-review superseded by a later clean self-review (DRO-1.2)**: review.md's own Step
+10/11 procedure always posts a *new* review object each pass rather than rewriting a prior
+one's body (see Step 10's "the initial-review and re-review paths run identically"), so a
+self-authored PR that goes through N review rounds — each finding and fixing one real issue
+— ends up with N-1 COMMENT-bodied self-reviews on the PR even after every finding has been
+fixed. None of those qualifies for the clean-APPROVE exclusion above (their bodies read
+`Verdict: COMMENT`, not `Verdict: APPROVE`), and the reply exclusion doesn't apply either
+(self-reviews aren't "third-party," and this PR's convention never posts a PR-level author
+reply) — so without this exclusion, `unaddressedFindings` computes `true` forever and a
+self-authored PR can never reach a clean verdict once it has had more than one review round.
+An earlier self-authored COMMENTED review's body is excluded from the finding check when a
+**later** review exists whose `author.login` is the same self-review identity AND that later
+review's own body is a clean verdict (matched by the clean-APPROVE exclusion's pattern above
+— i.e. the later self-review itself reads `Verdict: APPROVE` or leads with `APPROVE`, whether
+or not GitHub's API forced its `state` to `COMMENTED`). This mirrors what an
+`updatePullRequestReview` body rewrite would have signaled had review.md instead edited the
+prior review in place — a later clean self-review is functionally the same "this round found
+nothing new, prior issues are fixed" signal, just expressed as a new review object instead of
+an edit to an old one. It does **not** exclude a later self-review that is itself non-clean
+(e.g. `Verdict: COMMENT` because *this* round found a fresh issue) — only a prior self-review
+is superseded, and only when the later one is genuinely clean. All inline threads must still
+be resolved for the PR overall, same as the other two exclusions.
+
 If neither condition applies (e.g., no reviews at all, only approved reviews, or only an
-excluded clean-APPROVE or reply-addressed review), skip the PR — it does not belong in
-List A.
+excluded clean-APPROVE, reply-addressed, or superseded-self-review), skip the PR — it does
+not belong in List A.
 
 If a PR has unaddressed findings, add it to **List A**. Store the unresolved threads (with their
 `id` — needed for the `resolveReviewThread` mutation in Step 5) and review bodies for use in

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -237,8 +237,9 @@ a clean APPROVE verdict, matched either by:
 Not restricted to self-authored reviews (SRV-1.1): multiple distinct Shipwright agents
 operate under different GitHub identities in the same repo, so WHO posted a clean APPROVE
 verdict is not meaningful — the verdict text itself is the ground truth. Per review.md's
-Step 10 note ("Self-review event override"), GitHub rejects self-APPROVE via the API, so an
-agent's own clean approval of its own PR is always posted as `COMMENTED` with a body like
+Step 10 mechanical verdict computation (the `selfReview` input), GitHub rejects self-APPROVE
+via the API, so an agent's own clean approval of its own PR is always posted as `COMMENTED`
+with a body like
 `"APPROVE — looks good, no changes needed."` or a narrative containing `"Verdict: APPROVE"`
 instead of an `APPROVED` review. Without this exclusion, that clean approval would look
 identical to a real finding and loop the patch cron forever on an already-approved PR. The

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -818,7 +818,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
     expect(gateBlock).toContain("override");
   });
 
-  it("the gate computes the verdict once and feeds both the event field and the Verdict body label from that value", () => {
+  it("the gate feeds unaddressedFindings into Step 10's mechanical three-input verdict computation, not a standalone formula", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
     const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
@@ -827,7 +827,33 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
     expect(gateIdx).toBeGreaterThan(-1);
     const gateBlock = searchWindow.slice(gateIdx, gateIdx + 2500);
 
-    expect(gateBlock).toContain("Verdict: COMMENT");
+    expect(gateBlock).toContain("compute-review-verdict.ts");
+    expect(gateBlock).toContain("three-input truth table");
+    // The stale two-input inline formula from before Step 10's mechanical gate must not
+    // reappear -- it contradicted the three-input truth table (RUC-1.1/DRO-1.1 review
+    // finding: Step 9.5 must not restate a freehand fallback to the subagent's own
+    // recommendation).
+    expect(gateBlock).not.toContain(
+      'unaddressedFindings ? "COMMENT" : {code-reviewer subagent\'s recommended',
+    );
+  });
+
+  it("the gate's cross-reference to the other two verdict inputs does not point at the deleted 'Self-review event override' subsection", () => {
+    const step9Idx = content.indexOf("## Step 9: Write Review File");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
+    const searchWindow = content.slice(step9Idx, eventSelectionIdx);
+
+    const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");
+    expect(gateIdx).toBeGreaterThan(-1);
+    const gateBlock = searchWindow.slice(gateIdx, gateIdx + 2500);
+
+    // This PR folds the old named "Self-review event override" subsection into Step 10's
+    // unnamed mechanical paragraph -- Step 9.5's cross-reference must point at the
+    // mechanical computation (the selfReview input), not at the now-deleted subsection name
+    // (RUC-1.1/DRO-1.1 review finding: a dangling cross-reference to removed prose).
+    expect(gateBlock).not.toContain("Step 10 self-review COMMENT-forcing override");
+    expect(gateBlock).toContain("`selfReview` input");
+    expect(gateBlock).toContain("Step 10's mechanical");
   });
 
   it("the gate references the OR condition of any unresolved inline thread, matching patch.md's Step 3a", () => {

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -936,6 +936,83 @@ describe("review.md — Step 10 worked example distinguishes self-review-COMMENT
     expect(workedExampleSection.toLowerCase()).toContain('same `event: "comment"`');
     expect(workedExampleSection.toLowerCase()).toContain("different");
   });
+
+  it("Case 3 describes any-author PR with no prior unaddressed findings but a fresh blocking finding this pass", () => {
+    const case3Idx = workedExampleSection.indexOf("**Case 3");
+    expect(case3Idx).toBeGreaterThan(-1);
+    const case3Block = workedExampleSection.slice(case3Idx, case3Idx + 700);
+
+    expect(case3Block.toLowerCase()).toContain("any-author");
+    expect(case3Block).toContain("`selfReview = false`");
+    expect(case3Block).toContain("`unaddressedFindings = false`");
+    expect(case3Block).toContain("`currentPassHasBlockingFindings =\n  true`");
+    expect(case3Block).toContain('event: "COMMENT"');
+    expect(case3Block).toContain("Verdict: COMMENT");
+  });
+
+  it("Case 3 explains that without the new input this case would silently compute as APPROVE, same failure mode as Case 1", () => {
+    const case3Idx = workedExampleSection.indexOf("**Case 3");
+    expect(case3Idx).toBeGreaterThan(-1);
+    const case3Block = workedExampleSection.slice(case3Idx, case3Idx + 700);
+
+    expect(case3Block.toLowerCase()).toContain("silently compute as a clean `approve`");
+    expect(case3Block.toLowerCase()).toContain("the same\n  failure mode as case 1");
+  });
+
+  it("references the currentPassHasBlockingFindings input computed by Step 8, distinct from Step 9.5's unaddressedFindings", () => {
+    expect(workedExampleSection).toContain("currentPassHasBlockingFindings");
+    expect(workedExampleSection).toContain("Step 8's threshold-filtered `findings[]`");
+  });
+
+  it("includes the 8-row truth table with its header row covering all three boolean inputs", () => {
+    expect(workedExampleSection).toContain(
+      "| selfReview | unaddressedFindings | currentPassHasBlockingFindings | event | verdictLabel |",
+    );
+    expect(workedExampleSection.toLowerCase()).toContain("8-row truth table");
+  });
+
+  it("the truth table encodes all 2^3 = 8 boolean combinations with the correct event/verdictLabel outputs", () => {
+    const tableRows = [
+      "| true | false | false | COMMENT (self-review override) | APPROVE |",
+      "| true | false | true | COMMENT (self-review override) | COMMENT |",
+      "| true | true | false | COMMENT (self-review override) | COMMENT |",
+      "| true | true | true | COMMENT (self-review override) | COMMENT |",
+      "| false | false | false | APPROVE | APPROVE |",
+      "| false | false | true | COMMENT | COMMENT |",
+      "| false | true | false | COMMENT | COMMENT |",
+      "| false | true | true | COMMENT | COMMENT |",
+    ];
+    for (const row of tableRows) {
+      expect(workedExampleSection).toContain(row);
+    }
+  });
+});
+
+describe("review.md — Step 8 computes CURRENT_PASS_HAS_BLOCKING_FINDINGS from threshold-filtered findings (DRO-1.1)", () => {
+  it("defines CURRENT_PASS_HAS_BLOCKING_FINDINGS as true when any remaining finding is important or critical severity", () => {
+    const computeIdx = content.indexOf("**Compute `CURRENT_PASS_HAS_BLOCKING_FINDINGS`**");
+    expect(computeIdx).toBeGreaterThan(-1);
+    const computeBlock = content.slice(computeIdx, computeIdx + 700);
+
+    expect(computeBlock).toContain("`true` if any remaining finding is `important` or `critical` severity, else `false`");
+  });
+
+  it("ties CURRENT_PASS_HAS_BLOCKING_FINDINGS to Step 10/10.5's compute-review-verdict.ts input and cross-references Case 3", () => {
+    const computeIdx = content.indexOf("**Compute `CURRENT_PASS_HAS_BLOCKING_FINDINGS`**");
+    expect(computeIdx).toBeGreaterThan(-1);
+    const computeBlock = content.slice(computeIdx, computeIdx + 700);
+
+    expect(computeBlock).toContain("compute-review-verdict.ts");
+    expect(computeBlock).toContain("Step 10's worked example, Case 3");
+  });
+
+  it("distinguishes CURRENT_PASS_HAS_BLOCKING_FINDINGS (this pass, fresh) from Step 9.5's unaddressedFindings (prior, posted state)", () => {
+    const computeIdx = content.indexOf("**Compute `CURRENT_PASS_HAS_BLOCKING_FINDINGS`**");
+    expect(computeIdx).toBeGreaterThan(-1);
+    const computeBlock = content.slice(computeIdx, computeIdx + 700);
+
+    expect(computeBlock).toContain("independent of Step\n9.5's `unaddressedFindings`");
+  });
 });
 
 describe("review.md — Review Quality Rules reflect mechanical enforcement (RUC-1.1)", () => {

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -899,6 +899,25 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
       'At least one review with `state == "COMMENTED"` or `state == "CHANGES_REQUESTED"` has a\n  non-empty `body`, excluding:',
     );
   });
+
+  it("the gate documents the superseded-self-review exclusion (DRO-1.2), so a self-authored PR with multiple COMMENT-only rounds can still reach a clean verdict once fixed", () => {
+    const step9Idx = content.indexOf("## Step 9: Write Review File");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
+    const searchWindow = content.slice(step9Idx, eventSelectionIdx);
+
+    const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");
+    expect(gateIdx).toBeGreaterThan(-1);
+    const gateBlock = searchWindow.slice(gateIdx, gateIdx + 2500);
+
+    // Without this exclusion, a self-authored PR reviewed via a fresh review object each
+    // round (rather than a body rewrite) would have unaddressedFindings compute true
+    // forever, even after every prior finding is fixed -- there is no combination of
+    // computeVerdict() inputs that reaches verdictLabel "APPROVE" while
+    // unaddressedFindings is true (DRO-1.1/DRO-1.2 review finding, observed on this PR's
+    // own review history).
+    expect(gateBlock).toContain("superseded by a later, genuinely clean self-review");
+    expect(gateBlock).toContain("DRO-1.2");
+  });
 });
 
 describe("review.md — Step 10 worked example distinguishes self-review-COMMENT-event from unresolved-finding-COMMENT-verdict (RVG-1.2)", () => {

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -782,7 +782,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
     // The gate lives either as its own section between Step 9 and Step 10, or
     // as the first thing inside Step 10 before "Event selection".
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     expect(eventSelectionIdx).toBeGreaterThan(step10Idx);
 
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
@@ -792,7 +792,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
   it("the gate forces event to COMMENT when unaddressed findings are present", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     expect(step9Idx).toBeGreaterThan(-1);
     expect(eventSelectionIdx).toBeGreaterThan(-1);
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
@@ -807,7 +807,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
   it("the gate overrides the code-reviewer subagent's recommendation and the self-review override, without being mutually exclusive", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
 
     const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");
@@ -820,7 +820,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
   it("the gate computes the verdict once and feeds both the event field and the Verdict body label from that value", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
 
     const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");
@@ -832,7 +832,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
   it("the gate references the OR condition of any unresolved inline thread, matching patch.md's Step 3a", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
 
     const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");
@@ -843,7 +843,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
   it("the gate does not persist a new dedup state field -- it is computed live, consistent with the Design Constitution", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
 
     const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");
@@ -855,7 +855,7 @@ describe("review.md — unaddressed-findings hard gate before Step 10 (RUC-1.1)"
 
   it("the review-body condition has no headRefOid restriction, matching patch.md's Step 3a exactly", () => {
     const step9Idx = content.indexOf("## Step 9: Write Review File");
-    const eventSelectionIdx = content.indexOf("**Event selection**");
+    const eventSelectionIdx = content.indexOf("## Step 11: Post or Stage");
     const searchWindow = content.slice(step9Idx, eventSelectionIdx);
 
     const gateIdx = searchWindow.toLowerCase().indexOf("unaddressed findings");

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -543,14 +543,19 @@ A PR has **unaddressed findings** when ANY of the following are true:
 - At least one review with `state == "COMMENTED"` or `state == "CHANGES_REQUESTED"` has a
   non-empty `body`, excluding:
   - a clean self-APPROVE (per `isCleanApproveBody`/CPF-2.1 — a review whose body starts with
-    `APPROVE` or contains a `Verdict: APPROVE` label), and
+    `APPROVE` or contains a `Verdict: APPROVE` label),
   - a review addressed by a subsequent PR-author reply (per CPF-2.3 — the PR author posted a
     PR-level comment with `createdAt` after that review's `submittedAt`, and all inline
-    threads are resolved)
+    threads are resolved), and
+  - an earlier self-authored review superseded by a later, genuinely clean self-review from
+    the same author (per DRO-1.2 — this PR's own review history is the motivating case: a
+    self-authored PR reviewed via a fresh review object each round, rather than a body
+    rewrite, never triggers the clean-self-APPROVE exclusion above for its earlier rounds
+    even after every finding in them is fixed)
 
 This is the same computation patch.md's Step 3a performs to decide whether a PR belongs in
-its List A — see that section for the full clean-APPROVE and author-reply exclusion rules
-(not restated here to avoid a fourth divergent copy).
+its List A — see that section for the full clean-APPROVE, author-reply, and
+superseded-self-review exclusion rules (not restated here to avoid a fourth divergent copy).
 
 **If unaddressed findings are present, force the verdict to `COMMENT`** — this
 `unaddressedFindings` boolean is one of the three inputs Step 10's mechanical

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -415,6 +415,14 @@ Apply policy thresholds to the subagent's `findings[]`:
 **Keep it tight.** A good review has 2-5 actionable items. If the subagent returned
 more, trim to the highest-confidence few.
 
+**Compute `CURRENT_PASS_HAS_BLOCKING_FINDINGS`** from the threshold-filtered findings above:
+`true` if any remaining finding is `important` or `critical` severity, else `false`. This is
+Step 10/10.5's `currentPassHasBlockingFindings` input to `compute-review-verdict.ts` — it
+reflects what THIS review pass found (fresh, post-threshold-filtering), independent of Step
+9.5's `unaddressedFindings` (which only reflects prior, already-posted GitHub review state).
+Without this input, a fresh critical finding in an otherwise-clean review pass with zero prior
+unresolved threads would silently compute as `APPROVE` — see Step 10's worked example, Case 3.
+
 ---
 
 ## Step 9: Write Review File
@@ -571,19 +579,24 @@ store.
 
 Follow `references/post-review-guide.md` for the full mechanics.
 
-**The event/verdict decision is mechanical, not freehand.** Two inputs are already computed
+**The event/verdict decision is mechanical, not freehand.** Three inputs are already computed
 by this point in the procedure:
 - `selfReview` = `true` if the PR's `author.login == CURRENT_USER`, else `false`.
 - `unaddressedFindings` = the boolean Step 9.5's hard gate computed (real unresolved findings
-  present at head, per that step's exact definition).
+  from BEFORE this review pass — unresolved prior GitHub review threads/comments — present at
+  head, per that step's exact definition).
+- `currentPassHasBlockingFindings` = `true` if Step 8's threshold-filtered `findings[]` for
+  THIS review pass contains at least one `important` or `critical` severity finding, else
+  `false`. This is distinct from `unaddressedFindings`: it reflects what the code-reviewer
+  subagent found fresh in Steps 7/8, not prior GitHub-posted review state.
 
-Invoke `compute-review-verdict.ts` to turn those two booleans into the `event` and
+Invoke `compute-review-verdict.ts` to turn those three booleans into the `event` and
 `verdictLabel` to use — do not decide the event or the body's `Verdict: ...` label by
 narrative judgment:
 
 ```bash
 bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
-  "{\"selfReview\": ${SELF_REVIEW}, \"unaddressedFindings\": ${UNADDRESSED_FINDINGS}}"
+  "{\"selfReview\": ${SELF_REVIEW}, \"unaddressedFindings\": ${UNADDRESSED_FINDINGS}, \"currentPassHasBlockingFindings\": ${CURRENT_PASS_HAS_BLOCKING_FINDINGS}}"
 # -> {"event":"APPROVE"|"COMMENT","verdictLabel":"APPROVE"|"COMMENT"}
 ```
 
@@ -618,10 +631,10 @@ it was written as if it were Case 2. Both cases resolve to the
 but they MUST produce **different** `Verdict: ...` body labels:
 
 - **Case 1 — self-authored PR, all findings resolved via Step 9.5's exclusions.** The PR's
-  `author.login == CURRENT_USER` (`selfReview = true`) and Step 9.5's unaddressed-findings gate
+  `author.login == CURRENT_USER` (`selfReview = true`), Step 9.5's unaddressed-findings gate
   computes no unaddressed findings (`unaddressedFindings = false`) — every review either is a
-  clean self-APPROVE or was addressed by a subsequent author reply, per the exclusions above.
-  This is a genuinely clean approval.
+  clean self-APPROVE or was addressed by a subsequent author reply — and the current pass has
+  no blocking findings (`currentPassHasBlockingFindings = false`). A genuinely clean approval.
   Result: `event: "COMMENT"` (forced by the self-review override, since GitHub blocks
   self-APPROVE via the API — not because there's anything wrong with the PR), body **must**
   read `"Verdict: APPROVE — ..."`. Writing `Verdict: COMMENT` here is the exact bug observed
@@ -630,11 +643,21 @@ but they MUST produce **different** `Verdict: ...` body labels:
 - **Case 2 — any-author PR, a genuine unresolved finding still present at head.** Step 9.5's
   gate computes real unaddressed findings (`unaddressedFindings = true`) — an unresolved inline
   thread, or a qualifying `COMMENTED`/`CHANGES_REQUESTED` review body not excluded by the
-  clean-APPROVE or author-reply rules. This holds regardless of `selfReview`. Result:
-  `event: "COMMENT"`, body correctly reads `"Verdict: COMMENT — ..."`. This is the only case
-  where `Verdict: COMMENT` is the right label.
-- **Normal clean approve — any-author PR, no unaddressed findings.** `selfReview = false` and
-  `unaddressedFindings = false`. Result: `event: "APPROVE"`, body reads
+  clean-APPROVE or author-reply rules. This holds regardless of `selfReview` or
+  `currentPassHasBlockingFindings`. Result: `event: "COMMENT"`, body correctly reads
+  `"Verdict: COMMENT — ..."`.
+- **Case 3 — any-author PR, no prior unaddressed findings, but a fresh blocking finding in
+  this pass.** `selfReview = false` and `unaddressedFindings = false` (zero prior unresolved
+  GitHub review threads/comments), but Step 8's threshold-filtered `findings[]` for THIS review
+  pass contains an important/critical severity finding (`currentPassHasBlockingFindings =
+  true`). Without this input, this case would silently compute as a clean `APPROVE` — the same
+  failure mode as Case 1 above, reintroduced by a different path. Result: `event: "COMMENT"`,
+  body correctly reads `"Verdict: COMMENT — ..."`. This restores the old "Event selection"
+  rule: "If any finding at important/critical severity remains after threshold filtering:
+  COMMENT — no exceptions."
+- **Normal clean approve — any-author PR, no unaddressed findings, no blocking findings this
+  pass.** `selfReview = false`, `unaddressedFindings = false`, and
+  `currentPassHasBlockingFindings = false`. Result: `event: "APPROVE"`, body reads
   `"Verdict: APPROVE — ..."`. This is the ordinary non-self-review approve path.
 
 Both self-review-forced-COMMENT cases select `event: "COMMENT"` for entirely different reasons
@@ -642,15 +665,19 @@ Both self-review-forced-COMMENT cases select `event: "COMMENT"` for entirely dif
 body label is the *only* signal that distinguishes them for downstream automation, so it must
 always reflect the actual computed verdict, never be copied from the `event` value or from
 generic "this went through COMMENT" boilerplate. `compute-review-verdict.ts`'s `computeVerdict`
-implements this exact 4-row truth table so it can never drift into freehand narrative
-judgment again:
+implements this exact 8-row truth table (2^3 boolean combinations) so it can never drift into
+freehand narrative judgment again:
 
-| selfReview | unaddressedFindings | event | verdictLabel |
-|---|---|---|---|
-| true | false | COMMENT (self-review override) | APPROVE |
-| true | true | COMMENT (self-review override) | COMMENT |
-| false | false | APPROVE | APPROVE |
-| false | true | COMMENT | COMMENT |
+| selfReview | unaddressedFindings | currentPassHasBlockingFindings | event | verdictLabel |
+|---|---|---|---|---|
+| true | false | false | COMMENT (self-review override) | APPROVE |
+| true | false | true | COMMENT (self-review override) | COMMENT |
+| true | true | false | COMMENT (self-review override) | COMMENT |
+| true | true | true | COMMENT (self-review override) | COMMENT |
+| false | false | false | APPROVE | APPROVE |
+| false | false | true | COMMENT | COMMENT |
+| false | true | false | COMMENT | COMMENT |
+| false | true | true | COMMENT | COMMENT |
 
 Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`:
 
@@ -683,11 +710,12 @@ should be held; the inline comments convey the specific feedback to the author.
 ### Step 10.5: Hard-Gate Validation (Before Posting)
 
 Before Step 11 posts or stages anything, validate the constructed `body` against the same
-`selfReview`/`unaddressedFindings` inputs used above, via the script's validation mode:
+`selfReview`/`unaddressedFindings`/`currentPassHasBlockingFindings` inputs used above, via the
+script's validation mode:
 
 ```bash
 bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
-  "{\"selfReview\": ${SELF_REVIEW}, \"unaddressedFindings\": ${UNADDRESSED_FINDINGS}, \"body\": $(jq -Rs . <<< "$BODY")}"
+  "{\"selfReview\": ${SELF_REVIEW}, \"unaddressedFindings\": ${UNADDRESSED_FINDINGS}, \"currentPassHasBlockingFindings\": ${CURRENT_PASS_HAS_BLOCKING_FINDINGS}, \"body\": $(jq -Rs . <<< "$BODY")}"
 ```
 
 - If the result's `valid` field is `true`, proceed to Step 11.

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -592,7 +592,14 @@ by this point in the procedure:
 
 Invoke `compute-review-verdict.ts` to turn those three booleans into the `event` and
 `verdictLabel` to use — do not decide the event or the body's `Verdict: ...` label by
-narrative judgment:
+narrative judgment. Assign each computed value to a shell variable first (each must be the
+literal string `true` or `false`):
+
+```bash
+SELF_REVIEW={true or false, from selfReview above}
+UNADDRESSED_FINDINGS={true or false, from unaddressedFindings above}
+CURRENT_PASS_HAS_BLOCKING_FINDINGS={true or false, from currentPassHasBlockingFindings above}
+```
 
 ```bash
 bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
@@ -711,7 +718,13 @@ should be held; the inline comments convey the specific feedback to the author.
 
 Before Step 11 posts or stages anything, validate the constructed `body` against the same
 `selfReview`/`unaddressedFindings`/`currentPassHasBlockingFindings` inputs used above, via the
-script's validation mode:
+script's validation mode. `SELF_REVIEW`, `UNADDRESSED_FINDINGS`, and
+`CURRENT_PASS_HAS_BLOCKING_FINDINGS` carry over unchanged from Step 10; `BODY` is the `body`
+string built for `pr_review_{pr}.json` above:
+
+```bash
+BODY={the "body" string built for pr_review_{pr}.json above}
+```
 
 ```bash
 bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -552,20 +552,22 @@ This is the same computation patch.md's Step 3a performs to decide whether a PR 
 its List A — see that section for the full clean-APPROVE and author-reply exclusion rules
 (not restated here to avoid a fourth divergent copy).
 
-**If unaddressed findings are present, force the verdict to `COMMENT`** — compute the
-verdict once (`unaddressedFindings ? "COMMENT" : {code-reviewer subagent's recommended
-verdict}`) and feed that single value into both Step 10's `event` field (`COMMENT`) and the
-review body's `Verdict: ...` label (literal text `Verdict: COMMENT`), the same body-label
-convention Step 10 already documents. This gate:
+**If unaddressed findings are present, force the verdict to `COMMENT`** — this
+`unaddressedFindings` boolean is one of the three inputs Step 10's mechanical
+`compute-review-verdict.ts` call uses to compute the `event` and `verdictLabel`; it is not
+combined with the code-reviewer subagent's own top-line recommendation here (see Step 10 for
+the full three-input truth table, which also folds in `selfReview` and
+`currentPassHasBlockingFindings`). This gate:
 - **Overrides the code-reviewer subagent's severity-based recommendation** from Step 7 —
   even if the subagent recommends APPROVE (e.g. only suggestion-level findings, or no
   findings at all in the new diff), a genuinely unresolved inline thread or qualifying
   review from a prior pass still forces `COMMENT`.
-- **Is not mutually exclusive with the Step 10 self-review COMMENT-forcing override** below
-  — a self-reviewed PR can independently trigger the self-review override (GitHub rejects
-  self-APPROVE via the API) AND this gate (real unaddressed feedback exists); either one on
-  its own is sufficient to force `COMMENT`, and this gate must not be skipped just because
-  the PR is a self-review. This holds even when the review narrative would otherwise
+- **Is not mutually exclusive with the other two inputs to Step 10's mechanical
+  computation** — the `selfReview` input (a self-review override: GitHub rejects
+  self-APPROVE via the API) and the `currentPassHasBlockingFindings` input (Step 8's
+  threshold-filtered findings for this pass) can each independently force `COMMENT` too; any
+  one of the three is sufficient, and this gate must not be skipped just because another
+  input already forces `COMMENT`. This holds even when the review narrative would otherwise
   self-report `Verdict: APPROVE` — the computed verdict always wins over narrative wording.
 
 This gate is computed live from the GraphQL data fetched in Step 5.5 at review-post time —

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -571,20 +571,33 @@ store.
 
 Follow `references/post-review-guide.md` for the full mechanics.
 
-**Unaddressed-findings gate takes priority**: apply Step 9.5's gate first. When it computes
-`COMMENT`, use that verdict for both `event` and the `Verdict: ...` body label below,
-regardless of what follows in this step.
+**The event/verdict decision is mechanical, not freehand.** Two inputs are already computed
+by this point in the procedure:
+- `selfReview` = `true` if the PR's `author.login == CURRENT_USER`, else `false`.
+- `unaddressedFindings` = the boolean Step 9.5's hard gate computed (real unresolved findings
+  present at head, per that step's exact definition).
 
-**Self-review event override**: If the PR's `author.login == CURRENT_USER`, set `event: "COMMENT"`
-regardless of the review outcome — GitHub rejects self-APPROVE via the API. The actual verdict
-(`APPROVE` or `COMMENT`) is still recorded faithfully in the review file so the deploy skill
-can read the verdict directly from the GitHub review body.
+Invoke `compute-review-verdict.ts` to turn those two booleans into the `event` and
+`verdictLabel` to use — do not decide the event or the body's `Verdict: ...` label by
+narrative judgment:
+
+```bash
+bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
+  "{\"selfReview\": ${SELF_REVIEW}, \"unaddressedFindings\": ${UNADDRESSED_FINDINGS}}"
+# -> {"event":"APPROVE"|"COMMENT","verdictLabel":"APPROVE"|"COMMENT"}
+```
+
+Use the returned `event` for the JSON's `event` field, and the returned `verdictLabel` to
+build the literal `Verdict: {verdictLabel}` phrase leading the `body`. This single script call
+replaces both the old "Self-review event override" prose and the old "Event selection" prose
+below — see the truth table and worked example that follow for *why* the gate exists, but the
+*procedure* is: call the script, use its output verbatim.
 
 **The `body` field MUST contain the literal phrase `Verdict: APPROVE` or `Verdict: COMMENT`**,
-matching whichever verdict was selected below in Event selection — not just implied wording or
-free-form approval prose. `agent/src/check-patch.ts`'s `isSelfCleanApprove` (`VERDICT_APPROVE_LABEL =
+matching the `verdictLabel` computed above — not just implied wording or free-form approval
+prose. `agent/src/check-patch.ts`'s `isSelfCleanApprove` (`VERDICT_APPROVE_LABEL =
 /verdict\**\s*:\s*\**approve\b/i`) scans the GitHub-posted review body for this exact phrase to
-recognize a clean self-approve on a self-authored PR (where `event` is forced to `COMMENT` above,
+recognize a clean self-approve on a self-authored PR (where `event` is forced to `COMMENT`,
 since GitHub blocks self-APPROVE via the API). A body like "Clean conversion, all routes
 verified, no blocking issues." reads as a genuine approval to a human but contains neither
 `APPROVE` nor `Verdict: APPROVE`, so `isSelfCleanApprove` never matches it — the patch cron then
@@ -593,35 +606,51 @@ label, on both the initial-review and re-review paths (Steps 10/11 run identical
 see Step 14's re-review flow).
 
 **Worked example — the two cases production actually confused.** This convention was not
-followed on two separate PRs in another repo in this deployment (one self-authored, one not):
-both produced review bodies reading `Verdict: COMMENT` even though the narrative was explicitly
-clean — e.g. "No blocking issues found... checks out clean." In both cases the underlying
-situation was actually Case 1 below (a clean review that should read `Verdict: APPROVE`), but it
-was written as if it were Case 2. Both cases resolve to the **same `event: "COMMENT"`** — that
-surface-level identity is exactly why they get conflated — but they MUST produce **different**
-`Verdict: ...` body labels:
+followed on two separate PRs in another repo in this deployment (one self-authored, one not),
+and recurred again two days after that guidance landed, on another PR review in the same
+deployment — proof that prose guidance alone was not sufficient enforcement, which is why the
+decision is now mechanical (`compute-review-verdict.ts`) rather than freehand. All of these
+mislabeled review bodies read `Verdict: COMMENT` even though the narrative was explicitly
+clean — e.g. "No blocking issues found... checks out clean." In each case the underlying
+situation was actually Case 1 below (a clean review that should read `Verdict: APPROVE`), but
+it was written as if it were Case 2. Both cases resolve to the
+**same `event: "COMMENT"`** — that surface-level identity is exactly why they get conflated —
+but they MUST produce **different** `Verdict: ...` body labels:
 
 - **Case 1 — self-authored PR, all findings resolved via Step 9.5's exclusions.** The PR's
-  `author.login == CURRENT_USER` and Step 9.5's unaddressed-findings gate computes no
-  unaddressed findings (every review either is a clean self-APPROVE or was addressed by a
-  subsequent author reply, per the exclusions above). This is a genuinely clean approval.
+  `author.login == CURRENT_USER` (`selfReview = true`) and Step 9.5's unaddressed-findings gate
+  computes no unaddressed findings (`unaddressedFindings = false`) — every review either is a
+  clean self-APPROVE or was addressed by a subsequent author reply, per the exclusions above.
+  This is a genuinely clean approval.
   Result: `event: "COMMENT"` (forced by the self-review override, since GitHub blocks
   self-APPROVE via the API — not because there's anything wrong with the PR), body **must**
   read `"Verdict: APPROVE — ..."`. Writing `Verdict: COMMENT` here is the exact bug observed
   in production: it makes a clean PR invisible to `isSelfCleanApprove` and the patch cron
   treats it as an unaddressed finding forever.
 - **Case 2 — any-author PR, a genuine unresolved finding still present at head.** Step 9.5's
-  gate computes real unaddressed findings (an unresolved inline thread, or a qualifying
-  `COMMENTED`/`CHANGES_REQUESTED` review body not excluded by the clean-APPROVE or
-  author-reply rules). Result: `event: "COMMENT"`, body correctly reads
-  `"Verdict: COMMENT — ..."`. This is the only case where `Verdict: COMMENT` is the right
-  label.
+  gate computes real unaddressed findings (`unaddressedFindings = true`) — an unresolved inline
+  thread, or a qualifying `COMMENTED`/`CHANGES_REQUESTED` review body not excluded by the
+  clean-APPROVE or author-reply rules. This holds regardless of `selfReview`. Result:
+  `event: "COMMENT"`, body correctly reads `"Verdict: COMMENT — ..."`. This is the only case
+  where `Verdict: COMMENT` is the right label.
+- **Normal clean approve — any-author PR, no unaddressed findings.** `selfReview = false` and
+  `unaddressedFindings = false`. Result: `event: "APPROVE"`, body reads
+  `"Verdict: APPROVE — ..."`. This is the ordinary non-self-review approve path.
 
-Both cases select `event: "COMMENT"` for entirely different reasons (an API restriction on
-authorship vs. a real quality gate on content) — the `Verdict: ...` body label is the *only*
-signal that distinguishes them for downstream automation, so it must always reflect the actual
-computed verdict, never be copied from the `event` value or from generic "this went through
-COMMENT" boilerplate.
+Both self-review-forced-COMMENT cases select `event: "COMMENT"` for entirely different reasons
+(an API restriction on authorship vs. a real quality gate on content) — the `Verdict: ...`
+body label is the *only* signal that distinguishes them for downstream automation, so it must
+always reflect the actual computed verdict, never be copied from the `event` value or from
+generic "this went through COMMENT" boilerplate. `compute-review-verdict.ts`'s `computeVerdict`
+implements this exact 4-row truth table so it can never drift into freehand narrative
+judgment again:
+
+| selfReview | unaddressedFindings | event | verdictLabel |
+|---|---|---|---|
+| true | false | COMMENT (self-review override) | APPROVE |
+| true | true | COMMENT (self-review override) | COMMENT |
+| false | false | APPROVE | APPROVE |
+| false | true | COMMENT | COMMENT |
 
 Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`:
 
@@ -648,15 +677,26 @@ For a COMMENT verdict, the `body` follows the same convention, e.g.
 line is in the diff (`git diff origin/{base}...HEAD -- {file}`). Only lines within diff
 hunks are valid for inline comments. Move others to the review body.
 
-**Event selection** (from policy `allowed_events`):
-- If **any** finding at `important` (75-89) or `critical` (90-100) severity remains
-  after threshold filtering: `COMMENT` — no exceptions
-- If all remaining findings are `suggestion` level (50-74) or there are no findings:
-  `APPROVE`
-- Never `REQUEST_CHANGES`
-
 Inline comments are included regardless of verdict. The verdict signals whether the PR
 should be held; the inline comments convey the specific feedback to the author.
+
+### Step 10.5: Hard-Gate Validation (Before Posting)
+
+Before Step 11 posts or stages anything, validate the constructed `body` against the same
+`selfReview`/`unaddressedFindings` inputs used above, via the script's validation mode:
+
+```bash
+bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
+  "{\"selfReview\": ${SELF_REVIEW}, \"unaddressedFindings\": ${UNADDRESSED_FINDINGS}, \"body\": $(jq -Rs . <<< "$BODY")}"
+```
+
+- If the result's `valid` field is `true`, proceed to Step 11.
+- If `valid` is `false` (mismatched label, or no `Verdict: ...` label found at all), **hard
+  abort** — do not post or stage the review. Print the script's `error` field, fix the `body`
+  in `pr_review_{pr}.json` to use the correct `Verdict: {verdictLabel}` phrase from Step 10,
+  and re-run this validation before proceeding. This is the enforcement gate that the recurring
+  mislabeling incidents above prove prose guidance alone did not provide — a mismatch must
+  never silently proceed to posting.
 
 ---
 

--- a/plugins/shipwright/references/post-review-guide.md
+++ b/plugins/shipwright/references/post-review-guide.md
@@ -124,12 +124,25 @@ that cannot be deleted or dismissed via the API.
 
 ## APPROVE vs COMMENT Rule
 
-- **COMMENT**: any finding at `important` (75-89) or `critical` (90-100) severity
-  remains after threshold filtering — no exceptions
-- **APPROVE**: all remaining findings are `suggestion` level (50-74), or there are
-  no findings at all
+**The event/verdict decision is mechanical, not freehand** — `commands/review.md` Step 10
+computes it by invoking `scripts/compute-review-verdict.ts` with three booleans, rather than
+by narrative severity judgment:
 
-APPROVE means the PR is clean enough to merge. If there is anything blocking or
+- `selfReview` — the PR's `author.login == CURRENT_USER`
+- `unaddressedFindings` — Step 9.5's hard gate: real unresolved findings from BEFORE this
+  review pass (unresolved prior GitHub review threads/comments)
+- `currentPassHasBlockingFindings` — `true` if Step 8's threshold-filtered `findings[]` for
+  THIS review pass contains any `important` (75-89) or `critical` (90-100) severity finding
+
+`event` is `COMMENT` whenever any of those three is `true` (GitHub rejects self-APPROVE via
+the API, a prior unaddressed finding exists, or a fresh blocking finding was found this pass);
+otherwise `APPROVE`. The body's `Verdict: ...` label reflects the actual quality verdict:
+`COMMENT` whenever `unaddressedFindings` or `currentPassHasBlockingFindings` is `true`,
+`APPROVE` otherwise — regardless of why `event` was forced to `COMMENT`. See
+`commands/review.md` Step 10's full 8-row truth table and worked example.
+
+APPROVE means the PR is clean enough to merge: no unresolved prior findings and no
+important/critical finding surfaced in this pass. If there is anything blocking or
 important, COMMENT so it gets addressed before the deploy pipeline runs.
 
 **Never use REQUEST_CHANGES** -- it blocks the PR and requires the reviewer to

--- a/plugins/shipwright/scripts/compute-review-verdict.ts
+++ b/plugins/shipwright/scripts/compute-review-verdict.ts
@@ -9,8 +9,8 @@
 // expected label before the review is posted.
 //
 // CLI:
-//   bun run plugins/shipwright/scripts/compute-review-verdict.ts '{"selfReview":true,"unaddressedFindings":false}'
-//   bun run plugins/shipwright/scripts/compute-review-verdict.ts '{"selfReview":true,"unaddressedFindings":false,"body":"Verdict: APPROVE — ..."}'
+//   bun run plugins/shipwright/scripts/compute-review-verdict.ts '{"selfReview":true,"unaddressedFindings":false,"currentPassHasBlockingFindings":false}'
+//   bun run plugins/shipwright/scripts/compute-review-verdict.ts '{"selfReview":true,"unaddressedFindings":false,"currentPassHasBlockingFindings":false,"body":"Verdict: APPROVE — ..."}'
 // or pipe the same JSON blob via stdin.
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -20,6 +20,7 @@ export type Verdict = "APPROVE" | "COMMENT";
 export type ComputeVerdictInput = {
   selfReview: boolean;
   unaddressedFindings: boolean;
+  currentPassHasBlockingFindings: boolean;
 };
 
 export type ComputeVerdictResult = {
@@ -38,30 +39,43 @@ export type ValidateReviewVerdictResult = {
 
 // ─── computeVerdict ───────────────────────────────────────────────────────────
 //
-// The 4-row truth table (review.md Step 10, "Worked example" + "Event
-// selection"):
+// The 8-row truth table (2^3 boolean combinations; review.md Step 10, "Worked
+// example" + "Event selection"):
 //
-// | selfReview | unaddressedFindings | event                            | verdictLabel |
-// |------------|----------------------|-----------------------------------|--------------|
-// | true       | false                | COMMENT (self-review override)   | APPROVE      |  Case 1
-// | true       | true                 | COMMENT (self-review override)   | COMMENT      |  Case 2 (self-review variant)
-// | false      | false                | APPROVE                          | APPROVE      |  normal clean approve
-// | false      | true                 | COMMENT                          | COMMENT      |  Case 2
+// | selfReview | unaddressedFindings | currentPassHasBlockingFindings | event                            | verdictLabel |
+// |------------|----------------------|--------------------------------|-----------------------------------|--------------|
+// | true       | false                | false                          | COMMENT (self-review override)   | APPROVE      |  Case 1
+// | true       | false                | true                           | COMMENT (self-review override)   | COMMENT      |  Case 1 + fresh blocking finding
+// | true       | true                 | false                          | COMMENT (self-review override)   | COMMENT      |  Case 2 (self-review variant)
+// | true       | true                 | true                           | COMMENT (self-review override)   | COMMENT      |  Case 2 (self-review variant)
+// | false      | false                | false                          | APPROVE                          | APPROVE      |  normal clean approve
+// | false      | false                | true                           | COMMENT                          | COMMENT      |  fresh blocking finding, no prior unaddressed
+// | false      | true                 | false                          | COMMENT                          | COMMENT      |  Case 2
+// | false      | true                 | true                           | COMMENT                          | COMMENT      |  Case 2
 //
 // `event` is COMMENT whenever selfReview is true (GitHub rejects self-APPROVE
-// via the API) OR unaddressedFindings is true (Step 9.5's hard gate) — either
-// condition alone is sufficient, matching Step 9.5/Step 10's "not mutually
-// exclusive" note. `verdictLabel` reflects the *actual* quality verdict:
-// COMMENT only when there is a genuine unaddressed finding, regardless of why
-// `event` was forced to COMMENT.
+// via the API) OR unaddressedFindings is true (Step 9.5's hard gate) OR
+// currentPassHasBlockingFindings is true (Step 8's threshold-filtered
+// findings for THIS review pass contain an important/critical severity
+// finding) — any one condition alone is sufficient, matching Step 9.5/Step
+// 10's "not mutually exclusive" note. `verdictLabel` reflects the *actual*
+// quality verdict: COMMENT whenever there is a genuine unaddressed finding
+// (prior, per Step 9.5) OR a genuine blocking finding in the current pass
+// (per Step 8), regardless of why `event` was forced to COMMENT. This
+// restores the old "Event selection" behavior ("any finding at
+// important/critical severity remains after threshold filtering: COMMENT —
+// no exceptions") that a purely selfReview/unaddressedFindings computation
+// cannot express — without currentPassHasBlockingFindings, an any-author PR
+// with no prior unresolved GitHub review threads but a fresh critical
+// finding in this pass would silently compute as APPROVE.
 export function computeVerdict(
   input: ComputeVerdictInput,
 ): ComputeVerdictResult {
+  const hasBlockingSignal =
+    input.unaddressedFindings || input.currentPassHasBlockingFindings;
   const event: Verdict =
-    input.selfReview || input.unaddressedFindings ? "COMMENT" : "APPROVE";
-  const verdictLabel: Verdict = input.unaddressedFindings
-    ? "COMMENT"
-    : "APPROVE";
+    input.selfReview || hasBlockingSignal ? "COMMENT" : "APPROVE";
+  const verdictLabel: Verdict = hasBlockingSignal ? "COMMENT" : "APPROVE";
   return { event, verdictLabel };
 }
 
@@ -100,14 +114,14 @@ export function validateReviewVerdict(
   if (actual === null) {
     return {
       valid: false,
-      error: `No "Verdict: APPROVE" or "Verdict: COMMENT" label found in the review body. Expected "Verdict: ${expected}" (selfReview=${input.selfReview}, unaddressedFindings=${input.unaddressedFindings}). Add the literal "Verdict: ${expected}" phrase to the body before posting.`,
+      error: `No "Verdict: APPROVE" or "Verdict: COMMENT" label found in the review body. Expected "Verdict: ${expected}" (selfReview=${input.selfReview}, unaddressedFindings=${input.unaddressedFindings}, currentPassHasBlockingFindings=${input.currentPassHasBlockingFindings}). Add the literal "Verdict: ${expected}" phrase to the body before posting.`,
     };
   }
 
   if (actual !== expected) {
     return {
       valid: false,
-      error: `Verdict label mismatch: body reads "Verdict: ${actual}" but the computed verdict for selfReview=${input.selfReview}, unaddressedFindings=${input.unaddressedFindings} is "Verdict: ${expected}". Fix the body to read "Verdict: ${expected}" before posting — do not post with a mismatched label (this is the exact production bug DRO-1.1 guards against).`,
+      error: `Verdict label mismatch: body reads "Verdict: ${actual}" but the computed verdict for selfReview=${input.selfReview}, unaddressedFindings=${input.unaddressedFindings}, currentPassHasBlockingFindings=${input.currentPassHasBlockingFindings} is "Verdict: ${expected}". Fix the body to read "Verdict: ${expected}" before posting — do not post with a mismatched label (this is the exact production bug DRO-1.1 guards against).`,
     };
   }
 
@@ -119,6 +133,7 @@ export function validateReviewVerdict(
 type CliInput = {
   selfReview: boolean;
   unaddressedFindings: boolean;
+  currentPassHasBlockingFindings: boolean;
   body?: string;
 };
 
@@ -132,9 +147,15 @@ function parseCliInput(raw: string): CliInput {
       'Input JSON must have a boolean "unaddressedFindings" field',
     );
   }
+  if (typeof parsed.currentPassHasBlockingFindings !== "boolean") {
+    throw new Error(
+      'Input JSON must have a boolean "currentPassHasBlockingFindings" field',
+    );
+  }
   return {
     selfReview: parsed.selfReview,
     unaddressedFindings: parsed.unaddressedFindings,
+    currentPassHasBlockingFindings: parsed.currentPassHasBlockingFindings,
     body: parsed.body,
   };
 }
@@ -148,6 +169,7 @@ if (import.meta.main) {
     const result = validateReviewVerdict({
       selfReview: input.selfReview,
       unaddressedFindings: input.unaddressedFindings,
+      currentPassHasBlockingFindings: input.currentPassHasBlockingFindings,
       body: input.body,
     });
     console.log(JSON.stringify(result));

--- a/plugins/shipwright/scripts/compute-review-verdict.ts
+++ b/plugins/shipwright/scripts/compute-review-verdict.ts
@@ -89,8 +89,8 @@ export function computeVerdict(
 // plugins/shipwright is a separate, repo-agnostic package from agent/src —
 // see plugins/shipwright/CLAUDE.md.
 
-const VERDICT_APPROVE_LABEL = /verdict\**\s*:\**\s*\**approve\b/i;
-const VERDICT_COMMENT_LABEL = /verdict\**\s*:\**\s*\**comment\b/i;
+const VERDICT_APPROVE_LABEL = /verdict\**\s*:\s*\**approve\b/i;
+const VERDICT_COMMENT_LABEL = /verdict\**\s*:\s*\**comment\b/i;
 
 function extractVerdictLabel(body: string): Verdict | null {
   if (VERDICT_APPROVE_LABEL.test(body)) return "APPROVE";

--- a/plugins/shipwright/scripts/compute-review-verdict.ts
+++ b/plugins/shipwright/scripts/compute-review-verdict.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+// Mechanical review-verdict computation gate (DRO-1.1).
+//
+// Extracts the Case 1/Case 2 verdict truth table documented in
+// plugins/shipwright/commands/review.md Step 10 (see the "Worked example"
+// there for the recurring production incident this gate exists to prevent)
+// into a pure function, plus a validation entrypoint that checks a
+// constructed review body's `Verdict: ...` label against the computed
+// expected label before the review is posted.
+//
+// CLI:
+//   bun run plugins/shipwright/scripts/compute-review-verdict.ts '{"selfReview":true,"unaddressedFindings":false}'
+//   bun run plugins/shipwright/scripts/compute-review-verdict.ts '{"selfReview":true,"unaddressedFindings":false,"body":"Verdict: APPROVE — ..."}'
+// or pipe the same JSON blob via stdin.
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type Verdict = "APPROVE" | "COMMENT";
+
+export type ComputeVerdictInput = {
+  selfReview: boolean;
+  unaddressedFindings: boolean;
+};
+
+export type ComputeVerdictResult = {
+  event: Verdict;
+  verdictLabel: Verdict;
+};
+
+export type ValidateReviewVerdictInput = ComputeVerdictInput & {
+  body: string;
+};
+
+export type ValidateReviewVerdictResult = {
+  valid: boolean;
+  error?: string;
+};
+
+// ─── computeVerdict ───────────────────────────────────────────────────────────
+//
+// The 4-row truth table (review.md Step 10, "Worked example" + "Event
+// selection"):
+//
+// | selfReview | unaddressedFindings | event                            | verdictLabel |
+// |------------|----------------------|-----------------------------------|--------------|
+// | true       | false                | COMMENT (self-review override)   | APPROVE      |  Case 1
+// | true       | true                 | COMMENT (self-review override)   | COMMENT      |  Case 2 (self-review variant)
+// | false      | false                | APPROVE                          | APPROVE      |  normal clean approve
+// | false      | true                 | COMMENT                          | COMMENT      |  Case 2
+//
+// `event` is COMMENT whenever selfReview is true (GitHub rejects self-APPROVE
+// via the API) OR unaddressedFindings is true (Step 9.5's hard gate) — either
+// condition alone is sufficient, matching Step 9.5/Step 10's "not mutually
+// exclusive" note. `verdictLabel` reflects the *actual* quality verdict:
+// COMMENT only when there is a genuine unaddressed finding, regardless of why
+// `event` was forced to COMMENT.
+export function computeVerdict(
+  input: ComputeVerdictInput,
+): ComputeVerdictResult {
+  const event: Verdict =
+    input.selfReview || input.unaddressedFindings ? "COMMENT" : "APPROVE";
+  const verdictLabel: Verdict = input.unaddressedFindings
+    ? "COMMENT"
+    : "APPROVE";
+  return { event, verdictLabel };
+}
+
+// ─── Verdict label matching ───────────────────────────────────────────────────
+//
+// Mirrors agent/src/check-helpers.ts's VERDICT_APPROVE_LABEL convention
+// (`/verdict\**\s*:\s*\**approve\b/i`) — case-insensitive, optional markdown
+// bold markers around "verdict", the colon, and/or the verdict word, not
+// anchored to end-of-line since review bodies trail reasoning after the
+// verdict on the same line. Duplicated here (rather than imported) because
+// plugins/shipwright is a separate, repo-agnostic package from agent/src —
+// see plugins/shipwright/CLAUDE.md.
+
+const VERDICT_APPROVE_LABEL = /verdict\**\s*:\**\s*\**approve\b/i;
+const VERDICT_COMMENT_LABEL = /verdict\**\s*:\**\s*\**comment\b/i;
+
+function extractVerdictLabel(body: string): Verdict | null {
+  if (VERDICT_APPROVE_LABEL.test(body)) return "APPROVE";
+  if (VERDICT_COMMENT_LABEL.test(body)) return "COMMENT";
+  return null;
+}
+
+// ─── validateReviewVerdict ────────────────────────────────────────────────────
+//
+// Computes the expected verdictLabel via computeVerdict(), extracts the
+// actual `Verdict: ...` label from `body`, and returns a structured
+// {valid, error} result — never throws — so review.md's Step 10 procedure
+// gets a clean hard-gate signal: a mismatch or a missing label both abort
+// the post-review step and force a fix rather than silently proceeding.
+export function validateReviewVerdict(
+  input: ValidateReviewVerdictInput,
+): ValidateReviewVerdictResult {
+  const { verdictLabel: expected } = computeVerdict(input);
+  const actual = extractVerdictLabel(input.body);
+
+  if (actual === null) {
+    return {
+      valid: false,
+      error: `No "Verdict: APPROVE" or "Verdict: COMMENT" label found in the review body. Expected "Verdict: ${expected}" (selfReview=${input.selfReview}, unaddressedFindings=${input.unaddressedFindings}). Add the literal "Verdict: ${expected}" phrase to the body before posting.`,
+    };
+  }
+
+  if (actual !== expected) {
+    return {
+      valid: false,
+      error: `Verdict label mismatch: body reads "Verdict: ${actual}" but the computed verdict for selfReview=${input.selfReview}, unaddressedFindings=${input.unaddressedFindings} is "Verdict: ${expected}". Fix the body to read "Verdict: ${expected}" before posting — do not post with a mismatched label (this is the exact production bug DRO-1.1 guards against).`,
+    };
+  }
+
+  return { valid: true };
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+type CliInput = {
+  selfReview: boolean;
+  unaddressedFindings: boolean;
+  body?: string;
+};
+
+function parseCliInput(raw: string): CliInput {
+  const parsed = JSON.parse(raw) as Partial<CliInput>;
+  if (typeof parsed.selfReview !== "boolean") {
+    throw new Error('Input JSON must have a boolean "selfReview" field');
+  }
+  if (typeof parsed.unaddressedFindings !== "boolean") {
+    throw new Error(
+      'Input JSON must have a boolean "unaddressedFindings" field',
+    );
+  }
+  return {
+    selfReview: parsed.selfReview,
+    unaddressedFindings: parsed.unaddressedFindings,
+    body: parsed.body,
+  };
+}
+
+if (import.meta.main) {
+  const arg = process.argv[2];
+  const raw = arg && arg.length > 0 ? arg : await Bun.stdin.text();
+  const input = parseCliInput(raw);
+
+  if (typeof input.body === "string") {
+    const result = validateReviewVerdict({
+      selfReview: input.selfReview,
+      unaddressedFindings: input.unaddressedFindings,
+      body: input.body,
+    });
+    console.log(JSON.stringify(result));
+    if (!result.valid) process.exit(1);
+  } else {
+    const result = computeVerdict(input);
+    console.log(JSON.stringify(result));
+  }
+}

--- a/plugins/shipwright/scripts/compute-review-verdict.unit.test.ts
+++ b/plugins/shipwright/scripts/compute-review-verdict.unit.test.ts
@@ -6,6 +6,8 @@
 // "Worked example" for the recurring production incident this mechanical
 // gate exists to prevent.
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
 import {
   computeVerdict,
@@ -168,14 +170,35 @@ describe("validateReviewVerdict", () => {
     expect(result.error).toMatch(/Verdict/i);
   });
 
-  it("matches case-insensitively and tolerates markdown bold markers around the label", () => {
+  it("matches case-insensitively and tolerates markdown bold markers around the verdict word", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
+      body: "verdict: **approve** — all checks pass.",
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  // Regression test for the empirical mismatch found in PR #2515 review round 3:
+  // the label regexes here must match agent/src/check-helpers.ts's
+  // VERDICT_APPROVE_LABEL (`/verdict\**\s*:\s*\**approve\b/i`) exactly. A body
+  // with bold markers wrapping "Verdict:" (colon included, e.g. "**Verdict:**")
+  // is NOT matched by the canonical pattern — only bold markers around the
+  // verdict word itself are. If this file's regex ever diverges again (e.g. by
+  // reintroducing `\s*` between the colon and `\**`), this body would be
+  // wrongly treated as a valid "Verdict: APPROVE" label here while
+  // agent/src/check-patch.ts's isSelfCleanApprove (canonical pattern) would NOT
+  // recognize it as a clean self-approve — reintroducing DRO-1.1's motivating
+  // bug via a different code path.
+  it("does not match when bold markers wrap the colon itself, matching the canonical check-helpers.ts pattern exactly", () => {
     const result = validateReviewVerdict({
       selfReview: false,
       unaddressedFindings: false,
       currentPassHasBlockingFindings: false,
       body: "**Verdict:** approve — all checks pass.",
     });
-    expect(result).toEqual({ valid: true });
+    expect(result.valid).toBe(false);
   });
 
   it("matches a Verdict label embedded with surrounding narrative text", () => {
@@ -186,5 +209,67 @@ describe("validateReviewVerdict", () => {
       body: "Some preamble.\n\nVerdict: COMMENT — still one unresolved thread on error handling.\n\nMore trailing notes.",
     });
     expect(result).toEqual({ valid: true });
+  });
+});
+
+describe("VERDICT_APPROVE_LABEL / VERDICT_COMMENT_LABEL regex parity with check-helpers.ts", () => {
+  // This file's label regexes are duplicated (not imported) from
+  // agent/src/check-helpers.ts's VERDICT_APPROVE_LABEL, per the module
+  // comment above their definitions — plugins/shipwright is a separate,
+  // repo-agnostic package that can't import from agent/src. A prior review
+  // round on PR #2515 found the two had silently diverged (an extra `\**`
+  // after the colon here). Extract both regex sources directly and assert
+  // they're identical so the two can never drift apart again undetected.
+  const CHECK_HELPERS_PATH = join(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "agent",
+    "src",
+    "check-helpers.ts",
+  );
+  const THIS_FILE_PATH = join(import.meta.dir, "compute-review-verdict.ts");
+
+  it("VERDICT_APPROVE_LABEL here matches check-helpers.ts's canonical pattern exactly", () => {
+    const checkHelpersSource = readFileSync(CHECK_HELPERS_PATH, "utf-8");
+    const tsMatch = checkHelpersSource.match(
+      /export const VERDICT_APPROVE_LABEL =\s*\/(.*)\/i;/,
+    );
+    expect(tsMatch).not.toBeNull();
+    const canonicalPattern = tsMatch?.[1] ?? "";
+    expect(canonicalPattern.length).toBeGreaterThan(0);
+
+    const thisFileSource = readFileSync(THIS_FILE_PATH, "utf-8");
+    const localMatch = thisFileSource.match(
+      /const VERDICT_APPROVE_LABEL = \/(.*)\/i;/,
+    );
+    expect(localMatch).not.toBeNull();
+    const localPattern = localMatch?.[1] ?? "";
+
+    expect(localPattern).toBe(canonicalPattern);
+  });
+
+  it("VERDICT_COMMENT_LABEL here mirrors the same approve/comment structure as the canonical pattern (approve substring swapped for comment)", () => {
+    const checkHelpersSource = readFileSync(CHECK_HELPERS_PATH, "utf-8");
+    const tsMatch = checkHelpersSource.match(
+      /export const VERDICT_APPROVE_LABEL =\s*\/(.*)\/i;/,
+    );
+    expect(tsMatch).not.toBeNull();
+    const canonicalApprovePattern = tsMatch?.[1] ?? "";
+    const expectedCommentPattern = canonicalApprovePattern.replace(
+      /approve\\b$/,
+      "comment\\b",
+    );
+    expect(expectedCommentPattern).not.toBe(canonicalApprovePattern);
+
+    const thisFileSource = readFileSync(THIS_FILE_PATH, "utf-8");
+    const localMatch = thisFileSource.match(
+      /const VERDICT_COMMENT_LABEL = \/(.*)\/i;/,
+    );
+    expect(localMatch).not.toBeNull();
+    const localPattern = localMatch?.[1] ?? "";
+
+    expect(localPattern).toBe(expectedCommentPattern);
   });
 });

--- a/plugins/shipwright/scripts/compute-review-verdict.unit.test.ts
+++ b/plugins/shipwright/scripts/compute-review-verdict.unit.test.ts
@@ -13,34 +13,74 @@ import {
 } from "./compute-review-verdict";
 
 describe("computeVerdict", () => {
-  it("selfReview=true, unaddressedFindings=false -> Case 1: event COMMENT (self-review override), label APPROVE", () => {
+  it("selfReview=true, unaddressedFindings=false, currentPassHasBlockingFindings=false -> Case 1: event COMMENT (self-review override), label APPROVE", () => {
     const result = computeVerdict({
       selfReview: true,
       unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
     });
     expect(result).toEqual({ event: "COMMENT", verdictLabel: "APPROVE" });
   });
 
-  it("selfReview=true, unaddressedFindings=true -> Case 2 self-review variant: event COMMENT, label COMMENT", () => {
+  it("selfReview=true, unaddressedFindings=false, currentPassHasBlockingFindings=true -> event COMMENT, label COMMENT (fresh blocking finding on an otherwise-clean self-review)", () => {
     const result = computeVerdict({
       selfReview: true,
-      unaddressedFindings: true,
+      unaddressedFindings: false,
+      currentPassHasBlockingFindings: true,
     });
     expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
   });
 
-  it("selfReview=false, unaddressedFindings=false -> normal clean approve: event APPROVE, label APPROVE", () => {
+  it("selfReview=true, unaddressedFindings=true, currentPassHasBlockingFindings=false -> Case 2 self-review variant: event COMMENT, label COMMENT", () => {
+    const result = computeVerdict({
+      selfReview: true,
+      unaddressedFindings: true,
+      currentPassHasBlockingFindings: false,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
+  });
+
+  it("selfReview=true, unaddressedFindings=true, currentPassHasBlockingFindings=true -> event COMMENT, label COMMENT", () => {
+    const result = computeVerdict({
+      selfReview: true,
+      unaddressedFindings: true,
+      currentPassHasBlockingFindings: true,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
+  });
+
+  it("selfReview=false, unaddressedFindings=false, currentPassHasBlockingFindings=false -> normal clean approve: event APPROVE, label APPROVE", () => {
     const result = computeVerdict({
       selfReview: false,
       unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
     });
     expect(result).toEqual({ event: "APPROVE", verdictLabel: "APPROVE" });
   });
 
-  it("selfReview=false, unaddressedFindings=true -> Case 2: event COMMENT, label COMMENT", () => {
+  it("selfReview=false, unaddressedFindings=false, currentPassHasBlockingFindings=true -> Case 3 (the bug this fix closes): event COMMENT, label COMMENT, not a silent APPROVE", () => {
+    const result = computeVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+      currentPassHasBlockingFindings: true,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
+  });
+
+  it("selfReview=false, unaddressedFindings=true, currentPassHasBlockingFindings=false -> Case 2: event COMMENT, label COMMENT", () => {
     const result = computeVerdict({
       selfReview: false,
       unaddressedFindings: true,
+      currentPassHasBlockingFindings: false,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
+  });
+
+  it("selfReview=false, unaddressedFindings=true, currentPassHasBlockingFindings=true -> event COMMENT, label COMMENT", () => {
+    const result = computeVerdict({
+      selfReview: false,
+      unaddressedFindings: true,
+      currentPassHasBlockingFindings: true,
     });
     expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
   });
@@ -51,6 +91,7 @@ describe("validateReviewVerdict", () => {
     const result = validateReviewVerdict({
       selfReview: true,
       unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
       body: "Verdict: APPROVE — Clean conversion, all routes verified, no blocking issues.",
     });
     expect(result).toEqual({ valid: true });
@@ -60,15 +101,27 @@ describe("validateReviewVerdict", () => {
     const result = validateReviewVerdict({
       selfReview: false,
       unaddressedFindings: true,
+      currentPassHasBlockingFindings: false,
       body: "Verdict: COMMENT — missing error handling on the retry path.",
     });
     expect(result).toEqual({ valid: true });
   });
 
-  it("catches the exact production mismatch: Case 1 (selfReview=true, unaddressedFindings=false) mislabeled 'Verdict: COMMENT'", () => {
+  it("returns valid:true when the body's Verdict label matches the computed label (Case 3, correctly labeled: fresh blocking finding, no prior unaddressed findings)", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+      currentPassHasBlockingFindings: true,
+      body: "Verdict: COMMENT — new critical finding: unbounded recursion on the retry path.",
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("catches the exact production mismatch: Case 1 (selfReview=true, unaddressedFindings=false, currentPassHasBlockingFindings=false) mislabeled 'Verdict: COMMENT'", () => {
     const result = validateReviewVerdict({
       selfReview: true,
       unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
       body: "Verdict: COMMENT — No blocking issues found... checks out clean.",
     });
     expect(result.valid).toBe(false);
@@ -81,6 +134,20 @@ describe("validateReviewVerdict", () => {
     const result = validateReviewVerdict({
       selfReview: false,
       unaddressedFindings: true,
+      currentPassHasBlockingFindings: false,
+      body: "Verdict: APPROVE — looks fine to me.",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toMatch(/APPROVE/);
+    expect(result.error).toMatch(/COMMENT/);
+  });
+
+  it("catches the exact bug this fix closes: a fresh critical finding with no prior unaddressed findings mislabeled 'Verdict: APPROVE'", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+      currentPassHasBlockingFindings: true,
       body: "Verdict: APPROVE — looks fine to me.",
     });
     expect(result.valid).toBe(false);
@@ -93,6 +160,7 @@ describe("validateReviewVerdict", () => {
     const result = validateReviewVerdict({
       selfReview: false,
       unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
       body: "Looks good, approved.",
     });
     expect(result.valid).toBe(false);
@@ -104,6 +172,7 @@ describe("validateReviewVerdict", () => {
     const result = validateReviewVerdict({
       selfReview: false,
       unaddressedFindings: false,
+      currentPassHasBlockingFindings: false,
       body: "**Verdict:** approve — all checks pass.",
     });
     expect(result).toEqual({ valid: true });
@@ -113,6 +182,7 @@ describe("validateReviewVerdict", () => {
     const result = validateReviewVerdict({
       selfReview: true,
       unaddressedFindings: true,
+      currentPassHasBlockingFindings: false,
       body: "Some preamble.\n\nVerdict: COMMENT — still one unresolved thread on error handling.\n\nMore trailing notes.",
     });
     expect(result).toEqual({ valid: true });

--- a/plugins/shipwright/scripts/compute-review-verdict.unit.test.ts
+++ b/plugins/shipwright/scripts/compute-review-verdict.unit.test.ts
@@ -1,0 +1,120 @@
+// Unit tests for compute-review-verdict.ts — pure logic, no I/O.
+//
+// Covers the Case 1/Case 2 truth table documented in
+// plugins/shipwright/commands/review.md Step 10 (lines ~604-618) plus the
+// non-self-review clean-approve path further down that step. See review.md's
+// "Worked example" for the recurring production incident this mechanical
+// gate exists to prevent.
+
+import { describe, expect, it } from "bun:test";
+import {
+  computeVerdict,
+  validateReviewVerdict,
+} from "./compute-review-verdict";
+
+describe("computeVerdict", () => {
+  it("selfReview=true, unaddressedFindings=false -> Case 1: event COMMENT (self-review override), label APPROVE", () => {
+    const result = computeVerdict({
+      selfReview: true,
+      unaddressedFindings: false,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "APPROVE" });
+  });
+
+  it("selfReview=true, unaddressedFindings=true -> Case 2 self-review variant: event COMMENT, label COMMENT", () => {
+    const result = computeVerdict({
+      selfReview: true,
+      unaddressedFindings: true,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
+  });
+
+  it("selfReview=false, unaddressedFindings=false -> normal clean approve: event APPROVE, label APPROVE", () => {
+    const result = computeVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+    });
+    expect(result).toEqual({ event: "APPROVE", verdictLabel: "APPROVE" });
+  });
+
+  it("selfReview=false, unaddressedFindings=true -> Case 2: event COMMENT, label COMMENT", () => {
+    const result = computeVerdict({
+      selfReview: false,
+      unaddressedFindings: true,
+    });
+    expect(result).toEqual({ event: "COMMENT", verdictLabel: "COMMENT" });
+  });
+});
+
+describe("validateReviewVerdict", () => {
+  it("returns valid:true when the body's Verdict label matches the computed label (Case 1, correctly labeled)", () => {
+    const result = validateReviewVerdict({
+      selfReview: true,
+      unaddressedFindings: false,
+      body: "Verdict: APPROVE — Clean conversion, all routes verified, no blocking issues.",
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("returns valid:true when the body's Verdict label matches the computed label (Case 2, correctly labeled)", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: true,
+      body: "Verdict: COMMENT — missing error handling on the retry path.",
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("catches the exact production mismatch: Case 1 (selfReview=true, unaddressedFindings=false) mislabeled 'Verdict: COMMENT'", () => {
+    const result = validateReviewVerdict({
+      selfReview: true,
+      unaddressedFindings: false,
+      body: "Verdict: COMMENT — No blocking issues found... checks out clean.",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toMatch(/APPROVE/);
+    expect(result.error).toMatch(/COMMENT/);
+  });
+
+  it("catches a mismatch in the other direction: Case 2 mislabeled 'Verdict: APPROVE'", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: true,
+      body: "Verdict: APPROVE — looks fine to me.",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toMatch(/APPROVE/);
+    expect(result.error).toMatch(/COMMENT/);
+  });
+
+  it("returns valid:false with a clear error when the body has no Verdict label at all", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+      body: "Looks good, approved.",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toMatch(/Verdict/i);
+  });
+
+  it("matches case-insensitively and tolerates markdown bold markers around the label", () => {
+    const result = validateReviewVerdict({
+      selfReview: false,
+      unaddressedFindings: false,
+      body: "**Verdict:** approve — all checks pass.",
+    });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("matches a Verdict label embedded with surrounding narrative text", () => {
+    const result = validateReviewVerdict({
+      selfReview: true,
+      unaddressedFindings: true,
+      body: "Some preamble.\n\nVerdict: COMMENT — still one unresolved thread on error handling.\n\nMore trailing notes.",
+    });
+    expect(result).toEqual({ valid: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts the review.md Step 10 Case 1/Case 2 verdict truth table (documented as prose-only guidance) into a pure function `computeVerdict()` in a new `plugins/shipwright/scripts/compute-review-verdict.ts`, covering all 4 `selfReview` x `unaddressedFindings` combinations.
- Adds `validateReviewVerdict()`, a validation entrypoint that checks a constructed review body's `Verdict: ...` label against the computed expected label and returns a structured, actionable error on mismatch.
- Rewires review.md Step 10 to invoke the script for `event`/`verdictLabel` computation instead of freehand model judgment, and adds a new Step 10.5 that hard-gates on the validation result before the post-review step proceeds — a mismatch aborts and forces a fix.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | computeVerdict() covers all 4 truth-table combinations | MET |
| 2 | Validation entrypoint catches a mismatched label with a clear, actionable error | MET |
| 3 | review.md Step 10 rewritten to invoke the script and hard-gate on validation before posting | MET |
| 4 | New *.unit.test.ts covers all 4 combinations + mismatch-detection; no existing tests retired | MET |

## Test Plan
- `compute-review-verdict.unit.test.ts` — 11 tests covering all 4 truth-table rows, valid-match cases, the exact production mismatch (Case 1 mislabeled COMMENT), a reverse mismatch, missing-label detection, and casing/markdown edge cases.
- `review.content.test.ts` — 7 pre-existing tests re-pointed to the still-present `## Step 11: Post or Stage` boundary marker (only used as a search-window boundary, not an assertion target); all still pass.
- [x] `task lint`, `task typecheck`, `task ci` (coverage gate: 81.30% lines / 82.20% functions, threshold 80%) all pass. One pre-existing, unrelated failure in `agent/src/claude.unit.test.ts` confirmed present on `main` via `git stash` — not introduced by this change.

Generated with [Claude Code](https://claude.com/claude-code)
