### PR TITLE
fix(task-store): defense-in-depth on Task claim()

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -169,7 +169,7 @@ Returns `204`. Agent tokens can only delete their own tasks.
 POST /tasks/:id/claim
 ```
 
-Atomically claims a pending task — a single conditional `UPDATE ... WHERE status='pending'`. Sets `status=in_progress`, `claimedBy`, `claimedAt`, `heartbeatAt`, and `startedAt` (or keeps existing if already set) in one round-trip. No request body is sent by agent tokens — the service pins `claimedBy` to the calling agent's ID server-side. Admin tokens must supply `{ claimedBy: string }` in the body. Returns `200` with the updated task on success, or `409` if already claimed or not in pending status.
+Atomically claims a pending task — a single conditional `UPDATE ... WHERE status='pending' AND "claimedBy" IS NULL`. Sets `status=in_progress`, `claimedBy`, `claimedAt`, `heartbeatAt`, and `startedAt` (or keeps existing if already set) in one round-trip. No request body is sent by agent tokens — the service pins `claimedBy` to the calling agent's ID server-side. Admin tokens must supply `{ claimedBy: string }` in the body. Returns `200` with the updated task on success, or `409` if already claimed or not in pending status.
 
 #### Heartbeat
 

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -75,8 +75,10 @@ async function readJson(c: {
 // assignee/claimant match), so without this guard a repo-scoped agent token
 // could overwrite an actively claimed task's status back to "pending",
 // making it immediately re-claimable by a different agent while the
-// original session still holds it (TaskService.claim()'s atomic UPDATE
-// gates solely on status = 'pending', never on claimedBy IS NULL).
+// original session still holds it (TaskService.claim()'s atomic UPDATE now
+// also gates on claimedBy IS NULL, but a PATCH bypassing /claim or /release
+// could still directly clear claimedBy/status, defeating that protection
+// outside the atomic claim path).
 const LIFECYCLE_GUARD_KEYS = ["claimedBy", "claimedAt", "heartbeatAt"] as const;
 
 // admin tokens (agentId === null) are unrestricted, mirroring the existing

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -452,7 +452,7 @@ export class TaskService implements TaskServiceLike {
           "heartbeatAt" = ${now},
           "startedAt" = COALESCE("startedAt", ${now}),
           "updatedAt" = now()
-      WHERE id = ${id} AND status = 'pending'
+      WHERE id = ${id} AND status = 'pending' AND "claimedBy" IS NULL
     `;
 
     if (affected === 0) {

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -438,8 +438,8 @@ export class TaskService implements TaskServiceLike {
   /**
    * Atomically claim a pending task.
    *
-   * Single conditional UPDATE — `WHERE id = $1 AND status = 'pending'`. If 0 rows
-   * are affected the task is either missing or already claimed: distinguish the
+   * Single conditional UPDATE — `WHERE id = $1 AND status = 'pending' AND "claimedBy" IS NULL`.
+   * If 0 rows are affected the task is either missing or already claimed: distinguish the
    * two with a follow-up read so callers get 404 vs 409.
    */
   async claim(id: string, claimedBy: string): Promise<Task> {

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -939,16 +939,14 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
   }
 
   /**
-   * makeClaimPrismaDouble — simulates claim() behavior with an in-memory row.
-   * The double allows configuring whether to enforce the claimedBy=null guard.
-   * When enforceClaimedByGuard=true, the double checks both status AND claimedBy IS NULL.
-   * When enforceClaimedByGuard=false, it only checks status (simulating the old behavior).
+   * makeClaimPrismaDouble — simulates a Postgres row against the *actual* SQL
+   * text claim() sends. Reads the tagged-template `strings` to determine
+   * whether the query's WHERE clause includes the "claimedBy" IS NULL guard,
+   * rather than hardcoding that behavior — so this double breaks (and the
+   * ConflictError test below fails) if claim()'s WHERE clause regresses.
    * Also implements task.findUnique to support the existing 404-vs-409 disambiguation.
    */
-  function makeClaimPrismaDouble(
-    initialTask: Task,
-    enforceClaimedByGuard = true,
-  ) {
+  function makeClaimPrismaDouble(initialTask: Task) {
     // In-memory row state — must be let because $executeRaw mutates it
     let row = { ...initialTask };
 
@@ -957,10 +955,9 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
         strings: TemplateStringsArray,
         ...values: unknown[]
       ): Promise<number> {
-        // Simulate the WHERE clause in claim():
-        // - always check: id matches AND status = 'pending'
-        // - when enforceClaimedByGuard=true: also check claimedBy IS NULL
-        // In real Postgres, the query would return 0 rows affected if any condition fails.
+        // Determine which WHERE conditions the real SQL text actually asserts.
+        const sql = strings.join("?");
+        const requiresClaimedByNull = /"claimedBy"\s+IS\s+NULL/i.test(sql);
 
         // values[0] is claimedBy (the new claimer)
         // values[values.length - 1] is id (the task ID)
@@ -969,11 +966,9 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
 
         const matchesId = row.id === taskId;
         const matchesStatus = row.status === "pending";
-        const matchesClaimedBy = row.claimedBy === null;
+        const matchesClaimedBy = !requiresClaimedByNull || row.claimedBy === null;
 
-        const shouldUpdate = enforceClaimedByGuard
-          ? matchesId && matchesStatus && matchesClaimedBy
-          : matchesId && matchesStatus;
+        const shouldUpdate = matchesId && matchesStatus && matchesClaimedBy;
 
         if (shouldUpdate) {
           // Update succeeds — simulate applying the SET clause by reassigning row
@@ -1023,15 +1018,12 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
   });
 
   it("claim() throws ConflictError when task is pending but claimedBy is already set (defense-in-depth guard)", async () => {
-    // enforceClaimedByGuard=true simulates the post-implementation behavior
-    // where the WHERE clause checks both status='pending' AND claimedBy IS NULL.
     const prisma = makeClaimPrismaDouble(
       makeFullTask({
         id: "task-1",
         status: "pending",
         claimedBy: "agent-original",
       }),
-      true, // enforceClaimedByGuard=true (with the new guard)
     );
     const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
     const service = new TaskService(prisma, clock);

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -1028,15 +1028,9 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
     const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
     const service = new TaskService(prisma, clock);
 
-    try {
-      await service.claim("task-1", "agent-new");
-      expect.unreachable("claim() should have thrown ConflictError");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ConflictError);
-      if (err instanceof ConflictError) {
-        expect(err.message).toContain("already claimed");
-      }
-    }
+    await expect(service.claim("task-1", "agent-new")).rejects.toThrow(
+      ConflictError,
+    );
   });
 
   it("claim() throws NotFoundError when task does not exist", async () => {
@@ -1050,12 +1044,9 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
     const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
     const service = new TaskService(prisma, clock);
 
-    try {
-      await service.claim("task-missing", "agent-1");
-      expect.unreachable("claim() should have thrown NotFoundError");
-    } catch (err) {
-      expect(err).toBeInstanceOf(NotFoundError);
-    }
+    await expect(service.claim("task-missing", "agent-1")).rejects.toThrow(
+      NotFoundError,
+    );
   });
 
   it("claim() throws ConflictError when task status is not pending", async () => {
@@ -1069,15 +1060,8 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
     const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
     const service = new TaskService(prisma, clock);
 
-    try {
-      await service.claim("task-1", "agent-1");
-      expect.unreachable("claim() should have thrown ConflictError");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ConflictError);
-      if (err instanceof ConflictError) {
-        expect(err.message).toContain("already claimed");
-      }
-    }
+    await expect(service.claim("task-1", "agent-1")).rejects.toThrow(
+      ConflictError,
+    );
   });
-
 });

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { computeBlockedBy } from "./blocked-by.ts";
-import { BadRequestError } from "./errors.ts";
+import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
 import type { PrismaClient, Task } from "./index.ts";
 import type { ReadyTaskLike } from "./ready.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
 import { type TaskListFilters, TaskService } from "./task-service.ts";
