### PR TITLE
feat: add bundle-incomplete gate before patch.md CI-fix dispatch (PH-1.1)

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -768,6 +768,92 @@ describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation a
     const otherwiseSection = section.slice(otherwiseIdx);
     expect(otherwiseSection).toContain("Step 6c");
   });
+
+  it("otherwise branch hands off to Step 6b.7, not straight to 6c", () => {
+    const section = getStep6b6Section();
+    const otherwiseIdx = section.indexOf("**Otherwise**");
+    expect(otherwiseIdx).toBeGreaterThan(-1);
+    const otherwiseSection = section.slice(otherwiseIdx);
+    expect(otherwiseSection).toContain("Step 6b.7");
+  });
+});
+
+describe("patch.md — bundle-incomplete self-check before CI-fix dispatch (PH-1.1)", () => {
+  function getStep6b7Section() {
+    const step6b7Idx = content.indexOf(
+      "### Step 6b.7: Bundle Completeness Gate (PH-1.1)",
+    );
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b7Idx).toBeGreaterThan(-1);
+    expect(step6cIdx).toBeGreaterThan(-1);
+    return content.slice(step6b7Idx, step6cIdx);
+  }
+
+  it("Step 6b.7 exists between Step 6b.6 (escalation check) and Step 6c (dispatch)", () => {
+    const step6b6Idx = content.indexOf(
+      "### Step 6b.6: Escalation Check (CFE-1.1)",
+    );
+    const step6b7Idx = content.indexOf(
+      "### Step 6b.7: Bundle Completeness Gate (PH-1.1)",
+    );
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b6Idx).toBeGreaterThan(-1);
+    expect(step6b7Idx).toBeGreaterThan(step6b6Idx);
+    expect(step6cIdx).toBeGreaterThan(step6b7Idx);
+  });
+
+  it("re-queries /tasks?branch= and checks for pending/in_progress/blocked statuses, matching isBundleComplete's signal", () => {
+    const section = getStep6b7Section();
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks?branch=");
+    expect(section).toContain('"pending"');
+    expect(section).toContain('"in_progress"');
+    expect(section).toContain('"blocked"');
+  });
+
+  it("uses {branch} already in scope rather than re-deriving HEAD_BRANCH via gh pr view again", () => {
+    const section = getStep6b7Section();
+    expect(section).not.toContain("gh pr view");
+    expect(section).not.toContain("headRefName");
+  });
+
+  it("contains [silent] and the fully-interpolated [skip-reason:patch:deferred:bundle-incomplete:{branch}] marker", () => {
+    const section = getStep6b7Section();
+    expect(section).toContain("[silent]");
+    expect(section).toContain(
+      "[skip-reason:patch:deferred:bundle-incomplete:",
+    );
+    expect(section).toContain(
+      "[skip-reason:patch:deferred:bundle-incomplete:{branch}]",
+    );
+  });
+
+  it("does not require a specific ordering between [skip-reason:...] and [silent]", () => {
+    const section = getStep6b7Section();
+    expect(section).toContain("does not matter");
+  });
+
+  it("releases the Step 6b.5 pre-work claim before stopping", () => {
+    const section = getStep6b7Section();
+    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+  });
+
+  it("fully stops the command on incomplete bundle rather than continuing to the next PR in List D (unlike Step 6b.6)", () => {
+    const section = getStep6b7Section();
+    expect(section).not.toContain("next PR in List D");
+    expect(section).not.toContain("Step 7");
+    const hasStopLanguage =
+      /stop\s+here/is.test(section) || /stop\s+the\s+command/is.test(section);
+    expect(hasStopLanguage).toBe(true);
+  });
+
+  it("otherwise branch (bundle complete) proceeds to Step 6c and does not emit [silent]", () => {
+    const section = getStep6b7Section();
+    const otherwiseIdx = section.indexOf("**Otherwise**");
+    expect(otherwiseIdx).toBeGreaterThan(-1);
+    const otherwiseSection = section.slice(otherwiseIdx);
+    expect(otherwiseSection).toContain("Step 6c");
+    expect(otherwiseSection).not.toContain("[silent]");
+  });
 });
 
 describe("patch.md — shared patch model tier resolution (MTR-2.1)", () => {

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1378,9 +1378,9 @@ same signal before dispatch is ever considered — but that filter only guards t
 bypasses `check-patch.ts` entirely, and time can also pass between candidate selection and
 this point in the run (a bundle-mate task can start, or get blocked, after this PR was
 selected). Mirror deploy.md's Step 2b here, immediately before Step 6c's dispatch, so an
-incomplete bundle is caught on both paths — this is where the vitals-os#3558 incident
-actually happened: re-query the same sibling-branch-status signal now, right before
-dispatching the CI-fix subagent, rather than trusting the state candidate selection saw.
+incomplete bundle is caught on both paths — this is where a prior CI-fix-on-an-incomplete-
+bundle incident actually happened: re-query the same sibling-branch-status signal now, right
+before dispatching the CI-fix subagent, rather than trusting the state candidate selection saw.
 
 ```bash
 BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={branch}" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1368,7 +1368,55 @@ decision already recorded on the PR.
 
 **Otherwise** (neither the PR record has `blocked: true` nor its linked task has
 `status: 'blocked'`): no escalation
-is on record for this PR — proceed normally to Step 6c.
+is on record for this PR — proceed to Step 6b.7.
+
+### Step 6b.7: Bundle Completeness Gate (PH-1.1)
+
+`check-patch.ts`'s `isBundleComplete` (CPB-1.1) already filters this PR's candidacy on the
+same signal before dispatch is ever considered — but that filter only guards the
+`shipwright-loop`-driven path. A human running `/shipwright:patch org/repo#123` directly
+bypasses `check-patch.ts` entirely, and time can also pass between candidate selection and
+this point in the run (a bundle-mate task can start, or get blocked, after this PR was
+selected). Mirror deploy.md's Step 2b here, immediately before Step 6c's dispatch, so an
+incomplete bundle is caught on both paths — this is where the vitals-os#3558 incident
+actually happened: re-query the same sibling-branch-status signal now, right before
+dispatching the CI-fix subagent, rather than trusting the state candidate selection saw.
+
+```bash
+BRANCH_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={branch}" 2>/dev/null || echo '{"tasks":[],"total":0,"limit":50,"offset":0}')
+INCOMPLETE_TASKS=$(echo "$BRANCH_TASKS" | jq '[.tasks[] | select(.status == "pending" or .status == "in_progress" or .status == "blocked") | {id, status}]')
+INCOMPLETE=$(echo "$INCOMPLETE_TASKS" | jq 'length')
+```
+
+**If `INCOMPLETE > 0`** (one or more bundle-mate tasks on this branch are still in flight):
+do NOT dispatch the fix subagent — a CI-fix pushed now would land on top of a branch that
+other tasks are still actively developing.
+
+1. Release the pre-work claim from Step 6b.5 — no fix is in flight, this cycle intentionally
+   stops short of dispatching one:
+   ```bash
+   curl -s -o /dev/null -X POST \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+   ```
+2. Print:
+   ```
+   ⏸ Bundle gate: {INCOMPLETE} task(s) on branch {branch} are still in flight:
+     {for each item in INCOMPLETE_TASKS: "  - {id} ({status})"}
+     Deferring CI-fix dispatch until bundle-mates reach pr_open.
+   ```
+3. Stop here. `patch.md` is explicit-single-PR-target-only (WLS-3.3) — there is no other
+   candidate to fall back to, so this fully stops the command rather than moving on to
+   another PR the way Step 6b.6 does. Emit `[skip-reason:patch:deferred:bundle-incomplete:{branch}]`
+   alongside `[silent]` (interpolating `{branch}` from the value already in scope) — order
+   relative to `[silent]` does not matter, both are recognized regardless of position. The
+   skip-reason marker records exactly which branch's bundle gate blocked this dispatch in the
+   `AgentCronRun.skipReason` field, visible in the admin cron-logs UI, instead of the generic
+   `command:no-work` reason the loop orchestrator falls back to for silent dispatches that
+   don't tag a specific reason.
+
+**Otherwise** (`INCOMPLETE == 0` — no tasks tracked on this branch, or all tasks are past
+`pending`/`in_progress`/`blocked`): the bundle is complete — proceed to Step 6c.
 
 ### Step 6c: Dispatch Fix Subagent
 


### PR DESCRIPTION
## Summary
- Add a new `Step 6b.7: Bundle Completeness Gate (PH-1.1)` to `patch.md`, placed immediately before Step 6c's CI-fix subagent dispatch — mirroring `deploy.md`'s Step 2b bundle-completeness re-check.
- Re-queries the same sibling-branch-status signal `check-patch.ts`'s `isBundleComplete` (CPB-1.1) uses (`GET /tasks?branch={branch}`, incomplete if any task is `pending`/`in_progress`/`blocked`). When incomplete, releases the Step 6b.5 pre-work claim and stops the command with `[silent]` + `[skip-reason:patch:deferred:bundle-incomplete:{branch}]` instead of dispatching the CI-fix subagent.
- This protects the direct-invocation path (`/shipwright:patch org/repo#123` run by a human bypasses `check-patch.ts`'s candidate filter entirely) as well as the window between candidate selection and dispatch in the loop-driven path — this is where the vitals-os#3558 incident happened.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New pre-Step-6 check re-queries the isBundleComplete (CPB-1.1) signal | MET | Step 6b.7 queries `/tasks?branch={branch}`, checks `pending`/`in_progress`/`blocked`, matching `check-helpers.ts`'s `createBundleCompleteQuery` |
| 2 | Stops with `[silent]` + `[skip-reason:patch:deferred:bundle-incomplete:{branch}]`, no CI-fix dispatch | MET | Step 6b.7 releases the claim, prints a status message, emits both markers, and does not proceed to Step 6c |
| 3 | New content-test coverage in `patch.content.test.ts`, mirroring `deploy.content.test.ts`; no existing tests retired | MET | 9 new tests under a `(PH-1.1)` describe block, plus 1 assertion added to the existing CFE-1.1 block confirming the hand-off; no tests removed |

## Test Plan
- [x] New `describe("patch.md — bundle-incomplete self-check before CI-fix dispatch (PH-1.1)", ...)` block in `patch.content.test.ts` — TDD red→green confirmed (9 new tests failed before the implementation, pass after)
- [x] `bun test plugins/shipwright/commands/patch.content.test.ts` — 127/127 pass; `deploy.content.test.ts` unaffected (98/98)
- [x] `task test` (full suite) — 5890 pass, 397 skip, 1 pre-existing unrelated flake (`agent/src/claude.unit.test.ts` extraAllowedTools — reproduces on clean main, unrelated to this diff)
- [x] `task typecheck` — clean across all 7 workspaces
- [x] `task lint` — clean

Generated with [Claude Code](https://claude.com/claude-code)
