### PR TITLE
refactor: extract shared post-filter helper for listReady/listBlocked (ATB-1.3)

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -186,7 +186,7 @@ Agent tokens (as opposed to admin tokens) can now have a scoped list of reposito
 - **Pool task visibility changes**: You may now see unassigned tasks with `repo` values that match your agent's scope.
 - **No action required**: The changes are additive; existing assigned-task queries behave identically. Only the visibility of pool tasks expands.
 
-**For implementers of `TaskService.listReady()`**: The method signature has changed from `listReady(agentId?: string)` to `listReady(agentId?: string, repos?: string[], filters?: ListReadyFilters)`. Implementations that override `listReady()` must update to accept the `repos` parameter and apply the same filtering rule: include unassigned pool tasks whose `repo` is in the `repos` list. When `filters` is supplied, apply its `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, and `assignee` fields as post-filters after dependency resolution (never folded into the initial query, since a filtered-out task can still satisfy a dependency edge for an in-scope task).
+**For implementers of `TaskService.listReady()`**: The method signature has changed from `listReady(agentId?: string)` to `listReady(agentId?: string, repos?: string[], filters?: TaskListPostFilters)`. Implementations that override `listReady()` must update to accept the `repos` parameter and apply the same filtering rule: include unassigned pool tasks whose `repo` is in the `repos` list. When `filters` is supplied, apply its `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, and `assignee` fields as post-filters after dependency resolution (never folded into the initial query, since a filtered-out task can still satisfy a dependency edge for an in-scope task).
 
 ---
 

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -103,7 +103,7 @@ the table — `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, `
 under `?ready=true` and `?state=blocked` exactly as it does on the plain list path.
 `TaskService.listReady()` applies these as a post-filter *after* `resolveReadyTasks()` has
 resolved the complete dependency graph; `TaskService.listBlocked()` applies the identically-shaped
