### PR TITLE
feat(test-roadmap): auto-emit stage-3 coverage promotion task on gate closure

### DIFF
--- a/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
@@ -166,7 +166,7 @@ describe("SKILL.md — coverage_gate Process step invokes the CLI script", () =>
       "Compute the coverage_gate block by invoking",
     );
     const nextStepIdx = content.indexOf(
-      '9. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`',
+      "9. **Auto-emit the stage-3 coverage-promotion task",
     );
     expect(idx).toBeGreaterThan(-1);
     expect(nextStepIdx).toBeGreaterThan(idx);
@@ -223,7 +223,7 @@ describe("SKILL.md — refuses to write test-readiness-plan.md on script failure
       "Compute the coverage_gate block by invoking",
     );
     const nextStepIdx = content.indexOf(
-      '9. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`',
+      "9. **Auto-emit the stage-3 coverage-promotion task",
     );
     expect(idx).toBeGreaterThan(-1);
     expect(nextStepIdx).toBeGreaterThan(idx);
@@ -261,7 +261,7 @@ describe("SKILL.md — refuses to write test-readiness-plan.md on script failure
 describe("SKILL.md — template placeholders wired from the script output", () => {
   it("lists all seven Coverage Gate placeholders in the render step", () => {
     const renderIdx = content.indexOf(
-      "Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`",
+      "10. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`",
     );
     expect(renderIdx).toBeGreaterThan(-1);
     const section = content.slice(renderIdx, renderIdx + 800);
@@ -311,6 +311,142 @@ describe("SKILL.md — feature-coverage gaps sequenced ahead of line-coverage fi
     expect(failureModesIdx).toBeGreaterThan(-1);
     const section = content.slice(failureModesIdx);
     expect(section).toMatch(/line-coverage filler task ahead of a feature-coverage-closing task/i);
+  });
+});
+
+describe("SKILL.md — step 6 cross-references the 3rd auto-emitted coverage-pairing stage", () => {
+  function step6Section(): string {
+    const idx = content.indexOf("6. **Apply the pairing rule**");
+    const nextStepIdx = content.indexOf(
+      "7. **Apply the E2E classification guardrail**",
+    );
+    expect(idx).toBeGreaterThan(-1);
+    expect(nextStepIdx).toBeGreaterThan(idx);
+    return content.slice(idx, nextStepIdx);
+  }
+
+  it("mentions the coverage-check pairing has a 3rd, auto-emitted stage", () => {
+    const section = step6Section();
+    expect(section).toMatch(/3(?:rd|-stage)/i);
+    expect(section).toMatch(/auto-emit/i);
+  });
+
+  it("references repo-config/SKILL.md's Coverage-check pairing (3-stage lifecycle) section", () => {
+    const section = step6Section();
+    expect(section).toContain("repo-config/SKILL.md");
+    expect(section).toContain("Coverage-check pairing (3-stage lifecycle)");
+  });
+});
+
+describe("SKILL.md — Process step 9 auto-emits the stage-3 coverage-promotion task", () => {
+  function step9Section(): string {
+    const idx = content.indexOf(
+      "9. **Auto-emit the stage-3 coverage-promotion task",
+    );
+    const nextStepIdx = content.indexOf(
+      "10. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`",
+    );
+    expect(idx).toBeGreaterThan(-1);
+    expect(nextStepIdx).toBeGreaterThan(idx);
+    return content.slice(idx, nextStepIdx);
+  }
+
+  it("exists as a numbered Process step between the coverage_gate step and the template-render step", () => {
+    const coverageGateIdx = content.indexOf(
+      "Compute the coverage_gate block by invoking",
+    );
+    const step9Idx = content.indexOf(
+      "9. **Auto-emit the stage-3 coverage-promotion task",
+    );
+    const step10Idx = content.indexOf(
+      "10. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`",
+    );
+    expect(coverageGateIdx).toBeGreaterThan(-1);
+    expect(step9Idx).toBeGreaterThan(coverageGateIdx);
+    expect(step10Idx).toBeGreaterThan(step9Idx);
+  });
+
+  it("gates emission on coverage_gate.line_coverage_pct >= 90 (only emitted when the gate closes)", () => {
+    const section = step9Section();
+    expect(section).toContain("line_coverage_pct");
+    expect(section).toMatch(/>=\s*90|≥\s*90/);
+  });
+
+  it("does not emit a promotion task when line_coverage_pct < 90", () => {
+    const section = step9Section();
+    expect(section).toMatch(/<\s*90/);
+    expect(section).toMatch(/no promotion task|nothing to do/i);
+  });
+
+  it("states the never-decrease check (stage 2) remains the active gate below 90%", () => {
+    const section = step9Section();
+    expect(section).toMatch(/never-decrease/i);
+    expect(section).toMatch(/still the active gate|remains the active gate/i);
+  });
+
+  it("follows the existing auto-pairing emission mechanism with no manual trigger step", () => {
+    const section = step9Section();
+    expect(section).toMatch(/auto-pairing/i);
+    expect(section).toMatch(/no manual (step|trigger)/i);
+  });
+
+  it("requires a dedup/already-filed check before emitting, to stay idempotent across re-runs", () => {
+    const section = step9Section();
+    expect(section).toMatch(/already been filed|already filed|already exists/i);
+    expect(section).toMatch(/idempoten/i);
+  });
+
+  it("reuses step 4's existing paginated task-store query result set for the dedup scan", () => {
+    const section = step9Section();
+    expect(section).toMatch(/step 4/i);
+    expect(section).toMatch(/scan/i);
+  });
+
+  it("skips emission (no duplicate row) when a matching stage-3 promotion task is found", () => {
+    const section = step9Section();
+    expect(section).toMatch(/skip/i);
+    expect(section).toMatch(/duplicate/i);
+  });
+
+  it("emits exactly one new T-NNN row into Milestone 1 with bucket: infra when the gate closes", () => {
+    const section = step9Section();
+    expect(section).toMatch(/exactly one/i);
+    expect(section).toContain("T-NNN");
+    expect(section).toMatch(/Milestone 1/);
+    expect(section).toContain("bucket: infra");
+  });
+
+  it("wires depends_on the stage-2 never-decrease task, mirroring step 6's pairing depends_on mechanism", () => {
+    const section = step9Section();
+    expect(section).toContain("depends_on");
+    expect(section).toMatch(/never-decrease/i);
+    expect(section).toMatch(/step 6/i);
+  });
+});
+
+describe("SKILL.md — Failure modes to avoid covers the stage-3 promotion task", () => {
+  function failureModesSection(): string {
+    const idx = content.indexOf("## Failure modes to avoid");
+    expect(idx).toBeGreaterThan(-1);
+    return content.slice(idx);
+  }
+
+  it("warns against refiling the stage-3 promotion task on every re-run once already emitted", () => {
+    const section = failureModesSection();
+    const hasBullet =
+      /refile/i.test(section) &&
+      /stage-3|promotion task/i.test(section) &&
+      /already/i.test(section);
+    expect(hasBullet).toBe(true);
+  });
+
+  it("warns against emitting the stage-3 promotion task before the gate has actually closed", () => {
+    const section = failureModesSection();
+    const hasBullet =
+      /before the gate/i.test(section) &&
+      /(closed|closes)/i.test(section) &&
+      /90/.test(section);
+    expect(hasBullet).toBe(true);
   });
 });
 

--- a/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts
@@ -422,6 +422,12 @@ describe("SKILL.md — Process step 9 auto-emits the stage-3 coverage-promotion 
     expect(section).toMatch(/never-decrease/i);
     expect(section).toMatch(/step 6/i);
   });
+
+  it("emits the stage-3 row with no depends_on when the scan finds no stage-2 task (onboarding-skip rule applied)", () => {
+    const section = step9Section();
+    expect(section).toMatch(/onboarding-skip/i);
+    expect(section).toMatch(/no stage-2 task is found|no depends_on/i);
+  });
 });
 
 describe("SKILL.md — Failure modes to avoid covers the stage-3 promotion task", () => {

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -351,6 +351,12 @@ Anything the audit couldn't determine without a human call. Common entries:
          wires `depends_on` for workflow-task → branch-protection-task pairs, so
          `test-fix`'s existing `depends_on:` parsing (Step 2.3 / Step 5.4) requires zero
          changes to pick up this new row.
+       - **Onboarding-skip fallback:** if no stage-2 task is found in the scan, this
+         means the onboarding-skip rule applied — the repo was already at ≥90% line
+         coverage at onboarding time and never had a stage-2 never-decrease task filed
+         (see `repo-config/SKILL.md`'s "Coverage-check pairing (3-stage lifecycle)"
+         section, "Onboarding skip rule"). In that case, emit the stage-3 row with no
+         `depends_on` — there is no stage-2 predecessor task to wire it to.
    This preserves the existing division of responsibility: `test-roadmap` stays
    markdown-only (no new task-store write path, no new skill) — it just adds one more row
    to the same Section 5 walk that step 6 already populates, and `test-fix` files it

--- a/plugins/shipwright/skills/test-roadmap/SKILL.md
+++ b/plugins/shipwright/skills/test-roadmap/SKILL.md
@@ -277,6 +277,13 @@ Anything the audit couldn't determine without a human call. Common entries:
    `test-fix/SKILL.md` anti-gaming check — exists to catch that ad-hoc row if and when one is
    added, not to reorder anything this walk generates on its own.
 6. **Apply the pairing rule** from `${CLAUDE_PLUGIN_ROOT}/skills/repo-config/SKILL.md`: every task that creates or modifies a CI workflow file MUST emit a paired branch-protection task that `depends_on` the workflow task. Without this, the audit ships as advisory rather than enforced. The pairing rule is non-negotiable; skipping it is the failure mode the user will catch and the plugin will be blamed for.
+
+   **Note — the coverage-check pairing has a 3rd, auto-emitted stage.** The general
+   2-stage pairing pattern above (workflow task → paired branch-protection task) has a
+   third stage specific to the coverage-required-check: `test-roadmap` itself
+   auto-emits a stage-3 promotion task on a later re-run once the coverage gate closes.
+   See `repo-config/SKILL.md`'s "Coverage-check pairing (3-stage lifecycle)" section for
+   the full 3-stage table; Process step 9 below is where this repo implements stage 3.
 7. **Apply the E2E classification guardrail** (non-negotiable): Before emitting any task with `layer: e2e`, verify against test-system.md's "Classifying a new test" step that the proposed test journey actually exercises a real browser (step 4: "Does it test a multi-step browser flow? → e2e (Playwright)"). If the journey is a backend orchestration flow, an API contract test, or any other non-browser interaction, downgrade the task to `layer: integration` or `layer: smoke` with a one-line note explaining why (e.g., "backend orchestration flow — moved to smoke"). This guardrail prevents shipping e2e tasks that violate the test classification rules, ensuring the e2e layer contains only true multi-step browser-driven flows.
 8. **Compute the coverage_gate block by invoking `scripts/check-coverage-gate.ts` — never
    hand-compute the verdict.** Source the four required inputs the same way Step 4c of
@@ -320,22 +327,50 @@ Anything the audit couldn't determine without a human call. Common entries:
    step 9 and do not write a partial or fabricated `test-readiness-plan.md` — mirrors
    Process step 1's "Abort if any missing" failure mode, applied to the coverage_gate
    computation instead of the three prior-artifact reads.
-9. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`. Fill.
-   Write to `docs/test-readiness/test-readiness-plan.md`.
-   - Fill the `## Coverage Gate` section's seven placeholders
+9. **Auto-emit the stage-3 coverage-promotion task when the gate closes.** Using step 8's
+   just-computed `line_coverage_pct`, this is the auto-pairing mechanism firing for the
+   coverage-check's 3rd stage (see the step-6 note above and `repo-config/SKILL.md`'s
+   "Coverage-check pairing (3-stage lifecycle)" section) — it follows the existing
+   auto-pairing emission mechanism, no manual trigger step:
+   - **If `line_coverage_pct < 90`:** no promotion task. The never-decrease check (stage 2)
+     is still the active gate. Nothing to do — proceed to step 10.
+   - **If `line_coverage_pct >= 90`:** before emitting, check whether a stage-3 promotion
+     task has already been filed for this repo, so a later re-run doesn't refile it every
+     cycle once the gate has closed — idempotency matters here (see
+     `plugins/shipwright/CLAUDE.md`'s "6. Skills Are Idempotent" principle). Reuse step 4's
+     existing task-store query result set (it already fetches every task for this repo,
+     paginated past the 500-row default) — scan that same result set for a task whose
+     title/outcome matches the stage-3 promotion pattern (e.g. "Promote coverage required
+     check from never-decrease to hard ≥90% gate").
+     - **If found:** skip — no duplicate row.
+     - **If not found:** emit exactly one new `T-NNN` row into the Section 5 task list
+       (Milestone 1, `bucket: infra`) with:
+       - Outcome: "Promote coverage required check from never-decrease to hard ≥90% gate"
+       - `depends_on` the stage-2 never-decrease task's `T-NNN` (found via the same scan,
+         matching its title pattern) — mirrors exactly how step 6's pairing rule already
+         wires `depends_on` for workflow-task → branch-protection-task pairs, so
+         `test-fix`'s existing `depends_on:` parsing (Step 2.3 / Step 5.4) requires zero
+         changes to pick up this new row.
+   This preserves the existing division of responsibility: `test-roadmap` stays
+   markdown-only (no new task-store write path, no new skill) — it just adds one more row
+   to the same Section 5 walk that step 6 already populates, and `test-fix` files it
+   exactly like any other paired row.
+10. Load `${CLAUDE_PLUGIN_ROOT}/assets/templates/test-readiness-plan.md.tmpl`. Fill.
+    Write to `docs/test-readiness/test-readiness-plan.md`.
+    - Fill the `## Coverage Gate` section's seven placeholders
      (`{{FEATURE_COVERAGE_PCT}}`, `{{FEATURE_COVERAGE_SOURCE}}`, `{{LINE_COVERAGE_PCT}}`,
      `{{LINE_COVERAGE_SOURCE}}`, `{{COVERAGE_VERDICT}}`, `{{FEATURE_TARGET}}`,
-     `{{LINE_TARGET}}`) verbatim from step 8's script output.
-   - **`{{M3_HEADING_AND_DOD}}` is gated on `deploy_model`** (Process step 1) — the
-     template has no static text for this milestone precisely because it must reflect
-     the gate:
-     - When `deploy_model == 'staged'`: fill with
-       `### Milestone 3 — Canary suite live\n**DOD:** Smoke + E2E canary-eligible tests run green against the deployed env in <60s wall time.`
-     - When `deploy_model != 'staged'` (declared `direct`, declared `none`, or
-       undeclared): fill with the single note line —
-       `### Milestone 3 — Canary suite live\n**DOD:** canary not applicable -- deploy_model={value}`
-       (no task list, no DOD beyond the note) — where `{value}` is `direct`, `none`, or
-       `undeclared`.
+      `{{LINE_TARGET}}`) verbatim from step 8's script output.
+    - **`{{M3_HEADING_AND_DOD}}` is gated on `deploy_model`** (Process step 1) — the
+      template has no static text for this milestone precisely because it must reflect
+      the gate:
+      - When `deploy_model == 'staged'`: fill with
+        `### Milestone 3 — Canary suite live\n**DOD:** Smoke + E2E canary-eligible tests run green against the deployed env in <60s wall time.`
+      - When `deploy_model != 'staged'` (declared `direct`, declared `none`, or
+        undeclared): fill with the single note line —
+        `### Milestone 3 — Canary suite live\n**DOD:** canary not applicable -- deploy_model={value}`
+        (no task list, no DOD beyond the note) — where `{value}` is `direct`, `none`, or
+        `undeclared`.
 
 ## Failure modes to avoid
 
@@ -368,3 +403,11 @@ Anything the audit couldn't determine without a human call. Common entries:
   "deferred — not implemented" note is meant to block. Check `recorded_fixture_automation`
   (Process step 1) before emitting any recorded-fixture-refresh task; when it's `not planned`,
   emit zero tasks per the Milestone 1 exception above rather than one monolithic task.
+- **Don't refile the stage-3 coverage-promotion task on every re-run once it's already been
+  emitted.** Process step 9's dedup scan (reusing step 4's task-store query result set) exists
+  precisely to make this idempotent — a re-run that finds a matching promotion task already
+  filed must skip emission, not add a duplicate `T-NNN` row each cycle.
+- **Don't emit the stage-3 coverage-promotion task before the gate has actually closed.**
+  Process step 9 is gated on `coverage_gate.line_coverage_pct >= 90` (step 8's freshly
+  computed value) — a repo still below 90% keeps the never-decrease check (stage 2) as its
+  active gate; do not promote to the hard ≥90% gate early.


