### PR TITLE
fix: close PR claim()'s lost-update race

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -297,11 +297,12 @@ Body:
 | `phase` | no | Pipeline phase (`review`, `patch`, or `deploy`; default: `review`). When set, the phase is updated and reviewState is preserved. Phase-specific behavior on record creation: `review` sets `readyForReviewAt=now`; `deploy` sets `readyForDeployAt=now`; `patch` does not set a ready timestamp. |
 | `prCreatedAt` | no | ISO timestamp of the GitHub PR's actual creation time. Only applied when the claim creates a new record (`201`); ignored on subsequent claims (`200`) of an existing record since the field is immutable once set. |
 
-Claim semantics:
-- No existing record → creates and returns `201`
-- Same `commitSha`, same `phase`, and already claimed by another agent → returns `409` (phase already locked)
-- Already claimed (claimedBy !== null) AND same `commitSha` AND `reviewState !== pending` (review phase only) → returns `409` (already reviewed at this commit)
-- Not claimed, OR different `commitSha`, OR `reviewState === pending` → updates and returns `200` (new cycle)
+Claim semantics (atomic via Postgres row locking):
+- No existing record → creates and returns `201`; a concurrent INSERT loser hits the `@@unique([repo, prNumber])` constraint → `409`
+- Existing record with conflict conditions re-checked in the UPDATE's WHERE clause (Postgres holds the row lock, ensuring only one writer wins):
+  - Same `commitSha`, same `phase`, and already claimed by another agent → no rows affected → `409` (phase already locked)
+  - Already claimed (claimedBy !== null) AND same `commitSha` AND `reviewState !== pending` (review phase only) → no rows affected → `409` (already reviewed at this commit)
+- Not claimed, OR different `commitSha`, OR `reviewState === pending` → row affected → updates and returns `200` (new cycle)
 
 The `taskId` field is optional and does not trigger any side effects on the Task table — it is stored as metadata on the PR record only for reference.
 

