### PR TITLE
feat: add open-PR supersession guard to test-readiness cron

### DIFF
--- a/plugins/shipwright/skills/test-readiness/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-readiness/SKILL.content.test.ts
@@ -1,0 +1,97 @@
+/**
+ * test-readiness content tests — open-PR supersession guard.
+ *
+ * Step 1 previously cut a fresh `docs/test-readiness-refresh-{YYYYMMDD}`
+ * branch from origin/main every day the cron fired, with only a same-day
+ * reuse check. When a prior day's docs-refresh PR touching the same
+ * `docs/test-readiness/*.md` files got stuck open, the next day's run
+ * created a fresh competing PR against the same files — if that one merged
+ * first, the stuck PR became permanently unmergeable (confirmed in
+ * production: a newer same-pattern PR merging turned an older open
+ * docs-refresh PR CONFLICTING).
+ *
+ * These tests assert Step 1 documents checking for an existing open PR on
+ * a `docs/test-readiness-refresh-*` branch (any date) before creating a new
+ * branch, reusing/checking out that branch and merging origin/main into it
+ * instead of branching fresh, and — on merge conflict — skipping Steps 2-4
+ * for that repo only with a distinct report string in Step 4's summary.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+
+function readSkill(): string {
+  return readFileSync(SKILL_MD_PATH, "utf8");
+}
+
+describe("test-readiness — SKILL.md exists", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+});
+
+describe("test-readiness — Step 1 open-PR supersession guard", () => {
+  it("checks for an existing open PR on a docs/test-readiness-refresh-* branch before creating a new branch", () => {
+    const content = readSkill();
+    expect(content).toContain("gh pr list");
+    expect(content).toContain("--state open");
+    expect(content).toContain("docs/test-readiness-refresh-");
+  });
+
+  it("uses headRefName,createdAt fields and filters client-side by branch prefix", () => {
+    const content = readSkill();
+    expect(content).toContain("headRefName");
+    expect(content).toContain("createdAt");
+  });
+
+  it("runs the open-PR check ahead of the existing same-day-reuse block", () => {
+    const content = readSkill();
+    const openPrCheckIdx = content.indexOf("gh pr list");
+    const sameDayReuseIdx = content.indexOf("same-day rerun");
+    expect(openPrCheckIdx).toBeGreaterThan(-1);
+    expect(sameDayReuseIdx).toBeGreaterThan(-1);
+    expect(openPrCheckIdx).toBeLessThan(sameDayReuseIdx);
+  });
+
+  it("documents reusing/checking out the earlier-day branch instead of branching fresh", () => {
+    const lower = readSkill().toLowerCase();
+    expect(
+      lower.includes("reuse") &&
+        (lower.includes("checkout") || lower.includes("check out")),
+    ).toBe(true);
+  });
+
+  it("documents merging current origin/main into the reused branch", () => {
+    const content = readSkill();
+    expect(content).toMatch(/git merge origin\/main/);
+  });
+
+  it("documents skipping Steps 2-4 for that repo only on merge conflict", () => {
+    const content = readSkill();
+    expect(content).toMatch(/merge conflict/i);
+    expect(content).toContain("that repo only");
+  });
+});
+
+describe("test-readiness — Step 4 reports the reuse-merge conflict distinctly", () => {
+  it("adds a distinct skip reason for reuse-merge conflicts, not folded into 'all artifacts fresh'", () => {
+    const content = readSkill();
+    expect(content).toContain("skipped — all artifacts fresh");
+    expect(content).toMatch(
+      /skipped — reuse-merge conflict, needs manual resolution/,
+    );
+  });
+
+  it("keeps the new skip reason string distinct from the existing fresh-artifacts skip reason", () => {
+    const content = readSkill();
+    const freshIdx = content.indexOf("skipped — all artifacts fresh");
+    const conflictIdx = content.indexOf(
+      "skipped — reuse-merge conflict, needs manual resolution",
+    );
+    expect(freshIdx).toBeGreaterThan(-1);
+    expect(conflictIdx).toBeGreaterThan(-1);
+    expect(freshIdx).not.toBe(conflictIdx);
+  });
+});

--- a/plugins/shipwright/skills/test-readiness/SKILL.md
+++ b/plugins/shipwright/skills/test-readiness/SKILL.md
@@ -98,7 +98,57 @@ matching approach as `research-docs.md` Step A0.
 
 **For each repo in the resolved list, set up (or reuse) a worktree + branch
 and run Steps 2-4 there** — never edit `repos/{dirname}` directly (see this
-repo's own root `CLAUDE.md` for the worktree convention):
+repo's own root `CLAUDE.md` for the worktree convention).
+
+**Open-PR supersession check (run first, before any branch is created).**
+A prior day's docs-refresh PR touching the same `docs/test-readiness/*.md`
+files may still be open — e.g. stuck on review, CI, or awaiting a human.
+Branching fresh from `origin/main` every day regardless creates a second PR
+competing for the same files; if the new one merges first, the stuck PR
+becomes permanently unmergeable (confirmed: a same-pattern collision turned
+an older open docs-refresh PR CONFLICTING once a newer one merged). Before
+creating a new branch, query for an existing **open** PR on any
+`docs/test-readiness-refresh-*` branch (any date, not just today) for this
+repo:
+
+```bash
+gh pr list --repo {org}/{repo} --state open \
+  --json number,headRefName,createdAt
+```
+
+`gh` has no glob support for head-branch matching, so filter the JSON result
+client-side, keeping only entries whose `headRefName` starts with
+`docs/test-readiness-refresh-`. This check is distinct from, and runs
+**ahead of**, the same-day-reuse check below — it looks for *any* earlier-day
+open PR, not just today's.
+
+- **No matching open PR found:** fall through to the fresh-branch flow below,
+  unchanged.
+- **Exactly one earlier-day open PR found:** reuse that PR's branch instead
+  of branching fresh. Check out the existing branch into a worktree (or reuse
+  an existing worktree for it if one is already present) and merge current
+  `origin/main` into it:
+  ```bash
+  git -C repos/{dirname} pull
+  git -C repos/{dirname} worktree add \
+    $SHIPWRIGHT_WORKTREE_DIR/{dirname}-docs-test-readiness-refresh-{existing-date} \
+    {existing-branch-name}
+  cd $SHIPWRIGHT_WORKTREE_DIR/{dirname}-docs-test-readiness-refresh-{existing-date}
+  git merge origin/main
+  ```
+  - **Merge succeeds cleanly:** proceed to Steps 2-4 in this worktree as
+    normal — the branch and its open PR are now caught up with `main` and
+    will absorb this run's updates instead of being superseded by a
+    competing PR.
+  - **Merge conflict:** do not attempt to resolve it automatically. Abort the
+    merge (`git merge --abort`), **skip Steps 2-4 for that repo only**, and
+    report the conflict explicitly and distinctly in Step 4's aggregated
+    summary (see Step 4 below) — do not fold this into the "skipped — all
+    artifacts fresh" case, since the repo was not fresh, it was blocked.
+    Other repos in the resolved list are unaffected and continue processing
+    normally.
+
+**Fresh-branch flow (no earlier-day open PR found, or same-day rerun):**
 
 ```bash
 git -C repos/{dirname} pull
@@ -110,7 +160,11 @@ git -C repos/{dirname} worktree add \
 Branch naming: `docs/test-readiness-refresh-<YYYYMMDD>` (today's date). If a
 worktree/branch with that name already exists (e.g. a same-day rerun), reuse
 it rather than recreating — check `$SHIPWRIGHT_WORKTREE_DIR` for an existing
-`{dirname}-docs-test-readiness-refresh-{YYYYMMDD}` directory first.
+`{dirname}-docs-test-readiness-refresh-{YYYYMMDD}` directory first. This
+same-day-reuse check is separate from the open-PR supersession check above:
+this one matches on today's exact branch name only, regardless of PR state;
+the supersession check above matches on any earlier-day PR still open on
+GitHub.
 
 All relative paths in Steps 2-4 (`docs/test-readiness/*.md`, phase artifact
 mtimes, git history, etc.) resolve against that repo's worktree, not the bare
@@ -153,8 +207,13 @@ proceed to Step 4.
 After every repo in the resolved list has been processed, print one
 aggregated summary across all repos, with a per-repo section: which phases
 ran (or "skipped — all artifacts fresh" / "skipped — precheck did not flag
-this repo"), and the number of task-store tasks created or updated (from
-phase 5 output) for that repo.
+this repo" / "skipped — reuse-merge conflict, needs manual resolution" for
+the open-PR supersession case above), and the number of task-store tasks
+created or updated (from phase 5 output) for that repo. The reuse-merge
+conflict status is reported distinctly from "skipped — all artifacts
+fresh" — the two mean different things (blocked vs. nothing to do) and must
+not be folded together, so a human scanning the summary can immediately spot
+the repo that needs manual conflict resolution on its open PR.
 
 ## Failure handling
 


### PR DESCRIPTION
## Summary
- Adds an open-PR supersession check to `test-readiness/SKILL.md` Step 1, run before creating a new branch: query for any earlier-day open PR on a `docs/test-readiness-refresh-*` branch for the target repo, and reuse/checkout that branch + merge `origin/main` into it instead of branching fresh.
- On merge conflict, aborts the merge, skips Steps 2-4 for that repo only, and reports it via a new distinct Step 4 summary status (`"skipped — reuse-merge conflict, needs manual resolution"`), kept separate from the existing `"skipped — all artifacts fresh"` case.
- Adds `SKILL.content.test.ts` (9 tests) asserting both the reuse-before-fresh-branch and conflict-skip instructions are present, following this repo's markdown-driven skill-assertion convention.

Fixes the root cause behind vitals-os#4101 becoming permanently unmergeable after vitals-os#4134 (a same-pattern PR) merged first against the same `docs/test-readiness/*.md` files.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 1 checks for an existing open PR on a `docs/test-readiness-refresh-*` branch ahead of the same-day-reuse check | MET |
| 2 | Reuses/checks out an earlier-day open PR's branch + merges `origin/main` instead of branching fresh | MET |
| 3 | On merge conflict, skips Steps 2-4 for that repo only, distinct Step 4 summary status | MET |
| 4 | New `*.content.test.ts` asserting both instructions, matching repo convention | MET |

## Test Plan
- `bun test plugins/shipwright/skills/test-readiness/SKILL.content.test.ts` — 9/9 pass
- `task lint`, `task typecheck`, `task check-strings`, `task check-config-docs`, `task check-version-sync` — all pass
- `bun test --coverage --coverage-reporter=lcov` + `bun run scripts/check-coverage.ts` — 81.35%/82.21% (threshold 80%/80%), 1 pre-existing unrelated failure (`agent/src/claude.unit.test.ts` `extraAllowedTools` flake, reproduces on clean main)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
