### PR TITLE
test: cover hitl bootstrap sequence via planner/executor split (T-080)

### DIFF
--- a/.claude/shipwright/test-readiness-decisions.md
+++ b/.claude/shipwright/test-readiness-decisions.md
@@ -83,3 +83,43 @@ e2e suite doesn't already exercise.
 matching `*.spec.ts` covering it, or if `site/` adopts a `bun:test` unit
 convention (at which point unit coverage becomes consistent with the rest of the
 project and worth adding).
+
+### scripts/hitl.ts bootstrap sequence — planner/executor split, unit layer not integration
+
+**Item:** `test-t-080-shipwright` (T-080) flagged the HITL dev-loop bootstrap's
+full clone→seed→boot→poll sequence in `scripts/hitl.ts` as an ambiguous item
+under rule (d), ambiguous fix approach. The orchestration functions
+(`runPreflight`, `provisionWorkspace`, `startServices`, `runLoop`) called
+`Bun.spawnSync`/`Bun.spawn` directly with no injected exec seam, no existing
+test in the repo faked the boot of long-running services (task-store + admin),
+and the row's scope crossed the task-store/admin/agent package boundaries with
+no shared fixture convention spanning all three. The task prescribed
+`Layer: integration` and a `scripts/hitl.integration.test.ts`.
+**Decision:** Split `scripts/hitl.ts` into pure planners plus a thin injected
+executor, and cover the sequence at the **unit** layer in
+`scripts/hitl.bootstrap.unit.test.ts` — not as an integration test. The
+prescribed integration layer and filename are deliberately not used.
+**Rationale:** The repo already solved this exact shape once, in
+`scripts/dev-tmux.ts`: `buildStackCommands()` is a pure builder returning an
+ordered command list and `runStack(panes, exec)` drives an injected `ExecFn`,
+covered by `scripts/dev-tmux.unit.test.ts` at the unit layer. `hitl.ts` was
+already half-built this way (`computeProvisionPlan`, `computeMissingClones` are
+pure and unit-tested). Extending that pattern — `buildHitlConfig`,
+`buildPreflightSteps`, `buildServiceSpecs`, `runSteps` — covers the sequencing,
+argv, cwd, and cross-wired service env without a new fixture convention. The
+task's own acceptance criteria are self-contradictory on this point: they demand
+the sequence be "proven correct end-to-end" *and* that "no real … long-running
+task-store/admin service processes are spawned." Anything satisfying the second
+clause proves the *plan*, not the boot, so the honest layer is unit. Booting the
+services for real would require Postgres, exceed the integration speed budget,
+and — for a script that ships nowhere (`scripts/hitl.ts` is a local dev
+entrypoint referenced only by `Taskfile.yml`'s `task hitl`; it is absent from
+`agent/Dockerfile` and the Helm chart) — buy no confidence proportional to that
+cost.
+**Revisit:** Revisit if `scripts/hitl.ts` starts shipping in a deployed artifact
+(agent image or Helm chart), if the bootstrap grows a step whose failure mode is
+genuinely I/O-shaped rather than sequencing-shaped (e.g. port-binding or
+migration-ordering bugs observed in practice), or if the repo adopts a shared
+multi-service integration fixture that makes a real boot cheap. Note also that
+T-080's `criticality: high` tag looks miscalibrated for a dev-only script — if
+this row resurfaces, re-tier it before re-planning the work.

