### PR TITLE
fix: write back terminal reviewState from Live-Review Pre-Check (RVD-2.2)

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -584,6 +584,81 @@ describe("review.md — RVD-1.2 terminal-review skip emits [silent] + skip-reaso
   });
 });
 
+describe("review.md — RVD-1.2 terminal-review skip writes back task-store reviewState (RVD-2.2)", () => {
+  it("the terminal-review branch contains a PATCH call to /prs/{PR_RECORD_ID} with reviewState:posted", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    expect(preCheckIdx).toBeGreaterThan(-1);
+    expect(fastPathIdx).toBeGreaterThan(preCheckIdx);
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("PATCH");
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs/");
+    expect(section).toContain("PR_RECORD_ID");
+    expect(section).toContain("reviewState");
+    expect(section).toContain("posted");
+  });
+
+  it("the PATCH body sets reviewedCommitSha to headRefOid", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    const patchIdx = section.indexOf("PATCH");
+    expect(patchIdx).toBeGreaterThan(-1);
+    const patchBlock = section.slice(patchIdx, patchIdx + 700);
+
+    expect(patchBlock).toContain("reviewedCommitSha");
+    expect(patchBlock).toContain("headRefOid");
+  });
+
+  it("determines PR_RECORD_ID by reusing PRECLAIM_RECORD_ID when present, else looking it up by repo+prNumber", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("PRECLAIM_RECORD_ID");
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs?repo=");
+    expect(section).toContain("prNumber=");
+  });
+
+  it("documents not double-writing when the record already reflects the terminal state at this head commit", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    const lower = section.toLowerCase();
+    expect(lower).toContain("already");
+    expect(lower).toMatch(/double-write|double write/);
+  });
+
+  it("the write-back logic appears before the 'Skipping' print and the [silent] stop", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    const patchIdx = section.indexOf("PATCH");
+    const skippingIdx = section.indexOf("Skipping #{pr}");
+    const silentIdx = section.lastIndexOf("[silent]");
+
+    expect(patchIdx).toBeGreaterThan(-1);
+    expect(skippingIdx).toBeGreaterThan(-1);
+    expect(silentIdx).toBeGreaterThan(-1);
+    expect(patchIdx).toBeLessThan(skippingIdx);
+    expect(patchIdx).toBeLessThan(silentIdx);
+  });
+
+  it("explains the write-back is safe against pr-state-reconciler.ts's CHU-2.4 posted-scan reverting it, citing hasAnyReviewAtHead", () => {
+    const preCheckIdx = content.indexOf("### Live-Review Pre-Check (RVD-1.2)");
+    const fastPathIdx = content.indexOf("### Pre-Claim Fast Path (CBD-1.4)");
+    const section = content.slice(preCheckIdx, fastPathIdx);
+
+    expect(section).toContain("pr-state-reconciler.ts");
+    expect(section).toContain("hasAnyReviewAtHead");
+    expect(section).toContain("reconcilePostedReviewStateRecord");
+  });
+});
+
 describe("review.md — Step 14.3 already-reviewed-at-commit skip emits [silent] + skip-reason marker (STD-1.5)", () => {
   it("the already-reviewed-at-commit skip block contains the skip-reason marker before [silent], exempting it from the HITL auto-block skip counter", () => {
     const step14Idx = content.indexOf("## Step 14: Resolve and Claim the Target PR");

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -1081,6 +1081,63 @@ if [ -n "$PRECLAIM_RECORD_ID" ]; then
 fi
 ```
 
+Before printing the skip message, write this terminal outcome back to the task-store PR
+record so the same mis-selection doesn't recur every tick — this is the fix for the
+cross-task-store race this whole pre-check exists to catch: if the record's `reviewState`
+doesn't already reflect "reviewed at this head", the next tick's candidate selection
+(`check-review.ts`) or another pre-check run sees a stale `pending` (or a `posted` record
+pinned to an older commit) and re-selects this PR again, indefinitely.
+
+Determine `PR_RECORD_ID`: reuse `PRECLAIM_RECORD_ID` directly if it was set (it already
+names the correct record — no extra fetch needed). Otherwise look the record up by
+repo+prNumber, the same lookup Step 14's Pre-Claim Fast Path uses below:
+```bash
+if [ -n "$PRECLAIM_RECORD_ID" ]; then
+  PR_RECORD_ID="$PRECLAIM_RECORD_ID"
+  record=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}")
+else
+  record=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" | jq -c '.prs[0] // empty')
+  PR_RECORD_ID=$(echo "$record" | jq -r '.id // empty')
+fi
+recordReviewState=$(echo "$record" | jq -r '.reviewState // empty')
+recordReviewedCommitSha=$(echo "$record" | jq -r '.reviewedCommitSha // empty')
+```
+
+Only PATCH when the record doesn't already reflect this outcome — avoid a double-write when
+it's already correct. The record is already correct when `reviewState` is `posted` or
+`approved` AND `reviewedCommitSha` already equals `headRefOid`; a `posted`/`approved` record
+still pinned to an older commit (`reviewedCommitSha != headRefOid`) is stale and needs the
+write:
+```bash
+if [ -n "$PR_RECORD_ID" ] && ! { [ "$recordReviewState" = "posted" -o "$recordReviewState" = "approved" ] && [ "$recordReviewedCommitSha" = "$headRefOid" ]; }; then
+  curl -sf -X PATCH \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}" \
+    -d '{"reviewState": "posted", "reviewedCommitSha": "'"$headRefOid"'"}' >/dev/null
+fi
+```
+Note this PATCH sets `reviewedCommitSha` only, not `commitSha` — `commitSha` is the separate
+claim-lock field (overwritten on every claim, per Rule 2 in this plugin's design
+constitution) and this code path takes no claim, so there's nothing to lock; only the
+review-dedup field (`reviewedCommitSha`) is meaningful here.
+
+**Caveat (why this is safe against the CHU-2.4 reconciler):** `agent/src/pr-state-reconciler.ts`'s
+background `reconcileReviewState()` runs a posted-scan sub-pass via
+`reconcilePostedReviewStateRecord()`, which reverts a `posted` record back to `pending` only
+when `hasAnyReviewAtHead()` returns `false` for that record's live GitHub data — i.e. only
+when NO review object exists at the current head commit at all. This write-back only ever
+runs when `$terminal == true`, which by construction means a real, terminal-labeled review
+object was found at `headRefOid` by the GraphQL query above — so `hasAnyReviewAtHead()` is
+guaranteed `true` for this record on the very next reconcile pass, and
+`reconcilePostedReviewStateRecord()` takes its `"no-op"` branch, leaving the record
+untouched. Unlike the Step 5 "unresolved human feedback" write-back above (whose caveat
+applies when the trigger is a plain issue-level PR comment with no accompanying formal
+review object), there is no equivalent gap here: a formal review object is exactly what
+`$terminal == true` asserts exists.
+
 Then print:
 ```
 Skipping #{pr} — a review already exists at this commit (${headRefOid:0:7}) on GitHub (cross-task-store check), nothing to do.


### PR DESCRIPTION
## Summary
- `review.md`'s Live-Review Pre-Check (RVD-1.2) now writes back a terminal `reviewState` to the task-store PR record when it detects a terminal review already exists at head on GitHub, instead of only releasing the pre-claim and stopping silently.
- Determines `PR_RECORD_ID` by reusing `PRECLAIM_RECORD_ID` (if a pre-claim marker was present) or looking the record up by `repo`+`prNumber`, then PATCHes `{"reviewState": "posted", "reviewedCommitSha": "{headRefOid}"}` — but only when the record doesn't already reflect this outcome at the current head, avoiding a double-write.
- Fixes the recurring mis-selection this task-store instance would otherwise see every tick: without this write-back, a stale `pending` (or `posted`-at-an-older-commit) record keeps this PR re-selectable indefinitely, even after RVD-2.1 lands (RVD-2.1 only fixes `check-review.ts`'s selection path — this is `review.md`'s own separate GraphQL-based detection with no corresponding selection-side fix).

## Reconciler safety (acceptance criterion 3)
This write-back cannot be undone by `pr-state-reconciler.ts`'s CHU-2.4 `reconcileReviewState()` sub-pass. That pass's `reconcilePostedReviewStateRecord()` reverts a `posted` record back to `pending` only when `hasAnyReviewAtHead()` returns `false` (`agent/src/pr-state-reconciler.ts:1002`: `if (hasAnyReviewAtHead(reviewData)) return "no-op";`). This write-back only ever runs when `$terminal == true`, which by construction means a real, terminal-labeled review object was found at `headRefOid` by the GraphQL query — so `hasAnyReviewAtHead()` is guaranteed `true` for this record on the next reconcile pass, and the reconciler takes its no-op branch, leaving the record untouched.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | PATCHes task-store PR record to reviewState:posted + reviewedCommitSha before stopping, no double-write when already correct | MET | New PATCH block in review.md's `$terminal==true` branch, guarded by a condition checking `recordReviewState` ∈ {posted,approved} AND `recordReviewedCommitSha == headRefOid` before skipping the write |
| 2 | Content test added to review.content.test.ts asserting PATCH + reviewState/reviewedCommitSha | MET | New `describe` block with 6 `it` cases asserting PATCH call, reviewedCommitSha/headRefOid, PR_RECORD_ID resolution, double-write avoidance, ordering, and reconciler-safety citations |
| 3 | Explicit verification that reconciler cannot undo this, citing hasAnyReviewAtHead() | MET | New "Caveat" paragraph citing `agent/src/pr-state-reconciler.ts`'s `reconcileReviewState()` → `reconcilePostedReviewStateRecord()` and its `hasAnyReviewAtHead()` guard, verified against actual source |
| 4 | Safe to deploy standalone, no dependency on RVD-2.1/RVD-2.3 | MET | Change is confined to review.md prose + its content test; no coupling to check-review.ts or other RVD tasks |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/review.content.test.ts` — 116/116 pass (6 new test cases)
- `task lint` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- Full `task ci` / `test:coverage`: 3 pre-existing failures in unrelated files (`task-store/src/routes/prs.openapi.smoke.test.ts`, `metrics/src/lib/errors.unit.test.ts`, `agent/src/claude.unit.test.ts`) — confirmed unrelated since this diff only touches `review.md` and `review.content.test.ts`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
