### PR TITLE
docs: refresh stale references for 2026-08-15 sync

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"297fb61e89c9438ab815d9e8d62b550f7b8ef79b","timestamp":"2026-08-14T00:00:00Z"}
+{"sha":"7e63e6999be17db9c41359f406b9f3fe54432a29","timestamp":"2026-08-15T00:00:00Z"}


### PR DESCRIPTION
## Summary

Routine docs-freshness sync for the window `297fb61e..7e63e699` (44 changed files: version/chart-tag auto-bumps, `check-coverage*.ts` gate rework, `scripts/hitl.ts` internal refactor + new bootstrap test, `test-readiness` plugin skill updates, planning docs).

**No stale documentation content found.** Every candidate doc under `docs/*.md` that references a changed file was checked against the actual diff:

- `docs/agent.md`, `docs/configuration.md`, `docs/migration.md` — reference `agent/src/check-review.ts`. Verified: `docs/agent.md` already fully and accurately documents the RCT-1.1 (`hasFreshNonAgentComment`) broadening from "PR author only" to "anyone but the reviewing agent" — matches the current source signature exactly. `docs/configuration.md`/`docs/migration.md`'s mentions are generic file-list context, unaffected by this change.
- `docs/architecture.md` — references `package.json` files across workspaces. All four diffs were pure version bumps (no script/name changes).
- `docs/helm-repo.md` — references `Chart.yaml`/`values.yaml`/`CHANGELOG.md`. All diffs were auto-bump image-tag/version updates only; no structural key changes.
- `docs/testing.md` — references `check-coverage.ts`. The 89/89 threshold documented already matches the current source; `check-coverage-gate.ts` (new) is a `test-roadmap` skill-internal CLI helper, self-documented there, out of `docs/testing.md`'s CI-gate scope.
- `docs/consolidation.md`, `docs/observability.md`, `docs/task-store.md` — initially flagged as candidates via basename match on generic `SKILL.md`, but on inspection these reference unrelated skills (`consolidation-scan`, `error-scan`, `task-store`), not any of the changed `test-*`/`repo-config` skill files. False positives, not stale.

CLAUDE.md's docs reference section was checked — no new/removed docs, no changes needed. No undocumented modules were identified among the changed files (all tests, scripts, config, chart, and plugin-internal skill content), so no missing-doc tasks were filed.

This PR only bumps the sync anchor (`state/docs-last-synced.json`) so the next scheduled run doesn't re-scan the same window.

## Test plan

- [x] N/A — anchor-only change, no code or doc content modified