### PR TITLE
fix: honor session/repo/org/source/claimedBy/pr/branch/assignee filters in listReady()

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -186,7 +186,7 @@ Agent tokens (as opposed to admin tokens) can now have a scoped list of reposito
 - **Pool task visibility changes**: You may now see unassigned tasks with `repo` values that match your agent's scope.
 - **No action required**: The changes are additive; existing assigned-task queries behave identically. Only the visibility of pool tasks expands.
 
-**For implementers of `TaskService.listReady()`**: The method signature has changed from `listReady(agentId?: string)` to `listReady(agentId?: string, repos?: string[])`. Implementations that override `listReady()` must update to accept the `repos` parameter and apply the same filtering rule: include unassigned pool tasks whose `repo` is in the `repos` list.
+**For implementers of `TaskService.listReady()`**: The method signature has changed from `listReady(agentId?: string)` to `listReady(agentId?: string, repos?: string[], filters?: ListReadyFilters)`. Implementations that override `listReady()` must update to accept the `repos` parameter and apply the same filtering rule: include unassigned pool tasks whose `repo` is in the `repos` list. When `filters` is supplied, apply its `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, and `assignee` fields as post-filters after dependency resolution (never folded into the initial query, since a filtered-out task can still satisfy a dependency edge for an in-scope task).
 
 ---
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -47,7 +47,7 @@ Query params:
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
 | `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked` |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `hitl !== true` (Type A HITL tasks excluded; Type B tasks with `requiresHumanApproval=true` remain included), no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. The `?sort` parameter is not supported with `?ready=true`. |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `hitl !== true` (Type A HITL tasks excluded; Type B tasks with `requiresHumanApproval=true` remain included), no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. `session`/`source`/`repo`/`org`/`claimedBy`/`pr`/`branch`/`assignee` all apply under `?ready=true` identically to the plain list path (applied as an AND filter *after* dependency resolution — a task excluded by one of these filters can still satisfy a dependency edge for an in-scope task, since resolution needs the complete graph). `hitl` and `requiresHumanApproval` are not filterable here — `hitl` is structurally excluded from the ready set by definition (see above), and `requiresHumanApproval` intentionally does not gate the ready set at all (see its own row below). `limit`/`offset`/`sort`/`updatedSince` have no effect under `?ready=true` (see the unpaginated-convenience-endpoint note below). Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string, repeatable | Filter by repo (`org/repo` format). Repeat the param to match any repo in the list (e.g. `?repo=org/a&repo=org/b`). A single `?repo=` behaves identically to before (exact match). |
@@ -94,7 +94,19 @@ they compute over the entire task graph (dependency resolution needs every task,
 `limit`/`offset` slice) and always return every matching task in one response. Their `total`
 is simply `tasks.length`; `limit`/`offset` query params have no effect on these two branches. The
 `?sort` parameter applies to `?state=blocked` (sort by `createdAt`; default `asc`), but is not
-supported with `?ready=true`.
+supported with `?ready=true`. `updatedSince` has no effect on either branch, for the same
+whole-graph reason.
+
+Aside from those pagination/sort/recency exceptions (and `hitl`/`requiresHumanApproval`, which
+keep the ready-specific semantics documented in their own rows above), every other filter in
+the table — `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, `assignee` — applies
+under `?ready=true` exactly as it does on the plain list path. `TaskService.listReady()` applies
+these as a post-filter *after* `resolveReadyTasks()` has resolved the complete dependency graph,
+never folded into the initial query — a task that gets filtered out of the final response can
+still correctly satisfy a dependency edge for another, in-scope task. `repo`/`org` matching
+mirrors the same array-any-match (`repo`) / `startsWith "<org>/"` (`org`) / AND-between-both
+semantics described above for the plain list path, just evaluated in-memory instead of as a
+Prisma `where` clause.
 
 **Agent token visibility:**
 - **With repo scope** (repos configured): Return tasks where `assignee === agentId` OR (`assignee === null` AND `repo` is in the agent's scope). This union of explicitly-assigned and pool tasks enables the agent to claim unassigned work from its scoped repositories.

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -800,6 +800,75 @@ describe("task-store API (smoke)", () => {
     expect(capturedArgs[0]?.repos).toEqual(["acme-inc/backend-api"]);
   });
 
+  it("GET /tasks?ready=true forwards session/source/repo/org/claimedBy/pr/branch/assignee to listReady", async () => {
+    const capturedFilters: Array<Record<string, unknown> | undefined> = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async listReady(
+        _agentId?: string,
+        _repos?: string[],
+        filters?: Record<string, unknown>,
+      ) {
+        capturedFilters.push(filters);
+        return [];
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeTokenService(),
+      taskService: spyTaskService,
+    });
+
+    const res = await app.request(
+      "/tasks?ready=true&session=session-a&source=entropy-fix&repo=acme-inc%2Fbackend-api&org=acme-inc&claimedBy=agent-9&pr=42&branch=feat%2Ffoo&assignee=agent-9",
+      { headers: auth() },
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]).toMatchObject({
+      session: "session-a",
+      source: "entropy-fix",
+      repo: ["acme-inc/backend-api"],
+      org: ["acme-inc"],
+      claimedBy: "agent-9",
+      pr: 42,
+      branch: "feat/foo",
+      assignee: "agent-9",
+    });
+  });
+
+  it("GET /tasks?ready=true without the new filter params forwards them as undefined to listReady", async () => {
+    const capturedFilters: Array<Record<string, unknown> | undefined> = [];
+
+    const spyTaskService: TaskServiceLike = {
+      ...fakeTaskService(),
+      async listReady(
+        _agentId?: string,
+        _repos?: string[],
+        filters?: Record<string, unknown>,
+      ) {
+        capturedFilters.push(filters);
+        return [];
+      },
+    };
+
+    const app = makeApp({
+      tokenService: fakeTokenService(),
+      taskService: spyTaskService,
+    });
+
+    const res = await app.request("/tasks?ready=true", { headers: auth() });
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]?.session).toBeUndefined();
+    expect(capturedFilters[0]?.source).toBeUndefined();
+    expect(capturedFilters[0]?.claimedBy).toBeUndefined();
+    expect(capturedFilters[0]?.pr).toBeUndefined();
+    expect(capturedFilters[0]?.branch).toBeUndefined();
+    expect(capturedFilters[0]?.assignee).toBeUndefined();
+  });
+
   it("GET /tasks?repo=acme-inc/backend-api&pr=42 returns pool task for agent with matching repo", async () => {
     const capturedFilters: TaskListFilters[] = [];
 

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -549,18 +549,31 @@ export function createTasksRoutes(
     const repos = c.get("repos");
     const scopeDegraded = c.get("scopeDegraded");
     const stateRaw = c.req.query("state");
+    const prRaw = c.req.query("pr");
 
-    // Note: ?updatedSince is intentionally NOT threaded into listReady()/
-    // listBlocked() below. Both are convenience endpoints computed over the
-    // *entire* task graph (dependency resolution needs every task, not a
-    // recency-windowed subset) and the acceptance criteria for this filter
-    // only cover the plain GET /tasks list path, not these two branches.
+    // Note: ?updatedSince, ?limit, ?offset, and ?sort are intentionally NOT
+    // threaded into listReady()/listBlocked() below (sort partially — see
+    // the ?state=blocked branch). Both are convenience endpoints computed
+    // over the *entire* task graph (dependency resolution needs every task,
+    // not a recency-windowed or paginated subset). session/source/repo/org/
+    // claimedBy/pr/branch/assignee DO apply to listReady() (TRF-1.1) — same
+    // parsing as the fallback branch below, just also forwarded here.
     // ?ready=true is the legacy spelling; ?state=ready is the new form.
     if (c.req.query("ready") === "true" || stateRaw === "ready") {
       // Pass repos to listReady for repo-scoped agent tokens.
       const tasks = await taskService.listReady(
         agentId ?? undefined,
         repos ?? undefined,
+        {
+          session: c.req.query("session"),
+          source: c.req.query("source"),
+          repo: c.req.queries("repo"),
+          org: c.req.queries("org"),
+          claimedBy: c.req.query("claimedBy"),
+          pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
+          branch: c.req.query("branch"),
+          assignee: c.req.query("assignee"),
+        },
       );
       return c.json({ tasks, total: tasks.length, scopeDegraded }, 200);
     }
@@ -575,7 +588,6 @@ export function createTasksRoutes(
       return c.json({ tasks, total: tasks.length, scopeDegraded }, 200);
     }
 
-    const prRaw = c.req.query("pr");
     const limitRaw = c.req.query("limit");
     const offsetRaw = c.req.query("offset");
     const state =

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -295,6 +295,40 @@ describe("GET /tasks state filter (smoke)", () => {
     expect(body.total).toBe(0);
   });
 
+  it("GET /tasks?state=ready forwards session/source/repo/org/claimedBy/pr/branch/assignee to listReady", async () => {
+    const capturedFilters: Array<Record<string, unknown> | undefined> = [];
+    const baseFake = fakeTaskService({});
+    const taskService: TaskServiceLike = {
+      ...baseFake,
+      async listReady(
+        agentId?: string,
+        repos?: string[],
+        filters?: Record<string, unknown>,
+      ) {
+        capturedFilters.push(filters);
+        return [];
+      },
+    };
+    const app = makeApp(taskService);
+
+    const res = await app.request(
+      "/tasks?state=ready&session=session-a&source=entropy-fix&repo=acme-inc%2Fbackend-api&org=acme-inc&claimedBy=agent-9&pr=42&branch=feat%2Ffoo&assignee=agent-9",
+      { headers: auth() },
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]).toMatchObject({
+      session: "session-a",
+      source: "entropy-fix",
+      repo: ["acme-inc/backend-api"],
+      org: ["acme-inc"],
+      claimedBy: "agent-9",
+      pr: 42,
+      branch: "feat/foo",
+      assignee: "agent-9",
+    });
+  });
+
   // ─── state=in_progress ───────────────────────────────────────────────────────
 
   it("GET /tasks?state=in_progress returns 200", async () => {

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -50,8 +50,92 @@ function parseUpdatedSince(value: string): Date {
   return date;
 }
 
+/**
+ * In-memory equivalent of buildRepoOrgWhere's repo/org matching, evaluated
+ * against a single already-resolved Task rather than built as a Prisma
+ * where-clause fragment. Semantics are intentionally identical:
+ *   - repo (string): exact match against task.repo
+ *   - repo (string[]): true if task.repo is any of the listed repos
+ *   - org (string | string[]): true if task.repo starts with "<org>/" for
+ *     any of the listed orgs
+ *   - repo AND org both present: both must match (AND, not OR)
+ *   - neither present: true (no restriction)
+ * Empty arrays are treated the same as absent, matching buildRepoOrgWhere.
+ */
+function matchesRepoOrg(
+  task: { repo: string | null },
+  repo: string | string[] | undefined,
+  org: string | string[] | undefined,
+): boolean {
+  if (typeof repo === "string") {
+    if (task.repo !== repo) return false;
+  } else if (repo && repo.length > 0) {
+    if (task.repo === null || !repo.includes(task.repo)) return false;
+  }
+
+  if (org) {
+    const orgs = typeof org === "string" ? [org] : org;
+    if (orgs.length > 0) {
+      if (task.repo === null) return false;
+      const repoValue = task.repo;
+      if (!orgs.some((o) => repoValue.startsWith(`${o}/`))) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Post-filter predicate for TaskService.listReady() — see ListReadyFilters'
+ * doc comment for why this is applied after dependency resolution instead
+ * of being folded into the initial findMany(). Every set field is AND'd
+ * together; undefined/absent fields impose no restriction.
+ */
+function matchesReadyFilters(task: Task, filters: ListReadyFilters): boolean {
+  if (filters.session !== undefined && task.session !== filters.session)
+    return false;
+  if (filters.source !== undefined && task.source !== filters.source)
+    return false;
+  if (filters.claimedBy !== undefined && task.claimedBy !== filters.claimedBy)
+    return false;
+  if (filters.pr !== undefined && task.pr !== filters.pr) return false;
+  if (filters.branch !== undefined && task.branch !== filters.branch)
+    return false;
+  if (filters.assignee !== undefined && task.assignee !== filters.assignee)
+    return false;
+  if (!matchesRepoOrg(task, filters.repo, filters.org)) return false;
+  return true;
+}
+
 /** A Task augmented with a computed blockedBy array. */
 export type TaskWithBlockedBy = Task & { blockedBy: BlockedByEntry[] };
+
+/**
+ * Filters accepted by TaskService.listReady(), applied as an in-memory
+ * post-filter over the already-resolved ready array (see listReady() below)
+ * — never folded into the initial findMany(), since dependency resolution
+ * needs the complete task graph (a filtered-out task may still be a
+ * dependency of an in-scope task).
+ *
+ * Deliberately excludes status/state/hitl/requiresHumanApproval/limit/
+ * offset/sort/updatedSince/agentScope: the ready set's status/hitl
+ * semantics are structural (see ready.ts), pagination/sort don't apply to
+ * this whole-graph convenience endpoint (see docs/task-store.md), and
+ * agentId/repos scoping already has its own dedicated parameters mirroring
+ * the pre-existing signature.
+ */
+export interface ListReadyFilters {
+  session?: string;
+  source?: string;
+  /** Array-any-match, mirrors buildRepoOrgWhere's `{ repo: { in: repos } }`. */
+  repo?: string | string[];
+  /** startsWith "<org>/" match, mirrors buildRepoOrgWhere's OR clause. Combines with `repo` via AND. */
+  org?: string | string[];
+  claimedBy?: string;
+  pr?: number;
+  branch?: string;
+  assignee?: string;
+}
 
 /** Filters accepted by TaskService.list. */
 export interface TaskListFilters {
@@ -111,7 +195,11 @@ export interface TaskListResult {
 /** The subset of TaskService the routes depend on. */
 export interface TaskServiceLike {
   list(filters?: TaskListFilters): Promise<TaskListResult>;
-  listReady(agentId?: string, repos?: string[]): Promise<Task[]>;
+  listReady(
+    agentId?: string,
+    repos?: string[],
+    filters?: ListReadyFilters,
+  ): Promise<Task[]>;
   listBlocked(
     agentId?: string,
     repos?: string[],
@@ -256,10 +344,23 @@ export class TaskService implements TaskServiceLike {
    * When `repos` is provided (repo-scoped agent token), unassigned pool tasks
    * whose repo is in the repos list are also included.
    *
+   * `filters` (session/source/repo/org/claimedBy/pr/branch/assignee) is
+   * applied as an additional AND condition, strictly *after*
+   * resolveReadyTasks() has resolved the graph — see ListReadyFilters'
+   * doc comment for why this can't be folded into the initial findMany().
+   * repo/org matching mirrors buildRepoOrgWhere's semantics (array-any-match
+   * for repo; startsWith "<org>/" for org; AND between the two), just
+   * evaluated in-memory against already-resolved Task objects rather than
+   * built as a Prisma where-clause.
+   *
    * Tasks are returned in ascending createdAt order (oldest first) to ensure
    * deterministic selection regardless of insertion order.
    */
-  async listReady(agentId?: string, repos?: string[]): Promise<Task[]> {
+  async listReady(
+    agentId?: string,
+    repos?: string[],
+    filters?: ListReadyFilters,
+  ): Promise<Task[]> {
     // Load all tasks so dependency resolution sees the full graph, then filter
     // the result set to the caller's agent if one is specified.
     const tasks = await this.prisma.task.findMany({
@@ -270,17 +371,19 @@ export class TaskService implements TaskServiceLike {
       async () => false,
       () => this.clock.now(),
     );
-    if (agentId) {
-      return ready.filter(
-        (t) =>
-          t.assignee === agentId ||
-          (repos !== undefined &&
-            t.assignee === null &&
-            t.repo !== null &&
-            repos.includes(t.repo)),
-      );
-    }
-    return ready;
+    const scoped = agentId
+      ? ready.filter(
+          (t) =>
+            t.assignee === agentId ||
+            (repos !== undefined &&
+              t.assignee === null &&
+              t.repo !== null &&
+              repos.includes(t.repo)),
+        )
+      : ready;
+    return filters
+      ? scoped.filter((t) => matchesReadyFilters(t, filters))
+      : scoped;
   }
 
   /**

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -966,7 +966,8 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
 
         const matchesId = row.id === taskId;
         const matchesStatus = row.status === "pending";
-        const matchesClaimedBy = !requiresClaimedByNull || row.claimedBy === null;
+        const matchesClaimedBy =
+          !requiresClaimedByNull || row.claimedBy === null;
 
         const shouldUpdate = matchesId && matchesStatus && matchesClaimedBy;
 
@@ -1063,5 +1064,362 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
     await expect(service.claim("task-1", "agent-1")).rejects.toThrow(
       ConflictError,
     );
+  });
+});
+
+// ─── TaskService.listReady() session/repo/org/source/claimedBy/pr/branch/assignee filters (TRF-1.1) ───
+
+describe("TaskService.listReady() filters (unit)", () => {
+  /**
+   * makeReadyTask — full task object for use in the listReady() Prisma
+   * double. Defaults to a ready, unclaimed, dependency-free pending task.
+   */
+  function makeReadyTask(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "task-1",
+      title: "A task",
+      status: "pending",
+      source: null,
+      session: null,
+      repo: null,
+      description: null,
+      acceptanceCriteria: [],
+      layer: null,
+      branch: null,
+      dependencies: [],
+      pr: null,
+      hours: null,
+      startedAt: null,
+      prCreatedAt: null,
+      mergedAt: null,
+      blockedAt: null,
+      blockedReason: null,
+      note: null,
+      type: null,
+      priority: null,
+      cancelledAt: null,
+      completedAt: null,
+      deployingAt: null,
+      ciFixAttempts: null,
+      mergeCommit: null,
+      prUrl: null,
+      assignee: null,
+      issue: null,
+      model: null,
+      complexity: null,
+      hitl: null,
+      requiresHumanApproval: false,
+      claimedBy: null,
+      agentHint: null,
+      claimedAt: null,
+      heartbeatAt: null,
+      createdAt: new Date("2026-08-10T12:00:00.000Z"),
+      updatedAt: new Date("2026-08-10T12:00:00.000Z"),
+      ...overrides,
+    } as Task;
+  }
+
+  /** Prisma double serving a fixed set of tasks to the whole-graph findMany(). */
+  function makeReadyPrismaDouble(tasks: Task[]) {
+    const prisma = {
+      task: {
+        findMany() {
+          return Promise.resolve(tasks);
+        },
+      },
+    };
+    return prisma as unknown as PrismaClient;
+  }
+
+  // ─── session ──────────────────────────────────────────────────────────────
+
+  it("listReady({ session }) returns only tasks matching the session", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", session: "session-a" }),
+      makeReadyTask({ id: "t2", session: "session-b" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      session: "session-a",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── source ───────────────────────────────────────────────────────────────
+
+  it("listReady({ source }) returns only tasks matching the source", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", source: "entropy-fix" }),
+      makeReadyTask({ id: "t2", source: "plan-session" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      source: "entropy-fix",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── claimedBy ────────────────────────────────────────────────────────────
+
+  it("listReady({ claimedBy }) returns only tasks matching claimedBy", async () => {
+    // claimedBy is set on a ready task even though claimed tasks are
+    // typically in_progress — the filter is applied uniformly regardless.
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", claimedBy: "agent-x" }),
+      makeReadyTask({ id: "t2", claimedBy: "agent-y" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      claimedBy: "agent-x",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── pr ───────────────────────────────────────────────────────────────────
+
+  it("listReady({ pr }) returns only tasks matching the PR number", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", pr: 42 }),
+      makeReadyTask({ id: "t2", pr: 99 }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, { pr: 42 });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── branch ───────────────────────────────────────────────────────────────
+
+  it("listReady({ branch }) returns only tasks matching the branch", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", branch: "feat/a" }),
+      makeReadyTask({ id: "t2", branch: "feat/b" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      branch: "feat/a",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── assignee ─────────────────────────────────────────────────────────────
+
+  it("listReady({ assignee }) returns only tasks matching the assignee", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", assignee: "agent-x" }),
+      makeReadyTask({ id: "t2", assignee: "agent-y" }),
+      makeReadyTask({ id: "t3", assignee: null }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      assignee: "agent-x",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── repo (array-any-match, mirrors buildRepoOrgWhere) ─────────────────────
+
+  it("listReady({ repo: string }) returns only tasks with an exact repo match", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", repo: "acme/foo" }),
+      makeReadyTask({ id: "t2", repo: "acme/bar" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      repo: "acme/foo",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("listReady({ repo: string[] }) returns tasks matching any repo in the list", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", repo: "acme/foo" }),
+      makeReadyTask({ id: "t2", repo: "acme/bar" }),
+      makeReadyTask({ id: "t3", repo: "acme/baz" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      repo: ["acme/foo", "acme/bar"],
+    });
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+  });
+
+  // ─── org (startsWith "<org>/", mirrors buildRepoOrgWhere) ──────────────────
+
+  it("listReady({ org: string }) returns tasks whose repo starts with '<org>/'", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", repo: "app-vitals/shipwright" }),
+      makeReadyTask({ id: "t2", repo: "acme/backend-api" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      org: "app-vitals",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("listReady({ org: string[] }) returns tasks matching any org", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", repo: "app-vitals/shipwright" }),
+      makeReadyTask({ id: "t2", repo: "acme/backend-api" }),
+      makeReadyTask({ id: "t3", repo: "other/repo" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      org: ["app-vitals", "acme"],
+    });
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+  });
+
+  it("listReady({ repo, org }) ANDs repo and org, mirroring buildRepoOrgWhere", async () => {
+    const prisma = makeReadyPrismaDouble([
+      // Matches both repo list AND org.
+      makeReadyTask({ id: "t1", repo: "app-vitals/shipwright" }),
+      // Matches repo list but not org.
+      makeReadyTask({ id: "t2", repo: "acme/backend-api" }),
+      // Matches org but not repo list.
+      makeReadyTask({ id: "t3", repo: "app-vitals/other-repo" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      repo: ["app-vitals/shipwright", "acme/backend-api"],
+      org: "app-vitals",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  // ─── combined filters ───────────────────────────────────────────────────────
+
+  it("listReady() combines multiple new filters together (AND semantics)", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", session: "session-a", source: "entropy-fix" }),
+      makeReadyTask({ id: "t2", session: "session-a", source: "plan-session" }),
+      makeReadyTask({ id: "t3", session: "session-b", source: "entropy-fix" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      session: "session-a",
+      source: "entropy-fix",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("listReady() combines new filters with agentId/repos scoping", async () => {
+    const prisma = makeReadyPrismaDouble([
+      // Owned by agent-1, matches source filter.
+      makeReadyTask({
+        id: "t1",
+        assignee: "agent-1",
+        source: "entropy-fix",
+        repo: "acme/backend-api",
+      }),
+      // Owned by agent-1, but wrong source — excluded by the new filter.
+      makeReadyTask({
+        id: "t2",
+        assignee: "agent-1",
+        source: "plan-session",
+        repo: "acme/backend-api",
+      }),
+      // Unassigned pool task in scope, matches source filter.
+      makeReadyTask({
+        id: "t3",
+        assignee: null,
+        source: "entropy-fix",
+        repo: "acme/backend-api",
+      }),
+      // Owned by a different agent — excluded by agentId scoping regardless
+      // of matching the source filter.
+      makeReadyTask({
+        id: "t4",
+        assignee: "agent-2",
+        source: "entropy-fix",
+        repo: "acme/backend-api",
+      }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady("agent-1", ["acme/backend-api"], {
+      source: "entropy-fix",
+    });
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t3"]);
+  });
+
+  // ─── undefined/empty filters do not exclude tasks ──────────────────────────
+
+  it("listReady() with no filters object returns every ready task (back-compat)", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1" }),
+      makeReadyTask({ id: "t2" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady();
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+  });
+
+  it("listReady({}) (empty filters object) returns every ready task", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1" }),
+      makeReadyTask({ id: "t2" }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {});
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+  });
+
+  // ─── dependency graph resolved before filtering ────────────────────────────
+
+  it("listReady() applies filters strictly after dependency resolution — an excluded task still satisfies a dependent's readiness", async () => {
+    // depTask is 'done' (satisfies dependency rules) but belongs to a
+    // different session — the session filter must not remove it from the
+    // whole-graph resolution pass, only from the final returned list. The
+    // dependent task must still show up as ready.
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({
+        id: "dep-task",
+        status: "done",
+        session: "session-other",
+      }),
+      makeReadyTask({
+        id: "dependent-task",
+        status: "pending",
+        session: "session-a",
+        dependencies: ["dep-task"],
+      }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      session: "session-a",
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["dependent-task"]);
   });
 });

--- a/task-store/src/tasks.integration.test.ts
+++ b/task-store/src/tasks.integration.test.ts
@@ -622,6 +622,108 @@ describeOrSkip("Task store schema (integration)", () => {
     expect(resultIds).toEqual(expectedOrder);
   });
 
+  // ─── TaskService.listReady() session/repo/org/source/claimedBy/pr/branch/assignee filters (TRF-1.1) ───
+
+  it("listReady({ session }) applies the session filter strictly after dependency resolution — a filtered-out dependency still satisfies its dependent's readiness", async () => {
+    const taskService = new TaskService(prisma);
+
+    // Dependency belongs to a different session than the filter — if the
+    // filter were folded into the initial query (instead of applied as a
+    // post-filter over the fully-resolved graph), this task would be
+    // invisible to resolveReadyTasks() and the dependent below would be
+    // wrongly excluded from the ready set.
+    const depTask = await prisma.task.create({
+      data: {
+        title: "Dependency (different session, already done)",
+        status: "done",
+        session: "session-other",
+        repo: "acme-inc/backend-api",
+      },
+    });
+    const dependentTask = await prisma.task.create({
+      data: {
+        title: "Dependent (in-scope session)",
+        status: "pending",
+        session: "session-a",
+        repo: "acme-inc/backend-api",
+        dependencies: [depTask.id],
+      },
+    });
+    // A distractor pending task in the filtered session with no
+    // dependencies, to prove the filter doesn't just pass everything.
+    await prisma.task.create({
+      data: {
+        title: "Unrelated same-session task, wrong repo",
+        status: "pending",
+        session: "session-a",
+        repo: "acme-inc/other-repo",
+      },
+    });
+
+    const result = await taskService.listReady(undefined, undefined, {
+      session: "session-a",
+    });
+
+    const titles = result.map((t) => t.title);
+    expect(titles).toContain("Dependent (in-scope session)");
+    // The filtered-out dependency itself must not appear in the final
+    // result (it belongs to a different session)...
+    expect(titles).not.toContain(
+      "Dependency (different session, already done)",
+    );
+    // ...yet the dependent task must still be considered ready, proving
+    // dependency resolution saw the complete graph before filtering.
+    expect(result.map((t) => t.id)).toContain(dependentTask.id);
+  });
+
+  it("listReady() combines session/source/repo/org/claimedBy/pr/branch/assignee filters with agentId/repos scoping", async () => {
+    const taskService = new TaskService(prisma);
+
+    await prisma.task.create({
+      data: {
+        title: "Matches every filter",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "acme-inc/backend-api",
+        session: "session-a",
+        source: "entropy-fix",
+      },
+    });
+    await prisma.task.create({
+      data: {
+        title: "Wrong source, owned by agent-1",
+        status: "pending",
+        assignee: "agent-1",
+        repo: "acme-inc/backend-api",
+        session: "session-a",
+        source: "plan-session",
+      },
+    });
+    await prisma.task.create({
+      data: {
+        title: "Matches filters but owned by a different agent",
+        status: "pending",
+        assignee: "agent-2",
+        repo: "acme-inc/backend-api",
+        session: "session-a",
+        source: "entropy-fix",
+      },
+    });
+
+    const result = await taskService.listReady(
+      "agent-1",
+      ["acme-inc/backend-api"],
+      { session: "session-a", source: "entropy-fix" },
+    );
+
+    const titles = result.map((t) => t.title);
+    expect(titles).toContain("Matches every filter");
+    expect(titles).not.toContain("Wrong source, owned by agent-1");
+    expect(titles).not.toContain(
+      "Matches filters but owned by a different agent",
+    );
+  });
+
   it("list() with agentScope AND repo filter applies repo as additional AND condition", async () => {
     const taskService = new TaskService(prisma);
 


### PR DESCRIPTION
## Summary
- `TaskService.listReady()` now accepts an optional `filters` param (session, source, repo, org, claimedBy, pr, branch, assignee), applied as a post-filter strictly after `resolveReadyTasks()` resolves the full dependency graph — mirrors the existing agentId/repos post-filter and `buildRepoOrgWhere`'s repo/org semantics (array-any-match for repo, `startsWith "<org>/"` for org, AND between the two).
- `tasks.ts`'s `ready=true`/`state=ready` route branch now parses and forwards all eight filters from the query string, same parsing already used by the fallback list path.
- `docs/task-store.md` and `docs/migration.md` updated to document the new filter behavior; `hitl`/`requiresHumanApproval` and the `limit`/`offset`/`sort`/`updatedSince` exceptions remain unchanged.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `listReady()` accepts filters param, post-filter after `resolveReadyTasks()`, mirrors `buildRepoOrgWhere` | MET |
| 2 | `tasks.ts` ready branch reads & forwards all 8 params | MET |
| 3 | `docs/task-store.md` updated | MET |
| 4 | Additive tests: unit + integration + smoke | MET |

## Test Plan
- Unit tests in `task-service.unit.test.ts` covering each new filter alone and combined with agentId/repos scoping
- Integration test in `tasks.integration.test.ts` proving filtering happens post-dependency-resolution (a filtered-out task still satisfies a dependency edge for an in-scope task)
- Smoke tests in `api.smoke.test.ts` and `state-filter.smoke.test.ts` asserting the route forwards each new param to `listReady()`
- No existing tests retired — purely additive
- [x] Pre-commit checks passing (lint, check-strings, typecheck, check-config-docs, check-version-sync all green; full-suite `bun test` has 1 pre-existing flaky failure confirmed to also reproduce on clean `origin/main`, unrelated to this diff)

Generated with [Claude Code](https://claude.com/claude-code)
