### PR TITLE
fix: write reviewedCommitSha in review.md Step 11b's post-completion PATCH

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -684,6 +684,24 @@ describe("review.md — reviewedCommitSha written/read for dedup (RCS-1.2)", () 
     expect(section).not.toContain("record.commitSha");
   });
 
+  it("Step 11b's PATCH_DATA sets reviewedCommitSha for both the APPROVE branch and the else branch", () => {
+    const step11bIdx = content.indexOf("## Step 11b: Mark PullRequest Record Posted");
+    const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");
+    expect(step11bIdx).toBeGreaterThan(-1);
+    expect(step14Idx).toBeGreaterThan(step11bIdx);
+    const section = content.slice(step11bIdx, step14Idx);
+
+    const approveIdx = section.indexOf('\\"reviewState\\": \\"approved\\"');
+    expect(approveIdx).toBeGreaterThan(-1);
+    const approveBlock = section.slice(approveIdx - 200, approveIdx + 200);
+    expect(approveBlock).toContain("reviewedCommitSha");
+
+    const elseIdx = section.indexOf(
+      'PATCH_DATA="{\\"agentId\\": \\"$SHIPWRIGHT_AGENT_ID\\", \\"reviewedCommitSha\\"',
+    );
+    expect(elseIdx).toBeGreaterThan(-1);
+  });
+
   it("the initial /prs/claim call's commitSha argument is unchanged (claim-lock field, not reviewedCommitSha)", () => {
     const step4Idx = content.indexOf("## Step 4: Checkout into Worktree");
     const step5Idx = content.indexOf("## Step 5: Gather Context");

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -964,15 +964,15 @@ curl -sf -X POST \
   "${SHIPWRIGHT_TASK_STORE_URL}/prs/${PR_RECORD_ID}/complete" >/dev/null 2>&1
 ```
 
-### 3. Set agentId (and reviewState for APPROVE)
+### 3. Set agentId, reviewedCommitSha (and reviewState for APPROVE)
 
-Set `agentId` from `$SHIPWRIGHT_AGENT_ID`. For APPROVE verdicts, also set `reviewState=approved`; for COMMENT/CHANGES_REQUESTED, set agentId only:
+Set `agentId` from `$SHIPWRIGHT_AGENT_ID` and `reviewedCommitSha` from `{headRefOid}` (same shell variable used elsewhere in Step 11, e.g. lines 926, 935 — no re-fetch). For APPROVE verdicts, also set `reviewState=approved`; for COMMENT/CHANGES_REQUESTED, set agentId and reviewedCommitSha only:
 
 ```bash
 if [ "{verdict}" = "APPROVE" ]; then
-  PATCH_DATA="{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewState\": \"approved\"}"
+  PATCH_DATA="{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewState\": \"approved\", \"reviewedCommitSha\": \"{headRefOid}\"}"
 else
-  PATCH_DATA="{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\"}"
+  PATCH_DATA="{\"agentId\": \"$SHIPWRIGHT_AGENT_ID\", \"reviewedCommitSha\": \"{headRefOid}\"}"
 fi
 curl -sf -X PATCH \
   -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \


### PR DESCRIPTION
## Summary
- Step 11b's post-completion PATCH ("Mark PullRequest Record Posted") only set `agentId` (+`reviewState` for APPROVE), so on this repo's `auto_post_reviews: true` policy every posted review left `reviewedCommitSha` permanently null on the task-store `PullRequest` record.
- `reviewedCommitSha` is what `check-review.ts`'s dedup logic (RCS-1.2/RCS-1.3) and `review.md`'s own Step 14.3 defense-in-depth check compare against live `headRefOid` to skip redundant re-review — with it always null on the auto-post path, that check was a permanent no-op.
- Added `"reviewedCommitSha": "{headRefOid}"` to both branches of Step 11b's `PATCH_DATA`, reusing the same `{headRefOid}` shell variable already in scope (no re-fetch, matches the existing pattern at lines 926/935).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 11b's PATCH_DATA (APPROVE and else branches) includes `"reviewedCommitSha": "{headRefOid}"` | MET |
| 2 | New content test in `review.content.test.ts` asserting both verdict branches set `reviewedCommitSha` | MET |
| 3 | `headRefOid` referenced consistently with its existing usage pattern (lines 926, 935) — same shell variable, no re-fetch | MET |

## Test Plan
- `bun test plugins/shipwright/commands/review.content.test.ts` — 110 pass, 0 fail
- `bun test plugins/shipwright/commands/` — 637 pass, 0 fail
- `bunx biome lint` on changed files — clean
- `task ci` — only failure is `agent/src/claude.unit.test.ts` (`extraAllowedTools` test), confirmed pre-existing on `main`, unrelated to this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
