### PR TITLE
fix(chart): make task minikube:up reliable on Apple Silicon and behind the shared ingress rewrite-target

### DIFF
--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.31
+version: 1.11.32
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,12 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "ingress: metrics /dashboard and admin / paths switch to no-op-rewrite capture-group paths when task-store's shared rewrite-target is active, preventing 404s on Apple Silicon/minikube deployments (task minikube:up reliability)"
+    - kind: fixed
+      description: "metrics liveness/readiness probes and the helm test now honor metrics.provider.basePath instead of assuming a bare /health or /dashboard path"
     - kind: changed
-      description: "auto-bump to chart v1.11.31 triggered by release tag agent-v1.147.0"
+      description: "examples/values-minikube.yaml — added explicit CPU/memory resource requests/limits for metrics, taskStore, and chat"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/examples/values-minikube.yaml
+++ b/charts/shipwright/examples/values-minikube.yaml
@@ -74,6 +74,13 @@ admin:
 
 metrics:
   enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   provider:
     basePath: /dashboard
     # adminUrl / taskStoreUrl have NO chart default — both default to "" in
@@ -95,6 +102,13 @@ metrics:
 
 taskStore:
   enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   database:
     # Opt into the chart-managed bundled-PostgreSQL database. The default is the
     # non-empty "shipwright-secrets", which would require a hand-created Secret.
@@ -107,6 +121,13 @@ chat:
   enabled: true
   database:
     existingSecret: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
 agent:
   # No deployment-wide Claude credential is set here — set ANTHROPIC_API_KEY (or

--- a/charts/shipwright/templates/ingress.yaml
+++ b/charts/shipwright/templates/ingress.yaml
@@ -34,8 +34,22 @@ spec:
           # more-specific /dashboard prefix wins (ingress controllers match the
           # longest prefix, but ordering keeps intent explicit). Omitted entirely
           # when metrics is disabled.
-          - path: /dashboard
-            pathType: Prefix
+          #
+          # `rewrite-target` is a per-INGRESS annotation, not per-path — once
+          # task-store's exposure turns it on below, nginx applies "/$2" to
+          # EVERY path in this object, not just task-store's. A plain "/dashboard"
+          # Prefix path has no $2 capture group, so nginx rewrites every request
+          # under it to an empty/garbled path and the metrics app 404s. The
+          # metrics app expects the FULL "/dashboard..." path verbatim (it mounts
+          # its whole router under provider.basePath, then re-applies that same
+          # prefix internally — see metrics-deployment.yaml's probe paths), so
+          # when the shared rewrite is active this path must round-trip through
+          # $2 unchanged: an empty group 1 plus a group 2 that recaptures the
+          # entire matched suffix, making "/$2" a no-op rewrite. Ordinary
+          # "/dashboard" is fine, and simpler, when task-store isn't exposed and
+          # no rewrite-target exists to interact with.
+          - path: {{ if $exposeTaskStore }}/()(dashboard.*){{ else }}/dashboard{{ end }}
+            pathType: {{ if $exposeTaskStore }}ImplementationSpecific{{ else }}Prefix{{ end }}
             backend:
               service:
                 name: {{ include "shipwright.metrics.fullname" . }}
@@ -56,9 +70,12 @@ spec:
                   name: http
           {{- end }}
           # Admin UI/API at the root. Everything not matched by a more-specific
-          # path above is routed to the admin service.
-          - path: /
-            pathType: Prefix
+          # path above is routed to the admin service. Same no-op-rewrite
+          # treatment as metrics above, and for the same reason: the admin app
+          # serves real routes below "/" (e.g. /admin/agents/new) and expects
+          # them verbatim, not collapsed by the shared rewrite-target.
+          - path: {{ if $exposeTaskStore }}/()(.*){{ else }}/{{ end }}
+            pathType: {{ if $exposeTaskStore }}ImplementationSpecific{{ else }}Prefix{{ end }}
             backend:
               service:
                 name: {{ include "shipwright.admin.fullname" . }}

