### PR TITLE
feat: add task_id/pr_number Sentry tag to loop-orchestrator dispatch()

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -401,6 +401,10 @@ const getLoopOrchestrator = createLoopOrchestratorGetter({
   runner: (message, onProgress) => runner(message, undefined, onProgress),
   cronRunReporter: cronRunReporter ?? new NoopCronRunReporter(),
   workQueueReporter,
+  // LO-1.1: same optional-by-convention pattern as every other sentryClient
+  // call site in this file (undefined, i.e. fully inert, when SENTRY_DSN is
+  // unset) — see LoopOrchestratorDeps's sentryClient doc comment.
+  sentryClient: process.env.SENTRY_DSN ? Sentry : undefined,
 });
 
 if (runtimeClient && agentId) {

--- a/agent/src/loop-orchestrator.ts
+++ b/agent/src/loop-orchestrator.ts
@@ -62,6 +62,7 @@
  * noise.
  */
 
+import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import {
   buildProductionDeps as buildDeployDeps,
   getDeployCandidates,
@@ -197,6 +198,27 @@ export interface LoopOrchestratorDeps {
   loopCronId: string;
   /** Clock for deterministic run timestamps. Defaults to SystemClock(). */
   clock?: Clock;
+  /**
+   * LO-1.1 — optional injected Sentry client, mirroring cron-failure-
+   * reporter.ts's sentryClient?.captureException pattern (undefined when
+   * SENTRY_DSN is unset, matching every other optional-by-convention
+   * sentryClient call site in this codebase). When present, dispatch()'s
+   * entire per-item execution runs inside `sentryClient.withScope(...)` —
+   * a forked (not shared/mutated) Sentry scope tagged with `item_type`/
+   * `item_id` for the item currently being dispatched. Any Sentry event
+   * captured while that scope is active (dispatch()'s own
+   * captureException call on a thrown runner failure below, or a
+   * console.warn/console.error forwarded as a Sentry Log by
+   * consoleLoggingIntegration) carries those tags, so a Sentry
+   * Issue/Log is attributable to the specific task/PR in flight — not
+   * just "which service/agent" (lib/sentry.ts's static initialScope
+   * tags). `withScope` is optional on ErrorCapturingClient — a fake that
+   * only implements `captureException` (the older, pre-LO-1.1 shape)
+   * still type-checks; dispatch() falls back to running the per-item body
+   * unscoped when either `sentryClient` or `sentryClient.withScope` is
+   * absent.
+   */
+  sentryClient?: ErrorCapturingClient;
 }
 
 // ─── Command routing ──────────────────────────────────────────────────────────
@@ -370,6 +392,7 @@ export function createLoopOrchestrator(
     workQueueReporter,
     loopCronId,
     clock = SystemClock(),
+    sentryClient,
   } = deps;
 
   // Persisted across ticks: guards against a second concurrent drain.
@@ -456,8 +479,19 @@ export function createLoopOrchestrator(
    * `recordId` is the task's plain id for a task item, or the PullRequest DB
    * record's CUID (from claimPr's result) for a PR item. See the recordSkip
    * doc comment on LoopOrchestratorDeps for the full rationale.
+   *
+   * LO-1.1: the entire body below runs inside `sentryClient.withScope(...)`
+   * (see the thin `dispatch` wrapper below this function) — a Sentry scope
+   * forked just for this call and tagged `item_type`/`item_id` for the item
+   * being dispatched. Any Sentry event captured while this function is
+   * in flight (its own captureException call in the catch block below, or a
+   * console.warn/console.error forwarded as a Sentry Log by
+   * consoleLoggingIntegration) carries those tags — see LoopOrchestratorDeps's
+   * sentryClient doc comment for the full rationale and why a fork (not a
+   * bare Sentry.setTag() global mutation) is required for correctness under
+   * concurrent/sequential dispatches.
    */
-  async function dispatch(
+  async function dispatchItem(
     phase: LoopPhase,
     phaseId: string | null,
     itemType: "task" | "pr",
@@ -562,6 +596,15 @@ export function createLoopOrchestrator(
         itemId,
       );
       markCronRunFailureReported(err);
+      // LO-1.1: captured while the sentryClient.withScope fork set up by the
+      // dispatch() wrapper below is still active — item_type/item_id tags
+      // are attached to this Issue automatically. Previously a per-item
+      // dispatch failure was only ever surfaced as a console.warn at the
+      // runLoopTick call site (never reaching reportCronFailure's
+      // captureException, since that catch swallows-and-continues rather
+      // than rethrowing out of the tick) — this is a genuinely new Sentry
+      // Issue capture point, not a duplicate of cron-failure-reporter.ts's.
+      sentryClient?.captureException(err);
       throw err;
     }
 
@@ -659,6 +702,58 @@ export function createLoopOrchestrator(
     );
     // SKT-2.1: real progress clears any prior skip streak.
     await callSkipTracker("resetSkip", () => resetSkip(itemType, recordId));
+  }
+
+  /**
+   * LO-1.1 — thin wrapper around dispatchItem(): forks a Sentry scope (via
+   * the injected sentryClient's withScope) tagged `item_type`/`item_id` for
+   * the item about to be dispatched, then runs dispatchItem() entirely
+   * inside that fork. A fork — not a bare `Sentry.setTag()` global mutation
+   * — is required for correctness: setTag would mutate one shared scope
+   * object, so two dispatch() calls (sequential across drain iterations, or
+   * concurrent across cron ticks were that ever possible) would race to
+   * overwrite each other's tags, mistagging whichever Sentry event fires
+   * last. `sentryClient.withScope`'s AsyncLocalStorage-based propagation
+   * (real @sentry/bun) keeps each fork's tags isolated and correctly
+   * attributed even across the awaited chain inside dispatchItem(), while
+   * never leaking into a sibling call's fork.
+   *
+   * Falls back to calling dispatchItem() unscoped when no sentryClient is
+   * injected, or when the injected client doesn't implement `withScope`
+   * (the pre-LO-1.1 ErrorCapturingClient shape, e.g. a fake that only
+   * implements captureException) — identical behavior to today for every
+   * existing caller/test that doesn't opt in.
+   */
+  async function dispatch(
+    phase: LoopPhase,
+    phaseId: string | null,
+    itemType: "task" | "pr",
+    itemId: string,
+    recordId: string,
+    preClaimMarker?: string,
+  ): Promise<void> {
+    if (!sentryClient?.withScope) {
+      return dispatchItem(
+        phase,
+        phaseId,
+        itemType,
+        itemId,
+        recordId,
+        preClaimMarker,
+      );
+    }
+    return sentryClient.withScope(async (scope) => {
+      scope.setTag("item_type", itemType);
+      scope.setTag("item_id", itemId);
+      return dispatchItem(
+        phase,
+        phaseId,
+        itemType,
+        itemId,
+        recordId,
+        preClaimMarker,
+      );
+    });
   }
 
   return async function runLoopTick(jobs: CronJobLike[]): Promise<void> {
@@ -1074,6 +1169,8 @@ export interface LoopOrchestratorGetterDeps {
   cronRunReporter: CronRunReporter;
   workQueueReporter: WorkQueueReporter;
   createOrchestrator?: typeof createProductionLoopOrchestrator;
+  /** LO-1.1 — see LoopOrchestratorDeps's sentryClient doc comment. */
+  sentryClient?: ErrorCapturingClient;
 }
 
 /**
@@ -1108,6 +1205,7 @@ export function createLoopOrchestratorGetter(
         cronRunReporter: deps.cronRunReporter,
         workQueueReporter: deps.workQueueReporter,
         loopCronId,
+        sentryClient: deps.sentryClient,
       })
         .then((orch) => {
           orchestrator = orch;
@@ -1135,6 +1233,8 @@ export interface LoopOrchestratorProductionOptions {
   workQueueReporter: WorkQueueReporter;
   loopCronId?: string;
   clock?: Clock;
+  /** LO-1.1 — see LoopOrchestratorDeps's sentryClient doc comment. */
+  sentryClient?: ErrorCapturingClient;
 }
 
 /**
@@ -1186,5 +1286,6 @@ export async function createProductionLoopOrchestrator(
     workQueueReporter: opts.workQueueReporter,
     loopCronId: opts.loopCronId ?? "shipwright-loop",
     clock: opts.clock ?? SystemClock(),
+    sentryClient: opts.sentryClient,
   });
 }

--- a/agent/src/loop-orchestrator.unit.test.ts
+++ b/agent/src/loop-orchestrator.unit.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import {
   ClaudeRunError,
   ClaudeTimeoutError,
@@ -210,6 +212,65 @@ function makeRecordingWorkQueueReporter(): {
   return { reporter, snapshots };
 }
 
+// ─── Stub Sentry client (LO-1.1) ────────────────────────────────────────────
+
+/**
+ * A fake ErrorCapturingClient whose `withScope` genuinely forks a per-call
+ * tag bag using node:async_hooks's `AsyncLocalStorage` — the same
+ * primitive @sentry/bun's async context strategy uses under the hood — so
+ * this fake exercises real per-async-context isolation semantics rather
+ * than a simplified approximation. A naive stack (push on enter, pop on
+ * exit) would look correct for sequential calls but is WRONG under
+ * concurrency: two `withScope` calls interleaved on the event loop would
+ * push/pop out of order, letting one call's `captureException` see the
+ * OTHER call's tags (a real bug this fake must not itself introduce — see
+ * the concurrent isolation test below, which specifically catches this
+ * class of bug). `AsyncLocalStorage.run()` binds the fork to the async
+ * execution context itself, so `captureException` called from inside
+ * `callback`'s continuation always reads the correct fork regardless of
+ * interleaving with sibling calls. `captureException` snapshots (not
+ * references) whichever fork is active in `als.getStore()` at call time; a
+ * bare `Sentry.setTag()`-style implementation (one shared mutable object,
+ * no forking at all) would make every captured exception see the LAST tag
+ * written — exactly the failure mode the isolation tests below must catch.
+ */
+function makeFakeSentryClient(): {
+  client: ErrorCapturingClient;
+  captured: Array<{ err: unknown; tags: Record<string, string> }>;
+} {
+  const captured: Array<{ err: unknown; tags: Record<string, string> }> = [];
+  const als = new AsyncLocalStorage<Record<string, string>>();
+
+  const client: ErrorCapturingClient = {
+    captureException: (err: unknown) => {
+      const active = als.getStore() ?? {};
+      captured.push({ err, tags: { ...active } });
+    },
+    withScope: async <T>(
+      callback: (scope: {
+        setTag: (key: string, value: string) => unknown;
+      }) => Promise<T>,
+    ): Promise<T> => {
+      // Fork: a brand-new tag bag per call, seeded from nothing (real
+      // Sentry.withScope forks the CURRENT scope's tags too, but no
+      // production call site here relies on inherited tags, so an empty
+      // fork is sufficient and keeps the isolation property maximally
+      // strict).
+      const forked: Record<string, string> = {};
+      return als.run(forked, () =>
+        callback({
+          setTag: (key: string, value: string) => {
+            forked[key] = value;
+            return undefined;
+          },
+        }),
+      );
+    },
+  };
+
+  return { client, captured };
+}
+
 // ─── Stub runner ──────────────────────────────────────────────────────────
 
 /** Records each dispatched message and returns a scripted result per call. */
@@ -383,6 +444,10 @@ interface MakeDepsOptions {
   // throw, following the claimTask/claimPr default-stub pattern above.
   recordSkip?: (itemType: "task" | "pr", recordId: string) => Promise<void>;
   resetSkip?: (itemType: "task" | "pr", recordId: string) => Promise<void>;
+  // LO-1.1: optional injected Sentry client double — undefined by default
+  // (matching production's optional-by-convention sentryClient), so existing
+  // tests that don't pass this option are unaffected.
+  sentryClient?: ErrorCapturingClient;
 }
 
 /**
@@ -464,6 +529,7 @@ function makeDeps(options: MakeDepsOptions = {}): LoopOrchestratorDeps {
       })),
     recordSkip: options.recordSkip ?? (async () => {}),
     resetSkip: options.resetSkip ?? (async () => {}),
+    sentryClient: options.sentryClient,
   };
 }
 
@@ -3102,6 +3168,164 @@ describe("createLoopOrchestrator", () => {
     expect(
       warnings.some((w) => w.includes("SWC-BOOM")),
     ).toBe(true);
+  });
+
+  // ─── Sentry per-item tag isolation (LO-1.1) ─────────────────────────────────
+
+  test("LO-1.1: two dispatch() calls for different items produce Sentry events tagged with their own item, not each other's", async () => {
+    // Both dispatched items fail at the runner — each dispatch() throw is
+    // caught (CBD-2.3) but still calls cronRunReporter.completeRun BEFORE
+    // rethrowing; the rethrow is what a real caller (index.ts's cron-sync
+    // callback) would forward into reportCronFailure()'s
+    // sentryClient?.captureException. Here we call captureException directly
+    // inside a scripted runner failure path to prove item_type/item_id tag
+    // isolation across two sequential dispatch()-triggering ticks — the
+    // specific failure mode a bare Sentry.setTag() (shared mutable state)
+    // would introduce is BOTH captured exceptions ending up tagged with the
+    // LAST item dispatched, rather than each with its own.
+    const { client: sentryClient, captured } = makeFakeSentryClient();
+
+    // First tick: a single dev-task item whose dispatch always throws. The
+    // throw is caught by dispatch()'s own catch block, which — per this
+    // task's brief — must have already captured the exception to Sentry
+    // under a scope tagged with THIS item's type/id before rethrowing.
+    const consumedA = new Set<string>();
+    const depsA = makeDeps({
+      devTaskCandidates: [task("TASK-A", "2026-01-01T00:00:00Z")],
+      consumed: consumedA,
+      claimTask: consumingClaimTask(consumedA),
+      sentryClient,
+      runner: async () => {
+        throw new Error("boom for TASK-A");
+      },
+    });
+    const loopA = createLoopOrchestrator(depsA);
+    await withCapturedWarnings(async () => {
+      await loopA([job("shipwright-dev-task", true)]);
+    });
+
+    // Second tick: a different item (a PR, not a task — different itemType
+    // too) whose dispatch also always throws, dispatched via a SEPARATE
+    // orchestrator instance/tick from the first. A leaking/global tag
+    // implementation would still show TASK-A's tags here (or worse, mix
+    // both), since nothing about a naive Sentry.setTag() call scopes it to
+    // a single dispatch.
+    const consumedB = new Set<string>();
+    const prCandidateB = pr("acme/y#42", "2026-01-01T00:00:00Z", "review");
+    const depsB = makeDeps({
+      reviewCandidates: [prCandidateB],
+      consumed: consumedB,
+      claimPr: async (candidate) => {
+        consumedB.add(candidate.id);
+        return { id: candidate.id, commitSha: candidate.commitSha };
+      },
+      sentryClient,
+      runner: async () => {
+        throw new Error("boom for acme/y#42");
+      },
+    });
+    const loopB = createLoopOrchestrator(depsB);
+    await withCapturedWarnings(async () => {
+      await loopB([job("shipwright-review", true)]);
+    });
+
+    // Both dispatches' exceptions were captured...
+    expect(captured).toHaveLength(2);
+
+    // ...each tagged with its OWN item, not the other's. This is the
+    // isolation assertion: a global-mutation implementation would make both
+    // entries show the same (last-written) tags.
+    expect(captured[0]?.tags.item_type).toBe("task");
+    expect(captured[0]?.tags.item_id).toBe("TASK-A");
+    expect((captured[0]?.err as Error | undefined)?.message).toBe(
+      "boom for TASK-A",
+    );
+
+    expect(captured[1]?.tags.item_type).toBe("pr");
+    expect(captured[1]?.tags.item_id).toBe("acme/y#42");
+    expect((captured[1]?.err as Error | undefined)?.message).toBe(
+      "boom for acme/y#42",
+    );
+  });
+
+  test("LO-1.1: concurrent in-flight dispatch()es for different items do not cross-contaminate each other's Sentry tags", async () => {
+    // Stronger isolation proof than the sequential test above: two
+    // dispatch()-triggering ticks run CONCURRENTLY (both runners gated on
+    // the same manually-released promise), so their withScope forks are
+    // genuinely interleaved in the event loop, not just temporally
+    // separated. A bare Sentry.setTag() global mutation would very likely
+    // leak one item's tag onto the other's captured exception under this
+    // interleaving.
+    const { client: sentryClient, captured } = makeFakeSentryClient();
+
+    let releaseA!: () => void;
+    const gateA = new Promise<void>((res) => {
+      releaseA = res;
+    });
+    let releaseB!: () => void;
+    const gateB = new Promise<void>((res) => {
+      releaseB = res;
+    });
+
+    const consumedA = new Set<string>();
+    const depsA = makeDeps({
+      devTaskCandidates: [task("CONC-A", "2026-01-01T00:00:00Z")],
+      consumed: consumedA,
+      claimTask: consumingClaimTask(consumedA),
+      sentryClient,
+      runner: async () => {
+        await gateA;
+        throw new Error("boom for CONC-A");
+      },
+    });
+
+    const consumedB = new Set<string>();
+    const prCandidateB = pr("acme/z#9", "2026-01-01T00:00:00Z", "patch");
+    const depsB = makeDeps({
+      patchCandidates: [prCandidateB],
+      consumed: consumedB,
+      claimPr: async (candidate) => {
+        consumedB.add(candidate.id);
+        return { id: candidate.id, commitSha: candidate.commitSha };
+      },
+      sentryClient,
+      runner: async () => {
+        await gateB;
+        throw new Error("boom for acme/z#9");
+      },
+    });
+
+    const loopA = createLoopOrchestrator(depsA);
+    const loopB = createLoopOrchestrator(depsB);
+
+    const tickA = withCapturedWarnings(async () => {
+      await loopA([job("shipwright-dev-task", true)]);
+    });
+    const tickB = withCapturedWarnings(async () => {
+      await loopB([job("shipwright-patch", true)]);
+    });
+
+    // Release B first, then A — deliberately the reverse of dispatch order,
+    // so a stack/shared-state bug that just tracks "most recently entered
+    // scope" can't accidentally pass by matching temporal order.
+    releaseB();
+    releaseA();
+    await Promise.all([tickA, tickB]);
+
+    expect(captured).toHaveLength(2);
+
+    const taskCapture = captured.find(
+      (c) => (c.err as Error | undefined)?.message === "boom for CONC-A",
+    );
+    const prCapture = captured.find(
+      (c) => (c.err as Error | undefined)?.message === "boom for acme/z#9",
+    );
+
+    expect(taskCapture?.tags.item_type).toBe("task");
+    expect(taskCapture?.tags.item_id).toBe("CONC-A");
+
+    expect(prCapture?.tags.item_type).toBe("pr");
+    expect(prCapture?.tags.item_id).toBe("acme/z#9");
   });
 
   // ─── Pre-claim tests (CBD-1.3 — PR items) ──────────────────────────────────

--- a/agent/src/loop-orchestrator.unit.test.ts
+++ b/agent/src/loop-orchestrator.unit.test.ts
@@ -10,7 +10,10 @@
 
 import { describe, expect, test } from "bun:test";
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
+import type {
+  ErrorCapturingClient,
+  ScopeTagSetter,
+} from "@shipwright/lib/sentry";
 import {
   ClaudeRunError,
   ClaudeTimeoutError,
@@ -116,7 +119,15 @@ function makeRecordingReporter(): {
       itemType,
       itemId,
     ) {
-      completes.push({ cronId, runId, outcome, opts, phaseId, itemType, itemId });
+      completes.push({
+        cronId,
+        runId,
+        outcome,
+        opts,
+        phaseId,
+        itemType,
+        itemId,
+      });
     },
     async skipRun(
       cronId,
@@ -247,9 +258,7 @@ function makeFakeSentryClient(): {
       captured.push({ err, tags: { ...active } });
     },
     withScope: async <T>(
-      callback: (scope: {
-        setTag: (key: string, value: string) => unknown;
-      }) => Promise<T>,
+      callback: (scope: ScopeTagSetter) => Promise<T>,
     ): Promise<T> => {
       // Fork: a brand-new tag bag per call, seeded from nothing (real
       // Sentry.withScope forks the CURRENT scope's tags too, but no
@@ -572,9 +581,7 @@ async function withCapturedWarnings(
 // original afterward even if `fn` throws. Mirrors withCapturedWarnings above
 // — used to assert on the busy-stall escalation's console.error call without
 // touching the console.warn capture used by the non-escalated busy-skip path.
-async function withCapturedErrors(
-  fn: () => Promise<void>,
-): Promise<string[]> {
+async function withCapturedErrors(fn: () => Promise<void>): Promise<string[]> {
   const errorMessages: string[] = [];
   const originalError = console.error.bind(console);
   console.error = (...args: unknown[]) => {
@@ -2613,9 +2620,7 @@ describe("createLoopOrchestrator", () => {
       async () => {
         const { clock } = makeMutableClockForBackoff("2026-01-01T00:00:00Z");
         const calls: string[] = [];
-        const devTaskCandidates = [
-          task("SWC-BOOM", "2026-01-01T00:00:00Z"),
-        ];
+        const devTaskCandidates = [task("SWC-BOOM", "2026-01-01T00:00:00Z")];
 
         const deps = {
           ...makeDeps({
@@ -3165,9 +3170,7 @@ describe("createLoopOrchestrator", () => {
     expect(skips).toEqual([]);
 
     // The failure is logged, observable, and identifies the offending item.
-    expect(
-      warnings.some((w) => w.includes("SWC-BOOM")),
-    ).toBe(true);
+    expect(warnings.some((w) => w.includes("SWC-BOOM"))).toBe(true);
   });
 
   // ─── Sentry per-item tag isolation (LO-1.1) ─────────────────────────────────

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,7 +18,7 @@ When `SENTRY_DSN` is set, a service reports:
 - **`console.log` / `console.warn` / `console.error` calls**, forwarded as structured Sentry Logs via `consoleLoggingIntegration`.
 - **Request path and method** for errors that occur inside an HTTP handler (via `@sentry/hono`'s `sentry()` middleware, or the app's own `onError` hook).
 - **Caller identity** (admin or agent token) in error logs from admin, metrics, and task-store, for tracing which token triggered an unhandled error.
-- **Tags** — structured key-value metadata attached to every event: `service` (the reporting service name, always present), and `agent_id` (when initializing Sentry for an agent runner with an `agentId`).
+- **Tags** — structured key-value metadata attached to every event: `service` (the reporting service name, always present), and `agent_id` (when initializing Sentry for an agent runner with an `agentId`). These process-wide tags are set once at init time via `buildSentryInitOptions()`'s static `initialScope`. The agent additionally tags `item_type`/`item_id` (`"task"` or `"pr"`, plus that item's id) on any Sentry event captured during `loop-orchestrator.ts`'s `dispatch()` — its per-item execution runs inside a forked Sentry scope (`sentryClient.withScope(...)`, not a bare `Sentry.setTag()` global mutation) so the tags are scoped to that single dispatch and never leak across concurrent or sequential dispatches. This lets a Sentry Issue or Log be attributed to the specific task/PR that was in flight, not just "which service/agent" — see `lib/sentry.ts`'s `ErrorCapturingClient.withScope` and `loop-orchestrator.ts`'s `dispatch()`.
 
 ## What is never collected
 

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -25,16 +25,39 @@ interface SentryClient {
 }
 
 /**
+ * Narrowed to the one method a scope fork needs to expose — setting a tag on
+ * the forked (not shared/global) scope passed into `withScope`'s callback.
+ * The real `Sentry.Scope` from `@sentry/bun` satisfies this shape via its
+ * `setTag` method; it has many more methods, but callers of `withScope` below
+ * only ever need this one.
+ */
+export interface ScopeTagSetter {
+  setTag: (key: string, value: string) => unknown;
+}
+
+/**
  * Narrowed to the methods callers need to report unhandled errors and
  * expected-but-notable events, so tests can inject a fake without
  * mock.module(). Mirrors the SentryClient pattern — the real `Sentry` from
  * `@sentry/bun` satisfies this shape via its `captureException`/
- * `captureMessage` exports. `captureMessage` is optional so existing fakes
- * that only implement `captureException` keep type-checking.
+ * `captureMessage`/`withScope` exports. `captureMessage` and `withScope` are
+ * optional so existing fakes that only implement `captureException` keep
+ * type-checking.
+ *
+ * `withScope` mirrors `@sentry/bun`'s `Sentry.withScope` signature: it forks
+ * the current scope for the duration of the async `callback`, so tags set on
+ * the forked scope (via `ScopeTagSetter.setTag`) are visible to any Sentry
+ * event (Issue or Log) captured while `callback` is in flight, without
+ * mutating any other concurrent or sequential call's scope. Real `Sentry`
+ * satisfies this via its AsyncLocalStorage-based async context strategy —
+ * scope propagation survives the awaited callback, including nested awaits.
  */
 export interface ErrorCapturingClient {
   captureException: (err: unknown) => void;
   captureMessage?: (message: string) => void;
+  withScope?: <T>(
+    callback: (scope: ScopeTagSetter) => Promise<T>,
+  ) => Promise<T>;
 }
 
 /** Max depth walked when scrubbing, so a pathological/deeply-nested object can't hang scrubbing. */


### PR DESCRIPTION
## Summary
- Wraps `loop-orchestrator.ts`'s per-item `dispatch()` execution in a forked Sentry scope (`sentryClient.withScope(...)`) tagged `item_type`/`item_id`, so any Sentry Issue or Log emitted while a task/PR is in flight is attributable to that specific work item — not just "which service/agent."
- Adds an optional `withScope` method + `ScopeTagSetter` type to `ErrorCapturingClient` (`lib/sentry.ts`), mirroring the existing injectable `sentryClient` pattern from `cron-failure-reporter.ts`. Falls back to unscoped execution when no client (or no `withScope`) is injected — zero behavior change for existing callers.
- Adds a genuinely new Sentry Issue capture point: `dispatchItem()`'s catch block now calls `sentryClient?.captureException(err)` while the per-item scope fork is active, before rethrowing.
- Documents the new `item_type`/`item_id` tags in `docs/observability.md`.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | dispatch()'s per-item execution wrapped so any Sentry event carries item_type/item_id tags | MET | `dispatch()` wrapper forks scope via `sentryClient.withScope()`, tags it, runs `dispatchItem()` (renamed from original `dispatch()`) inside the fork |
| 2 | Test proves tag isolation across two dispatch() calls for different items | MET | New sequential + concurrent isolation tests in `loop-orchestrator.unit.test.ts`, using a real `AsyncLocalStorage`-backed fake Sentry client |
| 3 | New unit test in loop-orchestrator.unit.test.ts, no existing tests retired | MET | Two new tests added under "Sentry per-item tag isolation (LO-1.1)"; nothing removed |

## Test Plan
- `bun test agent/src/loop-orchestrator.unit.test.ts` — 101 pass, including 2 new tests: sequential tag isolation and concurrent/interleaved tag isolation (gates released in reverse dispatch order to defeat stack-order coincidence)
- `task typecheck` — all 7 workspaces green
- `task lint` — clean
- `task ci` — 1 pre-existing, unrelated failure in `agent/src/claude.unit.test.ts` ("extraAllowedTools > empty extraAllowedTools produces identical args to no extraAllowedTools"), verified present identically on the last commit whose GitHub Actions CI genuinely passed (`23d202bc`) in this same sandbox — not caused by this change. Aggregate coverage gate passed (81.39% lines / 82.32% functions vs 80% threshold).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
