### PR TITLE
feat: add POST /prs/:id/findings endpoint with server-side source/disposition authority enforcement

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -374,6 +374,7 @@ Writable fields: `staged`, `commitSha`, `reviewedCommitSha`, `taskId`, `agentId`
 | `POST /prs/:id/release` | Clear `claimedBy`/`claimedAt`/`heartbeatAt`. Resets `reviewState=pending` unless it is already a terminal value (`posted`/`approved`), in which case `reviewState` is left untouched |
 | `POST /prs/:id/skip` | Increment `skipCount`, update `lastSkippedAt` to now. When `skipCount` crosses threshold (3), auto-set `blocked=true` and `blockedReason="Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)"` |
 | `POST /prs/:id/skip/reset` | Reset `skipCount` back to 0 and clear `lastSkippedAt`. If the PR is currently blocked with a `blockedReason` matching the skip-auto-block message (contains `"consecutive skips"`), also clears `blocked=false` and `blockedReason=null` in the same update — otherwise `blocked`/`blockedReason` are left untouched (e.g. a block set by the CI-failure-streak mechanism in `POST /prs/:id/patch` is not cleared) |
+| `POST /prs/:id/findings` | Append a review/patch finding to the PR. Request body: `{ref, disposition, source, evidence, at?}` where `disposition` is one of `resolved`, `superseded`, `rejected`; `source` is one of `review`, `patch`. Authority rule (server-enforced): `source:"patch"` may only submit `disposition:"rejected"` (returns `400` otherwise); `source:"review"` may submit any disposition. Returns `201` with the created `PrFinding` record. |
 
 #### PR state enums
 
@@ -396,6 +397,23 @@ Writable fields: `staged`, `commitSha`, `reviewedCommitSha`, `taskId`, `agentId`
 `consecutiveCiFailureCount`: integer (default `0`) — consecutive count of patch cycles whose `ciFailureSignature` matched the stored `lastCiFailureSignature`. When a new, differing signature arrives (or none was previously stored), the count resets to 1 and the new signature is stored. When it crosses the threshold (3, matching `SPIN_DETECTION_THRESHOLD` and `SKIP_BLOCK_THRESHOLD`), the service auto-sets `blocked=true` and `blockedReason="Auto-blocked after {count} consecutive CI failures: {signature}"` to halt repeated dispatch cycles. Updated by `POST /prs/:id/patch` when `ciFailureSignature` is provided; left untouched when the field is omitted.
 
 `reviewedCommitSha`: optional string — the review pipeline's exclusive commit-tracking field, separate from the shared `commitSha` field written by claim()/patch()/deploy for their own multi-phase bookkeeping. Set via `PATCH /prs/:id`. Used by the review phase to independently track the commit at which a review was conducted, allowing review state to persist across pipeline transitions without interference from concurrent patch/deploy phase operations updating `commitSha`.
+
+`findings`: optional array of `PrFinding` objects — review/patch findings recorded against this PR. Appended via `POST /prs/:id/findings`. Always included in responses from `GET /prs/:id` and list queries; omitted from responses if the finding population is disabled or if findings have not been recorded. Each finding records a specific review or patch action that addressed a code finding (e.g., "resolved null-check bug in follow-up commit", "rejected as out-of-scope").
+
+#### PR Finding type
+
+A `PrFinding` object represents a single code finding that has been triaged during the review or patch phase:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier (auto-generated, e.g., `clxfinding123456`) |
+| `prRecordId` | string | Reference to the parent PR record's ID |
+| `ref` | string | Identifier for the finding location (e.g., `src/foo.ts:42`, or a slug like `null-check-bug`) |
+| `disposition` | enum | Triage outcome: `resolved` (the finding was fixed), `superseded` (another fix addressed it), or `rejected` (out-of-scope/not a real issue) |
+| `source` | enum | Which pipeline recorded this finding: `review` (code review phase) or `patch` (automated patch/fix phase). Authority rule (enforced server-side): `source:"patch"` may only submit `disposition:"rejected"`; `source:"review"` may submit any disposition. |
+| `evidence` | string | Human-readable explanation of the triage decision (e.g., `"Fixed the null check in commit abc123"`, `"Already superseded by the bounds-check fix"`, `"This is intentional — caller guarantees non-null"`) |
+| `at` | string | ISO timestamp of when the finding was triaged / resolved (defaults to current time if omitted on creation) |
+| `createdAt` | string | ISO timestamp when the task-store record itself was created |
 
 #### PR timestamp fields
 

