### PR TITLE
fix: admin blocked-task badge/detail render crash + BlockedByEntry parity test

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -9,7 +9,7 @@
     "postinstall": "prisma generate --schema=prisma/schema.prisma",
     "test": "NODE_ENV=test bun test",
     "test:e2e": "bunx playwright test",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.type-parity.json",
     "db:generate": "prisma generate --schema=prisma/schema.prisma",
     "db:migrate": "prisma migrate deploy --schema=prisma/schema.prisma"
   },

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -83,7 +83,8 @@ function relativeTime(date: Date, now: Date = new Date()): string {
 // Inline type — mirrors task-store/src/blocked-by.ts without cross-package coupling.
 export type BlockedByEntry =
   | { type: "hitl"; notified?: true }
-  | { type: "dependency"; id: string; status: string };
+  | { type: "dependency"; id: string; status: string }
+  | { type: "blocked"; reason: string | null };
 
 // Inline type mirroring PullRequest fields relevant to the task detail UI.
 // Avoids cross-package coupling to @shipwright/task-store.
@@ -1749,6 +1750,9 @@ export function renderTasksPage(
         if (b.type === "hitl") {
           return `<span class="badge badge-hitl" style="font-size:10px;margin-left:6px">Waiting: HITL</span>`;
         }
+        if (b.type === "blocked") {
+          return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${escapeHtml(b.reason ?? "Blocked")}</span>`;
+        }
         return `<span class="badge badge-dep" style="font-size:10px;margin-left:6px">Blocked: ${readOnly ? escapeHtml(b.id) : taskLink(b.id)}</span>`;
       })
       .join("");
@@ -2196,6 +2200,9 @@ export function renderTaskDetailPage(
                     ? "HITL gate (notification sent — awaiting clearance)"
                     : "HITL gate (notification pending)";
                   return `<li style="font-size:14px;line-height:1.6;margin-bottom:4px">${escapeHtml(label)}</li>`;
+                }
+                if (b.type === "blocked") {
+                  return `<li style="font-size:14px;line-height:1.6;margin-bottom:4px">Blocked: ${escapeHtml(b.reason ?? "Blocked")}</li>`;
                 }
                 return `<li style="font-size:14px;line-height:1.6;margin-bottom:4px">dep:${taskLink(b.id)} (${escapeHtml(b.status)})</li>`;
               })

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2467,6 +2467,61 @@ describe("renderTasksPage — blocker badges", () => {
     expect(html).not.toContain("<script>alert(1)</script>");
     expect(html).toContain("&lt;script&gt;");
   });
+
+  // Regression test for Sentry issue 7665355727: a {type:"blocked"} entry
+  // (status:"blocked" tasks) previously fell through to the dependency
+  // branch and crashed on taskLink(b.id)/escapeHtml(undefined).
+  test("blocked entry with a populated reason renders the reason, not a crash", () => {
+    const taskBlockedWithReason: TaskItem = {
+      id: "TASK-9",
+      title: "Explicitly blocked",
+      status: "blocked",
+      session: null,
+      repo: null,
+      assignee: null,
+      claimedBy: null,
+      blockedBy: [{ type: "blocked", reason: "Waiting on external vendor" }],
+    };
+    expect(() => render([taskBlockedWithReason])).not.toThrow();
+    const html = render([taskBlockedWithReason]);
+    expect(html).toContain("Waiting on external vendor");
+    expect(html).not.toContain("undefined");
+  });
+
+  test("blocked entry with a null reason renders a fallback label, not a crash", () => {
+    const taskBlockedNoReason: TaskItem = {
+      id: "TASK-10",
+      title: "Blocked, no reason recorded",
+      status: "blocked",
+      session: null,
+      repo: null,
+      assignee: null,
+      claimedBy: null,
+      blockedBy: [{ type: "blocked", reason: null }],
+    };
+    expect(() => render([taskBlockedNoReason])).not.toThrow();
+    const html = render([taskBlockedNoReason]);
+    expect(html).toContain("Blocked");
+    expect(html).not.toContain("undefined");
+  });
+
+  test("blocked entry's reason is HTML-escaped", () => {
+    const taskBlockedXss: TaskItem = {
+      id: "TASK-11",
+      title: "Blocked with unsafe reason",
+      status: "blocked",
+      session: null,
+      repo: null,
+      assignee: null,
+      claimedBy: null,
+      blockedBy: [
+        { type: "blocked", reason: "<script>alert(1)</script>" },
+      ],
+    };
+    const html = render([taskBlockedXss]);
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
 });
 
 // ─── renderTasksPage — PR column ──────────────────────────────────────────────
@@ -3141,6 +3196,39 @@ describe("renderTaskDetailPage — blockers", () => {
       blockedBy: [
         { type: "dependency", id: "<script>xss()</script>", status: "pending" },
       ],
+    });
+    expect(html).not.toContain("<script>xss");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  // Regression test for Sentry issue 7665355727: a {type:"blocked"} entry
+  // previously fell through to the dependency branch and crashed on
+  // taskLink(b.id)/escapeHtml(b.status), both undefined for this variant.
+  test("blocked entry with a populated reason renders the reason, not a crash", () => {
+    expect(() =>
+      render({
+        blockedBy: [{ type: "blocked", reason: "Waiting on external vendor" }],
+      }),
+    ).not.toThrow();
+    const html = render({
+      blockedBy: [{ type: "blocked", reason: "Waiting on external vendor" }],
+    });
+    expect(html).toContain("Waiting on external vendor");
+    expect(html).not.toContain("undefined");
+  });
+
+  test("blocked entry with a null reason renders a fallback label, not a crash", () => {
+    expect(() =>
+      render({ blockedBy: [{ type: "blocked", reason: null }] }),
+    ).not.toThrow();
+    const html = render({ blockedBy: [{ type: "blocked", reason: null }] });
+    expect(html).toContain("Blocked");
+    expect(html).not.toContain("undefined");
+  });
+
+  test("blocked entry's reason is HTML-escaped in the blockers list", () => {
+    const html = render({
+      blockedBy: [{ type: "blocked", reason: "<script>xss()</script>" }],
     });
     expect(html).not.toContain("<script>xss");
     expect(html).toContain("&lt;script&gt;");

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2514,9 +2514,7 @@ describe("renderTasksPage — blocker badges", () => {
       repo: null,
       assignee: null,
       claimedBy: null,
-      blockedBy: [
-        { type: "blocked", reason: "<script>alert(1)</script>" },
-      ],
+      blockedBy: [{ type: "blocked", reason: "<script>alert(1)</script>" }],
     };
     const html = render([taskBlockedXss]);
     expect(html).not.toContain("<script>alert(1)</script>");

--- a/admin/src/blocked-by-type-parity.check.ts
+++ b/admin/src/blocked-by-type-parity.check.ts
@@ -1,0 +1,75 @@
+/**
+ * admin/src/blocked-by-type-parity.check.ts
+ *
+ * Compile-time-only parity check between admin's hand-mirrored `BlockedByEntry`
+ * (admin-ui-pages.ts — kept deliberately decoupled from @shipwright/task-store,
+ * see the "avoids cross-package coupling" comments in that file) and the real
+ * `BlockedByEntry` union in task-store/src/blocked-by.ts.
+ *
+ * This file has NO runtime behavior and is never imported by application code —
+ * it exists purely so `tsc --noEmit` fails the build when task-store's union
+ * gains (or loses) a variant that admin's mirror hasn't been updated to match.
+ * It is type-checked via the dedicated `tsconfig.type-parity.json` project
+ * (see admin/package.json's `typecheck` script), which is the only place in
+ * this package allowed to reach outside admin/'s own `rootDir` — purely for
+ * this type-level comparison, with zero runtime import and zero package.json
+ * dependency on @shipwright/task-store.
+ *
+ * Intentionally NOT a strict two-way "every field on every variant matches"
+ * check: task-store's `{ type: "hitl" }` variant has no `notified` field,
+ * while admin's mirror carries an optional `notified?: true` used purely for
+ * UI copy (see renderTaskDetailPage's blockers section) — that pre-existing,
+ * known divergence is not a bug and must not fail this check. What this check
+ * *does* guard: every variant (keyed by `type`) that exists on task-store's
+ * side must have a same-`type` counterpart on admin's side that is at least
+ * as permissive (i.e. every real value assignable to the task-store variant
+ * must also be assignable to admin's matching variant). Add a new variant to
+ * task-store's union without a matching admin variant, and the exhaustiveness
+ * check below fails to compile.
+ */
+
+import type { BlockedByEntry as RealBlockedByEntry } from "../../task-store/src/blocked-by.ts";
+import type { BlockedByEntry as AdminBlockedByEntry } from "./admin-ui-pages.ts";
+
+// Every `type` discriminant present in task-store's real union.
+type RealType = RealBlockedByEntry["type"];
+
+// Every `type` discriminant present in admin's mirrored union.
+type AdminType = AdminBlockedByEntry["type"];
+
+/**
+ * Fails to compile if task-store adds/renames a variant's `type` without a
+ * same-named counterpart being added to admin's mirror. This is the actual
+ * regression this file guards against (e.g. the missing "blocked" variant
+ * that caused Sentry issue 7665355727).
+ */
+type _AssertEveryRealTypeHasAdminCounterpart = RealType extends AdminType
+  ? true
+  : ["missing admin BlockedByEntry variant for type", Exclude<RealType, AdminType>];
+const _assertEveryRealTypeHasAdminCounterpart: _AssertEveryRealTypeHasAdminCounterpart = true;
+void _assertEveryRealTypeHasAdminCounterpart;
+
+/**
+ * For each `type`, every real task-store shape must be assignable to admin's
+ * matching shape (admin's mirror may be *more* permissive, e.g. the known
+ * extra optional `notified` field on "hitl", but never *less* permissive —
+ * it must still accept every real value task-store can actually produce).
+ */
+type AssertVariantAssignable<T extends RealType> = Extract<
+  RealBlockedByEntry,
+  { type: T }
+> extends Extract<AdminBlockedByEntry, { type: T }>
+  ? true
+  : ["admin BlockedByEntry variant for type", T, "is not assignable from task-store's real shape"];
+
+type _AssertHitlAssignable = AssertVariantAssignable<"hitl">;
+const _assertHitlAssignable: _AssertHitlAssignable = true;
+void _assertHitlAssignable;
+
+type _AssertDependencyAssignable = AssertVariantAssignable<"dependency">;
+const _assertDependencyAssignable: _AssertDependencyAssignable = true;
+void _assertDependencyAssignable;
+
+type _AssertBlockedAssignable = AssertVariantAssignable<"blocked">;
+const _assertBlockedAssignable: _AssertBlockedAssignable = true;
+void _assertBlockedAssignable;

--- a/admin/src/blocked-by-type-parity.check.ts
+++ b/admin/src/blocked-by-type-parity.check.ts
@@ -45,7 +45,10 @@ type AdminType = AdminBlockedByEntry["type"];
  */
 type _AssertEveryRealTypeHasAdminCounterpart = RealType extends AdminType
   ? true
-  : ["missing admin BlockedByEntry variant for type", Exclude<RealType, AdminType>];
+  : [
+      "missing admin BlockedByEntry variant for type",
+      Exclude<RealType, AdminType>,
+    ];
 const _assertEveryRealTypeHasAdminCounterpart: _AssertEveryRealTypeHasAdminCounterpart = true;
 void _assertEveryRealTypeHasAdminCounterpart;
 
@@ -60,7 +63,11 @@ type AssertVariantAssignable<T extends RealType> = Extract<
   { type: T }
 > extends Extract<AdminBlockedByEntry, { type: T }>
   ? true
-  : ["admin BlockedByEntry variant for type", T, "is not assignable from task-store's real shape"];
+  : [
+      "admin BlockedByEntry variant for type",
+      T,
+      "is not assignable from task-store's real shape",
+    ];
 
 type _AssertHitlAssignable = AssertVariantAssignable<"hitl">;
 const _assertHitlAssignable: _AssertHitlAssignable = true;

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/blocked-by-type-parity.check.ts"]
 }

--- a/admin/tsconfig.type-parity.json
+++ b/admin/tsconfig.type-parity.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true
+  },
+  "include": [
+    "src/blocked-by-type-parity.check.ts",
+    "src/admin-ui-pages.ts",
+    "../task-store/src/blocked-by.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Add the missing `{ type: "blocked"; reason: string | null }` variant to admin's hand-mirrored `BlockedByEntry` type, matching `task-store/src/blocked-by.ts` exactly.
- Fix `renderBlockerBadges` and the task-detail blockers renderer to handle this variant (escaped `reason`, "Blocked" fallback when null) instead of falling through to `taskLink(b.id)`/`escapeHtml(b.status)`, which crashed with `undefined` for this variant (Sentry issue 7665355727).
- Add a compile-time-only type-parity check (`admin/src/blocked-by-type-parity.check.ts` + dedicated `tsconfig.type-parity.json`) that fails the build if task-store's real union diverges from admin's mirror in the future — no runtime import, no new `admin/package.json` dependency.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `BlockedByEntry` gains `{ type: "blocked"; reason: string \| null }` matching task-store exactly | MET |
| 2 | `renderBlockerBadges` adds a `b.type==="blocked"` branch rendering escaped `reason` with fallback | MET |
| 3 | Task-detail blockers renderer gets the identical fix | MET |
| 4 | Compile-time-only type-parity test added, no runtime import, no new dependency | MET |
| 5 | Unit tests cover both renderers × {populated reason, null reason}, asserting no throw + correct escaped HTML | MET |

## Test Plan
- 6 new unit tests in `admin-ui-pages.unit.test.ts` (populated reason, null reason, XSS-escaping — 3 per renderer), all reproducing the exact Sentry crash before the fix and passing after.
- Full admin unit suite: 574 pass / 0 fail.
- `task lint`, `task check-strings`, `task check-version-sync`, `task check-config-docs`, `task typecheck` (all 7 packages, including the new type-parity project) all pass cleanly.
- Coverage: `admin/src/admin-ui-pages.ts` at 97.8%; aggregate repo-wide coverage 81.36% lines / 82.31% functions (threshold 80%/80%) — gate passes.
- `task test:coverage` has one pre-existing, unrelated failure (`extraAllowedTools > empty extraAllowedTools produces identical args...` in `agent/src/claude.unit.test.ts`) — confirmed to reproduce identically on `main` with none of this PR's changes applied.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