--- a/task-store/src/pull-request-service.integration.test.ts
+++ b/task-store/src/pull-request-service.integration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * task-store/src/pull-request-service.integration.test.ts
+ *
+ * Integration tests for PullRequestService.claim()'s UPDATE-path lost-update
+ * race against a real Postgres DB.
+ *
+ * Distinct from pull-request.integration.test.ts, which covers the CREATE-path
+ * race (two claims against an *empty* table — arbitrated by the
+ * @@unique([repo, prNumber]) constraint). This file seeds an existing PR row
+ * first, then races two more claim() calls at the SAME commitSha/phase against
+ * that row, exercising the UPDATE path where the conflict re-check must live in
+ * the SQL WHERE clause (not only a pre-update JS `if`) for Postgres to be the
+ * sole arbiter under READ COMMITTED.
+ *
+ * Requires DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST to be set; skips otherwise.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { ConflictError } from "./errors.ts";
+import { PullRequestService } from "./pull-request-service.ts";
+
+const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+describeOrSkip(
+  "PullRequestService.claim() UPDATE-path race (integration)",
+  () => {
+    let prisma: PrismaClient;
+    let service: PullRequestService;
+
+    beforeEach(async () => {
+      prisma = makePrisma();
+      service = new PullRequestService(prisma);
+      await prisma.pullRequest.deleteMany();
+    });
+
+    afterEach(async () => {
+      await prisma.$disconnect();
+    });
+
+    it("concurrent claims (same commitSha/phase) against an EXISTING released record: exactly one wins, the other gets ConflictError", async () => {
+      const repo = "app-vitals/shipwright";
+      const prNumber = 5100;
+      const commitSha = "sha-update-race";
+
+      // Seed an existing, unclaimed record at this commitSha with reviewState
+      // 'pending' (so a review-phase claim is legitimately allowed to win). This
+      // guarantees both racers take the UPDATE branch (existing !== null), not
+      // the CREATE branch — that's the whole point vs. the sibling file's test.
+      await prisma.pullRequest.create({
+        data: {
+          repo,
+          prNumber,
+          commitSha,
+          reviewState: "pending",
+          state: "open",
+          claimedBy: null,
+        },
+      });
+
+      // Race two simultaneous claim() calls for phase=review at the same
+      // commitSha. Both read the same stale snapshot (claimedBy: null,
+      // reviewState: 'pending' → JS-side guards pass for both). Only one UPDATE
+      // may actually take the claim; the other must surface ConflictError once
+      // the row it tries to update no longer matches the conflict-free WHERE.
+      const results = await Promise.allSettled([
+        service.claim(
+          repo,
+          prNumber,
+          commitSha,
+          "agent-a",
+          undefined,
+          "review",
+        ),
+        service.claim(
+          repo,
+          prNumber,
+          commitSha,
+          "agent-b",
+          undefined,
+          "review",
+        ),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+
+      // The core assertion the fix guarantees: exactly one winner, exactly one
+      // ConflictError. Against the pre-fix code both writers could pass the
+      // stale JS check and the second's UPDATE (WHERE id = ? only) would
+      // silently clobber the first — yielding two fulfilled results.
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+
+      const winner = fulfilled[0];
+      if (winner.status === "fulfilled") {
+        expect(winner.value.status).toBe(200);
+        expect(winner.value.record.reviewState).toBe("in_progress");
+        expect(winner.value.record.claimedBy).not.toBeNull();
+        expect(["agent-a", "agent-b"]).toContain(
+          winner.value.record.claimedBy ?? "",
+        );
+      }
+
+      const loser = rejected[0];
+      if (loser.status === "rejected") {
+        expect(loser.reason).toBeInstanceOf(ConflictError);
+      }
+
+      // Exactly one claim landed in the DB, held by the winner.
+      const row = await prisma.pullRequest.findUnique({
+        where: { repo_prNumber: { repo, prNumber } },
+      });
+      expect(row).not.toBeNull();
+      if (!row) return;
+      expect(row.claimedBy).not.toBeNull();
+      if (winner.status === "fulfilled") {
+        expect(row.claimedBy).toBe(winner.value.record.claimedBy);
+      }
+      expect(row.reviewState).toBe("in_progress");
+    });
+
+    it("sequential claim after a claim on the same commitSha/phase still returns ConflictError (guard preserved)", async () => {
+      const repo = "app-vitals/shipwright";
+      const prNumber = 5101;
+      const commitSha = "sha-sequential-guard";
+
+      // First claim creates + claims the record for review.
+      const first = await service.claim(repo, prNumber, commitSha, "agent-a");
+      expect(first.record.claimedBy).toBe("agent-a");
+
+      // A second claim at the same commitSha/phase while still claimed must 409
+      // — the moved-into-WHERE conflict check must reproduce the old guard
+      // exactly, not just for the concurrent case.
+      let caught: unknown;
+      try {
+        await service.claim(
+          repo,
+          prNumber,
+          commitSha,
+          "agent-b",
+          undefined,
+          "review",
+        );
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ConflictError);
+
+      // The original claim is untouched.
+      const row = await prisma.pullRequest.findUnique({
+        where: { repo_prNumber: { repo, prNumber } },
+      });
+      expect(row?.claimedBy).toBe("agent-a");
+    });
+
+    it("legacy review guard (claimed, same commitSha, reviewState !== pending) still surfaces ConflictError via the WHERE clause", async () => {
+      const repo = "app-vitals/shipwright";
+      const prNumber = 5102;
+      const commitSha = "sha-legacy-guard";
+      const now = new Date().toISOString();
+
+      // Seed a record already claimed at this commitSha with a non-pending,
+      // non-matching phase (phase is null) so ONLY the legacy review guard —
+      // not the modern phase guard — is what must reject the claim.
+      await prisma.pullRequest.create({
+        data: {
+          repo,
+          prNumber,
+          commitSha,
+          reviewState: "in_progress",
+          state: "open",
+          phase: null,
+          claimedBy: "agent-x",
+          claimedAt: now,
+          heartbeatAt: now,
+        },
+      });
+
+      let caught: unknown;
+      try {
+        await service.claim(
+          repo,
+          prNumber,
+          commitSha,
+          "agent-y",
+          undefined,
+          "review",
+        );
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ConflictError);
+
+      // Still held by the original claimant.
+      const row = await prisma.pullRequest.findUnique({
+        where: { repo_prNumber: { repo, prNumber } },
+      });
+      expect(row?.claimedBy).toBe("agent-x");
+    });
+  },
+);

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -5,10 +5,13 @@
  *
  * claim() is atomic via a Prisma $transaction:
  *   1. Find existing record by @@unique([repo, prNumber])
- *   2. Already claimed (claimedBy !== null) AND same commitSha AND
- *      reviewState !== 'pending' → ConflictError(409)
- *   3. Not claimed, OR different commitSha, OR reviewState === 'pending' → update (200)
- *   4. No record → create (201)
+ *   2. Update with the conflict conditions re-checked in the UPDATE's own WHERE
+ *      clause (so Postgres, holding the row lock, is the sole arbiter of a
+ *      concurrent claim — not a possibly-stale JS snapshot). A write that no
+ *      longer matches affects 0 rows → P2025 → ConflictError(409) (or, if the
+ *      row was deleted, NotFoundError). Otherwise → update (200)
+ *   3. No record → create (201); a concurrent INSERT loser hits the
+ *      @@unique([repo, prNumber]) constraint → P2002 → ConflictError(409)
  *
  * Timestamp fields are stored as ISO strings to match the application contract;
  * only createdAt/updatedAt are DateTime columns.
@@ -397,36 +400,6 @@ export class PullRequestService implements PullRequestServiceLike {
       });
 
       if (existing) {
-        // Conflict: same commitSha AND already claimed by someone for the same phase.
-        // Heartbeat staleness is not checked here — a stale claim still blocks; only
-        // the reaper resolves staleness and clears stale claims.
-        if (
-          existing.commitSha === commitSha &&
-          existing.claimedBy !== null &&
-          existing.phase === phase
-        ) {
-          throw new ConflictError(
-            `pr ${repo}#${prNumber} is already claimed with the same commit`,
-          );
-        }
-
-        // Legacy review conflict: already claimed, same commitSha, and
-        // reviewState is not pending (covers the case where phase was not
-        // set yet). The claimedBy check keeps this guard from firing while
-        // the PR is idle (claimedBy: null) — e.g. after release()/complete()
-        // clear the claim — so a legitimate re-claim (such as the
-        // fresh-author-reply re-candidacy case) is not permanently blocked.
-        if (
-          phase === "review" &&
-          existing.claimedBy !== null &&
-          existing.commitSha === commitSha &&
-          existing.reviewState !== "pending"
-        ) {
-          throw new ConflictError(
-            `pr ${repo}#${prNumber} is already claimed with the same commit`,
-          );
-        }
-
         // Build update payload based on phase
         const updateData: Prisma.PullRequestUpdateInput = {
           commitSha,
@@ -447,11 +420,72 @@ export class PullRequestService implements PullRequestServiceLike {
         }
         // phase === 'patch': do NOT touch reviewState (preserve 'posted')
 
-        const record = await tx.pullRequest.update({
-          where: { id: existing.id },
-          data: updateData,
-        });
-        return { status: 200 as const, record };
+        // Re-validate the two conflict conditions in the UPDATE's own WHERE
+        // clause so Postgres — holding the row lock at execution time — is the
+        // sole arbiter of who wins a concurrent claim, not application-level JS
+        // reading a possibly-stale findUnique() snapshot. Under READ COMMITTED
+        // two racers could both pass a pre-update JS `if` against the same stale
+        // read and the second writer would silently clobber the first's claim
+        // (a lost-update race, CRF-1.1). Expressing the guards as negated WHERE
+        // filters means the losing writer matches 0 rows and Prisma throws
+        // P2025 instead — which we disambiguate into ConflictError vs
+        // NotFoundError below.
+        //
+        // Conflict conditions (the UPDATE must match only when NEITHER holds):
+        //   1. Modern phase guard: same commitSha AND already claimed AND same phase.
+        //      Heartbeat staleness is not checked — a stale claim still blocks; only
+        //      the reaper resolves staleness and clears stale claims.
+        //   2. Legacy review guard (phase === 'review' only): already claimed, same
+        //      commitSha, and reviewState !== 'pending' (covers the case where phase
+        //      was not set yet). The claimedBy check keeps this guard from firing
+        //      while the PR is idle (claimedBy: null) — e.g. after release()/
+        //      complete() clear the claim — so a legitimate re-claim (such as the
+        //      fresh-author-reply re-candidacy case) is not permanently blocked.
+        const conflictConditions: Prisma.PullRequestWhereInput[] = [
+          { commitSha, claimedBy: { not: null }, phase },
+        ];
+        if (phase === "review") {
+          conflictConditions.push({
+            commitSha,
+            claimedBy: { not: null },
+            reviewState: { not: "pending" },
+          });
+        }
+
+        try {
+          const record = await tx.pullRequest.update({
+            where: {
+              id: existing.id,
+              NOT: { OR: conflictConditions },
+            },
+            data: updateData,
+          });
+          return { status: 200 as const, record };
+        } catch (err: unknown) {
+          // The combined WHERE matched 0 rows → Prisma throws P2025. Distinguish
+          // the two causes: the row still exists (a concurrent claim() now
+          // satisfies a conflict condition — the expected outcome this fix
+          // closes the race for) → ConflictError; the row was deleted entirely
+          // (much rarer) → genuine NotFoundError.
+          if (
+            typeof err === "object" &&
+            err !== null &&
+            "code" in err &&
+            (err as { code: string }).code === "P2025"
+          ) {
+            const stillExists = await tx.pullRequest.findUnique({
+              where: { id: existing.id },
+              select: { id: true },
+            });
+            if (stillExists) {
+              throw new ConflictError(
+                `pr ${repo}#${prNumber} is already claimed with the same commit`,
+              );
+            }
+            throw new NotFoundError(`pr ${repo}#${prNumber} not found`);
+          }
+          throw err;
+        }
       }
 
       // No existing record → create.


### PR DESCRIPTION
## Summary
- `PullRequestService.claim()` re-validates its conflict guards (modern phase guard + legacy commitSha/reviewState guard) directly in the UPDATE's SQL `WHERE` clause instead of only in a preceding JS `if`, closing a lost-update race where two concurrent claimants could both pass a stale `findUnique()` snapshot under READ COMMITTED and the second writer would silently clobber the first's claim.
- Mirrors the existing single-conditional-UPDATE pattern already used by `TaskService.claim()` and the `claimedBy: null` optimistic-lock filter in `claimNext()`.
- When the WHERE clause matches 0 rows (Prisma P2025), a follow-up `findUnique` disambiguates: row still present → `ConflictError(409)` (unchanged message); row deleted → `NotFoundError`.
- Refreshed `docs/task-store.md`'s claim semantics section to describe the atomic WHERE-clause re-check.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Conflict conditions re-validated in the UPDATE's own SQL WHERE clause, not only a preceding JS `if`; a write that no longer matches affects 0 rows and surfaces as the existing `ConflictError(409)` | MET |
| 2 | Conflict-detection semantics unchanged from the caller's perspective — internal atomicity fix only | MET |
| 3 | New integration test in `pull-request-service.integration.test.ts` races two concurrent `claim()` calls against the same PR/commitSha on real Postgres, asserting exactly one succeeds and the other throws `ConflictError`; existing unit tests kept as-is | MET |

## Test Plan
- New `task-store/src/pull-request-service.integration.test.ts` (3 tests, gated on `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST`, runs against real Postgres in CI):
  - Concurrent claims against an existing record: exactly one wins, the other gets `ConflictError`
  - Sequential claim guard preserved
  - Legacy review guard still surfaces `ConflictError` via the WHERE clause
- `task typecheck` and `task lint` pass
- `task test` — full suite passes except one pre-existing, unrelated flaky test (`agent/src/claude.unit.test.ts` extraAllowedTools) confirmed failing identically on a clean `origin/main` checkout; GitHub Actions CI on that same commit (`a7364d4c`) is green, so this is a local-sandbox-only flake, not a regression from this change.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