--- a/task-store/src/app.ts
+++ b/task-store/src/app.ts
@@ -66,6 +66,9 @@ const noopPrService: PullRequestServiceLike = {
   async claimNext(_agentId, _maxConcurrent, _repos?) {
     return null;
   },
+  async appendFinding(_prId, _data) {
+    return {} as never;
+  },
 };
 
 export interface TaskStoreDeps {

--- a/task-store/src/generate-spec.ts
+++ b/task-store/src/generate-spec.ts
@@ -123,6 +123,9 @@ const stubPrService: PullRequestServiceLike = {
   async claimNext() {
     return null;
   },
+  async appendFinding() {
+    return {} as never;
+  },
 };
 
 // ─── Spec assembly ────────────────────────────────────────────────────────────

--- a/task-store/src/index.ts
+++ b/task-store/src/index.ts
@@ -13,8 +13,15 @@ export {
   PrState,
   PrReviewState,
   PrPhase,
+  PrFindingDisposition,
+  PrFindingSource,
 } from "../prisma/client/index.js";
-export type { Task, TaskToken, PullRequest } from "../prisma/client/index.js";
+export type {
+  Task,
+  TaskToken,
+  PullRequest,
+  PrFinding,
+} from "../prisma/client/index.js";
 export type {
   BlockedByEntry,
   TaskWithBlockedBy,

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -245,6 +245,34 @@ export const TaskSchema = z
 
 export type Task = z.infer<typeof TaskSchema>;
 
+// ─── PR Finding ───────────────────────────────────────────────────────────────
+// Defined ahead of PullRequestSchema so PullRequestSchema's `findings` field
+// can reference it directly (no z.lazy — there's no circular reference here,
+// and zod-to-openapi can't introspect a z.lazy() wrapper without an explicit
+// `type` annotation via .openapi()).
+
+export const PrFindingSchema = z
+  .object({
+    id: z.string().openapi({ example: "clxfinding123456" }),
+    prRecordId: z.string().openapi({ example: "clx0987654321" }),
+    ref: z.string().openapi({ example: "src/foo.ts:42" }),
+    disposition: z
+      .enum(["resolved", "superseded", "rejected"])
+      .openapi({ example: "resolved" }),
+    source: z.enum(["review", "patch"]).openapi({ example: "review" }),
+    evidence: z.string().openapi({
+      example: "Fixed the null check in the follow-up commit.",
+    }),
+    at: z.string().openapi({ example: "2026-08-17T12:00:00.000Z" }),
+    createdAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-08-17T12:00:00.000Z" }),
+  })
+  .openapi("PrFinding");
+
+export type PrFinding = z.infer<typeof PrFindingSchema>;
+
 // ─── Pull Request ─────────────────────────────────────────────────────────────
 
 export const PullRequestSchema = z
@@ -364,6 +392,13 @@ export const PullRequestSchema = z
       .string()
       .datetime()
       .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+    findings: z
+      .array(PrFindingSchema)
+      .optional()
+      .openapi({
+        description:
+          "Review/patch findings recorded against this PR, if the caller's query included them (GET /prs/:id and list responses always include this array).",
+      }),
   })
   .openapi("PullRequest");
 
@@ -710,3 +745,30 @@ export const ClaimNextResponseSchema = z
     phase: z.enum(["review", "patch", "deploy"]).openapi({ example: "review" }),
   })
   .openapi("ClaimNextResponse");
+
+/** Request body for POST /prs/:id/findings. */
+export const CreateFindingBodySchema = z
+  .object({
+    ref: z.string().openapi({
+      example: "src/foo.ts:42",
+      description: "Identifier for the finding (e.g. file:line or a slug).",
+    }),
+    disposition: z.enum(["resolved", "superseded", "rejected"]).openapi({
+      example: "resolved",
+      description:
+        "Triage outcome. source:'patch' may only submit 'rejected' — server-enforced (400 otherwise); source:'review' may submit any value.",
+    }),
+    source: z.enum(["review", "patch"]).openapi({
+      example: "review",
+      description: "Which pipeline phase is recording this finding.",
+    }),
+    evidence: z.string().openapi({
+      example: "Fixed the null check in the follow-up commit.",
+    }),
+    at: z.string().optional().openapi({
+      example: "2026-08-17T12:00:00.000Z",
+      description:
+        "ISO timestamp of when the finding was triaged. Defaults to the current time when omitted.",
+    }),
+  })
+  .openapi("CreateFindingBody");

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -16,12 +16,18 @@
  *   - GET /prs/:id → 404 when missing
  *   - POST /prs/:id/heartbeat → updates heartbeatAt
  *   - POST /prs/:id/release → clears claim, reviewState=pending
