### PR TITLE
feat: add Factory to self-hosted architecture comparison table

### DIFF
--- a/site/src/pages/self-hosted.astro
+++ b/site/src/pages/self-hosted.astro
@@ -12,7 +12,7 @@ import ComparisonTable from "../components/ComparisonTable.astro";
 import TryItCta from "../components/TryItCta.astro";
 import { escapeHtml } from "../lib/html-escape";
 
-const verifiedDate = "July 14, 2026";
+const verifiedDate = "August 11, 2026";
 
 // Sources (Appendix, devin-alternative-positioning-research.md).
 const src = {
@@ -21,6 +21,8 @@ const src = {
   openhandsLicense: "https://github.com/OpenHands/OpenHands/blob/main/LICENSE",
   coder: "https://coder.com/docs",
   devinDeployment: "https://docs.devin.ai/enterprise/deployment/overview",
+  factoryDeployment: "https://docs.factory.ai/enterprise/network-and-deployment",
+  factoryPricing: "https://factory.ai/pricing",
 };
 
 const architectureRows = [
@@ -69,6 +71,15 @@ const architectureRows = [
     citation: src.devinDeployment,
     self: false,
   },
+  {
+    tool: "Factory",
+    license: "Proprietary",
+    architecture: "Cloud-orchestrated by default — full airgap is Enterprise-only.",
+    detail:
+      "Cloud-Managed and Hybrid both keep orchestration in Factory's cloud (Hybrid limits it to metadata). The Fully Airgapped tier genuinely removes Factory's servers from the loop at runtime, including orchestration — but it ships only through the Enterprise plan's sales-gated flow, with no self-serve path at any price point.",
+    citation: [src.factoryDeployment, src.factoryPricing],
+    self: false,
+  },
 ];
 
 // ComparisonTable props for the architecture table. Header/cell style
@@ -89,25 +100,35 @@ const architectureColumns = [
   },
 ];
 
-const architectureTableRows = architectureRows.map((row) => ({
-  highlight: row.self,
-  cells: [
-    {
-      style: "padding:0.9rem 1rem 0.9rem 0; vertical-align:top;",
-      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${escapeHtml(row.tool)} </span>`,
-    },
-    {
-      style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: ` ${escapeHtml(row.license)} `,
-    },
-    {
-      style: "padding:0.9rem 1rem 0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: row.citation
-        ? ` <strong>${escapeHtml(row.architecture)}</strong> <span> ${escapeHtml(row.detail)}</span>  <a href="${row.citation}" class="text-sm">\n[source]\n</a>  `
-        : ` <strong>${escapeHtml(row.architecture)}</strong> <span> ${escapeHtml(row.detail)}</span>  `,
-    },
-  ],
-}));
+const architectureTableRows = architectureRows.map((row) => {
+  const citations = Array.isArray(row.citation)
+    ? row.citation
+    : row.citation
+      ? [row.citation]
+      : [];
+  const sourceLinks = citations
+    .map((c) => `<a href="${c}" class="text-sm">\n[source]\n</a>`)
+    .join("  ");
+  return {
+    highlight: row.self,
+    cells: [
+      {
+        style: "padding:0.9rem 1rem 0.9rem 0; vertical-align:top;",
+        html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${escapeHtml(row.tool)} </span>`,
+      },
+      {
+        style: "padding:0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: ` ${escapeHtml(row.license)} `,
+      },
+      {
+        style: "padding:0.9rem 1rem 0.9rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: sourceLinks
+          ? ` <strong>${escapeHtml(row.architecture)}</strong> <span> ${escapeHtml(row.detail)}</span>  ${sourceLinks}  `
+          : ` <strong>${escapeHtml(row.architecture)}</strong> <span> ${escapeHtml(row.detail)}</span>  `,
+      },
+    ],
+  };
+});
 ---
 
 <BaseLayout

--- a/site/tests/self-hosted.spec.ts
+++ b/site/tests/self-hosted.spec.ts
@@ -44,12 +44,12 @@ test("architecture comparison distinguishes fully-in-your-cloud from hybrid, wit
   const text = (await page.locator("main").textContent())?.toLowerCase() ?? "";
   expect(text).toContain("fully in your own cloud");
   expect(text).toContain("hybrid");
-  for (const tool of ["shipwright", "cursor", "openhands", "coder agents", "devin"]) {
+  for (const tool of ["shipwright", "cursor", "openhands", "coder agents", "devin", "factory"]) {
     expect(text).toContain(tool);
   }
   // Every non-Shipwright row carries a [source] citation link.
   const sourceLinks = await page.getByRole("link", { name: /source/i }).count();
-  expect(sourceLinks).toBeGreaterThanOrEqual(4);
+  expect(sourceLinks).toBeGreaterThanOrEqual(5);
 });
 
 test("OpenCode is never named on this page", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Adds a `Factory` row to the `/self-hosted` architecture-comparison table, describing its Cloud-Managed, Hybrid, and Fully Airgapped deployment tiers and the Enterprise-only gating on the airgapped option (cites `docs.factory.ai/enterprise/network-and-deployment` and `factory.ai/pricing`).
- Generalizes the row-rendering helper to accept either a single citation or an array of citations, since the Factory row needs two distinct source links.
- Re-verifies all five rows' citation URLs live and bumps `verifiedDate` to the actual ship date (August 11, 2026).

## ⚠ Stale claim found on re-verification (Coder Agents row)

Per this task's acceptance criteria, the four pre-existing rows' citations were re-checked live before bumping `verifiedDate`. Cursor, OpenHands, and Devin's claims still hold against their current source pages. **The Coder Agents row is now stale** and was intentionally left unedited (out of scope for this task):

- **Current row text:** "No built-in cloud runtime to compare — it wraps agents you run... Scope stops at code, tests, and PRs. No spec phase, no deploy stage, no built-in cron."
- **What `coder.com/docs` says today:** "Coder Agents is a native AI coding agent built into Coder. The agent loop runs in the Coder control plane on your infrastructure."

Coder appears to have shipped a native built-in agent since the original research (dated 2026-07-14), contradicting the "wraps agents you run, no built-in runtime" framing. This needs a follow-up task to rewrite the Coder row's `architecture`/`detail` text — flagging here per the "flag explicitly in the PR description rather than silently updating the date" instruction rather than scope-creeping this PR.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Factory row added, citing both required URLs, describing 3 tiers + Enterprise gating | MET |
| 2 | Re-verify 4 existing rows' citations before bumping date; flag staleness | MET (Coder staleness flagged above) |
| 3 | Bump `verifiedDate` to actual ship date | MET |
| 4 | Respect MESSAGING.md D5 (price-free) / D10 (cited + dated) | MET |
| 5 | Extend `self-hosted.spec.ts` tool list + `sourceLinks` >= 5 | MET |

## Test Plan
- `bunx playwright test tests/self-hosted.spec.ts` — 9/9 passing
- Full site suite (224 passing; 4 pre-existing `docs-search.spec.ts` failures are a `SKIP_PAGEFIND=1` local-env artifact, unrelated)
- `bunx astro build` — succeeds
- `npm run brand-lint` on built `dist/self-hosted/index.html` — on-brand
- `task lint`, `task check-strings` — passing
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
