### PR TITLE
feat: apply hitl filter to Ready and Blocked task-list tabs

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -46,8 +46,8 @@ Query params:
 | Param | Type | Description |
 |-------|------|-------------|
 | `status` | string | Filter by exact status (e.g. `pending`, `in_progress`, `pr_open`) |
-| `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked`. `blocked` returns tasks with `status=blocked` OR (a non-terminal status AND an unresolved `blockedBy` entry — dependency or HITL). `session`/`source`/`repo`/`org`/`claimedBy`/`pr`/`branch`/`assignee` all apply under `?state=blocked` identically to the plain list path and to `?ready=true` (applied as an AND filter *after* the full task graph is loaded and dependency resolution has run — a task excluded by one of these filters can still contribute a `blockedBy` entry for an in-scope dependent task, since resolution needs the complete graph). `limit`/`offset`/`updatedSince` have no effect under `?state=blocked` (see the unpaginated-convenience-endpoint note below); `sort` does apply (see that same note). |
-| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `hitl !== true` (Type A HITL tasks excluded), no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. `session`/`source`/`repo`/`org`/`claimedBy`/`pr`/`branch`/`assignee` all apply under `?ready=true` identically to the plain list path (applied as an AND filter *after* dependency resolution — a task excluded by one of these filters can still satisfy a dependency edge for an in-scope task, since resolution needs the complete graph). `hitl` is not filterable here — it is structurally excluded from the ready set by definition (see above). `limit`/`offset`/`sort`/`updatedSince` have no effect under `?ready=true` (see the unpaginated-convenience-endpoint note below). Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. |
+| `state` | string | `open` (all non-terminal), `closed` (terminal), `in_progress`, `ready`, `blocked`. `blocked` returns tasks with `status=blocked` OR (a non-terminal status AND an unresolved `blockedBy` entry — dependency or HITL). `session`/`source`/`repo`/`org`/`claimedBy`/`pr`/`branch`/`assignee`/`hitl` all apply under `?state=blocked` identically to the plain list path and to `?ready=true` (applied as an AND filter *after* the full task graph is loaded and dependency resolution has run — a task excluded by one of these filters can still contribute a `blockedBy` entry for an in-scope dependent task, since resolution needs the complete graph). `limit`/`offset`/`updatedSince` have no effect under `?state=blocked` (see the unpaginated-convenience-endpoint note below); `sort` does apply (see that same note). |
+| `ready` | `true` | Alias for `state=ready` — returns only tasks with `status=pending`, `hitl !== true` (Type A HITL tasks excluded), no fresh same-branch in-progress sibling (exclusivity guard, see "Same-branch exclusivity guard" below), and all dependencies satisfied. `session`/`source`/`repo`/`org`/`claimedBy`/`pr`/`branch`/`assignee`/`hitl` all apply under `?ready=true` identically to the plain list path (applied as an AND filter *after* dependency resolution — a task excluded by one of these filters can still satisfy a dependency edge for an in-scope task, since resolution needs the complete graph). `limit`/`offset`/`sort`/`updatedSince` have no effect under `?ready=true` (see the unpaginated-convenience-endpoint note below). Tasks are always returned in ascending `createdAt` order (oldest first) to ensure deterministic selection regardless of insertion order. |
 | `source` | string | Filter by task source (e.g. `plan-session`, `entropy-fix`, `manual`) |
 | `session` | string | Filter by planning session slug |
 | `repo` | string, repeatable | Filter by repo (`org/repo` format). Repeat the param to match any repo in the list (e.g. `?repo=org/a&repo=org/b`). A single `?repo=` behaves identically to before (exact match). |
@@ -96,9 +96,8 @@ is simply `tasks.length`; `limit`/`offset` query params have no effect on these 
 supported with `?ready=true`. `updatedSince` has no effect on either branch, for the same
 whole-graph reason.
 