+ *   - POST /prs/:id/findings → persists a finding (source:"review")
+ *   - POST /prs/:id/findings → 400 when source:"patch" submits a disposition
+ *     other than "rejected" (server-side authority enforcement)
+ *   - POST /prs/:id/findings → 200/201 when source:"patch" submits
+ *     disposition:"rejected" (patch's one allowed disposition)
+ *   - GET /prs/:id → response includes findings: PrFinding[]
  */
 
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
-import type { PullRequest } from "./index.ts";
+import type { PrFinding, PullRequest } from "./index.ts";
 import type {
   PullRequestListFilters,
   PullRequestListResult,
@@ -72,6 +78,20 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     updatedAt: new Date(),
     ...overrides,
   } as PullRequest;
+}
+
+function makeFinding(overrides: Partial<PrFinding> = {}): PrFinding {
+  return {
+    id: "finding-1",
+    prRecordId: "pr-1",
+    ref: "src/foo.ts:1",
+    disposition: "resolved",
+    source: "review",
+    evidence: "fixed in follow-up commit",
+    at: "2026-08-17T00:00:00.000Z",
+    createdAt: new Date(),
+    ...overrides,
+  } as PrFinding;
 }
 
 /** Admin token service (agentId: null). */
@@ -153,6 +173,16 @@ interface CapturedClaimCall {
   prCreatedAt?: string;
 }
 
+/** Captured args from each fakePrService.appendFinding() call. */
+interface CapturedAppendFindingCall {
+  prId: string;
+  ref: string;
+  disposition: "resolved" | "superseded" | "rejected";
+  source: "review" | "patch";
+  evidence: string;
+  at?: string;
+}
+
 /** Minimal in-memory PullRequestServiceLike fake. */
 function fakePrService(
   opts: {
@@ -165,6 +195,8 @@ function fakePrService(
       phase: "review" | "patch" | "deploy";
     } | null;
     claimCalls?: CapturedClaimCall[];
+    appendFindingCalls?: CapturedAppendFindingCall[];
+    appendFindingResult?: PrFinding | Error;
   } = {},
 ): PullRequestServiceLike {
   const store = opts.store ?? new Map<string, PullRequest>();
@@ -363,6 +395,35 @@ function fakePrService(
     } | null> {
       if ("claimNextResult" in opts) return opts.claimNextResult ?? null;
       return null;
+    },
+
+    async appendFinding(
+      prId: string,
+      data: {
+        ref: string;
+        disposition: "resolved" | "superseded" | "rejected";
+        source: "review" | "patch";
+        evidence: string;
+        at?: string;
+      },
+    ): Promise<PrFinding> {
+      opts.appendFindingCalls?.push({ prId, ...data });
+      if (opts.appendFindingResult !== undefined) {
+        if (opts.appendFindingResult instanceof Error) {
+          throw opts.appendFindingResult;
+        }
+        return opts.appendFindingResult;
+      }
+      if (!store.has(prId)) throw new NotFoundError("pr not found");
+      return makeFinding({
+        id: `finding-${prId}-${Date.now()}`,
+        prRecordId: prId,
+        ref: data.ref,
+        disposition: data.disposition,
+        source: data.source,
+        evidence: data.evidence,
+        at: data.at ?? new Date().toISOString(),
+      });
     },
   };
 }
