### PR TITLE
docs: extend repo-config branch-protection pairing to 3-stage lifecycle

### DIFF
--- a/plugins/shipwright/skills/repo-config/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/repo-config/SKILL.content.test.ts
@@ -1,0 +1,178 @@
+/**
+ * repo-config content tests — coverage-check 3-stage branch-protection
+ * pairing lifecycle (RAT-1.1).
+ *
+ * The existing "pairing rule" section documents a 2-stage pattern (CI job
+ * lands -> dependent task enables it as required) for general workflow
+ * tasks (test.yml, canary, deploy). The coverage-required-check needs a
+ * third stage because raising the floor straight to a hard 90% gate would
+ * instantly break every repo currently below it:
+ *
+ *   1. coverage CI job lands
+ *   2. "coverage must not decrease" required check enabled immediately
+ *      (paired task, same mechanism as the existing 2-stage pattern)
+ *   3. hard >=90% required check, auto-emitted by test-roadmap once it
+ *      confirms coverage_gate.line_coverage_pct >= 90 on a re-run
+ *
+ * A repo already >=90% at onboarding time skips stage 2 entirely and goes
+ * straight to stage 3 — no wasted never-decrease-only intermediate stage.
+ *
+ * These tests assert the new section exists alongside (not replacing) the
+ * original 2-stage table, and that its prose covers the 3-stage sequence,
+ * the never-decrease-immediately concept, test-roadmap's auto-promotion
+ * role, and the >=90%-skip-straight-to-hard-gate onboarding rule.
+ */
+import { beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SKILL_MD_PATH = join(import.meta.dir, "SKILL.md");
+
+let content: string;
+
+beforeAll(() => {
+  content = existsSync(SKILL_MD_PATH)
+    ? readFileSync(SKILL_MD_PATH, "utf-8")
+    : "";
+});
+
+describe("SKILL.md — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(SKILL_MD_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(content.length).toBeGreaterThan(200);
+  });
+});
+
+describe("SKILL.md — frontmatter", () => {
+  it("has frontmatter with name: repo-config", () => {
+    expect(content).toContain("name: repo-config");
+  });
+
+  it("has frontmatter with a description field", () => {
+    expect(content).toMatch(/^description:/m);
+  });
+});
+
+describe("SKILL.md — existing 2-stage pairing table stays intact", () => {
+  it("still has the original pairing-rule section header", () => {
+    expect(content).toContain("## The pairing rule (Phase 4 — test-roadmap)");
+  });
+
+  it("still documents the original workflow -> branch-protection table", () => {
+    expect(content).toContain(
+      "| Workflow task | Paired branch-protection task |",
+    );
+    expect(content).toContain("Create / update `test.yml` with required jobs");
+    expect(content).toContain("Add canary workflow");
+    expect(content).toContain("Add deploy workflow");
+  });
+
+  it("still documents the depends_on sequencing rationale", () => {
+    expect(content).toContain("`depends_on`");
+    expect(content).toMatch(/chicken-and-egg/i);
+  });
+});
+
+describe("SKILL.md — coverage-check 3-stage lifecycle section", () => {
+  it("has a new section header for the coverage-check pairing lifecycle", () => {
+    expect(content).toMatch(/## Coverage-check pairing \(3-stage lifecycle\)/);
+  });
+
+  it("places the new section after the existing pairing rule and before the closing checklist", () => {
+    const pairingIdx = content.indexOf(
+      "## The pairing rule (Phase 4 — test-roadmap)",
+    );
+    const coverageIdx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const closingIdx = content.indexOf(
+      "## The closing checklist (Phase 5 — test-fix)",
+    );
+    expect(pairingIdx).toBeGreaterThan(-1);
+    expect(coverageIdx).toBeGreaterThan(pairingIdx);
+    expect(closingIdx).toBeGreaterThan(coverageIdx);
+  });
+
+  it("frames the section as an extension of, not a replacement for, the general 2-stage pattern", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toMatch(/extends?/i);
+    expect(section).toMatch(/2-stage/);
+  });
+
+  it("documents all three stages: job lands, never-decrease required, hard-90%-required", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toMatch(/coverage CI job lands/i);
+    expect(section).toMatch(/never-decrease/i);
+    expect(section).toMatch(
+      /hard-90%-required|hard.*90%.*required|hard ≥?>=?\s*90%/i,
+    );
+  });
+
+  it("states the never-decrease check is required immediately, mirroring the existing pairing pattern", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toMatch(/immediately/i);
+  });
+
+  it("names test-roadmap as the component that auto-emits the promotion task on gap closure", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toContain("test-roadmap");
+    expect(section).toMatch(/auto(?:matic(?:ally)?|-emit|matically emits?)/i);
+  });
+
+  it("references the coverage_gate.line_coverage_pct >= 90 detection condition", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toContain("line_coverage_pct");
+    expect(section).toMatch(/>=\s*90|≥\s*90/);
+  });
+
+  it("states promotion happens without manual intervention", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toMatch(
+      /no manual (step|intervention)|without manual intervention/i,
+    );
+  });
+
+  it("documents the >=90%-at-onboarding skip rule directly to the hard gate", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    const mentionsSkip = /skip/i.test(section);
+    const mentionsOnboarding = /onboard/i.test(section);
+    const mentionsDirectlyToHardGate =
+      /directly|straight/i.test(section) &&
+      /hard gate|hard.*90%/i.test(section);
+    expect(mentionsSkip).toBe(true);
+    expect(mentionsOnboarding).toBe(true);
+    expect(mentionsDirectlyToHardGate).toBe(true);
+  });
+
+  it("clarifies the never-decrease stage is unnecessary when already at or above 90%", () => {
+    const idx = content.indexOf(
+      "## Coverage-check pairing (3-stage lifecycle)",
+    );
+    const section = content.slice(idx, idx + 2500);
+    expect(section).toMatch(/unnecessar(?:y|ily)/i);
+  });
+});

