### PR TITLE
feat: feature-gap sequencing + anti-gaming rule

### DIFF
--- a/plugins/shipwright/TESTING.md
+++ b/plugins/shipwright/TESTING.md
@@ -1358,6 +1358,24 @@ opted out. This is the fix for an incident where a target repo's roadmap sat a s
 `pending`/HITL for multiple cycles, asking for the entire ~15-service loop (~8 net-new
 production credentials) in one shot, with no prior live-recording precedent to automate.
 
+### TR-28 — Feature-coverage gaps sequenced ahead of line-coverage filler + anti-gaming citation rule
+**Steps:** No automated test covers the sequencing/rejection judgment itself — both are
+prompt-only generation/filing logic (content-assertion tests in `SKILL.content.test.ts`
+cover only that the instruction text exists, not that an LLM run obeys it). Verify via two
+dry runs: (a) run `/test-roadmap` against a repo whose Phase 3 migration output has, within
+the same milestone, both a feature-coverage-gap-closing row (a `critical`/`high` tier item
+closing a named feature/error-path gap) and a line-coverage-filler row (a row whose only
+stated justification is raising `line_coverage_pct`). (b) run `/test-fix` against a
+`test-readiness-plan.md` whose task list contains a line-coverage-bucket row with no cited
+feature/error-path mapping in its outcome column (assertion-free filler, e.g. "add a test for
+a trivial getter to raise line coverage").
+**Expected:** (a) In the generated task list, every feature-coverage-closing `T-NNN` row for
+that milestone is sequenced ahead of every line-coverage-filler `T-NNN` row for the same
+milestone — a milestone with only one gap type is unaffected (no-op). (b) `/test-fix` skips
+filing the uncited row and prints `Skipping {T-NNN} — line-coverage task has no cited
+feature/error-path mapping (possible coverage gaming)`; a line-coverage row that does cite a
+genuine uncovered error path (e.g. an untested `catch` block) files normally.
+
 ---
 
 ## Versioning Checklist (for every PR to this repo)

--- a/plugins/shipwright/skills/test-fix/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-fix/SKILL.content.test.ts
@@ -31,6 +31,25 @@ describe("test-fix — SKILL.md exists", () => {
   });
 });
 