@@ -1579,5 +1640,168 @@ describe("/prs routes (smoke)", () => {
     expect(res.status).toBe(200);
     // Admin tokens bypass scope — repos must be undefined
     expect(capturedRepos).toBeUndefined();
+  });
+
+  // ─── POST /prs/:id/findings ───────────────────────────────────────────────
+
+  it('POST /prs/:id/findings with source:"review", disposition:"resolved" persists the finding (200/201)', async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "review",
+        evidence: "Fixed in the follow-up commit.",
+      }),
+    });
+    expect([200, 201]).toContain(res.status);
+    const body = (await res.json()) as PrFinding;
+    expect(body.ref).toBe("src/foo.ts:42");
+    expect(body.disposition).toBe("resolved");
+    expect(body.source).toBe("review");
+    expect(appendFindingCalls).toHaveLength(1);
+    expect(appendFindingCalls[0]?.prId).toBe("pr-1");
+    expect(appendFindingCalls[0]?.disposition).toBe("resolved");
+    expect(appendFindingCalls[0]?.source).toBe("review");
+  });
+
+  it('POST /prs/:id/findings with source:"patch", disposition:"resolved" returns 400 (authority violation)', async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "patch",
+        evidence: "Claims to have fixed it.",
+      }),
+    });
+    expect(res.status).toBe(400);
+    // The service must never be called — the rejection is enforced server-side
+    // before persistence, not merely a downstream validation.
+    expect(appendFindingCalls).toHaveLength(0);
+  });
+
+  it('POST /prs/:id/findings with source:"patch", disposition:"superseded" returns 400 (authority violation)', async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "superseded",
+        source: "patch",
+        evidence: "Claims a later fix superseded this.",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /prs/:id/findings with source:"patch", disposition:"rejected" succeeds (patch\'s one allowed disposition)', async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "rejected",
+        source: "patch",
+        evidence: "Not a real issue — false positive.",
+      }),
+    });
+    expect([200, 201]).toContain(res.status);
+    const body = (await res.json()) as PrFinding;
+    expect(body.disposition).toBe("rejected");
+    expect(body.source).toBe("patch");
+    expect(appendFindingCalls).toHaveLength(1);
+  });
+
+  it('POST /prs/:id/findings with source:"review", disposition:"superseded" succeeds (review has no restriction)', async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = makeApp({ prService: fakePrService({ store }) });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "superseded",
+        source: "review",
+        evidence: "Superseded by a later review finding.",
+      }),
+    });
+    expect([200, 201]).toContain(res.status);
+  });
+
+  it("POST /prs/:id/findings returns 404 when the PR does not exist", async () => {
+    const app = makeApp({
+      prService: fakePrService({
+        store: new Map(),
+        appendFindingResult: new NotFoundError("pr not found"),
+      }),
+    });
+
+    const res = await app.request("/prs/missing/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "review",
+        evidence: "evidence",
+      }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // ─── GET /prs/:id includes findings[] ─────────────────────────────────────
+
+  it("GET /prs/:id response includes findings: PrFinding[]", async () => {
+    const findings = [
+      makeFinding({ id: "finding-1", prRecordId: "pr-1" }),
+      makeFinding({
+        id: "finding-2",
+        prRecordId: "pr-1",
+        ref: "src/bar.ts:7",
+        disposition: "rejected",
+        source: "patch",
+      }),
+    ];
+    const app = makeApp({
+      prService: fakePrService({
+        getResult: makePr({ id: "pr-1", findings } as Partial<PullRequest>),
+      }),
+    });
+    const res = await app.request("/prs/pr-1", { headers: adminAuth() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PullRequest & { findings: PrFinding[] };
+    expect(body.findings).toHaveLength(2);
+    expect(body.findings[0].ref).toBe("src/foo.ts:1");
+    expect(body.findings[1].disposition).toBe("rejected");
   });
 });

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -1758,6 +1758,57 @@ describe("/prs routes (smoke)", () => {
     expect([200, 201]).toContain(res.status);
   });
 
+  it("POST /prs/:id/findings returns 400 when ref is an empty string", async () => {
+    // Zod's z.string() body-schema check accepts an empty string (it isn't
+    // .min(1)), so this exercises the handler's own `!ref` truthiness check
+    // rather than being intercepted by the OpenAPIHono request validator.
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "",
+        disposition: "resolved",
+        source: "review",
+        evidence: "Fixed in the follow-up commit.",
+      }),
+    });
+    expect(res.status).toBe(400);
+    // The service must never be called — validation fails before persistence.
+    expect(appendFindingCalls).toHaveLength(0);
+  });
+
+  it("POST /prs/:id/findings returns 400 when evidence is an empty string", async () => {
+    // Same rationale as the empty-ref case above — z.string() lets an empty
+    // string reach the handler, which is where evidence's `!evidence` check
+    // actually rejects it.
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "review",
+        evidence: "",
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(appendFindingCalls).toHaveLength(0);
+  });
+
   it("POST /prs/:id/findings returns 404 when the PR does not exist", async () => {
     const app = makeApp({
       prService: fakePrService({

--- a/task-store/src/pull-request-service.integration.test.ts
+++ b/task-store/src/pull-request-service.integration.test.ts
@@ -17,7 +17,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { PrismaClient } from "../prisma/client/index.js";
-import { ConflictError } from "./errors.ts";
+import { ConflictError, NotFoundError } from "./errors.ts";
 import { PullRequestService } from "./pull-request-service.ts";
 
 const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
@@ -208,3 +208,108 @@ describeOrSkip(
     });
   },
 );
+
+describeOrSkip("PullRequestService.appendFinding() (integration)", () => {
+  let prisma: PrismaClient;
+  let service: PullRequestService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    service = new PullRequestService(prisma);
+    await prisma.prFinding.deleteMany();
+    await prisma.pullRequest.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("persists a finding via the service and a subsequent get() returns it in findings[]", async () => {
+    const pr = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 6100 },
+    });
+
+    const finding = await service.appendFinding(pr.id, {
+      ref: "src/foo.ts:42",
+      disposition: "resolved",
+      source: "review",
+      evidence: "Fixed the null check in the follow-up commit.",
+      at: "2026-08-17T12:00:00.000Z",
+    });
+
+    expect(finding.prRecordId).toBe(pr.id);
+    expect(finding.ref).toBe("src/foo.ts:42");
+    expect(finding.disposition).toBe("resolved");
+    expect(finding.source).toBe("review");
+
+    const fetched = await service.get(pr.id);
+    expect(fetched).not.toBeNull();
+    if (!fetched) return;
+    const withFindings = fetched as typeof fetched & {
+      findings: Array<{ id: string; ref: string }>;
+    };
+    expect(withFindings.findings).toHaveLength(1);
+    expect(withFindings.findings[0].id).toBe(finding.id);
+    expect(withFindings.findings[0].ref).toBe("src/foo.ts:42");
+  });
+
+  it("stamps `at` with the current time via the injected Clock when omitted by the caller", async () => {
+    const fixedNow = new Date("2026-08-18T00:00:00.000Z");
+    const fixedService = new PullRequestService(prisma, {
+      now: () => fixedNow,
+    });
+    const pr = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 6101 },
+    });
+
+    const finding = await fixedService.appendFinding(pr.id, {
+      ref: "src/bar.ts:1",
+      disposition: "rejected",
+      source: "patch",
+      evidence: "Not a real issue.",
+    });
+
+    expect(finding.at).toBe(fixedNow.toISOString());
+  });
+
+  it("throws NotFoundError when the PR does not exist", async () => {
+    let caught: unknown;
+    try {
+      await service.appendFinding("does-not-exist", {
+        ref: "src/foo.ts:1",
+        disposition: "resolved",
+        source: "review",
+        evidence: "evidence",
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(NotFoundError);
+  });
+
+  it("allows concurrent appendFinding calls for the same PR (race-safe plain INSERT)", async () => {
+    const pr = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 6102 },
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        service.appendFinding(pr.id, {
+          ref: `src/concurrent.ts:${i}`,
+          disposition: "resolved",
+          source: i % 2 === 0 ? "review" : "patch",
+          evidence: `finding ${i}`,
+          at: "2026-08-17T05:00:00.000Z",
+        }),
+      ),
+    );
+
+    expect(results).toHaveLength(5);
+
+    const fetched = await service.get(pr.id);
+    const withFindings = fetched as typeof fetched & {
+      findings: unknown[];
+    };
+    expect(withFindings?.findings).toHaveLength(5);
+  });
+});

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -22,6 +22,9 @@ import { type Clock, SystemClock } from "./clock.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
 import {
   Prisma,
+  type PrFinding,
+  type PrFindingDisposition,
+  type PrFindingSource,
   type PrismaClient,
   type PrPhase,
   type PullRequest,
@@ -172,6 +175,16 @@ export interface PullRequestListResult {
   offset: number;
 }
 
+/** Input for PullRequestService.appendFinding. */
+export interface AppendFindingInput {
+  ref: string;
+  disposition: PrFindingDisposition;
+  source: PrFindingSource;
+  evidence: string;
+  /** ISO timestamp. Defaults to the service's Clock.now() when omitted. */
+  at?: string;
+}
+
 /** The subset of PullRequestService the routes depend on. */
 export interface PullRequestServiceLike {
   list(filters?: PullRequestListFilters): Promise<PullRequestListResult>;
@@ -201,6 +214,7 @@ export interface PullRequestServiceLike {
     maxConcurrent: number,
     repos?: string[],
   ): Promise<{ pr: PullRequest; phase: PrPhase } | null>;
+  appendFinding(prId: string, data: AppendFindingInput): Promise<PrFinding>;
 }
 
 export class PullRequestService implements PullRequestServiceLike {
@@ -253,6 +267,7 @@ export class PullRequestService implements PullRequestServiceLike {
       const candidates = await this.prisma.pullRequest.findMany({
         where,
         orderBy,
+        include: { findings: true },
       });
 
       const taskIds = [
@@ -288,6 +303,7 @@ export class PullRequestService implements PullRequestServiceLike {
         orderBy,
         take: limit,
         skip: offset,
+        include: { findings: true },
       }),
       this.prisma.pullRequest.count({ where }),
     ]);
@@ -296,7 +312,10 @@ export class PullRequestService implements PullRequestServiceLike {
   }
 
   async get(id: string): Promise<PullRequest | null> {
-    return this.prisma.pullRequest.findUnique({ where: { id } });
+    return this.prisma.pullRequest.findUnique({
+      where: { id },
+      include: { findings: true },
+    });
   }
 
   // ─── Writes ────────────────────────────────────────────────────────────────
@@ -895,6 +914,48 @@ export class PullRequestService implements PullRequestServiceLike {
     } catch (err: unknown) {
       throw this.translateNotFound(err, "pr not found");
     }
+  }
+
+  /**
+   * Append a PrFinding row to a PR — a single unlocked INSERT, race-safe
+   * against concurrent writers (see the schema.prisma comment on PrFinding
+   * for the rationale: a JSON-array read-modify-write PATCH is not race-safe,
+   * a plain INSERT is). Validates the PR exists first via an explicit
+   * findUnique() check (rather than letting a bad prRecordId surface as a
+   * Prisma P2003 FK-violation error) so callers get a clean 404 via
+   * NotFoundError, matching the translateNotFound pattern used elsewhere.
+   *
+   * Server-side source/disposition authority enforcement (source:'patch' may
+   * only submit disposition:'rejected') lives in the route handler
+   * (routes/prs.ts), consistent with this codebase's existing pattern of
+   * validating request fields inline in the handler before calling the
+   * service (see claimRoute's repo/prNumber/commitSha checks).
+   *
+   * `at` defaults to this.clock.now() when the caller omits it, keeping the
+   * route handler thin (mirrors this.clock usage elsewhere in this class).
+   */
+  async appendFinding(
+    prId: string,
+    data: AppendFindingInput,
+  ): Promise<PrFinding> {
+    const existing = await this.prisma.pullRequest.findUnique({
+      where: { id: prId },
+      select: { id: true },
+    });
+    if (!existing) {
+      throw new NotFoundError("pr not found");
+    }
+
+    return this.prisma.prFinding.create({
+      data: {
+        prRecordId: prId,
+        ref: data.ref,
+        disposition: data.disposition,
+        source: data.source,
+        evidence: data.evidence,
+        at: data.at ?? this.clock.now().toISOString(),
+      },
+    });
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -1164,3 +1164,115 @@ describe("PullRequestService.complete() claim release", () => {
     expect(data.readyForPatchAt).toBe(NOW.toISOString());
   });
 });
