### PR TITLE
feat: add server-side itemId/phaseId filters to cron-runs API

### DIFF
--- a/admin/src/agent-cron-runs.integration.test.ts
+++ b/admin/src/agent-cron-runs.integration.test.ts
@@ -306,6 +306,150 @@ describeOrSkip("AgentCronRunService (integration)", () => {
     );
   });
 
+  it("list() opts.itemId narrows results to runs dispatched against that item", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-01T08:00:00Z"),
+      skipped: false,
+      itemType: "task",
+      itemId: "WLS-2.2",
+    });
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-02T08:00:00Z"),
+      skipped: false,
+      itemType: "pr",
+      itemId: "acme/x#123",
+    });
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-03T08:00:00Z"),
+      skipped: false,
+    });
+
+    const { items, total } = await runService.list(cronId, agentId, {
+      itemId: "WLS-2.2",
+    });
+
+    expect(total).toBe(1);
+    expect(items).toHaveLength(1);
+    expect(items[0].itemId).toBe("WLS-2.2");
+  });
+
+  it("list() opts.phaseId narrows results to runs dispatched by that phase cron", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+    const phaseCronReview = await cronJobService.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Test prompt",
+      silent: true,
+      name: "shipwright-review",
+    });
+    const phaseCronDeploy = await cronJobService.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Test prompt",
+      silent: true,
+      name: "shipwright-deploy",
+    });
+
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-01T08:00:00Z"),
+      skipped: false,
+      phaseId: phaseCronReview.id,
+    });
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-02T08:00:00Z"),
+      skipped: false,
+      phaseId: phaseCronDeploy.id,
+    });
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-03T08:00:00Z"),
+      skipped: false,
+    });
+
+    const { items, total } = await runService.list(cronId, agentId, {
+      phaseId: phaseCronReview.id,
+    });
+
+    expect(total).toBe(1);
+    expect(items).toHaveLength(1);
+    expect(items[0].phaseId).toBe(phaseCronReview.id);
+  });
+
+  it("list() combines itemId and phaseId filters (AND, not OR)", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+    const phaseCronReview = await cronJobService.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Test prompt",
+      silent: true,
+      name: "shipwright-review",
+    });
+    const phaseCronDeploy = await cronJobService.create(agentId, {
+      schedule: "0 9 * * *",
+      prompt: "Test prompt",
+      silent: true,
+      name: "shipwright-deploy",
+    });
+
+    // Matches both filters
+    const matching = await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-01T08:00:00Z"),
+      skipped: false,
+      itemType: "pr",
+      itemId: "acme/x#123",
+      phaseId: phaseCronReview.id,
+    });
+    // Same itemId, different phaseId — must not match
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-02T08:00:00Z"),
+      skipped: false,
+      itemType: "pr",
+      itemId: "acme/x#123",
+      phaseId: phaseCronDeploy.id,
+    });
+    // Same phaseId, different itemId — must not match
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-03T08:00:00Z"),
+      skipped: false,
+      itemType: "pr",
+      itemId: "acme/y#456",
+      phaseId: phaseCronReview.id,
+    });
+
+    const { items, total } = await runService.list(cronId, agentId, {
+      itemId: "acme/x#123",
+      phaseId: phaseCronReview.id,
+    });
+
+    expect(total).toBe(1);
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe(matching.id);
+  });
+
+  it("list() with neither itemId nor phaseId returns unfiltered results (existing behavior unchanged)", async () => {
+    const agentId = await createAgent(prisma);
+    const cronId = await createCron(cronJobService, agentId);
+
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-01T08:00:00Z"),
+      skipped: false,
+      itemId: "WLS-2.2",
+    });
+    await runService.create(cronId, agentId, {
+      startedAt: new Date("2026-01-02T08:00:00Z"),
+      skipped: false,
+    });
+
+    const { items, total } = await runService.list(cronId, agentId, {
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(total).toBe(2);
+    expect(items).toHaveLength(2);
+  });
+
   it("list() returns modelBreakdown rows for a run with multiple models", async () => {
     const agentId = await createAgent(prisma);
     const cronId = await createCron(cronJobService, agentId);

--- a/admin/src/agent-cron-runs.ts
+++ b/admin/src/agent-cron-runs.ts
@@ -75,6 +75,10 @@ export interface PatchAgentCronRunInput {
 export interface ListAgentCronRunsOptions {
   limit?: number;
   offset?: number;
+  /** Narrow to runs dispatched against this work item (e.g. "WLS-2.2" or "acme/x#123"). */
+  itemId?: string;
+  /** Narrow to runs dispatched by this phase cron (a child AgentCronJob id). */
+  phaseId?: string;
 }
 
 export interface AgentCronRunList {
@@ -257,17 +261,23 @@ export class AgentCronRunService {
       throw new NotFoundError(`cron job ${cronId} not found`);
     }
 
+    const where: Prisma.AgentCronRunWhereInput = { cronId, agentId };
+    if (opts?.itemId) {
+      where.itemId = opts.itemId;
+    }
+    if (opts?.phaseId) {
+      where.phaseId = opts.phaseId;
+    }
+
     const [items, total] = await this.prisma.$transaction([
       this.prisma.agentCronRun.findMany({
-        where: { cronId, agentId },
+        where,
         orderBy: { startedAt: "desc" },
         take: limit,
         skip: offset,
         include: { modelBreakdown: true },
       }),
-      this.prisma.agentCronRun.count({
-        where: { cronId, agentId },
-      }),
+      this.prisma.agentCronRun.count({ where }),
     ]);
 
     return { items, total, limit, offset };

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -3065,6 +3065,75 @@ describe("admin API — cron runs", () => {
     expect(body.items[0].phaseId).toBeNull();
   });
 
+  it("GET /agents/:id/crons/:cronId/runs accepts itemId and phaseId query params end-to-end", async () => {
+    const base = makeMockDepsWithRunService();
+    const listCalls: Array<{
+      cronId: string;
+      agentId: string;
+      opts: unknown;
+    }> = [];
+    const deps: AdminDeps = {
+      ...base,
+      agentCronRunService: {
+        ...base.agentCronRunService,
+        list: async (cronId, agentId, opts) => {
+          listCalls.push({ cronId, agentId, opts });
+          return {
+            items: [],
+            total: 0,
+            limit: opts?.limit ?? 20,
+            offset: opts?.offset ?? 0,
+          };
+        },
+      },
+    };
+    const app = createAdminApp(deps);
+
+    const res = await app.request(
+      `/agents/${AGENT_ID}/crons/${CRON_ID}/runs?itemId=acme%2Fx%23123&phaseId=phase-cron-review`,
+      { headers: { Cookie: `admin_session=${cookie}` } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0].opts).toMatchObject({
+      itemId: "acme/x#123",
+      phaseId: "phase-cron-review",
+    });
+  });
+
+  it("GET /agents/:id/crons/:cronId/runs omits itemId/phaseId from list() opts when not passed as query params", async () => {
+    const base = makeMockDepsWithRunService();
+    const listCalls: Array<{ opts: unknown }> = [];
+    const deps: AdminDeps = {
+      ...base,
+      agentCronRunService: {
+        ...base.agentCronRunService,
+        list: async (cronId, agentId, opts) => {
+          listCalls.push({ opts });
+          return {
+            items: [],
+            total: 0,
+            limit: opts?.limit ?? 20,
+            offset: opts?.offset ?? 0,
+          };
+        },
+      },
+    };
+    const app = createAdminApp(deps);
+
+    const res = await app.request(`/agents/${AGENT_ID}/crons/${CRON_ID}/runs`, {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0].opts).toMatchObject({
+      itemId: undefined,
+      phaseId: undefined,
+    });
+  });
+
   it("GET /agents/:id/crons/:cronId/runs exposes phaseId when the run has one", async () => {
     const deps = makeMockDepsWithRunService({ phaseId: "phase-cron-review" });
     const app = createAdminApp(deps);

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -1317,10 +1317,12 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
   // GET /agents/:id/crons/:cronId/runs — list cron runs (paginated)
   app.openapi(listCronRunsRoute, async (c) => {
     const { id: agentId, cronId } = c.req.valid("param");
-    const { limit, offset } = c.req.valid("query");
+    const { limit, offset, itemId, phaseId } = c.req.valid("query");
     const result = await agentCronRunService.list(cronId, agentId, {
       limit,
       offset,
+      itemId,
+      phaseId,
     });
     return c.json(
       {

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -440,6 +440,10 @@ export const ListCronRunsQuerySchema = z
       .optional()
       .transform((v) => (v ? Number.parseInt(v, 10) : 0))
       .openapi({ example: "0" }),
+    /** Narrow to runs dispatched against this work item (e.g. "WLS-2.2" or "acme/x#123"). */
+    itemId: z.string().optional().openapi({ example: "acme/x#123" }),
+    /** Narrow to runs dispatched by this phase cron (a child AgentCronJob id). */
+    phaseId: z.string().optional().openapi({ example: "clx1234567890" }),
   })
   .openapi("ListCronRunsQuery");
 

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -299,7 +299,7 @@ Returns `201` with the created run record.
 GET /agents/:id/crons/:cronId/runs
 ```
 
-Query params: `limit` (default 20), `offset` (default 0). Returns `{ items: AgentCronRun[], total: number }`.
+Query params: `limit` (default 20), `offset` (default 0), `itemId` (optional; narrows to runs dispatched against this work item), `phaseId` (optional; narrows to runs dispatched by this phase cron). `itemId`/`phaseId` filter server-side via the Prisma `where` clause and can be combined (AND, not OR). Returns `{ items: AgentCronRun[], total: number }`.
 
 Each run record includes: `id`, `cronId`, `agentId`, `startedAt`, `completedAt`, `skipped`, `skipReason`, `outcome`, `error`, `phaseId` (nullable; child `AgentCronJob` id (FK) of the pipeline phase this run served — dev-task/review/patch/deploy; null for legacy five-job crons or runs with no phase attribution), `itemType`, `itemId`, `sessionId` (nullable; Claude session id this cron run corresponds to), `createdAt`, `modelBreakdown` (per-model token and cost breakdown array, each entry: `{ model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd }`). Top-level token fields (`inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`/`model`) were dropped from `AgentCronRun` — all token accounting now lives on `modelBreakdown`. The legacy `phase` string field was replaced by a `phaseId` foreign key (LPC-3.1). Note: the resolved `phaseCron` relation (`{ id, name }`) is only included by `listForAgent()`, used by the HTML cron-logs page — not by this JSON endpoint.
 

--- a/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
@@ -232,10 +232,11 @@ describe("SKILL.md — admin API run lookup", () => {
     expect(content).toContain("itemId");
   });
 
-  it("documents that runs endpoint filtering is done client-side, not via query params", () => {
-    const hasClientSideNote =
-      content.includes("client-side") || content.includes("client side");
-    expect(hasClientSideNote).toBe(true);
+  it("documents that runs endpoint filtering is done server-side via itemId/phaseId query params", () => {
+    const hasServerSideNote =
+      content.includes("server-side `itemId`/`phaseId`") ||
+      (content.includes("server-side") && content.includes("query filters"));
+    expect(hasServerSideNote).toBe(true);
   });
 
   it("uses SHIPWRIGHT_AGENT_API_KEY bearer auth for admin API calls", () => {
@@ -431,8 +432,8 @@ describe("SKILL.md — Step 1b populates ITEM_ARG in name+time mode (review fix)
   it("assigns ITEM_ARG from BEST_RUN's itemId in the name+time branch", () => {
     // Must appear in the BEST_RUN resolution block, not just anywhere in the doc.
     const bestRunBlock = content.slice(
-      content.indexOf("**Name+time mode** — filter client-side to `phaseId"),
-      content.indexOf("**Item mode** — filter client-side to `itemId"),
+      content.indexOf("**Name+time mode** — fetch runs scoped to `phaseId"),
+      content.indexOf("**Item mode** — fetch runs scoped to `itemId"),
     );
     expect(bestRunBlock).toContain('ITEM_ARG=$(echo "$BEST_RUN" | jq -r \'.itemId // empty\')');
   });

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -107,48 +107,52 @@ cron matches `<name>` — fall back to the pre-admin-API approach documented in
 the **Fallback: pre-admin-API history** section below, and skip the rest of
 this step.
 
-### 1b. List runs for the loop cron and filter client-side
+### 1b. List runs for the loop cron, filtered server-side
 
-`GET /agents/{id}/crons/{cronId}/runs` only supports `limit`/`offset` — there is
-**no server-side `phaseId` or `itemId` query filter**. Fetch pages of runs and
-filter the returned `items` array in your own script; do not pass `phaseId=` or
-`itemId=` as query params, the server ignores them.
+`GET /agents/{id}/crons/{cronId}/runs` supports `limit`/`offset` plus
+server-side `itemId`/`phaseId` query filters — pass `phaseId=` (name+time mode)
+or `itemId=` (item mode) directly as query params and the server narrows the
+Prisma `where` clause accordingly. There's no need to paginate through the full
+run history and filter client-side anymore.
+
+**Name+time mode** — fetch runs scoped to `phaseId=$PHASE_ID` directly. A
+single phase's run history is typically much smaller than the loop cron's full
+history, so one call with a generous `limit` is usually enough; only paginate
+(mirroring the loop below, scoped by `phaseId`) if `total` exceeds what you
+fetched:
 
 ```bash
-# Paginate through runs (limit=100 per page, cap at 5 pages / 500 runs).
-ALL_RUNS_FILE=$(mktemp)
-echo "[]" > "$ALL_RUNS_FILE"
-OFFSET=0
-LIMIT=100
-for PAGE in 1 2 3 4 5; do
+PHASE_RUNS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons/$LOOP_CRON_ID/runs?phaseId=$PHASE_ID&limit=100")
+PHASE_RUNS_FILE=$(mktemp)
+echo "$PHASE_RUNS_JSON" | jq '.items' > "$PHASE_RUNS_FILE"
+
+TOTAL=$(echo "$PHASE_RUNS_JSON" | jq -r '.total')
+OFFSET=100
+while [ "$OFFSET" -lt "$TOTAL" ]; do
   PAGE_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-    "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons/$LOOP_CRON_ID/runs?limit=$LIMIT&offset=$OFFSET")
-  ITEMS=$(echo "$PAGE_JSON" | jq '.items')
-  TOTAL=$(echo "$PAGE_JSON" | jq -r '.total')
-  ALL_RUNS_FILE_NEW=$(mktemp)
-  jq -s '.[0] + .[1]' "$ALL_RUNS_FILE" <(echo "$ITEMS") > "$ALL_RUNS_FILE_NEW"
-  mv "$ALL_RUNS_FILE_NEW" "$ALL_RUNS_FILE"
-  OFFSET=$((OFFSET + LIMIT))
-  if [ "$OFFSET" -ge "$TOTAL" ]; then
-    break
-  fi
+    "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons/$LOOP_CRON_ID/runs?phaseId=$PHASE_ID&limit=100&offset=$OFFSET")
+  PHASE_RUNS_FILE_NEW=$(mktemp)
+  jq -s '.[0] + .[1]' "$PHASE_RUNS_FILE" <(echo "$PAGE_JSON" | jq '.items') > "$PHASE_RUNS_FILE_NEW"
+  mv "$PHASE_RUNS_FILE_NEW" "$PHASE_RUNS_FILE"
+  OFFSET=$((OFFSET + 100))
 done
-echo "Fetched $(jq 'length' "$ALL_RUNS_FILE") total runs for loopCronId=$LOOP_CRON_ID"
+echo "Fetched $(jq 'length' "$PHASE_RUNS_FILE") runs for phaseId=$PHASE_ID"
 ```
 
-**Name+time mode** — filter client-side to `phaseId === <PHASE_ID>`, then pick
-the run whose `startedAt` is closest to `TARGET_EPOCH` (computed in 3a):
+Then pick the run whose `startedAt` is closest to `TARGET_EPOCH` (computed in
+3a) — this ranking is still done client-side, since the API doesn't take a
+"closest to a timestamp" query:
 
 ```bash
-BEST_RUN=$(jq -r --arg phase "$PHASE_ID" --argjson target "$TARGET_EPOCH" '
-  map(select(.phaseId == $phase))
-  | map(. + {distance: ((((.startedAt | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601) - $target) | if . < 0 then -. else . end)})
+BEST_RUN=$(jq -r --argjson target "$TARGET_EPOCH" '
+  map(. + {distance: ((((.startedAt | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601) - $target) | if . < 0 then -. else . end)})
   | sort_by(.distance)
   | first
-' "$ALL_RUNS_FILE")
+' "$PHASE_RUNS_FILE")
 
 if [ "$BEST_RUN" = "null" ] || [ -z "$BEST_RUN" ]; then
-  echo "No runs found for phaseId=$PHASE_ID within the fetched page cap — fall back to the pre-admin-API path."
+  echo "No runs found for phaseId=$PHASE_ID — fall back to the pre-admin-API path."
 else
   RUN_STARTED_AT=$(echo "$BEST_RUN" | jq -r '.startedAt')
   # Populate ITEM_ARG from the resolved run's itemId so Step 2's ground-truth
@@ -164,17 +168,26 @@ specific PR/task), `ITEM_ARG` stays empty and Step 2's item-scoped signals
 degrade gracefully — same behavior as when they're checked against an
 already-empty `ITEM_ARG` today.
 
-**Item mode** — filter client-side to `itemId === <ITEM_ARG>`, returning every
-matching run across all four phases, sorted chronologically:
+**Item mode** — fetch runs scoped to `itemId=$ITEM_ARG` directly; the server
+returns every matching run across all four phases in one call, no client-side
+`select()` needed:
 
 ```bash
-ITEM_RUNS=$(jq -r --arg item "$ITEM_ARG" '
-  map(select(.itemId == $item)) | sort_by(.startedAt)
-' "$ALL_RUNS_FILE")
+ITEM_RUNS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/crons/$LOOP_CRON_ID/runs?itemId=$ITEM_ARG&limit=100")
+
+# The API's orderBy is startedAt desc; re-sort ascending (chronological) for
+# the dispatch-history narrative below.
+ITEM_RUNS=$(echo "$ITEM_RUNS_JSON" | jq -r '.items | sort_by(.startedAt)')
 
 echo "Found $(echo "$ITEM_RUNS" | jq 'length') dispatch(es) for item \"$ITEM_ARG\":"
 echo "$ITEM_RUNS" | jq -r '.[] | "  \(.startedAt)  phaseId=\(.phaseId)  outcome=\(.outcome)  skipped=\(.skipped)"'
 ```
+
+If `total` in `ITEM_RUNS_JSON` exceeds the fetched `limit`, paginate with
+`itemId=$ITEM_ARG&limit=100&offset=<n>` the same way as the name+time mode loop
+above before sorting — in practice an item's dispatch count across four phases
+is small enough that this rarely triggers.
 
 If `ITEM_RUNS` is empty, no run was ever dispatched for that PR/task through the
 admin-tracked loop cron — either it predates run tracking, or the item was
@@ -505,8 +518,8 @@ this workspace's CWD doesn't match where the cron actually ran — see the
 
 Runs that predate admin-API run tracking (or that the admin API can't resolve
 for any reason — unreachable, no `shipwright-loop` cron found, no phase cron
-matching `<name>`, no runs returned for the resolved `phaseId`/`itemId` within
-the pagination cap) have no exact `startedAt` to anchor on. For those, fall
+matching `<name>`, no runs returned for the resolved `phaseId`/`itemId`) have no
+exact `startedAt` to anchor on. For those, fall
 back to the original fuzzy approach: a ±90 minute mtime window plus
 `[Cron job:]` string-matching in the transcript's first user message. This path
 only applies to `name-time` mode — `--item` mode has no time argument to build

--- a/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
@@ -232,10 +232,11 @@ describe("SKILL.md — admin API run lookup", () => {
     expect(content).toContain("itemId");
   });
 
-  it("documents that runs endpoint filtering is done client-side, not via query params", () => {
-    const hasClientSideNote =
-      content.includes("client-side") || content.includes("client side");
-    expect(hasClientSideNote).toBe(true);
+  it("documents that runs endpoint filtering is done server-side via itemId/phaseId query params", () => {
+    const hasServerSideNote =
+      content.includes("server-side `itemId`/`phaseId`") ||
+      (content.includes("server-side") && content.includes("query filters"));
+    expect(hasServerSideNote).toBe(true);
   });
 
   it("uses SHIPWRIGHT_AGENT_API_KEY bearer auth for admin API calls", () => {


### PR DESCRIPTION
## Summary
- Extend `ListCronRunsQuerySchema` with optional `itemId`/`phaseId` query params and thread them through `listCronRunsRoute`'s handler into `agentCronRunService.list()`.
- Refactor `AgentCronRunService.list()` to build a `Prisma.AgentCronRunWhereInput` conditionally, mirroring `listForAgent()`'s existing pattern — `findMany` and `count` share the same where clause.
- Update `investigate-cron/SKILL.md` Step 1b to use the new server-side `itemId=`/`phaseId=` filters directly instead of paginating up to 500 runs and filtering client-side.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `?itemId=X` and `?phaseId=Y` (individually and combined) filter server-side via the Prisma where clause | MET |
| 2 | Existing unfiltered/limit/offset behavior unchanged when neither param is passed | MET |
| 3 | `investigate-cron/SKILL.md` Step 1b updated, removing the "no server-side filter" caveat and 500-row pagination workaround | MET |
| 4 | New integration tests (itemId-only, phaseId-only, combined) + smoke test for route acceptance, additive only | MET |

## Test Plan
- New integration tests in `admin/src/agent-cron-runs.integration.test.ts`: itemId-only, phaseId-only, combined (AND) filtering, and unfiltered-baseline regression — all against a seeded Postgres DB.
- New smoke tests in `admin/src/agents-api.smoke.test.ts`: query params accepted end-to-end through the Hono route, and correctly omitted when absent.
- `task lint` and `task typecheck` pass.
- `task ci`'s full test suite passes except one pre-existing, unrelated flake (`agent/src/claude.unit.test.ts`'s `extraAllowedTools` suite), reproduces identically on clean `main`.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
