### PR TITLE
chore(docs): bump docs-freshness sync anchor

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"aca0cf73c086ea50cdcbb785f611e027f757c575","timestamp":"2026-08-13T07:08:54Z"}
+{"sha":"297fb61e89c9438ab815d9e8d62b550f7b8ef79b","timestamp":"2026-08-14T00:00:00Z"}


### PR DESCRIPTION
## Summary
- Docs-freshness cron audit for 2026-08-14: 8 candidate docs (`agent.md`, `architecture.md`, `configuration.md`, `consolidation.md`, `helm-repo.md`, `migration.md`, `observability.md`, `task-store.md`) checked against source changes since the last sync (anchor `aca0cf7`) — all verified current, no broken references found.
- Bumps the sync anchor to HEAD (`297fb61`) so the next cron run diffs from here.

## Test plan
- [x] N/A — anchor-only change, no doc content edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)