+
+// ─── appendFinding() ────────────────────────────────────────────────────────
+//
+// Unlike the DB-backed race test in pull-request-service.integration.test.ts
+// (which requires DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST and self-skips
+// without it), this exercises appendFinding()'s own two code paths — the
+// existence check and the create() call — against a hand-built Prisma
+// double, no real Postgres required. Mirrors makePrismaDouble above but adds
+// the prFinding.create() surface appendFinding() depends on.
+
+interface CreateFindingCall {
+  data: Record<string, unknown>;
+}
+
+function makeFindingPrismaDouble(prExists: boolean) {
+  const createCalls: CreateFindingCall[] = [];
+
+  const prisma = {
+    pullRequest: {
+      findUnique(_args: unknown): Promise<{ id: string } | null> {
+        return Promise.resolve(prExists ? { id: "pr-1" } : null);
+      },
+    },
+    prFinding: {
+      create(args: CreateFindingCall): Promise<Record<string, unknown>> {
+        createCalls.push(args);
+        return Promise.resolve({ id: "finding-1", ...args.data });
+      },
+    },
+    _createCalls: createCalls,
+  };
+
+  return prisma as unknown as {
+    pullRequest: { findUnique: (args: unknown) => Promise<{ id: string } | null> };
+    prFinding: { create: (args: CreateFindingCall) => Promise<Record<string, unknown>> };
+    _createCalls: CreateFindingCall[];
+  };
+}
+
+describe("PullRequestService.appendFinding()", () => {
+  const NOW = new Date("2026-07-10T12:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  test("inserts a PrFinding row scoped to prRecordId when the PR exists", async () => {
+    const prisma = makeFindingPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    const finding = await svc.appendFinding("pr-1", {
+      ref: "src/foo.ts:42",
+      disposition: "resolved",
+      source: "review",
+      evidence: "Fixed in the follow-up commit.",
+    });
+
+    expect(prisma._createCalls).toHaveLength(1);
+    const { data } = prisma._createCalls[0];
+    expect(data.prRecordId).toBe("pr-1");
+    expect(data.ref).toBe("src/foo.ts:42");
+    expect(data.disposition).toBe("resolved");
+    expect(data.source).toBe("review");
+    expect(data.evidence).toBe("Fixed in the follow-up commit.");
+    expect(finding.id).toBe("finding-1");
+  });
+
+  test("defaults `at` to clock.now() when the caller omits it", async () => {
+    const prisma = makeFindingPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.appendFinding("pr-1", {
+      ref: "src/foo.ts:42",
+      disposition: "rejected",
+      source: "patch",
+      evidence: "Not a real issue.",
+    });
+
+    const { data } = prisma._createCalls[0];
+    expect(data.at).toBe(NOW.toISOString());
+  });
+
+  test("uses the caller-supplied `at` when provided, rather than clock.now()", async () => {
+    const prisma = makeFindingPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+    const explicitAt = "2026-06-01T00:00:00.000Z";
+
+    await svc.appendFinding("pr-1", {
+      ref: "src/foo.ts:42",
+      disposition: "resolved",
+      source: "review",
+      evidence: "Fixed.",
+      at: explicitAt,
+    });
+
+    const { data } = prisma._createCalls[0];
+    expect(data.at).toBe(explicitAt);
+  });
+
+  test("throws NotFoundError and never calls prFinding.create() when the PR does not exist", async () => {
+    const prisma = makeFindingPrismaDouble(false);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await expect(
+      svc.appendFinding("missing-pr", {
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "review",
+        evidence: "Fixed.",
+      }),
+    ).rejects.toThrow(NotFoundError);
+
+    expect(prisma._createCalls).toHaveLength(0);
+  });
+});