--- a/scripts/hitl.bootstrap.unit.test.ts
+++ b/scripts/hitl.bootstrap.unit.test.ts
@@ -1,0 +1,548 @@
+/**
+ * scripts/hitl.bootstrap.unit.test.ts
+ * Unit tests for scripts/hitl.ts's bootstrap planners — the clone→seed→boot→poll
+ * sequence (T-080).
+ *
+ * Mirrors the dev-tmux.unit.test.ts pattern: the orchestration is split into
+ * pure builders (buildPreflightSteps / buildServiceSpecs) plus a thin executor
+ * (runSteps), so we assert the exact ordered step sequence, argv, cwd, and env
+ * through an INJECTED executor — without spawning gh, prisma, or the
+ * long-running task-store/admin services. No mock.module(), no global.*
+ * overrides, no real filesystem access (existence checks are injected).
+ *
+ * Why unit and not integration: the only behavior left below these builders is
+ * I/O-bound (does the OS run this argv, does the service bind its port). That
+ * seam is `execStep`, driven here by a recording fake. Booting the real
+ * services would need Postgres and blow the integration speed budget for zero
+ * added confidence over the sequence assertions. Recorded as a deliberate
+ * layer decision in .claude/shipwright/test-readiness-decisions.md.
+ *
+ * Existing pure-helper coverage lives in scripts/hitl.unit.test.ts and is
+ * untouched — this file adds the orchestration-sequence layer on top.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ADMIN_PORT,
+  type HitlConfig,
+  type HitlStep,
+  TASK_STORE_PORT,
+  buildCloneSteps,
+  buildHitlConfig,
+  buildMigrationSteps,
+  buildPrCommand,
+  buildPreflightSteps,
+  buildProvisionSteps,
+  buildServiceSpecs,
+  buildTokenSeedStep,
+  runSteps,
+} from "./hitl.ts";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = "/repo";
+const HOME = "/home/dev";
+
+/** A config with no env overrides beyond the ones a test cares about. */
+function cfg(env: Record<string, string | undefined> = {}): HitlConfig {
+  return buildHitlConfig(env, HOME, REPO_ROOT);
+}
+
+/** Existence predicate over an explicit set — no filesystem access. */
+function existsIn(paths: string[]): (p: string) => boolean {
+  const set = new Set(paths);
+  return (p) => set.has(p);
+}
+
+const nothingExists = () => false;
+const everythingExists = () => true;
+
+/** Records steps instead of performing them. */
+function recorder() {
+  const seen: HitlStep[] = [];
+  return { seen, exec: (step: HitlStep) => void seen.push(step) };
+}
+
+// ---------------------------------------------------------------------------
+// buildHitlConfig — the env→config mapping
+// ---------------------------------------------------------------------------
+
+describe("buildHitlConfig", () => {
+  test("defaults hitlHome under the home dir and derives the workspace tree", () => {
+    const c = cfg();
+    expect(c.hitlHome).toBe("/home/dev/.shipwright");
+    expect(c.workspace).toBe("/home/dev/.shipwright/workspace");
+    expect(c.reposDir).toBe("/home/dev/.shipwright/workspace/repos");
+    expect(c.worktreesDir).toBe("/home/dev/.shipwright/workspace/worktrees");
+  });
+
+  test("SHIPWRIGHT_HITL_HOME overrides the root and every derived path", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_HOME: "/custom/root" });
+    expect(c.hitlHome).toBe("/custom/root");
+    expect(c.workspace).toBe("/custom/root/workspace");
+    expect(c.reposDir).toBe("/custom/root/workspace/repos");
+  });
+
+  test("defaults the host to localhost and builds service URLs from the ports", () => {
+    const c = cfg();
+    expect(c.host).toBe("localhost");
+    expect(c.taskStoreUrl).toBe(`http://localhost:${TASK_STORE_PORT}`);
+    expect(c.adminUrl).toBe(`http://localhost:${ADMIN_PORT}`);
+  });
+
+  test("SHIPWRIGHT_HITL_HOST rewrites both service URLs", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_HOST: "host.docker.internal" });
+    expect(c.taskStoreUrl).toBe(
+      `http://host.docker.internal:${TASK_STORE_PORT}`,
+    );
+    expect(c.adminUrl).toBe(`http://host.docker.internal:${ADMIN_PORT}`);
+  });
+
+  test("prefixes the Postgres URLs with USER when set", () => {
+    const c = cfg({ USER: "alice" });
+    expect(c.adminDatabaseUrl).toBe(
+      "postgresql://alice@localhost:5432/shipwright_dev",
+    );
+    expect(c.taskStoreDatabaseUrl).toBe(
+      "postgresql://alice@localhost:5432/shipwright_task_store_dev",
+    );
+  });
+
+  test("omits the USER prefix entirely when USER is unset", () => {
+    const c = cfg({});
+    expect(c.adminDatabaseUrl).toBe(
+      "postgresql://localhost:5432/shipwright_dev",
+    );
+    expect(c.taskStoreDatabaseUrl).toBe(
+      "postgresql://localhost:5432/shipwright_task_store_dev",
+    );
+  });
+
+  test("parses the repo and author allowlists, and the poll interval", () => {
+    const c = cfg({
+      SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright, app-vitals/other",
+      SHIPWRIGHT_HITL_AUTHORS: "alice,bob",
+      SHIPWRIGHT_HITL_POLL_INTERVAL: "15",
+    });
+    expect(c.repos).toEqual(["app-vitals/shipwright", "app-vitals/other"]);
+    expect(c.authors).toEqual(["alice", "bob"]);
+    expect(c.pollIntervalS).toBe(15);
+  });
+
+  test("defaults the poll interval to 60s", () => {
+    expect(cfg().pollIntervalS).toBe(60);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provision — the "seed" half of clone→seed
+// ---------------------------------------------------------------------------
+
+describe("buildProvisionSteps", () => {
+  test("plans every dir plus both template seeds on a fresh workspace", () => {
+    const steps = buildProvisionSteps(cfg(), nothingExists);
+    expect(steps.filter((s) => s.kind === "mkdir").map((s) => s.path)).toEqual([
+      "/home/dev/.shipwright/workspace",
+      "/home/dev/.shipwright/workspace/repos",
+      "/home/dev/.shipwright/workspace/worktrees",
+      "/home/dev/.shipwright/workspace/state/reviews",
+      "/home/dev/.shipwright/workspace/.claude",
+    ]);
+
+    const seeds = steps.filter((s) => s.kind === "seed-file");
+    expect(seeds.map((s) => s.path)).toEqual([
+      "/home/dev/.shipwright/workspace/CLAUDE.md",
+      "/home/dev/.shipwright/workspace/state/agent-policy.md",
+    ]);
+    expect(seeds.map((s) => s.templatePath)).toEqual([
+      "/repo/agent/workspace/CLAUDE-HITL.md.template",
+      "/repo/agent/workspace/state/agent-policy.md.template",
+    ]);
+  });
+
+  test("plans nothing when the workspace is already fully provisioned", () => {
+    expect(buildProvisionSteps(cfg(), everythingExists)).toEqual([]);
+  });
+
+  test("plans only the dirs that are actually missing", () => {
+    const c = cfg();
+    const steps = buildProvisionSteps(
+      c,
+      existsIn([
+        c.workspace,
+        c.reposDir,
+        `${c.workspace}/CLAUDE.md`,
+        `${c.workspace}/state/agent-policy.md`,
+      ]),
+    );
+    expect(steps.map((s) => s.path)).toEqual([
+      "/home/dev/.shipwright/workspace/worktrees",
+      "/home/dev/.shipwright/workspace/state/reviews",
+      "/home/dev/.shipwright/workspace/.claude",
+    ]);
+  });
+
+  test("seeds CLAUDE.md alone when only agent-policy.md already exists", () => {
+    const c = cfg();
+    const seeds = buildProvisionSteps(
+      c,
+      existsIn([`${c.workspace}/state/agent-policy.md`]),
+    ).filter((s) => s.kind === "seed-file");
+    expect(seeds).toHaveLength(1);
+    expect(seeds[0]?.path).toBe("/home/dev/.shipwright/workspace/CLAUDE.md");
+  });
+
+  test("mkdir steps always precede seed-file steps", () => {
+    const kinds = buildProvisionSteps(cfg(), nothingExists).map((s) => s.kind);
+    expect(kinds.lastIndexOf("mkdir")).toBeLessThan(kinds.indexOf("seed-file"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clone — missing-clone detection triggering `gh repo clone`
+// ---------------------------------------------------------------------------
+
+describe("buildCloneSteps", () => {
+  test("plans a gh repo clone for each configured repo not yet present", () => {
+    const c = cfg({
+      SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright,app-vitals/other",
+    });
+    const steps = buildCloneSteps(c, nothingExists);
+    expect(steps).toHaveLength(2);
+    expect(steps[0]?.argv).toEqual([
+      "gh",
+      "repo",
+      "clone",
+      "app-vitals/shipwright",
+      "/home/dev/.shipwright/workspace/repos/shipwright",
+    ]);
+    expect(steps[0]?.cwd).toBe(REPO_ROOT);
+    expect(steps[0]?.kind).toBe("clone");
+  });
+
+  test("skips repos already cloned under reposDir", () => {
+    const c = cfg({
+      SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright,app-vitals/other",
+    });
+    const steps = buildCloneSteps(
+      c,
+      existsIn(["/home/dev/.shipwright/workspace/repos/shipwright"]),
+    );
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.argv?.[3]).toBe("app-vitals/other");
+  });
+
+  test("plans no clones when no repos are configured", () => {
+    expect(buildCloneSteps(cfg(), nothingExists)).toEqual([]);
+  });
+
+  test("names the repo in the failure label so a failed clone is attributable", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright" });
+    expect(buildCloneSteps(c, nothingExists)[0]?.label).toBe(
+      "gh repo clone failed for app-vitals/shipwright",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migrations + token seed — the schema half of "seed"
+// ---------------------------------------------------------------------------
+
+describe("buildMigrationSteps", () => {
+  test("orders task-store generate → migrate → token seed → admin generate → migrate", () => {
+    const steps = buildMigrationSteps(cfg());
+    expect(steps.map((s) => [s.cwd, s.argv?.slice(1, 4).join(" ")])).toEqual([
+      ["/repo/task-store", "prisma generate --schema=prisma/schema.prisma"],
+      ["/repo/task-store", "prisma migrate deploy"],
+      [REPO_ROOT, "run /repo/scripts/seed-task-store-token.ts --db-url"],
+      ["/repo/admin", "prisma generate --schema=prisma/schema.prisma"],
+      ["/repo/admin", "prisma migrate deploy"],
+    ]);
+  });
+
+  test("scopes each migrate step to its own service's DATABASE_URL", () => {
+    const c = cfg({ USER: "alice" });
+    const steps = buildMigrationSteps(c);
+    expect(steps[1]?.env).toEqual({
+      DATABASE_URL_SHIPWRIGHT_TASK_STORE:
+        "postgresql://alice@localhost:5432/shipwright_task_store_dev",
+    });
+    expect(steps[4]?.env).toEqual({
+      DATABASE_URL_SHIPWRIGHT_ADMIN:
+        "postgresql://alice@localhost:5432/shipwright_dev",
+    });
+  });
+
+  test("leaves generate steps env-free — they touch no database", () => {
+    const steps = buildMigrationSteps(cfg());
+    expect(steps[0]?.env).toBeUndefined();
+    expect(steps[3]?.env).toBeUndefined();
+  });
+
+  test("seeds the admin token against an already-migrated task-store DB", () => {
+    const steps = buildMigrationSteps(cfg());
+    // The seed must come after the task-store migrate, or the table is absent.
+    const migrateIdx = steps.findIndex((s) =>
+      s.label.startsWith("task-store migrate"),
+    );
+    const seedIdx = steps.findIndex((s) => s.label === "admin token seed failed");
+    expect(seedIdx).toBeGreaterThan(migrateIdx);
+  });
+});
+
+describe("buildTokenSeedStep", () => {
+  test("omits --agent-id for the admin token", () => {
+    const step = buildTokenSeedStep(cfg(), "admin-tok");
+    expect(step.argv).toEqual([
+      "bun",
+      "run",
+      "/repo/scripts/seed-task-store-token.ts",
+      "--db-url",
+      "postgresql://localhost:5432/shipwright_task_store_dev",
+      "--token",
+      "admin-tok",
+    ]);
+    expect(step.label).toBe("admin token seed failed");
+  });
+
+  test("appends --agent-id for the repo-scoped agent token", () => {
+    const step = buildTokenSeedStep(cfg(), "agent-tok", "agent-123");
+    expect(step.argv?.slice(-2)).toEqual(["--agent-id", "agent-123"]);
+    expect(step.label).toBe("agent token seed failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The full preflight sequence — clone→seed, end to end
+// ---------------------------------------------------------------------------
+
+describe("buildPreflightSteps", () => {
+  test("orders provision → clone → install-plugins → migrate on a fresh machine", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright" });
+    const kinds = buildPreflightSteps(c, nothingExists).map((s) => s.kind);
+    expect(kinds).toEqual([
+      "mkdir",
+      "mkdir",
+      "mkdir",
+      "mkdir",
+      "mkdir",
+      "seed-file",
+      "seed-file",
+      "clone",
+      "install-plugins",
+      "exec",
+      "exec",
+      "exec",
+      "exec",
+      "exec",
+    ]);
+  });
+
+  test("clones before installing plugins and migrating", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright" });
+    const kinds = buildPreflightSteps(c, nothingExists).map((s) => s.kind);
+    expect(kinds.indexOf("clone")).toBeLessThan(kinds.indexOf("install-plugins"));
+    expect(kinds.indexOf("install-plugins")).toBeLessThan(kinds.indexOf("exec"));
+  });
+
+  test("still runs plugins + migrations when nothing needs provisioning", () => {
+    const kinds = buildPreflightSteps(cfg(), everythingExists).map(
+      (s) => s.kind,
+    );
+    expect(kinds).toEqual([
+      "install-plugins",
+      "exec",
+      "exec",
+      "exec",
+      "exec",
+      "exec",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSteps — the executor seam
+// ---------------------------------------------------------------------------
+
+describe("runSteps", () => {
+  test("drives every planned step through the injected executor, in order", async () => {
+    const c = cfg({ SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright" });
+    const steps = buildPreflightSteps(c, nothingExists);
+    const rec = recorder();
+
+    await runSteps(steps, rec.exec);
+
+    expect(rec.seen).toHaveLength(steps.length);
+    expect(rec.seen.map((s) => s.kind)).toEqual(steps.map((s) => s.kind));
+  });
+
+  test("awaits an async executor before moving to the next step", async () => {
+    const order: string[] = [];
+    const steps: HitlStep[] = [
+      { kind: "mkdir", label: "a", path: "/a" },
+      { kind: "mkdir", label: "b", path: "/b" },
+    ];
+
+    await runSteps(steps, async (step) => {
+      order.push(`start:${step.label}`);
+      await Promise.resolve();
+      order.push(`end:${step.label}`);
+    });
+
+    expect(order).toEqual(["start:a", "end:a", "start:b", "end:b"]);
+  });
+
+  test("propagates an executor failure and stops the sequence", async () => {
+    const seen: string[] = [];
+    const steps: HitlStep[] = [
+      { kind: "exec", label: "first", argv: ["true"] },
+      { kind: "exec", label: "boom", argv: ["false"] },
+      { kind: "exec", label: "never", argv: ["true"] },
+    ];
+
+    await expect(
+      runSteps(steps, (step) => {
+        seen.push(step.label);
+        if (step.label === "boom") throw new Error(step.label);
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(seen).toEqual(["first", "boom"]);
+  });
+
+  test("returns the steps it ran", async () => {
+    const steps = buildMigrationSteps(cfg());
+    expect(await runSteps(steps, () => {})).toEqual(steps);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boot — service specs, without booting anything
+// ---------------------------------------------------------------------------
+
+describe("buildServiceSpecs", () => {
+  test("plans task-store first, then admin", () => {
+    expect(buildServiceSpecs(cfg(), {}).map((s) => s.label)).toEqual([
+      "task-store",
+      "admin",
+    ]);
+  });
+
+  test("points each service at its own entrypoint from the repo root", () => {
+    const [taskStore, admin] = buildServiceSpecs(cfg(), {});
+    expect(taskStore?.argv).toEqual([
+      "bun",
+      "run",
+      "/repo/task-store/src/main.ts",
+    ]);
+    expect(admin?.argv).toEqual(["bun", "/repo/admin/src/main.ts"]);
+    expect(taskStore?.cwd).toBe(REPO_ROOT);
+    expect(admin?.cwd).toBe(REPO_ROOT);
+  });
+
+  test("gives each service its own port and database", () => {
+    const [taskStore, admin] = buildServiceSpecs(cfg({ USER: "alice" }), {});
+    expect(taskStore?.env.PORT).toBe(String(TASK_STORE_PORT));
+    expect(taskStore?.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE).toBe(
+      "postgresql://alice@localhost:5432/shipwright_task_store_dev",
+    );
+    expect(admin?.env.PORT).toBe(String(ADMIN_PORT));
+    expect(admin?.env.DATABASE_URL_SHIPWRIGHT_ADMIN).toBe(
+      "postgresql://alice@localhost:5432/shipwright_dev",
+    );
+    expect(admin?.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE).toBeUndefined();
+  });
+
+  test("cross-wires the two services' URLs and shared dev credentials", () => {
+    const c = cfg();
+    const [taskStore, admin] = buildServiceSpecs(c, {});
+    // task-store calls admin for agent lookups; admin calls task-store for tasks.
+    expect(taskStore?.env.SHIPWRIGHT_TASK_STORE_AGENTS_URL).toBe(c.adminUrl);
+    expect(admin?.env.SHIPWRIGHT_TASK_STORE_URL).toBe(c.taskStoreUrl);
+    // Both ends of the admin API key must agree.
+    expect(admin?.env.SHIPWRIGHT_ADMIN_API_KEYS).toContain(
+      taskStore?.env.SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY as string,
+    );
+    // The token task-store seeds is the one admin authenticates with.
+    expect(admin?.env.SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN).toBe(
+      taskStore?.env.TASK_STORE_SEED_ADMIN_TOKEN,
+    );
+  });
+
+  test("honors SHIPWRIGHT_HITL_HOST in the cross-wired URLs", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_HOST: "host.docker.internal" });
+    const [taskStore, admin] = buildServiceSpecs(c, {});
+    expect(taskStore?.env.SHIPWRIGHT_TASK_STORE_AGENTS_URL).toBe(
+      `http://host.docker.internal:${ADMIN_PORT}`,
+    );
+    expect(admin?.env.SHIPWRIGHT_TASK_STORE_URL).toBe(
+      `http://host.docker.internal:${TASK_STORE_PORT}`,
+    );
+  });
+
+  test("runs admin in dev-auth mode with dummy crypto material", () => {
+    const [, admin] = buildServiceSpecs(cfg(), {});
+    expect(admin?.env.ADMIN_DEV_AUTH).toBe("true");
+    expect(admin?.env.SHIPWRIGHT_ENCRYPTION_KEY).toMatch(/^0{64}$/);
+    expect(admin?.env.SHIPWRIGHT_SESSION_SECRET).toContain("not-for-production");
+  });
+
+  test("overlays onto the base env rather than replacing it", () => {
+    const [taskStore] = buildServiceSpecs(cfg(), {
+      PATH: "/usr/bin",
+      HOME: "/home/dev",
+    });
+    expect(taskStore?.env.PATH).toBe("/usr/bin");
+    expect(taskStore?.env.HOME).toBe("/home/dev");
+  });
+
+  test("service-specific values win over a conflicting base env", () => {
+    const [taskStore] = buildServiceSpecs(cfg(), { PORT: "9999" });
+    expect(taskStore?.env.PORT).toBe(String(TASK_STORE_PORT));
+  });
+
+  test("drops undefined base-env entries instead of passing them through", () => {
+    const [taskStore] = buildServiceSpecs(cfg(), { UNSET: undefined });
+    expect(Object.keys(taskStore?.env ?? {})).not.toContain("UNSET");
+  });
+
+  test("does not mutate the base env object", () => {
+    const base = { PATH: "/usr/bin" };
+    buildServiceSpecs(cfg(), base);
+    expect(base).toEqual({ PATH: "/usr/bin" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Poll → dispatch
+// ---------------------------------------------------------------------------
+
+describe("buildPrCommand", () => {
+  test("routes a review-phase candidate to /shipwright:review", () => {
+    expect(
+      buildPrCommand("app-vitals/shipwright#42", "review", {
+        id: "pr-1",
+        commitSha: "abc123",
+      }),
+    ).toBe("/shipwright:review app-vitals/shipwright#42 [preclaim:pr-1:abc123]");
+  });
+
+  test("routes a patch-phase candidate to /shipwright:patch", () => {
+    expect(
+      buildPrCommand("app-vitals/shipwright#42", "patch", {
+        id: "pr-1",
+        commitSha: "abc123",
+      }),
+    ).toBe("/shipwright:patch app-vitals/shipwright#42 [preclaim:pr-1:abc123]");
+  });
+
+  test("stamps the pre-claim marker so the command skips its own self-claim", () => {
+    const cmd = buildPrCommand("app-vitals/shipwright#7", "review", {
+      id: "claim-9",
+      commitSha: "deadbee",
+    });
+    expect(cmd).toContain("[preclaim:claim-9:deadbee]");
+  });
+});

--- a/scripts/hitl.bootstrap.unit.test.ts
+++ b/scripts/hitl.bootstrap.unit.test.ts
@@ -244,6 +244,15 @@ describe("buildCloneSteps", () => {
       "gh repo clone failed for app-vitals/shipwright",
     );
   });
+
+  test("carries a start-of-step progress message distinct from the failure label", () => {
+    const c = cfg({ SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright" });
+    const step = buildCloneSteps(c, nothingExists)[0];
+    expect(step?.startLabel).toBe(
+      "cloning app-vitals/shipwright into /home/dev/.shipwright/workspace/repos/shipwright...",
+    );
+    expect(step?.startLabel).not.toBe(step?.label);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -290,6 +299,21 @@ describe("buildMigrationSteps", () => {
     const seedIdx = steps.findIndex((s) => s.label === "admin token seed failed");
     expect(seedIdx).toBeGreaterThan(migrateIdx);
   });
+
+  test("gives every step a start-of-step progress message distinct from its failure label", () => {
+    const steps = buildMigrationSteps(cfg());
+    for (const step of steps) {
+      expect(step.startLabel).toBeTruthy();
+      expect(step.startLabel).not.toBe(step.label);
+    }
+    expect(steps.map((s) => s.startLabel)).toEqual([
+      "running task-store prisma generate...",
+      "running task-store prisma migrate...",
+      "seeding task-store admin token...",
+      "running admin prisma generate...",
+      "running admin prisma migrate...",
+    ]);
+  });
 });
 
 describe("buildTokenSeedStep", () => {
@@ -305,12 +329,16 @@ describe("buildTokenSeedStep", () => {
       "admin-tok",
     ]);
     expect(step.label).toBe("admin token seed failed");
+    expect(step.startLabel).toBe("seeding task-store admin token...");
   });
 
   test("appends --agent-id for the repo-scoped agent token", () => {
     const step = buildTokenSeedStep(cfg(), "agent-tok", "agent-123");
     expect(step.argv?.slice(-2)).toEqual(["--agent-id", "agent-123"]);
     expect(step.label).toBe("agent token seed failed");
+    expect(step.startLabel).toBe(
+      "seeding task-store agent token (agentId: agent-123)...",
+    );
   });
 });
 
@@ -415,6 +443,23 @@ describe("runSteps", () => {
   test("returns the steps it ran", async () => {
     const steps = buildMigrationSteps(cfg());
     expect(await runSteps(steps, () => {})).toEqual(steps);
+  });
+
+  test("exposes each exec/clone step's startLabel to the executor for progress logging", async () => {
+    const c = cfg({ SHIPWRIGHT_HITL_REPOS: "app-vitals/shipwright" });
+    const steps = [...buildCloneSteps(c, nothingExists), ...buildMigrationSteps(c)];
+    const startLabels: (string | undefined)[] = [];
+
+    await runSteps(steps, (step) => {
+      startLabels.push(step.startLabel);
+    });
+
+    // Every clone/exec step in the preflight sequence carries a distinct
+    // start-of-step message a real executor can log before spawning.
+    expect(startLabels).toHaveLength(steps.length);
+    expect(startLabels.every((s) => typeof s === "string" && s.length > 0)).toBe(
+      true,
+    );
   });
 });
 

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -77,25 +77,21 @@ export const HITL_ALLOWED_TOOLS = [
 // ---------------------------------------------------------------------------
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
-const HITL_HOME =
-  process.env.SHIPWRIGHT_HITL_HOME ?? join(homedir(), ".shipwright");
-const WORKSPACE = join(HITL_HOME, "workspace");
-const REPOS_DIR = join(WORKSPACE, "repos");
-const WORKTREES_DIR = join(WORKSPACE, "worktrees");
 
 // ---------------------------------------------------------------------------
 // Constants — mirrors dev-tmux.ts defaults; no env vars required
 // ---------------------------------------------------------------------------
 
-const TASK_STORE_PORT = 3002;
-const ADMIN_PORT = 3001;
-const HOST = process.env.SHIPWRIGHT_HITL_HOST ?? "localhost";
-const TASK_STORE_URL = `http://${HOST}:${TASK_STORE_PORT}`;
-const ADMIN_URL = `http://${HOST}:${ADMIN_PORT}`;
+export const TASK_STORE_PORT = 3002;
+export const ADMIN_PORT = 3001;
 const DEV_TOKEN = "dev-task-store-admin-token";
 const DEV_AGENT_TOKEN = "dev-task-store-hitl-token";
 const DEV_ADMIN_API_KEY = "dev-hitl-admin-key";
 const HITL_AGENT_NAME = "hitl";
+
+const DUMMY_ENCRYPTION_KEY =
+  "0000000000000000000000000000000000000000000000000000000000000000";
+const DUMMY_SESSION_SECRET = "dev-session-secret-not-for-production-use!";
 
 /**
  * Parses the comma-separated SHIPWRIGHT_HITL_REPOS env value into a list of
@@ -111,8 +107,6 @@ export function parseHitlRepos(raw: string | undefined): string[] {
         .filter(Boolean)
     : [];
 }
-
-const HITL_REPOS = parseHitlRepos(process.env.SHIPWRIGHT_HITL_REPOS);
 
 /**
  * Parses the comma-separated SHIPWRIGHT_HITL_AUTHORS env value into a list of
@@ -132,19 +126,92 @@ export function parseHitlAuthors(raw: string | undefined): string[] {
     : [];
 }
 
-const HITL_AUTHORS = parseHitlAuthors(process.env.SHIPWRIGHT_HITL_AUTHORS);
-const POLL_INTERVAL_S = Number(
-  process.env.SHIPWRIGHT_HITL_POLL_INTERVAL ?? "60",
-);
+// ---------------------------------------------------------------------------
+// Config — every env-derived value in one pure, injectable record
+// ---------------------------------------------------------------------------
 
-const DEV_DB_USER = process.env.USER ?? "";
-const DEV_DB_PREFIX = DEV_DB_USER ? `${DEV_DB_USER}@` : "";
-const DEV_DATABASE_URL = `postgresql://${DEV_DB_PREFIX}localhost:5432/shipwright_dev`;
-const DEV_TASK_STORE_DATABASE_URL = `postgresql://${DEV_DB_PREFIX}localhost:5432/shipwright_task_store_dev`;
+/**
+ * The full env-derived configuration for a HITL run. Everything the bootstrap
+ * sequence needs to plan its work: paths, ports, URLs, dev credentials, and
+ * the repo/author allowlists. Assembled once by buildHitlConfig() so the
+ * builders below stay pure functions of (config) rather than reaching into
+ * process.env at module scope.
+ */
+export type HitlConfig = {
+  repoRoot: string;
+  hitlHome: string;
+  workspace: string;
+  reposDir: string;
+  worktreesDir: string;
+  claudeMdTemplate: string;
+  agentPolicyTemplate: string;
+  repos: string[];
+  authors: string[];
+  pollIntervalS: number;
+  host: string;
+  taskStoreUrl: string;
+  adminUrl: string;
+  adminDatabaseUrl: string;
+  taskStoreDatabaseUrl: string;
+};
 
-const DUMMY_ENCRYPTION_KEY =
-  "0000000000000000000000000000000000000000000000000000000000000000";
-const DUMMY_SESSION_SECRET = "dev-session-secret-not-for-production-use!";
+/**
+ * Builds the HitlConfig from an env bag, the user's home dir, and the repo
+ * root. Pure and exported so the env→config mapping (defaults, overrides, the
+ * USER-prefixed Postgres URLs) is unit-testable without touching process.env
+ * or the real filesystem.
+ */
+export function buildHitlConfig(
+  env: Record<string, string | undefined>,
+  homeDir: string,
+  repoRoot: string,
+): HitlConfig {
+  const hitlHome = env.SHIPWRIGHT_HITL_HOME ?? join(homeDir, ".shipwright");
+  const workspace = join(hitlHome, "workspace");
+  const host = env.SHIPWRIGHT_HITL_HOST ?? "localhost";
+  const dbUser = env.USER ?? "";
+  const dbPrefix = dbUser ? `${dbUser}@` : "";
+
+  return {
+    repoRoot,
+    hitlHome,
+    workspace,
+    reposDir: join(workspace, "repos"),
+    worktreesDir: join(workspace, "worktrees"),
+    claudeMdTemplate: join(
+      repoRoot,
+      "agent",
+      "workspace",
+      "CLAUDE-HITL.md.template",
+    ),
+    agentPolicyTemplate: join(
+      repoRoot,
+      "agent",
+      "workspace",
+      "state",
+      "agent-policy.md.template",
+    ),
+    repos: parseHitlRepos(env.SHIPWRIGHT_HITL_REPOS),
+    authors: parseHitlAuthors(env.SHIPWRIGHT_HITL_AUTHORS),
+    pollIntervalS: Number(env.SHIPWRIGHT_HITL_POLL_INTERVAL ?? "60"),
+    host,
+    taskStoreUrl: `http://${host}:${TASK_STORE_PORT}`,
+    adminUrl: `http://${host}:${ADMIN_PORT}`,
+    adminDatabaseUrl: `postgresql://${dbPrefix}localhost:5432/shipwright_dev`,
+    taskStoreDatabaseUrl: `postgresql://${dbPrefix}localhost:5432/shipwright_task_store_dev`,
+  };
+}
+
+const CONFIG = buildHitlConfig(process.env, homedir(), REPO_ROOT);
+
+const WORKSPACE = CONFIG.workspace;
+const REPOS_DIR = CONFIG.reposDir;
+const WORKTREES_DIR = CONFIG.worktreesDir;
+const TASK_STORE_URL = CONFIG.taskStoreUrl;
+const ADMIN_URL = CONFIG.adminUrl;
+const HITL_REPOS = CONFIG.repos;
+const HITL_AUTHORS = CONFIG.authors;
+const POLL_INTERVAL_S = CONFIG.pollIntervalS;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -178,21 +245,6 @@ async function waitForHealth(url: string, label: string): Promise<void> {
 // ---------------------------------------------------------------------------
 // Workspace provisioning — mirrors agent/src/setup.ts ensureAgentHome()
 // ---------------------------------------------------------------------------
-
-const HITL_TEMPLATE = join(
-  REPO_ROOT,
-  "agent",
-  "workspace",
-  "CLAUDE-HITL.md.template",
-);
-
-const AGENT_POLICY_TEMPLATE = join(
-  REPO_ROOT,
-  "agent",
-  "workspace",
-  "state",
-  "agent-policy.md.template",
-);
 
 /**
  * Pure planning step for provisionWorkspace(): given the set of dirs the
@@ -238,37 +290,239 @@ export function computeMissingClones(
     .filter(({ dest }) => !exists(dest));
 }
 
-function provisionWorkspace(): void {
+// ---------------------------------------------------------------------------
+// Bootstrap step builders — pure planners, mirroring dev-tmux.ts's
+// buildStackCommands()/runStack() split. Each builder returns the ORDERED
+// sequence of steps the bootstrap will perform; runSteps() drives them
+// through an injected executor. Tests assert the sequence without spawning
+// processes, touching the filesystem, or booting services.
+// ---------------------------------------------------------------------------
+
+export type HitlStepKind =
+  | "mkdir"
+  | "seed-file"
+  | "clone"
+  | "install-plugins"
+  | "exec";
+
+/** One planned step in the HITL bootstrap sequence. */
+export type HitlStep = {
+  kind: HitlStepKind;
+  /** Human-readable label, also used for the failure message on exec steps. */
+  label: string;
+  /** Target directory (mkdir) or destination file (seed-file). */
+  path?: string;
+  /** Source template path for seed-file steps. */
+  templatePath?: string;
+  /** argv for clone/exec steps. */
+  argv?: string[];
+  /** Working directory for clone/exec steps. */
+  cwd?: string;
+  /** Env overrides layered onto the base env for exec steps. */
+  env?: Record<string, string>;
+};
+
+/** Runs a single planned step. Injected so tests can record instead of act. */
+export type StepExecFn = (step: HitlStep) => void | Promise<void>;
+
+/**
+ * Plans the workspace provisioning steps: the dirs to create and the template
+ * files to seed. Pure — takes an injectable existence check and returns the
+ * steps rather than performing them.
+ */
+export function buildProvisionSteps(
+  cfg: HitlConfig,
+  exists: (path: string) => boolean,
+): HitlStep[] {
   const dirs = [
-    WORKSPACE,
-    REPOS_DIR,
-    WORKTREES_DIR,
-    join(WORKSPACE, "state", "reviews"),
-    join(WORKSPACE, ".claude"),
+    cfg.workspace,
+    cfg.reposDir,
+    cfg.worktreesDir,
+    join(cfg.workspace, "state", "reviews"),
+    join(cfg.workspace, ".claude"),
   ];
-  const claudeMd = join(WORKSPACE, "CLAUDE.md");
-  const agentPolicy = join(WORKSPACE, "state", "agent-policy.md");
+  const claudeMd = join(cfg.workspace, "CLAUDE.md");
+  const agentPolicy = join(cfg.workspace, "state", "agent-policy.md");
 
-  const plan = computeProvisionPlan(dirs, claudeMd, agentPolicy, existsSync);
-
-  for (const dir of plan.missingDirs) {
-    mkdirSync(dir, { recursive: true });
-  }
+  const plan = computeProvisionPlan(dirs, claudeMd, agentPolicy, exists);
+  const steps: HitlStep[] = plan.missingDirs.map((dir) => ({
+    kind: "mkdir",
+    label: `mkdir ${dir}`,
+    path: dir,
+  }));
 
   if (plan.needsClaudeMd) {
-    const template = readFileSync(HITL_TEMPLATE, "utf8");
-    writeFileSync(claudeMd, template, { flag: "wx" });
-    log("seeded CLAUDE.md");
+    steps.push({
+      kind: "seed-file",
+      label: "seeded CLAUDE.md",
+      path: claudeMd,
+      templatePath: cfg.claudeMdTemplate,
+    });
   }
-
   if (plan.needsAgentPolicy) {
-    const template = readFileSync(AGENT_POLICY_TEMPLATE, "utf8");
-    writeFileSync(agentPolicy, template, { flag: "wx" });
-    log("seeded agent-policy.md");
+    steps.push({
+      kind: "seed-file",
+      label: "seeded agent-policy.md",
+      path: agentPolicy,
+      templatePath: cfg.agentPolicyTemplate,
+    });
   }
 
-  if (plan.missingDirs.length > 0) {
-    log(`workspace provisioned: ${WORKSPACE}`);
+  return steps;
+}
+
+/**
+ * Plans the auto-clone steps for any configured repo not already present
+ * under reposDir. Pure — wraps computeMissingClones() into executable steps.
+ */
+export function buildCloneSteps(
+  cfg: HitlConfig,
+  exists: (path: string) => boolean,
+): HitlStep[] {
+  return computeMissingClones(cfg.repos, cfg.reposDir, exists).map(
+    ({ repo, dest }) => ({
+      kind: "clone" as const,
+      label: `gh repo clone failed for ${repo}`,
+      argv: ["gh", "repo", "clone", repo, dest],
+      cwd: cfg.repoRoot,
+    }),
+  );
+}
+
+/**
+ * Plans the schema/seed steps: prisma generate + migrate for both the
+ * task-store and admin services, plus the admin token seed between them.
+ * Ordering matters — the token seed runs against an already-migrated
+ * task-store DB, and admin migrates last.
+ */
+export function buildMigrationSteps(cfg: HitlConfig): HitlStep[] {
+  const prismaArgs = (cmd: "generate" | "deploy"): string[] =>
+    cmd === "generate"
+      ? ["bunx", "prisma", "generate", "--schema=prisma/schema.prisma"]
+      : [
+          "bunx",
+          "prisma",
+          "migrate",
+          "deploy",
+          "--schema=prisma/schema.prisma",
+        ];
+
+  return [
+    {
+      kind: "exec",
+      label: "task-store prisma generate failed",
+      argv: prismaArgs("generate"),
+      cwd: join(cfg.repoRoot, "task-store"),
+    },
+    {
+      kind: "exec",
+      label: "task-store migrate failed",
+      argv: prismaArgs("deploy"),
+      cwd: join(cfg.repoRoot, "task-store"),
+      env: { DATABASE_URL_SHIPWRIGHT_TASK_STORE: cfg.taskStoreDatabaseUrl },
+    },
+    buildTokenSeedStep(cfg, DEV_TOKEN),
+    {
+      kind: "exec",
+      label: "admin prisma generate failed",
+      argv: prismaArgs("generate"),
+      cwd: join(cfg.repoRoot, "admin"),
+    },
+    {
+      kind: "exec",
+      label: "admin migrate failed",
+      argv: prismaArgs("deploy"),
+      cwd: join(cfg.repoRoot, "admin"),
+      env: { DATABASE_URL_SHIPWRIGHT_ADMIN: cfg.adminDatabaseUrl },
+    },
+  ];
+}
+
+/**
+ * Plans a task-store token seed. Used twice: once during preflight for the
+ * admin token (no agent id), and again after ensureHitlAgent() resolves an
+ * agent id so the agent token is repo-scoped.
+ */
+export function buildTokenSeedStep(
+  cfg: HitlConfig,
+  token: string,
+  agentId?: string,
+): HitlStep {
+  return {
+    kind: "exec",
+    label: agentId ? "agent token seed failed" : "admin token seed failed",
+    argv: [
+      "bun",
+      "run",
+      join(cfg.repoRoot, "scripts", "seed-task-store-token.ts"),
+      "--db-url",
+      cfg.taskStoreDatabaseUrl,
+      "--token",
+      token,
+      ...(agentId ? ["--agent-id", agentId] : []),
+    ],
+    cwd: cfg.repoRoot,
+  };
+}
+
+/**
+ * Plans the complete preflight sequence in execution order:
+ * provision → clone → install plugins → migrate/seed. This is the
+ * clone→seed half of the bootstrap, as one assertable list.
+ */
+export function buildPreflightSteps(
+  cfg: HitlConfig,
+  exists: (path: string) => boolean,
+): HitlStep[] {
+  return [
+    ...buildProvisionSteps(cfg, exists),
+    ...buildCloneSteps(cfg, exists),
+    { kind: "install-plugins", label: "installing shipwright plugin..." },
+    ...buildMigrationSteps(cfg),
+  ];
+}
+
+/** Drives a planned step sequence through an injected executor, in order. */
+export async function runSteps(
+  steps: HitlStep[],
+  exec: StepExecFn,
+): Promise<HitlStep[]> {
+  for (const step of steps) {
+    await exec(step);
+  }
+  return steps;
+}
+
+/**
+ * The real executor: performs a planned step's I/O. Used only by the
+ * entrypoint — tests inject a recording executor instead.
+ */
+async function execStep(step: HitlStep): Promise<void> {
+  switch (step.kind) {
+    case "mkdir":
+      mkdirSync(step.path as string, { recursive: true });
+      return;
+    case "seed-file": {
+      const template = readFileSync(step.templatePath as string, "utf8");
+      writeFileSync(step.path as string, template, { flag: "wx" });
+      log(step.label);
+      return;
+    }
+    case "install-plugins":
+      log(step.label);
+      await installPlugins();
+      return;
+    case "clone":
+    case "exec": {
+      const result = Bun.spawnSync(step.argv as string[], {
+        cwd: step.cwd,
+        ...(step.env ? { env: { ...process.env, ...step.env } } : {}),
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      if (result.exitCode !== 0) throw new Error(step.label);
+      return;
+    }
   }
 }
 
@@ -277,85 +531,8 @@ function provisionWorkspace(): void {
 // ---------------------------------------------------------------------------
 
 async function runPreflight(): Promise<void> {
-  provisionWorkspace();
-
-  const missingClones = computeMissingClones(HITL_REPOS, REPOS_DIR, existsSync);
-  for (const { repo, dest } of missingClones) {
-    log(`cloning ${repo} into ${dest}...`);
-    const clone = Bun.spawnSync(["gh", "repo", "clone", repo, dest], {
-      cwd: REPO_ROOT,
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    if (clone.exitCode !== 0)
-      throw new Error(`gh repo clone failed for ${repo}`);
-    log(`cloned ${repo}`);
-  }
-
-  log("installing shipwright plugin...");
-  await installPlugins();
-
-  log("running task-store prisma generate + migrate...");
-  const tsGen = Bun.spawnSync(
-    ["bunx", "prisma", "generate", "--schema=prisma/schema.prisma"],
-    {
-      cwd: join(REPO_ROOT, "task-store"),
-      stdout: "inherit",
-      stderr: "inherit",
-    },
-  );
-  if (tsGen.exitCode !== 0)
-    throw new Error("task-store prisma generate failed");
-
-  const tsMigrate = Bun.spawnSync(
-    ["bunx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"],
-    {
-      cwd: join(REPO_ROOT, "task-store"),
-      env: {
-        ...process.env,
-        DATABASE_URL_SHIPWRIGHT_TASK_STORE: DEV_TASK_STORE_DATABASE_URL,
-      },
-      stdout: "inherit",
-      stderr: "inherit",
-    },
-  );
-  if (tsMigrate.exitCode !== 0) throw new Error("task-store migrate failed");
-
-  log("seeding task-store admin token...");
-  const adminSeed = Bun.spawnSync(
-    [
-      "bun",
-      "run",
-      join(REPO_ROOT, "scripts", "seed-task-store-token.ts"),
-      "--db-url",
-      DEV_TASK_STORE_DATABASE_URL,
-      "--token",
-      DEV_TOKEN,
-    ],
-    { cwd: REPO_ROOT, stdout: "inherit", stderr: "inherit" },
-  );
-  if (adminSeed.exitCode !== 0) throw new Error("admin token seed failed");
-
-  log("running admin prisma generate + migrate...");
-  const adminGen = Bun.spawnSync(
-    ["bunx", "prisma", "generate", "--schema=prisma/schema.prisma"],
-    { cwd: join(REPO_ROOT, "admin"), stdout: "inherit", stderr: "inherit" },
-  );
-  if (adminGen.exitCode !== 0) throw new Error("admin prisma generate failed");
-
-  const adminMigrate = Bun.spawnSync(
-    ["bunx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"],
-    {
-      cwd: join(REPO_ROOT, "admin"),
-      env: {
-        ...process.env,
-        DATABASE_URL_SHIPWRIGHT_ADMIN: DEV_DATABASE_URL,
-      },
-      stdout: "inherit",
-      stderr: "inherit",
-    },
-  );
-  if (adminMigrate.exitCode !== 0) throw new Error("admin migrate failed");
+  await runSteps(buildPreflightSteps(CONFIG, existsSync), execStep);
+  log(`workspace provisioned: ${WORKSPACE}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -367,45 +544,71 @@ type ServiceHandle = {
   proc: ReturnType<typeof Bun.spawn>;
 };
 
-function startServices(): ServiceHandle[] {
-  const taskStore = Bun.spawn(
-    ["bun", "run", join(REPO_ROOT, "task-store", "src", "main.ts")],
-    {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        PORT: String(TASK_STORE_PORT),
-        DATABASE_URL_SHIPWRIGHT_TASK_STORE: DEV_TASK_STORE_DATABASE_URL,
-        TASK_STORE_SEED_ADMIN_TOKEN: DEV_TOKEN,
-        SHIPWRIGHT_TASK_STORE_AGENTS_URL: ADMIN_URL,
-        SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY: DEV_ADMIN_API_KEY,
-      },
-      stdout: "inherit",
-      stderr: "inherit",
-    },
-  );
+/** A service the bootstrap boots: what to run, where, and with what env. */
+export type ServiceSpec = {
+  label: string;
+  argv: string[];
+  cwd: string;
+  env: Record<string, string>;
+};
 
-  const admin = Bun.spawn(["bun", join(REPO_ROOT, "admin", "src", "main.ts")], {
-    cwd: REPO_ROOT,
-    env: {
-      ...process.env,
-      PORT: String(ADMIN_PORT),
-      DATABASE_URL_SHIPWRIGHT_ADMIN: DEV_DATABASE_URL,
-      SHIPWRIGHT_ENCRYPTION_KEY: DUMMY_ENCRYPTION_KEY,
-      SHIPWRIGHT_SESSION_SECRET: DUMMY_SESSION_SECRET,
-      ADMIN_DEV_AUTH: "true",
-      SHIPWRIGHT_ADMIN_API_KEYS: `hitl:${DEV_ADMIN_API_KEY}:*`,
-      SHIPWRIGHT_TASK_STORE_URL: TASK_STORE_URL,
-      SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN: DEV_TOKEN,
-    },
-    stdout: "inherit",
-    stderr: "inherit",
-  });
+/**
+ * Plans the boot step: the exact argv, cwd, and fully-resolved env for the
+ * task-store and admin services, layered onto a caller-supplied base env.
+ * Pure — mirrors buildClaudeSpawnEnv()'s overlay contract, so the boot
+ * sequence is assertable without spawning long-running processes.
+ */
+export function buildServiceSpecs(
+  cfg: HitlConfig,
+  baseEnv: Record<string, string | undefined>,
+): ServiceSpec[] {
+  const base = Object.fromEntries(
+    Object.entries(baseEnv).filter(([, v]) => v !== undefined),
+  ) as Record<string, string>;
 
   return [
-    { label: "task-store", proc: taskStore },
-    { label: "admin", proc: admin },
+    {
+      label: "task-store",
+      argv: ["bun", "run", join(cfg.repoRoot, "task-store", "src", "main.ts")],
+      cwd: cfg.repoRoot,
+      env: {
+        ...base,
+        PORT: String(TASK_STORE_PORT),
+        DATABASE_URL_SHIPWRIGHT_TASK_STORE: cfg.taskStoreDatabaseUrl,
+        TASK_STORE_SEED_ADMIN_TOKEN: DEV_TOKEN,
+        SHIPWRIGHT_TASK_STORE_AGENTS_URL: cfg.adminUrl,
+        SHIPWRIGHT_TASK_STORE_AGENTS_API_KEY: DEV_ADMIN_API_KEY,
+      },
+    },
+    {
+      label: "admin",
+      argv: ["bun", join(cfg.repoRoot, "admin", "src", "main.ts")],
+      cwd: cfg.repoRoot,
+      env: {
+        ...base,
+        PORT: String(ADMIN_PORT),
+        DATABASE_URL_SHIPWRIGHT_ADMIN: cfg.adminDatabaseUrl,
+        SHIPWRIGHT_ENCRYPTION_KEY: DUMMY_ENCRYPTION_KEY,
+        SHIPWRIGHT_SESSION_SECRET: DUMMY_SESSION_SECRET,
+        ADMIN_DEV_AUTH: "true",
+        SHIPWRIGHT_ADMIN_API_KEYS: `hitl:${DEV_ADMIN_API_KEY}:*`,
+        SHIPWRIGHT_TASK_STORE_URL: cfg.taskStoreUrl,
+        SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN: DEV_TOKEN,
+      },
+    },
   ];
+}
+
+function startServices(): ServiceHandle[] {
+  return buildServiceSpecs(CONFIG, process.env).map((spec) => ({
+    label: spec.label,
+    proc: Bun.spawn(spec.argv, {
+      cwd: spec.cwd,
+      env: spec.env,
+      stdout: "inherit",
+      stderr: "inherit",
+    }),
+  }));
 }
 
 function killServices(handles: ServiceHandle[]): void {
@@ -560,23 +763,9 @@ export async function ensureHitlAgent(
   return null;
 }
 
-function seedAgentToken(agentId: string): void {
+async function seedAgentToken(agentId: string): Promise<void> {
   log(`seeding task-store agent token (agentId: ${agentId})...`);
-  const result = Bun.spawnSync(
-    [
-      "bun",
-      "run",
-      join(REPO_ROOT, "scripts", "seed-task-store-token.ts"),
-      "--db-url",
-      DEV_TASK_STORE_DATABASE_URL,
-      "--token",
-      DEV_AGENT_TOKEN,
-      "--agent-id",
-      agentId,
-    ],
-    { cwd: REPO_ROOT, stdout: "inherit", stderr: "inherit" },
-  );
-  if (result.exitCode !== 0) throw new Error("agent token seed failed");
+  await execStep(buildTokenSeedStep(CONFIG, DEV_AGENT_TOKEN, agentId));
 }
 
 // ---------------------------------------------------------------------------
@@ -614,6 +803,22 @@ export function buildTaskCommand(task: Pick<Task, "id" | "hitl">): string {
   return task.hitl
     ? `/shipwright:hitl ${task.id}`
     : `/shipwright:dev-task ${task.id}`;
+}
+
+/**
+ * Picks the command to launch for a claimed PR candidate, stamping the
+ * orchestrator pre-claim marker the review/patch commands consume so they
+ * skip their own redundant self-claim (CBD-1.4/1.5). Pure — the claim itself
+ * happens in runLoop(); this only formats the resulting dispatch.
+ */
+export function buildPrCommand(
+  prId: string,
+  phase: string,
+  claim: { id: string; commitSha: string },
+): string {
+  const marker = `[preclaim:${claim.id}:${claim.commitSha}]`;
+  const command = phase === "review" ? "review" : "patch";
+  return `/shipwright:${command} ${prId} ${marker}`;
 }
 
 async function fetchReadyTasks(): Promise<Task[]> {
@@ -783,11 +988,7 @@ async function runLoop(): Promise<void> {
         continue;
       }
 
-      const preclaimMarker = `[preclaim:${claimResult.id}:${claimResult.commitSha}]`;
-      command =
-        next.pr.phase === "review"
-          ? `/shipwright:review ${next.pr.id} ${preclaimMarker}`
-          : `/shipwright:patch ${next.pr.id} ${preclaimMarker}`;
+      command = buildPrCommand(next.pr.id, next.pr.phase, claimResult);
       label = `${next.pr.id} — ${next.pr.title ?? ""}`;
     }
 
@@ -851,7 +1052,7 @@ if (import.meta.main) {
 
     const agentId = await ensureHitlAgent();
     if (agentId) {
-      seedAgentToken(agentId);
+      await seedAgentToken(agentId);
     } else {
       log("warning: no hitl agent — agent token will not be repo-scoped");
     }

--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -310,6 +310,14 @@ export type HitlStep = {
   kind: HitlStepKind;
   /** Human-readable label, also used for the failure message on exec steps. */
   label: string;
+  /**
+   * Progress message logged before a clone/exec step runs (e.g. "cloning
+   * {repo} into {dest}..."). Distinct from `label`, which is phrased as a
+   * failure message ("X failed") and would read oddly printed up front.
+   * Steps that don't need start-of-step visibility (mkdir, seed-file,
+   * install-plugins) omit it.
+   */
+  startLabel?: string;
   /** Target directory (mkdir) or destination file (seed-file). */
   path?: string;
   /** Source template path for seed-file steps. */
@@ -383,6 +391,7 @@ export function buildCloneSteps(
     ({ repo, dest }) => ({
       kind: "clone" as const,
       label: `gh repo clone failed for ${repo}`,
+      startLabel: `cloning ${repo} into ${dest}...`,
       argv: ["gh", "repo", "clone", repo, dest],
       cwd: cfg.repoRoot,
     }),
@@ -411,12 +420,14 @@ export function buildMigrationSteps(cfg: HitlConfig): HitlStep[] {
     {
       kind: "exec",
       label: "task-store prisma generate failed",
+      startLabel: "running task-store prisma generate...",
       argv: prismaArgs("generate"),
       cwd: join(cfg.repoRoot, "task-store"),
     },
     {
       kind: "exec",
       label: "task-store migrate failed",
+      startLabel: "running task-store prisma migrate...",
       argv: prismaArgs("deploy"),
       cwd: join(cfg.repoRoot, "task-store"),
       env: { DATABASE_URL_SHIPWRIGHT_TASK_STORE: cfg.taskStoreDatabaseUrl },
@@ -425,12 +436,14 @@ export function buildMigrationSteps(cfg: HitlConfig): HitlStep[] {
     {
       kind: "exec",
       label: "admin prisma generate failed",
+      startLabel: "running admin prisma generate...",
       argv: prismaArgs("generate"),
       cwd: join(cfg.repoRoot, "admin"),
     },
     {
       kind: "exec",
       label: "admin migrate failed",
+      startLabel: "running admin prisma migrate...",
       argv: prismaArgs("deploy"),
       cwd: join(cfg.repoRoot, "admin"),
       env: { DATABASE_URL_SHIPWRIGHT_ADMIN: cfg.adminDatabaseUrl },
@@ -451,6 +464,9 @@ export function buildTokenSeedStep(
   return {
     kind: "exec",
     label: agentId ? "agent token seed failed" : "admin token seed failed",
+    startLabel: agentId
+      ? `seeding task-store agent token (agentId: ${agentId})...`
+      : "seeding task-store admin token...",
     argv: [
       "bun",
       "run",
@@ -514,6 +530,7 @@ async function execStep(step: HitlStep): Promise<void> {
       return;
     case "clone":
     case "exec": {
+      if (step.startLabel) log(step.startLabel);
       const result = Bun.spawnSync(step.argv as string[], {
         cwd: step.cwd,
         ...(step.env ? { env: { ...process.env, ...step.env } } : {}),


### PR DESCRIPTION
Covers the HITL dev-loop bootstrap's clone→seed→boot→poll sequence (task `test-t-080-shipwright`), which was HITL-blocked on an ambiguous fix approach.

**Approach:** splits `scripts/hitl.ts` into pure planners + a thin injected executor, mirroring the existing `scripts/dev-tmux.ts` pattern (`buildStackCommands()` / `runStack(panes, exec)`).

- `buildHitlConfig()` — all env-derived values in one injectable record; module-level constants now derive from it
- `buildProvisionSteps()` / `buildCloneSteps()` / `buildMigrationSteps()` / `buildTokenSeedStep()` / `buildPreflightSteps()` — ordered `HitlStep[]` plans
- `buildServiceSpecs()` — the boot step's argv/cwd/env, overlaid on a caller-supplied base env
- `buildPrCommand()` — the poll→dispatch path for claimed PR candidates
- `runSteps(steps, exec)` + `execStep` — executor seam; behavior unchanged

**Tests:** `scripts/hitl.bootstrap.unit.test.ts`, 43 tests. No `mock.module()`, no `global.*`, no real filesystem, no spawned processes.

**Deliberate deviation:** the task prescribed `Layer: integration` and `scripts/hitl.integration.test.ts`; this lands at the unit layer instead. Its acceptance criteria demand the sequence be "proven correct end-to-end" *and* that no real long-running services be spawned — anything satisfying the second proves the plan, not the boot. Rationale and revisit conditions recorded in `.claude/shipwright/test-readiness-decisions.md`.

Existing `scripts/hitl.unit.test.ts` coverage is untouched.