### PR TITLE
docs: refresh stale references for 2026-08-18 sync

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Shipwright Harness is the open-source autonomous delivery system in your own env
 | **A** | **Plugin** (the system) | `plugins/shipwright/` | The Claude Code plugin users `/plugin install` — commands, skills, agents, scripts for the full delivery loop. Repo-agnostic. |
 | **B** | **Metrics dashboard** | `metrics/` | Hono service: backend-agnostic `MetricsProvider` JSON endpoints + a server-rendered dashboard. Two modes: fixtures (offline), taskstore (live task-store + admin APIs). |
 | **C** | **Shipwright agent** | `agent/` + `admin/` | Hono service + Prisma store (in `@shipwright/admin`); a thin autonomous runner: pick next ready task → build → ship PR → forward metrics. |
-| **D** | **Task store service** | `task-store/` | Postgres-backed task queue, PR tracking, and scoped tokens. Prisma schema defines `Task`, `PullRequest`, and `TaskToken` models; re-exported as `@shipwright/task-store` for use by plugin scripts and agent services. Replaces the JSON file fallback. |
+| **D** | **Task store service** | `task-store/` | Postgres-backed task queue, PR tracking, and scoped tokens. Prisma schema defines `Task`, `PullRequest`, `PrFinding`, and `TaskToken` models; re-exported as `@shipwright/task-store` for use by plugin scripts and agent services. Replaces the JSON file fallback. |
 
 The hard architectural rule: **no new coupling.** The plugin stays repo-agnostic; the metrics service and the agent each stand alone. Everything runs offline by default (fixtures / injected doubles / scratch queue); live external calls happen only when an env var explicitly enables them.
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -97,15 +97,23 @@ The chat service requires:
   a database connection.
 - **Admin-token wiring** (`chat.adminToken`) to light up the admin console's
   Chat tab (`/admin/chat`). Without it the tab renders "Chat service not
-  configured". Add a raw token to a Secret (key
-  `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` by default), then:
+  configured". Leave `chat.adminToken.existingSecret` unset and the chart
+  **generates the token for you**, into its own chart-managed chat Secret
+  (reused across `helm upgrade` via the same `lookup`-based idiom as the
+  auto-generated DB secrets above — nothing to create by hand):
+
+```bash
+helm upgrade shipwright charts/shipwright --set chat.enabled=true
+```
+
+  To supply your own token instead, add a raw one to a Secret (key
+  `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` by default), then point
+  `chat.adminToken.existingSecret` at it:
 
 ```bash
 kubectl -n shipwright patch secret shipwright-secrets --type merge \
   -p "{\"stringData\":{\"SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN\":\"$(openssl rand -hex 32)\"}}"
 ```
-
-Then upgrade the chart:
 
 ```bash
 helm upgrade shipwright charts/shipwright \
@@ -113,14 +121,14 @@ helm upgrade shipwright charts/shipwright \
   --set chat.adminToken.existingSecret=shipwright-secrets
 ```
 
-  The chart injects the **same raw token** into both sides: the chat container
-  gets it as `CHAT_SEED_ADMIN_TOKEN` (the service upserts the SHA-256 hash into
-  its DB at every boot — idempotent), and the admin container gets it as
-  `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` plus `SHIPWRIGHT_CHAT_SERVICE_URL`
-  pointing at the in-cluster chat Service. This also enables per-agent
-  chat-token minting during agent provisioning, which injects
-  `SHIPWRIGHT_CHAT_SERVICE_URL`/`SHIPWRIGHT_CHAT_SERVICE_TOKEN` into each
-  provisioned agent pod so its chat poll loop starts. Agents provisioned
+  Either way, the chart injects the **same raw token** into both sides: the
+  chat container gets it as `CHAT_SEED_ADMIN_TOKEN` (the service upserts the
+  SHA-256 hash into its DB at every boot — idempotent), and the admin
+  container gets it as `SHIPWRIGHT_CHAT_SERVICE_ADMIN_TOKEN` plus
+  `SHIPWRIGHT_CHAT_SERVICE_URL` pointing at the in-cluster chat Service. This
+  also enables per-agent chat-token minting during agent provisioning, which
+  injects `SHIPWRIGHT_CHAT_SERVICE_URL`/`SHIPWRIGHT_CHAT_SERVICE_TOKEN` into
+  each provisioned agent pod so its chat poll loop starts. Agents provisioned
   **before** this wiring existed need a re-provision to pick up the chat env.
 - **Optional agent scope resolution:** when agents create chat tokens, the chat
   service can query which repos a token may access. Pass these via `chat.extraEnv`