+describe("test-fix — anti-gaming rejection rule for uncited line-coverage tasks", () => {
+  it("requires a line-coverage task to cite the specific feature or genuine uncovered error path it maps to", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toContain("line-coverage");
+    expect(lower).toMatch(/cite (the )?specific feature|cite.{0,60}error path/s);
+  });
+
+  it("rejects or flags a citation-less line-coverage row instead of filing it as a normal task", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toMatch(/assertion-free filler/);
+    expect(lower).toMatch(/(reject|flag)/);
+  });
+
+  it("names the gaming pattern of padding coverage without closing a real gap", () => {
+    const lower = readSkill().toLowerCase();
+    expect(lower).toMatch(/gam(e|ing)/);
+  });
+});
+
 describe("test-fix — Step 4 dedup query is pagination-safe", () => {
   it("raises the dedup query limit well above the API's default page size", () => {
     expect(readSkill()).toContain("limit=1000");

--- a/plugins/shipwright/skills/test-fix/SKILL.md
+++ b/plugins/shipwright/skills/test-fix/SKILL.md
@@ -94,6 +94,21 @@ Before starting, check for flags:
      here beyond noting the overlap.
    This runs once, here in Step 2, so both the `--dry-run` preview (Step 6) and the real queue
    path (Step 7) operate on the same already-verified row set.
+6. **Anti-gaming check — reject an uncited line-coverage row.** A `bucket`/`layer` row whose
+   only justification is raising `line_coverage_pct` (a **line-coverage** task, per
+   `test-roadmap/SKILL.md`'s sequencing rule in its own Process step 5) must cite, in its
+   `outcome` column or paired description text, the specific feature or genuine uncovered
+   error path it maps to — e.g. a named feature from `test-inventory.md`, or a specific
+   uncovered error path/branch (an untested `catch` block, an untested validation branch). This
+   is a structural check only: it confirms a citation is present, it does not verify the
+   citation is true. If a line-coverage row has no such citation — assertion-free filler added
+   just to move the aggregate line-coverage number, e.g. testing a trivial getter with no real
+   behavior at stake — **reject it: skip filing the row**, the same silent-skip convention used
+   for the Checklist Items 1–2 drops above. Print: `Skipping {T-NNN} — line-coverage task has no
+   cited feature/error-path mapping (possible coverage gaming)`. A line-coverage row that cites
+   a genuine uncovered error path (e.g. "closes the untested retry-exhaustion catch block in
+   `paymentsGatewayClient.ts`") is not gaming and files normally — this check targets
+   citation-less filler, not every line-coverage-bucket row.
 
 ---
 

--- a/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
@@ -279,6 +279,41 @@ describe("SKILL.md — template placeholders wired from the script output", () =
   });
 });
 
+describe("SKILL.md — feature-coverage gaps sequenced ahead of line-coverage filler", () => {
+  function step5Section(): string {
+    const idx = content.indexOf(
+      "5. Generate the task list by walking the migration buckets",
+    );
+    const nextStepIdx = content.indexOf(
+      "6. **Apply the pairing rule**",
+    );
+    expect(idx).toBeGreaterThan(-1);
+    expect(nextStepIdx).toBeGreaterThan(idx);
+    return content.slice(idx, nextStepIdx);
+  }
+
+  it("states that within a milestone, feature-coverage-closing tasks are sequenced ahead of line-coverage filler tasks", () => {
+    const section = step5Section();
+    expect(section).toMatch(/feature-coverage/i);
+    expect(section).toMatch(/ahead of/i);
+    expect(section).toMatch(/line-coverage/i);
+    expect(section).toMatch(/filler/i);
+  });
+
+  it("scopes the sequencing rule to when both gap types coexist in the same milestone", () => {
+    const section = step5Section();
+    expect(section).toMatch(/same milestone/i);
+    expect(section).toMatch(/both/i);
+  });
+
+  it("reinforces the sequencing rule in Failure modes to avoid", () => {
+    const failureModesIdx = content.indexOf("## Failure modes to avoid");
+    expect(failureModesIdx).toBeGreaterThan(-1);
+    const section = content.slice(failureModesIdx);
+    expect(section).toMatch(/line-coverage filler task ahead of a feature-coverage-closing task/i);
+  });
+});
+
 describe("test-readiness-plan.md.tmpl — file exists and has content", () => {
   it("file exists", () => {
     expect(existsSync(TEMPLATE_PATH)).toBe(true);

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -267,6 +267,15 @@ Anything the audit couldn't determine without a human call. Common entries:
    emitted `T-NNN` sequence — line-coverage filler never precedes a feature-coverage-closing
    task within the same milestone. This is a no-op when a milestone contains only one gap type
    (all feature-coverage-closing, or all line-coverage filler): there is nothing to reorder.
+
+   **Note on line-coverage filler provenance:** the five migration buckets this walk pulls
+   from (reuse/promote/rebuild/delete/net-new) are all inventory-derived — every row this walk
+   emits traces to a concrete `test-inventory.md`/`test-migration.md` item, so this walk itself
+   has no path that emits a line-coverage-filler row. Line-coverage filler rows are the kind a
+   human or an agent adds by hand to a milestone outside this walk (e.g. padding a milestone to
+   hit a line-coverage target before merge). This sequencing rule — and the matching
+   `test-fix/SKILL.md` anti-gaming check — exists to catch that ad-hoc row if and when one is
+   added, not to reorder anything this walk generates on its own.
 6. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
 7. **Apply the E2E classification guardrail** (non-negotiable): Before emitting any task with `layer: e2e`, verify against test-system.md's "Classifying a new test" step that the proposed test journey actually exercises a real browser (step 4: "Does it test a multi-step browser flow? → e2e (Playwright)"). If the journey is a backend orchestration flow, an API contract test, or any other non-browser interaction, downgrade the task to `layer: integration` or `layer: smoke` with a one-line note explaining why (e.g., "backend orchestration flow — moved to smoke"). This guardrail prevents shipping e2e tasks that violate the test classification rules, ensuring the e2e layer contains only true multi-step browser-driven flows.
 8. **Compute the coverage_gate block by invoking `scripts/check-coverage-gate.ts` — never

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -255,6 +255,18 @@ Anything the audit couldn't determine without a human call. Common entries:
      pipeline that doesn't exist.
    - Milestone 4: all `high` tier items (net-new + rebuild + promote)
    - Milestone 5: all `delete (redundant)` items + remaining `rebuild` cleanup + plugin feedback collector
+
+   **Sequencing rule — feature-coverage gaps ahead of line-coverage filler (within the same
+   milestone).** A milestone can contain two distinct gap types: **feature-coverage-closing**
+   tasks (a task whose outcome closes an actual untested feature/critical-path item — e.g. a
+   `critical`/`high` tier row from the inventory buckets, or any row whose outcome closes a
+   named feature/error-path gap) and **line-coverage filler** tasks (a task whose only
+   justification is raising the aggregate `line_coverage_pct`, with no feature/error-path gap
+   behind it). Whenever both types are being generated for the same milestone, order every
+   feature-coverage-closing task ahead of every line-coverage filler task in that milestone's
+   emitted `T-NNN` sequence — line-coverage filler never precedes a feature-coverage-closing
+   task within the same milestone. This is a no-op when a milestone contains only one gap type
+   (all feature-coverage-closing, or all line-coverage filler): there is nothing to reorder.
 6. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
 7. **Apply the E2E classification guardrail** (non-negotiable): Before emitting any task with `layer: e2e`, verify against test-system.md's "Classifying a new test" step that the proposed test journey actually exercises a real browser (step 4: "Does it test a multi-step browser flow? → e2e (Playwright)"). If the journey is a backend orchestration flow, an API contract test, or any other non-browser interaction, downgrade the task to `layer: integration` or `layer: smoke` with a one-line note explaining why (e.g., "backend orchestration flow — moved to smoke"). This guardrail prevents shipping e2e tasks that violate the test classification rules, ensuring the e2e layer contains only true multi-step browser-driven flows.
 8. **Compute the coverage_gate block by invoking `scripts/check-coverage-gate.ts` — never
@@ -333,6 +345,10 @@ Anything the audit couldn't determine without a human call. Common entries:
   canary-plumbing tasks for a pipeline that doesn't exist, requiring 8 tasks to be
   manually cancelled. When not staged, emit the `canary not applicable -- deploy_model={value}`
   note in section 4 and skip the milestone — zero tasks, not a smaller pile of tasks.
+- **Don't sequence a line-coverage filler task ahead of a feature-coverage-closing task within
+  the same milestone.** When both gap types are present in a milestone, the feature-coverage
+  gap is the real gap; a line-coverage filler task only moves the aggregate percentage. Order
+  feature-coverage-closing tasks first.
 - **Don't bundle "build a never-proven capability" and "automate it on a schedule" into one
   task.** This is not hypothetical either: one target repo's cycle-3 roadmap asked for the
   whole recorded-fixture-refresh loop (~15 services, ~8 net-new production credentials) in a


### PR DESCRIPTION
## Summary
- Add a sequencing rule to `test-roadmap/SKILL.md`'s task-list generation step: when a milestone has both a feature-coverage gap and a line-coverage gap, feature-coverage-closing tasks are always sequenced ahead of line-coverage filler tasks.
- Add an anti-gaming rejection rule to `test-fix/SKILL.md`'s task-filing step: a line-coverage task must cite the specific feature or genuine uncovered error path it maps to, or `test-fix` skips filing it as likely coverage-gaming filler.
- Extend `test-roadmap/SKILL.content.test.ts` and `test-fix/SKILL.content.test.ts` with content-assertion tests for both new rules, and add a `TR-28` dry-run verification entry to `TESTING.md`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | test-roadmap's task-list generation instructions sequence feature-gap-closing tasks ahead of line-coverage filler tasks whenever both gap types coexist in a milestone | MET |
| 2 | test-fix's task-filing instructions reject a line-coverage task with no cited feature/error-path mapping | MET |
| 3 | Test decision: extend the existing test-roadmap/SKILL.content.test.ts and test-fix/SKILL.content.test.ts for the new instructions | MET |

## Test Plan
- `bun test plugins/shipwright/skills/test-fix/SKILL.content.test.ts plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts` — 48 pass
- `bunx biome lint .` — clean
- `bun run --filter='*' --sequential typecheck` — clean
- [x] Pre-commit checks passing (full `task ci` green except one pre-existing, unrelated failure in `task-store/src/routes/prs.openapi.smoke.test.ts` that also fails identically on `main`)

Generated with [Claude Code](https://claude.com/claude-code)