-Aside from those pagination/sort/recency exceptions (and `hitl`, which
-keeps the ready-specific semantics documented in its own row above), every other filter in
-the table — `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, `assignee` — applies
+Aside from those pagination/sort/recency exceptions, every filter in
+the table — `session`, `source`, `repo`, `org`, `claimedBy`, `pr`, `branch`, `assignee`, `hitl` — applies
 under `?ready=true` and `?state=blocked` exactly as it does on the plain list path.
 `TaskService.listReady()` applies these as a post-filter *after* `resolveReadyTasks()` has
 resolved the complete dependency graph; `TaskService.listBlocked()` applies the identically-shaped
@@ -108,7 +107,9 @@ into the initial query — a task that gets filtered out of the final response c
 satisfy a dependency edge (for `?ready=true`) or contribute a `blockedBy` entry (for
 `?state=blocked`) for another, in-scope task. `repo`/`org` matching mirrors the same
 array-any-match (`repo`) / `startsWith "<org>/"` (`org`) / AND-between-both semantics described
-above for the plain list path, just evaluated in-memory instead of as a Prisma `where` clause.
+above for the plain list path, just evaluated in-memory instead of as a Prisma `where` clause. `hitl` is a simple
+equality AND-filter: when omitted it has no effect (matches all `hitl` values); when set to `true` or `false`,
+it matches only tasks where `task.hitl` equals that value.
 
 **Agent token visibility:**
 - **With repo scope** (repos configured): Return tasks where `assignee === agentId` OR (`assignee === null` AND `repo` is in the agent's scope). This union of explicitly-assigned and pool tasks enables the agent to claim unassigned work from its scoped repositories.

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -98,7 +98,10 @@ function assertNoLifecycleFieldWrite(
 //   hitlNotifiedAt — dropped in HSR-1; Task.hitl itself is unchanged and stays writable.
 //   requiresHumanApproval — dropped in RHA-1.4; the merge-approval gate that consulted
 //   it was removed from the deploy workflow in RHA-1.1.
-const REMOVED_TASK_FIELDS = ["hitlNotifiedAt", "requiresHumanApproval"] as const;
+const REMOVED_TASK_FIELDS = [
+  "hitlNotifiedAt",
+  "requiresHumanApproval",
+] as const;
 
 function stripRemovedFields(body: Record<string, unknown>): void {
   for (const key of REMOVED_TASK_FIELDS) {
@@ -552,15 +555,21 @@ export function createTasksRoutes(
     const scopeDegraded = c.get("scopeDegraded");
     const stateRaw = c.req.query("state");
     const prRaw = c.req.query("pr");
+    const hitl =
+      c.req.query("hitl") === "true"
+        ? true
+        : c.req.query("hitl") === "false"
+          ? false
+          : undefined;
 
     // Note: ?updatedSince, ?limit, and ?offset are intentionally NOT
     // threaded into listReady()/listBlocked() below (?sort applies only to
     // the ?state=blocked branch). Both are convenience endpoints computed
     // over the *entire* task graph (dependency resolution needs every task,
     // not a recency-windowed or paginated subset). session/source/repo/org/
-    // claimedBy/pr/branch/assignee DO apply to both listReady() (TRF-1.1)
-    // and listBlocked() (ATB-1.2) — same parsing as the fallback branch
-    // below, just also forwarded here.
+    // claimedBy/pr/branch/assignee/hitl DO apply to both listReady()
+    // (TRF-1.1) and listBlocked() (ATB-1.2, HTF-1.1) — same parsing as the
+    // fallback branch below, just also forwarded here.
     // ?ready=true is the legacy spelling; ?state=ready is the new form.
     if (c.req.query("ready") === "true" || stateRaw === "ready") {
       // Pass repos to listReady for repo-scoped agent tokens.
@@ -576,6 +585,7 @@ export function createTasksRoutes(
           pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
           branch: c.req.query("branch"),
           assignee: c.req.query("assignee"),
+          hitl,
         },
       );
       return c.json({ tasks, total: tasks.length, scopeDegraded }, 200);
@@ -596,6 +606,7 @@ export function createTasksRoutes(
           pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
           branch: c.req.query("branch"),
           assignee: c.req.query("assignee"),
+          hitl,
         },
       );
       return c.json({ tasks, total: tasks.length, scopeDegraded }, 200);
@@ -624,12 +635,7 @@ export function createTasksRoutes(
       claimedBy: c.req.query("claimedBy"),
       pr: prRaw !== undefined ? Number.parseInt(prRaw, 10) : undefined,
       branch: c.req.query("branch"),
-      hitl:
-        c.req.query("hitl") === "true"
-          ? true
-          : c.req.query("hitl") === "false"
-            ? false
-            : undefined,
+      hitl,
       limit:
         limitRaw !== undefined
           ? Number.parseInt(limitRaw, 10) || undefined

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -333,6 +333,78 @@ describe("GET /tasks state filter (smoke)", () => {
     });
   });
 
+  // ─── hitl filter for state=ready (HTF-1.1) ─────────────────────────────────
+
+  it("GET /tasks?state=ready&hitl=true forwards hitl: true to listReady", async () => {
+    const capturedFilters: Array<Record<string, unknown> | undefined> = [];
+    const baseFake = fakeTaskService({});
+    const taskService: TaskServiceLike = {
+      ...baseFake,
+      async listReady(
+        agentId?: string,
+        repos?: string[],
+        filters?: Record<string, unknown>,
+      ) {
+        capturedFilters.push(filters);
+        return [];
+      },
+    };
+    const app = makeApp(taskService);
+
+    const res = await app.request("/tasks?state=ready&hitl=true", {
+      headers: auth(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]).toMatchObject({ hitl: true });
+  });
+
+  it("GET /tasks?state=ready&hitl=false forwards hitl: false to listReady", async () => {
+    const capturedFilters: Array<Record<string, unknown> | undefined> = [];
+    const baseFake = fakeTaskService({});
+    const taskService: TaskServiceLike = {
+      ...baseFake,
+      async listReady(
+        agentId?: string,
+        repos?: string[],
+        filters?: Record<string, unknown>,
+      ) {
+        capturedFilters.push(filters);
+        return [];
+      },
+    };
+    const app = makeApp(taskService);
+
+    const res = await app.request("/tasks?state=ready&hitl=false", {
+      headers: auth(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]).toMatchObject({ hitl: false });
+  });
+
+  it("GET /tasks?state=ready without ?hitl forwards hitl: undefined to listReady", async () => {
+    const capturedFilters: Array<Record<string, unknown> | undefined> = [];
+    const baseFake = fakeTaskService({});
+    const taskService: TaskServiceLike = {
+      ...baseFake,
+      async listReady(
+        agentId?: string,
+        repos?: string[],
+        filters?: Record<string, unknown>,
+      ) {
+        capturedFilters.push(filters);
+        return [];
+      },
+    };
+    const app = makeApp(taskService);
+
+    const res = await app.request("/tasks?state=ready", { headers: auth() });
+
+    expect(res.status).toBe(200);
+    expect(capturedFilters[0]).toMatchObject({ hitl: undefined });
+  });
+
   // ─── state=in_progress ───────────────────────────────────────────────────────
 
   it("GET /tasks?state=in_progress returns 200", async () => {
@@ -594,5 +666,50 @@ describe("GET /tasks state filter (smoke)", () => {
       branch: undefined,
       assignee: undefined,
     });
+  });
+
+  // ─── hitl filter for state=blocked (HTF-1.1) ───────────────────────────────
+
+  it("GET /tasks?state=blocked&hitl=true forwards hitl: true to listBlocked", async () => {
+    const capturedListBlockedFilters: Array<
+      Record<string, unknown> | undefined
+    > = [];
+    const taskService = fakeTaskService({ capturedListBlockedFilters });
+    const app = makeApp(taskService);
+
+    const res = await app.request("/tasks?state=blocked&hitl=true", {
+      headers: auth(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedListBlockedFilters[0]).toMatchObject({ hitl: true });
+  });
+
+  it("GET /tasks?state=blocked&hitl=false forwards hitl: false to listBlocked", async () => {
+    const capturedListBlockedFilters: Array<
+      Record<string, unknown> | undefined
+    > = [];
+    const taskService = fakeTaskService({ capturedListBlockedFilters });
+    const app = makeApp(taskService);
+
+    const res = await app.request("/tasks?state=blocked&hitl=false", {
+      headers: auth(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedListBlockedFilters[0]).toMatchObject({ hitl: false });
+  });
+
+  it("GET /tasks?state=blocked without ?hitl forwards hitl: undefined to listBlocked", async () => {
+    const capturedListBlockedFilters: Array<
+      Record<string, unknown> | undefined
+    > = [];
+    const taskService = fakeTaskService({ capturedListBlockedFilters });
+    const app = makeApp(taskService);
+
+    const res = await app.request("/tasks?state=blocked", { headers: auth() });
+
+    expect(res.status).toBe(200);
+    expect(capturedListBlockedFilters[0]).toMatchObject({ hitl: undefined });
   });
 });

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -129,6 +129,7 @@ function matchesTaskFilters(task: Task, filters: TaskListPostFilters): boolean {
     return false;
   if (filters.assignee !== undefined && task.assignee !== filters.assignee)
     return false;
+  if (filters.hitl !== undefined && task.hitl !== filters.hitl) return false;
   if (!matchesRepoOrg(task, filters.repo, filters.org)) return false;
   return true;
 }
@@ -145,12 +146,22 @@ export type TaskWithBlockedBy = Task & { blockedBy: BlockedByEntry[] };
  * still be a dependency of an in-scope task, and must still contribute a
  * blockedBy entry for it).
  *
- * Deliberately excludes status/state/hitl/limit/
- * offset/sort/updatedSince/agentScope: the ready/blocked sets' status/hitl
- * semantics are structural (see ready.ts / listBlocked()'s doc comment),
- * pagination/sort don't apply to these whole-graph convenience endpoints
- * (see docs/task-store.md), and agentId/repos scoping already has its own
- * dedicated parameters mirroring the pre-existing signatures.
+ * Deliberately excludes status/state/limit/offset/sort/updatedSince/
+ * agentScope: the ready/blocked sets' status semantics are structural (see
+ * ready.ts / listBlocked()'s doc comment) — status/state itself is never a
+ * user-settable narrowing filter here, since it's what defines the ready/
+ * blocked set in the first place. Pagination/sort don't apply to these
+ * whole-graph convenience endpoints (see docs/task-store.md), and
+ * agentId/repos scoping already has its own dedicated parameters mirroring
+ * the pre-existing signatures.
+ *
+ * `hitl` IS included, unlike the structural fields above: computeBlockedBy()
+ * already sets a {type:"hitl"} blockedBy entry whenever task.hitl === true
+ * (blocked-by.ts:66-68), so narrowing the already-resolved ready/blocked set
+ * by task.hitl is a plain equality AND-filter — the same shape as the other
+ * fields below (session/source/claimedBy/pr/branch/assignee), not a
+ * structural change to which tasks are considered ready/blocked in the
+ * first place.
  */
 export interface TaskListPostFilters {
   session?: string;
@@ -163,6 +174,7 @@ export interface TaskListPostFilters {
   pr?: number;
   branch?: string;
   assignee?: string;
+  hitl?: boolean;
 }
 
 /** Filters accepted by TaskService.list. */

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { computeBlockedBy } from "./blocked-by.ts";
+import { FixedClock } from "./clock.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
 import type { PrismaClient, Task } from "./index.ts";
 import type { ReadyTaskLike } from "./ready.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
 import { type TaskListFilters, TaskService } from "./task-service.ts";
-import { FixedClock } from "./clock.ts";
 
 // ─── Minimal in-memory stub matching only the logic under test ────────────────
 
@@ -1210,6 +1210,54 @@ describe("TaskService.listReady() filters (unit)", () => {
     expect(result.map((t) => t.id)).toEqual(["t1"]);
   });
 
+  // ─── hitl (HTF-1.1) ───────────────────────────────────────────────────────
+  //
+  // resolveReadyTasks() already excludes task.hitl === true from the ready
+  // set entirely (see ready.ts:80) — hitl:true tasks are never ready
+  // regardless of this filter. The new post-filter narrows among the
+  // *already-ready* set (hitl: false or hitl: null), so hitl: true here
+  // always yields [], and hitl: false narrows out hitl: null tasks.
+
+  it("listReady({ hitl: true }) returns no tasks — hitl:true tasks are never ready", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", hitl: false }),
+      makeReadyTask({ id: "t2", hitl: null }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      hitl: true,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("listReady({ hitl: false }) returns only tasks with hitl === false", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", hitl: false }),
+      makeReadyTask({ id: "t2", hitl: null }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {
+      hitl: false,
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("listReady() with hitl unset returns every ready task regardless of hitl value (back-compat)", async () => {
+    const prisma = makeReadyPrismaDouble([
+      makeReadyTask({ id: "t1", hitl: false }),
+      makeReadyTask({ id: "t2", hitl: null }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listReady(undefined, undefined, {});
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+  });
+
   // ─── assignee ─────────────────────────────────────────────────────────────
 
   it("listReady({ assignee }) returns only tasks matching the assignee", async () => {
@@ -1649,6 +1697,61 @@ describe("TaskService.listBlocked() filters (unit)", () => {
     expect(result.map((t) => t.id)).toEqual(["t1"]);
   });
 
+  // ─── hitl (HTF-1.1) ───────────────────────────────────────────────────────
+  //
+  // Unlike listReady(), hitl:true tasks DO appear in the blocked set —
+  // computeBlockedBy() sets a {type:"hitl"} blockedBy entry whenever
+  // task.hitl === true (blocked-by.ts:66-68), so a pending hitl:true task is
+  // blocked. Both fixtures below use status:"blocked" explicitly so they're
+  // included in the blocked set regardless of hitl-driven blockedBy content,
+  // isolating the hitl post-filter itself from listBlocked()'s inclusion
+  // rules.
+
+  it("listBlocked({ hitl: true }) returns only tasks with hitl === true", async () => {
+    const prisma = makeBlockedFilterPrismaDouble([
+      makeBlockedFilterTask({ id: "t1", status: "blocked", hitl: true }),
+      makeBlockedFilterTask({ id: "t2", status: "blocked", hitl: false }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listBlocked(undefined, undefined, undefined, {
+      hitl: true,
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("listBlocked({ hitl: false }) returns only tasks with hitl === false", async () => {
+    const prisma = makeBlockedFilterPrismaDouble([
+      makeBlockedFilterTask({ id: "t1", status: "blocked", hitl: true }),
+      makeBlockedFilterTask({ id: "t2", status: "blocked", hitl: false }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listBlocked(undefined, undefined, undefined, {
+      hitl: false,
+    });
+
+    expect(result.map((t) => t.id)).toEqual(["t2"]);
+  });
+
+  it("listBlocked() with hitl unset returns every blocked task regardless of hitl value (back-compat)", async () => {
+    const prisma = makeBlockedFilterPrismaDouble([
+      makeBlockedFilterTask({ id: "t1", status: "blocked", hitl: true }),
+      makeBlockedFilterTask({ id: "t2", status: "blocked", hitl: false }),
+    ]);
+    const service = new TaskService(prisma);
+
+    const result = await service.listBlocked(
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+  });
+
   // ─── assignee ─────────────────────────────────────────────────────────────
 
   it("listBlocked({ assignee }) returns only tasks matching the assignee", async () => {
@@ -1928,7 +2031,12 @@ describe("TaskService.listBlocked() filters (unit)", () => {
     ]);
     const service = new TaskService(prisma);
 
-    const result = await service.listBlocked(undefined, undefined, undefined, {});
+    const result = await service.listBlocked(
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
 
     expect(result.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
   });


### PR DESCRIPTION
## Summary
- Add optional `hitl?: boolean` to `TaskListPostFilters` and apply it as an equality AND-filter in `matchesTaskFilters()`, so the Ready and Blocked task-list tabs now respect the HITL filter (previously silently ignored — only `in_progress`/`closed` tabs applied it correctly via the generic fallback branch).
- Thread the already-parsed `?hitl=true|false` query param into both the `state=ready` and `state=blocked` branches in `routes/tasks.ts`, mirroring the parsing already used in the fallback branch.
- Update `TaskListPostFilters`' doc comment to remove `hitl` from the "deliberately excluded" list and explain why it's now a supported post-filter.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `TaskListPostFilters` gains `hitl?: boolean`; `matchesTaskFilters()` applies `task.hitl === filters.hitl` only when defined | MET |
| 2 | `routes/tasks.ts`'s `state=ready`/`state=blocked` branches parse `?hitl=` and forward it to `listReady()`/`listBlocked()` | MET |
| 3 | Doc comment updated to remove hitl from "deliberately excluded" list | MET |
| 4 | Unit tests (listReady/listBlocked, true/false/unset) + smoke tests (GET forwarding) added, no existing tests retired | MET |

## Test Plan
- `bun test task-store/src/task-service.unit.test.ts task-store/src/state-filter.smoke.test.ts` — new hitl coverage for both `listReady()` and `listBlocked()`, plus smoke tests asserting query-param forwarding
- `bun test task-store/` — 555 pass, 0 fail, 152 skip (no regressions; one pre-existing unrelated failure in `prs.openapi.smoke.test.ts` confirmed present on `main` before this branch)
- `bun run --filter='*' --sequential typecheck` — clean
- `bunx biome check` on touched files — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