+import { FixedClock } from "./clock.ts";
 
 // ─── Minimal in-memory stub matching only the logic under test ────────────────
 
@@ -884,4 +885,207 @@ describe("TaskService.distinct() orgs field (unit)", () => {
     expect(result.repos).toEqual([]);
     expect(result.orgs).toEqual([]);
   });
+});
+
+// ─── TaskService.claim() defense-in-depth claimedBy guard ──────────────────
+
+describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
+  /**
+   * makeFullTask — full task object for use in Prisma doubles.
+   */
+  function makeFullTask(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "task-1",
+      title: "A task",
+      status: "pending",
+      source: null,
+      session: null,
+      repo: null,
+      description: null,
+      acceptanceCriteria: [],
+      layer: null,
+      branch: null,
+      dependencies: [],
+      pr: null,
+      hours: null,
+      addedAt: null,
+      startedAt: null,
+      prCreatedAt: null,
+      mergedAt: null,
+      blockedAt: null,
+      blockedReason: null,
+      note: null,
+      type: null,
+      priority: null,
+      cancelledAt: null,
+      completedAt: null,
+      deployingAt: null,
+      ciFixAttempts: null,
+      mergeCommit: null,
+      prUrl: null,
+      assignee: null,
+      issue: null,
+      model: null,
+      complexity: null,
+      hitl: null,
+      claimedBy: null,
+      agentHint: null,
+      claimedAt: null,
+      heartbeatAt: null,
+      createdAt: new Date("2026-08-10T12:00:00.000Z"),
+      updatedAt: new Date("2026-08-10T12:00:00.000Z"),
+      ...overrides,
+    } as Task;
+  }
+
+  /**
+   * makeClaimPrismaDouble — simulates claim() behavior with an in-memory row.
+   * The double allows configuring whether to enforce the claimedBy=null guard.
+   * When enforceClaimedByGuard=true, the double checks both status AND claimedBy IS NULL.
+   * When enforceClaimedByGuard=false, it only checks status (simulating the old behavior).
+   * Also implements task.findUnique to support the existing 404-vs-409 disambiguation.
+   */
+  function makeClaimPrismaDouble(
+    initialTask: Task,
+    enforceClaimedByGuard = true,
+  ) {
+    // In-memory row state — must be let because $executeRaw mutates it
+    let row = { ...initialTask };
+
+    const prisma = {
+      async $executeRaw(
+        strings: TemplateStringsArray,
+        ...values: unknown[]
+      ): Promise<number> {
+        // Simulate the WHERE clause in claim():
+        // - always check: id matches AND status = 'pending'
+        // - when enforceClaimedByGuard=true: also check claimedBy IS NULL
+        // In real Postgres, the query would return 0 rows affected if any condition fails.
+
+        // values[0] is claimedBy (the new claimer)
+        // values[values.length - 1] is id (the task ID)
+        const newClaimedBy = values[0] as string;
+        const taskId = values[values.length - 1] as string;
+
+        const matchesId = row.id === taskId;
+        const matchesStatus = row.status === "pending";
+        const matchesClaimedBy = row.claimedBy === null;
+
+        const shouldUpdate = enforceClaimedByGuard
+          ? matchesId && matchesStatus && matchesClaimedBy
+          : matchesId && matchesStatus;
+
+        if (shouldUpdate) {
+          // Update succeeds — simulate applying the SET clause by reassigning row
+          row = {
+            ...row,
+            status: "in_progress",
+            claimedBy: newClaimedBy,
+            claimedAt: new Date().toISOString(),
+            heartbeatAt: new Date().toISOString(),
+            startedAt: row.startedAt ?? new Date().toISOString(),
+            updatedAt: new Date(),
+          };
+          return 1; // 1 row affected
+        }
+        // WHERE clause did not match — no rows affected
+        return 0;
+      },
+      task: {
+        findUnique({ where }: { where: { id: string } }): Promise<Task | null> {
+          if (where.id === row.id) {
+            return Promise.resolve({ ...row });
+          }
+          return Promise.resolve(null);
+        },
+      },
+    };
+
+    return prisma as unknown as PrismaClient;
+  }
+
+  it("claim() succeeds when task is pending with claimedBy=null (happy path)", async () => {
+    const prisma = makeClaimPrismaDouble(
+      makeFullTask({
+        id: "task-1",
+        status: "pending",
+        claimedBy: null,
+      }),
+    );
+    const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
+    const service = new TaskService(prisma, clock);
+
+    const result = await service.claim("task-1", "agent-1");
+
+    expect(result.id).toBe("task-1");
+    expect(result.status).toBe("in_progress");
+    expect(result.claimedBy).toBe("agent-1");
+  });
+
+  it("claim() throws ConflictError when task is pending but claimedBy is already set (defense-in-depth guard)", async () => {
+    // enforceClaimedByGuard=true simulates the post-implementation behavior
+    // where the WHERE clause checks both status='pending' AND claimedBy IS NULL.
+    const prisma = makeClaimPrismaDouble(
+      makeFullTask({
+        id: "task-1",
+        status: "pending",
+        claimedBy: "agent-original",
+      }),
+      true, // enforceClaimedByGuard=true (with the new guard)
+    );
+    const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
+    const service = new TaskService(prisma, clock);
+
+    try {
+      await service.claim("task-1", "agent-new");
+      expect.unreachable("claim() should have thrown ConflictError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConflictError);
+      if (err instanceof ConflictError) {
+        expect(err.message).toContain("already claimed");
+      }
+    }
+  });
+
+  it("claim() throws NotFoundError when task does not exist", async () => {
+    const prisma = makeClaimPrismaDouble(
+      makeFullTask({
+        id: "task-1",
+        status: "pending",
+        claimedBy: null,
+      }),
+    );
+    const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
+    const service = new TaskService(prisma, clock);
+
+    try {
+      await service.claim("task-missing", "agent-1");
+      expect.unreachable("claim() should have thrown NotFoundError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NotFoundError);
+    }
+  });
+
+  it("claim() throws ConflictError when task status is not pending", async () => {
+    const prisma = makeClaimPrismaDouble(
+      makeFullTask({
+        id: "task-1",
+        status: "in_progress",
+        claimedBy: null,
+      }),
+    );
+    const clock = FixedClock(new Date("2026-08-10T12:00:00.000Z"));
+    const service = new TaskService(prisma, clock);
+
+    try {
+      await service.claim("task-1", "agent-1");
+      expect.unreachable("claim() should have thrown ConflictError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConflictError);
+      if (err instanceof ConflictError) {
+        expect(err.message).toContain("already claimed");
+      }
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary
- Tighten `TaskService.claim()`'s atomic UPDATE `WHERE` clause to also require `"claimedBy" IS NULL`, so the "pending implies claimedBy null" invariant is enforced inside `claim()` itself instead of relying on every other write path (`release()`, `StaleClaimReaper`, the TPL-1.1 route-level PATCH denylist) to uphold it.
- A task with `status='pending'` and a non-null `claimedBy` now fails to claim (`ConflictError`, 409) instead of silently overwriting the existing claim.
- Added unit test coverage for the guard, the unchanged happy path, and the existing 404/409 disambiguation — verified the new guard test actually regresses (fails) when the WHERE clause fix is reverted, confirming it's not a tautological test.
- Refreshed `docs/task-store.md`'s `POST /tasks/:id/claim` description to reflect the tightened WHERE clause.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `claim()`'s raw SQL adds `AND "claimedBy" IS NULL` to WHERE clause | MET |
| 2 | pending+non-null-claimedBy no longer claimable, throws ConflictError | MET |
| 3 | Normal claim (pending+null claimedBy → success) unchanged; existing tests pass unmodified | MET |
| 4 | One new unit test added for the guard case; no existing tests retired | MET |

## Test Plan
- `bun test task-store/src/task-service.unit.test.ts` — 43/43 pass (4 new tests: happy path, claimedBy guard, not-found, non-pending status)
- Manually verified regression detection: reverted the WHERE clause guard locally, confirmed the new ConflictError test fails; restored the fix, confirmed it passes again
- `task typecheck` and `task lint` — clean
- `task ci` (full monorepo `test:coverage` gate) — 1 unrelated pre-existing failure in `task-store/src/routes/prs.openapi.smoke.test.ts` (a `validateRepo`/`repos.includes` cross-suite test-isolation flake, unrelated to this change — doesn't touch `prs.ts`, doesn't reproduce when that test file runs in isolation, and reproduces identically on `main` under the same full-suite conditions)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
