### PR TITLE
feat: c8/nyc Istanbul JSON parser adapter

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -85,6 +85,76 @@ export const LcovParser: CoverageParser = {
   },
 };
 
+// Raw Istanbul coverage shapes (c8/nyc's native `coverage-final.json`), pared
+// down to the fields FileStats derivation needs. branchMap/b are present in
+// real output but irrelevant here.
+type IstanbulStatement = { start: { line: number } };
+type IstanbulFileCoverage = {
+  path: string;
+  statementMap: Record<string, IstanbulStatement>;
+  fnMap: Record<string, unknown>;
+  s: Record<string, number>;
+  f: Record<string, number>;
+};
+
+// Derives line coverage the same way istanbul-lib-coverage does: Istanbul
+// tracks coverage per *statement*, not per line, so a single line with
+// multiple statements (e.g. a chained expression split across `;`s on one
+// line) must be deduplicated onto its starting line number rather than
+// counted per statement. A line counts as "found" once if any statement
+// starts on it, and as "hit" if at least one statement starting on that
+// line has a hit count > 0.
+function deriveLineCoverage(
+  statementMap: Record<string, IstanbulStatement>,
+  hits: Record<string, number>,
+): { lf: number; lh: number } {
+  const maxHitsByLine = new Map<number, number>();
+
+  for (const [id, statement] of Object.entries(statementMap)) {
+    const line = statement.start.line;
+    const hit = hits[id] ?? 0;
+    const current = maxHitsByLine.get(line) ?? 0;
+    maxHitsByLine.set(line, Math.max(current, hit));
+  }
+
+  let lh = 0;
+  for (const maxHit of maxHitsByLine.values()) {
+    if (maxHit > 0) lh++;
+  }
+
+  return { lf: maxHitsByLine.size, lh };
+}
+
+// Parses c8/nyc's native Istanbul JSON format (e.g. `c8 --reporter=json` or
+// `nyc report --reporter=json`, a.k.a. `coverage-final.json`): a JSON object
+// keyed by absolute file path, each value carrying statementMap/s (statement
+// hit counts) and fnMap/f (function hit counts). Line coverage is NOT a raw
+// statement count — see deriveLineCoverage above.
+export const IstanbulParser: CoverageParser = {
+  parse(content: string): FileStats[] {
+    if (!content.trim()) return [];
+
+    let raw: Record<string, IstanbulFileCoverage>;
+    try {
+      raw = JSON.parse(content);
+    } catch {
+      return [];
+    }
+
+    const files: FileStats[] = [];
+
+    for (const [, file] of Object.entries(raw)) {
+      const { lf, lh } = deriveLineCoverage(file.statementMap, file.s);
+      const fnf = Object.keys(file.fnMap).length;
+      const fnh = Object.values(file.f).filter((hit) => hit > 0).length;
+
+      files.push({ path: file.path, lf, lh, fnf, fnh });
+    }
+
+    return files;
+  },
+};
+
 async function main() {
   const lcov = await Bun.file(LCOV_PATH)
     .text()

--- a/scripts/check-coverage.unit.test.ts
+++ b/scripts/check-coverage.unit.test.ts
@@ -2,12 +2,14 @@
  * Unit tests for scripts/check-coverage.ts
  *
  * Verifies LcovParser (the CoverageParser implementation for the lcov.info
- * format) against a hand-built fixture. Pure logic, no I/O: parse(content)
- * takes a raw lcov string and returns FileStats[] — nothing here touches
- * the filesystem or triggers the script's process.exit side effects.
+ * format) and IstanbulParser (the CoverageParser implementation for c8/nyc's
+ * native Istanbul JSON format) against hand-built fixtures. Pure logic, no
+ * I/O: parse(content) takes a raw string and returns FileStats[] — nothing
+ * here touches the filesystem or triggers the script's process.exit side
+ * effects.
  */
 import { describe, expect, test } from "bun:test";
