### PR TITLE
feat: detect stale-cancelled CI in patch; rerun before escalating to CI-fix

### DIFF
--- a/agent/src/check-patch.ts
+++ b/agent/src/check-patch.ts
@@ -84,6 +84,30 @@ export interface PrReviewData {
 
 export interface CiCheckStatus {
   hasFailing: boolean;
+  /**
+   * True when this PR's latest run for some workflow is `cancelled`, with no
+   * newer run for that same workflow since (PCC-1.1) — e.g. a job that hit
+   * `timeout-minutes` and was reported by GitHub's API as `cancelled` rather
+   * than `timed_out`. Distinct from `hasFailing` — not mutually exclusive
+   * with it, since a different workflow can genuinely fail at the same time.
+   * A PR qualifying solely through this field is still a valid patch
+   * candidate (see getPatchCandidates below) so patch.md's rerun-first
+   * branch (Step 6b.8) gets a chance to resolve it before ever escalating to
+   * the CI-fix subagent.
+   *
+   * Optional (defaults to false when absent) so existing fixtures/deps that
+   * predate PCC-1.1 and only ever set `hasFailing` keep compiling and
+   * behaving exactly as before — this field is purely additive.
+   */
+  hasCancelled?: boolean;
+  /**
+   * The `id` of the qualifying cancelled run (needed for `gh run rerun
+   * {run_id}` in patch.md's Step 6b.8), when `hasCancelled` is true. When
+   * multiple workflows qualify, the highest `run_number` wins — arbitrary
+   * but deterministic, since patch.md only needs one run id to attempt a
+   * rerun. `undefined` when `hasCancelled` is false.
+   */
+  cancelledRunId?: number;
 }
 
 export interface MergeStatusInfo {
@@ -162,19 +186,38 @@ export interface CheckPatchDeps {
   isBundleComplete?: (branch: string) => Promise<boolean>;
 }
 
-// ─── CI status (dedup stale reruns — CPC-1.1) ─────────────────────────────────
+// ─── CI status (dedup stale reruns — CPC-1.1, PCC-1.1) ────────────────────────
+
+/**
+ * Reduces a list of Actions API run entries to the latest run per workflow
+ * (highest run_number per workflow_id).
+ *
+ * The GitHub Actions API returns one entry per *run*, not per workflow — a
+ * rerun of a failed/cancelled workflow appears as an additional entry with
+ * the same workflow_id and a higher run_number, alongside the original
+ * entry. Evaluating every historical run at a SHA (rather than just the
+ * latest per workflow) produces a false positive when an older run
+ * failed/was cancelled but a newer rerun succeeded. This mirrors how `gh pr
+ * checks` already reports only the latest run per check. Shared by both
+ * `hasFailingCi` and `findCancelledRuns` below so the dedup semantics never
+ * drift between the two checks.
+ */
+function latestRunPerWorkflow<
+  T extends { workflow_id: number; run_number: number },
+>(runs: T[]): T[] {
+  const latestByWorkflow = new Map<number, T>();
+  for (const run of runs) {
+    const current = latestByWorkflow.get(run.workflow_id);
+    if (!current || run.run_number > current.run_number) {
+      latestByWorkflow.set(run.workflow_id, run);
+    }
+  }
+  return [...latestByWorkflow.values()];
+}
 
 /**
  * Returns true if any workflow's latest run (highest run_number per
  * workflow_id) failed or timed out.
- *
- * The GitHub Actions API returns one entry per *run*, not per workflow — a
- * rerun of a failed workflow appears as an additional entry with the same
- * workflow_id and a higher run_number, alongside the original failed entry.
- * Evaluating every historical run at a SHA (rather than just the latest per
- * workflow) produces a false positive when a failure was later rerun and
- * passed. This mirrors how `gh pr checks` already reports only the latest
- * run per check.
  */
 export function hasFailingCi(
   runs: {
@@ -183,17 +226,36 @@ export function hasFailingCi(
     conclusion: string | null;
   }[],
 ): boolean {
-  const latestByWorkflow = new Map<number, (typeof runs)[number]>();
-  for (const run of runs) {
-    const current = latestByWorkflow.get(run.workflow_id);
-    if (!current || run.run_number > current.run_number) {
-      latestByWorkflow.set(run.workflow_id, run);
-    }
-  }
-
-  return [...latestByWorkflow.values()].some(
+  return latestRunPerWorkflow(runs).some(
     (r) => r.conclusion === "failure" || r.conclusion === "timed_out",
   );
+}
+
+/**
+ * Returns the qualifying run(s) — one per workflow, at most — whose LATEST
+ * run (highest run_number per workflow_id) has conclusion "cancelled", with
+ * no newer run for that workflow since (PCC-1.1). "Latest" already implies
+ * "no newer run since" once the per-workflow dedup below has run — mirrors
+ * hasFailingCi's dedup exactly (via the shared latestRunPerWorkflow helper)
+ * but is evaluated independently: a run that's cancelled is not treated as
+ * failure-equivalent by hasFailingCi, and a run that's failure/timed_out is
+ * not counted here — the two checks are not mutually exclusive (a PR can
+ * have one workflow genuinely fail and a different workflow's latest run be
+ * cancelled at the same time).
+ *
+ * Returns the full run objects (not just a boolean) so callers can recover
+ * the qualifying run's `id` for `gh run rerun {run_id}` (patch.md Step
+ * 6b.8) — the boolean-only shape of hasFailingCi doesn't carry enough
+ * information for that follow-up action.
+ */
+export function findCancelledRuns<
+  T extends {
+    workflow_id: number;
+    run_number: number;
+    conclusion: string | null;
+  },
+>(runs: T[]): T[] {
+  return latestRunPerWorkflow(runs).filter((r) => r.conclusion === "cancelled");
 }
 
 // ─── Staleness check (mirrors patch.md Step 3b) ───────────────────────────────
@@ -454,7 +516,11 @@ export async function getPatchCandidates(
           pr.number,
           pr.headRefOid,
         );
-        if (ciStatus.hasFailing) {
+        // A PR qualifying solely via hasCancelled (no genuine failure) is
+        // still a valid patch candidate (PCC-1.1) — patch.md's Step 6b.8
+        // rerun-first branch is what actually resolves it, but candidacy
+        // itself is decided here per the Candidate Selection Contract.
+        if (ciStatus.hasFailing || ciStatus.hasCancelled) {
           needsPatch = true;
         }
       }
@@ -635,6 +701,7 @@ export async function buildProductionDeps(opts: {
     ) => {
       type ApiResponse = {
         workflow_runs: {
+          id: number;
           status: string;
           conclusion: string | null;
           workflow_id: number;
@@ -647,12 +714,23 @@ export async function buildProductionDeps(opts: {
           `repos/${org}/${repo}/actions/runs?head_sha=${sha}`,
         ]);
         const hasFailing = hasFailingCi(data.workflow_runs);
-        return { hasFailing };
+        const cancelledRuns = findCancelledRuns(data.workflow_runs);
+        // Highest run_number wins when more than one workflow's latest run
+        // is cancelled — arbitrary but deterministic, since patch.md's Step
+        // 6b.8 only needs one run id to attempt a rerun.
+        const cancelledRunId = cancelledRuns.sort(
+          (a, b) => b.run_number - a.run_number,
+        )[0]?.id;
+        return {
+          hasFailing,
+          hasCancelled: cancelledRuns.length > 0,
+          ...(cancelledRunId !== undefined ? { cancelledRunId } : {}),
+        };
       } catch (err) {
         process.stderr.write(
           `check-patch: actions/runs query failed for PR ${pr} sha ${sha}: ${String(err)}\n`,
         );
-        return { hasFailing: false };
+        return { hasFailing: false, hasCancelled: false };
       }
     },
     fetchMergeStatus: async (org: string, repo: string, pr: number) => {

--- a/agent/src/check-patch.unit.test.ts
+++ b/agent/src/check-patch.unit.test.ts
@@ -19,6 +19,7 @@ import {
   type MergeStatusInfo,
   type OwnPr,
   type PrReviewData,
+  findCancelledRuns,
   getPatchCandidates,
   hasFailingCi,
 } from "./check-patch.ts";
@@ -466,6 +467,46 @@ describe("getPatchCandidates", () => {
       }),
     );
     expect(result).toHaveLength(1);
+  });
+
+  // ─── cancelled-only CI candidacy (PCC-1.1) ──────────────────────────────────
+
+  test("returns a candidate when PR's only CI signal is hasCancelled (no genuine failure)", async () => {
+    const pr = makeOwnPr({ number: 10 });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: {},
+        ciStatusByPr: {
+          10: { hasFailing: false, hasCancelled: true, cancelledRunId: 555 },
+        },
+      }),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  test("returns empty array when hasCancelled is false and hasFailing is false (green CI, no findings, no conflict)", async () => {
+    const pr = makeOwnPr({ number: 10 });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: {},
+        ciStatusByPr: { 10: { hasFailing: false, hasCancelled: false } },
+      }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when PR has no findings, green CI, and no merge conflict (defaults hasCancelled to false when omitted)", async () => {
+    const pr = makeOwnPr({ number: 10 });
+    const result = await getPatchCandidates(
+      makeDeps({
+        ownPrs: [pr],
+        reviewDataByPr: {},
+        ciStatusByPr: { 10: { hasFailing: false } },
+      }),
+    );
+    expect(result).toEqual([]);
   });
 
   test("returns empty array when PR is merely behind main (not dirty) with no other issues", async () => {
@@ -1553,7 +1594,7 @@ describe("getPatchCandidates", () => {
     expect(result).toEqual([]);
   });
 
-  test("a PR whose linked task has status:\"blocked\" is excluded from patch candidacy (isTaskBlockedForDispatch, new behavior)", async () => {
+  test('a PR whose linked task has status:"blocked" is excluded from patch candidacy (isTaskBlockedForDispatch, new behavior)', async () => {
     const pr = makeOwnPr({ number: 10 });
     const deps = makeDeps({
       ownPrs: [pr],
@@ -1752,5 +1793,64 @@ describe("hasFailingCi", () => {
   test("returns false for a single passing run", () => {
     const runs = [{ workflow_id: 1, run_number: 1, conclusion: "success" }];
     expect(hasFailingCi(runs)).toBe(false);
+  });
+});
+
+// ─── findCancelledRuns (PCC-1.1) ───────────────────────────────────────────────
+
+describe("findCancelledRuns", () => {
+  test("cancelled with no newer run for that workflow → true (returns the qualifying run)", () => {
+    const runs = [
+      { id: 111, workflow_id: 1, run_number: 1, conclusion: "cancelled" },
+    ];
+    const result = findCancelledRuns(runs);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 111,
+      workflow_id: 1,
+      run_number: 1,
+    });
+  });
+
+  test("cancelled but a newer run for the same workflow exists and succeeded → false (no qualifying runs)", () => {
+    const runs = [
+      { id: 111, workflow_id: 1, run_number: 1, conclusion: "cancelled" },
+      { id: 112, workflow_id: 1, run_number: 2, conclusion: "success" },
+    ];
+    expect(findCancelledRuns(runs)).toEqual([]);
+  });
+
+  test("one workflow's latest run is cancelled AND a different workflow's latest run genuinely failed — both signals independently detectable", () => {
+    const runs = [
+      { id: 201, workflow_id: 1, run_number: 1, conclusion: "cancelled" },
+      { id: 202, workflow_id: 2, run_number: 1, conclusion: "failure" },
+    ];
+    const cancelled = findCancelledRuns(runs);
+    expect(cancelled).toHaveLength(1);
+    expect(cancelled[0]).toMatchObject({ id: 201, workflow_id: 1 });
+
+    // hasFailingCi (unchanged) still independently reports the failed workflow.
+    expect(hasFailingCi(runs)).toBe(true);
+  });
+
+  test("returns false for an empty runs array", () => {
+    expect(findCancelledRuns([])).toEqual([]);
+  });
+
+  test("returns false for a single passing run", () => {
+    const runs = [
+      { id: 1, workflow_id: 1, run_number: 1, conclusion: "success" },
+    ];
+    expect(findCancelledRuns(runs)).toEqual([]);
+  });
+
+  test("a workflow's earlier run was cancelled but a later rerun (same workflow_id, higher run_number) also cancelled → still true (latest is cancelled)", () => {
+    const runs = [
+      { id: 301, workflow_id: 1, run_number: 1, conclusion: "cancelled" },
+      { id: 302, workflow_id: 1, run_number: 2, conclusion: "cancelled" },
+    ];
+    const result = findCancelledRuns(runs);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 302, workflow_id: 1 });
   });
 });

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -801,10 +801,12 @@ describe("patch.md — bundle-incomplete self-check before CI-fix dispatch (PH-1
     const step6b7Idx = content.indexOf(
       "### Step 6b.7: Bundle Completeness Gate (PH-1.1)",
     );
-    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    const step6b8Idx = content.indexOf(
+      "### Step 6b.8: Rerun-First for Cancelled-Only CI (PCC-1.1)",
+    );
     expect(step6b7Idx).toBeGreaterThan(-1);
-    expect(step6cIdx).toBeGreaterThan(-1);
-    return content.slice(step6b7Idx, step6cIdx);
+    expect(step6b8Idx).toBeGreaterThan(-1);
+    return content.slice(step6b7Idx, step6b8Idx);
   }
 
   it("Step 6b.7 exists between Step 6b.6 (escalation check) and Step 6c (dispatch)", () => {
@@ -864,12 +866,12 @@ describe("patch.md — bundle-incomplete self-check before CI-fix dispatch (PH-1
     expect(hasStopLanguage).toBe(true);
   });
 
-  it("otherwise branch (bundle complete) proceeds to Step 6c and does not emit [silent]", () => {
+  it("otherwise branch (bundle complete) proceeds to Step 6b.8 (which itself falls through to Step 6c) and does not emit [silent]", () => {
     const section = getStep6b7Section();
     const otherwiseIdx = section.indexOf("**Otherwise**");
     expect(otherwiseIdx).toBeGreaterThan(-1);
     const otherwiseSection = section.slice(otherwiseIdx);
-    expect(otherwiseSection).toContain("Step 6c");
+    expect(otherwiseSection).toContain("Step 6b.8");
     expect(otherwiseSection).not.toContain("[silent]");
   });
 });
@@ -1466,5 +1468,165 @@ describe("patch.md — capture and report CI failure signature (CSD-1.2)", () =>
     const section = getStep6d5Section();
     expect(section).toMatch(/if\s*\[\s*-n\s*"\$PR_RECORD_ID"\s*\]/);
     expect(section).toMatch(/if\s*\[\s*-n\s*"\$CI_FAILURE_SIGNATURE"\s*\]/);
+  });
+});
+
+describe("patch.md — detect stale-cancelled CI, rerun before escalating to CI-fix (PCC-1.1)", () => {
+  function getStep3cSection() {
+    const step3cIdx = content.indexOf(
+      "### Step 3c: Check for Failing CI (for PRs not in List C)",
+    );
+    const step3dIdx = content.indexOf("### Step 3d: Summary");
+    expect(step3cIdx).toBeGreaterThan(-1);
+    expect(step3dIdx).toBeGreaterThan(step3cIdx);
+    return content.slice(step3cIdx, step3dIdx);
+  }
+
+  function getStep6b8Section() {
+    const step6b8Idx = content.indexOf(
+      "### Step 6b.8: Rerun-First for Cancelled-Only CI (PCC-1.1)",
+    );
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b8Idx).toBeGreaterThan(-1);
+    expect(step6cIdx).toBeGreaterThan(step6b8Idx);
+    return content.slice(step6b8Idx, step6cIdx);
+  }
+
+  it("Step 3c independently detects cancelled CI using the same latest-run-per-workflow dedup, distinct from the failure/timed_out check", () => {
+    const section = getStep3cSection();
+    expect(section).toContain('conclusion == "cancelled"');
+    expect(section).toContain("CI_HAS_CANCELLED");
+    expect(section).toContain("CI_HAS_FAILING");
+    expect(section).toContain("CANCELLED_RUN_ID");
+    expect(section).toContain("independently");
+    expect(section).toContain("not mutually exclusive with");
+  });
+
+  it("Step 3c records that a cancelled-only PR (no CI_HAS_FAILING) routes to the new Step 6b.8 branch", () => {
+    const section = getStep3cSection();
+    expect(section).toContain("Step 6b.8");
+    expect(section).toContain("cancelled-only");
+  });
+
+  it("Step 6b.8 exists between Step 6b.7 (bundle gate) and Step 6c (dispatch)", () => {
+    const step6b7Idx = content.indexOf(
+      "### Step 6b.7: Bundle Completeness Gate (PH-1.1)",
+    );
+    const step6b8Idx = content.indexOf(
+      "### Step 6b.8: Rerun-First for Cancelled-Only CI (PCC-1.1)",
+    );
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    expect(step6b7Idx).toBeGreaterThan(-1);
+    expect(step6b8Idx).toBeGreaterThan(step6b7Idx);
+    expect(step6cIdx).toBeGreaterThan(step6b8Idx);
+  });
+
+  it("Step 6b.7's otherwise branch hands off to Step 6b.8, not straight to 6c", () => {
+    const step6b7Idx = content.indexOf(
+      "### Step 6b.7: Bundle Completeness Gate (PH-1.1)",
+    );
+    const step6b8Idx = content.indexOf(
+      "### Step 6b.8: Rerun-First for Cancelled-Only CI (PCC-1.1)",
+    );
+    const section = content.slice(step6b7Idx, step6b8Idx);
+    const otherwiseIdx = section.indexOf("**Otherwise**");
+    expect(otherwiseIdx).toBeGreaterThan(-1);
+    const otherwiseSection = section.slice(otherwiseIdx);
+    expect(otherwiseSection).toContain("Step 6b.8");
+  });
+
+  it("gates the rerun-first branch on cancelled-only, no failure/timed_out", () => {
+    const section = getStep6b8Section();
+    expect(section.toLowerCase()).toContain("cancelled-only, no failure/timed_out");
+    expect(section).toContain("CI_HAS_CANCELLED=true");
+    expect(section).toContain("CI_HAS_FAILING");
+    expect(section).toMatch(/CI_HAS_FAILING.{0,40}NOT also true/is);
+  });
+
+  it("a PR with a genuine failure/timed_out run skips this step entirely and proceeds directly to Step 6c", () => {
+    const section = getStep6b8Section();
+    expect(section).toMatch(
+      /does not hold.{0,400}proceed directly to\s+Step 6c/is,
+    );
+    expect(section).toContain("completely unaffected by the cancelled-only branch");
+  });
+
+  it("does not treat cancelled as failure-equivalent for concurrency/cancel-in-progress workflows — scoped to run state, not workflow identity", () => {
+    const section = getStep6b8Section();
+    for (const workflow of [
+      "chart-release.yml",
+      "sync-plugin-version.yml",
+      "auto-bump-chart.yml",
+      "deploy-site.yml",
+    ]) {
+      expect(section).toContain(workflow);
+    }
+    expect(section).toContain("concurrency");
+    expect(section.toLowerCase()).toMatch(/not to workflow\s+identity/);
+    expect(section.toLowerCase()).toContain("no-op");
+  });
+
+  it("calls `gh run rerun` for the cancelled run, with no commit and no subagent dispatch in this branch", () => {
+    const section = getStep6b8Section();
+    expect(section).toContain("gh run rerun");
+    expect(section).toContain("$CANCELLED_RUN_ID");
+    expect(section).toContain("no commit");
+    expect(section).toContain("no subagent dispatch");
+  });
+
+  it("polls for a terminal result with a brief, bounded cadence distinct from Step 6.5a's 30s/10-poll gate", () => {
+    const section = getStep6b8Section();
+    expect(section).toContain("gh run view");
+    expect(section).toMatch(/status.{0,20}conclusion/is);
+    expect(section).toMatch(/15 seconds/);
+    expect(section).toMatch(/8 times/);
+    expect(section).toContain("queued");
+    expect(section).toContain("in_progress");
+    expect(section).toContain("waiting");
+  });
+
+  it("renews the claim heartbeat on each poll iteration, same as other polling loops", () => {
+    const section = getStep6b8Section();
+    expect(section).toContain("/prs/$PR_RECORD_ID/heartbeat");
+  });
+
+  it("treats an exhausted poll window with no terminal result as inconclusive and falls through to Step 6c", () => {
+    const section = getStep6b8Section();
+    expect(section.toLowerCase()).toContain("inconclusive");
+    expect(section).toMatch(/exhausted.{0,200}Step 6c/is);
+  });
+
+  it("on a successful (or other non-cancelled/non-failure terminal) rerun, skips Step 6c, releases the claim, and moves to the next PR in List D", () => {
+    const section = getStep6b8Section();
+    expect(section).toContain("Skip Step 6c entirely");
+    expect(section).toContain("/prs/$PR_RECORD_ID/release");
+    expect(section).toContain("next PR in List D");
+  });
+
+  it("falls through to Step 6c only when the rerun itself ends cancelled or failure (or times out inconclusively)", () => {
+    const section = getStep6b8Section();
+    expect(section).toContain("ends `cancelled` or `failure`");
+    expect(section).toContain("repeated-timeout/hang signal");
+    expect(section).not.toContain("normal test failure");
+  });
+
+  it("collects the job's abnormal duration vs. typical duration from the Actions API for the Step 6c prompt", () => {
+    const section = getStep6b8Section();
+    expect(section).toContain("actions/runs/$CANCELLED_RUN_ID/jobs");
+    expect(section).toContain("started_at");
+    expect(section).toContain("completed_at");
+    expect(section).toContain("typical duration");
+  });
+
+  it("Step 6c's prompt construction notes the repeated-timeout/hang context when arriving via Step 6b.8", () => {
+    const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
+    const step6dIdx = content.indexOf("### Step 6d: Handle Subagent Status");
+    expect(step6cIdx).toBeGreaterThan(-1);
+    expect(step6dIdx).toBeGreaterThan(step6cIdx);
+    const section = content.slice(step6cIdx, step6dIdx);
+    expect(section).toContain("REPEATED TIMEOUT/HANG SIGNAL");
+    expect(section).toContain("Step 6b.8");
+    expect(section).toContain("repeated-timeout-context");
+    expect(section.toLowerCase()).toMatch(/not a normal test\s+failure/);
   });
 });

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -320,7 +320,7 @@ For each PR not in List C (DIRTY PRs have unreliable CI until conflicts are reso
 
 ```bash
 gh api "repos/{org}/{repo}/actions/runs?head_sha={headRefOid}&per_page=20" \
-  -q '.workflow_runs[] | {workflow_id, run_number, conclusion}'
+  -q '.workflow_runs[] | {id, workflow_id, run_number, conclusion}'
 ```
 
 A PR has **failing CI** when any workflow's **latest run** (highest `run_number` per
@@ -332,7 +332,23 @@ returns both the original failed run and the new rerun as separate entries with 
 produce a false positive if an older run failed but a newer rerun passed. Deduplication
 by keeping only the latest run per workflow mirrors the behavior of `gh pr checks`.
 
-If failing CI is found, add the PR to **List D**.
+If failing CI is found, add the PR to **List D** and set `CI_HAS_FAILING=true` for this PR.
+
+**Stale-cancelled CI (PCC-1.1):** using the same latest-run-per-workflow dedup above, a PR
+also has **cancelled CI** when any workflow's latest run has `conclusion == "cancelled"` —
+e.g. a job that hit `timeout-minutes` and was reported by GitHub's API as `cancelled` rather
+than `timed_out`. This is checked independently of, and is not mutually exclusive with, the
+failing-CI check above — a PR can have one workflow whose latest run genuinely failed and a
+different workflow whose latest run was cancelled at the same time. If cancelled CI is
+found, add the PR to **List D** (if not already there) and set `CI_HAS_CANCELLED=true` and
+record the qualifying run's `id` as `CANCELLED_RUN_ID` (highest `run_number` wins when more
+than one workflow qualifies) for this PR.
+
+A PR whose **only** List D signal is `CI_HAS_CANCELLED=true` (i.e. `CI_HAS_FAILING` is not
+also true for this PR — cancelled-only, no failure/timed_out) is handled by the new Step
+6b.8 rerun-first branch instead of going straight to Step 6c. A PR with a genuine
+failure/timed_out run (`CI_HAS_FAILING=true`), with or without an additional cancelled run
+elsewhere, is unaffected by Step 6b.8 and proceeds straight to Step 6c exactly as before.
 
 ### Step 3d: Summary
 
@@ -1333,7 +1349,97 @@ other tasks are still actively developing.
    don't tag a specific reason.
 
 **Otherwise** (`INCOMPLETE == 0` — no tasks tracked on this branch, or all tasks are past
-`pending`/`in_progress`/`blocked`): the bundle is complete — proceed to Step 6c.
+`pending`/`in_progress`/`blocked`): the bundle is complete — proceed to Step 6b.8.
+
+### Step 6b.8: Rerun-First for Cancelled-Only CI (PCC-1.1)
+
+Per the Candidate Selection Contract, `check-patch.ts`'s `getPatchCandidates` (via
+`fetchCiStatus`'s `hasCancelled` field) already decided this PR is a valid patch candidate —
+this step re-validates current-state safety immediately before acting, it does not
+requalify. Step 3c tracked, per PR, which List D signal(s) applied: `CI_HAS_FAILING` (a
+genuine `failure`/`timed_out` run) and/or `CI_HAS_CANCELLED` (a `cancelled` latest run for
+some workflow, with `CANCELLED_RUN_ID` holding the qualifying run's `id`).
+
+**Gate — cancelled-only, no failure/timed_out:** this step only applies when
+`CI_HAS_CANCELLED=true` AND `CI_HAS_FAILING` is NOT also true for this PR. A cancelled run
+is not equivalent to a real test failure — it is most often a job that hit
+`timeout-minutes` and was reported by GitHub's API as `cancelled` rather than `timed_out`,
+or an external cancellation with no code-level cause at all. A cheap rerun is a safe,
+essentially no-op action even for workflows that use `concurrency`/`cancel-in-progress`
+(e.g. `chart-release.yml`, `sync-plugin-version.yml`, `auto-bump-chart.yml`,
+`deploy-site.yml`) — this gate is scoped to the PR's latest-run state, not to workflow
+identity, so it is safe to run unconditionally whenever the cancelled-only condition holds.
+
+**If the gate does not hold** (`CI_HAS_FAILING=true`, with or without an additional
+cancelled run elsewhere on this PR): this PR has a genuine failure/timed_out run — skip this
+step entirely, completely unaffected by the cancelled-only branch, and proceed directly to
+Step 6c exactly as before.
+
+**Otherwise** (cancelled-only): attempt a rerun before touching anything else — no commit,
+no subagent dispatch in this branch.
+
+```bash
+gh run rerun "$CANCELLED_RUN_ID" --repo {org}/{repo}
+```
+
+Poll for a terminal result — a brief, bounded poll (not the full CI gate used elsewhere):
+every 15 seconds, up to 8 times (~2 minutes total). On each poll iteration, renew the claim
+heartbeat first, same reasoning as the heartbeat renewals before every subagent dispatch in
+Steps 4b/5b/6c:
+
+```bash
+curl -s -o /dev/null -X POST \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/heartbeat"
+
+gh run view "$CANCELLED_RUN_ID" --repo {org}/{repo} --json status,conclusion
+```
+
+Keep polling while `status` is `queued`, `in_progress`, or `waiting`. Stop as soon as
+`status == "completed"`.
+
+**Poll window exhausted with no terminal result:** treat this as inconclusive — the rerun
+must not leave the PR in limbo. Fall through to Step 6c exactly as the failed/cancelled case
+below does.
+
+**If the rerun's terminal `conclusion` is `success`, or any other non-cancelled,
+non-failure terminal state** (e.g. `neutral`, `skipped`): the PR is resolved — the cancelled
+CI was indeed stale/transient. Skip Step 6c entirely for this PR:
+
+1. Release the pre-work claim from Step 6b.5 — no fix is in flight, the rerun alone resolved
+   the PR:
+   ```bash
+   curl -s -o /dev/null -X POST \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/release"
+   ```
+2. Print:
+   ```
+   ✓ PR #{pr} — cancelled run {CANCELLED_RUN_ID} rerun succeeded, no fix needed — skipping CI-fix dispatch.
+   ```
+3. Move to the next PR in List D. If no candidates remain, continue to Step 7.
+
+**If the rerun itself ends `cancelled` or `failure` (or the poll window is exhausted without
+a terminal result, per above):** this is a repeated-timeout/hang signal, not a normal test
+failure — fall through to Step 6c as normal. Before dispatching, collect the job's abnormal
+duration vs. its typical duration for the Step 6c prompt, if obtainable:
+
+```bash
+gh api "repos/{org}/{repo}/actions/runs/$CANCELLED_RUN_ID/jobs" \
+  --jq '.jobs[] | {name, started_at, completed_at}'
+```
+
+Approximate a typical duration from a handful of recent successful runs of the same
+workflow (best-effort — use your judgment on how deep to go; this is context for the
+subagent prompt, not a statistical guarantee):
+
+```bash
+gh run list --workflow {workflow-name-or-id} --repo {org}/{repo} --status success \
+  --limit 5 --json startedAt,updatedAt
+```
+
+Store both durations (or a note that typical duration was unavailable) as
+`{repeated-timeout-context}` for use in Step 6c's prompt. Proceed to Step 6c.
 
 ### Step 6c: Dispatch Fix Subagent
 
@@ -1365,6 +1471,16 @@ TOOLCHAIN:
 
 CI FAILURE OUTPUT (last 200 lines):
 {log output from Step 6b}
+
+{if arriving via Step 6b.8's cancelled-only rerun-first branch (the rerun itself ended
+cancelled or failure, or its poll window was exhausted with no terminal result), include:
+"NOTE — REPEATED TIMEOUT/HANG SIGNAL: this PR's CI was cancelled (not a normal test
+failure), a rerun was attempted, and the rerun ALSO ended {cancelled|failure|inconclusive
+after polling}. This looks like a repeated timeout/hang rather than a deterministic test
+failure. Job duration vs. typical duration: {repeated-timeout-context from Step 6b.8, or
+'unavailable' if the duration lookup failed}. Investigate whether the job is hanging,
+hitting `timeout-minutes`, or genuinely regressed before treating this as an ordinary
+failing-test fix."}
 
 INSTRUCTIONS — follow in order:
 


### PR DESCRIPTION
## Summary
- Add `findCancelledRuns()` to `check-patch.ts` — detects a PR whose latest run for some workflow is `cancelled` (e.g. a job that hit `timeout-minutes`), using the same latest-run-per-workflow dedup as `hasFailingCi()`, and surfaces it as a distinct `hasCancelled`/`cancelledRunId` field so a cancelled-only PR still qualifies as a patch candidate.
- Add `patch.md` Step 6b.8: for a PR whose *only* List D signal is the cancelled bucket, attempt `gh run rerun {run_id}` and poll (15s × 8) for a terminal result before touching anything else — no commit, no subagent dispatch. A genuine failure/timed_out PR is unaffected and proceeds straight to Step 6c as before.
- If the rerun itself ends `cancelled`/`failure` (or the poll window is exhausted), fall through to the existing Step 6c CI-fix subagent, with the prompt flagging this as a repeated-timeout/hang signal and including job duration vs. typical duration context.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | check-patch.ts exposes a distinct cancelled-detection function, same dedup logic, surfaced via a separate `hasCancelled` field so cancelled-only PRs are still selected as patch candidates | MET | `findCancelledRuns()` shares `latestRunPerWorkflow()` with `hasFailingCi()`. `CiCheckStatus.hasCancelled`/`cancelledRunId` added. `getPatchCandidates` sets `needsPatch = true` on `hasFailing \|\| hasCancelled`. |
| 2 | patch.md branches on cancelled-only signal: `gh run rerun {run_id}` + brief poll, no commit/dispatch, before falling through; genuine failure/timed_out PRs unaffected | MET | New Step 6b.8 gated strictly on `CI_HAS_CANCELLED=true` and `CI_HAS_FAILING` false; PRs with `CI_HAS_FAILING=true` skip the step entirely. |
| 3 | Rerun ending cancelled/failure falls through to Step 6c with repeated-timeout/hang framing + duration context | MET | Step 6b.8 collects job duration vs. typical duration; Step 6c's prompt conditionally includes a "REPEATED TIMEOUT/HANG SIGNAL" note. |
| 4 | Additive unit + content tests, no existing tests retired | MET | New `describe("findCancelledRuns", ...)` block + `getPatchCandidates` tests; new content-test describe block for Step 6b.8. All prior tests still present and passing. |

## Test Plan
- `bun test agent/src/check-patch.unit.test.ts` — 73 pass, 0 fail
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 143 pass, 0 fail
- `task typecheck` — clean across all 7 workspaces
- `task lint` — clean
- `task check-strings` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
