### PR TITLE
fix(agent): pin Go/npm/bun caches to the PVC and raise ephemeral storage to 4Gi

### DIFF
--- a/admin/src/agent-manifest.ts
+++ b/admin/src/agent-manifest.ts
@@ -43,10 +43,18 @@ export const AGENT_WORKTREE_DIR = `${AGENT_HOME_MOUNT_PATH}/workspace/worktrees`
  * grow until the kubelet evicts neighbouring pods under node memory pressure
  * (observed: ~11.6Gi used against the 2Gi request). No CPU limit — CPU
  * contention throttles instead of evicting.
+ *
+ * ephemeral-storage is 4Gi, not the 1Gi Autopilot default: 1Gi left no room for
+ * a single build step's scratch space, and agents were evicted mid-run ("Pod
+ * ephemeral local storage usage exceeds the total limit of containers 1Gi"),
+ * losing the in-flight task. Tool caches are pinned to the PVC in the agent's
+ * runMiseStartup, so this budget only has to cover genuinely transient writes —
+ * e.g. a scan skill staging tool binaries in a mktemp dir. Requests and limits
+ * are kept equal because Autopilot bills the request either way.
  */
 export const AGENT_CONTAINER_RESOURCES = {
-  requests: { cpu: "500m", memory: "2Gi", "ephemeral-storage": "1Gi" },
-  limits: { memory: "8Gi", "ephemeral-storage": "1Gi" },
+  requests: { cpu: "500m", memory: "2Gi", "ephemeral-storage": "4Gi" },
+  limits: { memory: "8Gi", "ephemeral-storage": "4Gi" },
 };
 
 /** Non-root uid/gid the agent runs as (matches the agent image). */

