### PR TITLE
feat: add feature-grouping step to test-inventory

### DIFF
--- a/plugins/shipwright/assets/templates/test-inventory.md.tmpl
+++ b/plugins/shipwright/assets/templates/test-inventory.md.tmpl
@@ -28,6 +28,19 @@ This is the closed set of items that define the canary suite. Anything outside t
 
 {{CANARY_ROSTER}}
 
+## Features
+
+A coarser, separate grouping of the units above — for coverage rollup and prioritization
+only, not a per-file criticality->CI mapping. Every code unit is assigned to exactly one
+feature. Importance is prioritization-only and never excludes a feature from the
+`feature_coverage_pct` denominator.
+
+| Feature name | Member units | Required layer | Importance | Covered (y/n) |
+|---|---|---|---|---|
+{{FEATURES_ROWS}}
+
+**feature_coverage_pct:** {{FEATURE_COVERAGE_PCT}} (covered_features / total_features x 100 — no exclusion category of any kind)
+
 ## Per-category detail
 
 ### 1. Pure business logic

--- a/plugins/shipwright/skills/test-inventory/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-inventory/SKILL.content.test.ts
@@ -1,0 +1,149 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+const TEMPLATE_PATH = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "assets",
+  "templates",
+  "test-inventory.md.tmpl",
+);
+
+let content: string;
+let templateContent: string;
+
+beforeAll(() => {
+  content = existsSync(SKILL_MD_PATH)
+    ? readFileSync(SKILL_MD_PATH, "utf-8")
+    : "";
+  templateContent = existsSync(TEMPLATE_PATH)
+    ? readFileSync(TEMPLATE_PATH, "utf-8")
+    : "";
+});
+
+describe("SKILL.md — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(content.length).toBeGreaterThan(200);
+  });
+});
+
+describe("SKILL.md — frontmatter", () => {
+  it("has frontmatter with name: test-inventory", () => {
+    expect(content).toContain("name: test-inventory");
+  });
+
+  it("has frontmatter with a description field", () => {
+    expect(content).toMatch(/^description:/m);
+  });
+});
+
+describe("SKILL.md — feature-grouping step", () => {
+  it("describes heuristic inference using directory structure, route prefix, and entry point signals", () => {
+    expect(content).toMatch(/directory structure/i);
+    expect(content).toMatch(/route[ -]prefix/i);
+    expect(content).toMatch(/entry[ -]point/i);
+  });
+
+  it("requires every code unit be assigned to exactly one feature", () => {
+    expect(content).toMatch(/exactly one feature/i);
+  });
+
+  it("documents the four importance labels", () => {
+    expect(content).toContain("revenue-path");
+    expect(content).toContain("security-path");
+    expect(content).toContain("core");
+    expect(content).toContain("auxiliary");
+  });
+
+  it("states importance tagging is prioritization-only and never excludes a feature from the denominator", () => {
+    expect(content).toMatch(/prioritization[- ]only/i);
+    expect(content).toMatch(/never exclud(e|es|ing)/i);
+    expect(content).toMatch(/denominator/i);
+  });
+
+  it("does not conflate feature importance with Step 4's per-unit criticality tier", () => {
+    expect(content).toMatch(/not the same as/i);
+  });
+});
+
+describe("SKILL.md — ambiguous groupings reuse the existing classifier-confidence pattern", () => {
+  it("reuses the 'classifier was not confident' wording for ambiguous feature groupings", () => {
+    expect(content).toMatch(/classifier was not confident/i);
+  });
+
+  it("directs ambiguous feature groupings into the existing Ambiguous items section, not a new mechanism", () => {
+    expect(content).toMatch(/Ambiguous items/);
+    expect(content).toMatch(/not a\s+new\s+mechanism/i);
+  });
+});
+
+describe("SKILL.md — feature_coverage_pct formula", () => {
+  it("documents the formula verbatim as covered_features / total_features x 100", () => {
+    expect(content).toContain("covered_features / total_features x 100");
+  });
+
+  it("states there is no exclusion category of any kind", () => {
+    expect(content).toMatch(/no exclusion category of any kind/i);
+  });
+});
+
+describe("SKILL.md — negative constraint: no maintained per-file criticality→CI mapping", () => {
+  it("explicitly states the feature-grouping structure must not reintroduce a maintained per-file criticality-to-CI mapping", () => {
+    expect(content).toMatch(/must not reintroduce/i);
+    expect(content).toMatch(/per-file criticality/i);
+    expect(content).toMatch(/CI\s+mapping/i);
+  });
+
+  it("describes the feature structure as coarser and separate from Step 4's per-unit criticality ranking", () => {
+    expect(content).toMatch(/coarser/i);
+    expect(content).toMatch(/separate structure/i);
+  });
+});
+
+describe("SKILL.md — Step 6 mentions filling in Features section placeholders", () => {
+  it("references the Features section when writing the artifact", () => {
+    const step6Idx = content.indexOf("Step 6");
+    expect(step6Idx).toBeGreaterThan(-1);
+    const step6Section = content.slice(step6Idx, step6Idx + 1500);
+    expect(step6Section).toMatch(/Features section/i);
+  });
+});
+
+describe("test-inventory.md.tmpl — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(TEMPLATE_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(templateContent.length).toBeGreaterThan(200);
+  });
+});
+
+describe("test-inventory.md.tmpl — Features section", () => {
+  it("has a Features section header", () => {
+    expect(templateContent).toMatch(/^## Features/m);
+  });
+
+  it("has a table with the required columns", () => {
+    expect(templateContent).toContain("Feature name");
+    expect(templateContent).toContain("Member units");
+    expect(templateContent).toContain("Required layer");
+    expect(templateContent).toContain("Importance");
+    expect(templateContent).toMatch(/Covered \(y\/n\)/);
+  });
+
+  it("has a placeholder for the feature rows", () => {
+    expect(templateContent).toContain("{{FEATURES_ROWS}}");
+  });
+
+  it("has a placeholder surfacing the computed feature_coverage_pct value", () => {
+    expect(templateContent).toContain("{{FEATURE_COVERAGE_PCT}}");
+  });
+});

--- a/plugins/shipwright/skills/test-inventory/SKILL.md
+++ b/plugins/shipwright/skills/test-inventory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-inventory
 description: >
-  Phase 1 of the test-readiness pipeline. Crawls a target repo, classifies every meaningful unit of code (business logic, service boundary, HTTP route, error path, external integration, user journey), prescribes the appropriate test layer (unit / integration / smoke / E2E) using the rubrics, ranks each by criticality (critical / high / medium), and tags canary eligibility. Outputs a deduplicated inventory — each functional unit appears exactly once at its canonical layer per the no-duplicate-coverage rule. Writes `docs/test-readiness/test-inventory.md`. Invoke when the `/test-inventory` command runs.
+  Phase 1 of the test-readiness pipeline. Crawls a target repo, classifies every meaningful unit of code (business logic, service boundary, HTTP route, error path, external integration, user journey), prescribes the appropriate test layer (unit / integration / smoke / E2E) using the rubrics, ranks each by criticality (critical / high / medium), groups units into features with importance tags (revenue-path / security-path / core / auxiliary), and tags canary eligibility. Outputs a deduplicated inventory — each functional unit appears exactly once at its canonical layer per the no-duplicate-coverage rule. Writes `docs/test-readiness/test-inventory.md`. Invoke when the `/test-inventory` command runs.
 ---
 
 # test-inventory skill
@@ -98,6 +98,80 @@ repo's conventions), do not apply it — classify the file normally per the mech
 and note in the row why the registry entry was not applied (its revisit condition was met, or
 its recorded layer no longer applies) rather than silently ignoring the stale entry.
 
+### Step 3b — group into features
+
+Once units are classified and deduplicated (Step 3), group them into **features** — a
+coarser, separate structure used for a coverage rollup, not a replacement for the per-unit
+inventory built above.
+
+**Heuristic inference.** Infer feature boundaries from whichever signal is strongest for the
+repo's structure — do not force a single signal:
+- **Directory structure** — a top-level (or otherwise clearly-bounded) source directory
+  often maps 1:1 to a feature (e.g. `src/billing/`, `app/checkout/`).
+- **Route prefix** — HTTP routes sharing a common path prefix (e.g. everything under
+  `/api/orders/*`) usually belong to the same feature, even if their handlers live in
+  different files.
+- **Entry point** — a CLI command, queue consumer, or scheduled job entry point often
+  anchors a feature that fans out into several supporting units.
+
+Every code unit discovered in Step 2 must be assigned to **exactly one feature** — no
+orphans. If a unit genuinely spans two plausible features (e.g. shared utility code used by
+both billing and checkout), assign it to the feature it most directly serves and note the
+overlap rather than double-counting it or leaving it unassigned.
+
+**Importance tagging.** Tag each feature with exactly one of four labels:
+- `revenue-path` — directly on the path to revenue (checkout, billing, payments)
+- `security-path` — auth, authz, secrets handling, PII boundaries
+- `core` — primary product functionality outside the above two
+- `auxiliary` — internal tooling, admin-only surfaces, low-traffic utilities
+
+Importance is **prioritization-only** — it tells a human which features to shore up first.
+It never excludes a feature from the denominator used to compute `feature_coverage_pct`
+(defined below). An `auxiliary` feature is exactly as "counted" as a `revenue-path` feature;
+importance affects order of attention, not membership in the coverage calculation.
+
+**This is not the same as Step 4's per-unit criticality tier.** A feature's importance label
+and a unit's criticality tier (`critical` / `high` / `medium`, assigned in Step 4) are
+independent, differently-shaped concepts — one tags a coarse group, the other tags an
+individual unit — and must not be conflated or merged into a single field. Feature importance
+does not feed, replace, or override Step 4's per-unit criticality ranking, and per Step 4's
+own note, neither drives separate CI enforcement thresholds.
+
+**This feature-grouping structure must not reintroduce a maintained per-file criticality to
+CI mapping.** The whole point of Step 4's note ("Maintaining a criticality inventory just for
+CI enforcement creates mapping decay as the codebase evolves") applies here too, at a
+coarser grain: features and their importance labels are a coverage-rollup and prioritization
+structure only, never a maintained per-file (or per-feature) mapping that any CI gate
+consults directly. If a CI threshold is ever introduced, it must stay tier-agnostic, exactly
+as Step 4 already prescribes for criticality.
+
+**Ambiguous groupings.** When a unit's feature assignment is genuinely unclear, this is not a
+new mechanism — reuse the skill's existing pattern exactly: list it in the "Ambiguous items"
+section using the identical wording already used for classifier-confidence flags
+("classifier was not confident"; see Sampling tips and the template's Ambiguous items
+section). A reviewer confirms the grouping the same way they confirm an uncertain
+category/layer classification.
+
+**Required layer.** Each feature's "required layer" in the Features table is the *highest*
+layer among its member units' prescribed layers, per the canonical-layer hierarchy from
+Step 3 (`unit > integration > smoke > E2E`, lowest-to-highest reversed here — E2E is
+highest). E.g. a feature whose member units are prescribed unit, unit, and E2E has a
+required layer of E2E — the feature as a whole isn't provably covered until its
+highest-layer member is.
+
+**`feature_coverage_pct`.** Compute this value during the SKILL run as:
+
+```
+feature_coverage_pct = covered_features / total_features x 100
+```
+
+A feature counts as "covered" once every member unit in the per-unit inventory has at least
+one test at its prescribed layer (per Phase 3's findings, or per the pre-existing test suite
+if already known at inventory time). There is **no exclusion category of any kind** — every
+feature identified in this step is included in `total_features` regardless of its importance
+label, size, or anything else. Nothing is excluded from either numerator-eligibility or the
+denominator based on importance.
+
 ### Step 4 — rank by criticality
 
 Three tiers:
@@ -131,7 +205,7 @@ When `deploy_model == 'staged'`, proceed with the existing canary-eligibility ru
 
 ### Step 6 — write the artifact
 
-Load the template at `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-inventory.md.tmpl` and fill it in. Write to `docs/test-readiness/test-inventory.md` in the target repo. Create the directory if missing.
+Load the template at `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-inventory.md.tmpl` and fill it in, including the Features section — populate `{{FEATURES_ROWS}}` with one row per feature from Step 3b (feature name, member units, required layer, importance, covered y/n) and `{{FEATURE_COVERAGE_PCT}}` with the computed value. Write to `docs/test-readiness/test-inventory.md` in the target repo. Create the directory if missing.
 
 ## Sampling tips for large repos
 

--- a/plugins/shipwright/skills/test-inventory/SKILL.md
+++ b/plugins/shipwright/skills/test-inventory/SKILL.md
@@ -154,10 +154,9 @@ category/layer classification.
 
 **Required layer.** Each feature's "required layer" in the Features table is the *highest*
 layer among its member units' prescribed layers, per the canonical-layer hierarchy from
-Step 3 (`unit > integration > smoke > E2E`, lowest-to-highest reversed here — E2E is
-highest). E.g. a feature whose member units are prescribed unit, unit, and E2E has a
-required layer of E2E — the feature as a whole isn't provably covered until its
-highest-layer member is.
+Step 3, ascending from unit (lowest) to integration to smoke to E2E (highest). E.g. a
+feature whose member units are prescribed unit, unit, and E2E has a required layer of E2E —
+the feature as a whole isn't provably covered until its highest-layer member is.
 
 **`feature_coverage_pct`.** Compute this value during the SKILL run as:
 


### PR DESCRIPTION
## Summary
- Adds Step 3b to `test-inventory/SKILL.md`: a heuristic feature-grouping step (directory / route-prefix / entry-point inference) that assigns every classified code unit to exactly one feature and tags each feature with an importance label (`revenue-path` / `security-path` / `core` / `auxiliary`), documented as prioritization-only and never excluding a feature from the `feature_coverage_pct` denominator
- Extends `test-inventory.md.tmpl` with a `## Features` section (feature name, member units, required layer, importance, covered y/n) plus `{{FEATURES_ROWS}}` and `{{FEATURE_COVERAGE_PCT}}` placeholders
- Ambiguous groupings reuse the skill's existing "classifier was not confident" pattern in the Ambiguous items section verbatim — no new flagging mechanism; explicitly documents this structure must not reintroduce a maintained per-file criticality→CI mapping
- Adds `SKILL.content.test.ts` (first test file for this skill) asserting the new grouping instructions, the verbatim `covered_features / total_features x 100` formula, and the template's Features section are present

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | test-inventory.md.tmpl renders a features section with every code unit assigned to exactly one feature, tagged with an importance label | MET |
| 2 | Ambiguous groupings appear in the existing 'Ambiguous items' section using identical wording/pattern to today's classifier-confidence flags | MET |
| 3 | feature_coverage_pct formula documented verbatim in SKILL.md as covered_features / total_features x 100, with no exclusion category of any kind | MET |
| 4 | SKILL.content.test.ts added (first for this skill) asserting grouping instructions, formula text, and template section are present | MET |

## Test Plan
- `bun test plugins/shipwright/skills/test-inventory/SKILL.content.test.ts` — 22/22 pass
- `bunx biome lint .` — clean
- `bun plugins/shipwright/scripts/check-banned-strings.ts` — clean
- `bun run scripts/check-config-docs.ts` — clean
- `bun run scripts/sync-version.ts --check` — clean
- `bun run --filter='*' --sequential typecheck` — clean
- Full `bun test` suite — 6164 pass, 1 pre-existing unrelated flake (`metrics/src/lib/errors.unit.test.ts`, passes in isolation, order-dependent global leak unrelated to this docs-only change)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
