### PR TITLE
docs: bump docs-freshness sync anchor to ca3c8c3f

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"7e63e6999be17db9c41359f406b9f3fe54432a29","timestamp":"2026-08-15T00:00:00Z"}
+{"sha":"ca3c8c3f02f174ff763b9d92cd6c7588d9c180f0","timestamp":"2026-08-16T07:01:16Z"}


### PR DESCRIPTION
## Summary
- Routine docs-freshness cron run — audited docs against all commits since the last anchor (`7e63e699`).
- All changed source files were version/chart bumps (`marketplace.json`, `Chart.yaml`, `values.yaml`, `plugin.json`) with no doc-visible content change, plus the MTC-1.6 `coverage-tool-dispatch` addition — `docs/testing.md` already reflects that from the feature PR.
- No stale docs found, no missing-doc tasks filed. Bumping the sync anchor to current `HEAD` (`ca3c8c3f`).

## Test plan
- [x] Diffed every candidate doc's referenced paths/versions against the actual changed files — no broken references found.
🤖 Generated with [Claude Code](https://claude.com/claude-code)