@@ -238,8 +246,11 @@ echo "127.0.0.1 shipwright.local" | sudo tee -a /etc/hosts
 
 ### Sizing
 
-The agent pod dominates: **500m CPU / 2Gi memory requests, 8Gi limit**
-(`admin/src/agent-manifest.ts`). Everything else is small.
+The agent pod dominates: **500m CPU / 2Gi memory requests, 8Gi memory limit,
+4Gi ephemeral-storage** (`admin/src/agent-manifest.ts`). Ephemeral-storage was
+raised from a 1Gi default that left no room for a build step's scratch space
+and caused mid-run evictions; tool caches are pinned to the PVC, so this
+budget only covers genuinely transient writes. Everything else is small.
 
 | VM size | Good for |
 |---|---|
@@ -293,9 +304,14 @@ browsable URL is `/dashboard/dashboard`, not `/dashboard`:
 - Metrics dashboard: `http://shipwright.local/dashboard/dashboard`
 - Task store: `http://shipwright.local/task-store/health`
 
-`task minikube:up` prints these exact URLs (via `buildAccessUrls()` in
-`scripts/minikube.ts`) once the stack is reachable, rather than requiring you
-to work them out by hand.
+`task minikube:up` doesn't print this whole list — the console root (`/`)
+redirects to a Google sign-in page the Minikube profile never configures, a
+dead end for a fresh stack. Instead it prints and auto-opens exactly one link,
+`/admin/dev-login` (via `buildAccessUrls()` in `scripts/minikube.ts`), which
+mints a dev session outright and lands on `/admin/agents`; every other surface
+above is reachable from the console once you're signed in. If `/etc/hosts`
+isn't mapped yet it prints the `echo … | sudo tee -a /etc/hosts` line instead
+of opening the browser.
 
 Or port-forward instead (works with the default `networking.type=ClusterIP`):
 

--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"ca3c8c3f02f174ff763b9d92cd6c7588d9c180f0","timestamp":"2026-08-16T07:01:16Z"}
+{"sha":"a65cf615ab1b423068dfa55617fd2f35fd1820e4","timestamp":"2026-08-18T07:06:24Z"}


### PR DESCRIPTION
## Summary

Automated docs-freshness sync (cron) covering source changes since the last anchor (`ca3c8c3f0` → `a65cf615a`, 2026-08-16 → 2026-08-18).

- **docs/deploy-kubernetes.md**
  - "Reaching the services" — `task minikube:up` no longer prints the full admin/metrics/task-store URL list; it now auto-opens a single `/admin/dev-login` link (console root redirects to an unconfigured Google sign-in, a dead end on this profile), falling back to printing the `/etc/hosts` line when the host isn't mapped yet (`scripts/minikube.ts`).
  - "Sizing" — added the ephemeral-storage bump (1Gi → 4Gi) on the agent pod (`admin/src/agent-manifest.ts`), which fixed mid-run pod evictions from an unpinned Go module cache.
  - "Chat service (opt-in)" — the chart now auto-generates the chat admin token (chart-managed Secret, `lookup`-based idiom) when `chat.adminToken.existingSecret` is left unset, instead of requiring a hand-created Secret; documented both the new zero-config path and the existing bring-your-own-token path.
- **docs/architecture.md** — added `PrFinding` to the task-store service's Prisma model list (new PR-finding feature: `task-store/prisma/migrations/20260817224642_add_pr_finding`, `POST /prs/:id/findings`).
- **state/docs-last-synced.json** — anchor advanced to `a65cf615ab1b423068dfa55617fd2f35fd1820e4` / 2026-08-18T07:06:24Z.

Checked but found current (no edit needed): `docs/task-store.md` (already documents `PrFinding`/`POST /prs/:id/findings` fully — likely landed doc'd in the same feature PR), `docs/mcp-tools.md` (generated; findings endpoint correctly absent since it's not in the MCP tool allowlist), `docs/chat.md`, `docs/configuration.md`, `docs/agent.md`, `docs/helm-repo.md`, `docs/migration.md`. `CLAUDE.md`'s reference section is unchanged (no docs added/removed).

## Test plan

- [x] Docs-only change; no code paths touched.
- [x] Verified each edited claim against the actual diff between the old and new anchor SHAs (`git diff <old-sha>..origin/main -- <file>`) rather than guessing from filenames.
- [ ] CI (lint / check-strings / pr-title-lint) — will run on push.

🤖 Generated by the docs-freshness cron.