### PR TITLE
fix: add job-level timeout-minutes to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-bump-chart.yml
+++ b/.github/workflows/auto-bump-chart.yml
@@ -136,6 +136,7 @@ jobs:
   # completes (not merely starts).
   debounce:
     name: debounce burst of release tags
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     # This job only sleeps — it never touches the repo, so it needs none of
     # the workflow-level contents:write / pull-requests:write permissions.
@@ -155,6 +156,7 @@ jobs:
   bump-chart:
     name: bump chart version
     needs: debounce
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       contents: write      # push branch + commit

--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -16,6 +16,7 @@ jobs:
   filter:
     name: filter changed paths
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -50,6 +51,7 @@ jobs:
     name: build / tag / push
     needs: filter
     if: needs.filter.outputs.changed == 'true'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       packages: write # docker/login-action push to GHCR

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -16,6 +16,7 @@ jobs:
   filter:
     name: filter changed paths
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -51,6 +52,7 @@ jobs:
     name: build / tag / push
     needs: filter
     if: needs.filter.outputs.changed == 'true'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       packages: write # docker/login-action push to GHCR

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -16,6 +16,7 @@ jobs:
   filter:
     name: filter changed paths
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -50,6 +51,7 @@ jobs:
     name: build / tag / push
     needs: filter
     if: needs.filter.outputs.changed == 'true'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       packages: write # docker/login-action push to GHCR

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -16,6 +16,7 @@ jobs:
   filter:
     name: filter changed paths
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -50,6 +51,7 @@ jobs:
     name: build / tag / push
     needs: filter
     if: needs.filter.outputs.changed == 'true'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       packages: write # docker/login-action push to GHCR

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -16,6 +16,7 @@ jobs:
   filter:
     name: filter changed paths
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -50,6 +51,7 @@ jobs:
     name: build / tag / push
     needs: filter
     if: needs.filter.outputs.changed == 'true'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       packages: write # docker/login-action push to GHCR

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -16,6 +16,7 @@ jobs:
   filter:
     name: filter changed paths
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -50,6 +51,7 @@ jobs:
     name: build / tag / push
     needs: filter
     if: needs.filter.outputs.changed == 'true'
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       packages: write # docker/login-action push to GHCR

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -52,6 +52,7 @@ jobs:
   publish:
     name: package + publish (gh-pages)
     if: github.event_name == 'push'
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     concurrency:
       group: chart-release
@@ -129,6 +130,7 @@ jobs:
   dry-run:
     name: package + index (dry run)
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/check-chart-drift.yml
+++ b/.github/workflows/check-chart-drift.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   check-drift:
     name: check chart pins against latest release tags
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   # running them unnecessarily.
   changes:
     name: Detect changed paths
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       app: ${{ steps.filter.outputs.app }}
@@ -76,6 +77,7 @@ jobs:
 
   ci:
     name: lint / typecheck / test
+    timeout-minutes: 8
     runs-on: ubuntu-latest
     needs: changes
     # always() so this still runs (fail-open) if the changes job itself
@@ -177,6 +179,7 @@ jobs:
 
   site:
     name: site build / brand-lint / smoke
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
@@ -206,6 +209,7 @@ jobs:
 
   admin-docker-build:
     name: admin docker build
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
@@ -219,6 +223,7 @@ jobs:
 
   agent-docker-build:
     name: agent docker build
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
@@ -253,6 +258,7 @@ jobs:
 
   metrics-docker-build:
     name: metrics docker build
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.app == 'true')
@@ -266,6 +272,7 @@ jobs:
 
   e2e:
     name: e2e (metrics dashboard)
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: ci
     steps:
@@ -293,6 +300,7 @@ jobs:
 
   admin-e2e:
     name: e2e (admin UI)
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: ci
     steps:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   deploy:
     name: build + deploy (gh-pages)
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write # push site/dist to gh-pages

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -23,6 +23,7 @@ jobs:
   # Fast, no-cluster gate: lint + unit tests + schema validation.
   helm-checks:
     name: helm lint / unittest / validate
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -79,6 +80,7 @@ jobs:
   # variant, running `helm test` against each install.
   helm-e2e:
     name: ct install (kind)
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   lint-pr-title:
     name: Conventional-Commit PR title
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5 (post-v5.5.2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   guard:
     name: Admin check
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Assert actor is admin
@@ -34,6 +35,7 @@ jobs:
 
   release:
     name: semantic-release
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: guard
     steps:

--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -92,6 +92,7 @@ permissions:
 jobs:
   sync-version:
     name: sync plugin version
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       # Check out main (not the tag's commit) so we always sync from the


### PR DESCRIPTION
## Summary
- Adds job-level `timeout-minutes` to all 32 jobs across 15 GitHub Actions workflow files that were missing one, closing an entropy patrol finding (`workflow_job_timeout`, medium severity).
- Values follow the fix guidance's categorization: 8m for the unit/integration/smoke test job (`ci`), 20m for e2e and docker/image build jobs, 15m for release/version-bump automation, 30m for deploy/helm/infra jobs, and 10m for everything else (path filters, PR-title lint, drift checks).
- No behavior change — these are safety caps that only trigger if a job hangs past its expected runtime.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Every job across the 32 findings gets a job-level `timeout-minutes` | MET | `grep -rn "^    timeout-minutes:" .github/workflows/*.yml \| wc -l` → 32, matching the finding count exactly |
| 2 | Timeout values follow the fix guidance's category buckets (test/e2e/build/release/other) | MET | Each job's steps were inspected individually and classified before assigning a value (see commit message) |
| 3 | No unrelated changes | MET | `git diff --stat` shows only additive `timeout-minutes:` lines, 32 insertions across 15 files |

## Test Plan
- [x] Parsed every modified workflow file with `js-yaml` to confirm valid YAML and that every job now has `timeout-minutes` set
- [x] `task lint` passes
- [x] `task typecheck` passes
- [x] `task check-config-docs` passes
- [x] `task check-strings` passes
- [x] Docs pass (docs-refresher agent found no stale references — these are operational config changes with no documented behavior contract)

Generated with [Claude Code](https://claude.com/claude-code)
