### PR TITLE
feat: surface prior CURRENT_USER review bodies to code-reviewer subagent (PVD-1.2)

### DIFF
--- a/plugins/shipwright/agents/code-reviewer.md
+++ b/plugins/shipwright/agents/code-reviewer.md
@@ -15,6 +15,7 @@ The caller (the `/review` command's main thread) will pass you:
 - The contents of the root CLAUDE.md plus any CLAUDE.md files that live in directories containing changed files
 - (Optional) `acceptanceCriteria` from a mapped shipwright task
 - (Optional) `testReadinessContext` — contents of `docs/test-readiness/test-system.md` plus the Testing section of the repo's CLAUDE.md; when present, Rule 6 defers to this context instead of the universal baseline
+- (Optional) **Prior Findings — Requires Resolution Check** (PVD-1.2) — a list of prior review bodies this same agent posted on an earlier commit of this PR, each with a `ref` identifying it. When present, for **each** entry you must explicitly assess whether the issue that review originally described is still present in the current diff, and report your determination in the `priorFindingsStatus[]` output field (see Output Format below). Omitted entirely when there are no prior qualifying reviews to check.
 - Policy thresholds: `min_confidence` (default 75) and `max_findings` (default 5)
 
 You return a JSON array of findings. The main thread handles scoring thresholds, output formatting, posting to GitHub, and metrics.
@@ -90,7 +91,14 @@ Return a single JSON object:
   ],
   "strengths": ["{what the PR does well — keep brief, 0-3 bullets}"],
   "recommendation": "APPROVE|COMMENT",
