### PR TITLE
feat(admin): let /admin/agents/new provision an in-cluster agent without Slack

### DIFF
--- a/admin/e2e/test-server.ts
+++ b/admin/e2e/test-server.ts
@@ -233,6 +233,21 @@ function buildMockDeps(): AdminUIDeps {
         missingRequiredEnv: [],
       }),
     },
+    provisioner: {
+      canProvision: false,
+      provision: async () => ({
+        resourceName: "r",
+        secretName: "s",
+        deploymentName: "d",
+      }),
+      deprovision: async () => {},
+      reconcile: async () => ({
+        recreated: [],
+        updated: [],
+        orphans: [],
+        failed: [],
+      }),
+    },
     sessionSecret: ADMIN_E2E_SESSION_SECRET,
     googleClientId: "e2e-google-client-id",
     googleClientSecret: "e2e-google-client-secret",

--- a/admin/src/admin-dev-login.smoke.test.ts
+++ b/admin/src/admin-dev-login.smoke.test.ts
@@ -201,6 +201,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
     },
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",

--- a/admin/src/admin-local-agent.smoke.test.ts
+++ b/admin/src/admin-local-agent.smoke.test.ts
@@ -650,6 +650,7 @@ describe("admin UI — new local agent create flow", () => {
     canProvision?: boolean;
     provisionError?: Error;
     reconcileError?: Error;
+    deleteError?: Error;
   }) {
     const calls = {
       created: null as { name: string; selfHosted?: boolean } | null,
@@ -683,6 +684,7 @@ describe("admin UI — new local agent create flow", () => {
         },
         delete: async (id: string) => {
           calls.deleted.push(id);
+          if (opts?.deleteError) throw opts.deleteError;
         },
       },
       agentEnvService: {
@@ -798,6 +800,27 @@ describe("admin UI — new local agent create flow", () => {
     expect(res.headers.get("Location")).toBe(
       "/admin/agents/new?error=provision_failed",
     );
+    expect(calls.deleted).toEqual([NEW_AGENT_ID]);
+    expect(calls.reconciled).toEqual([]);
+  });
+
+  it("provisioning failure still redirects with provision_failed even when the rollback delete itself fails", async () => {
+    const { deps, calls } = makeProvisioningDeps({
+      provisionError: new Error("no cluster"),
+      deleteError: new Error("db unreachable"),
+    });
+    const res = await postAgent(deps, {
+      name: "doubly-doomed",
+      type: "coding",
+      runtime: "in-cluster",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/admin/agents/new?error=provision_failed",
+    );
+    // The rollback was attempted (and failed) but the create flow still
+    // reports provision_failed rather than throwing — the cleanup error is
+    // swallowed (logged), not propagated.
     expect(calls.deleted).toEqual([NEW_AGENT_ID]);
     expect(calls.reconciled).toEqual([]);
   });

--- a/admin/src/admin-local-agent.smoke.test.ts
+++ b/admin/src/admin-local-agent.smoke.test.ts
@@ -255,6 +255,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     googleClient: makeGoogleClient(),
     slackClient: BASE_SLACK_CLIENT,
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",
@@ -308,7 +309,7 @@ describe("admin UI — new local agent create flow", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain('name="name"');
-    expect(html).toContain("New Local Agent");
+    expect(html).toContain("New Agent");
   });
 
   it("GET /admin/agents/new — renders a required type select listing the registry's built-in types", async () => {
@@ -636,5 +637,207 @@ describe("admin UI — new local agent create flow", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).not.toContain("New local agent");
+  });
+
+  // ── runtime=in-cluster (Slack-free provisioning) ──────────────────────────
+
+  /**
+   * Builds deps with a recording provisioner / cron service / env service so a
+   * test can assert exactly what the create path did. `canProvision` defaults
+   * to true because these cases exercise the in-cluster branch.
+   */
+  function makeProvisioningDeps(opts?: {
+    canProvision?: boolean;
+    provisionError?: Error;
+    reconcileError?: Error;
+  }) {
+    const calls = {
+      created: null as { name: string; selfHosted?: boolean } | null,
+      provisioned: [] as Array<{ id: string; slug?: string }>,
+      reconciled: [] as string[],
+      deleted: [] as string[],
+      envPatches: [] as Array<{
+        agentId: string;
+        env: Record<string, string>;
+        secretKeys: Set<string> | undefined;
+      }>,
+    };
+    const base = makeMockDeps();
+    const deps = makeMockDeps({
+      agentService: {
+        ...base.agentService,
+        create: async (input: { name: string; selfHosted?: boolean }) => {
+          calls.created = input;
+          return {
+            id: NEW_AGENT_ID,
+            name: input.name,
+            slackId: null,
+            selfHosted: input.selfHosted ?? false,
+            repos: [],
+            authorAllowlist: [],
+            typeName: "coding",
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+            missingRequiredEnv: [],
+          };
+        },
+        delete: async (id: string) => {
+          calls.deleted.push(id);
+        },
+      },
+      agentEnvService: {
+        ...base.agentEnvService,
+        patch: async (
+          agentId: string,
+          env: Record<string, string>,
+          secretKeys?: Set<string>,
+        ) => {
+          calls.envPatches.push({ agentId, env, secretKeys });
+        },
+      },
+      agentCronJobService: {
+        ...base.agentCronJobService,
+        reconcileSystemCrons: async (agentId: string) => {
+          calls.reconciled.push(agentId);
+          if (opts?.reconcileError) throw opts.reconcileError;
+          return { created: 3, updated: 0, deleted: 0 };
+        },
+      },
+      provisioner: {
+        ...base.provisioner,
+        canProvision: opts?.canProvision ?? true,
+        provision: async (id: string, o?: { slug?: string }) => {
+          calls.provisioned.push({ id, slug: o?.slug });
+          if (opts?.provisionError) throw opts.provisionError;
+          return {
+            resourceName: "r",
+            secretName: "s",
+            deploymentName: "d",
+          };
+        },
+      },
+    });
+    return { deps, calls };
+  }
+
+  async function postAgent(
+    deps: AdminUIDeps,
+    fields: Record<string, string>,
+  ): Promise<Response> {
+    return createAdminUIApp(deps).request("/admin/agents", {
+      method: "POST",
+      body: new URLSearchParams(fields).toString(),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: `admin_session=${adminCookie}`,
+      },
+    });
+  }
+
+  it("runtime=in-cluster creates a non-self-hosted agent, provisions it, and seeds system crons", async () => {
+    const { deps, calls } = makeProvisioningDeps();
+    const res = await postAgent(deps, {
+      name: "minikube-agent",
+      type: "coding",
+      runtime: "in-cluster",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`/admin/agents/${NEW_AGENT_ID}`);
+    expect(calls.created?.selfHosted).toBe(false);
+    expect(calls.provisioned).toEqual([
+      { id: NEW_AGENT_ID, slug: "minikube-agent" },
+    ]);
+    expect(calls.reconciled).toEqual([NEW_AGENT_ID]);
+    expect(calls.deleted).toEqual([]);
+  });
+
+  it("runtime=self-hosted keeps the historical behavior — selfHosted:true, provisioner untouched", async () => {
+    const { deps, calls } = makeProvisioningDeps();
+    const res = await postAgent(deps, {
+      name: "docker-agent",
+      type: "coding",
+      runtime: "self-hosted",
+    });
+    expect(res.status).toBe(302);
+    expect(calls.created?.selfHosted).toBe(true);
+    expect(calls.provisioned).toEqual([]);
+  });
+
+  it("omitted runtime defaults to self-hosted", async () => {
+    const { deps, calls } = makeProvisioningDeps();
+    await postAgent(deps, { name: "no-runtime-field", type: "coding" });
+    expect(calls.created?.selfHosted).toBe(true);
+    expect(calls.provisioned).toEqual([]);
+  });
+
+  it("runtime=in-cluster is rejected before any row is created when provisioning is disabled", async () => {
+    const { deps, calls } = makeProvisioningDeps({ canProvision: false });
+    const res = await postAgent(deps, {
+      name: "nope",
+      type: "coding",
+      runtime: "in-cluster",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/admin/agents/new?error=provisioning_disabled",
+    );
+    expect(calls.created).toBeNull();
+    expect(calls.provisioned).toEqual([]);
+  });
+
+  it("provisioning failure rolls the agent row back and redirects with provision_failed", async () => {
+    const { deps, calls } = makeProvisioningDeps({
+      provisionError: new Error("no cluster"),
+    });
+    const res = await postAgent(deps, {
+      name: "doomed",
+      type: "coding",
+      runtime: "in-cluster",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/admin/agents/new?error=provision_failed",
+    );
+    expect(calls.deleted).toEqual([NEW_AGENT_ID]);
+    expect(calls.reconciled).toEqual([]);
+  });
+
+  it("a cron-seeding failure is non-fatal — the agent survives and the redirect succeeds", async () => {
+    const { deps, calls } = makeProvisioningDeps({
+      reconcileError: new Error("db down"),
+    });
+    const res = await postAgent(deps, {
+      name: "crons-broke",
+      type: "coding",
+      runtime: "in-cluster",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`/admin/agents/${NEW_AGENT_ID}`);
+    expect(calls.deleted).toEqual([]);
+  });
+
+  it("a supplied Claude token is stored as a secret env var before provisioning", async () => {
+    const { deps, calls } = makeProvisioningDeps();
+    await postAgent(deps, {
+      name: "with-creds",
+      type: "coding",
+      runtime: "in-cluster",
+      claudeCodeOauthToken: "sk-ant-oat01-example",
+    });
+    expect(calls.envPatches).toHaveLength(1);
+    const patch = calls.envPatches[0];
+    expect(patch?.agentId).toBe(NEW_AGENT_ID);
+    expect(patch?.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-example");
+    expect(patch?.secretKeys?.has("CLAUDE_CODE_OAUTH_TOKEN")).toBe(true);
+  });
+
+  it("no Claude token supplied → no env patch at all", async () => {
+    const { deps, calls } = makeProvisioningDeps();
+    await postAgent(deps, {
+      name: "no-creds",
+      type: "coding",
+      runtime: "in-cluster",
+    });
+    expect(calls.envPatches).toEqual([]);
   });
 });

--- a/admin/src/admin-tokens.smoke.test.ts
+++ b/admin/src/admin-tokens.smoke.test.ts
@@ -277,6 +277,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       },
     },
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -590,14 +590,19 @@ export function renderAgentsPage(
 </html>`;
 }
 
-// ─── New local agent page ─────────────────────────────────────────────────────
+// ─── New agent page ───────────────────────────────────────────────────────────
 
 export function renderNewLocalAgentPage(
   userName: string,
   types: AgentTypeOption[],
-  opts?: { error?: string },
+  opts?: { error?: string; canProvision?: boolean },
 ): string {
   const error = opts?.error;
+  // Whether the admin service can actually create cluster resources. When it
+  // can't (NoopAgentProvisioner — SHIPWRIGHT_K8S_PROVISIONING unset), offering
+  // "in-cluster" would silently produce an agent row with no pod, so the option
+  // is rendered disabled and self-hosted is preselected.
+  const canProvision = opts?.canProvision ?? false;
   const errorHtml = error
     ? `<div class="alert alert-error">${escapeHtml(error)}</div>`
     : "";
@@ -612,7 +617,7 @@ export function renderNewLocalAgentPage(
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>New Local Agent — Shipwright Admin</title>
+  <title>New Agent — Shipwright Admin</title>
   <style>${baseStyles()}</style>
 </head>
 <body>
@@ -621,14 +626,15 @@ export function renderNewLocalAgentPage(
     <div class="page-header">
       <div>
         <a href="/admin/agents" style="font-size:13px;color:#6b7280;text-decoration:none">← Agents</a>
-        <h1 class="page-title" style="margin-top:4px">New Local Agent</h1>
+        <h1 class="page-title" style="margin-top:4px">New Agent</h1>
       </div>
     </div>
     ${errorHtml}
     <div class="card">
       <p style="font-size:14px;color:#6b7280;margin-bottom:20px">
-        Create a self-hosted agent. The agent will run on your own infrastructure.
-        Slack provisioning can be done separately from the agent detail page.
+        Create an agent and choose where it runs. No Slack credentials are needed —
+        talk to the agent from the <a href="/admin/chat">Chat</a> tab. Slack can be
+        connected later from the <span class="mono">/admin/provision</span> wizard.
       </p>
       <form method="POST" action="/admin/agents" style="display:flex;flex-direction:column;gap:16px">
         <div class="form-group">
@@ -648,6 +654,46 @@ export function renderNewLocalAgentPage(
           <select id="type" name="type" class="form-input" required>
             ${typeOptions}
           </select>
+        </div>
+        <fieldset style="border:1px solid #e8e8ee;border-radius:8px;padding:16px">
+          <legend style="font-size:13px;font-weight:600;padding:0 8px">Runtime</legend>
+          <div class="form-group" style="margin-bottom:0">
+            <label style="display:block;font-size:13px;font-weight:500;margin-bottom:8px">
+              <input type="radio" name="runtime" value="in-cluster" ${canProvision ? "checked" : "disabled"} />
+              Provisioned in-cluster
+              <span style="font-weight:400;color:#6b7280">
+                — the admin service creates the Deployment, Secret, and PVC for you.
+              </span>
+            </label>
+            <label style="display:block;font-size:13px;font-weight:500">
+              <input type="radio" name="runtime" value="self-hosted" ${canProvision ? "" : "checked"} />
+              Self-hosted
+              <span style="font-weight:400;color:#6b7280">
+                — you run the container yourself (<span class="mono">task stack</span>, local Docker).
+              </span>
+            </label>
+            ${
+              canProvision
+                ? ""
+                : `<p style="font-size:12px;color:#6b7280;margin-top:8px">
+              In-cluster provisioning is unavailable — <span class="mono">SHIPWRIGHT_K8S_PROVISIONING</span> is not enabled on this admin service.
+            </p>`
+            }
+          </div>
+        </fieldset>
+        <div class="form-group">
+          <label class="form-label" for="claudeCodeOauthToken">Claude Code OAuth Token (optional)</label>
+          <input
+            id="claudeCodeOauthToken"
+            name="claudeCodeOauthToken"
+            type="password"
+            class="form-input"
+            placeholder="sk-ant-oat01-..."
+          />
+          <p style="font-size:12px;color:#6b7280;margin-top:4px">
+            Stored as the agent's <span class="mono">CLAUDE_CODE_OAUTH_TOKEN</span>. Required for the agent
+            to run — set it here or from the agent detail page.
+          </p>
         </div>
         <div class="form-group">
           <label class="form-label" for="repos">Repos (optional, one per line)</label>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -668,6 +668,75 @@ describe("renderNewLocalAgentPage", () => {
     const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE]);
     expect(html).toMatch(/<textarea[^>]*name="authorAllowlist"[^>]*>/);
   });
+
+  test("renders both runtime radios", () => {
+    const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE], {
+      canProvision: true,
+    });
+    expect(html).toMatch(
+      /<input[^>]*name="runtime"[^>]*value="in-cluster"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<input[^>]*name="runtime"[^>]*value="self-hosted"[^>]*>/,
+    );
+  });
+
+  test("canProvision: true preselects in-cluster and leaves it enabled", () => {
+    const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE], {
+      canProvision: true,
+    });
+    const inCluster = html.match(
+      /<input[^>]*value="in-cluster"[^>]*\/>/,
+    )?.[0] as string;
+    expect(inCluster).toContain("checked");
+    expect(inCluster).not.toContain("disabled");
+    const selfHosted = html.match(
+      /<input[^>]*value="self-hosted"[^>]*\/>/,
+    )?.[0] as string;
+    expect(selfHosted).not.toContain("checked");
+  });
+
+  test("canProvision: false disables in-cluster, preselects self-hosted, and explains why", () => {
+    const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE], {
+      canProvision: false,
+    });
+    const inCluster = html.match(
+      /<input[^>]*value="in-cluster"[^>]*\/>/,
+    )?.[0] as string;
+    expect(inCluster).toContain("disabled");
+    expect(inCluster).not.toContain("checked");
+    const selfHosted = html.match(
+      /<input[^>]*value="self-hosted"[^>]*\/>/,
+    )?.[0] as string;
+    expect(selfHosted).toContain("checked");
+    expect(html).toContain("SHIPWRIGHT_K8S_PROVISIONING");
+  });
+
+  test("omitted canProvision defaults to unavailable", () => {
+    const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE]);
+    const inCluster = html.match(
+      /<input[^>]*value="in-cluster"[^>]*\/>/,
+    )?.[0] as string;
+    expect(inCluster).toContain("disabled");
+  });
+
+  test("renders an optional CLAUDE_CODE_OAUTH_TOKEN input", () => {
+    const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE]);
+    expect(html).toMatch(
+      /<input[^>]*name="claudeCodeOauthToken"[^>]*type="password"[^>]*>/,
+    );
+    expect(html).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("asks for no Slack credentials and points at the chat UI", () => {
+    const html = renderNewLocalAgentPage(USER_NAME, [CODING_TYPE], {
+      canProvision: true,
+    });
+    expect(html).not.toContain("xoxp");
+    expect(html).not.toContain("xoxb");
+    expect(html).not.toMatch(/name="xoxpToken"/);
+    expect(html).toContain("/admin/chat");
+  });
 });
 
 // ─── renderAgentDetailPage — env vars section ────────────────────────────────

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -632,6 +632,22 @@ describe("admin UI — authenticated pages", () => {
     expect(html).toContain("admin@example.com");
   });
 
+  it("authenticated GET /admin/agents/new returns 200 with a required type select listing the agent types", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/agents/new", {
+      headers: { Cookie: `admin_session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Regression coverage for a bug where a consumer wiring up AdminUIDeps
+    // without the required `provisioner` field (it has no default, unlike
+    // agentTypeRegistry) caused this route to throw on `provisioner.canProvision`
+    // — a 500 that left the type picker (and its "required" select[name=type])
+    // missing entirely rather than merely disabled.
+    expect(html).toContain('<select id="type" name="type" class="form-input" required>');
+    expect(html).toContain('<option value="coding">Coding Agent</option>');
+  });
+
   it("nests shipwright-loop phase crons under the loop row instead of listing them flat", async () => {
     const LOOP_ID = "cron-loop-1";
     const PHASES = [

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -333,6 +333,7 @@ function makeMockDeps(
     googleClient: makeGoogleClient(),
     slackClient: { ...BASE_SLACK_CLIENT, ...slackClientOverride },
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",
@@ -2342,6 +2343,7 @@ describe("admin UI — provision start form", () => {
         }),
       },
       provisioner: {
+        canProvision: false,
         provision: async (id: string, opts: { slug: string }) => {
           provisionArgs = { id, opts };
           return { resourceName: "r", secretName: "s", deploymentName: "d" };
@@ -2445,6 +2447,7 @@ describe("admin UI — provision start form", () => {
         }),
       },
       provisioner: {
+        canProvision: false,
         provision: async () => {
           throw new Error("provisioning exploded");
         },
@@ -2530,6 +2533,7 @@ describe("admin UI — provision start form", () => {
         }),
       },
       provisioner: {
+        canProvision: false,
         provision: async () => ({
           resourceName: "r",
           secretName: "s",
@@ -3022,6 +3026,7 @@ describe("admin UI — agent delete route", () => {
     const chatThreadsDeletedFor: string[] = [];
     const deps = makeMockDeps({
       provisioner: {
+        canProvision: false,
         provision: async () => ({
           resourceName: "r",
           secretName: "s",
@@ -3130,6 +3135,7 @@ describe("admin UI — agent delete route", () => {
     let deleted: string | null = null;
     const deps = makeMockDeps({
       provisioner: {
+        canProvision: false,
         provision: async () => ({
           resourceName: "r",
           secretName: "s",
@@ -3217,6 +3223,7 @@ describe("admin UI — agent delete route", () => {
   it("admin POST /admin/agents/:id/delete → surfaces manualStepsRequired on the success redirect when the agent has secret env rows", async () => {
     const deps = makeMockDeps({
       provisioner: {
+        canProvision: false,
         provision: async () => ({
           resourceName: "r",
           secretName: "s",

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -775,19 +775,28 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     invalid_author_allowlist_format:
       "Author allowlist entries must be valid GitHub logins.",
     invalid_type: "Select a valid agent type.",
+    provisioning_disabled:
+      "In-cluster provisioning is not enabled on this admin service — create a self-hosted agent instead.",
+    provision_failed:
+      "Failed to provision the agent's cluster resources — the agent was not created.",
   };
 
-  // ─── New local agent form (MUST be before /:id to avoid "new" being captured as param)
+  // ─── New agent form (MUST be before /:id to avoid "new" being captured as param)
 
   app.get("/admin/agents/new", requireAuth, (c) => {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
     const rawError = c.req.query("error") ?? undefined;
     const error = rawError ? (ERROR_MESSAGES[rawError] ?? rawError) : undefined;
     const types = agentTypeRegistry.listTypes();
-    return html(renderNewLocalAgentPage(c.var.userEmail, types, { error }));
+    return html(
+      renderNewLocalAgentPage(c.var.userEmail, types, {
+        error,
+        canProvision: provisioner.canProvision,
+      }),
+    );
   });
 
-  // ─── Create agent (local / self-hosted) ──────────────────────────────────
+  // ─── Create agent (self-hosted or provisioned in-cluster) ────────────────
 
   app.post("/admin/agents", requireAuth, async (c) => {
     if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
@@ -795,12 +804,19 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     let typeName: string | undefined;
     let reposRaw: string | undefined;
     let authorAllowlistRaw: string | undefined;
+    let runtime: string | undefined;
+    let claudeCodeOauthToken: string | undefined;
     try {
       const formData = await c.req.formData();
       name = formData.get("name")?.toString()?.trim();
       typeName = formData.get("type")?.toString()?.trim();
       reposRaw = formData.get("repos")?.toString()?.trim();
       authorAllowlistRaw = formData.get("authorAllowlist")?.toString()?.trim();
+      runtime = formData.get("runtime")?.toString()?.trim();
+      claudeCodeOauthToken = formData
+        .get("claudeCodeOauthToken")
+        ?.toString()
+        ?.trim();
     } catch {
       return c.redirect("/admin/agents/new", 302);
     }
@@ -813,9 +829,18 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     if (!typeName || !agentTypeRegistry.tryGetManifest(typeName)) {
       return c.redirect("/admin/agents/new?error=invalid_type", 302);
     }
+    // Absent/unrecognized runtime means self-hosted — the historical behavior of
+    // this form, and what `task stack` depends on.
+    const inCluster = runtime === "in-cluster";
+    // Same "validate before creating any row" rule as the type check above: a
+    // no-op provisioner would let provision() succeed while creating nothing,
+    // leaving an agent row with no workload behind it.
+    if (inCluster && !provisioner.canProvision) {
+      return c.redirect("/admin/agents/new?error=provisioning_disabled", 302);
+    }
     const agent = await agentService.create({
       name,
-      selfHosted: true,
+      selfHosted: !inCluster,
       typeName,
     });
     // Attach repos if provided
@@ -854,6 +879,42 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       if (authorAllowlist.length > 0) {
         await agentService.updateFields(agent.id, { authorAllowlist });
       }
+    }
+    // Store the Claude credential before provisioning so the pod comes up with
+    // it already in its env bundle rather than failing its first turn.
+    if (claudeCodeOauthToken) {
+      await agentEnvService.patch(
+        agent.id,
+        { CLAUDE_CODE_OAUTH_TOKEN: claudeCodeOauthToken },
+        new Set(SECRET_ENV_VARS),
+      );
+    }
+    if (inCluster) {
+      // Roll the row back on failure so a retry with the same name doesn't
+      // collide with a half-created agent — mirrors POST /admin/provision/start.
+      try {
+        await provisioner.provision(agent.id, { slug: agent.name });
+      } catch (err) {
+        console.error("[admin-ui] provisioning failed, rolling back:", err);
+        await agentService.delete(agent.id).catch((cleanupErr) => {
+          console.error(
+            "[admin-ui] failed to roll back agent after provision error:",
+            cleanupErr,
+          );
+        });
+        return c.redirect("/admin/agents/new?error=provision_failed", 302);
+      }
+    }
+    // Best-effort, mirroring the same call at agent boot (agent/src/index.ts).
+    // reconcileSystemCrons is a full three-pass reconcile, so a second run is a
+    // no-op — and failing here would strand the operator next to a live agent.
+    try {
+      await agentCronJobService.reconcileSystemCrons(agent.id);
+    } catch (err) {
+      console.error(
+        "[admin-ui] failed to seed system crons (non-fatal):",
+        err,
+      );
     }
     return c.redirect(`/admin/agents/${agent.id}`, 302);
   });

--- a/admin/src/agent-chat-tokens.smoke.test.ts
+++ b/admin/src/agent-chat-tokens.smoke.test.ts
@@ -38,6 +38,7 @@ async function makeSessionCookie(secret = SESSION_SECRET): Promise<string> {
 // ─── Minimal provisioner stub ─────────────────────────────────────────────────
 
 const noopProvisioner: AgentProvisioner = {
+  canProvision: false,
   async provision(agentId: string): Promise<ProvisionResult> {
     return {
       resourceName: agentId,

--- a/admin/src/agent-cron-run-stats.smoke.test.ts
+++ b/admin/src/agent-cron-run-stats.smoke.test.ts
@@ -470,6 +470,7 @@ function makeMockDeps(): AdminDeps {
       },
     } as unknown as AdminDeps["prisma"],
     provisioner: {
+      canProvision: false,
       provision: async (agentId) => ({
         resourceName: agentId,
         secretName: `${agentId}-token`,

--- a/admin/src/agent-provisioner.ts
+++ b/admin/src/agent-provisioner.ts
@@ -79,6 +79,15 @@ export interface ReconcileResult {
 }
 
 export interface AgentProvisioner {
+  /**
+   * Whether this provisioner actually creates cluster resources. `false` on the
+   * no-op implementation (Kubernetes provisioning disabled), where provision()
+   * returns plausible names without touching a cluster. Callers that offer an
+   * "in-cluster" runtime choice must check this first — otherwise an operator
+   * picks it, provision() silently succeeds, and they get an agent row with no
+   * pod behind it.
+   */
+  readonly canProvision: boolean;
   /** Mint a token and create the agent's Secret + Deployment. Idempotent. */
   provision(
     agentId: string,
@@ -222,6 +231,8 @@ function isNotFound(err: unknown): boolean {
 // ─── Kubernetes implementation ──────────────────────────────────────────────
 
 export class KubernetesAgentProvisioner implements AgentProvisioner {
+  readonly canProvision = true;
+
   private readonly tokenKey: string;
 
   constructor(
@@ -611,6 +622,8 @@ export class KubernetesAgentProvisioner implements AgentProvisioner {
  * admin service construct and run unchanged without a cluster.
  */
 export class NoopAgentProvisioner implements AgentProvisioner {
+  readonly canProvision = false;
+
   async provision(
     agentId: string,
     _opts?: { slug?: string },

--- a/admin/src/agent-provisioner.unit.test.ts
+++ b/admin/src/agent-provisioner.unit.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   KubernetesAgentProvisioner,
   type KubernetesAgentProvisionerConfig,
+  NoopAgentProvisioner,
   containerDrifted,
 } from "./agent-provisioner.ts";
 import type { AgentTokenService } from "./agent-tokens.ts";
@@ -944,5 +945,22 @@ describe("KubernetesAgentProvisioner — chat-service token minting", () => {
     expect(minted).toHaveLength(1);
     // Deployment conflict rolled back the Secret — chat-service token must also be revoked.
     expect(revoked).toEqual([minted[0].id]);
+  });
+});
+
+// ─── canProvision ─────────────────────────────────────────────────────────────
+
+describe("canProvision", () => {
+  it("is false on the no-op provisioner — it creates no cluster resources", () => {
+    expect(new NoopAgentProvisioner().canProvision).toBe(false);
+  });
+
+  it("is true on the Kubernetes provisioner", () => {
+    const provisioner = new KubernetesAgentProvisioner(
+      emptyClient(),
+      stubTokens() as AgentTokenService,
+      BASE_CONFIG,
+    );
+    expect(provisioner.canProvision).toBe(true);
   });
 });

--- a/admin/src/agents-api.integration.test.ts
+++ b/admin/src/agents-api.integration.test.ts
@@ -717,6 +717,7 @@ describeOrSkip("admin CRUD API (integration)", () => {
 
   it("POST /agents with provisioner failure rolls back seeded AgentTool and AgentPlugin rows via cascade delete", async () => {
     const throwingProvisioner: AgentProvisioner = {
+      canProvision: false,
       provision: async () => {
         throw new Error("provisioner failure");
       },

--- a/admin/src/agents-api.sentry.smoke.test.ts
+++ b/admin/src/agents-api.sentry.smoke.test.ts
@@ -33,6 +33,8 @@ const SESSION_SECRET = "test-admin-session-secret-32-bytes!";
 
 /** No-op AgentProvisioner double — provisioning is not exercised by these tests. */
 class NoopProvisioner implements AgentProvisioner {
+  readonly canProvision = false;
+
   async provision(): Promise<ProvisionResult> {
     return {
       resourceName: AGENT_ID,

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -79,6 +79,8 @@ function fakeAgentTypeRegistry(
  * call. Injected via deps — no mock.module, no global overrides.
  */
 class RecordingProvisioner implements AgentProvisioner {
+  readonly canProvision = true;
+
   readonly provisioned: string[] = [];
   readonly deprovisioned: string[] = [];
   reconcileResult: {
@@ -1713,6 +1715,7 @@ describe("admin API — delete agent", () => {
     // step) rather than throwing, so the row must survive and the response
     // must be 200 with agentDeleted: false — NOT a 500.
     const provisioner: AgentProvisioner = {
+      canProvision: false,
       async provision(agentId: string): Promise<ProvisionResult> {
         return {
           resourceName: agentId,
@@ -2352,6 +2355,7 @@ describe("admin API — selfHosted field", () => {
     // Track which agents are passed to reconcile
     const agentsPassed: Array<{ id: string; slug?: string }> = [];
     const trackingProvisioner: AdminDeps["provisioner"] = {
+      canProvision: false,
       async provision(agentId, opts) {
         return provisioner.provision(agentId, opts);
       },

--- a/admin/src/chat.smoke.test.ts
+++ b/admin/src/chat.smoke.test.ts
@@ -344,6 +344,7 @@ function makeBaseDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       },
     },
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -287,6 +287,7 @@ function makeMockDeps(
     },
     slackClient: makeMockSlackClient(),
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",

--- a/admin/src/server.smoke.test.ts
+++ b/admin/src/server.smoke.test.ts
@@ -122,6 +122,7 @@ function buildComposedApp() {
     agentWorkQueueService: { push: notImplemented, get: notImplemented },
     prisma: stubPrisma,
     provisioner: {
+      canProvision: false,
       provision: notImplemented,
       deprovision: notImplemented,
       reconcile: notImplemented,
@@ -192,6 +193,7 @@ function buildComposedApp() {
       updateFields: notImplemented,
     },
     provisioner: {
+      canProvision: false,
       provision: notImplemented,
       deprovision: notImplemented,
       reconcile: notImplemented,

--- a/admin/src/slack-provisioning.integration.test.ts
+++ b/admin/src/slack-provisioning.integration.test.ts
@@ -263,6 +263,7 @@ function makeMockDeps(
     },
     slackClient,
     provisioner: {
+      canProvision: false,
       provision: async () => ({
         resourceName: "r",
         secretName: "s",

--- a/agent/src/cron-handler.integration.test.ts
+++ b/agent/src/cron-handler.integration.test.ts
@@ -428,3 +428,109 @@ describe("handleCronRequest + sessionId wiring into completeRun (CSI-2.2)", () =
     expect(completeCalls[0]?.opts?.sessionId).toBeUndefined();
   });
 });
+
+// ─── Chat-only agent (no Slack client) ────────────────────────────────────────
+
+describe("cron dispatch on an agent with no Slack credentials", () => {
+  /**
+   * A chat-only agent gets `slack: undefined` from index.ts rather than a
+   * WebClient wrapped around an empty token. The job must still run and be
+   * recorded as completed — only the delivery step is skipped.
+   */
+  test("a channel-targeted job completes and posts nothing", async () => {
+    const { reporter, completeCalls } = makeRecordingReporter();
+    let posted = false;
+    const runner = async (): Promise<ClaudeRunResult> => {
+      posted = false;
+      return { result: "work happened", sessionId: "s1" };
+    };
+
+    await handleCronRequest(
+      { jobId: "chat-only-channel", prompt: "hello", channel: "C-X" },
+      {
+        slack: undefined,
+        runner,
+        cronRunReporter: reporter,
+        clock: makeMutableClock(new Date("2026-07-20T00:00:00Z")),
+      },
+    );
+
+    expect(completeCalls).toHaveLength(1);
+    expect(completeCalls[0]?.outcome).toBe("completed");
+    expect(posted).toBe(false);
+  });
+
+  test("a DM-targeted job completes and opens no conversation", async () => {
+    const { reporter, completeCalls } = makeRecordingReporter();
+    const runner = async (): Promise<ClaudeRunResult> => ({
+      result: "work happened",
+      sessionId: "s1",
+    });
+
+    await handleCronRequest(
+      { jobId: "chat-only-dm", prompt: "hello", user: "U-X" },
+      {
+        slack: undefined,
+        runner,
+        cronRunReporter: reporter,
+        clock: makeMutableClock(new Date("2026-07-20T00:00:00Z")),
+      },
+    );
+
+    expect(completeCalls).toHaveLength(1);
+    expect(completeCalls[0]?.outcome).toBe("completed");
+  });
+
+  test("a silent job is unaffected — it never reached delivery anyway", async () => {
+    const { reporter, completeCalls } = makeRecordingReporter();
+    const runner = async (): Promise<ClaudeRunResult> => ({
+      result: "quiet work",
+      sessionId: "s1",
+    });
+
+    await handleCronRequest(
+      { jobId: "chat-only-silent", prompt: "hello", silent: true },
+      {
+        slack: undefined,
+        runner,
+        cronRunReporter: reporter,
+        clock: makeMutableClock(new Date("2026-07-20T00:00:00Z")),
+      },
+    );
+
+    expect(completeCalls).toHaveLength(1);
+    expect(completeCalls[0]?.outcome).toBe("completed");
+  });
+
+  test("with a Slack client present, a channel job still delivers", async () => {
+    const { reporter, completeCalls } = makeRecordingReporter();
+    const channels: string[] = [];
+    const recordingSlack = {
+      chat: {
+        postMessage: async (args: { channel: string }) => {
+          channels.push(args.channel);
+          return { ok: true, ts: "1234567890.000001" };
+        },
+      },
+      conversations: { open: async () => ({ channel: { id: "D_DM" } }) },
+    } as unknown as WebClient;
+    const runner = async (): Promise<ClaudeRunResult> => ({
+      result: "work happened",
+      sessionId: "s1",
+    });
+
+    await handleCronRequest(
+      { jobId: "slack-present", prompt: "hello", channel: "C-X" },
+      {
+        slack: recordingSlack,
+        runner,
+        cronRunReporter: reporter,
+        clock: makeMutableClock(new Date("2026-07-20T00:00:00Z")),
+      },
+    );
+
+    expect(channels).toEqual(["C-X"]);
+    expect(completeCalls[0]?.outcome).toBe("completed");
+  });
+});
+

--- a/agent/src/cron-handler.ts
+++ b/agent/src/cron-handler.ts
@@ -109,7 +109,12 @@ interface CronRequest {
 }
 
 export interface CronHandlerDeps {
-  slack: WebClient;
+  /**
+   * Slack client, or `undefined` on a chat-only agent (no Slack credentials).
+   * When absent, a job with a channel/user delivery target still runs and is
+   * recorded as completed — the delivery step is skipped, not failed.
+   */
+  slack: WebClient | undefined;
   runner: ClaudeRunner;
   formatter?: (text: string) => string;
   /** Called after a successful post so the caller can track the thread. */
@@ -278,7 +283,7 @@ export async function handleCronRequest(
       console.error(
         `[agent:cron] preCheck for job "${jobId}" crashed (exit ${checkExitCode})${detail ? `: ${detail}` : ""} — session suppressed`,
       );
-      if (deps.alertsChannel) {
+      if (deps.alertsChannel && deps.slack) {
         try {
           await deps.slack.chat.postMessage({
             channel: deps.alertsChannel,
@@ -431,6 +436,20 @@ export async function handleCronRequest(
     // [silent] marker suppresses channel posts (and channel-wins-over-user posts)
     // DMs always get a reply — [silent] is ignored when routing to a DM
     console.log(`[agent:cron] job "${jobId}" completed (silent — no post)`);
+    await cronRunReporter?.completeRun(jobId, runId, clock.now(), "completed", {
+      ...buildTokenPayload(usage, modelUsage),
+      sessionId,
+    });
+    return;
+  }
+
+  // Chat-only agent: the job produced output but there is no Slack client to
+  // deliver it with. Record the run as completed — the work happened — and skip
+  // delivery rather than throwing invalid_auth on the first postMessage.
+  if (!slack) {
+    console.warn(
+      `[agent:cron] job "${jobId}" completed but Slack is not configured — delivery skipped (set SLACK_BOT_TOKEN + SLACK_APP_TOKEN, or mark the job silent)`,
+    );
     await cronRunReporter?.completeRun(jobId, runId, clock.now(), "completed", {
       ...buildTokenPayload(usage, modelUsage),
       sessionId,

--- a/agent/src/cutover-validate.integration.test.ts
+++ b/agent/src/cutover-validate.integration.test.ts
@@ -96,7 +96,7 @@ describe("validateCutover", () => {
     expect(results.every((r) => r.passed)).toBe(true);
   });
 
-  it("fails when SLACK_BOT_TOKEN is missing", async () => {
+  it("does NOT fail when SLACK_BOT_TOKEN is missing — a chat-only agent is a supported configuration", async () => {
     const { SLACK_BOT_TOKEN: _s, ...env } = makeAppAuthEnv();
     const client = new RecordedShipwrightConfigClient(makeConfig(env), [
       makeCron("cron-1"),
@@ -104,18 +104,30 @@ describe("validateCutover", () => {
     const results = await validateCutover(client, AGENT_ID);
     const slackCheck = results.find((r) => r.name === "SLACK_BOT_TOKEN");
     expect(slackCheck).toBeDefined();
-    expect(slackCheck?.passed).toBe(false);
+    expect(slackCheck?.passed).toBe(true);
+    expect(slackCheck?.message).toContain("chat-only");
+    // The whole run still passes — nothing else depended on Slack.
+    expect(results.every((r) => r.passed)).toBe(true);
   });
 
-  it("names the failing check when SLACK_BOT_TOKEN is missing", async () => {
+  it("reports SLACK_BOT_TOKEN as present when it is set", async () => {
+    const client = new RecordedShipwrightConfigClient(
+      makeConfig(makeAppAuthEnv()),
+      [makeCron("cron-1")],
+    );
+    const results = await validateCutover(client, AGENT_ID);
+    const slackCheck = results.find((r) => r.name === "SLACK_BOT_TOKEN");
+    expect(slackCheck?.passed).toBe(true);
+    expect(slackCheck?.message).toBe("SLACK_BOT_TOKEN is present");
+  });
+
+  it("names no failing check when only SLACK_BOT_TOKEN is missing", async () => {
     const { SLACK_BOT_TOKEN: _s, ...env } = makeAppAuthEnv();
     const client = new RecordedShipwrightConfigClient(makeConfig(env), [
       makeCron("cron-1"),
     ]);
     const results = await validateCutover(client, AGENT_ID);
-    const failed = results.filter((r) => !r.passed);
-    expect(failed.length).toBe(1);
-    expect(failed[0].name).toBe("SLACK_BOT_TOKEN");
+    expect(results.filter((r) => !r.passed)).toEqual([]);
   });
 
   it("fails when GitHub auth credentials are missing", async () => {
@@ -144,11 +156,12 @@ describe("validateCutover", () => {
     const client = new RecordedShipwrightConfigClient(makeConfig({}), []);
     const results = await validateCutover(client, AGENT_ID);
     const failed = results.filter((r) => !r.passed);
-    expect(failed.length).toBeGreaterThanOrEqual(3);
+    expect(failed.length).toBeGreaterThanOrEqual(2);
     const names = failed.map((r) => r.name);
-    expect(names).toContain("SLACK_BOT_TOKEN");
     expect(names).toContain("github_auth");
     expect(names).toContain("crons");
+    // Slack is informational — an empty env does not fail it.
+    expect(names).not.toContain("SLACK_BOT_TOKEN");
   });
 
   it("fails when GH_APP_INSTALLATION_ID is missing (partial App creds)", async () => {

--- a/agent/src/cutover-validate.ts
+++ b/agent/src/cutover-validate.ts
@@ -4,7 +4,8 @@
  * runtime API for required credentials and crons.
  *
  * Checks:
- *  - SLACK_BOT_TOKEN present in env bundle
+ *  - SLACK_BOT_TOKEN reported (informational — absence means a chat-only agent,
+ *    which is a supported configuration, so this check never fails)
  *  - GitHub auth credentials present (App: GH_APP_ID + GH_APP_PRIVATE_KEY +
  *    GH_APP_INSTALLATION_ID; or PAT: GH_TOKEN)
  *  - At least one cron job configured
@@ -55,11 +56,15 @@ export async function validateCutover(
 
   return [
     {
+      // Slack is an optional interaction surface, not a requirement: an agent
+      // with no Slack credentials runs in offline mode (agent/src/index.ts) and
+      // is driven from the admin chat UI instead. Absence is reported, not
+      // failed — otherwise every chat-only agent fails cutover by design.
       name: "SLACK_BOT_TOKEN",
-      passed: hasSlack,
+      passed: true,
       message: hasSlack
         ? "SLACK_BOT_TOKEN is present"
-        : "SLACK_BOT_TOKEN is missing from env bundle",
+        : "SLACK_BOT_TOKEN is not set — chat-only agent (interact via /admin/chat)",
     },
     {
       name: "github_auth",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -118,7 +118,18 @@ console.log(`[agent] agent home initialized: ${config.paths.home}`);
 const slackClock = SystemClock();
 const sessions = createFileSessionStore(config.paths.sessions);
 
-const slack = new WebClient(config.slack.botToken ?? "");
+// Slack is optional (see Step 7). Building a WebClient around an empty token
+// would make every downstream call fail with `invalid_auth` instead of being
+// skipped, so a chat-only agent gets no client at all and callers branch on
+// `undefined`.
+const slackAppConfig = {
+  botToken: config.slack.botToken ?? "",
+  appToken: config.slack.appToken ?? "",
+  signingSecret: config.slack.signingSecret ?? "",
+};
+const slack = hasSlackCredentials(slackAppConfig)
+  ? new WebClient(slackAppConfig.botToken)
+  : undefined;
 const runner = createRunClaude(
   Bun.spawn,
   sessions,
@@ -525,12 +536,6 @@ if (config.chat.serviceUrl && config.chat.serviceToken) {
 // without an appToken, so the agent runs Slack ONLY when both tokens are present.
 // Absent creds → offline mode: skip Slack, keep health green, interact via the chat UI.
 
-const slackAppConfig = {
-  botToken: config.slack.botToken ?? "",
-  appToken: config.slack.appToken ?? "",
-  signingSecret: config.slack.signingSecret ?? "",
-};
-
 let app: ReturnType<typeof createSlackApp> | undefined;
 
 if (hasSlackCredentials(slackAppConfig)) {
@@ -557,7 +562,9 @@ if (hasSlackCredentials(slackAppConfig)) {
   markSlackConnected();
   console.log("[agent] Slack app started — running");
 
-  await sendBackOnlineDm(slack, config.owner.user);
+  // `slack` is non-undefined whenever hasSlackCredentials() held, but TypeScript
+  // cannot narrow it across this distance.
+  if (slack) await sendBackOnlineDm(slack, config.owner.user);
 } else {
   console.warn(
     "[agent] Slack credentials absent (need SLACK_BOT_TOKEN + SLACK_APP_TOKEN) — " +

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -325,9 +325,21 @@ kubectl port-forward svc/shipwright-chat       3002:3000 -n shipwright
 ### Creating your first agent
 
 **The chart creates no agents.** Agents are provisioned at runtime by the admin
-service, so make one at `http://shipwright.local/admin/agents/new`, and set its
-Claude credential (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`) there — this
-chart does not provision deployment-wide Claude credentials.
+service, so make one at `http://shipwright.local/admin/agents/new`:
+
+- Pick **Provisioned in-cluster** for the runtime — the admin service creates the
+  agent's Deployment, Secret, and PVC for you. (The option is disabled unless
+  `agent.provisioning.enabled` is set, which puts `SHIPWRIGHT_K8S_PROVISIONING=enabled`
+  on the admin service.) **Self-hosted** is for agents whose container you run
+  yourself.
+- Paste a Claude credential (`CLAUDE_CODE_OAUTH_TOKEN`) into the form — this chart
+  does not provision deployment-wide Claude credentials. You can also set
+  `ANTHROPIC_API_KEY` from the agent's detail page afterwards.
+
+**No Slack credentials are required.** An agent with no Slack tokens boots in
+offline mode and is driven from the admin console's **Chat** tab
+(`http://shipwright.local/admin/chat`). Slack is optional and can be connected
+later from the `/admin/provision` wizard.
 
 ### TLS and security
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,26 @@ Durable notes for breaking changes and the steps needed to migrate across versio
 
 ---
 
+## New: `AgentProvisioner.canProvision`
+
+**Version**: next
+
+The `AgentProvisioner` interface gained a required `readonly canProvision: boolean`.
+It reports whether the implementation actually creates cluster resources:
+`KubernetesAgentProvisioner` sets it to `true`, `NoopAgentProvisioner` to `false`.
+
+This exists because `NoopAgentProvisioner.provision()` returns plausible resource
+names without touching a cluster. The admin console's **New Agent** form now offers
+an "in-cluster" runtime, and without this flag an operator could pick it on a
+deployment where provisioning is off, get a successful-looking create, and end up
+with an agent row that has no pod behind it.
+
+**For custom `AgentProvisioner` implementations**: add the property. Set it to
+`true` if your `provision()` really creates the workload, `false` if it is a stub.
+Nothing else in the interface changed.
+
+---
+
 ## New: `TaskService.list()` multi-repo/org filters and distinct `orgs` field
 
 **Version**: next (ORF-1.2)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -135,6 +135,10 @@ A browser window opens automatically to the admin dev-login page. The **agent** 
 
 In the admin console, go to **Agents → New** (<http://localhost:3001/admin/agents/new>) and create an agent, picking a type from the picker (e.g. **Coding Agent**).
 
+Leave the runtime on **Self-hosted** — `task stack` runs the agent's container for you in the agent pane. (The **Provisioned in-cluster** option is disabled here anyway: it needs `SHIPWRIGHT_K8S_PROVISIONING`, which only the Helm chart sets. See [deploy-kubernetes.md](./deploy-kubernetes.md) for that path.)
+
+No Slack credentials are needed — you'll talk to the agent from the Chat tab in Step 4.
+
 The agent pane's wait-loop polls the database and detects the new agent automatically — no stack restart needed. Once detected, it seeds the agent's chat token and starts the Docker container with that agent's id.
 
 Relaunching the stack later with an agent already created proceeds immediately — the wait-loop resolves on its first check, so you never need to delete and recreate an agent just to restart `task stack`.

--- a/scripts/minikube.ts
+++ b/scripts/minikube.ts
@@ -457,6 +457,14 @@ function printNextSteps(): void {
   console.log("\n────────────────────────────────────────────────────────────");
   console.log("Shipwright is up.\n");
   console.log(`  ${urls.devLogin}\n`);
+  console.log("Then create an agent:\n");
+  console.log(`  ${urls.agentNew}\n`);
+  console.log(
+    "  Runtime: pick 'Provisioned in-cluster' and paste a Claude credential.",
+  );
+  console.log(
+    "  No Slack needed — chat with the agent from the console's Chat tab.\n",
+  );
 
   if (!ingressHostResolves()) {
     console.log(`${INGRESS_HOST} is not in /etc/hosts yet — add it, then open`);


### PR DESCRIPTION
## Summary
- Adds a runtime choice (self-hosted vs provisioned in-cluster) to `/admin/agents/new`, so minikube/local users can get a real K8s workload without a Slack App Configuration Token — talk to the agent via `/admin/chat` instead.
- `AgentProvisioner` gains `canProvision` so the in-cluster option is only offered when `SHIPWRIGHT_K8S_PROVISIONING` is actually enabled.
- System crons are seeded and an optional `CLAUDE_CODE_OAUTH_TOKEN` can be set right on the form.
- Agent runtime: `cutover-validate`'s `SLACK_BOT_TOKEN` check is now informational (a chat-only agent no longer fails cutover), and cron delivery skips gracefully instead of throwing `invalid_auth` when no Slack client is configured.
- `/admin/provision` (the Slack app wizard) is untouched.

## Test plan
- [x] `bun run --filter='*' typecheck`
- [x] `task lint`
- [x] `bun test` (6562 pass; 1 pre-existing unrelated failure on `main` in `check-deploy.unit.test.ts`)
- [x] New/updated unit, smoke, and integration tests for the runtime picker, provisioning rollback, non-fatal cron reconcile, and Slack-absent cron delivery
- [ ] Manual verification on minikube (`task minikube:up` → create agent with in-cluster runtime → confirm pod + chat round-trip)