--- a/plugins/shipwright/skills/repo-config/SKILL.md
+++ b/plugins/shipwright/skills/repo-config/SKILL.md
@@ -92,6 +92,31 @@ Pattern:
 
 The branch-protection task `depends_on` the workflow task. Land workflow first; verify green on main for a few days; then enable protection. Sequencing is in this order to avoid the chicken-and-egg block.
 
+## Coverage-check pairing (3-stage lifecycle)
+
+The coverage-required-check is a specific instance of the pairing rule above, extending the
+general 2-stage pattern (job lands → dependent task enables it as required) to a 3-stage
+lifecycle. The general 2-stage table still governs `test.yml`/canary/deploy workflow tasks
+unchanged — this section adds a third stage for the coverage gate only, because jumping
+straight from "no coverage check" to "hard ≥90% required check" would instantly break every
+repo currently below that floor. `test-roadmap` (Phase 4) is the component that detects gap
+closure and auto-emits the stage-3 promotion task, mirroring the same role it plays applying
+the pairing rule above.
+
+Stages:
+
+| Stage | Trigger | What happens |
+|---|---|---|
+| 1. Coverage CI job lands | `test.yml` gains a coverage-computing job | No required check yet — signal only |
+| 2. Never-decrease required (immediately) | Paired task, same mechanism as the pairing rule above | Branch protection requires a "coverage must not decrease" status check as soon as the coverage CI job lands — `depends_on` the job-lands task, enabled immediately, not deferred |
+| 3. Hard ≥90% required (auto-emitted) | `test-roadmap` re-run detects `coverage_gate.line_coverage_pct >= 90` | `test-roadmap` automatically emits a repo-config task promoting the required check from never-decrease to a hard ≥90% gate — no manual step |
+
+**Onboarding skip rule:** a repo already at ≥90% line coverage at onboarding time skips
+stage 2 entirely and goes straight to stage 3 — the hard ≥90% gate. Passing through the
+never-decrease stage first would be unnecessary when the repo already clears the target
+floor; only repos onboarding below 90% need the never-decrease stage as an interim gate
+while their roadmap closes the gap.
+
 ## The closing checklist (Phase 5 — test-fix)
 
 Every task-store task `test-fix` queues must carry closing-checklist concerns in its


### PR DESCRIPTION
## Summary
- Extends `repo-config/SKILL.md`'s documented 2-stage branch-protection pairing pattern with a new, separate "Coverage-check pairing (3-stage lifecycle)" section for the coverage-required-check specifically: coverage CI job lands → "coverage must not decrease" required check enabled immediately → hard ≥90% required check, auto-emitted by `test-roadmap` once it confirms `coverage_gate.line_coverage_pct >= 90` on a re-run.
- Documents the onboarding skip rule: a repo already at ≥90% line coverage at onboarding skips the never-decrease stage entirely and goes straight to the hard gate.
- Adds `plugins/shipwright/skills/repo-config/SKILL.content.test.ts` — the first test file for this skill — with 17 tests asserting the new section's content and that the original 2-stage table/section remains fully intact.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | repo-config/SKILL.md documents the 3-stage lifecycle, extending rather than replacing the existing 2-stage pairing table | MET |
| 2 | A repo already >=90% at onboarding is documented as skipping straight to the hard gate, no unnecessary never-decrease stage | MET |
| 3 | Test decision: add plugins/shipwright/skills/repo-config/SKILL.content.test.ts (new — first test file for this skill) asserting the 3-stage pattern text is present | MET |

## Test Plan
- `bun test plugins/shipwright/skills/repo-config/SKILL.content.test.ts` — 17/17 pass
- `bunx biome lint .` — clean
- `task check-strings` — clean
- Typecheck — clean
- Full `task ci` has one pre-existing, unrelated failure (`agent/src/claude.unit.test.ts` — "empty extraAllowedTools produces identical args to no extraAllowedTools"), confirmed to also fail on `main` unmodified — not introduced by this PR, out of scope for RAT-1.1.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
