### PR TITLE
feat: add mcp-server Helm chart artifacts (disabled by default)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.39] - 2026-08-13
+
+### Added
+
+- `mcpServer.*` renders the mcp-server Deployment/Service/ServiceAccount (TSM-3.2), mirroring task-store. Disabled by default (`mcpServer.enabled=false`) — safe to merge, changes nothing in any live cluster. Both `SHIPWRIGHT_MCP_SERVER_TOKEN` and `SHIPWRIGHT_TASK_STORE_TOKEN` are always sourced via `secretKeyRef` from `mcpServer.auth.existingSecret`, never plaintext env
+
 ## [1.11.38] - 2026-08-13
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.38
+version: 1.11.39
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,16 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.11.38 triggered by release tag admin-v1.74.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.38 triggered by release tag agent-v1.150.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.38 triggered by release tag chat-v1.34.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.38 triggered by release tag metrics-v1.37.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.38 triggered by release tag task-store-v1.55.0"
+    - kind: added
+      description: "mcpServer.* renders the mcp-server Deployment/Service/ServiceAccount (TSM-3.2), mirroring task-store. Disabled by default (mcpServer.enabled=false) — safe to merge, changes nothing in any live cluster. Both SHIPWRIGHT_MCP_SERVER_TOKEN and SHIPWRIGHT_TASK_STORE_TOKEN are always sourced via secretKeyRef from mcpServer.auth.existingSecret, never plaintext env"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -414,6 +414,40 @@ opting in is an explicit `existingSecret: ""`.
 {{- end }}
 
 {{/*
+MCP server component fullname: "<fullname>-mcp-server".
+*/}}
+{{- define "shipwright.mcpServer.fullname" -}}
+{{- printf "%s-mcp-server" (include "shipwright.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+MCP server selector labels — fullname selector labels plus the component label.
+*/}}
+{{- define "shipwright.mcpServer.selectorLabels" -}}
+{{ include "shipwright.selectorLabels" . }}
+app.kubernetes.io/component: mcp-server
+{{- end }}
+
+{{/*
+MCP server labels — common labels plus the component label.
+*/}}
+{{- define "shipwright.mcpServer.labels" -}}
+{{ include "shipwright.labels" . }}
+app.kubernetes.io/component: mcp-server
+{{- end }}
+
+{{/*
+MCP server ServiceAccount name.
+*/}}
+{{- define "shipwright.mcpServer.serviceAccountName" -}}
+{{- if .Values.mcpServer.serviceAccount.create }}
+{{- default (include "shipwright.mcpServer.fullname" .) .Values.mcpServer.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.mcpServer.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Chat component fullname: "<fullname>-chat".
 */}}
 {{- define "shipwright.chat.fullname" -}}

--- a/charts/shipwright/templates/mcp-server-deployment.yaml
+++ b/charts/shipwright/templates/mcp-server-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.mcpServer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "shipwright.mcpServer.fullname" . }}
+  labels:
+    {{- include "shipwright.mcpServer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mcpServer.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "shipwright.mcpServer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "shipwright.mcpServer.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "shipwright.mcpServer.serviceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: mcp-server
+          image: {{ include "shipwright.imageRef" (dict "context" $ "repository" .Values.mcpServer.image.repository "tag" (.Values.mcpServer.image.tag | default .Chart.AppVersion)) | quote }}
+          imagePullPolicy: {{ .Values.mcpServer.image.pullPolicy | default .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3010
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3010
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3010
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          env:
+            # Bind the mcp-server to the chart-standard port 3010 (matches the
+            # app's own DEFAULT_PORT — see mcp-server/src/main.ts).
+            - name: PORT
+              value: "3010"
+            # Inbound auth (TSM-2.6): main.ts throws at startup if this is
+            # unset, so it is always sourced here — never plaintext env — from
+            # mcpServer.auth.existingSecret (bring-your-own, always).
+            - name: SHIPWRIGHT_MCP_SERVER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mcpServer.auth.existingSecret }}
+                  key: {{ .Values.mcpServer.auth.mcpServerTokenKey | default "SHIPWRIGHT_MCP_SERVER_TOKEN" }}
+            # Outbound: the task-store this instance proxies to. Required —
+            # main.ts has no fallback. Not auto-derived from taskStore.* since
+            # mcp-server may point at a task-store outside this chart.
+            - name: SHIPWRIGHT_TASK_STORE_URL
+              value: {{ required "mcpServer.taskStoreUrl is required when mcpServer.enabled=true" .Values.mcpServer.taskStoreUrl | quote }}
+            # Outbound auth token, sourced the same way as the inbound token
+            # above — never plaintext env.
+            - name: SHIPWRIGHT_TASK_STORE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mcpServer.auth.existingSecret }}
+                  key: {{ .Values.mcpServer.auth.taskStoreTokenKey | default "SHIPWRIGHT_TASK_STORE_TOKEN" }}
+            {{- with .Values.mcpServer.extraEnv }}
+            # mcpServer.extraEnv: caller-supplied env vars appended last so they
+            # can override anything above if needed.
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.mcpServer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/shipwright/templates/mcp-server-service.yaml
+++ b/charts/shipwright/templates/mcp-server-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mcpServer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "shipwright.mcpServer.fullname" . }}
+  labels:
+    {{- include "shipwright.mcpServer.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mcpServer.service.type | default "ClusterIP" }}
+  ports:
+    - name: http
+      port: {{ .Values.mcpServer.service.port }}
+      targetPort: 3010
+      protocol: TCP
+  selector:
+    {{- include "shipwright.mcpServer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/shipwright/templates/mcp-server-serviceaccount.yaml
+++ b/charts/shipwright/templates/mcp-server-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.mcpServer.enabled .Values.mcpServer.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "shipwright.mcpServer.serviceAccountName" . }}
+  labels:
+    {{- include "shipwright.mcpServer.labels" . | nindent 4 }}
+  {{- with .Values.mcpServer.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/shipwright/tests/mcp_server_workload_test.yaml
+++ b/charts/shipwright/tests/mcp_server_workload_test.yaml
@@ -1,0 +1,351 @@
+suite: mcp-server Deployment / Service / ServiceAccount workloads
+# TSM-3.2 adds the mcp-server workload templates. These assert the structural
+# facts: image (pinned to the GHCR default), container port 3010, /health
+# liveness + readiness probes, Service shape, and that BOTH inbound
+# (SHIPWRIGHT_MCP_SERVER_TOKEN) and outbound (SHIPWRIGHT_TASK_STORE_TOKEN)
+# tokens are sourced via secretKeyRef — NEVER plaintext env — from the
+# existingSecret (shipwright-secrets by default). mcp-server has no database,
+# so there is no bundled-PostgreSQL path to test here (unlike task-store).
+tests:
+  - it: renders the mcp-server Deployment with the GHCR-pinned image and port 3010
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/app-vitals/shipwright-mcp-server:mcp-server-v\\d+\\.\\d+\\.\\d+$"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 3010
+
+  - it: uses the default mcp-server image repository (ghcr.io/app-vitals/shipwright-mcp-server)
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/app-vitals/shipwright-mcp-server:mcp-server-v0.35.0
+
+  - it: sets liveness and readiness probes against /health on port 3010
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 3010
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 3010
+
+  - it: wires standard selector labels onto the Deployment
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: mcp-server
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: shipwright
+    release:
+      name: r
+
+  - it: applies the configured mcp-server resources
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.resources:
+        requests:
+          cpu: 111m
+          memory: 222Mi
+        limits:
+          cpu: 333m
+          memory: 444Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 111m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 444Mi
+
+  - it: sets PORT to 3010
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORT
+            value: "3010"
+
+  - it: passes SHIPWRIGHT_TASK_STORE_URL as a plain value
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_URL
+            value: http://shipwright-task-store:3000
+
+  # ── inbound auth: SHIPWRIGHT_MCP_SERVER_TOKEN ────────────────────────────
+
+  - it: wires SHIPWRIGHT_MCP_SERVER_TOKEN from the default existingSecret (shipwright-secrets)
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_MCP_SERVER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: SHIPWRIGHT_MCP_SERVER_TOKEN
+
+  - it: wires SHIPWRIGHT_MCP_SERVER_TOKEN from a custom existingSecret
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.auth.existingSecret: my-mcp-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_MCP_SERVER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-mcp-secret
+                key: SHIPWRIGHT_MCP_SERVER_TOKEN
+
+  - it: never sources SHIPWRIGHT_MCP_SERVER_TOKEN as a plaintext value
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_MCP_SERVER_TOKEN
+            value: shipwright-secrets
+
+  # ── outbound auth: SHIPWRIGHT_TASK_STORE_TOKEN ───────────────────────────
+
+  - it: wires SHIPWRIGHT_TASK_STORE_TOKEN from the default existingSecret (shipwright-secrets)
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: SHIPWRIGHT_TASK_STORE_TOKEN
+
+  - it: wires SHIPWRIGHT_TASK_STORE_TOKEN from a custom existingSecret
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.auth.existingSecret: my-mcp-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-mcp-secret
+                key: SHIPWRIGHT_TASK_STORE_TOKEN
+
+  - it: never sources SHIPWRIGHT_TASK_STORE_TOKEN as a plaintext value
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_TOKEN
+            value: shipwright-secrets
+
+  - it: honors custom key names for both tokens
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.auth.mcpServerTokenKey: CUSTOM_MCP_TOKEN_KEY
+      mcpServer.auth.taskStoreTokenKey: CUSTOM_TASK_STORE_TOKEN_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_MCP_SERVER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: CUSTOM_MCP_TOKEN_KEY
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_TASK_STORE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: shipwright-secrets
+                key: CUSTOM_TASK_STORE_TOKEN_KEY
+
+  # ── Service ───────────────────────────────────────────────────────────────
+
+  - it: renders the mcp-server Service (ClusterIP) mapping the service port to targetPort 3010
+    template: templates/mcp-server-service.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 3010
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3010
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: mcp-server
+
+  - it: honors a custom mcpServer.service.type and port
+    template: templates/mcp-server-service.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.service.type: NodePort
+      mcpServer.service.port: 30010
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 30010
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3010
+
+  # ── ServiceAccount ───────────────────────────────────────────────────────
+
+  - it: renders a ServiceAccount for the mcp-server workload by default
+    template: templates/mcp-server-serviceaccount.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+    release:
+      name: r
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: r-shipwright-mcp-server
+
+  - it: renders NO ServiceAccount when mcpServer.serviceAccount.create=false
+    template: templates/mcp-server-serviceaccount.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── mcpServer.extraEnv ────────────────────────────────────────────────────
+
+  - it: appends mcpServer.extraEnv entries to the container env
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.extraEnv:
+        - name: CUSTOM_VAR
+          value: "test-value"
+        - name: FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: MY_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_VAR
+            value: "test-value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FROM_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: MY_KEY
+
+  - it: keeps extraEnv rendering LAST so caller overrides still win
+    # Kubernetes resolves duplicate env names to the LAST occurrence.
+    template: templates/mcp-server-deployment.yaml
+    set:
+      mcpServer.enabled: true
+      mcpServer.taskStoreUrl: http://shipwright-task-store:3000
+      mcpServer.extraEnv:
+        - name: SHIPWRIGHT_TASK_STORE_URL
+          value: "http://override-task-store:3000"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].name
+          value: SHIPWRIGHT_TASK_STORE_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].value
+          value: "http://override-task-store:3000"
+
+  # ── disabled by default ──────────────────────────────────────────────────
+
+  - it: renders NO mcp-server workloads when mcpServer.enabled=false (the default)
+    templates:
+      - templates/mcp-server-deployment.yaml
+      - templates/mcp-server-service.yaml
+      - templates/mcp-server-serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -372,6 +372,36 @@
         }
       ]
     },
