### PR TITLE
feat: PFL-2.1 review.md persists resolved/superseded ledger entries

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1529,3 +1529,93 @@ describe("review.md — Step 9.5 wires the fourth exclusion via priorFindingsSta
     expect(step95Section).toContain("CPF-2.3");
   });
 });
+
+describe("review.md — findings ledger persistence (PFL-2.1)", () => {
+  let step5Section: string;
+  let step7Section: string;
+
+  beforeAll(() => {
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const step6Idx = content.indexOf("## Step 6: Classify Changes by Domain");
+    expect(step5Idx).toBeGreaterThan(-1);
+    expect(step6Idx).toBeGreaterThan(step5Idx);
+    step5Section = content.slice(step5Idx, step6Idx);
+
+    const step7Idx = content.indexOf("## Step 7: Deep Review");
+    const step8Idx = content.indexOf("## Step 8: Score and Classify Findings");
+    expect(step7Idx).toBeGreaterThan(-1);
+    expect(step8Idx).toBeGreaterThan(step7Idx);
+    step7Section = content.slice(step7Idx, step8Idx);
+  });
+
+  it("Step 5.5 has a Findings Ledger Persistence subsection tagged PFL-2.1", () => {
+    expect(step5Section).toContain("PFL-2.1");
+    expect(step5Section.toLowerCase()).toContain("findings ledger");
+  });
+
+  it("posts a resolved ledger entry for each isSelfCleanApprove prior review, with source: review", () => {
+    const ledgerIdx = step5Section.indexOf("PFL-2.1");
+    expect(ledgerIdx).toBeGreaterThan(-1);
+    const ledgerSection = step5Section.slice(ledgerIdx);
+
+    expect(ledgerSection).toContain("isSelfCleanApprove");
+    expect(ledgerSection).toContain('"disposition": "resolved"');
+    expect(ledgerSection).toContain('"source": "review"');
+    expect(ledgerSection).toContain("/findings");
+    expect(ledgerSection).toContain("reviewRef(review)");
+  });
+
+  it("posts a superseded ledger entry for each isSupersededBySelfReview prior review, with source: review", () => {
+    const ledgerIdx = step5Section.indexOf("PFL-2.1");
+    expect(ledgerIdx).toBeGreaterThan(-1);
+    const ledgerSection = step5Section.slice(ledgerIdx);
+
+    expect(ledgerSection).toContain("isSupersededBySelfReview");
+    expect(ledgerSection).toContain('"disposition": "superseded"');
+    expect(ledgerSection).toContain('"source": "review"');
+  });
+
+  it("documents the ledger POST is best-effort persistence, not a new decision, and non-fatal on failure", () => {
+    const ledgerIdx = step5Section.indexOf("PFL-2.1");
+    expect(ledgerIdx).toBeGreaterThan(-1);
+    const ledgerSection = step5Section.slice(ledgerIdx);
+
+    expect(ledgerSection.toLowerCase()).toContain("best-effort");
+    expect(ledgerSection.toLowerCase()).toContain("non-fatal");
+  });
+
+  it("Step 7 posts a resolved ledger entry for each priorFindingsStatus[] entry with resolved: true", () => {
+    expect(step7Section).toContain("PFL-2.1");
+    const ledgerIdx = step7Section.indexOf("PFL-2.1");
+    expect(ledgerIdx).toBeGreaterThan(-1);
+    const ledgerSection = step7Section.slice(ledgerIdx);
+
+    expect(ledgerSection).toContain("resolved === true");
+    expect(ledgerSection).toContain('"disposition": "resolved"');
+    expect(ledgerSection).toContain('"source": "review"');
+    expect(ledgerSection).toContain("/findings");
+    expect(ledgerSection).toContain("entry.evidence");
+  });
+
+  it("Step 7's ledger write is scoped to entries already parsed from the subagent, not a new decision", () => {
+    const ledgerIdx = step7Section.indexOf("PFL-2.1");
+    expect(ledgerIdx).toBeGreaterThan(-1);
+    const ledgerSection = step7Section.slice(ledgerIdx);
+
+    expect(ledgerSection.toLowerCase()).toContain("best-effort");
+    expect(ledgerSection.toLowerCase()).toContain("non-fatal");
+  });
+
+  it("uses the standard task-store curl convention with Authorization bearer and Content-Type json", () => {
+    const step5LedgerIdx = step5Section.indexOf("PFL-2.1");
+    const step5Ledger = step5Section.slice(step5LedgerIdx);
+    const step7LedgerIdx = step7Section.indexOf("PFL-2.1");
+    const step7Ledger = step7Section.slice(step7LedgerIdx);
+
+    for (const section of [step5Ledger, step7Ledger]) {
+      expect(section).toContain("Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN");
+      expect(section).toContain("Content-Type: application/json");
+      expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/findings");
+    }
+  });
+});

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1591,10 +1591,19 @@ describe("review.md — findings ledger persistence (PFL-2.1)", () => {
     const ledgerSection = step7Section.slice(ledgerIdx);
 
     expect(ledgerSection).toContain("resolved === true");
-    expect(ledgerSection).toContain('"disposition": "resolved"');
-    expect(ledgerSection).toContain('"source": "review"');
+    expect(ledgerSection).toContain('disposition: "resolved"');
+    expect(ledgerSection).toContain('source: "review"');
     expect(ledgerSection).toContain("/findings");
     expect(ledgerSection).toContain("entry.evidence");
+  });
+
+  it("Step 7 builds the ledger POST body via jq -n --arg to safely escape subagent-authored free-text evidence", () => {
+    const ledgerIdx = step7Section.indexOf("PFL-2.1");
+    expect(ledgerIdx).toBeGreaterThan(-1);
+    const ledgerSection = step7Section.slice(ledgerIdx);
+
+    expect(ledgerSection).toContain("jq -n --arg");
+    expect(ledgerSection).toContain('--arg evidence "{entry.evidence}"');
   });
 
   it("Step 7's ledger write is scoped to entries already parsed from the subagent, not a new decision", () => {

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -297,6 +297,51 @@ back to `'sonnet'`.
    or superseded self-reviews), the field is simply empty and Step 7 omits the corresponding
    prompt input entirely (see Step 7).
 
+   #### Findings Ledger Persistence — Self-Review Judgments (PFL-2.1)
+
+   The two exclusions just applied above (`isSelfCleanApprove`, `isSupersededBySelfReview`) are
+   real judgments — a review is being decided as resolved or superseded right now, in order to
+   exclude it from `priorQualifyingReviews`. This subsection makes that judgment durable by
+   persisting it to the findings ledger (`POST /prs/:id/findings`, PFL-1.2). **This does not
+   change what was just decided above** — it is purely additive logging of a decision already
+   made; `priorQualifyingReviews` itself is unaffected by whether these POSTs succeed.
+
+   For every CURRENT_USER review considered above (`author.login === CURRENT_USER`,
+   `commit.oid !== headRefOid`) that was excluded from `priorQualifyingReviews` because
+   `isSelfCleanApprove(review, CURRENT_USER)` is true, POST a `resolved` ledger entry:
+   ```bash
+   curl -sf -X POST \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/findings" \
+     -d '{"ref": "{reviewRef(review)}", "disposition": "resolved", "source": "review", "evidence": "Self-review is a clean APPROVE with no blocking findings."}' \
+     >/dev/null 2>&1 || echo "⚠ ledger POST failed for {reviewRef(review)} — continuing (non-fatal)"
+   ```
+   `ref` is `reviewRef(review)` (the same full-`commit.oid`+`submittedAt` format used
+   throughout this step); `evidence` is a short description of the clean-APPROVE judgment, not
+   freehand — it need not restate the review body.
+
+   For every CURRENT_USER review considered above that was instead excluded because
+   `isSupersededBySelfReview(review, allReviews, CURRENT_USER)` is true, POST a `superseded`
+   ledger entry:
+   ```bash
+   curl -sf -X POST \
+     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/findings" \
+     -d '{"ref": "{reviewRef(review)}", "disposition": "superseded", "source": "review", "evidence": "Superseded by a later clean self-review submitted at {laterReview.submittedAt}."}' \
+     >/dev/null 2>&1 || echo "⚠ ledger POST failed for {reviewRef(review)} — continuing (non-fatal)"
+   ```
+   `{laterReview.submittedAt}` is the `submittedAt` of the later, genuinely-clean self-review
+   that `isSupersededBySelfReview` matched — cite it so the ledger entry's evidence is
+   self-contained.
+
+   **Best-effort, not a new decision.** These POSTs persist judgments `isSelfCleanApprove` and
+   `isSupersededBySelfReview` already computed above — they do not gate, delay, or alter
+   `priorQualifyingReviews`, Step 7's subagent dispatch, or any later step. A failed POST (non-2xx,
+   timeout, or any other curl error) is non-fatal: log the warning shown above and continue: the
+   review pipeline must never block on a ledger write.
+
 6. **CLAUDE.md files**: read root CLAUDE.md + CLAUDE.md files in directories containing changed files
 
 7. **Test-readiness context** (optional): try to read `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}/docs/test-readiness/test-system.md`. If absent, note that no repo-specific test-readiness doc exists. When the changed files include any path that looks like a test file — by common conventions across languages (e.g. files named or located in a way that signals they contain tests, such as files in `test/`, `tests/`, `spec/`, or `__tests__/` directories, or files whose names follow typical test-naming conventions for the project's language), also extract the "## Testing" section from the root CLAUDE.md (if present). Use the project's language and toolchain (visible from the diff and CLAUDE.md) to recognise test files — do not apply a fixed set of glob patterns. Combine both pieces into `testReadinessContext`. If neither produces content, `testReadinessContext` is absent — omit it entirely from the subagent prompt.
@@ -441,6 +486,35 @@ identifies which prior review the entry addresses (matching the `ref` passed in 
 explaining why the issue is not resolved. Parse the full response and carry the data into
 Step 8 and Step 9 (Step 9's Re-Review "Prior Findings Resolution" table is populated from
 `priorFindingsStatus[]` — see Step 9).
+
+#### Findings Ledger Persistence — Prior Findings Attestations (PFL-2.1)
+
+Once `priorFindingsStatus[]` has been parsed above, persist each `resolved: true` attestation
+to the findings ledger. **This does not change the attestation itself** — Step 9's Re-Review
+table and Step 9.5's `isResolvedByPriorFindingsStatus` exclusion still consume
+`priorFindingsStatus[]` exactly as parsed; this is purely additive logging of the subagent's
+own determination, using its own evidence string verbatim:
+
+```bash
+for entry in priorFindingsStatus[] where entry.resolved === true:
+  curl -sf -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/findings" \
+    -d '{"ref": "{entry.ref}", "disposition": "resolved", "source": "review", "evidence": "{entry.evidence}"}' \
+    >/dev/null 2>&1 || echo "⚠ ledger POST failed for {entry.ref} — continuing (non-fatal)"
+```
+
+`{entry.ref}` and `{entry.evidence}` are the same `ref`/`evidence` values from the parsed
+`priorFindingsStatus[]` entry — `evidence` is passed through verbatim, not rewritten.
+Entries with `resolved: false` are not posted here (there is nothing resolved to persist;
+they remain a normal unaddressed finding via the qualifying-review path).
+
+**Best-effort, not a new decision.** These POSTs persist attestations the subagent already
+made in its response above — they do not gate Step 8, Step 9, or Step 9.5's own consumption
+of `priorFindingsStatus[]`. A failed POST (non-2xx, timeout, or any other curl error) is
+non-fatal: log the warning shown above and continue — the actual review-posting logic must
+not be gated on ledger-write success.
 
 If the subagent returns malformed JSON, retry once with a reminder of the schema. If it
 still fails, fall back to an inline review in the main thread using the same rules

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -497,18 +497,24 @@ own determination, using its own evidence string verbatim:
 
 ```bash
 for entry in priorFindingsStatus[] where entry.resolved === true:
+  BODY=$(jq -n --arg ref "{entry.ref}" --arg evidence "{entry.evidence}" \
+    '{ref: $ref, disposition: "resolved", source: "review", evidence: $evidence}')
   curl -sf -X POST \
     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
     -H "Content-Type: application/json" \
     "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/findings" \
-    -d '{"ref": "{entry.ref}", "disposition": "resolved", "source": "review", "evidence": "{entry.evidence}"}' \
+    -d "$BODY" \
     >/dev/null 2>&1 || echo "⚠ ledger POST failed for {entry.ref} — continuing (non-fatal)"
 ```
 
 `{entry.ref}` and `{entry.evidence}` are the same `ref`/`evidence` values from the parsed
-`priorFindingsStatus[]` entry — `evidence` is passed through verbatim, not rewritten.
-Entries with `resolved: false` are not posted here (there is nothing resolved to persist;
-they remain a normal unaddressed finding via the qualifying-review path).
+`priorFindingsStatus[]` entry — `evidence` is passed through verbatim, not rewritten, but
+`entry.evidence` is subagent-authored free text (a `file:line` reference, diff excerpt, or
+explanation — see Step 7's Output Format above), so it is built via `jq -n --arg` rather than
+interpolated directly into a JSON string literal — the same escaping pattern Step 9.5 and
+Step 10.5 use for LLM-authored free text elsewhere in this file. Entries with `resolved: false`
+are not posted here (there is nothing resolved to persist; they remain a normal unaddressed
+finding via the qualifying-review path).
 
 **Best-effort, not a new decision.** These POSTs persist attestations the subagent already
 made in its response above — they do not gate Step 8, Step 9, or Step 9.5's own consumption


### PR DESCRIPTION
## Summary
- Adds two new additive subsections to `review.md`'s Step 5.5 that POST `resolved`/`superseded` ledger entries (`source: "review"`) to `/prs/:id/findings` whenever a prior self-authored review is excluded via `isSelfCleanApprove` or `isSupersededBySelfReview`.
- Adds a third additive subsection to Step 7 that POSTs a `resolved` ledger entry for each `priorFindingsStatus[]` entry the code-reviewer subagent attests `resolved: true`.
- These writes are purely additive persistence of judgments already computed — they do not change what `priorQualifyingReviews`, Step 9's re-review table, or Step 9.5's unaddressed-findings gate decide, and a failed POST is explicitly non-fatal (logged, pipeline continues).

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | review.md instructs a POST to /prs/:id/findings with source:"review" and the correct disposition/ref/evidence at the point priorFindingsStatus / clean-approve / supersession is determined | MET | 3 new curl POST blocks added at Step 5.5 (isSelfCleanApprove→resolved, isSupersededBySelfReview→superseded) and Step 7 (priorFindingsStatus[] resolved:true→resolved), all `source: "review"` |
| 2 | Existing priorFindingsStatus computation and self-review-supersession logic in review.md is unchanged -- only the persistence step is added | MET | Diff is pure addition (164 insertions, 0 deletions); no existing prose lines touched |
| 3 | Test decision: add a content test (review.content.test.ts) asserting the relevant step instructs the ledger POST with correct source/disposition; no existing test is retired | MET | New `describe("review.md — findings ledger persistence (PFL-2.1)")` block, 7 tests; all pre-existing tests untouched |

## Test Plan
- [x] `bun test plugins/shipwright/commands/review.content.test.ts` — 130/130 pass (7 new tests confirmed RED before the review.md edit, GREEN after)
- [x] `task lint`, `task check-strings`, `task typecheck`, `task check-config-docs`, `task check-version-sync`, `task secret-scan` — all pass
- [x] `task test:coverage` — 1 pre-existing failure (`extraAllowedTools` in `agent/src/claude.unit.test.ts`), verified to reproduce identically on clean `main`, unrelated to this diff
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