-import { LcovParser } from "./check-coverage";
+import { IstanbulParser, LcovParser } from "./check-coverage";
 
 describe("LcovParser.parse", () => {
   test("parses a single-file lcov record into FileStats", () => {
@@ -141,5 +143,107 @@ describe("LcovParser.parse", () => {
     expect(totalLh).toBe(68);
     expect(totalFnf).toBe(10);
     expect(totalFnh).toBe(7);
+  });
+});
+
+describe("IstanbulParser.parse", () => {
+  test("derives line coverage from statement starting lines, not a raw statement count", () => {
+    // Two statements on line 1 (one hit, one not — line still counts as
+    // covered because at least one statement on it was hit), one statement
+    // on line 3 (not hit). Distinct starting lines = 2 (line 1, line 3), so
+    // lf must be 2, not 3 (the raw statementMap count).
+    const fixture = {
+      "/abs/path/to/file.js": {
+        path: "/abs/path/to/file.js",
+        statementMap: {
+          "0": { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+          "1": { start: { line: 1, column: 12 }, end: { line: 1, column: 20 } },
+          "2": { start: { line: 3, column: 2 }, end: { line: 3, column: 30 } },
+        },
+        fnMap: {
+          "0": { name: "foo" },
+        },
+        s: { "0": 5, "1": 0, "2": 0 },
+        f: { "0": 3 },
+        branchMap: {},
+        b: {},
+      },
+    };
+
+    const result = IstanbulParser.parse(JSON.stringify(fixture));
+
+    expect(result).toEqual([
+      { path: "/abs/path/to/file.js", lf: 2, lh: 1, fnf: 1, fnh: 1 },
+    ]);
+  });
+
+  test("counts function coverage from fnMap size and hit count in f", () => {
+    const fixture = {
+      "/abs/path/to/multi-fn.js": {
+        path: "/abs/path/to/multi-fn.js",
+        statementMap: {
+          "0": { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+        },
+        fnMap: {
+          "0": { name: "hitFn" },
+          "1": { name: "missedFn" },
+        },
+        s: { "0": 1 },
+        f: { "0": 4, "1": 0 },
+        branchMap: {},
+        b: {},
+      },
+    };
+
+    const result = IstanbulParser.parse(JSON.stringify(fixture));
+
+    expect(result).toEqual([
+      { path: "/abs/path/to/multi-fn.js", lf: 1, lh: 1, fnf: 2, fnh: 1 },
+    ]);
+  });
+
+  test("parses multiple files, preserving Object.entries key order", () => {
+    const fixture = {
+      "/abs/path/to/first.js": {
+        path: "/abs/path/to/first.js",
+        statementMap: {
+          "0": { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+          "1": { start: { line: 2, column: 0 }, end: { line: 2, column: 5 } },
+        },
+        fnMap: {},
+        s: { "0": 1, "1": 1 },
+        f: {},
+        branchMap: {},
+        b: {},
+      },
+      "/abs/path/to/second.js": {
+        path: "/abs/path/to/second.js",
+        statementMap: {
+          "0": { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+        },
+        fnMap: {
+          "0": { name: "bar" },
+        },
+        s: { "0": 0 },
+        f: { "0": 0 },
+        branchMap: {},
+        b: {},
+      },
+    };
+
+    const result = IstanbulParser.parse(JSON.stringify(fixture));
+
+    expect(result).toEqual([
+      { path: "/abs/path/to/first.js", lf: 2, lh: 2, fnf: 0, fnh: 0 },
+      { path: "/abs/path/to/second.js", lf: 1, lh: 0, fnf: 1, fnh: 0 },
+    ]);
+  });
+
+  test("returns an empty array for empty content", () => {
+    expect(IstanbulParser.parse("")).toEqual([]);
+  });
+
+  test("returns an empty array for an empty JSON object", () => {
+    expect(IstanbulParser.parse("{}")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add `IstanbulParser` implementing the `CoverageParser` interface (MTC-1.1), parsing c8/nyc's native Istanbul-format JSON (`coverage-final.json`)
- Derives line coverage by deduplicating statements onto their starting line number (matching `istanbul-lib-coverage` semantics), not a raw statement count
- Derives function coverage directly from `fnMap`/`f`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | IstanbulParser implements CoverageParser against c8/nyc Istanbul-format JSON | MET | `scripts/check-coverage.ts` exports `IstanbulParser: CoverageParser` |
| 2 | Test decision: unit test against a synthetic fixture Istanbul-format JSON file | MET | `scripts/check-coverage.unit.test.ts` — 5 new tests with inline synthetic fixtures |

## Test Plan
- Unit tests cover: same-line statement dedup (line covered if any statement on it is hit), function hit/miss counting, multi-file ordering, and empty-input (`""` / `"{}"`) edge cases
- `bun test scripts/check-coverage.unit.test.ts` — 10/10 pass
- `bunx biome lint` — clean
- `bun run --filter='*' --sequential typecheck` — clean
- Aggregate coverage gate (`bun scripts/check-coverage.ts`) — 81.27% lines / 82.47% functions, both above 80% threshold
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
