### PR TITLE
fix: suppress zizmor findings already accepted-risk in .github/zizmor.yml

### DIFF
--- a/plugins/shipwright/skills/security-scan/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/security-scan/SKILL.content.test.ts
@@ -352,6 +352,107 @@ describe("SKILL.md — osv-cve authoritative for bun.lock dependency CVEs", () =
   });
 });
 
+describe("SKILL.md — Step 3.5a zizmor.yml suppression filter", () => {
+  it("has a Step 3.5a subsection for suppressing zizmor findings covered by .github/zizmor.yml", () => {
+    expect(content).toContain("3.5a");
+    expect(content).toContain(".github/zizmor.yml");
+  });
+
+  it("is positioned between Step 3.5 and Step 4 (scoped to zizmor specifically)", () => {
+    const start = content.indexOf("### 3.5a");
+    const step35End = content.indexOf(
+      "If the repo has no `.github/workflows/` directory",
+    );
+    const step4Start = content.indexOf("## Step 4:");
+    expect(start).toBeGreaterThan(-1);
+    expect(step35End).toBeGreaterThan(-1);
+    expect(step4Start).toBeGreaterThan(-1);
+    expect(start).toBeGreaterThan(step35End);
+    expect(start).toBeLessThan(step4Start);
+  });
+
+  it("explains zizmor's own line-based ignore matching is unreliable due to line drift", () => {
+    const text = content.toLowerCase();
+    const hasDrift =
+      text.includes("line drift") || text.includes("line-based");
+    const hasUnreliable =
+      text.includes("unreliable") || text.includes("fragile");
+    expect(hasDrift).toBe(true);
+    expect(hasUnreliable).toBe(true);
+  });
+
+  it("instructs skipping the filter entirely when .github/zizmor.yml does not exist", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    expect(section.toLowerCase()).toContain("does not exist");
+    expect(section.toLowerCase()).toContain("skip");
+  });
+
+  it("documents parsing ignore entries into rule/file/line/stepName tuples", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    expect(section).toContain("stepName");
+  });
+
+  it("documents a small line tolerance for matching (e.g. ±5 lines)", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    expect(section.toLowerCase()).toContain("tolerance");
+    expect(section).toContain("5");
+  });
+
+  it("documents re-resolving the ignore entry's line via the named step comment as a fallback match", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    expect(section.toLowerCase()).toContain("step name");
+  });
+
+  it("documents that a non-matching rule+file keeps the finding (not suppressed)", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    expect(section.toLowerCase()).toContain("not suppressed");
+  });
+
+  it("documents that suppressed findings are dropped before Step 6 and never reach the report or ledger", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    const text = section.toLowerCase();
+    expect(text).toContain("step 6");
+    expect(text.includes("security-report.md") || text.includes("report")).toBe(
+      true,
+    );
+    expect(text).toContain("ledger");
+  });
+
+  it("references the live ignore-entry format from this repo's own .github/zizmor.yml", () => {
+    const section = content.slice(
+      content.indexOf("### 3.5a"),
+      content.indexOf("## Step 4:"),
+    );
+    expect(section).toContain("auto-bump-chart.yml:178");
+  });
+
+  it("cross-references the zizmor suppression filter at the top of Step 6", () => {
+    const step6Section = content.slice(
+      content.indexOf("## Step 6:"),
+      content.indexOf("## Step 7:"),
+    );
+    expect(step6Section.toLowerCase()).toContain("3.5a");
+  });
+});
+
 describe("SKILL.md — ledger classification with repo-namespaced keys", () => {
   it("references the security-patrol ledger location", () => {
     expect(content).toContain("state/security-patrol-ledger.json");

--- a/plugins/shipwright/skills/security-scan/SKILL.md
+++ b/plugins/shipwright/skills/security-scan/SKILL.md
@@ -272,6 +272,48 @@ tar -xz -f "$TOOLS_DIR/zizmor.tar.gz" -C "$TOOLS_DIR" zizmor
 If the repo has no `.github/workflows/` directory, record "no workflows to scan" — not a
 failure.
 
+### 3.5a Suppress zizmor Findings Already Covered by `.github/zizmor.yml`
+
+zizmor supports its own `ignore` config in `.github/zizmor.yml`, keyed by exact `file:line`.
+That native matching is fragile for this purpose: it pins an **exact line number**, and any
+commit that shifts lines above an ignored step — even an unrelated change elsewhere in the
+workflow file — moves the finding to a new line and breaks the exact match. When that
+happens, a finding a human already reviewed and explicitly accepted as risk silently
+resurfaces in `zizmor-report.json` as if it were new, purely from line drift, not from any
+change to the risk decision itself. This step applies a drift-tolerant suppression filter on
+top of zizmor's raw output before any zizmor finding reaches Step 6 — so a reader skimming
+Step 6 should know zizmor findings have already been filtered by the time they get there.
+
+1. **No `.github/zizmor.yml`.** If the file does not exist in the repo, skip this filter
+   entirely — proceed with every zizmor finding unfiltered.
+2. **Parse ignore entries.** If it exists, parse every rule's `ignore` list into
+   `{rule, file, line, stepName}` tuples. Each entry is `{file}:{line}` followed by a
+   trailing `# "Step Name" — reason` comment — the step name is the quoted text immediately
+   after the `#`. For example, this repo's own `.github/zizmor.yml` has entries like:
+   ```
+   artipacked:
+     ignore:
+       - auto-bump-chart.yml:178 # "Checkout main" — pushed from by `git push -u origin "$BRANCH"`
+   ```
+   which parses to `{rule: "artipacked", file: "auto-bump-chart.yml", line: 178, stepName: "Checkout main"}`.
+3. **Match each zizmor finding against the parsed tuples**, rule+file first:
+   - No rule+file match in the ignore list → keep the finding; it is not suppressed.
+   - Rule+file match found → treat it as the same accepted-risk step (and suppress it) when
+     **either**:
+     (a) the finding's line is within a small tolerance of the ignore entry's line (±5
+     lines), **or**
+     (b) re-reading the named workflow file confirms a step named `stepName` still exists
+     at/near the finding's actual line (handles drift larger than the tolerance).
+   - If neither holds — the named step is gone or renamed — do **not** suppress. Let the
+     finding proceed normally; it may be a genuinely new or different finding at that
+     location, not the same accepted-risk decision.
+4. **Suppressed findings are dropped here, before Step 6.** A suppressed finding gets no
+   finding record at all — it never appears in `security-report.md` (Step 8) and is never
+   diffed against the ledger (Step 7). Step 7's existing "present in ledger as unresolved but
+   absent from this run ⇒ resolved" logic already handles the case where a finding that used
+   to be unresolved becomes suppressed on a later run — no additional ledger-side logic is
+   needed for that transition.
+
 ---
 
 ## Step 4: Tier 2 — LLM-Driven authn/authz + Hardcoded-Credential Checks
@@ -319,6 +361,10 @@ Presence/configuration checks, each recorded as a finding when **absent/misconfi
 ---
 
 ## Step 6: Finding-Record Shape
+
+zizmor findings reach this step only after passing the Step 3.5a suppression filter —
+anything matching an accepted-risk entry in `.github/zizmor.yml` was already dropped and
+never gets a record here.
 
 All findings from Tier 1, Tier 2, and Tier 3 use one common record shape:
 
@@ -524,6 +570,10 @@ SECURITY SCAN COMPLETE
   verification — treat an unverifiable tool as unavailable (fallback) instead.
 - **Trivy stays excluded.** Do not reintroduce Trivy (GHSA-69fq-xp46-6x23) without an explicit
   security review; Grype + Syft cover container CVE + SBOM.
+- **Never report a zizmor finding already suppressed in `.github/zizmor.yml`.** Step 3.5a's
+  drift-tolerant match runs before any zizmor finding reaches Step 6 — a finding matching an
+  accepted-risk ignore entry is dropped, not merely deprioritized, and must never appear in
+  `security-report.md` or the ledger.
 - **Repo-namespaced IDs, always.** Every ledger key and finding ID is
   `security-{rule}-{repo-slug}-{YYYY-Www}` — never `{rule}-{YYYY-Www}` — so same-week
   multi-repo runs never collide (the `entropy-fix` task-ID collision bug).


### PR DESCRIPTION
## Summary
- Adds Step 3.5a to `security-scan`'s SKILL.md: parse `.github/zizmor.yml`'s `ignore` entries and suppress any zizmor finding whose rule+file already has a matching accepted-risk entry, tolerating line drift (±5 lines, or by re-resolving the entry's named step).
- Suppressed findings are dropped before Step 6 (finding-record shape) — they never reach `security-report.md` or the ledger, so `security-fix` (which only reads `security-report.md`) never files a task for them.
- Adds a `SKILL.content.test.ts` describe block asserting Step 3.5a's presence, positioning, and required content.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | security-scan checks .github/zizmor.yml ignore entries before filing a zizmor finding | MET | SKILL.md Step 3.5a |
| 2 | A finding matching artipacked.ignore (or other rule lists) is not filed as a new task | MET | Step 3.5a §4: suppressed findings dropped before Step 6, never reach security-report.md or the ledger |
| 3 | Existing already-blocked security-zizmor-lint-shipwright-* tasks are not re-created | MET | Suppression happens before Step 6/7; Step 7's existing "absent from run ⇒ resolved" ledger logic handles the transition |

## Test Plan
- [x] `bun test plugins/shipwright/skills/security-scan/SKILL.content.test.ts` — 73 pass
- [x] `task check-version-sync`, `task secret-scan` (local, gitleaks unavailable) — pass
- [x] `task test:coverage` — 1 pre-existing, unrelated failure (`extraAllowedTools` in `agent/src/claude.unit.test.ts`), confirmed reproducing on unmodified `main`
- [x] Independent spec-compliance review: all 3 acceptance criteria MET

Generated with [Claude Code](https://claude.com/claude-code)
