### PR TITLE
feat: add per-pass summary logging to pr-state-reconciler (RCO-1.5)

### DIFF
--- a/agent/src/pr-state-reconciler.ts
+++ b/agent/src/pr-state-reconciler.ts
@@ -79,9 +79,9 @@
  * on GitHub's MERGED confirmation, as before.
  */
 
-import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import {
   classifyReviewState,
   createPrRecordQuery,
@@ -421,6 +421,44 @@ function computeUpdatedSinceCutoff(nowMs: number): string {
   return new Date(nowMs - RECONCILER_UPDATED_SINCE_WINDOW_MS).toISOString();
 }
 
+/**
+ * RCO-1.5: per-pass record-outcome tally, accumulated across every repo a
+ * reconcile pass scans and logged once as a single summary line at the end
+ * of the pass — see `logPassSummary` below. A clean, fully successful pass
+ * previously produced zero log output, making it impossible to tell "ran and
+ * succeeded" apart from "never ran at all" from logs alone.
+ *
+ * `skippedClaimed` is always 0 for `reconcilePrState()`'s pass — `PrStateRecord`
+ * has no claim concept at all — but is included here for schema consistency
+ * across all three passes (`reconcilePrState`, and `reconcileReviewState`'s
+ * two scans, which DO have a live isActivelyClaimed skip).
+ */
+interface PassSummary {
+  /** Records fetched and considered by this pass (a per-repo list-call failure does NOT add to this — the would-be count is unknown). */
+  evaluated: number;
+  /** Records that received a PATCH. */
+  patched: number;
+  /** Records skipped because `isActivelyClaimed()` returned true — always 0 for reconcilePrState's pass. */
+  skippedClaimed: number;
+  /** Per-record reconcile failures PLUS per-repo list-call failures (each list failure counts as 1, representing the failed call itself). */
+  errored: number;
+}
+
+function newPassSummary(): PassSummary {
+  return { evaluated: 0, patched: 0, skippedClaimed: 0, errored: 0 };
+}
+
+/** Logs one summary line for a completed pass — see `PassSummary`'s doc comment for what each count means. */
+function logPassSummary(
+  prefix: string,
+  label: string,
+  summary: PassSummary,
+): void {
+  console.log(
+    `${prefix} ${label} summary: evaluated=${summary.evaluated} patched=${summary.patched} skippedClaimed=${summary.skippedClaimed} errored=${summary.errored}`,
+  );
+}
+
 /** Map GitHub's uppercase PR state to the task-store's lowercase PrState enum. */
 function mapGhStateToPrState(
   state: GhPrView["state"],
@@ -496,14 +534,19 @@ async function listAllPrOpenTasks(
  * PSR-1.2 rate-limit-incident rationale). The removal is isolated in its own
  * try/catch: a failure is logged but never propagates, and never undoes or
  * blocks the already-succeeded state PATCH above.
+ *
+ * RCO-1.5: returns "patched" or "no-op" (rather than void) so the calling
+ * loop in `reconcilePrState()` can tally outcomes for its end-of-pass summary
+ * log — purely a reporting addition, does not change which branch runs or
+ * what gets written.
  */
 async function reconcileRecord(
   deps: PrStateReconcilerDeps,
   record: PrStateRecord,
-): Promise<void> {
+): Promise<"patched" | "no-op"> {
   const ghState = await deps.ghViewPr(record.repo, record.prNumber);
   const newState = mapGhStateToPrState(ghState.state);
-  if (newState === null) return; // still open on GitHub — no-op
+  if (newState === null) return "no-op"; // still open on GitHub — no-op
 
   // claimedBy/claimedAt/heartbeatAt aren't in routes/prs.ts's PATCH
   // allowlist, so including them here is documentation-of-intent rather than
@@ -524,8 +567,8 @@ async function reconcileRecord(
 
   await deps.patchPrRecord(record.id, fields);
 
-  if (!deps.isCleanupMergedWorktreesEnabled) return;
-  if (!ghState.headRefName) return; // defensive — no branch to derive a worktree path from
+  if (!deps.isCleanupMergedWorktreesEnabled) return "patched";
+  if (!ghState.headRefName) return "patched"; // defensive — no branch to derive a worktree path from
 
   try {
     const [, shortRepo] = splitOrgRepo(record.repo);
@@ -537,6 +580,7 @@ async function reconcileRecord(
       err instanceof Error ? err.message : String(err),
     );
   }
+  return "patched";
 }
 
 /**
@@ -773,6 +817,14 @@ export async function reconcilePrOpenTasks(
  * lookup failure is logged and does not abort reconciliation of the rest
  * of the batch. Then runs the pr_open-task reconciliation pass (DSR-1.1) so
  * agent/src/index.ts's single call site doesn't need to change.
+ *
+ * RCO-1.5: logs one end-of-pass summary line (evaluated/patched/
+ * skippedClaimed/errored) via `logPassSummary` — additive only, does not
+ * change any reconciliation decision or write. `skippedClaimed` is always 0
+ * here (see `PassSummary`'s doc comment); included for schema consistency
+ * with `reconcileReviewState()`'s two scans. Scoped to this function's own
+ * PR-record scan only — `reconcilePrOpenTasks()` below has its own
+ * pre-existing error handling and is out of scope for this summary line.
  */
 export async function reconcilePrState(
   deps: PrStateReconcilerDeps,
@@ -785,6 +837,8 @@ export async function reconcilePrState(
   const scopedReposSet = new Set(deps.getScopedRepos());
   const scopedRepos = deps.repos.filter((repo) => scopedReposSet.has(repo));
 
+  const summary = newPassSummary();
+
   for (const repo of scopedRepos) {
     let records: PrStateRecord[];
     try {
@@ -794,21 +848,27 @@ export async function reconcilePrState(
         `[pr-state-reconciler] failed to list open PRs for ${repo}:`,
         err instanceof Error ? err.message : String(err),
       );
+      summary.errored += 1; // the failed list-call itself — would-be record count is unknown
       continue;
     }
 
     for (const record of records) {
+      summary.evaluated += 1;
       try {
-        await reconcileRecord(deps, record);
+        const outcome = await reconcileRecord(deps, record);
+        if (outcome === "patched") summary.patched += 1;
       } catch (err) {
         console.error(
           `[pr-state-reconciler] failed to reconcile ${repo}#${record.prNumber}:`,
           err instanceof Error ? err.message : String(err),
         );
+        summary.errored += 1;
       }
       await deps.delay(DEFAULT_RECONCILER_DELAY_MS);
     }
   }
+
+  logPassSummary("[pr-state-reconciler]", "pass", summary);
 
   await reconcilePrOpenTasks(deps);
 }
@@ -877,25 +937,32 @@ async function listAllReviewRecords(
  * Issues a PATCH only when GitHub shows a terminal review at the PR's
  * current head commit — a genuine unaddressed finding, a stale-commit-only
  * review, or no review at all are all left completely untouched.
+ *
+ * RCO-1.5: returns "patched" | "no-op" | "skipped-claimed" (rather than
+ * void) so the calling loop in `reconcileReviewState()` can tally outcomes
+ * for its end-of-pass summary log — purely a reporting addition, does not
+ * change which branch runs or what gets written.
  */
 async function reconcileReviewStateRecord(
   deps: PrReviewStateReconcilerDeps,
   record: PrReviewStateRecord,
-): Promise<void> {
+): Promise<"patched" | "no-op" | "skipped-claimed"> {
   // deps.claimTtlMs is NOT left unwired here: buildReviewStateProductionDeps
   // (below) reads process.env.SHIPWRIGHT_TASK_STORE_CLAIM_TTL_MS itself and
   // sets it on the returned deps object, so index.ts's bare
   // buildReviewStateReconcilerDeps({ ghGraphql }) call site still gets the
   // env var end-to-end — confirmed by this factory's own unit tests below.
   const claimTtlMs = deps.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS;
-  if (isActivelyClaimed(record, deps.clock, claimTtlMs)) return; // live claim — never overwrite
+  if (isActivelyClaimed(record, deps.clock, claimTtlMs))
+    return "skipped-claimed"; // live claim — never overwrite
 
   const [org, repoName] = splitOrgRepo(record.repo);
   const reviewData = await deps.fetchPrReviews(org, repoName, record.prNumber);
   const newReviewState = classifyReviewState(reviewData);
-  if (newReviewState === null) return; // nothing terminal at head — no-op
+  if (newReviewState === null) return "no-op"; // nothing terminal at head — no-op
 
   await deps.patchPrRecord(record.id, { reviewState: newReviewState });
+  return "patched";
 }
 
 /**
@@ -917,19 +984,25 @@ async function reconcileReviewStateRecord(
  *   - Anything else (a genuine unresolved finding at head, a still-terminal
  *     review, or a still-approved review) leaves the record completely
  *     untouched — there's nothing to heal.
+ *
+ * RCO-1.5: returns "patched" | "no-op" | "skipped-claimed" (rather than
+ * void) — see `reconcileReviewStateRecord`'s doc comment above for the same
+ * rationale.
  */
 async function reconcilePostedReviewStateRecord(
   deps: PrReviewStateReconcilerDeps,
   record: PrReviewStateRecord,
-): Promise<void> {
+): Promise<"patched" | "no-op" | "skipped-claimed"> {
   const claimTtlMs = deps.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS;
-  if (isActivelyClaimed(record, deps.clock, claimTtlMs)) return; // live claim — never overwrite
+  if (isActivelyClaimed(record, deps.clock, claimTtlMs))
+    return "skipped-claimed"; // live claim — never overwrite
 
   const [org, repoName] = splitOrgRepo(record.repo);
   const reviewData = await deps.fetchPrReviews(org, repoName, record.prNumber);
-  if (hasAnyReviewAtHead(reviewData)) return; // something at head (finding or terminal) — untouched
+  if (hasAnyReviewAtHead(reviewData)) return "no-op"; // something at head (finding or terminal) — untouched
 
   await deps.patchPrRecord(record.id, { reviewState: "pending" });
+  return "patched";
 }
 
 /**
@@ -945,6 +1018,10 @@ async function reconcilePostedReviewStateRecord(
  * trapping the PR out of every phase's candidate set. A single per-record
  * failure (claim check aside) is logged and does not abort reconciliation
  * of the rest of the batch, for either scan.
+ *
+ * RCO-1.5: each scan logs its OWN end-of-pass summary line (evaluated/
+ * patched/skippedClaimed/errored) via `logPassSummary` — additive only, does
+ * not change any reconciliation decision or write.
  */
 export async function reconcileReviewState(
   deps: PrReviewStateReconcilerDeps,
@@ -959,6 +1036,8 @@ export async function reconcileReviewState(
   const scopedReposSet = new Set(deps.getScopedRepos());
   const scopedRepos = deps.repos.filter((repo) => scopedReposSet.has(repo));
 
+  const pendingSummary = newPassSummary();
+
   for (const repo of scopedRepos) {
     let records: PrReviewStateRecord[];
     try {
@@ -970,21 +1049,35 @@ export async function reconcileReviewState(
         `[pr-state-reconciler:review] failed to list pending-review PRs for ${repo}:`,
         err instanceof Error ? err.message : String(err),
       );
+      pendingSummary.errored += 1; // the failed list-call itself — would-be record count is unknown
       continue;
     }
 
     for (const record of records) {
+      pendingSummary.evaluated += 1;
       try {
-        await reconcileReviewStateRecord(deps, record);
+        const outcome = await reconcileReviewStateRecord(deps, record);
+        if (outcome === "patched") pendingSummary.patched += 1;
+        else if (outcome === "skipped-claimed")
+          pendingSummary.skippedClaimed += 1;
       } catch (err) {
         console.error(
           `[pr-state-reconciler:review] failed to reconcile ${repo}#${record.prNumber}:`,
           err instanceof Error ? err.message : String(err),
         );
+        pendingSummary.errored += 1;
       }
       await deps.delay(DEFAULT_RECONCILER_DELAY_MS);
     }
   }
+
+  logPassSummary(
+    "[pr-state-reconciler:review]",
+    "pending scan",
+    pendingSummary,
+  );
+
+  const postedSummary = newPassSummary();
 
   for (const repo of scopedRepos) {
     let postedRecords: PrReviewStateRecord[];
@@ -999,21 +1092,29 @@ export async function reconcileReviewState(
         `[pr-state-reconciler:review] failed to list posted-review PRs for ${repo}:`,
         err instanceof Error ? err.message : String(err),
       );
+      postedSummary.errored += 1; // the failed list-call itself — would-be record count is unknown
       continue;
     }
 
     for (const record of postedRecords) {
+      postedSummary.evaluated += 1;
       try {
-        await reconcilePostedReviewStateRecord(deps, record);
+        const outcome = await reconcilePostedReviewStateRecord(deps, record);
+        if (outcome === "patched") postedSummary.patched += 1;
+        else if (outcome === "skipped-claimed")
+          postedSummary.skippedClaimed += 1;
       } catch (err) {
         console.error(
           `[pr-state-reconciler:review] failed to reconcile posted ${repo}#${record.prNumber}:`,
           err instanceof Error ? err.message : String(err),
         );
+        postedSummary.errored += 1;
       }
       await deps.delay(DEFAULT_RECONCILER_DELAY_MS);
     }
   }
+
+  logPassSummary("[pr-state-reconciler:review]", "posted scan", postedSummary);
 }
 
 // ─── Production deps ──────────────────────────────────────────────────────────

--- a/agent/src/pr-state-reconciler.unit.test.ts
+++ b/agent/src/pr-state-reconciler.unit.test.ts
@@ -3251,6 +3251,17 @@ async function captureConsoleLog(fn: () => Promise<void>): Promise<string[][]> {
   return logSpy;
 }
 
+/** Finds the captured summary log line matching `prefix` + `label` (e.g. `"[pr-state-reconciler]"` + `"pass summary"`). */
+function findSummaryLine(
+  logs: string[][],
+  prefix: string,
+  label: string,
+): string[] | undefined {
+  return logs.find((args) =>
+    args.some((a) => a.includes(prefix) && a.includes(label)),
+  );
+}
+
 describe("reconcilePrState — per-pass summary logging (RCO-1.5)", () => {
   test("mixed outcomes (patched, no-op, per-record error) — one summary line with correct counts", async () => {
     const patchedRecord = makeRecord({ id: "pr-patched", prNumber: 1 });
@@ -3279,11 +3290,10 @@ describe("reconcilePrState — per-pass summary logging (RCO-1.5)", () => {
       console.error = errOriginal;
     }
 
-    const summaryLine = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler]") && a.includes("pass summary"),
-      ),
+    const summaryLine = findSummaryLine(
+      logs,
+      "[pr-state-reconciler]",
+      "pass summary",
     );
     expect(summaryLine).toBeDefined();
     const text = summaryLine?.join(" ") ?? "";
@@ -3298,11 +3308,10 @@ describe("reconcilePrState — per-pass summary logging (RCO-1.5)", () => {
 
     const logs = await captureConsoleLog(() => reconcilePrState(deps));
 
-    const summaryLine = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler]") && a.includes("pass summary"),
-      ),
+    const summaryLine = findSummaryLine(
+      logs,
+      "[pr-state-reconciler]",
+      "pass summary",
     );
     expect(summaryLine).toBeDefined();
     const text = summaryLine?.join(" ") ?? "";
@@ -3330,11 +3339,10 @@ describe("reconcilePrState — per-pass summary logging (RCO-1.5)", () => {
       console.error = errOriginal;
     }
 
-    const summaryLine = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler]") && a.includes("pass summary"),
-      ),
+    const summaryLine = findSummaryLine(
+      logs,
+      "[pr-state-reconciler]",
+      "pass summary",
     );
     expect(summaryLine).toBeDefined();
     const text = summaryLine?.join(" ") ?? "";
@@ -3393,12 +3401,10 @@ describe("reconcileReviewState — per-pass summary logging (RCO-1.5)", () => {
       console.error = errOriginal;
     }
 
-    const summaryLine = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("pending scan summary"),
-      ),
+    const summaryLine = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "pending scan summary",
     );
     expect(summaryLine).toBeDefined();
     const text = summaryLine?.join(" ") ?? "";
@@ -3457,12 +3463,10 @@ describe("reconcileReviewState — per-pass summary logging (RCO-1.5)", () => {
       console.error = errOriginal;
     }
 
-    const summaryLine = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("posted scan summary"),
-      ),
+    const summaryLine = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "posted scan summary",
     );
     expect(summaryLine).toBeDefined();
     const text = summaryLine?.join(" ") ?? "";
@@ -3473,12 +3477,10 @@ describe("reconcileReviewState — per-pass summary logging (RCO-1.5)", () => {
 
     // The pending scan's own (separate) summary line must also be present,
     // scoped to zero records (no pendingRecords configured in this test).
-    const pendingSummary = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("pending scan summary"),
-      ),
+    const pendingSummary = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "pending scan summary",
     );
     expect(pendingSummary).toBeDefined();
     const pendingText = pendingSummary?.join(" ") ?? "";
@@ -3493,19 +3495,15 @@ describe("reconcileReviewState — per-pass summary logging (RCO-1.5)", () => {
 
     const logs = await captureConsoleLog(() => reconcileReviewState(deps));
 
-    const pendingSummary = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("pending scan summary"),
-      ),
+    const pendingSummary = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "pending scan summary",
     );
-    const postedSummary = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("posted scan summary"),
-      ),
+    const postedSummary = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "posted scan summary",
     );
     expect(pendingSummary).toBeDefined();
     expect(postedSummary).toBeDefined();
@@ -3539,19 +3537,15 @@ describe("reconcileReviewState — per-pass summary logging (RCO-1.5)", () => {
       console.error = errOriginal;
     }
 
-    const pendingSummary = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("pending scan summary"),
-      ),
+    const pendingSummary = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "pending scan summary",
     );
-    const postedSummary = logs.find((args) =>
-      args.some(
-        (a) =>
-          a.includes("[pr-state-reconciler:review]") &&
-          a.includes("posted scan summary"),
-      ),
+    const postedSummary = findSummaryLine(
+      logs,
+      "[pr-state-reconciler:review]",
+      "posted scan summary",
     );
     expect(pendingSummary).toBeDefined();
     expect(postedSummary).toBeDefined();

--- a/agent/src/pr-state-reconciler.unit.test.ts
+++ b/agent/src/pr-state-reconciler.unit.test.ts
@@ -14,7 +14,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import {
   existsSync,
   mkdirSync,
@@ -25,6 +24,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import type { PrReviewData, ReviewNode, ReviewThread } from "./check-patch.ts";
 import { type Clock, FixedClock } from "./clock.ts";
 import {
@@ -2497,9 +2497,7 @@ describe("reconcilePrState — pr_open task reconciliation pass", () => {
     expect(taskPatchCalls).toHaveLength(1);
     expect(taskPatchCalls[0].id).toBe("task-direct-bundle-started");
     expect(taskPatchCalls[0].fields.status).toBe("merged");
-    expect(taskPatchCalls[0].fields.mergedAt).toBe(
-      "2026-07-10T00:00:00.000Z",
-    );
+    expect(taskPatchCalls[0].fields.mergedAt).toBe("2026-07-10T00:00:00.000Z");
     expect(patchCalls).toHaveLength(1);
     expect(patchCalls[0].id).toBe("pr-record-602");
     expect(patchCalls[0].fields).toEqual({
@@ -3227,5 +3225,341 @@ describe("buildProductionDeps — removeWorktree staleness gate (WTR-1.4)", () =
     expect(existsSync(worktreePath)).toBe(false);
 
     rmSync(workspacePath, { recursive: true, force: true });
+  });
+});
+
+// ─── RCO-1.5: per-pass summary logging ─────────────────────────────────────
+
+/**
+ * Captures console.log calls for the duration of `fn`, restoring the
+ * original afterward (including on throw) — mirrors this file's existing
+ * console.error-capture pattern used throughout (see e.g. the RCP-1.1/RSG-1.2
+ * tests above), just for console.log instead, since the summary line is
+ * logged via console.log (a normal-operation summary, not a failure).
+ */
+async function captureConsoleLog(fn: () => Promise<void>): Promise<string[][]> {
+  const logSpy: string[][] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    logSpy.push(args.map((a) => (typeof a === "string" ? a : String(a))));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return logSpy;
+}
+
+describe("reconcilePrState — per-pass summary logging (RCO-1.5)", () => {
+  test("mixed outcomes (patched, no-op, per-record error) — one summary line with correct counts", async () => {
+    const patchedRecord = makeRecord({ id: "pr-patched", prNumber: 1 });
+    const noopRecord = makeRecord({ id: "pr-noop", prNumber: 2 });
+    const erroredRecord = makeRecord({ id: "pr-erroring", prNumber: 3 });
+    const { deps } = makeDeps({
+      openRecords: {
+        "acme/example-repo": [patchedRecord, noopRecord, erroredRecord],
+      },
+      ghResults: {
+        "acme/example-repo#1": {
+          state: "MERGED",
+          mergedAt: "2026-07-14T00:00:00.000Z",
+        },
+        "acme/example-repo#2": { state: "OPEN", mergedAt: null },
+        "acme/example-repo#3": new Error("gh lookup failed"),
+      },
+    });
+
+    const errOriginal = console.error;
+    console.error = () => {};
+    let logs: string[][];
+    try {
+      logs = await captureConsoleLog(() => reconcilePrState(deps));
+    } finally {
+      console.error = errOriginal;
+    }
+
+    const summaryLine = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler]") && a.includes("pass summary"),
+      ),
+    );
+    expect(summaryLine).toBeDefined();
+    const text = summaryLine?.join(" ") ?? "";
+    expect(text).toContain("evaluated=3");
+    expect(text).toContain("patched=1");
+    expect(text).toContain("skippedClaimed=0");
+    expect(text).toContain("errored=1");
+  });
+
+  test("zero records found — summary line still emitted with all-zero counts", async () => {
+    const { deps } = makeDeps({ openRecords: {} });
+
+    const logs = await captureConsoleLog(() => reconcilePrState(deps));
+
+    const summaryLine = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler]") && a.includes("pass summary"),
+      ),
+    );
+    expect(summaryLine).toBeDefined();
+    const text = summaryLine?.join(" ") ?? "";
+    expect(text).toContain("evaluated=0");
+    expect(text).toContain("patched=0");
+    expect(text).toContain("skippedClaimed=0");
+    expect(text).toContain("errored=0");
+  });
+
+  test("every repo's list call fails — summary line reflects zero-evaluated with the failure counted into errored", async () => {
+    const { deps } = makeDeps({
+      repos: ["acme/repo-a", "acme/repo-b"],
+      getScopedRepos: () => ["acme/repo-a", "acme/repo-b"],
+    });
+    deps.listOpenPrRecords = async () => {
+      throw new Error("task-store unreachable");
+    };
+
+    const errOriginal = console.error;
+    console.error = () => {};
+    let logs: string[][];
+    try {
+      logs = await captureConsoleLog(() => reconcilePrState(deps));
+    } finally {
+      console.error = errOriginal;
+    }
+
+    const summaryLine = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler]") && a.includes("pass summary"),
+      ),
+    );
+    expect(summaryLine).toBeDefined();
+    const text = summaryLine?.join(" ") ?? "";
+    expect(text).toContain("evaluated=0");
+    expect(text).toContain("patched=0");
+    expect(text).toContain("errored=2");
+  });
+});
+
+describe("reconcileReviewState — per-pass summary logging (RCO-1.5)", () => {
+  test("pending scan: mixed outcomes (patched, skipped-claimed, errored) get their own summary line", async () => {
+    const clock = FixedClock(new Date("2026-07-15T12:00:00.000Z"));
+    const patchedRecord = makeReviewStateRecord({
+      id: "pr-pending-patched",
+      prNumber: 1,
+    });
+    const claimedRecord = makeReviewStateRecord({
+      id: "pr-pending-claimed",
+      prNumber: 2,
+      claimedBy: "some-agent",
+      heartbeatAt: "2026-07-15T11:55:00.000Z", // fresh — within TTL
+    });
+    const erroredRecord = makeReviewStateRecord({
+      id: "pr-pending-erroring",
+      prNumber: 3,
+    });
+    const reviewData = makeReviewData({
+      headRefOid: "head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "APPROVED",
+            commit: { oid: "head-sha" },
+            body: "LGTM",
+          }),
+        ],
+      },
+    });
+    const { deps } = makeReviewStateDeps({
+      pendingRecords: {
+        "acme/example-repo": [patchedRecord, claimedRecord, erroredRecord],
+      },
+      reviewResults: {
+        "acme/example-repo#1": reviewData,
+        "acme/example-repo#3": new Error("gh fetch failed"),
+      },
+      clock,
+    });
+
+    const errOriginal = console.error;
+    console.error = () => {};
+    let logs: string[][];
+    try {
+      logs = await captureConsoleLog(() => reconcileReviewState(deps));
+    } finally {
+      console.error = errOriginal;
+    }
+
+    const summaryLine = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("pending scan summary"),
+      ),
+    );
+    expect(summaryLine).toBeDefined();
+    const text = summaryLine?.join(" ") ?? "";
+    expect(text).toContain("evaluated=3");
+    expect(text).toContain("patched=1");
+    expect(text).toContain("skippedClaimed=1");
+    expect(text).toContain("errored=1");
+  });
+
+  test("posted scan: mixed outcomes (patched, skipped-claimed, errored) get their own summary line, distinct from the pending scan's", async () => {
+    const clock = FixedClock(new Date("2026-07-15T12:00:00.000Z"));
+    const patchedRecord = makeReviewStateRecord({
+      id: "pr-posted-patched",
+      prNumber: 1814,
+    });
+    const claimedRecord = makeReviewStateRecord({
+      id: "pr-posted-claimed",
+      prNumber: 1818,
+      claimedBy: "some-agent",
+      heartbeatAt: "2026-07-15T11:55:00.000Z", // fresh — within TTL
+    });
+    const erroredRecord = makeReviewStateRecord({
+      id: "pr-posted-erroring",
+      prNumber: 1819,
+    });
+    // Stale-commit-only review — nothing at current head — heals to pending.
+    const staleReviewData = makeReviewData({
+      headRefOid: "new-head-sha",
+      reviews: {
+        nodes: [
+          makeReviewNode({
+            state: "CHANGES_REQUESTED",
+            commit: { oid: "stale-sha" },
+            body: "Please fix.",
+          }),
+        ],
+      },
+    });
+    const { deps } = makeReviewStateDeps({
+      postedRecords: {
+        "acme/example-repo": [patchedRecord, claimedRecord, erroredRecord],
+      },
+      reviewResults: {
+        "acme/example-repo#1814": staleReviewData,
+        "acme/example-repo#1819": new Error("gh fetch failed"),
+      },
+      clock,
+    });
+
+    const errOriginal = console.error;
+    console.error = () => {};
+    let logs: string[][];
+    try {
+      logs = await captureConsoleLog(() => reconcileReviewState(deps));
+    } finally {
+      console.error = errOriginal;
+    }
+
+    const summaryLine = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("posted scan summary"),
+      ),
+    );
+    expect(summaryLine).toBeDefined();
+    const text = summaryLine?.join(" ") ?? "";
+    expect(text).toContain("evaluated=3");
+    expect(text).toContain("patched=1");
+    expect(text).toContain("skippedClaimed=1");
+    expect(text).toContain("errored=1");
+
+    // The pending scan's own (separate) summary line must also be present,
+    // scoped to zero records (no pendingRecords configured in this test).
+    const pendingSummary = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("pending scan summary"),
+      ),
+    );
+    expect(pendingSummary).toBeDefined();
+    const pendingText = pendingSummary?.join(" ") ?? "";
+    expect(pendingText).toContain("evaluated=0");
+  });
+
+  test("zero records in both scans — both summary lines still emitted with all-zero counts", async () => {
+    const { deps } = makeReviewStateDeps({
+      pendingRecords: {},
+      postedRecords: {},
+    });
+
+    const logs = await captureConsoleLog(() => reconcileReviewState(deps));
+
+    const pendingSummary = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("pending scan summary"),
+      ),
+    );
+    const postedSummary = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("posted scan summary"),
+      ),
+    );
+    expect(pendingSummary).toBeDefined();
+    expect(postedSummary).toBeDefined();
+    for (const summary of [pendingSummary, postedSummary]) {
+      const text = summary?.join(" ") ?? "";
+      expect(text).toContain("evaluated=0");
+      expect(text).toContain("patched=0");
+      expect(text).toContain("skippedClaimed=0");
+      expect(text).toContain("errored=0");
+    }
+  });
+
+  test("every repo's list call fails in both scans — summary lines reflect zero-evaluated with the failures counted into errored", async () => {
+    const { deps } = makeReviewStateDeps({
+      repos: ["acme/repo-a", "acme/repo-b"],
+      getScopedRepos: () => ["acme/repo-a", "acme/repo-b"],
+    });
+    deps.listPendingReviewRecords = async () => {
+      throw new Error("task-store unreachable");
+    };
+    deps.listPostedReviewRecords = async () => {
+      throw new Error("task-store unreachable");
+    };
+
+    const errOriginal = console.error;
+    console.error = () => {};
+    let logs: string[][];
+    try {
+      logs = await captureConsoleLog(() => reconcileReviewState(deps));
+    } finally {
+      console.error = errOriginal;
+    }
+
+    const pendingSummary = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("pending scan summary"),
+      ),
+    );
+    const postedSummary = logs.find((args) =>
+      args.some(
+        (a) =>
+          a.includes("[pr-state-reconciler:review]") &&
+          a.includes("posted scan summary"),
+      ),
+    );
+    expect(pendingSummary).toBeDefined();
+    expect(postedSummary).toBeDefined();
+    for (const summary of [pendingSummary, postedSummary]) {
+      const text = summary?.join(" ") ?? "";
+      expect(text).toContain("evaluated=0");
+      expect(text).toContain("patched=0");
+      expect(text).toContain("errored=2");
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add a per-pass end-of-run summary log line to `pr-state-reconciler.ts`'s `reconcilePrState()` and to each of `reconcileReviewState()`'s two scans (pending and posted/CHU-2.4), reporting `evaluated`/`patched`/`skippedClaimed`/`errored` counts.
- Previously these passes only logged on individual record/list failures — a clean, fully successful pass produced zero log output, making it impossible to distinguish "ran and succeeded" from "never ran" from logs alone. This gap hampered a recent incident investigation into whether the reconciler's 45-minute passes were running on schedule.
- Purely additive logging: `reconcileRecord()`, `reconcileReviewStateRecord()`, and `reconcilePostedReviewStateRecord()` now return an outcome string (`"patched" | "no-op" | "skipped-claimed"`) instead of `void` so the calling loops can tally counts — no reconciliation decision or write (PATCH) behavior changed.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `reconcilePrState()` emits one summary log line per invocation with evaluated/patched/skippedClaimed/errored counts | MET |
| 2 | `reconcileReviewState()`'s pending scan and posted scan (CHU-2.4) each emit their own summary log line | MET |
| 3 | Summary emitted even with zero records, and even when every repo's list call fails (failure counted into errored) | MET |
| 4 | No reconciliation decision or write behavior changes — existing tests pass unchanged | MET |
| 5 | Unit tests assert summary counts for representative scenarios | MET |

## Test Plan
- 7 new unit tests in `agent/src/pr-state-reconciler.unit.test.ts` covering: mixed outcomes, zero-record passes, and all-repos-list-failure, for both `reconcilePrState` and each of `reconcileReviewState`'s two scans.
- Full `agent/` test suite passes (93/93 in the modified file; 2 pre-existing unrelated failures in `claude.unit.test.ts` confirmed present on `main` independent of this change, caused by this environment having `ANTHROPIC_FALLBACK_MODEL` set).
- `bun run --filter='*' --sequential typecheck` — all 7 workspaces pass with zero errors.
- `bunx biome lint .` — clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