+    "mcpServer": {
+      "allOf": [
+        { "$ref": "#/definitions/service" },
+        {
+          "type": "object",
+          "properties": {
+            "taskStoreUrl": { "type": "string" },
+            "auth": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "existingSecret": { "type": "string" },
+                "mcpServerTokenKey": { "type": "string" },
+                "taskStoreTokenKey": { "type": "string" }
+              }
+            },
+            "extraEnv": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
     "auth": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -645,6 +645,70 @@ taskStore:
     # -- Name of the task-store ServiceAccount. Generated if empty and create=true.
     name: ""
 
+# -- MCP server (@shipwright/mcp-server) — Model Context Protocol HTTP service that
+# proxies the task-store to remote MCP clients (e.g. Claude Desktop custom
+# connectors). Port 3010. Disabled by default — purely additive, safe to deploy
+# without this. mcp-server has no database of its own; it always proxies an
+# EXISTING task-store (in-cluster or external), so — unlike taskStore/chat —
+# there is no bundled-PostgreSQL path here.
+#
+# SAFETY: mcp-server proxies a privileged SHIPWRIGHT_TASK_STORE_TOKEN. Enabling
+# this component only renders a ClusterIP Service — it does NOT expose anything
+# externally. Deliberately exposing it (e.g. via networking.type=ingress/gateway)
+# is a separate, human decision outside this chart.
+mcpServer:
+  # -- Whether to render the mcp-server Deployment and Service.
+  enabled: false
+  image:
+    repository: ghcr.io/app-vitals/shipwright-mcp-server
+    tag: mcp-server-v0.35.0
+    pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
+  service:
+    # -- Service type for the mcp-server service. ClusterIP is Minikube-friendly.
+    type: ClusterIP
+    port: 3010
+  replicas: 1
+  # -- Compute resources for the mcp-server container. Minikube-friendly defaults.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  # -- Externally-reachable task-store base URL mcp-server proxies to (sets
+  # SHIPWRIGHT_TASK_STORE_URL). Required — main.ts has no fallback. Can point at
+  # this chart's own task-store component (e.g.
+  # http://<release>-task-store:3000) or at a task-store outside this chart;
+  # the chart does not auto-derive it from taskStore.* so either is supported.
+  taskStoreUrl: ""
+  # -- Auth wiring: both the inbound bearer token mcp-server itself requires
+  # (SHIPWRIGHT_MCP_SERVER_TOKEN — main.ts refuses to start without it) and the
+  # outbound task-store bearer token (SHIPWRIGHT_TASK_STORE_TOKEN) are ALWAYS
+  # bring-your-own-Secret; the chart never generates or stores these tokens
+  # itself. Both are sourced via secretKeyRef, never plaintext env.
+  auth:
+    # -- Name of a pre-existing Secret holding SHIPWRIGHT_MCP_SERVER_TOKEN and
+    # SHIPWRIGHT_TASK_STORE_TOKEN. Defaults to the same "shipwright-secrets"
+    # bring-your-own Secret used by the other components.
+    existingSecret: "shipwright-secrets"
+    # -- Key in existingSecret that holds SHIPWRIGHT_MCP_SERVER_TOKEN.
+    mcpServerTokenKey: SHIPWRIGHT_MCP_SERVER_TOKEN
+    # -- Key in existingSecret that holds SHIPWRIGHT_TASK_STORE_TOKEN.
+    taskStoreTokenKey: SHIPWRIGHT_TASK_STORE_TOKEN
+  # -- Extra env vars to inject into the mcp-server container. Appended LAST so
+  # caller overrides win.
+  extraEnv: []
+  # -- ServiceAccount for the mcp-server pod. Set create: false and name: <sa>
+  # to reuse an existing SA (e.g. the umbrella chart's Workload Identity SA).
+  serviceAccount:
+    # -- Whether a ServiceAccount is created for the mcp-server workload.
+    create: true
+    # -- Annotations for the mcp-server ServiceAccount. Generated if empty and create=true.
+    annotations: {}
+    # -- Name of the mcp-server ServiceAccount. Generated if empty and create=true.
+    name: ""
+
 # -- Chat service (@shipwright/chat) — Thread/Message store + scoped tokens. Port 3000.
 # Disabled by default — purely additive, safe to deploy without this.
 chat:

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -1,17 +1,17 @@
 # Deploying to Kubernetes
 
-> How to deploy the five Shipwright services (admin, metrics, agent, task-store, chat) to
-> Kubernetes with the `shipwright` Helm chart — local on Minikube, and in
+> How to deploy the Shipwright services (admin, metrics, agent, task-store, chat, and
+> MCP server) to Kubernetes with the `shipwright` Helm chart — local on Minikube, and in
 > production on GKE (Gateway API + cert-manager) or EKS (ALB + cert-manager).
 
 The chart lives at [`charts/shipwright`](../charts/shipwright) and is also
 published to a Helm repo on every chart version bump (see
 [`helm-repo.md`](./helm-repo.md)). It packages the admin (port **3001**), metrics
-(port **3460**), agent (port **3000**), task-store (port **3000**), and optional chat
-(port **3000**) services plus an optional bundled PostgreSQL dependency,
-with Minikube-friendly defaults throughout. Task-store and chat are disabled by
-default; the agent is provisioned dynamically when `agent.provisioning.enabled=true`
-is set.
+(port **3460**), agent (port **3000**), task-store (port **3000**), optional chat
+(port **3000**), and optional MCP server (port **3010**) services plus an optional bundled
+PostgreSQL dependency, with Minikube-friendly defaults throughout. Task-store, chat, and
+MCP server are disabled by default; the agent is provisioned dynamically when
+`agent.provisioning.enabled=true` is set.
 
 This guide covers three deployment targets end-to-end, then the cross-cutting
 concerns shared by all of them:
@@ -143,13 +143,53 @@ accessed via the agent's internal network, not the public host.
 See [configuration.md](./configuration.md#metrics--admin--chat--task-store-services)
 for the full list of chat service env vars and their defaults.
 
+### MCP server (opt-in)
+
+The optional MCP server (`@shipwright/mcp-server`) exposes the task-store API via the
+[Model Context Protocol](https://modelcontextprotocol.io/), allowing remote MCP clients
+(e.g. Claude Desktop custom connectors) to query and mutate tasks and pull requests. By
+default it is **disabled** (`mcpServer.enabled=false`) — purely additive and safe to deploy
+without. To enable it:
+
+```bash
+--set mcpServer.enabled=true --set mcpServer.taskStoreUrl=http://shipwright-task-store:3000
+```
+
+The MCP server requires:
+
+- **A task-store to proxy to** (either this chart's own task-store component or external).
+  Set via `mcpServer.taskStoreUrl` — the chart does not auto-derive it from `taskStore.*` so
+  both in-cluster and external task-stores are supported.
+- **Auth tokens via a Kubernetes Secret.** Both the inbound bearer token MCP server requires
+  (`SHIPWRIGHT_MCP_SERVER_TOKEN`, secures the tool proxy surface itself) and the outbound
+  task-store bearer token (`SHIPWRIGHT_TASK_STORE_TOKEN`, authenticates the mcp-server to
+  the task-store) are always sourced via `secretKeyRef`, never plaintext env. Add them to
+  a Secret (default: `shipwright-secrets`), then reference via
+  `mcpServer.auth.existingSecret`:
+
+```bash
+kubectl -n shipwright patch secret shipwright-secrets --type merge \
+  -p "{\"stringData\":{\"SHIPWRIGHT_MCP_SERVER_TOKEN\":\"$(openssl rand -hex 32)\",\"SHIPWRIGHT_TASK_STORE_TOKEN\":\"<token>\"}}"
+```
+
+The MCP server runs as a standalone `Deployment` (one pod by default) listening on
+port **3010**. By default the Service is `ClusterIP`-only and has no external route —
+reachable only from within the cluster. **Deliberately exposing it externally
+(e.g. via `networking.type=ingress` or `networking.type=gateway`) is a separate, human
+decision outside this chart.** The chart only renders the internal ClusterIP Service; any
+external path routing is operator-driven.
+
+See [configuration.md](./configuration.md#metrics--admin--chat--task-store-services)
+for the full list of MCP server env vars and their defaults.
+
 ---
 
 ## Minikube (local)
 
 The **full stack** — admin, metrics, task-store, chat, bundled PostgreSQL, and
 runtime agent provisioning — over plain HTTP, with **no hand-created Secrets**.
-The chart assembles every database connection string for you.
+The chart assembles every database connection string for you. The MCP server is disabled
+by default; enable it with `mcpServer.enabled=true` if needed.
 
 ### One command
 

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -50,12 +50,13 @@ once checks pass. Once the PR merges, `chart-release.yml` fires and publishes
 the new chart version. No manual version bump is required.
 
 The `values.yaml` pinning ensures the chart's GHCR image defaults (in the
-`admin`, `metrics`, `agent`, `taskStore`, and `chat` blocks) track the same
+`admin`, `metrics`, `agent`, `taskStore`, `chat`, and `mcpServer` blocks) track the same
 releases the chart version is crediting — preventing a scenario where the
 bumped chart would be deployed with stale image tags. Each batched release
 tag is pinned into its corresponding `values.yaml` path(s); for example,
-`admin-v0.156.2` pins into `admin.image.tag`, and `agent-v1.5.0` pins into
-both `agent.image.tag` and `agent.provisioning.image.tag`.
+`admin-v0.156.2` pins into `admin.image.tag`, `agent-v1.5.0` pins into
+both `agent.image.tag` and `agent.provisioning.image.tag`, and
+`mcp-server-v0.35.0` pins into `mcpServer.image.tag`.
 
 Services release independently, so it's common for two or three tags to land
 within seconds or minutes of each other. Rather than bumping the chart once

--- a/docs/helm-repo.md
+++ b/docs/helm-repo.md
@@ -54,9 +54,16 @@ The `values.yaml` pinning ensures the chart's GHCR image defaults (in the
 releases the chart version is crediting — preventing a scenario where the
 bumped chart would be deployed with stale image tags. Each batched release
 tag is pinned into its corresponding `values.yaml` path(s); for example,
-`admin-v0.156.2` pins into `admin.image.tag`, `agent-v1.5.0` pins into
-both `agent.image.tag` and `agent.provisioning.image.tag`, and
-`mcp-server-v0.35.0` pins into `mcpServer.image.tag`.
+`admin-v0.156.2` pins into `admin.image.tag`, and `agent-v1.5.0` pins into
+both `agent.image.tag` and `agent.provisioning.image.tag`.
+
+The `mcpServer` block follows the same `values.yaml` pinning shape as the
+other components, but `auto-bump-chart.yml`'s tag-push trigger and
+`service_for_tag`/`values_paths_for_service` cases do not yet include an
+`mcp-server-v*` entry — until that fast-follow lands, `mcp-server-v*` release
+tags will not auto-pin `mcpServer.image.tag` the way the other five
+components do. This is not a live-cluster risk today, since `mcpServer` is
+disabled by default (`mcpServer.enabled=false`).
 
 Services release independently, so it's common for two or three tags to land
 within seconds or minutes of each other. Rather than bumping the chart once


### PR DESCRIPTION
## Summary
- Add Helm chart artifacts for the mcp-server component (Deployment/Service/ServiceAccount), mirroring the existing task-store component
- `mcpServer.enabled` defaults to `false` — merging this PR changes nothing in any live cluster
- `SHIPWRIGHT_MCP_SERVER_TOKEN` and `SHIPWRIGHT_TASK_STORE_TOKEN` are always sourced via `secretKeyRef` (bring-your-own-Secret via `mcpServer.auth.existingSecret`), never plaintext env
- No external exposure — only a ClusterIP Service is rendered even when enabled; public exposure stays a separate, deliberate decision (per TSM-3.1)
- Chart.yaml version bumped 1.11.38 → 1.11.39, with matching CHANGELOG.md and `artifacthub.io/changes` entries
- Docs refreshed: `docs/deploy-kubernetes.md` and `docs/helm-repo.md` now document the new optional component

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `helm lint charts/shipwright` passes | MET | `1 chart(s) linted, 0 chart(s) failed` |
| 2 | `helm unittest` incl. new `tests/mcp_server_workload_test.yaml` (disabled→nothing renders; enabled→Deployment+Service+ServiceAccount; containerPort 3010; /health probes; secretKeyRef never plaintext; default image repo) | MET | New suite: 21/21 passed |
| 3 | `helm template --set mcpServer.enabled=true` renders valid manifests | MET | Verified directly |
| 4 | Default values leave mcpServer disabled/unexposed — stock `helm template` emits no mcp-server object | MET | Verified directly (0 matches) |
| 5 | Chart.yaml version incremented for `ct lint --check-version-increment` | MET | 1.11.38 → 1.11.39 |
| 6 | values.schema.json updated, `values_schema_test.yaml` still passes | MET | Schema entry added; the test *file* itself fails identically on clean `main` (helm-unittest/schema-validator version mismatch, unrelated pre-existing issue) |

## Test Plan
- [x] `helm lint charts/shipwright` — passes
- [x] `helm unittest charts/shipwright -f 'tests/mcp_server_workload_test.yaml'` — 21/21 passing
- [x] `helm template shipwright charts/shipwright --set mcpServer.enabled=true --set mcpServer.taskStoreUrl=...` — renders valid manifests
- [x] `helm template shipwright charts/shipwright` (stock values) — zero mcp-server objects
- [x] `task lint`, `task typecheck`, `task check-strings`, `task check-config-docs`, `task check-version-sync` — all pass
- [x] `task test:coverage` — 6086/6087 non-skipped tests pass; the 1 failure (`extraAllowedTools > empty extraAllowedTools produces identical args to no extraAllowedTools` in `agent/src/claude.unit.test.ts`) is a documented pre-existing flake, confirmed to reproduce identically on a clean `main` checkout, unrelated to this diff (zero TS/JS files touched)
- [ ] `ct lint --check-version-increment` — not runnable locally (chart-testing binary/Docker unavailable in this sandbox); CI will verify

Generated with [Claude Code](https://claude.com/claude-code)
