### PR TITLE
fix: compare reviewedCommitSha instead of commitSha in review-staged's stale-check gate

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -46,9 +46,8 @@ written by `/shipwright:review` and consumed by `/shipwright:review-staged`. The
 dedup state — the task store record owns that.
 
 Applies to: **review** (dedup by `reviewedCommitSha`), **review-staged** (stale check via
-`commitSha` vs current `headRefOid` — pending a follow-up to migrate to `reviewedCommitSha`),
-**deploy** (falls back to `gh pr view --json reviewDecision` when no task store APPROVE
-record exists)
+`reviewedCommitSha` vs current `headRefOid`), **deploy** (falls back to
+`gh pr view --json reviewDecision` when no task store APPROVE record exists)
 
 ### 3. A PR Created Outside Shipwright Is Fully Serviceable
 

--- a/plugins/shipwright/skills/review-staged/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/review-staged/SKILL.content.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+
+let content: string;
+
+beforeAll(() => {
+  if (existsSync(SKILL_MD_PATH)) {
+    content = readFileSync(SKILL_MD_PATH, "utf-8");
+  } else {
+    content = "";
+  }
+});
+
+describe("SKILL.md — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(content.length).toBeGreaterThan(200);
+  });
+});
+
+describe("SKILL.md — Step 3b stale-check references record.reviewedCommitSha, not record.commitSha", () => {
+  it("references record.reviewedCommitSha in the Stale staged review gate", () => {
+    const step3bIdx = content.indexOf("### 3b. Apply skip gates");
+    const endIdx = content.indexOf("### 3c.", step3bIdx);
+    expect(step3bIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(step3bIdx);
+    const section = content.slice(step3bIdx, endIdx);
+
+    expect(section).toContain("record.reviewedCommitSha");
+    expect(section).not.toContain("record.commitSha");
+  });
+});

--- a/plugins/shipwright/skills/review-staged/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/review-staged/SKILL.content.test.ts
@@ -35,4 +35,8 @@ describe("SKILL.md — Step 3b stale-check references record.reviewedCommitSha, 
     expect(section).toContain("record.reviewedCommitSha");
     expect(section).not.toContain("record.commitSha");
   });
+
+  it("has no remaining record.commitSha references anywhere in the file", () => {
+    expect(content).not.toContain("record.commitSha");
+  });
 });

--- a/plugins/shipwright/skills/review-staged/SKILL.md
+++ b/plugins/shipwright/skills/review-staged/SKILL.md
@@ -89,7 +89,7 @@ gh pr view {prNumber} --repo {org}/{repo} \
   `Skipping #{pr} — @{login} requested changes on {date} and there are no commits since.`
   (Use the same teammate-comment logic from `/shipwright:review` Step 3: not a bot,
   not `CURRENT_USER`, no commits pushed after the review.)
-- **Stale staged review** — if `record.commitSha` differs from the current `headRefOid`,
+- **Stale staged review** — if `record.reviewedCommitSha` differs from the current `headRefOid`,
   skip with: `Skipping #{pr} — new commits since review was staged. Re-run /shipwright:review {org}/{repo}#{pr}.`
 
 When a PR is skipped for any reason, leave its task store record untouched

--- a/plugins/shipwright/skills/review-staged/SKILL.md
+++ b/plugins/shipwright/skills/review-staged/SKILL.md
@@ -254,7 +254,7 @@ Done. {posted}/{N} posted, {skipped}/{N} skipped.
 - This skill never auto-posts. Every post requires an explicit "post it" from the owner.
 - This skill never merges. Merging is handled exclusively by `/shipwright:deploy`.
 - This skill never re-reviews. If the head SHA has moved (current `headRefOid` differs from
-  `record.commitSha`), it skips and points to `/shipwright:review {org}/{repo}#{pr}`.
+  `record.reviewedCommitSha`), it skips and points to `/shipwright:review {org}/{repo}#{pr}`.
 - Use `gh` CLI for all GitHub interactions. Respect the active `GH_TOKEN` / `gh auth` context.
 - The task store is the source of truth for staged state. No `state/reviews.json` reads or
   writes occur in this skill.


### PR DESCRIPTION
## Summary
- Fixed `review-staged.md` Step 3b's "Stale staged review" skip gate to compare `record.reviewedCommitSha` instead of `record.commitSha` against the current `headRefOid`. `commitSha` is the claim-lock field, overwritten by any later claim/patch/deploy action on the same PR, and is unsafe for review-dedup purposes.
- Fixed a second stale reference to `record.commitSha` in the skill's Notes section describing the same staleness-check behavior.
- Updated `plugins/shipwright/CLAUDE.md`'s Design Constitution to drop the now-resolved "pending follow-up" note for `review-staged`.
- Added `skills/review-staged/SKILL.content.test.ts` (none existed for this skill) asserting the stale-check gate references `record.reviewedCommitSha` and not `record.commitSha`, mirroring the pattern in `plugins/shipwright/commands/review.content.test.ts`.

This mirrors the identical fix already applied to `review.md` Step 14.2 under RCS-1.3.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 3b's stale-check compares record.reviewedCommitSha, not record.commitSha, against headRefOid | MET | SKILL.md:92 and Notes section both updated; zero `record.commitSha` occurrences remain |
| 2 | New content test file asserting the stale-check block references reviewedCommitSha, not commitSha | MET | `SKILL.content.test.ts` created with scoped + whole-file assertions |
| 3 | Content-only change, content test is the correct/only test layer | MET | Only markdown + `.content.test.ts` changed |

## Test Plan
- `bun test plugins/shipwright/skills/review-staged/SKILL.content.test.ts` — 4 pass
- [x] Pre-commit checks passing
- Note: `task ci` surfaces one pre-existing failure in `task-store/src/routes/prs.openapi.smoke.test.ts` (`validateRepo`/`repos.includes` TypeError) — confirmed present on `main` as well, unrelated to this change.

Generated with [Claude Code](https://claude.com/claude-code)
