### PR TITLE
chore(chart): bump chart version to 1.11.33

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.33] - 2026-08-12
+
+### Changed
+
+- auto-bump to chart v1.11.33 triggered by release tag(s): `agent-v1.147.1`
+
 ## [1.11.31] - 2026-08-12
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.32
+version: 1.11.33
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,12 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "ingress: metrics /dashboard and admin / paths switch to no-op-rewrite capture-group paths when task-store's shared rewrite-target is active, preventing 404s on Apple Silicon/minikube deployments (task minikube:up reliability)"
-    - kind: fixed
-      description: "metrics liveness/readiness probes and the helm test now honor metrics.provider.basePath instead of assuming a bare /health or /dashboard path"
     - kind: changed
-      description: "examples/values-minikube.yaml — added explicit CPU/memory resource requests/limits for metrics, taskStore, and chat"
+      description: "auto-bump to chart v1.11.33 triggered by release tag agent-v1.147.1"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -301,7 +301,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.147.0
+    tag: agent-v1.147.1
     pullPolicy: ""
   service:
     port: 3000
@@ -324,7 +324,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.147.0
+      tag: agent-v1.147.1
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.11.32 → 1.11.33

**Triggering tags:**
- `agent-v1.147.1`

**New chart version:** `1.11.33`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v1.147.1`
- `agent.provisioning.image.tag`: `agent-v1.147.1`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.11.33 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._