### PR TITLE
chore(chart): bump chart version to 1.11.51

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.51] - 2026-08-15
+
+### Changed
+
+- auto-bump to chart v1.11.51 triggered by release tag(s): `admin-v1.78.0`, `agent-v1.159.0`, `chat-v1.38.0`, `metrics-v1.41.0`, `task-store-v1.59.0`
+
 ## [1.11.50] - 2026-08-15
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.50
+version: 1.11.51
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,7 +30,15 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.11.50 triggered by release tag agent-v1.158.0"
+      description: "auto-bump to chart v1.11.51 triggered by release tag admin-v1.78.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.51 triggered by release tag agent-v1.159.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.51 triggered by release tag chat-v1.38.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.51 triggered by release tag metrics-v1.41.0"
+    - kind: changed
+      description: "auto-bump to chart v1.11.51 triggered by release tag task-store-v1.59.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -117,7 +117,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.77.0
+    tag: admin-v1.78.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -185,7 +185,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v1.40.0
+    tag: metrics-v1.41.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -301,7 +301,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.158.0
+    tag: agent-v1.159.0
     pullPolicy: ""
   service:
     port: 3000
@@ -324,7 +324,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.158.0
+      tag: agent-v1.159.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).
@@ -563,7 +563,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.58.0
+    tag: task-store-v1.59.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -716,7 +716,7 @@ chat:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-chat
-    tag: chat-v1.37.0
+    tag: chat-v1.38.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.11.50 → 1.11.51

**Triggering tags:**
- `admin-v1.78.0`
- `agent-v1.159.0`
- `chat-v1.38.0`
- `metrics-v1.41.0`
- `task-store-v1.59.0`

**New chart version:** `1.11.51`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.78.0`
- `agent.image.tag`: `agent-v1.159.0`
- `agent.provisioning.image.tag`: `agent-v1.159.0`
- `chat.image.tag`: `chat-v1.38.0`
- `metrics.image.tag`: `metrics-v1.41.0`
- `taskStore.image.tag`: `task-store-v1.59.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.11.51 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._