--- a/charts/shipwright/templates/metrics-deployment.yaml
+++ b/charts/shipwright/templates/metrics-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.metrics.provider.basePath }}/health
               port: 3460
             initialDelaySeconds: 10
             periodSeconds: 15
@@ -46,7 +46,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.metrics.provider.basePath }}/health
               port: 3460
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/charts/shipwright/templates/tests/test-connection.yaml
+++ b/charts/shipwright/templates/tests/test-connection.yaml
@@ -34,8 +34,12 @@ spec:
             exit 1
           fi
           {{- if .Values.metrics.enabled }}
-          # Metrics /dashboard MUST return 200 or 302 (auth/redirect tolerated).
-          METRICS_URL="http://{{ include "shipwright.metrics.fullname" . }}:{{ .Values.metrics.service.port }}/dashboard"
+          # Metrics dashboard route MUST return 200 or 302 (auth/redirect
+          # tolerated). The app mounts its whole router under
+          # metrics.provider.basePath (METRICS_BASE_PATH) when set, so the
+          # dashboard route lives at "${basePath}/dashboard", not the bare
+          # "/dashboard" — same prefixing as the liveness/readiness probes.
+          METRICS_URL="http://{{ include "shipwright.metrics.fullname" . }}:{{ .Values.metrics.service.port }}{{ .Values.metrics.provider.basePath }}/dashboard"
           echo "GET ${METRICS_URL} (expect 200 or 302)"
           metrics_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 --retry 5 --retry-delay 3 --retry-connrefused "${METRICS_URL}")"
           echo "metrics /dashboard -> ${metrics_code}"

--- a/charts/shipwright/tests/ingress_test.yaml
+++ b/charts/shipwright/tests/ingress_test.yaml
@@ -128,10 +128,66 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[1].backend.service.port.name
           value: http
-      # admin "/" catch-all remains last
+      # admin "/" catch-all remains last, though its path shape is also
+      # affected by the shared rewrite-target — see the dedicated test below.
+      - equal:
+          path: spec.rules[0].http.paths[2].backend.service.name
+          value: r-shipwright-admin
+
+  - it: switches metrics and admin to no-op-rewrite capture-group paths once the shared rewrite-target is active (TSP-1.1 regression)
+    # `rewrite-target` is per-INGRESS, not per-path: once task-store's exposure
+    # turns it on, nginx applies "/$2" to every path here, not just
+    # task-store's. A plain "/dashboard" or "/" Prefix path has no $2 group, so
+    # nginx would rewrite every request under them to an empty/garbled path —
+    # both the metrics dashboard and any admin route below "/" would 404. The
+    # fix makes $2 recapture the full original suffix for both, so "/$2" is a
+    # no-op round-trip once the shared rewrite is in play.
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+    release:
+      name: r
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /()(dashboard.*)
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: r-shipwright-metrics
       - equal:
           path: spec.rules[0].http.paths[2].path
+          value: /()(.*)
+      - equal:
+          path: spec.rules[0].http.paths[2].pathType
+          value: ImplementationSpecific
+      - equal:
+          path: spec.rules[0].http.paths[2].backend.service.name
+          value: r-shipwright-admin
+
+  - it: keeps the plain /dashboard and / paths when task-store is not exposed (no rewrite-target to interact with)
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+    release:
+      name: r
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /dashboard
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[1].path
           value: /
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
 
   - it: honors an overridden task-store pathPrefix on the Ingress path
     template: templates/ingress.yaml
@@ -238,6 +294,17 @@ tests:
       - notMatchRegex:
           path: spec.containers[0].command[2]
           pattern: /dashboard
+
+  - it: prefixes the metrics dashboard check with basePath (the app mounts its router under METRICS_BASE_PATH when set)
+    template: templates/tests/test-connection.yaml
+    set:
+      metrics.provider.basePath: "/dashboard"
+    release:
+      name: r
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "http://r-shipwright-metrics:3460/dashboard/dashboard"
 
   - it: renders no test-connection Pod when admin is disabled
     template: templates/tests/test-connection.yaml

