### PR TITLE
fix(minikube): unblock dev login and enable the admin Chat tab out of the box

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.11.55] - 2026-08-17
+
+### Fixed
+
+- `auth.mode=open`/`none` deployments no longer have dev auth blocked by the admin image's baked-in `NODE_ENV=production` default — set explicitly in `admin-deployment.yaml`
+
 ## [1.11.54] - 2026-08-15
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.54
+version: 1.11.55
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,16 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.11.54 triggered by release tag admin-v1.80.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.54 triggered by release tag agent-v1.162.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.54 triggered by release tag chat-v1.40.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.54 triggered by release tag metrics-v1.43.0"
-    - kind: changed
-      description: "auto-bump to chart v1.11.54 triggered by release tag task-store-v1.61.0"
+    - kind: fixed
+      description: "auth.mode=open/none deployments no longer have dev auth blocked by the admin image's baked-in NODE_ENV=production default — set explicitly in admin-deployment.yaml"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -125,8 +125,12 @@ spec:
             {{- end }}
             {{- if or (eq .Values.auth.mode "open") (eq .Values.auth.mode "none") }}
             # auth.mode=open (or deprecated alias "none") — dev auth, NO OAuth.
-            # Insecure: do not expose publicly. NODE_ENV is intentionally NOT set
-            # to production so the dev-auth path stays enabled.
+            # Insecure: do not expose publicly. NODE_ENV must be explicitly
+            # overridden to a non-production value: the admin image bakes
+            # NODE_ENV=production (admin/Dockerfile), which would hard-block the
+            # dev-auth path if left to the image default.
+            - name: NODE_ENV
+              value: "development"
             - name: ADMIN_DEV_AUTH
               value: "true"
             {{- else if eq .Values.auth.mode "google" }}

--- a/charts/shipwright/tests/admin_auth_modes_test.yaml
+++ b/charts/shipwright/tests/admin_auth_modes_test.yaml
@@ -1,5 +1,7 @@
 suite: admin auth modes (open vs google)
-# HD-3.1 auth modes. auth.mode=open → ADMIN_DEV_AUTH=true and NO NODE_ENV.
+# HD-3.1 auth modes. auth.mode=open → ADMIN_DEV_AUTH=true + NODE_ENV=development
+# (the image bakes NODE_ENV=production, which would hard-block dev auth if the
+# deployment left it to the image default).
 # auth.mode=google → NODE_ENV=production + Google OAuth env (from the admin
 # Secret) + SHIPWRIGHT_ADMIN_ALLOWED_EMAILS.
 templates:
@@ -17,10 +19,15 @@ tests:
             name: ADMIN_DEV_AUTH
             value: "true"
 
-  - it: open mode does NOT set NODE_ENV=production (keeps dev auth enabled)
+  - it: open mode sets NODE_ENV=development (overrides the image's baked-in production default)
     set:
       auth.mode: open
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_ENV
+            value: "development"
       - notContains:
           path: spec.template.spec.containers[0].env
           content:

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -317,7 +317,8 @@ chart does not provision deployment-wide Claude credentials.
 
 None — Minikube runs plain HTTP (`tls.certManager.enabled=false`, the default).
 
-> ⚠️ The Minikube profile sets `auth.mode=open`, which sets `ADMIN_DEV_AUTH=true`:
+> ⚠️ The Minikube profile sets `auth.mode=open`, which sets `ADMIN_DEV_AUTH=true`
+> (plus `NODE_ENV=development`, overriding the image's baked-in production default):
 > **anyone who can reach the admin service is treated as authenticated.** It also
 > sets a known literal PostgreSQL password. Never expose this install publicly.
 > For real access control use `auth.mode=google` (see the GKE section).
@@ -666,8 +667,11 @@ The admin service's `auth.mode` selects how users authenticate to the admin UI.
 
 ### `auth.mode=open` — dev auth (default)
 
-Sets `ADMIN_DEV_AUTH=true`: a working UI with **no real authentication**. Anyone
-who can reach the service is authenticated. This is the Minikube/dev default.
+Sets `ADMIN_DEV_AUTH=true` and `NODE_ENV=development`: a working UI with **no
+real authentication**. Anyone who can reach the service is authenticated. This is
+the Minikube/dev default. The explicit `NODE_ENV=development` matters — the admin
+image bakes `NODE_ENV=production`, which hard-blocks the dev-auth path unless the
+deployment overrides it.
 
 > ⚠️ **Security warning — do not expose `auth.mode=open` publicly.** It performs
 > no authentication: any client that can reach the admin service is treated as a


### PR DESCRIPTION
## Summary

Three fixes that together make `task minikube:up` produce a stack you can actually log into and chat with.

**1. Dev auth was hard-blocked by the image.** `auth.mode=open` sets `ADMIN_DEV_AUTH=true` but relied on `NODE_ENV` being *unset* to keep the dev-auth path alive. The admin image bakes `ENV NODE_ENV=production` (`admin/Dockerfile`), so the guard in `dev-auth-guard.ts` disabled dev auth and `/admin/dev-login` returned 404. The chart now sets `NODE_ENV=development` explicitly in the open/none branch.

**2. The post-install output pointed at a dead end.** It advertised the admin console root, which redirects to `/admin/login` — a page offering only a Google sign-in button that this profile never configures. `buildAccessUrls` now exposes `devLogin` and `printNextSteps` leads with it.

**3. The admin console's Chat tab was never wired.** Both `SHIPWRIGHT_CHAT_SERVICE_URL`/`SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` (admin) and `CHAT_SEED_ADMIN_TOKEN` (chat) were gated on a hand-created `chat.adminToken.existingSecret`, which the minikube profile deliberately avoids — so chat ran but nothing could talk to it. The chart now generates the token into its own chat Secret using the same lookup-persistence idiom as `admin-secret.yaml`, and both Deployments resolve through one helper so they always read the same value.

## Notes

- The chat Secret's two keys are now independently gated: the DSN on the bundled-PostgreSQL path, the token whenever chat is enabled without a caller-supplied Secret. It renders when either applies.
- `chat.enabled: false` still suppresses all chat wiring, even with `adminToken.existingSecret` set.
- Supplying your own `chat.adminToken.existingSecret` is unchanged.

## Testing

- `task helm:check` — lint, 329 unittest specs, kubeconform: all pass
- `bun test scripts/minikube.unit.test.ts` — 27 pass
- Dev login verified live on Minikube before the cluster was torn down: `/admin/dev-login` → 302 → `/admin/agents`, session cookie works (200). The chat wiring is verified by chart tests and `helm template`; it has not yet been exercised against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a3jURSc5pXi9Kdoa5ixtb