### PR DESCRIPTION
## Summary
- Extends `test-roadmap/SKILL.md`'s existing pairing-rule task-emission logic with a new Process step 9 that auto-emits the stage-3 hard-≥90% coverage-gate promotion task whenever a `/test-roadmap` re-run observes `coverage_gate.line_coverage_pct >= 90` — no manual trigger step, following the same auto-pairing mechanism already used for workflow-task/branch-protection-task pairs.
- The new step reuses the existing paginated task-store query from Process step 4 to dedup against an already-filed promotion task (idempotent across re-runs), and wires `depends_on` the stage-2 never-decrease task exactly like the existing pairing rule does — so `test-fix`'s existing `depends_on:` parsing requires no changes.
- Adds a cross-reference near Process step 6 pointing to `repo-config/SKILL.md`'s "Coverage-check pairing (3-stage lifecycle)" section, plus two new Failure-modes bullets (don't refile once emitted, don't emit before the gate closes).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Promotion task is emitted only when a test-roadmap re-run observes coverage_gate.line_coverage_pct >= 90 | MET |
| 2 | No manual step required — follows the existing auto-pairing emission mechanism | MET |
| 3 | Test decision: extend plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts for the new conditional-emission instructions | MET |

## Test Plan
- `bun test plugins/shipwright/skills/test-roadmap/SKILL.content.test.ts` — 54/54 pass
- `bunx biome lint .` — clean
- Typecheck (`bun run --filter='*' --sequential typecheck`) — clean across all workspaces
- Full `task ci` has one pre-existing, unrelated failure (`metrics/src/lib/errors.unit.test.ts` — a Sentry-capture test) confirmed to also fail identically on `main` unmodified — not introduced by this PR, out of scope.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