--- a/task-store/src/routes/prs.openapi.smoke.test.ts
+++ b/task-store/src/routes/prs.openapi.smoke.test.ts
@@ -208,6 +208,10 @@ function fakePrService(
     } | null> {
       return null;
     },
+
+    async appendFinding() {
+      return {} as never;
+    },
   };
 }
 

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -23,6 +23,9 @@
  *   POST   /prs/:id/skip      increment skipCount, auto-block at threshold
  *   POST   /prs/:id/skip/reset  reset skipCount back to 0; also clears blocked/blockedReason
  *                                but only when blockedReason matches the skip-auto-block pattern
+ *   POST   /prs/:id/findings  append a PrFinding row {ref, disposition, source, evidence, at?}
+ *                              — source:"patch" may only submit disposition:"rejected" (400
+ *                              otherwise); source:"review" may submit any disposition
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
@@ -34,8 +37,10 @@ import {
   ClaimNextBodySchema,
   ClaimNextResponseSchema,
   ClaimPrBodySchema,
+  CreateFindingBodySchema,
   ErrorSchema,
   PatchPrBodySchema,
+  PrFindingSchema,
   PrIdParamSchema,
   PrListQuerySchema,
   PrListResponseSchema,
@@ -297,6 +302,36 @@ const skipResetRoute = createRoute({
     200: {
       content: { "application/json": { schema: PullRequestSchema } },
       description: "Updated PR",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+const findingsRoute = createRoute({
+  method: "post",
+  path: "/:id/findings",
+  tags: ["PRs"],
+  summary:
+    "Append a review/patch finding to a PR — source:'patch' may only submit disposition:'rejected'",
+  request: {
+    params: PrIdParamSchema,
+    body: {
+      content: { "application/json": { schema: CreateFindingBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      content: { "application/json": { schema: PrFindingSchema } },
+      description: "Finding recorded",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description:
+        "Bad request — including the authority violation of source:'patch' submitting a disposition other than 'rejected'",
     },
     404: {
       content: { "application/json": { schema: ErrorSchema } },
@@ -582,6 +617,53 @@ export function createPrsRoutes(
   app.openapi(skipResetRoute, async (c): Promise<any> => {
     const pr = await prService.resetSkip(c.req.param("id"));
     return c.json(pr, 200);
+  });
+
+  // ─── Findings ──────────────────────────────────────────────────────────────
+  // Server-side source/disposition authority enforcement — mirrors the
+  // PATCH_ALLOWED_FIELDS allowlist pattern above: the API layer, not command
+  // prose, is the sole arbiter. source:"patch" cannot unilaterally resolve or
+  // supersede a finding it didn't originate (only "rejected" is permitted);
+  // source:"review" may write any disposition.
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(findingsRoute, async (c): Promise<any> => {
+    const body = await readJson(c);
+    const { ref, disposition, source, evidence, at } = body;
+
+    if (typeof ref !== "string" || !ref) {
+      throw new BadRequestError("ref is required");
+    }
+    if (
+      disposition !== "resolved" &&
+      disposition !== "superseded" &&
+      disposition !== "rejected"
+    ) {
+      throw new BadRequestError(
+        "disposition must be one of: resolved, superseded, rejected",
+      );
+    }
+    if (source !== "review" && source !== "patch") {
+      throw new BadRequestError("source must be one of: review, patch");
+    }
+    if (typeof evidence !== "string" || !evidence) {
+      throw new BadRequestError("evidence is required");
+    }
+    if (source === "patch" && disposition !== "rejected") {
+      throw new BadRequestError(
+        "source:'patch' may only submit disposition:'rejected' — only source:'review' may resolve or supersede a finding",
+      );
+    }
+
+    const resolvedAt = typeof at === "string" && at ? at : undefined;
+
+    const finding = await prService.appendFinding(c.req.param("id"), {
+      ref,
+      disposition,
+      source,
+      evidence,
+      at: resolvedAt,
+    });
+    return c.json(finding, 201);
   });
 
   return app;

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -32,7 +32,11 @@ import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import { readJson } from "@shipwright/lib/http";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, NotFoundError } from "../errors.ts";
-import type { PullRequest } from "../index.ts";
+import type {
+  PrFindingDisposition,
+  PrFindingSource,
+  PullRequest,
+} from "../index.ts";
 import {
   ClaimNextBodySchema,
   ClaimNextResponseSchema,
@@ -628,22 +632,21 @@ export function createPrsRoutes(
   // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
   app.openapi(findingsRoute, async (c): Promise<any> => {
     const body = await readJson(c);
-    const { ref, disposition, source, evidence, at } = body;
+    const { ref, evidence, at } = body;
+
+    // disposition/source are already constrained to their valid enum values
+    // by CreateFindingBodySchema's z.enum() — the OpenAPIHono request
+    // validator rejects any other value with its own 400 before this handler
+    // ever runs, so re-checking them here would be dead code; the cast below
+    // just recovers the type narrowing the validator already enforced at
+    // runtime. ref/evidence are schema-typed as z.string() (no .min(1)), so
+    // an empty string still reaches the handler — these two checks are the
+    // only ones that matter.
+    const disposition = body.disposition as PrFindingDisposition;
+    const source = body.source as PrFindingSource;
 
     if (typeof ref !== "string" || !ref) {
       throw new BadRequestError("ref is required");
-    }
-    if (
-      disposition !== "resolved" &&
-      disposition !== "superseded" &&
-      disposition !== "rejected"
-    ) {
-      throw new BadRequestError(
-        "disposition must be one of: resolved, superseded, rejected",
-      );
-    }
-    if (source !== "review" && source !== "patch") {
-      throw new BadRequestError("source must be one of: review, patch");
     }
     if (typeof evidence !== "string" || !evidence) {
       throw new BadRequestError("evidence is required");


### PR DESCRIPTION
## Summary
- Add `POST /prs/:id/findings` to persist a `PrFinding` row (`ref`, `disposition`, `source`, `evidence`, optional `at`) via `pull-request-service.ts`, enforcing server-side (400) that `source:"patch"` may only submit `disposition:"rejected"` — only `source:"review"` may write `resolved`/`superseded`, mirroring the existing PVD-1.3 guardrail and matching the codebase's allowlist-at-the-API-layer pattern (`PATCH_ALLOWED_FIELDS`)
- Include `findings: PrFinding[]` on `GET /prs/:id` and the list endpoint responses
- Refresh `docs/task-store.md` to document the new endpoint and type

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | POST /prs/:id/findings route added, persists a PrFinding row via pull-request-service.ts | MET |
| 2 | Server-side validation rejects (400) a source:"patch" request with disposition other than "rejected" | MET |
| 3 | GET /prs/:id and the list endpoint include findings: PrFinding[] in the response | MET |
| 4 | Smoke test for the new route's HTTP contract incl. 400 authority-violation case, plus integration test for the service-layer append method against real Postgres; no existing test retired | MET |

## Test Plan
- `prs.smoke.test.ts`: 200/201 for `source:"review"` (any disposition), 400 for `source:"patch"` + `resolved`/`superseded`, 200/201 for `source:"patch"` + `rejected`, 404 for missing PR, `GET /prs/:id` returns `findings[]`
- `pull-request-service.integration.test.ts` (new, DB-gated on `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST`, skips without it — same pattern as the existing `pr-finding.integration.test.ts`): `appendFinding()` persistence + `get()` round-trip, Clock-based `at` stamping, `NotFoundError` on missing PR, concurrent-insert race-safety
- [x] Pre-commit checks passing (`task lint`, `task typecheck`, full `bun test` suite: 636 pass / 0 fail in task-store)

Generated with [Claude Code](https://claude.com/claude-code)
