### PR TITLE
feat: extract CoverageParser interface from check-coverage.ts

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -5,7 +5,6 @@
 // coverageThreshold enforces a PER-FILE minimum instead, which would fail CI
 // on individual low-coverage files regardless of overall coverage — hence
 // this separate aggregate gate.
-export {};
 
 const THRESHOLD_LINES = 80;
 const THRESHOLD_FUNCTIONS = 80;
@@ -46,83 +45,107 @@ const EXCLUDE_PREFIXES = [
 const EXCLUDE_SUBSTRINGS = ["prisma/client/"];
 const LCOV_PATH = "coverage/lcov.info";
 
-const lcov = await Bun.file(LCOV_PATH)
-  .text()
-  .catch(() => {
-    console.error(
-      `No coverage file at ${LCOV_PATH}. Run: bun test --coverage --coverage-reporter=lcov`,
-    );
-    process.exit(1);
-  });
-
-type FileStats = {
+export type FileStats = {
+  path: string;
   lf: number;
   lh: number;
   fnf: number;
   fnh: number;
 };
-const files: Record<string, FileStats> = {};
-let current = "";
 
-for (const line of lcov.split("\n")) {
-  if (line.startsWith("SF:")) {
-    current = line.slice(3);
-    files[current] = { lf: 0, lh: 0, fnf: 0, fnh: 0 };
-  } else if (line.startsWith("LF:")) {
-    files[current].lf = Number.parseInt(line.slice(3), 10);
-  } else if (line.startsWith("LH:")) {
-    files[current].lh = Number.parseInt(line.slice(3), 10);
-  } else if (line.startsWith("FNF:")) {
-    files[current].fnf = Number.parseInt(line.slice(4), 10);
-  } else if (line.startsWith("FNH:")) {
-    files[current].fnh = Number.parseInt(line.slice(4), 10);
+export interface CoverageParser {
+  parse(content: string): FileStats[];
+}
+
+// Parses LCOV-format content (SF:/LF:/LH:/FNF:/FNH: records) into an
+// ordered FileStats[] — one entry per SF: block, in the order each first
+// appears in the content (mirrors the insertion order of the original
+// `files: Record<string, FileStats>` map this was extracted from).
+export const LcovParser: CoverageParser = {
+  parse(content: string): FileStats[] {
+    const files: FileStats[] = [];
+    let current: FileStats | undefined;
+
+    for (const line of content.split("\n")) {
+      if (line.startsWith("SF:")) {
+        current = { path: line.slice(3), lf: 0, lh: 0, fnf: 0, fnh: 0 };
+        files.push(current);
+      } else if (line.startsWith("LF:")) {
+        if (current) current.lf = Number.parseInt(line.slice(3), 10);
+      } else if (line.startsWith("LH:")) {
+        if (current) current.lh = Number.parseInt(line.slice(3), 10);
+      } else if (line.startsWith("FNF:")) {
+        if (current) current.fnf = Number.parseInt(line.slice(4), 10);
+      } else if (line.startsWith("FNH:")) {
+        if (current) current.fnh = Number.parseInt(line.slice(4), 10);
+      }
+    }
+
+    return files;
+  },
+};
+
+async function main() {
+  const lcov = await Bun.file(LCOV_PATH)
+    .text()
+    .catch(() => {
+      console.error(
+        `No coverage file at ${LCOV_PATH}. Run: bun test --coverage --coverage-reporter=lcov`,
+      );
+      process.exit(1);
+    });
+
+  const files = LcovParser.parse(lcov);
+
+  const relevant = files.filter(
+    (file) =>
+      !EXCLUDE_PREFIXES.some((ex) => file.path.startsWith(ex)) &&
+      !EXCLUDE_SUBSTRINGS.some((sub) => file.path.includes(sub)),
+  );
+
+  if (relevant.length === 0) {
+    console.log("No source files in coverage report.");
+    process.exit(0);
   }
-}
 
-const relevant = Object.entries(files).filter(
-  ([path]) =>
-    !EXCLUDE_PREFIXES.some((ex) => path.startsWith(ex)) &&
-    !EXCLUDE_SUBSTRINGS.some((sub) => path.includes(sub)),
-);
+  let totalLf = 0;
+  let totalLh = 0;
+  let totalFnf = 0;
+  let totalFnh = 0;
 
-if (relevant.length === 0) {
-  console.log("No source files in coverage report.");
-  process.exit(0);
-}
+  for (const { path, lf, lh, fnf, fnh } of relevant) {
+    totalLf += lf;
+    totalLh += lh;
+    totalFnf += fnf;
+    totalFnh += fnh;
 
-let totalLf = 0;
-let totalLh = 0;
-let totalFnf = 0;
-let totalFnh = 0;
+    const linePct = lf === 0 ? 100 : (lh / lf) * 100;
+    const icon = linePct >= THRESHOLD_LINES ? "✅" : "⚠️";
+    console.log(`${icon}  ${linePct.toFixed(1).padStart(5)}%  ${path}`);
+  }
 
-for (const [path, { lf, lh, fnf, fnh }] of relevant) {
-  totalLf += lf;
-  totalLh += lh;
-  totalFnf += fnf;
-  totalFnh += fnh;
+  const overallLines = totalLf === 0 ? 100 : (totalLh / totalLf) * 100;
+  const overallFunctions = totalFnf === 0 ? 100 : (totalFnh / totalFnf) * 100;
 
-  const linePct = lf === 0 ? 100 : (lh / lf) * 100;
-  const icon = linePct >= THRESHOLD_LINES ? "✅" : "⚠️";
-  console.log(`${icon}  ${linePct.toFixed(1).padStart(5)}%  ${path}`);
-}
-
-const overallLines = totalLf === 0 ? 100 : (totalLh / totalLf) * 100;
-const overallFunctions = totalFnf === 0 ? 100 : (totalFnh / totalFnf) * 100;
-
-console.log(`
+  console.log(`
 Lines:     ${overallLines.toFixed(2)}% (${totalLh}/${totalLf}) — threshold: ${THRESHOLD_LINES}%
 Functions: ${overallFunctions.toFixed(2)}% (${totalFnh}/${totalFnf}) — threshold: ${THRESHOLD_FUNCTIONS}%`);
 
-const failures: string[] = [];
-if (overallLines < THRESHOLD_LINES)
-  failures.push(`Lines ${overallLines.toFixed(2)}% < ${THRESHOLD_LINES}%`);
-if (overallFunctions < THRESHOLD_FUNCTIONS)
-  failures.push(
-    `Functions ${overallFunctions.toFixed(2)}% < ${THRESHOLD_FUNCTIONS}%`,
-  );
+  const failures: string[] = [];
+  if (overallLines < THRESHOLD_LINES)
+    failures.push(`Lines ${overallLines.toFixed(2)}% < ${THRESHOLD_LINES}%`);
+  if (overallFunctions < THRESHOLD_FUNCTIONS)
+    failures.push(
+      `Functions ${overallFunctions.toFixed(2)}% < ${THRESHOLD_FUNCTIONS}%`,
+    );
 
-if (failures.length > 0) {
-  console.error(`\n❌ Coverage gate failed: ${failures.join(", ")}`);
-  process.exit(1);
+  if (failures.length > 0) {
+    console.error(`\n❌ Coverage gate failed: ${failures.join(", ")}`);
+    process.exit(1);
+  }
+  console.log("✅ Coverage gate passed");
 }
-console.log("✅ Coverage gate passed");
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/check-coverage.unit.test.ts
+++ b/scripts/check-coverage.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for scripts/check-coverage.ts
+ *
+ * Verifies LcovParser (the CoverageParser implementation for the lcov.info
+ * format) against a hand-built fixture. Pure logic, no I/O: parse(content)
+ * takes a raw lcov string and returns FileStats[] — nothing here touches
+ * the filesystem or triggers the script's process.exit side effects.
+ */
+import { describe, expect, test } from "bun:test";
+import { LcovParser } from "./check-coverage";
+
+describe("LcovParser.parse", () => {
+  test("parses a single-file lcov record into FileStats", () => {
+    const fixture = [
+      "SF:agent/src/example.ts",
+      "FNF:10",
+      "FNH:8",
+      "LF:100",
+      "LH:90",
+      "end_of_record",
+    ].join("\n");
+
+    const result = LcovParser.parse(fixture);
+
+    expect(result).toEqual([
+      { path: "agent/src/example.ts", lf: 100, lh: 90, fnf: 10, fnh: 8 },
+    ]);
+  });
+
+  test("parses multiple files in the same order they appear in the content", () => {
+    const fixture = [
+      "SF:a/first.ts",
+      "LF:10",
+      "LH:5",
+      "FNF:2",
+      "FNH:1",
+      "end_of_record",
+      "SF:b/second.ts",
+      "LF:20",
+      "LH:20",
+      "FNF:4",
+      "FNH:4",
+      "end_of_record",
+      "SF:c/third.ts",
+      "LF:0",
+      "LH:0",
+      "FNF:0",
+      "FNH:0",
+      "end_of_record",
+    ].join("\n");
+
+    const result = LcovParser.parse(fixture);
+
+    expect(result).toEqual([
+      { path: "a/first.ts", lf: 10, lh: 5, fnf: 2, fnh: 1 },
+      { path: "b/second.ts", lf: 20, lh: 20, fnf: 4, fnh: 4 },
+      { path: "c/third.ts", lf: 0, lh: 0, fnf: 0, fnh: 0 },
+    ]);
+  });
+
+  test("returns an empty array for empty content", () => {
+    expect(LcovParser.parse("")).toEqual([]);
+  });
+
+  test("ignores unrelated lcov prefixes (e.g. DA:, BRF:, BRH:) without disturbing current file stats", () => {
+    const fixture = [
+      "TN:",
+      "SF:agent/src/example.ts",
+      "FNF:3",
+      "FNH:2",
+      "DA:1,1",
+      "DA:2,0",
+      "BRF:0",
+      "BRH:0",
+      "LF:5",
+      "LH:4",
+      "end_of_record",
+    ].join("\n");
+
+    const result = LcovParser.parse(fixture);
+
+    expect(result).toEqual([
+      { path: "agent/src/example.ts", lf: 5, lh: 4, fnf: 3, fnh: 2 },
+    ]);
+  });
+
+  test("matches the pre-refactor aggregate computation on a sample multi-file fixture", () => {
+    // Same fixture shape as check-coverage.ts would read from coverage/lcov.info:
+    // multiple SF: records, each followed by FNF:/FNH:/LF:/LH: lines.
+    const fixture = [
+      "SF:agent/src/foo.ts",
+      "FNF:4",
+      "FNH:4",
+      "LF:40",
+      "LH:38",
+      "end_of_record",
+      "SF:metrics/src/bar.ts",
+      "FNF:6",
+      "FNH:3",
+      "LF:60",
+      "LH:30",
+      "end_of_record",
+      "SF:node_modules/should-be-parsed-but-excluded-downstream/index.js",
+      "FNF:1",
+      "FNH:1",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+    ].join("\n");
+
+    const result = LcovParser.parse(fixture);
+
+    // Hand-computed expected values — replicates what the pre-refactor
+    // inline SF:/LF:/LH:/FNF:/FNH: loop would have produced as
+    // `files: Record<string, FileStats>` entries, now as an ordered array.
+    const expected = [
+      { path: "agent/src/foo.ts", lf: 40, lh: 38, fnf: 4, fnh: 4 },
+      { path: "metrics/src/bar.ts", lf: 60, lh: 30, fnf: 6, fnh: 3 },
+      {
+        path: "node_modules/should-be-parsed-but-excluded-downstream/index.js",
+        lf: 1,
+        lh: 1,
+        fnf: 1,
+        fnh: 1,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+
+    // Sanity-check the aggregate arithmetic matches what the summary report
+    // would compute for the non-excluded files (foo.ts + bar.ts only —
+    // exclusion filtering itself is check-coverage.ts's downstream concern,
+    // not LcovParser's, but this documents the no-op contract end to end).
+    const relevant = result.filter((f) => !f.path.startsWith("node_modules/"));
+    const totalLf = relevant.reduce((sum, f) => sum + f.lf, 0);
+    const totalLh = relevant.reduce((sum, f) => sum + f.lh, 0);
+    const totalFnf = relevant.reduce((sum, f) => sum + f.fnf, 0);
+    const totalFnh = relevant.reduce((sum, f) => sum + f.fnh, 0);
+
+    expect(totalLf).toBe(100);
+    expect(totalLh).toBe(68);
+    expect(totalFnf).toBe(10);
+    expect(totalFnh).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts a `CoverageParser` interface (`parse(content: string): FileStats[]`) from `scripts/check-coverage.ts` and moves the existing lcov-parsing loop into an `LcovParser` implementation of it.
- Wraps the script's I/O + gate logic in `main()`, guarded by `if (import.meta.main)`, so `LcovParser` can be imported and unit-tested without triggering the real file read / `process.exit` side effects.
- No behavior change: `THRESHOLD_LINES`/`THRESHOLD_FUNCTIONS` stay at 80, `EXCLUDE_PREFIXES`/`EXCLUDE_SUBSTRINGS` unchanged, output formatting unchanged.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | lcov-parsing behavior bit-for-bit unchanged | MET | Verified empirically: generated a real `coverage/lcov.info` via `bun test --coverage`, ran the pre-refactor script (via `git stash`) and the refactored script against the identical file — diff of stdout + exit code was empty. |
| 2 | LcovParser implements CoverageParser interface | MET | `export const LcovParser: CoverageParser = { parse(content: string): FileStats[] {...} }` |
| 3 | Fixture-driven `check-coverage.unit.test.ts` added | MET | New test file with 5 tests, including one that reproduces the pre-refactor aggregate computation on a sample multi-file fixture. |

## Test Plan
- `bun test scripts/check-coverage.unit.test.ts` — 5/5 pass
- `bun test scripts/` — 630 pass, 0 fail
- `bunx biome check` on changed files — clean
- Manual bit-for-bit diff of old vs. new script output against a real generated `coverage/lcov.info` — identical
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