--- a/admin/src/agent-manifest.unit.test.ts
+++ b/admin/src/agent-manifest.unit.test.ts
@@ -151,7 +151,16 @@ describe("buildAgentDeploymentManifest", () => {
     const resources = d.spec.template.spec.containers[0].resources;
     expect(resources?.requests?.memory).toBe("2Gi");
     expect(resources?.limits?.memory).toBe("8Gi");
-    expect(resources?.limits?.["ephemeral-storage"]).toBe("1Gi");
+  });
+
+  it("budgets 4Gi of ephemeral storage, matched across request and limit", () => {
+    const d = buildAgentDeploymentManifest(deployOpts);
+    const resources = d.spec.template.spec.containers[0].resources;
+    // 1Gi (the Autopilot default) evicted agents mid-run once a build step
+    // wrote any real scratch space. Request and limit stay equal — Autopilot
+    // bills the request regardless, so a lower request buys nothing.
+    expect(resources?.limits?.["ephemeral-storage"]).toBe("4Gi");
+    expect(resources?.requests?.["ephemeral-storage"]).toBe("4Gi");
   });
 
   it("defines liveness and readiness probes on the health port", () => {

--- a/agent/src/setup.integration.test.ts
+++ b/agent/src/setup.integration.test.ts
@@ -558,6 +558,10 @@ describe("runMiseStartup", () => {
   const originalMiseCacheDir = process.env.MISE_CACHE_DIR;
   const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
   const originalXdgDataHome = process.env.XDG_DATA_HOME;
+  const originalGoPath = process.env.GOPATH;
+  const originalGoModCache = process.env.GOMODCACHE;
+  const originalNpmCache = process.env.npm_config_cache;
+  const originalBunCache = process.env.BUN_INSTALL_CACHE_DIR;
   const originalHome = process.env.HOME;
   const originalPath = process.env.PATH;
 
@@ -573,6 +577,10 @@ describe("runMiseStartup", () => {
     process.env.MISE_CACHE_DIR = originalMiseCacheDir;
     process.env.XDG_CACHE_HOME = originalXdgCacheHome;
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    process.env.GOPATH = originalGoPath;
+    process.env.GOMODCACHE = originalGoModCache;
+    process.env.npm_config_cache = originalNpmCache;
+    process.env.BUN_INSTALL_CACHE_DIR = originalBunCache;
     process.env.HOME = originalHome;
     process.env.PATH = originalPath;
   });
@@ -610,6 +618,36 @@ describe("runMiseStartup", () => {
     expect(process.env.XDG_CACHE_HOME).toBe(join(testHome, "cache"));
     expect(existsSync(process.env.MISE_CACHE_DIR ?? "")).toBe(true);
     expect(existsSync(process.env.XDG_CACHE_HOME ?? "")).toBe(true);
+  });
+
+  it("pins the Go, npm and bun caches to the PVC (they ignore XDG)", async () => {
+    mkdirSync(join(testHome, "workspace"), { recursive: true });
+    const mockExec = async () => ({ stdout: "", exitCode: 0 });
+    await runMiseStartup(testHome, mockExec);
+
+    // GOMODCACHE defaults to $GOPATH/pkg/mod, which is under $HOME on the
+    // container's ephemeral overlay — a Terratest module tree there (~1.7GiB)
+    // blows the pod's ephemeral-storage limit and evicts it mid-run.
+    expect(process.env.GOPATH).toBe(join(testHome, "go"));
+    expect(process.env.GOMODCACHE).toBe(join(testHome, "go", "pkg", "mod"));
+    expect(process.env.npm_config_cache).toBe(join(testHome, "cache", "npm"));
+    expect(process.env.BUN_INSTALL_CACHE_DIR).toBe(
+      join(testHome, "cache", "bun"),
+    );
+
+    // Created eagerly so the first tool invocation writes to the PVC rather
+    // than falling back to a default path when the dir is missing.
+    expect(existsSync(process.env.GOMODCACHE ?? "")).toBe(true);
+    expect(existsSync(process.env.npm_config_cache ?? "")).toBe(true);
+    expect(existsSync(process.env.BUN_INSTALL_CACHE_DIR ?? "")).toBe(true);
+  });
+
+  it("leaves CARGO_HOME unset so mise owns the Rust toolchain install", async () => {
+    mkdirSync(join(testHome, "workspace"), { recursive: true });
+    const before = process.env.CARGO_HOME;
+    const mockExec = async () => ({ stdout: "", exitCode: 0 });
+    await runMiseStartup(testHome, mockExec);
+    expect(process.env.CARGO_HOME).toBe(before);
   });
 
   it("skips mise install when mise.toml absent", async () => {

--- a/agent/src/setup.ts
+++ b/agent/src/setup.ts
@@ -617,6 +617,9 @@ export function ensureAgentHome(home: string): void {
  * - Sets MISE_DATA_DIR so installs land on the PVC
  * - Sets MISE_CACHE_DIR + XDG_CACHE_HOME so download tarballs and tool caches
  *   land on the PVC instead of ephemeral storage
+ * - Sets GOPATH/GOMODCACHE + npm/bun cache dirs, which ignore XDG, for the same
+ *   reason — an unpinned Go module cache alone can exceed the pod's
+ *   ephemeral-storage limit and get it evicted mid-run
  * - Runs `mise install` when workspace/mise.toml is present (idempotent)
  * - Prepends mise shim paths to process.env.PATH so subprocesses find tools
  *
@@ -642,6 +645,29 @@ export async function runMiseStartup(
   process.env.XDG_CACHE_HOME = join(home, "cache");
   mkdirSync(process.env.MISE_CACHE_DIR, { recursive: true });
   mkdirSync(process.env.XDG_CACHE_HOME, { recursive: true });
+
+  // XDG_CACHE_HOME covers most tooling, but three package managers ignore XDG
+  // and default to fixed paths under $HOME — which is the container's ephemeral
+  // overlay, not the PVC. Left unpinned they are charged against the pod's
+  // ephemeral-storage limit and evict it mid-run ("Pod ephemeral local storage
+  // usage exceeds the total limit of containers"). Go is the worst offender:
+  // GOMODCACHE defaults to $GOPATH/pkg/mod (NOT $XDG_CACHE_HOME), and a single
+  // `go mod download` on a Terratest module fetches ~1.7GiB. Note GOCACHE (the
+  // build cache) already follows XDG_CACHE_HOME, so only the module cache leaks.
+  //
+  // Pinning these to the PVC also means the caches survive a pod restart
+  // instead of being re-downloaded from scratch on every boot.
+  //
+  // CARGO_HOME is deliberately NOT pinned here: mise manages the Rust toolchain
+  // for workspaces that declare it and sets CARGO_HOME itself, so pre-setting it
+  // would fight the toolchain install.
+  process.env.GOPATH = join(home, "go");
+  process.env.GOMODCACHE = join(home, "go", "pkg", "mod");
+  process.env.npm_config_cache = join(home, "cache", "npm");
+  process.env.BUN_INSTALL_CACHE_DIR = join(home, "cache", "bun");
+  mkdirSync(process.env.GOMODCACHE, { recursive: true });
+  mkdirSync(process.env.npm_config_cache, { recursive: true });
+  mkdirSync(process.env.BUN_INSTALL_CACHE_DIR, { recursive: true });
 
   // Activate mise in any bash session the agent spawns (e.g. Claude Code's Bash
   // tool). The shims-on-PATH prepend below only reaches direct subprocesses;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,10 @@ Controls how the admin service provisions the Kubernetes workload backing each a
 | `MISE_CACHE_DIR` | `string` | `<AGENT_HOME>/mise/cache` | Override the mise cache directory. Auto-derived from `AGENT_HOME`. |
 | `XDG_CACHE_HOME` | `string` | `<AGENT_HOME>/cache` | Override the XDG cache directory. Auto-derived from `AGENT_HOME`. |
 | `XDG_DATA_HOME` | `string` | `$HOME/.local/share` | Override the XDG data directory. Used to locate the mise data dir (`$XDG_DATA_HOME/mise`) when seeding a fresh PVC. |
+| `GOPATH` | `string` | `<AGENT_HOME>/go` | Go workspace root. Auto-derived from `AGENT_HOME`. Go ignores `XDG_CACHE_HOME` for modules, so leaving this at its `$HOME/go` default puts the module cache on the container's ephemeral overlay, where a single large dependency tree can exceed the pod's ephemeral-storage limit and evict it mid-run. |
+| `GOMODCACHE` | `string` | `<AGENT_HOME>/go/pkg/mod` | Go module cache. Auto-derived from `AGENT_HOME`; set explicitly so it stays on the PVC even if `GOPATH` is overridden. |
+| `npm_config_cache` | `string` | `<AGENT_HOME>/cache/npm` | npm cache directory. Auto-derived from `AGENT_HOME` — npm does not honour `XDG_CACHE_HOME` and would otherwise write to `$HOME/.npm` on ephemeral storage. |
+| `BUN_INSTALL_CACHE_DIR` | `string` | `<AGENT_HOME>/cache/bun` | Bun install cache directory. Auto-derived from `AGENT_HOME` — bun does not honour `XDG_CACHE_HOME` and would otherwise write to `$HOME/.bun/install/cache` on ephemeral storage. |
 | `SHIPWRIGHT_STARTUP_TIMEOUT_MS` | `number` | `180000` | Maximum milliseconds the entrypoint startup sequence may take before the agent exits. Override to a lower value (e.g. `10000`) in dev for faster fail-fast feedback. |
 | `AGENT_ALLOWED_TOOLS` | `string` (JSON array) | — | JSON array of allowed Claude tool patterns. Set by the admin service config sync; do not set manually in production. |
 


### PR DESCRIPTION
Provisioned agents were being evicted mid-run with `Pod ephemeral local storage usage exceeds the total limit of containers 1Gi`, losing the in-flight task. Two independent causes, both fixed here.

## Cache pinning (`agent/src/setup.ts`)

`runMiseStartup` already pins `MISE_*` and `XDG_CACHE_HOME` to the PVC, but three package managers ignore XDG and write under `$HOME` — the container's ephemeral overlay:

- `GOMODCACHE` defaults to `$GOPATH/pkg/mod`, **not** `$XDG_CACHE_HOME`. A single `go mod download` on a Terratest module pulls ~1.7GiB — over the whole pod budget on its own. (`GOCACHE`, the build cache, already follows XDG and was never the problem.)
- `npm` writes to `$HOME/.npm`, `bun` to `$HOME/.bun/install/cache`.

All four are now pinned under `AGENT_HOME`. Side benefit: the caches survive a pod restart instead of re-downloading on every boot.

`CARGO_HOME` is deliberately left alone — mise owns the Rust toolchain install and sets it itself.

## Ephemeral budget (`admin/src/agent-manifest.ts`)

`1Gi` → `4Gi`, request and limit. 1Gi was just the Autopilot default made explicit and left no headroom for legitimately transient writes — e.g. the security-scan skill staging five tool binaries in a `mktemp -d`. Pinning the caches fixes the confirmed cause; this stops the next unpinned tool from repeating it.

## Verification

- Evictions were confirmed against a live cluster: every eviction correlated with a cron run that started 2–5 min earlier and never completed.
- 3 new tests (cache pinning, dir creation, `CARGO_HOME` left untouched, 4Gi budget). `bun test`: 6471 pass.
- Coverage-neutral: +7 lines, +7 covered — aggregate unchanged at 83.48%.

Takes effect on the next agent pod restart for the cache pins; the resource bump needs a reconcile per agent.
