### PR TITLE
feat(minikube): enable the admin Chat tab and open the dev-login URL automatically

### DIFF
--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.57
+version: 1.11.58
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com

--- a/charts/shipwright/examples/values-minikube.yaml
+++ b/charts/shipwright/examples/values-minikube.yaml
@@ -121,6 +121,14 @@ chat:
   enabled: true
   database:
     existingSecret: ""
+  adminToken:
+    # Left empty on purpose: the chart then generates the chat admin token into
+    # its own chat Secret and injects that one value into BOTH the chat service
+    # (CHAT_SEED_ADMIN_TOKEN) and the admin console
+    # (SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN), so the admin console's Chat tab
+    # (/admin/chat) works with no hand-created Secret. Set this only to supply
+    # your own token via a pre-existing Secret.
+    existingSecret: ""
   resources:
     requests:
       cpu: 100m

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -490,6 +490,27 @@ DATABASE_URL_SHIPWRIGHT_CHAT on the bundled-PostgreSQL path).
 {{- end }}
 
 {{/*
+Name of the Secret holding the raw chat admin token, or "" when chat is
+disabled. Prefers a caller-supplied chat.adminToken.existingSecret; otherwise
+the chart manages the token itself in its own chat Secret (see
+chat-secret.yaml). Both the chat container (CHAT_SEED_ADMIN_TOKEN) and the
+admin container (SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN) resolve through this so
+the two always read the same value — that shared value is what makes the admin
+console's Chat tab work without a hand-created Secret.
+*/}}
+{{- define "shipwright.chat.adminTokenSecretName" -}}
+{{- if .Values.chat.enabled }}{{- .Values.chat.adminToken.existingSecret | default (include "shipwright.chat.secretName" .) }}{{- end }}
+{{- end }}
+
+{{/*
+Key within the chat admin-token Secret. One expression shared by the chart-managed
+Secret and both consumers, so a custom chat.adminToken.key stays consistent.
+*/}}
+{{- define "shipwright.chat.adminTokenSecretKey" -}}
+{{- .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+{{- end }}
+
+{{/*
 Chat database name: a SEPARATE database from admin, metrics and task-store
 (default "shipwright_chat"). See shipwright.taskStore.databaseName for why each
 Prisma service must own its own database.

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -244,21 +244,23 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
-            {{- if and .Values.chat.enabled .Values.chat.adminToken.existingSecret }}
+            {{- with (include "shipwright.chat.adminTokenSecretName" .) }}
             # ── Chat-service wiring ───────────────────────────────────────────
             # Enables the admin console's Chat tab (/admin/chat) and per-agent
             # chat-token minting during provisioning. The URL is the in-cluster
             # chat Service; the token is the same raw value the chat service
             # seeds at boot via CHAT_SEED_ADMIN_TOKEN, so the pair works out of
-            # the box. Override the URL via admin.extraEnv if needed (extraEnv
-            # is appended last and wins).
+            # the box — from the caller's chat.adminToken.existingSecret when
+            # set, otherwise from the chart-managed chat Secret. Override the
+            # URL via admin.extraEnv if needed (extraEnv is appended last and
+            # wins).
             - name: SHIPWRIGHT_CHAT_SERVICE_URL
-              value: {{ printf "http://%s:%v" (include "shipwright.chat.fullname" .) .Values.chat.service.port | quote }}
+              value: {{ printf "http://%s:%v" (include "shipwright.chat.fullname" $) $.Values.chat.service.port | quote }}
             - name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.chat.adminToken.existingSecret }}
-                  key: {{ .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+                  name: {{ . }}
+                  key: {{ include "shipwright.chat.adminTokenSecretKey" $ }}
             {{- end }}
             {{- if .Values.admin.sentry.dsn.existingSecret }}
             - name: SENTRY_DSN

--- a/charts/shipwright/templates/chat-deployment.yaml
+++ b/charts/shipwright/templates/chat-deployment.yaml
@@ -74,16 +74,18 @@ spec:
             {{- else }}
             {{- fail "chat.database.existingSecret is required when postgresql.enabled=false" }}
             {{- end }}
-            {{- if .Values.chat.adminToken.existingSecret }}
+            {{- with (include "shipwright.chat.adminTokenSecretName" .) }}
             # Seed the admin token (stored hashed) at boot so the admin console
             # can authenticate without manual token minting. Idempotent upsert —
             # the same raw value is injected into the admin Deployment as
-            # SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN.
+            # SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN. Sourced from the caller's
+            # chat.adminToken.existingSecret when set, otherwise from the
+            # chart-managed chat Secret.
             - name: CHAT_SEED_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.chat.adminToken.existingSecret }}
-                  key: {{ .Values.chat.adminToken.key | default "SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN" }}
+                  name: {{ . }}
+                  key: {{ include "shipwright.chat.adminTokenSecretKey" $ }}
             {{- end }}
             {{- with .Values.chat.extraEnv }}
             # chat.extraEnv: caller-supplied env vars appended last so they can

--- a/charts/shipwright/templates/chat-secret.yaml
+++ b/charts/shipwright/templates/chat-secret.yaml
@@ -1,20 +1,52 @@
-{{- if and .Values.chat.enabled (include "shipwright.chat.useBundledDatabase" .) }}
+{{- $bundledDb := include "shipwright.chat.useBundledDatabase" . }}
+{{- $manageToken := and .Values.chat.enabled (not .Values.chat.adminToken.existingSecret) }}
+{{- if and .Values.chat.enabled (or $bundledDb $manageToken) }}
 {{- /*
-  Chart-managed chat Secret — the bundled-PostgreSQL path only.
+  Chart-managed chat Secret. Holds two independent things, each rendered only
+  when the chart is responsible for it:
 
-  Mirrors task-store-secret.yaml exactly; see that file for the full rationale
-  (opt-in gating, why the DSN lives in a Secret rather than plaintext env, and
-  why no lookup-persistence idiom is needed for a deterministically-derived
-  value).
+    DATABASE_URL_SHIPWRIGHT_CHAT  — bundled-PostgreSQL path only. Mirrors
+      task-store-secret.yaml exactly; see that file for the full rationale
+      (opt-in gating, why the DSN lives in a Secret rather than plaintext env,
+      and why no lookup-persistence idiom is needed for a deterministically-
+      derived value).
+
+    the chat admin token — generated unless the caller supplied
+      chat.adminToken.existingSecret. Both the chat service (which seeds it at
+      boot via CHAT_SEED_ADMIN_TOKEN) and the admin console (which calls chat
+      with it) read this one key, so the Chat tab works with no hand-created
+      Secret. Unlike the DSN this value is NOT derivable, so it uses the same
+      lookup-persistence idiom as admin-secret.yaml: reuse the value already in
+      the cluster, generate only when absent. Without that, every `helm upgrade`
+      would mint a new token and desynchronize the two Deployments.
+
+      `helm template` and helm-unittest cannot execute `lookup`, so they always
+      take the generate branch — expected, and the same caveat admin-secret.yaml
+      documents.
 */}}
+{{- $secretName := include "shipwright.chat.secretName" . }}
+{{- $tokenKey := include "shipwright.chat.adminTokenSecretKey" . }}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- $adminToken := "" }}
+{{- if and $existing $existing.data (index $existing.data $tokenKey) }}
+{{- $adminToken = index $existing.data $tokenKey }}
+{{- else }}
+{{- $adminToken = (randAlphaNum 32 | b64enc) }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "shipwright.chat.secretName" . }}
+  name: {{ $secretName }}
   labels:
     {{- include "shipwright.chat.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if $bundledDb }}
   {{- $dbUrl := include "shipwright.postgresql.dsn" (dict "context" . "database" (include "shipwright.chat.databaseName" .)) }}
   DATABASE_URL_SHIPWRIGHT_CHAT: {{ $dbUrl | b64enc | quote }}
+  {{- end }}
+  {{- if $manageToken }}
+  # Generated on first install, reused on upgrade via the lookup idiom above.
+  {{ $tokenKey }}: {{ $adminToken | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -377,10 +377,37 @@ tests:
             name: SHIPWRIGHT_CHAT_SERVICE_URL
             value: http://r-shipwright-chat:3000
 
-  - it: does not inject chat-service env when chat.enabled but adminToken unset
+  - it: injects chat-service env from the chart-managed Secret when chat.enabled and adminToken unset
+    # No caller Secret required: the chart generates the token into its own chat
+    # Secret and both Deployments read it, so /admin/chat works out of the box.
+    # The chat side of the same pair is asserted in chat_workload_test.yaml.
     template: templates/admin-deployment.yaml
     set:
       chat.enabled: true
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_URL
+            value: http://r-shipwright-chat:3000
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-chat
+                key: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: does not inject chat-service env when chat is disabled, even with adminToken set
+    # chat.enabled gates the wiring: without a chat Service to talk to, pointing
+    # admin at one would be wiring to nothing.
+    template: templates/admin-deployment.yaml
+    set:
+      chat.enabled: false
+      chat.adminToken.existingSecret: shipwright-secrets
     release:
       name: r
     asserts:

--- a/charts/shipwright/tests/chat_secret_test.yaml
+++ b/charts/shipwright/tests/chat_secret_test.yaml
@@ -1,19 +1,28 @@
 suite: chat Secret — bundled-PostgreSQL DSN assembly and opt-in gating
-# Mirrors task_store_secret_test.yaml; see there for the full rationale. The
-# chart-managed chat Secret exists ONLY when chat.database.existingSecret is ""
-# AND the bundled PostgreSQL is enabled, so no pre-existing install renders it.
+# Mirrors task_store_secret_test.yaml for the DSN half; see there for the full
+# rationale. This Secret carries two INDEPENDENTLY gated keys:
+#   DATABASE_URL_SHIPWRIGHT_CHAT — only when chat.database.existingSecret is ""
+#     AND the bundled PostgreSQL is enabled.
+#   the chat admin token — whenever chat is enabled and the caller supplied no
+#     chat.adminToken.existingSecret.
+# So the Secret renders when EITHER half applies, and disappears only when
+# neither does.
 templates:
   - templates/chat-secret.yaml
 release:
   name: r
   namespace: shipwright
 tests:
-  - it: renders no Secret by default (existingSecret defaults to shipwright-secrets)
+  - it: renders a token-only Secret by default (database existingSecret defaults to shipwright-secrets)
     set:
       chat.enabled: true
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - isNotNullOrEmpty:
+          path: data.SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+      - isNull:
+          path: data.DATABASE_URL_SHIPWRIGHT_CHAT
 
   - it: renders no Secret when chat is disabled, even on the bundled path
     set:
@@ -23,19 +32,34 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders no Secret when an external database Secret is named
+  - it: omits the DSN but still carries the token when an external database Secret is named
     set:
       chat.enabled: true
       chat.database.existingSecret: my-external-secret
     asserts:
-      - hasDocuments:
-          count: 0
+      - isNull:
+          path: data.DATABASE_URL_SHIPWRIGHT_CHAT
+      - isNotNullOrEmpty:
+          path: data.SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
 
-  - it: renders no Secret when the bundled PostgreSQL is disabled
+  - it: omits the DSN but still carries the token when the bundled PostgreSQL is disabled
     set:
       chat.enabled: true
       chat.database.existingSecret: ""
       postgresql.enabled: false
+    asserts:
+      - isNull:
+          path: data.DATABASE_URL_SHIPWRIGHT_CHAT
+      - isNotNullOrEmpty:
+          path: data.SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: renders no Secret when the caller owns both halves
+    # Nothing left for the chart to manage: caller-supplied DB Secret AND
+    # caller-supplied token Secret.
+    set:
+      chat.enabled: true
+      chat.database.existingSecret: my-external-secret
+      chat.adminToken.existingSecret: my-chat-tokens
     asserts:
       - hasDocuments:
           count: 0
@@ -91,3 +115,40 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: chat
+
+  # ── chart-managed admin token ─────────────────────────────────────────────
+  # Generated when the caller supplies no chat.adminToken.existingSecret, so the
+  # admin console's Chat tab works with no hand-created Secret. helm-unittest
+  # cannot execute `lookup`, so these always exercise the generate branch.
+
+  - it: generates the chat admin token when no existingSecret is supplied
+    set:
+      chat.enabled: true
+      chat.database.existingSecret: ""
+      postgresql.auth.password: testpw
+    asserts:
+      - isNotNullOrEmpty:
+          path: data.SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: writes the generated token under a custom chat.adminToken.key
+    set:
+      chat.enabled: true
+      chat.database.existingSecret: ""
+      chat.adminToken.key: CHAT_ADMIN_RAW
+      postgresql.auth.password: testpw
+    asserts:
+      - isNotNullOrEmpty:
+          path: data.CHAT_ADMIN_RAW
+      - isNull:
+          path: data.SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+
+  - it: does not manage a token when the caller supplies their own Secret
+    set:
+      chat.enabled: true
+      chat.database.existingSecret: ""
+      chat.adminToken.existingSecret: my-chat-tokens
+      postgresql.auth.password: testpw
+    asserts:
+      - isNull:
+          path: data.SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
+

--- a/charts/shipwright/tests/chat_workload_test.yaml
+++ b/charts/shipwright/tests/chat_workload_test.yaml
@@ -123,20 +123,23 @@ tests:
 
   # ── Admin-token seeding (chat.adminToken) ────────────────────────────────
 
-  - it: does not inject CHAT_SEED_ADMIN_TOKEN by default (adminToken unset)
+  - it: seeds CHAT_SEED_ADMIN_TOKEN from the chart-managed Secret by default (adminToken unset)
+    # With no caller-supplied Secret the chart generates the token itself, so the
+    # admin console's Chat tab works without a hand-created Secret. The admin
+    # Deployment reads the same name/key — see admin_workload_test.yaml.
     template: templates/chat-deployment.yaml
     set:
       chat.enabled: true
     release:
       name: r
     asserts:
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: CHAT_SEED_ADMIN_TOKEN
             valueFrom:
               secretKeyRef:
-                name: shipwright-secrets
+                name: r-shipwright-chat
                 key: SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN
 
   - it: seeds CHAT_SEED_ADMIN_TOKEN from chat.adminToken.existingSecret (default key)

--- a/scripts/minikube.ts
+++ b/scripts/minikube.ts
@@ -471,20 +471,27 @@ function printNextSteps(): void {
 }
 
 /** True when /etc/hosts maps the ingress host. Unreadable file → assume no. */
-function ingressHostResolves(): boolean {
+export function ingressHostResolves(
+  readFile: (path: string, encoding: string) => string = (p, e) =>
+    readFileSync(p, e),
+): boolean {
   try {
-    return hostsEntryPresent(readFileSync("/etc/hosts", "utf8"), INGRESS_HOST);
+    return hostsEntryPresent(readFile("/etc/hosts", "utf8"), INGRESS_HOST);
   } catch {
     return false;
   }
 }
 
 /** Best-effort browser launch — never fails the bring-up. */
-function openInBrowser(url: string): void {
-  const argv = buildOpenCommand(url);
+export function openInBrowser(
+  url: string,
+  exec: ExecFn = realExec,
+  platform: string = process.platform,
+): void {
+  const argv = buildOpenCommand(url, platform);
   if (argv === null) return;
   try {
-    realExec(argv);
+    exec(argv);
   } catch {
     // No browser to launch (headless, no DISPLAY). The URL is printed above.
   }

--- a/scripts/minikube.ts
+++ b/scripts/minikube.ts
@@ -230,6 +230,7 @@ export function buildMinikubeCommands(opts: BuildOpts = {}): Command[] {
 
 export type AccessUrls = {
   admin: string;
+  devLogin: string;
   metrics: string;
   taskStore: string;
   agentNew: string;
@@ -244,11 +245,17 @@ export type AccessUrls = {
  * is itself named "/dashboard", so the two compose. See
  * charts/shipwright/templates/metrics-deployment.yaml's probe paths, which
  * hit the same basePath-prefixed shape for /health.
+ *
+ * devLogin is the entry point to hand a developer, NOT admin. This profile runs
+ * auth.mode=open, and "/" redirects to /admin/login — a page that only offers a
+ * Google sign-in button, which this profile never configures. That is a dead end.
+ * /admin/dev-login mints the dev session outright and lands on /admin/agents.
  */
 export function buildAccessUrls(host: string, port: number): AccessUrls {
   const base = `http://${host}:${port}`;
   return {
     admin: `${base}/`,
+    devLogin: `${base}/admin/dev-login`,
     metrics: `${base}/dashboard/dashboard`,
     taskStore: `${base}/task-store/health`,
     agentNew: `${base}/admin/agents/new`,
@@ -412,9 +419,17 @@ function printNextSteps(): void {
   console.log("Shipwright is up.\n");
   console.log("Add the ingress host to /etc/hosts (once):");
   console.log(`  echo "127.0.0.1 ${INGRESS_HOST}" | sudo tee -a /etc/hosts\n`);
+  console.log(
+    "Log in (auth.mode=open — this mints a dev session, no password):",
+  );
+  console.log(`  ${urls.devLogin}\n`);
   console.log(`  admin console   ${urls.admin}`);
   console.log(`  metrics         ${urls.metrics}`);
   console.log(`  task store      ${urls.taskStore}\n`);
+  console.log(
+    "Visit the dev-login link FIRST — the admin console redirects to a Google",
+  );
+  console.log("sign-in page that this profile does not configure.\n");
   console.log("No agent exists yet — create one at:");
   console.log(`  ${urls.agentNew}\n`);
   console.log(

--- a/scripts/minikube.ts
+++ b/scripts/minikube.ts
@@ -263,6 +263,35 @@ export function buildAccessUrls(host: string, port: number): AccessUrls {
 }
 
 /**
+ * Command that hands `url` to the OS browser, or null on a platform with no
+ * known opener. Best-effort by design — a headless box (CI, no DISPLAY, SSH)
+ * must still finish the bring-up, so the caller ignores failures here.
+ */
+export function buildOpenCommand(
+  url: string,
+  platform: string = process.platform,
+): string[] | null {
+  if (platform === "darwin") return ["open", url];
+  if (platform === "linux") return ["xdg-open", url];
+  return null;
+}
+
+/**
+ * Whether /etc/hosts still needs the ingress-host line. The whole stack is
+ * reached through `http://<host>:<port>`, so without this mapping the URL does
+ * not resolve and auto-open lands on a browser error page.
+ *
+ * Matches a real mapping only: the host must be a whole field on a line that is
+ * not commented out. A bare substring test would accept "#127.0.0.1 host".
+ */
+export function hostsEntryPresent(hostsFile: string, host: string): boolean {
+  return hostsFile
+    .split("\n")
+    .map((line) => line.split("#")[0])
+    .some((line) => line.trim().split(/\s+/).includes(host));
+}
+
+/**
  * Build the teardown sequence: uninstall the release, then delete the VM.
  *
  * Uninstall first so Helm can run its hooks and drop the PVCs while the API
@@ -413,36 +442,52 @@ function stopPortForward(): void {
   }
 }
 
+/**
+ * Final output: ONE url, opened for you.
+ *
+ * Deliberately just the dev-login link. Every other surface (admin console,
+ * metrics, task store, agent creation) is reachable from the console once you
+ * are signed in, and listing them here buried the only link that does anything
+ * useful on a cold stack — the console root redirects to a Google sign-in page
+ * this profile never configures, so it is a dead end. /admin/dev-login mints
+ * the dev session outright and lands on /admin/agents.
+ */
 function printNextSteps(): void {
   const urls = buildAccessUrls(INGRESS_HOST, INGRESS_LOCAL_PORT);
   console.log("\n────────────────────────────────────────────────────────────");
   console.log("Shipwright is up.\n");
-  console.log("Add the ingress host to /etc/hosts (once):");
-  console.log(`  echo "127.0.0.1 ${INGRESS_HOST}" | sudo tee -a /etc/hosts\n`);
-  console.log(
-    "Log in (auth.mode=open — this mints a dev session, no password):",
-  );
   console.log(`  ${urls.devLogin}\n`);
-  console.log(`  admin console   ${urls.admin}`);
-  console.log(`  metrics         ${urls.metrics}`);
-  console.log(`  task store      ${urls.taskStore}\n`);
-  console.log(
-    "Visit the dev-login link FIRST — the admin console redirects to a Google",
-  );
-  console.log("sign-in page that this profile does not configure.\n");
-  console.log("No agent exists yet — create one at:");
-  console.log(`  ${urls.agentNew}\n`);
-  console.log(
-    "Set that agent's ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in the",
-  );
-  console.log("admin UI before it can work.");
-  console.log(
-    "\nThe stack is reachable through a `kubectl port-forward` this script",
-  );
-  console.log(
-    `started in the background (pid file: ${PORT_FORWARD_PID_FILE}). It is`,
-  );
-  console.log("torn down automatically by: task minikube:down");
+
+  if (!ingressHostResolves()) {
+    console.log(`${INGRESS_HOST} is not in /etc/hosts yet — add it, then open`);
+    console.log("the link above:");
+    console.log(
+      `  echo "127.0.0.1 ${INGRESS_HOST}" | sudo tee -a /etc/hosts\n`,
+    );
+    return;
+  }
+
+  openInBrowser(urls.devLogin);
+}
+
+/** True when /etc/hosts maps the ingress host. Unreadable file → assume no. */
+function ingressHostResolves(): boolean {
+  try {
+    return hostsEntryPresent(readFileSync("/etc/hosts", "utf8"), INGRESS_HOST);
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort browser launch — never fails the bring-up. */
+function openInBrowser(url: string): void {
+  const argv = buildOpenCommand(url);
+  if (argv === null) return;
+  try {
+    realExec(argv);
+  } catch {
+    // No browser to launch (headless, no DISPLAY). The URL is printed above.
+  }
 }
 
 async function main(): Promise<void> {

--- a/scripts/minikube.unit.test.ts
+++ b/scripts/minikube.unit.test.ts
@@ -14,8 +14,10 @@ import { describe, expect, it } from "bun:test";
 import {
   buildAccessUrls,
   buildMinikubeCommands,
+  buildOpenCommand,
   buildTeardownCommands,
   type Command,
+  hostsEntryPresent,
   DEPLOYMENTS,
   missingBinaries,
   runCommands,
@@ -147,7 +149,9 @@ describe("buildMinikubeCommands — install shape", () => {
     const lines = argvLines(buildMinikubeCommands());
     for (const deployment of DEPLOYMENTS) {
       expect(
-        lines.some((l) => l.includes(`rollout status deployment/${deployment}`)),
+        lines.some((l) =>
+          l.includes(`rollout status deployment/${deployment}`),
+        ),
       ).toBe(true);
     }
   });
@@ -170,13 +174,15 @@ describe("buildMinikubeCommands — install shape", () => {
     const lines = argvLines(
       buildMinikubeCommands({ release: "sw2", namespace: "other" }),
     );
-    expect(lines.some((l) => l.includes("helm upgrade --install sw2"))).toBe(true);
-    expect(lines.some((l) => l.includes("helm test sw2 --namespace other"))).toBe(
+    expect(lines.some((l) => l.includes("helm upgrade --install sw2"))).toBe(
       true,
     );
     expect(
-      lines.every((l) => !l.includes("--namespace shipwright")),
+      lines.some((l) => l.includes("helm test sw2 --namespace other")),
     ).toBe(true);
+    expect(lines.every((l) => !l.includes("--namespace shipwright"))).toBe(
+      true,
+    );
   });
 });
 
@@ -190,7 +196,9 @@ describe("buildTeardownCommands", () => {
   });
 
   it("targets the configured release and namespace", () => {
-    const lines = argvLines(buildTeardownCommands({ release: "sw2", namespace: "n" }));
+    const lines = argvLines(
+      buildTeardownCommands({ release: "sw2", namespace: "n" }),
+    );
     expect(lines[0]).toBe("helm uninstall sw2 --namespace n");
   });
 });
@@ -202,13 +210,17 @@ describe("buildAccessUrls", () => {
     // dashboard route is itself named "/dashboard" — the two compose. A bare
     // "/dashboard" 404s; only "/dashboard/dashboard" resolves.
     const urls = buildAccessUrls("shipwright.local", 8080);
-    expect(urls.metrics).toBe("http://shipwright.local:8080/dashboard/dashboard");
+    expect(urls.metrics).toBe(
+      "http://shipwright.local:8080/dashboard/dashboard",
+    );
   });
 
   it("builds the admin, task-store, and agent-creation URLs against the given host and port", () => {
     const urls = buildAccessUrls("shipwright.local", 8080);
     expect(urls.admin).toBe("http://shipwright.local:8080/");
-    expect(urls.taskStore).toBe("http://shipwright.local:8080/task-store/health");
+    expect(urls.taskStore).toBe(
+      "http://shipwright.local:8080/task-store/health",
+    );
     expect(urls.agentNew).toBe("http://shipwright.local:8080/admin/agents/new");
   });
 
@@ -227,19 +239,83 @@ describe("buildAccessUrls", () => {
   });
 });
 
+describe("buildOpenCommand", () => {
+  it("uses `open` on macOS and `xdg-open` on Linux", () => {
+    expect(buildOpenCommand("http://x/y", "darwin")).toEqual([
+      "open",
+      "http://x/y",
+    ]);
+    expect(buildOpenCommand("http://x/y", "linux")).toEqual([
+      "xdg-open",
+      "http://x/y",
+    ]);
+  });
+
+  it("returns null on a platform with no known opener", () => {
+    // The caller treats null as "skip"; bringing the stack up must not depend
+    // on being able to launch a browser.
+    expect(buildOpenCommand("http://x/y", "win32")).toBeNull();
+    expect(buildOpenCommand("http://x/y", "aix")).toBeNull();
+  });
+});
+
+describe("hostsEntryPresent", () => {
+  it("finds the host as a whole field on an active line", () => {
+    expect(
+      hostsEntryPresent("127.0.0.1 shipwright.local", "shipwright.local"),
+    ).toBe(true);
+    expect(
+      hostsEntryPresent(
+        "127.0.0.1\tlocalhost shipwright.local\n",
+        "shipwright.local",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores commented-out mappings", () => {
+    // A bare substring test would accept this and then auto-open a dead link.
+    expect(
+      hostsEntryPresent("# 127.0.0.1 shipwright.local", "shipwright.local"),
+    ).toBe(false);
+    expect(
+      hostsEntryPresent(
+        "127.0.0.1 other # shipwright.local",
+        "shipwright.local",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a host that merely contains the name", () => {
+    expect(
+      hostsEntryPresent(
+        "127.0.0.1 not-shipwright.local.example",
+        "shipwright.local",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for an empty hosts file", () => {
+    expect(hostsEntryPresent("", "shipwright.local")).toBe(false);
+  });
+});
+
 describe("missingBinaries", () => {
   it("returns nothing when every required binary is present", () => {
     expect(missingBinaries(() => "/usr/local/bin/x")).toEqual([]);
   });
 
   it("reports every missing binary, not just the first", () => {
-    expect(missingBinaries(() => null)).toEqual(["minikube", "helm", "kubectl"]);
+    expect(missingBinaries(() => null)).toEqual([
+      "minikube",
+      "helm",
+      "kubectl",
+    ]);
   });
 
   it("reports only the ones actually absent", () => {
-    expect(missingBinaries((bin) => (bin === "helm" ? null : "/bin/x"))).toEqual([
-      "helm",
-    ]);
+    expect(
+      missingBinaries((bin) => (bin === "helm" ? null : "/bin/x")),
+    ).toEqual(["helm"]);
   });
 });
 

--- a/scripts/minikube.unit.test.ts
+++ b/scripts/minikube.unit.test.ts
@@ -212,6 +212,14 @@ describe("buildAccessUrls", () => {
     expect(urls.agentNew).toBe("http://shipwright.local:8080/admin/agents/new");
   });
 
+  it("points the login URL at /admin/dev-login, not the OAuth login page", () => {
+    // auth.mode=open configures no Google OAuth, so /admin/login is a dead end.
+    // Only /admin/dev-login mints a session on this profile.
+    const urls = buildAccessUrls("shipwright.local", 8080);
+    expect(urls.devLogin).toBe("http://shipwright.local:8080/admin/dev-login");
+    expect(urls.devLogin).not.toContain("/admin/login");
+  });
+
   it("honors an arbitrary host and port", () => {
     const urls = buildAccessUrls("127.0.0.1", 9999);
     expect(urls.admin).toBe("http://127.0.0.1:9999/");

--- a/scripts/minikube.unit.test.ts
+++ b/scripts/minikube.unit.test.ts
@@ -18,6 +18,8 @@ import {
   buildTeardownCommands,
   type Command,
   hostsEntryPresent,
+  ingressHostResolves,
+  openInBrowser,
   DEPLOYMENTS,
   missingBinaries,
   runCommands,
@@ -296,6 +298,56 @@ describe("hostsEntryPresent", () => {
 
   it("returns false for an empty hosts file", () => {
     expect(hostsEntryPresent("", "shipwright.local")).toBe(false);
+  });
+});
+
+describe("ingressHostResolves", () => {
+  it("returns true when the injected reader finds the host mapped", () => {
+    expect(
+      ingressHostResolves(() => "127.0.0.1 shipwright.local\n"),
+    ).toBe(true);
+  });
+
+  it("returns false when the injected reader finds no mapping", () => {
+    expect(
+      ingressHostResolves(() => "127.0.0.1 localhost\n"),
+    ).toBe(false);
+  });
+
+  it("returns false (not throw) when the injected reader fails", () => {
+    // Mirrors an unreadable /etc/hosts — the try/catch swallows the error.
+    expect(
+      ingressHostResolves(() => {
+        throw new Error("EACCES");
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("openInBrowser", () => {
+  it("execs the argv built by buildOpenCommand for the given platform", () => {
+    const calls: string[][] = [];
+    openInBrowser("http://x/y", (argv) => calls.push(argv), "darwin");
+    expect(calls).toEqual([["open", "http://x/y"]]);
+  });
+
+  it("does not call exec when buildOpenCommand has no known opener", () => {
+    const calls: string[][] = [];
+    openInBrowser("http://x/y", (argv) => calls.push(argv), "win32");
+    expect(calls).toEqual([]);
+  });
+
+  it("swallows a failing exec instead of throwing", () => {
+    // No browser to launch (headless, no DISPLAY) — the caller must not crash.
+    expect(() =>
+      openInBrowser(
+        "http://x/y",
+        () => {
+          throw new Error("no display");
+        },
+        "linux",
+      ),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #2689 (which fixed only the `NODE_ENV` dev-auth block). Two remaining problems with `task minikube:up`:

**1. The admin console's Chat tab was never wired.** The chat service ran, but nothing could talk to it: `SHIPWRIGHT_CHAT_SERVICE_URL` / `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` (admin) and `CHAT_SEED_ADMIN_TOKEN` (chat) were all gated behind a hand-created `chat.adminToken.existingSecret`, which the minikube profile deliberately avoids — so the admin pod had zero chat env vars.

The chart now generates the token into its own chat Secret using the same lookup-persistence idiom as `admin-secret.yaml` (generate on first install, reuse the cluster's value on upgrade). Both Deployments resolve name and key through one shared helper, so they cannot drift and `helm upgrade` cannot desynchronize them.

**2. The post-install output buried the only useful link.** It listed the admin console, metrics, task store, and agent-creation URLs — but the console root redirects to a Google sign-in page this profile never configures. Output is now exactly one URL, `/admin/dev-login`, and the script opens it for you.

## Notes

- The chat Secret's two keys are independently gated: the DSN on the bundled-PostgreSQL path, the token whenever chat is enabled without a caller-supplied Secret. The Secret renders when either applies.
- `chat.enabled: false` still suppresses all chat wiring, even with `adminToken.existingSecret` set.
- Supplying your own `chat.adminToken.existingSecret` is unchanged.
- Auto-open is best-effort: `open` on macOS, `xdg-open` on Linux, skipped elsewhere, and a launch failure never fails the bring-up. It is suppressed entirely when `/etc/hosts` lacks the `shipwright.local` mapping (the check ignores commented-out lines), so it cannot open a link that would not resolve.

## Testing

- `task helm:check` — lint, 329 unittest specs, kubeconform: all pass
- `bun test scripts/minikube.unit.test.ts` — 33 pass
- `task lint` — clean
- Output and auto-open decision verified against a real `/etc/hosts`
- Not yet exercised against a live cluster — the Minikube profile was deleted mid-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a3jURSc5pXi9Kdoa5ixtb