-  "recommendation_reason": "{one-sentence reasoning}"
+  "recommendation_reason": "{one-sentence reasoning}",
+  "priorFindingsStatus": [
+    {
+      "ref": "{the ref identifying which prior review this entry addresses}",
+      "resolved": true,
+      "evidence": "{file:line or diff excerpt proving the fix, or explaining why it's not resolved}"
+    }
+  ]
 }
 ```
 
@@ -102,3 +110,10 @@ Severity mapping:
 Do not emit findings below confidence 50. The main thread applies the caller's `min_confidence` threshold and trims to `max_findings`.
 
 If no findings meet the threshold: return an empty `findings` array and set `recommendation` to `APPROVE`.
+
+`priorFindingsStatus` (PVD-1.2) is **required whenever the caller passed the "Prior Findings —
+Requires Resolution Check" input** — one entry per prior review `ref` passed in, omitted (or an
+empty array) only when the caller passed no such input. `evidence` is required in **both** the
+`resolved: true` and `resolved: false` cases — never leave it blank: for a resolved finding, cite
+the exact `file:line` or diff excerpt proving the fix; for an unresolved finding, explain why the
+originally-described issue is still present.

--- a/plugins/shipwright/agents/code-reviewer.unit.test.ts
+++ b/plugins/shipwright/agents/code-reviewer.unit.test.ts
@@ -255,3 +255,62 @@ describe("test-readiness-tenets.md — retired in favor of principles.md", () =>
     expect(existsSync(tenetsPath)).toBe(false);
   });
 });
+
+describe("code-reviewer.md — prior findings attestation input and output (PVD-1.2)", () => {
+  it("documents the new optional prior-findings input in the caller-passes-in list", () => {
+    const inputsIdx = reviewerContent.indexOf("The caller");
+    expect(inputsIdx).toBeGreaterThan(-1);
+    const outputFormatIdx = reviewerContent.indexOf("## Output Format");
+    const inputsSection = reviewerContent.slice(inputsIdx, outputFormatIdx);
+
+    expect(inputsSection).toContain("Optional");
+    expect(inputsSection.toLowerCase()).toContain("prior");
+    expect(inputsSection.toLowerCase()).toContain("finding");
+  });
+
+  it("instructs the subagent to assess, for each prior finding, whether the issue is still present in the current diff", () => {
+    const inputsIdx = reviewerContent.indexOf("The caller");
+    const outputFormatIdx = reviewerContent.indexOf("## Output Format");
+    const inputsSection = reviewerContent.slice(inputsIdx, outputFormatIdx);
+
+    const priorIdx = inputsSection.toLowerCase().indexOf("prior");
+    expect(priorIdx).toBeGreaterThan(-1);
+    const wholeDoc = reviewerContent.toLowerCase();
+    expect(wholeDoc).toContain("still present");
+  });
+
+  it("documents priorFindingsStatus as a new top-level field in the Output Format JSON schema", () => {
+    const outputFormatIdx = reviewerContent.indexOf("## Output Format");
+    expect(outputFormatIdx).toBeGreaterThan(-1);
+    const outputSection = reviewerContent.slice(outputFormatIdx);
+
+    expect(outputSection).toContain("priorFindingsStatus");
+    expect(outputSection).toContain("ref");
+    expect(outputSection).toContain("resolved");
+    expect(outputSection).toContain("evidence");
+  });
+
+  it("documents priorFindingsStatus is required whenever prior-findings input was passed", () => {
+    const outputFormatIdx = reviewerContent.indexOf("## Output Format");
+    const outputSection = reviewerContent.slice(outputFormatIdx);
+
+    const fieldIdx = outputSection.indexOf("priorFindingsStatus");
+    expect(fieldIdx).toBeGreaterThan(-1);
+    const nearby = outputSection.slice(Math.max(0, fieldIdx - 400), fieldIdx + 800);
+
+    expect(nearby.toLowerCase()).toContain("required");
+  });
+
+  it("documents evidence is required in both the resolved:true and resolved:false cases", () => {
+    const outputFormatIdx = reviewerContent.indexOf("## Output Format");
+    const outputSection = reviewerContent.slice(outputFormatIdx);
+
+    const fieldIdx = outputSection.indexOf("priorFindingsStatus");
+    expect(fieldIdx).toBeGreaterThan(-1);
+    const nearby = outputSection.slice(fieldIdx, fieldIdx + 1200);
+
+    expect(nearby.toLowerCase()).toContain("evidence");
+    expect(nearby.toLowerCase()).toContain("required");
+    expect(nearby.toLowerCase()).toContain("both");
+  });
+});

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1133,3 +1133,145 @@ describe("review.md — Review Quality Rules reflect mechanical enforcement (RUC
     expect(bulletBlock.toLowerCase()).toContain("mechanically enforced");
   });
 });
+
+describe("review.md — Step 5.5 identifies prior qualifying CURRENT_USER reviews for subagent attestation (PVD-1.2)", () => {
+  let step5Section: string;
+
+  beforeAll(() => {
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const step6Idx = content.indexOf("## Step 6: Classify Changes by Domain");
+    expect(step5Idx).toBeGreaterThan(-1);
+    expect(step6Idx).toBeGreaterThan(step5Idx);
+    step5Section = content.slice(step5Idx, step6Idx);
+  });
+
+  it("documents identifying prior qualifying CURRENT_USER reviews at commits earlier than head", () => {
+    expect(step5Section).toContain("PVD-1.2");
+    expect(step5Section.toLowerCase()).toContain("prior qualifying");
+    expect(step5Section).toContain("CURRENT_USER");
+    expect(step5Section).toContain("commit.oid !== headRefOid");
+  });
+
+  it("cites reuse of isSelfCleanApprove and isSupersededBySelfReview from compute-unaddressed-findings.ts rather than re-deriving the rules in prose", () => {
+    const priorIdx = step5Section.indexOf("prior qualifying");
+    expect(priorIdx).toBeGreaterThan(-1);
+    const priorBlock = step5Section.slice(priorIdx, priorIdx + 2000);
+
+    expect(priorBlock).toContain("isSelfCleanApprove");
+    expect(priorBlock).toContain("isSupersededBySelfReview");
+    expect(priorBlock).toContain("compute-unaddressed-findings.ts");
+  });
+
+  it("qualifies on state COMMENTED or CHANGES_REQUESTED with a non-empty body, matching Step 9.5's own review-state filter", () => {
+    const priorIdx = step5Section.indexOf("prior qualifying");
+    expect(priorIdx).toBeGreaterThan(-1);
+    const priorBlock = step5Section.slice(priorIdx, priorIdx + 2000);
+
+    expect(priorBlock).toContain("COMMENTED");
+    expect(priorBlock).toContain("CHANGES_REQUESTED");
+    expect(priorBlock.toLowerCase()).toContain("non-empty");
+  });
+
+  it("produces a labeled artifact (priorQualifyingReviews) for Step 7's prompt to consume", () => {
+    expect(step5Section).toContain("priorQualifyingReviews");
+  });
+});
+
+describe("review.md — Step 7 dispatch prompt includes prior findings input when qualifying reviews exist (PVD-1.2)", () => {
+  let step7Section: string;
+
+  beforeAll(() => {
+    const step7Idx = content.indexOf("## Step 7: Deep Review");
+    const step8Idx = content.indexOf("## Step 8: Score and Classify Findings");
+    expect(step7Idx).toBeGreaterThan(-1);
+    expect(step8Idx).toBeGreaterThan(step7Idx);
+    step7Section = content.slice(step7Idx, step8Idx);
+  });
+
+  it("includes a new labeled prior-findings input referencing priorQualifyingReviews", () => {
+    expect(step7Section).toContain("priorQualifyingReviews");
+    expect(step7Section.toLowerCase()).toContain("prior findings");
+  });
+
+  it("documents the input is only included when priorQualifyingReviews is non-empty, omitted otherwise", () => {
+    const priorIdx = step7Section.indexOf("priorQualifyingReviews");
+    expect(priorIdx).toBeGreaterThan(-1);
+    const priorBlock = step7Section.slice(Math.max(0, priorIdx - 300), priorIdx + 600);
+
+    expect(priorBlock.toLowerCase()).toContain("omit");
+  });
+
+  it("documents that the subagent must return priorFindingsStatus[] with ref/resolved/evidence", () => {
+    expect(step7Section).toContain("priorFindingsStatus");
+    expect(step7Section).toContain("ref");
+    expect(step7Section).toContain("resolved");
+    expect(step7Section).toContain("evidence");
+  });
+
+  it("references PVD-1.2 in this section", () => {
+    expect(step7Section).toContain("PVD-1.2");
+  });
+});
+
+describe("review.md — Step 9 Prior Findings Resolution table is sourced from priorFindingsStatus (PVD-1.2)", () => {
+  let reReviewSection: string;
+
+  beforeAll(() => {
+    const reReviewIdx = content.indexOf("### Re-Review (Update)");
+    const step95Idx = content.indexOf("## Step 9.5:");
+    expect(reReviewIdx).toBeGreaterThan(-1);
+    expect(step95Idx).toBeGreaterThan(reReviewIdx);
+    reReviewSection = content.slice(reReviewIdx, step95Idx);
+  });
+
+  it("references the structured priorFindingsStatus[] data rather than pure freehand narrative", () => {
+    expect(reReviewSection).toContain("priorFindingsStatus");
+  });
+
+  it("maps resolved:true to Addressed and resolved:false to Not addressed, and evidence to the Evidence column", () => {
+    expect(reReviewSection).toContain("Prior Findings Resolution");
+    expect(reReviewSection).toContain("resolved: true");
+    expect(reReviewSection).toContain("Addressed");
+    expect(reReviewSection).toContain("resolved: false");
+    expect(reReviewSection).toContain("Not addressed");
+    expect(reReviewSection).toContain("evidence");
+  });
+});
+
+describe("review.md — Step 9.5 unaddressed-findings gate is unchanged by PVD-1.2 (regression guard)", () => {
+  let step95Section: string;
+
+  beforeAll(() => {
+    const step95Idx = content.indexOf("## Step 9.5:");
+    const step10Idx = content.indexOf("## Step 10: Build Review JSON");
+    expect(step95Idx).toBeGreaterThan(-1);
+    expect(step10Idx).toBeGreaterThan(step95Idx);
+    step95Section = content.slice(step95Idx, step10Idx);
+  });
+
+  it("still titles the section 'Unaddressed-Findings Hard Gate (RUC-1.1, PVD-1.1)'", () => {
+    expect(step95Section).toContain("Unaddressed-Findings Hard Gate (RUC-1.1, PVD-1.1)");
+  });
+
+  it("still states the computation is mechanical, not freehand", () => {
+    expect(step95Section).toContain("computed mechanically, not freehand");
+  });
+
+  it("still invokes compute-unaddressed-findings.ts with the same CLI call, unchanged", () => {
+    expect(step95Section).toContain(
+      'bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-unaddressed-findings.ts"',
+    );
+    expect(step95Section).toContain('{"unaddressedFindings":true|false}');
+    expect(step95Section).toContain("UNADDRESSED_FINDINGS=");
+  });
+
+  it("still forces the verdict to COMMENT when unaddressed findings are present, with the same override language", () => {
+    expect(step95Section).toContain("force the verdict to `COMMENT`");
+    expect(step95Section).toContain("Overrides the code-reviewer subagent's severity-based recommendation");
+  });
+
+  it("does not introduce any priorFindingsStatus/priorQualifyingReviews plumbing into its own computation", () => {
+    expect(step95Section).not.toContain("priorFindingsStatus");
+    expect(step95Section).not.toContain("priorQualifyingReviews");
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -262,6 +262,38 @@ back to `'sonnet'`.
    `comments.nodes[]` — the same shape patch.md's Step 3a extracts. Used below by the
    Unresolved Comment Check and by the unaddressed-findings gate before Step 10.
 
+   #### Prior Qualifying Reviews for Subagent Attestation (PVD-1.2)
+
+   From the same `reviews.nodes[]` fetched above, separately identify **prior qualifying
+   CURRENT_USER reviews** — reviews this agent posted on an earlier commit of this PR whose
+   findings the subagent should be asked to re-verify in Step 7. A review is a prior
+   qualifying review when ALL of the following hold:
+   - `state === "COMMENTED"` or `state === "CHANGES_REQUESTED"`
+   - `body` is non-empty
+   - `author.login === CURRENT_USER` (resolved in Step 3)
+   - `commit.oid !== headRefOid` (posted at a commit earlier than the current head — this is
+     the "prior" distinction from Step 9.5's own `commit.oid === headRefOid` filter, which
+     only looks at reviews **at** head; this collection deliberately looks at reviews
+     **before** head)
+   - NOT excluded by `isSelfCleanApprove` (a clean self-APPROVE) or by
+     `isSupersededBySelfReview` (DRO-1.2 — an earlier self-review superseded by a later,
+     genuinely clean self-review) — reuse these two functions exactly as exported from
+     `compute-unaddressed-findings.ts` (PVD-1.1), the same module Step 9.5 below invokes as
+     its single source of truth, rather than re-deriving their rules in prose here. This
+     collection intentionally does **not** apply Step 9.5's other two conditions
+     (unresolved-thread branching, `isAddressedByAuthorReply`) — those are specific to Step
+     9.5's "unaddressed findings" definition; this collection surfaces prior reviews
+     regardless of whether they've since been resolved, so the subagent can make its own
+     resolved/not-resolved determination for each one.
+
+   Call the result `priorQualifyingReviews` — a list of `{ ref, body }` pairs, where `ref` is
+   a short identifying label for each review (e.g. the commit short SHA plus `submittedAt`,
+   since the GraphQL query above does not fetch a review `id`/`url` field). When
+   `priorQualifyingReviews` is empty (no prior reviews, or all excluded by the two reused
+   exclusions above — e.g. a self-authored PR whose only prior reviews were clean self-approves
+   or superseded self-reviews), the field is simply empty and Step 7 omits the corresponding
+   prompt input entirely (see Step 7).
+
 6. **CLAUDE.md files**: read root CLAUDE.md + CLAUDE.md files in directories containing changed files
 
 7. **Test-readiness context** (optional): try to read `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}/docs/test-readiness/test-system.md`. If absent, note that no repo-specific test-readiness doc exists. When the changed files include any path that looks like a test file — by common conventions across languages (e.g. files named or located in a way that signals they contain tests, such as files in `test/`, `tests/`, `spec/`, or `__tests__/` directories, or files whose names follow typical test-naming conventions for the project's language), also extract the "## Testing" section from the root CLAUDE.md (if present). Use the project's language and toolchain (visible from the diff and CLAUDE.md) to recognise test files — do not apply a fixed set of glob patterns. Combine both pieces into `testReadinessContext`. If neither produces content, `testReadinessContext` is absent — omit it entirely from the subagent prompt.
@@ -385,10 +417,27 @@ a single prompt block containing:
   when no test-readiness content was gathered (the subagent falls back to the universal
   baseline in the testing-domain entries of `references/principles.md` when the field is
   absent)
+- **`Prior Findings — Requires Resolution Check`** (PVD-1.2) — when Step 5.5's
+  `priorQualifyingReviews` is non-empty, include this labeled input listing each prior
+  qualifying review's `ref` and full `body`. Omit this field entirely when
+  `priorQualifyingReviews` is empty — mirroring how `acceptanceCriteria` and
+  `testReadinessContext` are omitted rather than passed as an empty value. Instruct the
+  subagent that, for each entry, it must explicitly assess whether the issue that review
+  originally described is still present in the current diff, and return one
+  `priorFindingsStatus[]` entry per input `ref` (see the Output Format section of
+  `agents/code-reviewer.md`).
 - **Policy** — pass `min_confidence` and `max_findings` from Step 1
 
 The subagent returns a JSON object with `summary`, `findings[]`, `strengths[]`,
-`recommendation`, and `recommendation_reason`. Parse it and carry the data into Step 8.
+`recommendation`, `recommendation_reason`, and — whenever the `Prior Findings — Requires
+Resolution Check` input was passed above — `priorFindingsStatus[]`, an array of
+`{ ref, resolved, evidence }` entries, one per prior qualifying review passed in. `ref`
+identifies which prior review the entry addresses (matching the `ref` passed in above),
+`resolved` is a boolean, and `evidence` (required in both the `resolved: true` and
+`resolved: false` cases) is a `file:line` reference or diff excerpt proving the fix, or
+explaining why the issue is not resolved. Parse the full response and carry the data into
+Step 8 and Step 9 (Step 9's Re-Review "Prior Findings Resolution" table is populated from
+`priorFindingsStatus[]` — see Step 9).
 
 If the subagent returns malformed JSON, retry once with a reminder of the schema. If it
 still fails, fall back to an inline review in the main thread using the same rules
@@ -512,11 +561,19 @@ local file is the authoritative signal that *this* agent has a prior review to a
 
 ### Prior Findings Resolution
 
+Populate this table from the subagent's structured `priorFindingsStatus[]` response (Step 7,
+PVD-1.2) rather than freehand narrative — one row per entry, mapping `resolved: true` to
+`Addressed` and `resolved: false` to `Not addressed`, with the `evidence` field verbatim in
+the Evidence column:
+
 | Finding | Status | Evidence |
 |---------|--------|----------|
-| {issue 1} | Addressed | Fixed in `file.ts:45` |
-| {issue 2} | Partial | Logging added but no error ID |
-| {issue 3} | Not addressed | Still missing validation |
+| {ref} | Addressed | {evidence, e.g. Fixed in `file.ts:45`} |
+| {ref} | Not addressed | {evidence, e.g. Still missing validation} |
+
+Only present when Step 7's subagent dispatch included the `Prior Findings — Requires
+Resolution Check` input (i.e. `priorQualifyingReviews` was non-empty); omit this
+subsection when there was nothing to check.
 
 ### New Issues ({count})
 ...


### PR DESCRIPTION
## Summary
- Extend `review.md` Step 5.5 to identify prior qualifying `CURRENT_USER` reviews (reusing PVD-1.1's `isSelfCleanApprove`/`isSupersededBySelfReview` exclusions from `compute-unaddressed-findings.ts`) and pass their bodies to the `code-reviewer` subagent in Step 7 as a new labeled input when any exist
- Update `agents/code-reviewer.md` to document the new optional prior-findings input and the new required `priorFindingsStatus[]` output field (`{ ref, resolved, evidence }`), with evidence required in both the resolved and not-resolved cases
- Populate Step 9's "Prior Findings Resolution" table from the subagent's structured `priorFindingsStatus[]` response instead of freehand narrative
- Plumbing only — Step 9.5's `unaddressedFindings` gate computation and posted verdict behavior are unchanged (verified by a regression-guard test suite)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5.5 identifies prior qualifying CURRENT_USER reviews; Step 7 includes their bodies as a new labeled input | MET |
| 2 | agents/code-reviewer.md documents the new optional input and required `priorFindingsStatus[]` output ({ ref, resolved, evidence }) | MET |
| 3 | Step 9's Prior Findings Resolution table is sourced from `priorFindingsStatus[]` | MET |
| 4 | Step 9.5's unaddressedFindings computation is unchanged (regression-guard tests) | MET |
| 5 | Content tests assert Step 5.5/Step 7 prompt-construction include the new input/output field; no unit tests needed (no new TS logic) | MET |

## Test Plan
- `bun test plugins/shipwright/commands/review.content.test.ts plugins/shipwright/agents/code-reviewer.unit.test.ts` — 137 pass
- `bun test` (full suite) — 5998 pass, 1 pre-existing unrelated flake in `metrics/src/lib/errors.unit.test.ts` (passes in isolation, untouched by this diff)
- `bun run --filter='*' --sequential typecheck` — clean across all packages
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