--- a/charts/shipwright/tests/metrics_workload_test.yaml
+++ b/charts/shipwright/tests/metrics_workload_test.yaml
@@ -315,6 +315,18 @@ tests:
           content:
             name: METRICS_BASE_PATH
 
+  - it: prefixes the liveness/readiness probe paths with basePath (the app mounts /health under it via METRICS_BASE_PATH)
+    template: templates/metrics-deployment.yaml
+    set:
+      metrics.provider.basePath: "/dashboard"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /dashboard/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /dashboard/health
+
   - it: injects METRICS_REQUIRE_OWNER_ROLE=true when requireOwnerRole is true
     template: templates/metrics-deployment.yaml
     set:

--- a/scripts/minikube.ts
+++ b/scripts/minikube.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env bun
+import { mkdirSync, openSync, readFileSync, unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+
 /**
  * scripts/minikube.ts — bring the full Shipwright stack up on Minikube.
  *
  * Run via `task minikube:up` / `task minikube:down`.
  *
- * WHY A SCRIPT: the sequence has four ordering constraints that are easy to get
+ * WHY A SCRIPT: the sequence has five ordering constraints that are easy to get
  * wrong and produce confusing failures rather than clear errors:
  *
  *   1. VM sizing must be set at `minikube start`. The agent pod alone requests
@@ -12,9 +15,14 @@
  *      schedules it and then thrashes.
  *   2. `minikube addons enable ingress` must run BEFORE the install, or the
  *      rendered Ingress has no controller and nothing answers.
- *   3. `helm dependency build` must run BEFORE the install — Chart.lock pins the
+ *   3. The install must wait for the ingress controller's admission webhook pod
+ *      to be Ready before applying the chart. `addons enable` returns as soon as
+ *      the Deployment is created, not once the webhook Service has a ready
+ *      endpoint — installing immediately after races it and helm fails with
+ *      "connect: connection refused" against the webhook.
+ *   4. `helm dependency build` must run BEFORE the install — Chart.lock pins the
  *      PostgreSQL subchart from an OCI registry and it is not vendored expanded.
- *   4. The /etc/hosts entry can only be written AFTER the VM has an IP.
+ *   5. The /etc/hosts entry can only be written AFTER the VM has an IP.
  *
  * Architecture (mirrors scripts/dev-tmux.ts): a PURE builder
  * (buildMinikubeCommands / buildTeardownCommands) returns the command list, and
@@ -32,6 +40,17 @@ export const NAMESPACE = "shipwright";
 export const CHART_PATH = "charts/shipwright";
 export const VALUES_FILE = "charts/shipwright/examples/values-minikube.yaml";
 export const INGRESS_HOST = "shipwright.local";
+
+/**
+ * With the docker driver (the default on macOS/Colima), `minikube ip` returns
+ * an address on a Docker-internal network the host cannot route to at all —
+ * and even if it could, the ingress controller Service is NodePort (a high
+ * port), not port 80. So the host must reach it through a `kubectl
+ * port-forward` to a local port instead of the raw minikube IP on :80.
+ */
+export const INGRESS_LOCAL_PORT = 8080;
+export const PORT_FORWARD_PID_FILE = "state/minikube-port-forward.pid";
+export const PORT_FORWARD_LOG_FILE = "state/minikube-port-forward.log";
 
 /**
  * Default VM size. The floor for the platform plus one agent — see the sizing
@@ -131,6 +150,26 @@ export function buildMinikubeCommands(opts: BuildOpts = {}): Command[] {
     argv: ["minikube", "addons", "enable", "ingress"],
   });
 
+  // 2b. BEFORE the install: `addons enable` returns as soon as the controller
+  //     Deployment is created, not once its admission webhook is reachable. The
+  //     chart's Ingress resource is validated against that webhook on apply, so
+  //     installing immediately after enabling races it — the webhook Service has
+  //     no ready endpoint yet and helm fails with "connection refused".
+  cmds.push({
+    kind: "kubectl",
+    label: "wait for the ingress admission webhook",
+    argv: [
+      "kubectl",
+      "wait",
+      "--namespace",
+      "ingress-nginx",
+      "--for=condition=ready",
+      "pod",
+      "--selector=app.kubernetes.io/component=controller",
+      "--timeout=120s",
+    ],
+  });
+
   // 3. BEFORE the install: Chart.lock pins the PostgreSQL subchart via OCI.
   cmds.push({
     kind: "helm",
@@ -187,6 +226,33 @@ export function buildMinikubeCommands(opts: BuildOpts = {}): Command[] {
   }
 
   return cmds;
+}
+
+export type AccessUrls = {
+  admin: string;
+  metrics: string;
+  taskStore: string;
+  agentNew: string;
+};
+
+/**
+ * Build the browsable URLs for the stack once the local port-forward is up.
+ *
+ * The metrics path is "/dashboard/dashboard", not "/dashboard" — the metrics
+ * service mounts its entire router under provider.basePath (set to
+ * "/dashboard" in examples/values-minikube.yaml), and its own dashboard route
+ * is itself named "/dashboard", so the two compose. See
+ * charts/shipwright/templates/metrics-deployment.yaml's probe paths, which
+ * hit the same basePath-prefixed shape for /health.
+ */
+export function buildAccessUrls(host: string, port: number): AccessUrls {
+  const base = `http://${host}:${port}`;
+  return {
+    admin: `${base}/`,
+    metrics: `${base}/dashboard/dashboard`,
+    taskStore: `${base}/task-store/health`,
+    agentNew: `${base}/admin/agents/new`,
+  };
 }
 
 /**
@@ -246,7 +312,9 @@ export function runCommands(cmds: Command[], exec: ExecFn): Command[] {
 function realExec(argv: string[]): void {
   const result = Bun.spawnSync(argv, { stdout: "inherit", stderr: "inherit" });
   if (result.exitCode !== 0) {
-    throw new Error(`command failed (exit ${result.exitCode}): ${argv.join(" ")}`);
+    throw new Error(
+      `command failed (exit ${result.exitCode}): ${argv.join(" ")}`,
+    );
   }
 }
 
@@ -259,34 +327,107 @@ function minikubeIsRunning(): boolean {
   return new TextDecoder().decode(result.stdout).trim() === "Running";
 }
 
-function minikubeIp(): string | null {
-  const result = Bun.spawnSync(["minikube", "ip"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  if (result.exitCode !== 0) return null;
-  return new TextDecoder().decode(result.stdout).trim() || null;
+/** True if a process with this PID exists (signal 0 sends nothing, just probes). */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readPortForwardPid(): number | null {
+  try {
+    const pid = Number.parseInt(
+      readFileSync(PORT_FORWARD_PID_FILE, "utf8").trim(),
+      10,
+    );
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure a `kubectl port-forward` to the ingress controller is running on
+ * INGRESS_LOCAL_PORT, starting one if none is alive yet. Idempotent across
+ * repeated `task minikube:up` runs, the same way `minikubeIsRunning` is for
+ * the VM itself.
+ *
+ * WHY NOT `minikube tunnel`: that needs a sudo password and a terminal left
+ * open for the whole session. This uses the Kubernetes API connection that
+ * already works (kubectl talks to it throughout the rest of this script), so
+ * it needs no elevated privileges and no extra terminal.
+ */
+function ensurePortForward(): void {
+  const existing = readPortForwardPid();
+  if (existing !== null && isProcessAlive(existing)) {
+    console.log(
+      `\n[minikube] port-forward already running on :${INGRESS_LOCAL_PORT} (pid ${existing})`,
+    );
+    return;
+  }
+
+  mkdirSync(dirname(PORT_FORWARD_PID_FILE), { recursive: true });
+  const log = openSync(PORT_FORWARD_LOG_FILE, "a");
+  const proc = Bun.spawn(
+    [
+      "kubectl",
+      "port-forward",
+      "--namespace",
+      "ingress-nginx",
+      "svc/ingress-nginx-controller",
+      `${INGRESS_LOCAL_PORT}:80`,
+    ],
+    { stdout: log, stderr: log, stdin: "ignore" },
+  );
+  proc.unref();
+  Bun.write(PORT_FORWARD_PID_FILE, `${proc.pid}\n`);
+  console.log(
+    `\n[minikube] started port-forward on :${INGRESS_LOCAL_PORT} (pid ${proc.pid}, log: ${PORT_FORWARD_LOG_FILE})`,
+  );
+}
+
+/** Best-effort: kill the tracked port-forward, if any, and drop the PID file. */
+function stopPortForward(): void {
+  const pid = readPortForwardPid();
+  if (pid !== null && isProcessAlive(pid)) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Already gone — nothing to clean up.
+    }
+  }
+  try {
+    unlinkSync(PORT_FORWARD_PID_FILE);
+  } catch {
+    // No PID file to remove — fine.
+  }
 }
 
 function printNextSteps(): void {
-  const ip = minikubeIp();
+  const urls = buildAccessUrls(INGRESS_HOST, INGRESS_LOCAL_PORT);
   console.log("\n────────────────────────────────────────────────────────────");
   console.log("Shipwright is up.\n");
-  if (ip) {
-    console.log("Add the ingress host to /etc/hosts (once):");
-    console.log(`  echo "${ip} ${INGRESS_HOST}" | sudo tee -a /etc/hosts\n`);
-  }
-  console.log(`  admin console   http://${INGRESS_HOST}/`);
-  console.log(`  metrics         http://${INGRESS_HOST}/dashboard`);
-  console.log(`  task store      http://${INGRESS_HOST}/task-store/health\n`);
+  console.log("Add the ingress host to /etc/hosts (once):");
+  console.log(`  echo "127.0.0.1 ${INGRESS_HOST}" | sudo tee -a /etc/hosts\n`);
+  console.log(`  admin console   ${urls.admin}`);
+  console.log(`  metrics         ${urls.metrics}`);
+  console.log(`  task store      ${urls.taskStore}\n`);
   console.log("No agent exists yet — create one at:");
-  console.log(`  http://${INGRESS_HOST}/admin/agents/new\n`);
+  console.log(`  ${urls.agentNew}\n`);
   console.log(
     "Set that agent's ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in the",
   );
   console.log("admin UI before it can work.");
-  console.log("Tear down with: task minikube:down");
-  console.log("────────────────────────────────────────────────────────────");
+  console.log(
+    "\nThe stack is reachable through a `kubectl port-forward` this script",
+  );
+  console.log(
+    `started in the background (pid file: ${PORT_FORWARD_PID_FILE}). It is`,
+  );
+  console.log("torn down automatically by: task minikube:down");
 }
 
 async function main(): Promise<void> {
@@ -294,12 +435,15 @@ async function main(): Promise<void> {
 
   const missing = missingBinaries((bin) => Bun.which(bin));
   if (missing.length > 0) {
-    console.error(`[minikube] missing required binaries: ${missing.join(", ")}`);
+    console.error(
+      `[minikube] missing required binaries: ${missing.join(", ")}`,
+    );
     console.error("[minikube] install them and re-run.");
     process.exit(1);
   }
 
   if (down) {
+    stopPortForward();
     // Best-effort: a partially-installed stack should still tear down, so a
     // failing uninstall must not block `minikube delete`.
     for (const cmd of buildTeardownCommands()) {
@@ -324,6 +468,7 @@ async function main(): Promise<void> {
   }
 
   runCommands(buildMinikubeCommands({ alreadyRunning }), realExec);
+  ensurePortForward();
   printNextSteps();
 }
 

--- a/scripts/minikube.unit.test.ts
+++ b/scripts/minikube.unit.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, it } from "bun:test";
 import {
+  buildAccessUrls,
   buildMinikubeCommands,
   buildTeardownCommands,
   type Command,
@@ -38,6 +39,18 @@ describe("buildMinikubeCommands — ordering constraints", () => {
     expect(addon).toBeGreaterThanOrEqual(0);
     expect(install).toBeGreaterThanOrEqual(0);
     expect(addon).toBeLessThan(install);
+  });
+
+  it("waits for the ingress admission webhook AFTER enabling the addon and BEFORE the install", () => {
+    // `addons enable` returns once the controller Deployment exists, not once
+    // its webhook Service has a ready endpoint — installing immediately after
+    // races it and helm fails with "connection refused" against the webhook.
+    const cmds = buildMinikubeCommands();
+    const addon = indexOf(cmds, /addons enable ingress/);
+    const wait = indexOf(cmds, /wait.*ingress-nginx.*condition=ready/);
+    const install = indexOf(cmds, /helm upgrade --install/);
+    expect(wait).toBeGreaterThan(addon);
+    expect(wait).toBeLessThan(install);
   });
 
   it("resolves chart dependencies BEFORE the helm install", () => {
@@ -179,6 +192,30 @@ describe("buildTeardownCommands", () => {
   it("targets the configured release and namespace", () => {
     const lines = argvLines(buildTeardownCommands({ release: "sw2", namespace: "n" }));
     expect(lines[0]).toBe("helm uninstall sw2 --namespace n");
+  });
+});
+
+describe("buildAccessUrls", () => {
+  it("doubles the /dashboard segment for metrics", () => {
+    // The metrics service mounts its whole router under provider.basePath
+    // (set to "/dashboard" in examples/values-minikube.yaml), and its own
+    // dashboard route is itself named "/dashboard" — the two compose. A bare
+    // "/dashboard" 404s; only "/dashboard/dashboard" resolves.
+    const urls = buildAccessUrls("shipwright.local", 8080);
+    expect(urls.metrics).toBe("http://shipwright.local:8080/dashboard/dashboard");
+  });
+
+  it("builds the admin, task-store, and agent-creation URLs against the given host and port", () => {
+    const urls = buildAccessUrls("shipwright.local", 8080);
+    expect(urls.admin).toBe("http://shipwright.local:8080/");
+    expect(urls.taskStore).toBe("http://shipwright.local:8080/task-store/health");
+    expect(urls.agentNew).toBe("http://shipwright.local:8080/admin/agents/new");
+  });
+
+  it("honors an arbitrary host and port", () => {
+    const urls = buildAccessUrls("127.0.0.1", 9999);
+    expect(urls.admin).toBe("http://127.0.0.1:9999/");
+    expect(urls.metrics).toBe("http://127.0.0.1:9999/dashboard/dashboard");
   });
 });
 


### PR DESCRIPTION
## Summary
- Ordering race: `helm install` could run before the ingress admission webhook was ready — added a `kubectl wait` step in `scripts/minikube.ts`
- `metrics`, `taskStore`, and `chat` had no memory overrides in `values-minikube.yaml` (only `admin` did), too small for `prisma migrate deploy` at startup — brought all four in line at 512Mi
- Metrics liveness/readiness probes and the `helm test` connectivity check were hardcoded to un-prefixed paths, but the app mounts its whole router under `provider.basePath` when set — fixed both, with new `helm-unittest` coverage
- `nginx.ingress.kubernetes.io/rewrite-target: /$2` is an ingress-wide annotation, but only the task-store path used the two-capture-group regex it needs — it silently mangled the metrics and admin paths once task-store's exposure turned it on. Fixed with a no-op-rewrite capture-group pattern for both, conditional on whether task-store exposure is active
- `task minikube:up` now automatically starts a background `kubectl port-forward` to the ingress controller and prints working URLs, instead of the docker-driver's unreachable `minikube ip` on port 80 (which is also not the ingress controller's actual NodePort)

## Test plan
- [x] `bun test scripts/minikube.unit.test.ts` — 26 pass
- [x] `helm unittest charts/shipwright` — 303 pass across 22 suites
- [x] `bunx biome check` on all changed files
- [x] Full `task minikube:up` run against a live Minikube cluster — all 5 pods `Running`, `helm test` `Succeeded`
- [x] Verified ingress routing end-to-end via `kubectl port-forward` + `curl` with `Host: shipwright.local`: admin console, metrics dashboard, and task-store health all resolve correctly post-fix (previously 404/mangled)