### PR TITLE
chore(chart): bump chart version to 1.11.40

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.40] - 2026-08-13
+
+### Changed
+
+- auto-bump to chart v1.11.40 triggered by release tag(s): `agent-v1.151.0`
+
 ## [1.11.39] - 2026-08-13
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.39
+version: 1.11.40
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "mcpServer.* renders the mcp-server Deployment/Service/ServiceAccount (TSM-3.2), mirroring task-store. Disabled by default (mcpServer.enabled=false) — safe to merge, changes nothing in any live cluster. Both SHIPWRIGHT_MCP_SERVER_TOKEN and SHIPWRIGHT_TASK_STORE_TOKEN are always sourced via secretKeyRef from mcpServer.auth.existingSecret, never plaintext env"
+    - kind: changed
+      description: "auto-bump to chart v1.11.40 triggered by release tag agent-v1.151.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -301,7 +301,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.150.0
+    tag: agent-v1.151.0
     pullPolicy: ""
   service:
     port: 3000
@@ -324,7 +324,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.150.0
+      tag: agent-v1.151.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.11.39 → 1.11.40

**Triggering tags:**
- `agent-v1.151.0`

**New chart version:** `1.11.40`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v1.151.0`
- `agent.provisioning.image.tag`: `agent-v1.151.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.11.40 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._