### PR TITLE
refactor: collapse patch.md BLOCKED-escalation blocks into shared reference

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -3,11 +3,14 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const PATCH_MD_PATH = join(import.meta.dir, "patch.md");
+const ESCALATION_PATTERN_PATH = join(import.meta.dir, "references", "escalation-pattern.md");
 
 let content: string;
+let escalationPatternContent: string;
 
 beforeAll(() => {
   content = readFileSync(PATCH_MD_PATH, "utf-8");
+  escalationPatternContent = readFileSync(ESCALATION_PATTERN_PATH, "utf-8");
 });
 
 describe("patch.md — explicit-target-only argument contract (WLS-3.3)", () => {
@@ -146,34 +149,37 @@ describe("patch.md — pre-work PR claim lock (CLM-2.1)", () => {
     expect(preDispatchSection).toContain("List D");
   });
 
-  it("Step 4c (merge conflicts): BLOCKED path releases the pre-work claim", () => {
+  it("Step 4c (merge conflicts): BLOCKED path points at the shared escalation pattern, which releases the pre-work claim (PH-1.2)", () => {
     const step4cIdx = content.indexOf("### Step 4c: Handle Subagent Status");
     const step4c5Idx = content.indexOf("### Step 4c.5:");
     expect(step4cIdx).toBeGreaterThan(-1);
     expect(step4c5Idx).toBeGreaterThan(-1);
     const section = content.slice(step4cIdx, step4c5Idx);
     expect(section).toContain("BLOCKED");
-    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+    expect(section).toContain("references/escalation-pattern.md");
+    expect(escalationPatternContent).toContain("/prs/$PR_RECORD_ID/release");
   });
 
-  it("Step 5c (review findings): BLOCKED path releases the pre-work claim", () => {
+  it("Step 5c (review findings): BLOCKED path points at the shared escalation pattern, which releases the pre-work claim (PH-1.2)", () => {
     const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
     const step5c5Idx = content.indexOf("### Step 5c.5:");
     expect(step5cIdx).toBeGreaterThan(-1);
     expect(step5c5Idx).toBeGreaterThan(-1);
     const section = content.slice(step5cIdx, step5c5Idx);
     expect(section).toContain("BLOCKED");
-    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+    expect(section).toContain("references/escalation-pattern.md");
+    expect(escalationPatternContent).toContain("/prs/$PR_RECORD_ID/release");
   });
 
-  it("Step 6d (failing CI): BLOCKED path releases the pre-work claim", () => {
+  it("Step 6d (failing CI): BLOCKED path points at the shared escalation pattern, which releases the pre-work claim (PH-1.2)", () => {
     const step6dIdx = content.indexOf("### Step 6d: Handle Subagent Status");
     const step6d5Idx = content.indexOf("### Step 6d.5:");
     expect(step6dIdx).toBeGreaterThan(-1);
     expect(step6d5Idx).toBeGreaterThan(-1);
     const section = content.slice(step6dIdx, step6d5Idx);
     expect(section).toContain("BLOCKED");
-    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+    expect(section).toContain("references/escalation-pattern.md");
+    expect(escalationPatternContent).toContain("/prs/$PR_RECORD_ID/release");
   });
 
   it("post-fix step 4c.5 reuses PR_RECORD_ID instead of re-calling POST /prs/claim", () => {
@@ -561,7 +567,7 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
     expect(section).toContain("reply dated *before* the");
   });
 
-  it("escalation case reuses the shared PR_TASK_ID from Step 2.1 and PATCHes status: blocked (no fresh taskId fetch)", () => {
+  it("escalation case reuses the shared PR_TASK_ID from Step 2.1, and the shared escalation pattern PATCHes status: blocked (no fresh taskId fetch) (PH-1.2)", () => {
     const section = getStep5a7Section();
     expect(section).toContain("PR_TASK_ID");
     // No independent GET .../prs/$PR_RECORD_ID fetch for taskId purposes anymore — that
@@ -570,50 +576,62 @@ describe("patch.md — escalate to HITL instead of looping on a second-round dis
       /GET[^\n]*\n[^\n]*"\$SHIPWRIGHT_TASK_STORE_URL\/prs\/\$PR_RECORD_ID"[^\n]*\n[^\n]*taskId/,
     );
     expect(section).toMatch(/Step 2\.1|reuse/i);
-    expect(section).toContain("-X PATCH");
-    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
-    expect(section).toContain('"status": "blocked"');
+    expect(section).toContain("references/escalation-pattern.md");
+    expect(escalationPatternContent).toContain("-X PATCH");
+    expect(escalationPatternContent).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
+    expect(escalationPatternContent).toContain('"status": "blocked"');
   });
 
-  it("escalation case with no linked task PATCHes the PR record itself with blocked: true and a blockedReason, not just a warning", () => {
+  it("escalation case's {blockedReason} is stated inline, and the shared pattern PATCHes the PR record with blocked: true when no task is linked (PH-1.2)", () => {
     const section = getStep5a7Section();
+    expect(section).toContain("second-round disagreement between reviewer and automated fix");
+    expect(section).toContain("references/escalation-pattern.md");
     const patchPrSnippet =
-      '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \\\n     -d \'{"blocked": true, "blockedReason"';
-    expect(section).toContain("PR_TASK_ID` is empty");
-    expect(section).not.toContain("log a warning and skip the");
-    expect(section).toContain(
-      `curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \\\n     -H "Content-Type: application/json" \\\n     ${patchPrSnippet}`,
+      '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \\\n  -d \'{"blocked": true, "blockedReason"';
+    expect(escalationPatternContent).toContain("PR_TASK_ID` is empty");
+    expect(escalationPatternContent).not.toContain("log a warning and skip the");
+    expect(escalationPatternContent).toContain(
+      `curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \\\n  -H "Content-Type: application/json" \\\n  ${patchPrSnippet}`,
     );
-    expect(section).toContain("second-round disagreement");
-    const emptyBranchIdx = section.indexOf("PR_TASK_ID` is empty");
-    const patchPrIdx = section.indexOf(patchPrSnippet);
+    const emptyBranchIdx = escalationPatternContent.indexOf("PR_TASK_ID` is empty");
+    const patchPrIdx = escalationPatternContent.indexOf(patchPrSnippet);
     expect(patchPrIdx).toBeGreaterThan(emptyBranchIdx);
   });
 
-  it("escalation case posts exactly one PR comment via a temp file scoped by PR number", () => {
+  it("escalation case states its {temp_file_slug}/comment inline, and the shared pattern posts exactly one PR comment via a temp file scoped by PR number (PH-1.2)", () => {
     const section = getStep5a7Section();
-    expect(section).toContain("gh pr comment {pr} --repo {org}/{repo} --body-file");
+    expect(section).toContain("references/escalation-pattern.md");
+    expect(section).toContain("`escalation`");
     expect(section).toContain("/tmp/shipwright-patch-escalation-{pr}.txt");
-    expect(section).toContain("rm /tmp/shipwright-patch-escalation-{pr}.txt");
+    expect(escalationPatternContent).toContain(
+      "gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt",
+    );
+    expect(escalationPatternContent).toContain("rm /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt");
   });
 
-  it("escalation case releases the pre-work claim and skips to the next PR without dispatching a fix subagent", () => {
+  it("escalation case releases the pre-work claim (via the shared pattern) and skips to the next PR without dispatching a fix subagent", () => {
     const section = getStep5a7Section();
-    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+    expect(section).toContain("references/escalation-pattern.md");
+    expect(escalationPatternContent).toContain("/prs/$PR_RECORD_ID/release");
     expect(section).toContain("do not dispatch the fix subagent");
     expect(section).toContain("do not post another rebuttal");
     expect(section).toContain("do not reset");
     expect(section).toContain("Move to the next qualifying PR in List A");
   });
 
-  it("escalation case resolves the unresolved inline threads for the qualifying second-round review before releasing the claim", () => {
+  it("escalation case resolves the unresolved inline threads for the qualifying second-round review before releasing the claim (site-specific hook step, per escalation-pattern.md)", () => {
     const section = getStep5a7Section();
     expect(section).toContain("resolveReviewThread");
     expect(section).toContain("re-flag this same PR next");
+    expect(section).toContain("Extra step, unique to this site");
     const resolveIdx = section.indexOf("resolveReviewThread");
-    const releaseIdx = section.indexOf("/prs/$PR_RECORD_ID/release");
+    const releaseNoteIdx = section.indexOf("Claim released");
     expect(resolveIdx).toBeGreaterThan(-1);
-    expect(releaseIdx).toBeGreaterThan(resolveIdx);
+    // The site documents the thread-resolution step; the actual release call lives in the
+    // shared reference (verified above) and happens after this site-specific hook per
+    // escalation-pattern.md's step 3/4 ordering.
+    expect(releaseNoteIdx).toBeGreaterThan(-1);
+    expect(escalationPatternContent).toContain("Site-specific hook point");
   });
 
   it("does not reference commit.oid, a field Step 3a's reviews query never fetches", () => {
@@ -972,29 +990,35 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     return section.slice(blockedIdx);
   }
 
-  function assertEscalationBeforeRelease(
-    section: string,
-    opts: { taskPatchSnippet: string; prPatchSnippet: string; commentTmpPath: string },
-  ) {
-    const blocked = getBlockedBranch(section);
-
+  // PH-1.2: the literal PATCH/comment/release curl sequence lives once in
+  // references/escalation-pattern.md now, rather than being repeated at each of the 4 call
+  // sites. Verify the shared file's sequencing once, then verify each call site (a) points
+  // at the shared reference and (b) still carries its own distinct blockedReason/comment/
+  // temp-file-slug parameter values inline.
+  function assertSharedPatternSequencing() {
     // status: blocked PATCH to the linked task
-    expect(blocked).toContain(opts.taskPatchSnippet);
-    expect(blocked).toContain('"status": "blocked"');
+    expect(escalationPatternContent).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
+    expect(escalationPatternContent).toContain('"status": "blocked"');
 
     // blocked + blockedReason PATCH fallback to the PR record
-    expect(blocked).toContain(opts.prPatchSnippet);
-    expect(blocked).toContain("blockedReason");
+    expect(escalationPatternContent).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+    expect(escalationPatternContent).toContain("blockedReason");
 
     // PR comment via temp file
-    expect(blocked).toContain(`gh pr comment {pr} --repo {org}/{repo} --body-file ${opts.commentTmpPath}`);
-    expect(blocked).toContain(`rm ${opts.commentTmpPath}`);
+    expect(escalationPatternContent).toContain(
+      "gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt",
+    );
+    expect(escalationPatternContent).toContain("rm /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt");
 
     // Ordering: status PATCH + comment must occur BEFORE the release call
-    const taskPatchIdx = blocked.indexOf(opts.taskPatchSnippet);
-    const prPatchIdx = blocked.indexOf(opts.prPatchSnippet);
-    const commentIdx = blocked.indexOf(`--body-file ${opts.commentTmpPath}`);
-    const releaseIdx = blocked.indexOf("/prs/$PR_RECORD_ID/release");
+    const taskPatchIdx = escalationPatternContent.indexOf(
+      '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
+    );
+    const prPatchIdx = escalationPatternContent.indexOf(
+      '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
+    );
+    const commentIdx = escalationPatternContent.indexOf("--body-file /tmp/shipwright-patch-");
+    const releaseIdx = escalationPatternContent.indexOf("/prs/$PR_RECORD_ID/release");
 
     expect(releaseIdx).toBeGreaterThan(-1);
     expect(taskPatchIdx).toBeGreaterThan(-1);
@@ -1005,26 +1029,34 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     expect(commentIdx).toBeLessThan(releaseIdx);
   }
 
-  it("Step 4c BLOCKED branch escalates to HITL (task or PR record) and posts a PR comment before releasing the claim", () => {
-    const section = getStep4cSection();
-    assertEscalationBeforeRelease(section, {
-      taskPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
-      prPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
-      commentTmpPath: "/tmp/shipwright-patch-blocked-4c-{pr}.txt",
-    });
-    const blocked = getBlockedBranch(section);
-    expect(blocked.toLowerCase()).toContain("merge-conflict");
+  it("the shared escalation-pattern.md sequences task/PR PATCH + PR comment before the claim release", () => {
+    assertSharedPatternSequencing();
   });
 
-  it("Step 5c BLOCKED branch (first-round, plain BLOCKED) escalates to HITL and posts a PR comment before releasing the claim", () => {
-    const section = getStep5cSection();
-    assertEscalationBeforeRelease(section, {
-      taskPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
-      prPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
-      commentTmpPath: "/tmp/shipwright-patch-blocked-5c-{pr}.txt",
-    });
+  it("Step 4c BLOCKED branch points at the shared escalation pattern and states its own blockedReason/comment/temp-file-slug inline", () => {
+    const section = getStep4cSection();
     const blocked = getBlockedBranch(section);
-    expect(blocked.toLowerCase()).toContain("review-finding fix");
+    expect(blocked).toContain("references/escalation-pattern.md");
+    expect(blocked).toContain(
+      '"merge-conflict resolution blocked — automated conflict\n    resolution could not complete"',
+    );
+    expect(blocked.toLowerCase()).toContain("merge-conflict resolution subagent reported blocked");
+    expect(blocked).toContain("`blocked-4c`");
+    expect(blocked).toContain("/tmp/shipwright-patch-blocked-4c-{pr}.txt");
+    expect(blocked).toContain("Step 2.1");
+  });
+
+  it("Step 5c BLOCKED branch (first-round, plain BLOCKED) points at the shared escalation pattern and states its own blockedReason/comment/temp-file-slug inline", () => {
+    const section = getStep5cSection();
+    const blocked = getBlockedBranch(section);
+    expect(blocked).toContain("references/escalation-pattern.md");
+    expect(blocked).toContain(
+      '"review-finding fix blocked — automated fix subagent could not\n    complete"',
+    );
+    expect(blocked.toLowerCase()).toContain("review-finding fix subagent reported blocked");
+    expect(blocked).toContain("`blocked-5c`");
+    expect(blocked).toContain("/tmp/shipwright-patch-blocked-5c-{pr}.txt");
+    expect(blocked).toContain("Step 2.1");
   });
 
   it("Step 5c's BLOCKED escalation reuses PR_TASK_ID rather than re-fetching taskId", () => {
@@ -1036,15 +1068,19 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     );
   });
 
-  it("Step 6d BLOCKED branch escalates to HITL and posts a PR comment before releasing the claim", () => {
+  it("Step 6d BLOCKED branch points at the shared escalation pattern and states its own blockedReason/comment/temp-file-slug inline", () => {
     const section = getStep6dSection();
-    assertEscalationBeforeRelease(section, {
-      taskPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"',
-      prPatchSnippet: '"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"',
-      commentTmpPath: "/tmp/shipwright-patch-blocked-6d-{pr}.txt",
-    });
     const blocked = getBlockedBranch(section);
-    expect(blocked.toLowerCase()).toContain("ci-fix");
+    expect(blocked).toContain("references/escalation-pattern.md");
+    expect(blocked).toContain(
+      '"CI-fix blocked — automated CI-fix subagent could not\n    complete"',
+    );
+    expect(blocked.toLowerCase()).toContain("ci-fix subagent reported blocked");
+    expect(blocked).toContain("`blocked-6d`");
+    expect(blocked).toContain("/tmp/shipwright-patch-blocked-6d-{pr}.txt");
+    // Distinct from the other two BLOCKED sites: this one reuses PR_TASK_ID from Step 6b.6,
+    // not Step 2.1.
+    expect(blocked).toContain("Step 6b.6");
   });
 
   it("all three BLOCKED sites use distinct temp file names to avoid cross-worktree collisions", () => {
@@ -1063,7 +1099,7 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     expect(step5a7Section).toContain("second-round disagreement");
   });
 
-  it("Step 6d's BLOCKED escalation is consistent with Step 6b.6's pre-dispatch status check (same PATCH targets)", () => {
+  it("Step 6d's BLOCKED escalation is consistent with Step 6b.6's pre-dispatch status check (same PATCH targets, via the shared escalation pattern)", () => {
     const step6b6Idx = content.indexOf("### Step 6b.6: Escalation Check (CFE-1.1)");
     const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
     const step6b6Section = content.slice(step6b6Idx, step6cIdx);
@@ -1072,8 +1108,11 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
 
     const step6dSection = getStep6dSection();
     const blocked = getBlockedBranch(step6dSection);
-    expect(blocked).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
-    expect(blocked).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+    expect(blocked).toContain("references/escalation-pattern.md");
+    // The shared pattern Step 6d points at uses the same two PATCH targets as Step 6b.6's
+    // own pre-dispatch check.
+    expect(escalationPatternContent).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID"');
+    expect(escalationPatternContent).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
   });
 });
 
@@ -1271,9 +1310,9 @@ describe("patch.md — drop stale review-patch reference from claim-release step
     expect(content.toLowerCase()).not.toContain("review-patch");
   });
 
-  it("all three claim-release steps (4c.3, 5c.3, 6d.3) use the corrected 'a subsequent patch run' phrasing", () => {
-    const matches = content.match(/a subsequent patch run/g) ?? [];
-    expect(matches.length).toBe(3);
+  it("the shared escalation-pattern.md reference uses the corrected 'a subsequent patch run' phrasing (PH-1.2 collapsed the 3 formerly-separate inline copies into this one)", () => {
+    const matches = escalationPatternContent.match(/a subsequent patch run/g) ?? [];
+    expect(matches.length).toBe(1);
   });
 });
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -512,52 +512,22 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If the push already happened, log concerns and
   proceed to Step 4c.5 (upsert PR record). If the subagent did not push, note it in the
   final report and skip Step 4c.5.
-- **BLOCKED**: A generic BLOCKED release with no escalation flag makes this PR immediately
+- **BLOCKED**: The conflict-resolution subagent (dispatched in Step 4b) reported it could
+  not complete. A generic BLOCKED release with no escalation flag makes this PR immediately
   re-eligible for `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop`
   tick — `claimedBy`/`blocked` are the only exclusions it checks, and releasing the claim
-  below clears the former without setting the latter. Escalate to HITL first, mirroring Step
-  5a.7's (RPF-1.3) escalation pattern, before releasing the claim:
+  below clears the former without setting the latter. Escalate to HITL first, following
+  `references/escalation-pattern.md`'s shared PATCH/comment/release sequence, before
+  releasing the claim:
 
-  1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If
-     non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human decision:
-     ```bash
-     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       -H "Content-Type: application/json" \
-       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-       -d '{"status": "blocked", "blockedReason": "merge-conflict resolution blocked — automated conflict resolution could not complete"}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
-     ```
-     If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
-     instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
-     patch candidate every cycle, spinning forever:
-     ```bash
-     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       -H "Content-Type: application/json" \
-       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
-       -d '{"blocked": true, "blockedReason": "merge-conflict resolution blocked — automated conflict resolution could not complete"}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /prs/$PR_RECORD_ID blocked flag failed — continuing"
-     ```
-     Still post the PR comment below either way.
-  2. Post a single PR comment stating a human decision is needed. Write the body to a temp
-     file first, same convention as Step 5a.7's escalation comment (heredocs break
-     permission glob matching):
-     ```bash
-     # Write to /tmp/shipwright-patch-blocked-4c-{pr}.txt:
-     #   The merge-conflict resolution subagent reported BLOCKED and could not complete —
-     #   flagging for a human decision instead of retrying indefinitely.
-     gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-blocked-4c-{pr}.txt
-     rm /tmp/shipwright-patch-blocked-4c-{pr}.txt
-     ```
-     The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
-     across all worktrees.
-  3. Release the pre-work claim from Step 4a.6 so a subsequent patch run within
-     the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix never
-     completed, so nothing is actually in flight:
-     ```bash
-     [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
-       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-     ```
+  - **`{blockedReason}`**: `"merge-conflict resolution blocked — automated conflict
+    resolution could not complete"`
+  - **`{comment_body}`**: "The merge-conflict resolution subagent reported BLOCKED and
+    could not complete — flagging for a human decision instead of retrying indefinitely."
+  - **`{temp_file_slug}`**: `blocked-4c` (temp file:
+    `/tmp/shipwright-patch-blocked-4c-{pr}.txt`)
+  - **`PR_TASK_ID`**: reused from Step 2.1 (no fresh fetch)
+  - **Claim released**: the pre-work claim from Step 4a.6
 
   Log the blocker. Skip Steps 4c.5 and 4d. Move to the next PR in List C.
   Include the blocker in the final report.
@@ -770,80 +740,58 @@ second round.
 **If at least one candidate reply is judged `SAME_FINDING`** (a genuine second round on the
 same disagreement): escalate instead of looping. Skip the rest of Step 5 for this PR
 entirely — do not dispatch the fix subagent, do not post another rebuttal, and do not reset
-`reviewState`.
+`reviewState`. Escalate to HITL following `references/escalation-pattern.md`'s shared
+PATCH/comment/release sequence, with an extra thread-resolution step inserted between the
+comment and the claim release:
 
-1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. (Step 2.1
-   fetched `GET /prs?repo={org}/{repo}&prNumber={pr}` and captured `.prs[0].taskId` right
-   after Step 2 resolved this same PR, independent of any claim, so it's already available
-   by the time this check runs.)
-2. If `PR_TASK_ID` is non-empty, PATCH it to `status: 'blocked'` so the task is flagged for a human
-   decision:
-   ```bash
-   curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-     -H "Content-Type: application/json" \
-     "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-     -d '{"status": "blocked", "blockedReason": "second-round disagreement between reviewer and automated fix — escalated to HITL"}' > /dev/null 2>&1 || \
-     echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
-   ```
-   If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
-   instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
-   patch candidate every cycle, spinning forever:
-   ```bash
-   curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-     -H "Content-Type: application/json" \
-     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
-     -d '{"blocked": true, "blockedReason": "second-round disagreement between reviewer and automated fix — escalated to HITL"}' > /dev/null 2>&1 || \
-     echo "⚠ PATCH /prs/$PR_RECORD_ID blocked flag failed — continuing"
-   ```
-   Still post the PR comment below either way.
-3. Post a single PR comment stating a human decision is needed. Write the body to a temp
-   file first, same convention as the rebuttal comment in Step 5b [D] (heredocs break
-   permission glob matching):
-   ```bash
-   # Write to /tmp/shipwright-patch-escalation-{pr}.txt:
-   #   This finding was already rebutted once and the review still disagrees after
-   #   re-evaluating that rebuttal — this looks like a genuine disagreement between the
-   #   reviewer and the automated fix, not something another automated pass will resolve.
-   #   Flagging for a human decision instead of rebutting again.
-   gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-escalation-{pr}.txt
-   rm /tmp/shipwright-patch-escalation-{pr}.txt
-   ```
-   The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
-   across all worktrees.
-4. Resolve **all** currently-unresolved inline threads on this PR (from Step 3a's
-   `reviewThreads.nodes[]`) — not just threads tied to the qualifying second-round review.
-   Step 3a's query carries no field linking a thread back to the review that raised it
-   (only `id`, `isResolved`, and the first comment's `author.login`/`body`/`path`/`line`),
-   so scoping resolution to "threads belonging to" a specific review isn't something this
-   step can actually determine. Escalating already means giving up on automated resolution
-   for this cycle — the PR comment posted in step 3 above tells the human reader that
-   everything was escalated for manual review, not silently fixed, so resolving every
-   open thread here carries no silent-dismissal risk. Leaving any thread unresolved,
-   however, would leave it `isResolved == false`, so Step 3a's List A criteria would
-   re-flag this same PR next cycle and re-fire this same escalation indefinitely — the
-   exact loop this step exists to close. Use the same mutation as Step 5b [D]/[E]:
-   ```bash
-   gh api graphql -f query='
-   mutation {
-     resolveReviewThread(input: {threadId: "{thread.id}"}) {
-       thread { isResolved }
-     }
-   }'
-   ```
-   Run this for the Thread ID of every thread in Step 3a's `reviewThreads.nodes[]` with
-   `isResolved == false`. If there are none, there is nothing to resolve — move on.
-5. Release the pre-work claim from Step 5a.6 — no fix is in flight, this cycle intentionally
-   stops short of dispatching one:
-   ```bash
-   curl -s -o /dev/null -X POST \
-     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-   ```
-6. Print:
-   ```
-   ⏸ PR #{pr} — second-round disagreement detected, escalating to HITL (task {PR_TASK_ID or "none"}). Skipping rebuttal/reset for this cycle.
-   ```
-7. Move to the next qualifying PR in List A. If no candidates remain, continue to Step 6.
+- **`{blockedReason}`**: `"second-round disagreement between reviewer and automated fix —
+  escalated to HITL"`
+- **`{comment_body}`**: "This finding was already rebutted once and the review still
+  disagrees after re-evaluating that rebuttal — this looks like a genuine disagreement
+  between the reviewer and the automated fix, not something another automated pass will
+  resolve. Flagging for a human decision instead of rebutting again."
+- **`{temp_file_slug}`**: `escalation` (temp file: `/tmp/shipwright-patch-escalation-{pr}.txt`
+  — note this site's slug is `escalation`, not `blocked-5a7`, since it fires before
+  dispatch rather than after a BLOCKED report)
+- **`PR_TASK_ID`**: reused from Step 2.1 (no fresh fetch — Step 2.1 fetched
+  `GET /prs?repo={org}/{repo}&prNumber={pr}` and captured `.prs[0].taskId` right after Step 2
+  resolved this same PR, independent of any claim, so it's already available by the time
+  this check runs)
+- **Claim released**: the pre-work claim from Step 5a.6
+
+**Extra step, unique to this site — resolve unresolved inline threads before releasing the
+claim.** Resolve **all** currently-unresolved inline threads on this PR (from Step 3a's
+`reviewThreads.nodes[]`) — not just threads tied to the qualifying second-round review.
+Step 3a's query carries no field linking a thread back to the review that raised it (only
+`id`, `isResolved`, and the first comment's `author.login`/`body`/`path`/`line`), so scoping
+resolution to "threads belonging to" a specific review isn't something this step can
+actually determine. Escalating already means giving up on automated resolution for this
+cycle — the PR comment posted above tells the human reader that everything was escalated
+for manual review, not silently fixed, so resolving every open thread here carries no
+silent-dismissal risk. Leaving any thread unresolved, however, would leave it
+`isResolved == false`, so Step 3a's List A criteria would re-flag this same PR next cycle
+and re-fire this same escalation indefinitely — the exact loop this step exists to close.
+Use the same mutation as Step 5b [D]/[E]:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "{thread.id}"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Run this for the Thread ID of every thread in Step 3a's `reviewThreads.nodes[]` with
+`isResolved == false`. If there are none, there is nothing to resolve — move on. Do this
+before releasing the pre-work claim from Step 5a.6.
+
+After releasing the claim, print:
+```
+⏸ PR #{pr} — second-round disagreement detected, escalating to HITL (task {PR_TASK_ID or "none"}). Skipping rebuttal/reset for this cycle.
+```
+
+Move to the next qualifying PR in List A. If no candidates remain, continue to Step 6.
 
 **Otherwise** — either no candidate replies were found at all in Step 1 (a first-round
 rebuttal, or no rebuttal history at all), or candidates were found but every one was judged
@@ -1104,48 +1052,17 @@ Parse the subagent's STATUS:
   and came back unable to complete the fix. The same unbounded-retry risk applies: a generic
   release with no escalation flag makes this PR immediately re-eligible for
   `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop` tick. Escalate to
-  HITL first, mirroring Step 5a.7's escalation pattern, before releasing the claim:
+  HITL first, following `references/escalation-pattern.md`'s shared PATCH/comment/release
+  sequence, before releasing the claim:
 
-  1. Reuse `PR_TASK_ID`, already resolved once in Step 2.1 — no second fetch here. If
-     non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human decision:
-     ```bash
-     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       -H "Content-Type: application/json" \
-       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-       -d '{"status": "blocked", "blockedReason": "review-finding fix blocked — automated fix subagent could not complete"}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
-     ```
-     If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
-     instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
-     patch candidate every cycle, spinning forever:
-     ```bash
-     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       -H "Content-Type: application/json" \
-       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
-       -d '{"blocked": true, "blockedReason": "review-finding fix blocked — automated fix subagent could not complete"}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /prs/$PR_RECORD_ID blocked flag failed — continuing"
-     ```
-     Still post the PR comment below either way.
-  2. Post a single PR comment stating a human decision is needed. Write the body to a temp
-     file first, same convention as Step 5a.7's escalation comment (heredocs break
-     permission glob matching):
-     ```bash
-     # Write to /tmp/shipwright-patch-blocked-5c-{pr}.txt:
-     #   The review-finding fix subagent reported BLOCKED and could not complete — flagging
-     #   for a human decision instead of retrying indefinitely.
-     gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-blocked-5c-{pr}.txt
-     rm /tmp/shipwright-patch-blocked-5c-{pr}.txt
-     ```
-     The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
-     across all worktrees.
-  3. Release the pre-work claim from Step 5a.6 so a subsequent patch run within
-     the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix never
-     completed, so nothing is actually in flight:
-     ```bash
-     [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
-       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-     ```
+  - **`{blockedReason}`**: `"review-finding fix blocked — automated fix subagent could not
+    complete"`
+  - **`{comment_body}`**: "The review-finding fix subagent reported BLOCKED and could not
+    complete — flagging for a human decision instead of retrying indefinitely."
+  - **`{temp_file_slug}`**: `blocked-5c` (temp file:
+    `/tmp/shipwright-patch-blocked-5c-{pr}.txt`)
+  - **`PR_TASK_ID`**: reused from Step 2.1 (no fresh fetch)
+  - **Claim released**: the pre-work claim from Step 5a.6
 
   Log the blocker. Skip Steps 5c.5 and 5d. Move to the next qualifying PR.
   Include the blocker in the final report.
@@ -1459,54 +1376,25 @@ Parse the subagent's STATUS:
 - **DONE_WITH_CONCERNS**: Read concerns. If the push already happened, log concerns and
   proceed to Step 6d.5 (upsert PR record). If the subagent did not push, note it in the
   final report and skip Step 6d.5.
-- **BLOCKED**: A generic BLOCKED release with no escalation flag makes this PR immediately
-  re-eligible for `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop`
-  tick — and, absent the `blocked` flag Step 6b.6 (CFE-1.1) checks for, also re-eligible to
-  have this same CI-fix subagent re-dispatched against it next cycle. Escalate to HITL
-  first, mirroring Step 5a.7's (RPF-1.3) escalation pattern, before releasing the claim —
-  this is the same `blocked` flag Step 6b.6 already reads pre-dispatch (it runs before
-  dispatch, this runs after a BLOCKED report; they compose without conflict):
+- **BLOCKED**: The CI-fix subagent (dispatched in Step 6c) reported it could not complete.
+  A generic BLOCKED release with no escalation flag makes this PR immediately re-eligible
+  for `check-patch.ts`'s `getPatchCandidates()` on the next `shipwright-loop` tick — and,
+  absent the `blocked` flag Step 6b.6 (CFE-1.1) checks for, also re-eligible to have this
+  same CI-fix subagent re-dispatched against it next cycle. Escalate to HITL first,
+  following `references/escalation-pattern.md`'s shared PATCH/comment/release sequence,
+  before releasing the claim — this is the same `blocked` flag Step 6b.6 already reads
+  pre-dispatch (it runs before dispatch, this runs after a BLOCKED report; they compose
+  without conflict):
 
-  1. Reuse `PR_TASK_ID`, already resolved in Step 6b.6 — no second fetch here. If
-     non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human decision:
-     ```bash
-     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       -H "Content-Type: application/json" \
-       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
-       -d '{"status": "blocked", "blockedReason": "CI-fix blocked — automated CI-fix subagent could not complete"}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
-     ```
-     If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
-     instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a
-     patch candidate every cycle, spinning forever:
-     ```bash
-     curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       -H "Content-Type: application/json" \
-       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
-       -d '{"blocked": true, "blockedReason": "CI-fix blocked — automated CI-fix subagent could not complete"}' > /dev/null 2>&1 || \
-       echo "⚠ PATCH /prs/$PR_RECORD_ID blocked flag failed — continuing"
-     ```
-     Still post the PR comment below either way.
-  2. Post a single PR comment stating a human decision is needed. Write the body to a temp
-     file first, same convention as Step 5a.7's escalation comment (heredocs break
-     permission glob matching):
-     ```bash
-     # Write to /tmp/shipwright-patch-blocked-6d-{pr}.txt:
-     #   The CI-fix subagent reported BLOCKED and could not complete — flagging for a human
-     #   decision instead of retrying indefinitely.
-     gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-blocked-6d-{pr}.txt
-     rm /tmp/shipwright-patch-blocked-6d-{pr}.txt
-     ```
-     The temp file path MUST include the PR number to avoid collisions — `/tmp` is shared
-     across all worktrees.
-  3. Release the pre-work claim from Step 6b.5 so a subsequent patch run within
-     the reaper's TTL is not 409-blocked by a stale `phase: "patch"` lock — the fix never
-     completed, so nothing is actually in flight:
-     ```bash
-     [ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
-       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
-     ```
+  - **`{blockedReason}`**: `"CI-fix blocked — automated CI-fix subagent could not
+    complete"`
+  - **`{comment_body}`**: "The CI-fix subagent reported BLOCKED and could not complete —
+    flagging for a human decision instead of retrying indefinitely."
+  - **`{temp_file_slug}`**: `blocked-6d` (temp file:
+    `/tmp/shipwright-patch-blocked-6d-{pr}.txt`)
+  - **`PR_TASK_ID`**: reused from Step 6b.6 (no fresh fetch — note this differs from the
+    other BLOCKED sites, which reuse Step 2.1's resolution instead)
+  - **Claim released**: the pre-work claim from Step 6b.5
 
   Log the blocker. Skip Steps 6d.5 and 6e. Move to the next PR in List D.
   Include the blocker in the final report.

--- a/plugins/shipwright/commands/references/escalation-pattern.md
+++ b/plugins/shipwright/commands/references/escalation-pattern.md
@@ -1,0 +1,95 @@
+# BLOCKED-Escalation Pattern
+
+Shared PATCH/comment/release sequence used by `patch.md` whenever a subagent reports
+`STATUS: BLOCKED`, or a pre-dispatch check detects a condition that should be escalated to
+a human instead of retried automatically. A generic claim release with no escalation flag
+would make the PR immediately re-eligible for `check-patch.ts`'s `getPatchCandidates()` on
+the next `shipwright-loop` tick, re-dispatching the same automated attempt indefinitely.
+Escalating first — flagging the linked task (or PR record) as `blocked` and posting a PR
+comment — breaks that loop by giving a human the context to decide, and by giving
+`check-patch.ts`/`check-review.ts` a durable signal to stop re-flagging the PR.
+
+Each call site in `patch.md` links here for the mechanics and states its own trigger
+condition and parameter values inline. `PR_TASK_ID` and `PR_RECORD_ID` are assumed already
+resolved by the caller before this sequence runs — most sites reuse `PR_TASK_ID` from Step
+2.1 (resolved once, right after Step 2 resolves the target PR); Step 6d's BLOCKED handling
+instead reuses the `PR_TASK_ID` resolved by Step 6b.6's escalation check. `PR_RECORD_ID`
+comes from that site's own pre-work claim (Step 4a.6 / 5a.6 / 6b.5).
+
+## Parameters
+
+- **`{blockedReason}`** — the human-readable reason string sent to the task-store/PR-record
+  `blockedReason` field. Distinct per call site (e.g. "merge-conflict resolution blocked —
+  automated conflict resolution could not complete").
+- **`{comment_body}`** — the PR comment text explaining the escalation to a human reader.
+  Distinct per call site.
+- **`{temp_file_slug}`** — used to build the temp file path
+  `/tmp/shipwright-patch-{temp_file_slug}-{pr}.txt`. Distinct per call site (e.g.
+  `blocked-4c`, `blocked-5c`, `blocked-6d`, `escalation`).
+
+## The sequence
+
+**1. Flag the linked task, or the PR record if no task is linked.**
+
+Reuse the already-resolved `PR_TASK_ID` — do not re-fetch it here. If `PR_TASK_ID` is
+non-empty, PATCH the linked task to `status: 'blocked'` so it's flagged for a human
+decision:
+
+```bash
+curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" \
+  -d '{"status": "blocked", "blockedReason": "{blockedReason}"}' > /dev/null 2>&1 || \
+  echo "⚠ PATCH /tasks/$PR_TASK_ID blocked status failed — continuing"
+```
+
+If `PR_TASK_ID` is empty (no linked task on the PR record), PATCH the PR record itself
+instead — otherwise nothing is ever recorded to stop this PR from re-qualifying as a patch
+candidate every cycle, spinning forever:
+
+```bash
+curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID" \
+  -d '{"blocked": true, "blockedReason": "{blockedReason}"}' > /dev/null 2>&1 || \
+  echo "⚠ PATCH /prs/$PR_RECORD_ID blocked flag failed — continuing"
+```
+
+Still post the PR comment below either way, regardless of which PATCH fired.
+
+**2. Post exactly one PR comment via a temp file.**
+
+Write the body to a temp file first — heredocs break permission glob matching. The temp
+file path MUST include the PR number to avoid collisions, since `/tmp` is shared across all
+worktrees:
+
+```bash
+# Write {comment_body} to /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt
+gh pr comment {pr} --repo {org}/{repo} --body-file /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt
+rm /tmp/shipwright-patch-{temp_file_slug}-{pr}.txt
+```
+
+**3. (Site-specific hook point.)** Any extra step a call site needs happens here, between
+posting the comment and releasing the claim — e.g. Step 5a.7 resolves all currently-
+unresolved inline threads on the PR at this point, since escalating there means giving up
+on automated resolution for the PR this cycle, and leaving threads unresolved would make
+Step 3a re-flag the PR every cycle forever. Most sites have no extra step and skip straight
+to step 4.
+
+**4. Release the pre-work claim.**
+
+```bash
+[ -n "$PR_RECORD_ID" ] && curl -s -o /dev/null -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+```
+
+This ensures a subsequent patch run within the reaper's TTL is not 409-blocked by a stale
+`phase: "patch"` lock — the fix never completed (or was never dispatched), so nothing is
+actually in flight.
+
+**5. Log and continue — stays inline at the call site.** Each site prints its own status
+line and names its own "skip these steps, move to the next PR in List X" continuation. This
+step is not documented here because it differs structurally per site — different List
+letters, different skipped step numbers — so it belongs with the site's own prose, not in
+this shared reference.


### PR DESCRIPTION
## Summary
- Extracted the common PATCH-task/PR-record + comment + release-claim sequence shared by patch.md's 4 near-identical BLOCKED-escalation blocks (Steps 4c, 5c, 6d, 5a.7) into a new `plugins/shipwright/commands/references/escalation-pattern.md`, parameterized by `{blockedReason}`, `{comment_body}`, and `{temp_file_slug}`.
- Each of the 4 call sites now points at the shared reference and states only its own distinct trigger condition, parameter values, and "skip X, move to Y" tail inline — including Step 6d's distinct `PR_TASK_ID` source (Step 6b.6, not Step 2.1) and Step 5a.7's unique inline-thread-resolution hook step.
- Updated `patch.content.test.ts`'s step-boundary string-anchor assertions to verify each site references the shared pattern and still carries its own inline parameters, plus new assertions on `escalation-pattern.md` itself — no assertion silently starts matching nothing.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New `escalation-pattern.md` documents the shared sequence, parameterized by `{blockedReason}` | MET |
| 2 | All 4 sites reference the shared pattern, retaining only distinct trigger condition + blockedReason inline | MET |
| 3 | Test assertions updated to match new reference-pointing text; no assertion silently passes | MET |

## Test Plan
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 119/119 pass
- `task lint`, `task check-strings`, `task check-config-docs`, `task check-version-sync`, `task typecheck` — all pass
- `task test:coverage` — full suite green (1 pre-existing, unrelated failure in `agent/src/claude.unit.test.ts` confirmed present on `main` too)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
