### PR TITLE
feat: patch.md writes rejected ledger entry on rebuttal, keeps existing manual reviewState reset

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -526,6 +526,68 @@ describe("patch.md — reset reviewState to pending after a no-push, rebuttal-co
   });
 });
 
+describe("patch.md — POST a rejected ledger entry on rebuttal, alongside the existing manual reviewState reset (PFL-2.2)", () => {
+  it("Step 5c.5 POSTs a source:patch, disposition:rejected ledger entry to /prs/:id/findings for each REJECTed finding", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    expect(step5c5Idx).toBeGreaterThan(-1);
+    expect(step5dIdx).toBeGreaterThan(-1);
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/findings"');
+    expect(section).toContain('\\"source\\": \\"patch\\"');
+    expect(section).toContain('\\"disposition\\": \\"rejected\\"');
+  });
+
+  it("the ledger POST runs alongside the existing rebuttal comment + thread resolution, not gated on the no-push reviewState-reset condition", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    // The ledger POST must fire whenever findings were REJECTed this cycle, independent of
+    // NO_PUSH_REBUTTAL_CONFIRMED (which additionally requires no push happened) — it is not
+    // nested inside that gate.
+    const findingsIdx = section.indexOf("/prs/$PR_RECORD_ID/findings");
+    expect(findingsIdx).toBeGreaterThan(-1);
+    const reviewStateIdx = section.indexOf('"reviewState": "pending"');
+    expect(reviewStateIdx).toBeGreaterThan(-1);
+    expect(findingsIdx).not.toBe(reviewStateIdx);
+
+    const before = section.slice(Math.max(0, findingsIdx - 400), findingsIdx);
+    expect(before).not.toContain('if [ "$NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]');
+  });
+
+  it("Step 5c tracks REJECTed findings this cycle (ref + rejection reason) separately from NO_PUSH_REBUTTAL_CONFIRMED, for Step 5c.5 to loop over", () => {
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    const step5c5Idx = content.indexOf("### Step 5c.5:");
+    const section = content.slice(step5cIdx, step5c5Idx);
+
+    expect(section).toContain("REJECTED_FINDINGS_THIS_CYCLE");
+  });
+
+  it("does not modify the existing manual reviewState:pending PATCH — still present, still conditional on NO_PUSH_REBUTTAL_CONFIRMED", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    expect(section).toContain('if [ "$NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]');
+    expect(section).toContain("-X PATCH");
+    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
+    expect(section).toContain('-d \'{"reviewState": "pending"}\'');
+    expect(section).toContain("⚠ PATCH /prs/$PR_RECORD_ID reviewState reset failed — continuing");
+  });
+
+  it("the ledger POST call follows the same warn-and-continue error-handling idiom as the other Step 5c.5 task-store calls", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    const findingsIdx = section.indexOf("/prs/$PR_RECORD_ID/findings");
+    const after = section.slice(findingsIdx, findingsIdx + 400);
+    expect(after).toMatch(/\|\|\s*\\?\s*\n\s*echo "⚠/);
+  });
+});
+
 describe("patch.md — escalate to HITL instead of looping on a second-round disagreement (RPF-1.3)", () => {
   function getStep5a7Section() {
     const step5a7Idx = content.indexOf("### Step 5a.7: Second-Round Escalation Check (RPF-1.3)");

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1074,6 +1074,21 @@ Parse the subagent's STATUS:
   literal shell test — evaluate it the same way you just evaluated the "confirm ... rebuttal
   ... AND ... resolved the inline threads" check earlier in this bullet, then set the
   variable accordingly before Step 5c.5 reads it.
+
+  Separately from `NO_PUSH_REBUTTAL_CONFIRMED`, also record the set of REJECTed findings
+  from this cycle for Step 5c.5's ledger write, whenever the rebuttal-confirmation check
+  above found at least one REJECTed finding (independent of push/no-push — a mixed
+  ACCEPT+REJECT run that also pushed a commit still has REJECTed findings needing a ledger
+  entry). For each REJECTed finding in the subagent's CONCERNS, capture:
+  - **`ref`**: the same identifier already used to resolve that finding's thread in Step 5b
+    Instructions [D] — the inline thread's `path:line` for inline findings, or a short slug
+    for PR-body-level findings with no inline thread.
+  - **`evidence`**: the rejection reason already written into the rebuttal comment for that
+    finding.
+
+  Set `REJECTED_FINDINGS_THIS_CYCLE` to this list (empty if no finding was REJECTed this
+  cycle, e.g. the plain `DONE` case above or a `DONE_WITH_CONCERNS` run with only
+  non-REJECT concerns) before proceeding to Step 5c.5.
 - **BLOCKED**: This is a first-round BLOCKED report from the fix subagent itself — distinct
   from Step 5a.7's (RPF-1.3) second-round-disagreement escalation, which fires *before*
   dispatch when the same finding was already rebutted once. Here the subagent was dispatched
@@ -1114,6 +1129,15 @@ if [ -n "$PR_RECORD_ID" ]; then
     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/patch" \
     -d "{\"commitSha\": \"$HEAD_SHA_POST_PATCH\"}" > /dev/null 2>&1 || \
     echo "⚠ POST /prs/$PR_RECORD_ID/patch failed — continuing"
+  # Run once per entry in REJECTED_FINDINGS_THIS_CYCLE (from Step 5c) — {finding.ref} is
+  # that finding's path:line (or slug); {finding.evidence} is its rejection reason.
+  curl -sf -X POST \
+    -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/findings" \
+    -d "{\"ref\": \"{finding.ref}\", \"disposition\": \"rejected\", \"source\": \"patch\", \"evidence\": \"{finding.evidence}\"}" \
+    > /dev/null 2>&1 || \
+    echo "⚠ POST /prs/$PR_RECORD_ID/findings (rejected) failed — continuing"
   if [ "$NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]; then
     curl -sf -X PATCH \
       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
@@ -1126,6 +1150,21 @@ else
   echo "⚠ no PR_RECORD_ID from pre-work claim — skipping PR record update"
 fi
 ```
+
+Run the ledger-write `curl` once for each entry in `REJECTED_FINDINGS_THIS_CYCLE` (assigned
+in Step 5c — see there for how it's populated), POSTing one `source: "patch"`,
+`disposition: "rejected"` finding per REJECTed finding this cycle to
+`/prs/$PR_RECORD_ID/findings`, with `ref` set to that finding's identifying `path:line` (or
+slug, for PR-body-level findings) and `evidence` set to the rejection reason already used in
+the rebuttal comment. If `REJECTED_FINDINGS_THIS_CYCLE` is empty, skip this call entirely —
+there is nothing to record. This runs unconditionally whenever
+`REJECTED_FINDINGS_THIS_CYCLE` is non-empty — independent of `NO_PUSH_REBUTTAL_CONFIRMED`,
+so it also fires on a mixed ACCEPT+REJECT run that pushed a commit, not only the no-push
+case. This is additive: it does not replace or gate the existing manual
+`reviewState: "pending"` reset below, which stays exactly as it was and remains the only
+mechanism that makes a no-push rebuttal cycle re-qualify for review today (that dependency
+is removed in a later task, PFL-4.1, only after PFL-3.1 makes the ledger the read-side
+source of truth for re-review eligibility).
 
 `NO_PUSH_REBUTTAL_CONFIRMED` is assigned in Step 5c, before this step runs — see there for
 the exact condition. It does not require every finding in the run to be REJECTed — a mixed


### PR DESCRIPTION
## Summary
- `patch.md`'s Step 5c.5 now POSTs a `source:"patch"`, `disposition:"rejected"` ledger entry to `/prs/:id/findings` for each REJECTed finding from a rebuttal cycle, run independent of the no-push `NO_PUSH_REBUTTAL_CONFIRMED` gate (so it also fires on mixed ACCEPT+REJECT runs that pushed a commit).
- The existing manual `reviewState:"pending"` PATCH is left completely unmodified — this is additive only. Removing that manual reset is deferred to PFL-4.1, after PFL-3.1 makes the ledger the live read-side trigger for re-review eligibility.
- `patch.content.test.ts` gains a new content-test suite (5 tests) asserting the ledger POST is instructed alongside — not instead of — the existing reset, including an explicit guard that the old reset step is still present.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Rebuttal step posts `source:"patch"`, `disposition:"rejected"` ledger entry to `/prs/:id/findings`, in addition to existing behavior | MET |
| 2 | Existing manual `reviewState:"pending"` PATCH left in place, unmodified | MET |
| 3 | Content test asserts new ledger POST alongside existing manual reset; old reset step explicitly asserted present; no existing test retired | MET |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/patch.content.test.ts` — 151/151 pass (all pre-existing tests unmodified, 5 new tests added)
- `bun run --filter='*' --sequential typecheck` — clean
- `bunx biome lint .` — clean
- `task ci` — 2 pre-existing failures unrelated to this change (`agent/src/claude.unit.test.ts`, cron handler test), confirmed present on `main` baseline
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
