### PR TITLE
refactor: consolidate duplicated readJson helper into lib/http

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.131.0",
+      "version": "1.136.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -100,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.131.0",
+      "version": "1.136.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.131.0",
+      "version": "1.136.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/chat/src/routes/messages.ts
+++ b/chat/src/routes/messages.ts
@@ -25,6 +25,7 @@
  */
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { readJson } from "@shipwright/lib/http";
 import type { ChatAuthEnv } from "../auth.ts";
 import {
   BadRequestError,
@@ -40,20 +41,6 @@ import { parseIntParam } from "./utils.ts";
 
 /** Maximum allowed size for message attachment bytes (10 MB). */
 export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
-
-async function readJson(c: {
-  req: { json: () => Promise<unknown> };
-}): Promise<Record<string, unknown>> {
-  try {
-    const body = await c.req.json();
-    if (body && typeof body === "object" && !Array.isArray(body)) {
-      return body as Record<string, unknown>;
-    }
-    return {};
-  } catch {
-    return {};
-  }
-}
 
 // ─── Route-local schemas ──────────────────────────────────────────────────────
 

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,14 @@
+/** Parses a request body as a JSON object, returning `{}` on any error or non-object shape. */
+export async function readJson(c: {
+  req: { json: () => Promise<unknown> };
+}): Promise<Record<string, unknown>> {
+  try {
+    const body = await c.req.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      return body as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}

--- a/lib/http.unit.test.ts
+++ b/lib/http.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readJson } from "./http.ts";
+
+describe("readJson — valid bodies", () => {
+  test("returns the parsed object when the body is a plain object", async () => {
+    const c = { req: { json: async () => ({ foo: "bar" }) } };
+    expect(await readJson(c)).toEqual({ foo: "bar" });
+  });
+
+  test("returns an empty object when the body is an empty object", async () => {
+    const c = { req: { json: async () => ({}) } };
+    expect(await readJson(c)).toEqual({});
+  });
+});
+
+describe("readJson — invalid bodies", () => {
+  test("returns {} when the body is an array", async () => {
+    const c = { req: { json: async () => [1, 2, 3] } };
+    expect(await readJson(c)).toEqual({});
+  });
+
+  test("returns {} when the body is a string primitive", async () => {
+    const c = { req: { json: async () => "not an object" } };
+    expect(await readJson(c)).toEqual({});
+  });
+
+  test("returns {} when the body is null", async () => {
+    const c = { req: { json: async () => null } };
+    expect(await readJson(c)).toEqual({});
+  });
+
+  test("returns {} when req.json() throws", async () => {
+    const c = {
+      req: {
+        json: async () => {
+          throw new Error("invalid JSON");
+        },
+      },
+    };
+    expect(await readJson(c)).toEqual({});
+  });
+});

--- a/lib/package.json
+++ b/lib/package.json
@@ -8,6 +8,7 @@
     "./agent-default-tools": "./agent-default-tools.ts",
     "./claim-ttl": "./claim-ttl.ts",
     "./github-login": "./github-login.ts",
+    "./http": "./http.ts",
     "./org-repo": "./org-repo.ts",
     "./pricing": "./pricing.ts",
     "./request-context": "./request-context.ts",

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -26,6 +26,7 @@
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { readJson } from "@shipwright/lib/http";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, NotFoundError } from "../errors.ts";
 import type { PullRequest } from "../index.ts";
@@ -43,20 +44,6 @@ import {
 } from "../openapi-schemas.ts";
 import type { PullRequestServiceLike } from "../pull-request-service.ts";
 import { isOrgRepo } from "../validate.ts";
-
-async function readJson(c: {
-  req: { json: () => Promise<unknown> };
-}): Promise<Record<string, unknown>> {
-  try {
-    const body = await c.req.json();
-    if (body && typeof body === "object" && !Array.isArray(body)) {
-      return body as Record<string, unknown>;
-    }
-    return {};
-  } catch {
-    return {};
-  }
-}
 
 // repos === null means admin token — bypass scope check; still enforce format.
 function validateRepo(repo: unknown, repos: string[] | null): void {

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -35,6 +35,7 @@
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { readJson } from "@shipwright/lib/http";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.ts";
 import type { Prisma } from "../index.ts";
@@ -54,20 +55,6 @@ import {
 } from "../openapi-schemas.ts";
 import type { TaskServiceLike } from "../task-service.ts";
 import { isOrgRepo } from "../validate.ts";
-
-async function readJson(c: {
-  req: { json: () => Promise<unknown> };
-}): Promise<Record<string, unknown>> {
-  try {
-    const body = await c.req.json();
-    if (body && typeof body === "object" && !Array.isArray(body)) {
-      return body as Record<string, unknown>;
-    }
-    return {};
-  } catch {
-    return {};
-  }
-}
 
 // Fields that gate task claim ownership. Agent tokens must go through the
 // dedicated /claim and /release routes to change these — never generic PATCH.


### PR DESCRIPTION
## Summary
- Extract the byte-identical `readJson()` helper duplicated across `task-store/src/routes/tasks.ts`, `task-store/src/routes/prs.ts`, and `chat/src/routes/messages.ts` into a new shared `lib/http.ts` module.
- Export it via `lib/package.json`'s `./http` entry, following the existing one-file-per-concern convention (`org-repo.ts`, `github-login.ts`, etc.).
- Replace all three local definitions with `import { readJson } from "@shipwright/lib/http";`.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Add a `readJson` export to a new or existing lib/ module | MET | `lib/http.ts` |
| 2 | Update task-store/src/routes/tasks.ts to import the shared helper | MET | import added, local def removed |
| 3 | Update task-store/src/routes/prs.ts to import the shared helper | MET | import added, local def removed |
| 4 | Update chat/src/routes/messages.ts to import the shared helper | MET | import added, local def removed |
| 5 | Delete the three local copies | MET | no duplicate definitions remain |
| 6 | Test coverage per repo convention | MET | `lib/http.unit.test.ts`, 6 cases |

## Test Plan
- `lib/http.unit.test.ts` — 6/6 pass (valid object, empty object, array, string primitive, null, throwing `json()`)
- `bun test lib/ chat/ task-store/` — all pass
- `task typecheck` — all 7 workspaces pass
- `task lint` / `task check-strings` — pass
- `task ci` (`test:coverage`) — 1 pre-existing, unrelated failure (`agent/src/claude.unit.test.ts` extraAllowedTools sandbox flake, reproduces on clean main) — everything else green
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