-filter set (`ListBlockedFilters`, mirroring `listReady()`'s `ListReadyFilters`) as a post-filter
+filter set (`TaskListPostFilters`) as a post-filter
 *after* the full task graph is loaded and `computeBlockedBy()` has resolved it. Neither is folded
 into the initial query — a task that gets filtered out of the final response can still correctly
 satisfy a dependency edge (for `?ready=true`) or contribute a `blockedBy` entry (for

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -86,39 +86,13 @@ function matchesRepoOrg(
 }
 
 /**
- * Post-filter predicate for TaskService.listReady() — see ListReadyFilters'
- * doc comment for why this is applied after dependency resolution instead
- * of being folded into the initial findMany(). Every set field is AND'd
- * together; undefined/absent fields impose no restriction.
+ * Post-filter predicate shared by TaskService.listReady() and
+ * TaskService.listBlocked() — see TaskListPostFilters' doc comment for why
+ * this is applied after dependency resolution instead of being folded into
+ * the initial findMany(). Every set field is AND'd together; undefined/
+ * absent fields impose no restriction.
  */
-function matchesReadyFilters(task: Task, filters: ListReadyFilters): boolean {
-  if (filters.session !== undefined && task.session !== filters.session)
-    return false;
-  if (filters.source !== undefined && task.source !== filters.source)
-    return false;
-  if (filters.claimedBy !== undefined && task.claimedBy !== filters.claimedBy)
-    return false;
-  if (filters.pr !== undefined && task.pr !== filters.pr) return false;
-  if (filters.branch !== undefined && task.branch !== filters.branch)
-    return false;
-  if (filters.assignee !== undefined && task.assignee !== filters.assignee)
-    return false;
-  if (!matchesRepoOrg(task, filters.repo, filters.org)) return false;
-  return true;
-}
-
-/**
- * Post-filter predicate for TaskService.listBlocked() — see ListBlockedFilters'
- * doc comment for why this is applied after dependency resolution instead of
- * being folded into the initial findMany(). Every set field is AND'd
- * together; undefined/absent fields impose no restriction. Field-equality
- * checks intentionally near-duplicate matchesReadyFilters above (same filter
- * shape, different task set) — a future cleanup task consolidates the two.
- */
-function matchesBlockedFilters(
-  task: Task,
-  filters: ListBlockedFilters,
-): boolean {
+function matchesTaskFilters(task: Task, filters: TaskListPostFilters): boolean {
   if (filters.session !== undefined && task.session !== filters.session)
     return false;
   if (filters.source !== undefined && task.source !== filters.source)
@@ -138,45 +112,22 @@ function matchesBlockedFilters(
 export type TaskWithBlockedBy = Task & { blockedBy: BlockedByEntry[] };
 
 /**
- * Filters accepted by TaskService.listBlocked(), applied as an in-memory
- * post-filter over the already-resolved blocked array (see listBlocked()
- * below) — never folded into the initial findMany(), since computeBlockedBy
- * needs the complete task graph (a filtered-out task may still be a
- * dependency of an in-scope blocked task, and must still contribute a
+ * Filters shared by TaskService.listReady() and TaskService.listBlocked(),
+ * applied as an in-memory post-filter over the already-resolved
+ * ready/blocked array (see listReady()/listBlocked() below) — never folded
+ * into the initial findMany(), since both dependency resolution and
+ * computeBlockedBy need the complete task graph (a filtered-out task may
+ * still be a dependency of an in-scope task, and must still contribute a
  * blockedBy entry for it).
  *
- * Same field set as ListReadyFilters — kept as a distinct named type for
- * symmetry with listBlocked()'s own signature/doc comments, even though the
- * shape is identical today.
- */
-export interface ListBlockedFilters {
-  session?: string;
-  source?: string;
-  /** Array-any-match, mirrors buildRepoOrgWhere's `{ repo: { in: repos } }`. */
-  repo?: string | string[];
-  /** startsWith "<org>/" match, mirrors buildRepoOrgWhere's OR clause. Combines with `repo` via AND. */
-  org?: string | string[];
-  claimedBy?: string;
-  pr?: number;
-  branch?: string;
-  assignee?: string;
-}
-
-/**
- * Filters accepted by TaskService.listReady(), applied as an in-memory
- * post-filter over the already-resolved ready array (see listReady() below)
- * — never folded into the initial findMany(), since dependency resolution
- * needs the complete task graph (a filtered-out task may still be a
- * dependency of an in-scope task).
- *
  * Deliberately excludes status/state/hitl/requiresHumanApproval/limit/
- * offset/sort/updatedSince/agentScope: the ready set's status/hitl
- * semantics are structural (see ready.ts), pagination/sort don't apply to
- * this whole-graph convenience endpoint (see docs/task-store.md), and
- * agentId/repos scoping already has its own dedicated parameters mirroring
- * the pre-existing signature.
+ * offset/sort/updatedSince/agentScope: the ready/blocked sets' status/hitl
+ * semantics are structural (see ready.ts / listBlocked()'s doc comment),
+ * pagination/sort don't apply to these whole-graph convenience endpoints
+ * (see docs/task-store.md), and agentId/repos scoping already has its own
+ * dedicated parameters mirroring the pre-existing signatures.
  */
-export interface ListReadyFilters {
+export interface TaskListPostFilters {
   session?: string;
   source?: string;
   /** Array-any-match, mirrors buildRepoOrgWhere's `{ repo: { in: repos } }`. */
@@ -250,13 +201,13 @@ export interface TaskServiceLike {
   listReady(
     agentId?: string,
     repos?: string[],
-    filters?: ListReadyFilters,
+    filters?: TaskListPostFilters,
   ): Promise<Task[]>;
   listBlocked(
     agentId?: string,
     repos?: string[],
     sort?: "asc" | "desc",
-    filters?: ListBlockedFilters,
+    filters?: TaskListPostFilters,
   ): Promise<TaskWithBlockedBy[]>;
   distinct(
     agentId?: string,
@@ -399,7 +350,7 @@ export class TaskService implements TaskServiceLike {
    *
    * `filters` (session/source/repo/org/claimedBy/pr/branch/assignee) is
    * applied as an additional AND condition, strictly *after*
-   * resolveReadyTasks() has resolved the graph — see ListReadyFilters'
+   * resolveReadyTasks() has resolved the graph — see TaskListPostFilters'
    * doc comment for why this can't be folded into the initial findMany().
    * repo/org matching mirrors buildRepoOrgWhere's semantics (array-any-match
    * for repo; startsWith "<org>/" for org; AND between the two), just
@@ -412,7 +363,7 @@ export class TaskService implements TaskServiceLike {
   async listReady(
     agentId?: string,
     repos?: string[],
-    filters?: ListReadyFilters,
+    filters?: TaskListPostFilters,
   ): Promise<Task[]> {
     // Load all tasks so dependency resolution sees the full graph, then filter
     // the result set to the caller's agent if one is specified.
@@ -435,7 +386,7 @@ export class TaskService implements TaskServiceLike {
         )
       : ready;
     return filters
-      ? scoped.filter((t) => matchesReadyFilters(t, filters))
+      ? scoped.filter((t) => matchesTaskFilters(t, filters))
       : scoped;
   }
 
@@ -458,7 +409,7 @@ export class TaskService implements TaskServiceLike {
    * `filters` (session/source/repo/org/claimedBy/pr/branch/assignee) is
    * applied as an additional AND condition, strictly *after* the full task
    * graph is loaded and computeBlockedBy has resolved it — see
-   * ListBlockedFilters' doc comment for why this can't be folded into the
+   * TaskListPostFilters' doc comment for why this can't be folded into the
    * initial findMany(). repo/org matching mirrors buildRepoOrgWhere's
    * semantics (array-any-match for repo; startsWith "<org>/" for org; AND
    * between the two), just evaluated in-memory against already-resolved Task
@@ -468,7 +419,7 @@ export class TaskService implements TaskServiceLike {
     agentId?: string,
     repos?: string[],
     sort?: "asc" | "desc",
-    filters?: ListBlockedFilters,
+    filters?: TaskListPostFilters,
   ): Promise<TaskWithBlockedBy[]> {
     const allTasks = await this.prisma.task.findMany({
       orderBy: { createdAt: sort ?? "asc" },
@@ -485,7 +436,7 @@ export class TaskService implements TaskServiceLike {
             useRepoScope && t.repo !== null && repos?.includes(t.repo);
           if (!ownedByAssignee && !inRepoScope) return false;
         }
-        if (filters && !matchesBlockedFilters(t, filters)) return false;
+        if (filters && !matchesTaskFilters(t, filters)) return false;
         if (t.status === "blocked") return true;
         if (closedStatuses.has(t.status)) return false;
         return t.blockedBy.length > 0;


### PR DESCRIPTION
## Summary
- Collapses the structurally-identical `ListReadyFilters`/`ListBlockedFilters` interfaces and `matchesReadyFilters`/`matchesBlockedFilters` predicate functions (introduced by TRF-1.1 #2563 and ATB-1.2 #2566) into a single shared `TaskListPostFilters` interface and `matchesTaskFilters()` function, used by both `TaskService.listReady()` and `TaskService.listBlocked()`.
- Pure, behavior-preserving refactor — no filter semantics change, no new filters, no API surface change. `matchesRepoOrg()` was already shared prior to this change and is untouched.
- Refreshed `docs/task-store.md` and `docs/migration.md` references to the old type names.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Single shared function implements the post-filter logic, both methods call it | MET | `matchesTaskFilters(task, filters)` used by both `listReady()` and `listBlocked()` |
| 2 | No behavior change — filter semantics identical | MET | Field-check bodies are byte-identical to the union of the two prior functions; full test suite passes unmodified |
| 3 | Existing tests pass unmodified | MET | Zero test files touched — only `task-service.ts` (+docs) changed |
| 4 | No new filter-behavior test scenarios required | MET | Existing `listReady()`/`listBlocked()` filter suites already fully exercise the shared function indirectly |

## Test Plan
- `bun test task-store/` — 539 pass / 152 skip / 0 fail (identical before/after)
- `task lint`, `task typecheck`, `task check-strings`, `task check-config-docs`, `task check-version-sync`, `task secret-scan` — all pass
- `task ci` — 1 pre-existing failure unrelated to this diff: `agent/src/claude.unit.test.ts > extraAllowedTools > empty extraAllowedTools produces identical args to no extraAllowedTools`, reproduces identically on `main` (this branch touches only `task-store/src/task-service.ts` and docs, nothing in `agent/`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
