### PR TITLE
feat: add nullable agentId to PrFinding + thread through patch.md/appendFinding()

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.160.0",
+      "version": "1.167.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -100,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.160.0",
+      "version": "1.167.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.160.0",
+      "version": "1.167.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -374,7 +374,7 @@ Writable fields: `staged`, `commitSha`, `reviewedCommitSha`, `taskId`, `agentId`
 | `POST /prs/:id/release` | Clear `claimedBy`/`claimedAt`/`heartbeatAt`. Resets `reviewState=pending` unless it is already a terminal value (`posted`/`approved`), in which case `reviewState` is left untouched |
 | `POST /prs/:id/skip` | Increment `skipCount`, update `lastSkippedAt` to now. When `skipCount` crosses threshold (3), auto-set `blocked=true` and `blockedReason="Auto-blocked after {skipCount} consecutive skips (dispatched but found nothing to do)"` |
 | `POST /prs/:id/skip/reset` | Reset `skipCount` back to 0 and clear `lastSkippedAt`. If the PR is currently blocked with a `blockedReason` matching the skip-auto-block message (contains `"consecutive skips"`), also clears `blocked=false` and `blockedReason=null` in the same update — otherwise `blocked`/`blockedReason` are left untouched (e.g. a block set by the CI-failure-streak mechanism in `POST /prs/:id/patch` is not cleared) |
-| `POST /prs/:id/findings` | Append a review/patch finding to the PR. Request body: `{ref, disposition, source, evidence, at?}` where `disposition` is one of `resolved`, `superseded`, `rejected`; `source` is one of `review`, `patch`. Authority rule (server-enforced): `source:"patch"` may only submit `disposition:"rejected"` (returns `400` otherwise); `source:"review"` may submit any disposition. Returns `201` with the created `PrFinding` record. |
+| `POST /prs/:id/findings` | Append a review/patch finding to the PR. Request body: `{ref, disposition, source, evidence, at?, agentId?}` where `disposition` is one of `resolved`, `superseded`, `rejected`; `source` is one of `review`, `patch`. Authority rule (server-enforced): `source:"patch"` may only submit `disposition:"rejected"` (returns `400` otherwise); `source:"review"` may submit any disposition. Returns `201` with the created `PrFinding` record. |
 
 #### PR state enums
 
@@ -413,6 +413,7 @@ A `PrFinding` object represents a single code finding that has been triaged duri
 | `source` | enum | Which pipeline recorded this finding: `review` (code review phase) or `patch` (automated patch/fix phase). Authority rule (enforced server-side): `source:"patch"` may only submit `disposition:"rejected"`; `source:"review"` may submit any disposition. |
 | `evidence` | string | Human-readable explanation of the triage decision (e.g., `"Fixed the null check in commit abc123"`, `"Already superseded by the bounds-check fix"`, `"This is intentional — caller guarantees non-null"`) |
 | `at` | string | ISO timestamp of when the finding was triaged / resolved (defaults to current time if omitted on creation) |
+| `agentId` | string \| null | Optional agent instance that triaged this finding (e.g., the agent ID that performed the review or submitted the patch fix). Set via the `POST /prs/:id/findings` request body; defaults to `null` when omitted. |
 | `createdAt` | string | ISO timestamp when the task-store record itself was created |
 
 #### PR timestamp fields

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -586,6 +586,14 @@ describe("patch.md — POST a rejected ledger entry on rebuttal, alongside the e
     const after = section.slice(findingsIdx, findingsIdx + 400);
     expect(after).toMatch(/\|\|\s*\\?\s*\n\s*echo "⚠/);
   });
+
+  it("Step 5c.5 findings POST includes agentId set to $SHIPWRIGHT_AGENT_ID", () => {
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    const step5dIdx = content.indexOf("### Step 5d:");
+    const section = content.slice(step5c5Idx, step5dIdx);
+
+    expect(section).toContain('\\\"agentId\\\": \\\"$SHIPWRIGHT_AGENT_ID\\\"');
+  });
 });
 
 describe("patch.md — escalate to HITL instead of looping on a second-round disagreement (RPF-1.3)", () => {

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -1135,7 +1135,7 @@ if [ -n "$PR_RECORD_ID" ]; then
     -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
     -H "Content-Type: application/json" \
     "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID/findings" \
-    -d "{\"ref\": \"{finding.ref}\", \"disposition\": \"rejected\", \"source\": \"patch\", \"evidence\": \"{finding.evidence}\"}" \
+    -d "{\"ref\": \"{finding.ref}\", \"disposition\": \"rejected\", \"source\": \"patch\", \"evidence\": \"{finding.evidence}\", \"agentId\": \"$SHIPWRIGHT_AGENT_ID\"}" \
     > /dev/null 2>&1 || \
     echo "⚠ POST /prs/$PR_RECORD_ID/findings (rejected) failed — continuing"
   if [ "$NO_PUSH_REBUTTAL_CONFIRMED" = "true" ]; then

--- a/task-store/prisma/migrations/20260818000000_add_pr_finding_agent_id/migration.sql
+++ b/task-store/prisma/migrations/20260818000000_add_pr_finding_agent_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PrFinding" ADD COLUMN "agentId" TEXT;

--- a/task-store/prisma/schema.prisma
+++ b/task-store/prisma/schema.prisma
@@ -252,6 +252,7 @@ model PrFinding {
   source      PrFindingSource
   evidence    String
   at          String
+  agentId     String?
 
   createdAt DateTime @default(now())
 

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -264,6 +264,10 @@ export const PrFindingSchema = z
       example: "Fixed the null check in the follow-up commit.",
     }),
     at: z.string().openapi({ example: "2026-08-17T12:00:00.000Z" }),
+    agentId: z.string().nullable().openapi({
+      example: "agent-abc123",
+      description: "Agent instance that triaged this finding, if any.",
+    }),
     createdAt: z
       .string()
       .datetime()
@@ -769,6 +773,10 @@ export const CreateFindingBodySchema = z
       example: "2026-08-17T12:00:00.000Z",
       description:
         "ISO timestamp of when the finding was triaged. Defaults to the current time when omitted.",
+    }),
+    agentId: z.string().optional().openapi({
+      example: "agent-abc123",
+      description: "Agent instance that triaged this finding.",
     }),
   })
   .openapi("CreateFindingBody");

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -89,6 +89,7 @@ function makeFinding(overrides: Partial<PrFinding> = {}): PrFinding {
     source: "review",
     evidence: "fixed in follow-up commit",
     at: "2026-08-17T00:00:00.000Z",
+    agentId: null,
     createdAt: new Date(),
     ...overrides,
   } as PrFinding;
@@ -181,6 +182,7 @@ interface CapturedAppendFindingCall {
   source: "review" | "patch";
   evidence: string;
   at?: string;
+  agentId?: string;
 }
 
 /** Minimal in-memory PullRequestServiceLike fake. */
@@ -405,6 +407,7 @@ function fakePrService(
         source: "review" | "patch";
         evidence: string;
         at?: string;
+        agentId?: string;
       },
     ): Promise<PrFinding> {
       opts.appendFindingCalls?.push({ prId, ...data });
@@ -423,6 +426,7 @@ function fakePrService(
         source: data.source,
         evidence: data.evidence,
         at: data.at ?? new Date().toISOString(),
+        agentId: data.agentId ?? null,
       });
     },
   };
@@ -1828,6 +1832,56 @@ describe("/prs routes (smoke)", () => {
       }),
     });
     expect(res.status).toBe(404);
+  });
+
+  it("POST /prs/:id/findings includes agentId in the response when provided in the request body", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "review",
+        evidence: "Fixed in the follow-up commit.",
+        agentId: "agent-xyz789",
+      }),
+    });
+    expect([200, 201]).toContain(res.status);
+    const body = (await res.json()) as PrFinding;
+    expect(body.agentId).toBe("agent-xyz789");
+    expect(appendFindingCalls).toHaveLength(1);
+    expect(appendFindingCalls[0]?.agentId).toBe("agent-xyz789");
+  });
+
+  it("POST /prs/:id/findings succeeds when agentId is omitted from the request body", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const appendFindingCalls: CapturedAppendFindingCall[] = [];
+    const app = makeApp({
+      prService: fakePrService({ store, appendFindingCalls }),
+    });
+
+    const res = await app.request("/prs/pr-1/findings", {
+      method: "POST",
+      headers: { ...adminAuth(), "content-type": "application/json" },
+      body: JSON.stringify({
+        ref: "src/foo.ts:42",
+        disposition: "resolved",
+        source: "review",
+        evidence: "Fixed in the follow-up commit.",
+      }),
+    });
+    expect([200, 201]).toContain(res.status);
+    const body = (await res.json()) as PrFinding;
+    expect(appendFindingCalls).toHaveLength(1);
+    expect(appendFindingCalls[0]?.agentId).toBeUndefined();
   });
 
   // ─── GET /prs/:id includes findings[] ─────────────────────────────────────

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -183,6 +183,8 @@ export interface AppendFindingInput {
   evidence: string;
   /** ISO timestamp. Defaults to the service's Clock.now() when omitted. */
   at?: string;
+  /** Agent instance that triaged this finding. */
+  agentId?: string;
 }
 
 /** The subset of PullRequestService the routes depend on. */
@@ -954,6 +956,7 @@ export class PullRequestService implements PullRequestServiceLike {
         source: data.source,
         evidence: data.evidence,
         at: data.at ?? this.clock.now().toISOString(),
+        agentId: data.agentId ?? null,
       },
     });
   }

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -1275,4 +1275,35 @@ describe("PullRequestService.appendFinding()", () => {
 
     expect(prisma._createCalls).toHaveLength(0);
   });
+
+  test("includes agentId in the create() data when provided by the caller", async () => {
+    const prisma = makeFindingPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.appendFinding("pr-1", {
+      ref: "src/foo.ts:42",
+      disposition: "resolved",
+      source: "review",
+      evidence: "Fixed in the follow-up commit.",
+      agentId: "agent-abc123",
+    });
+
+    const { data } = prisma._createCalls[0];
+    expect(data.agentId).toBe("agent-abc123");
+  });
+
+  test("defaults `agentId` to null when the caller omits it", async () => {
+    const prisma = makeFindingPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.appendFinding("pr-1", {
+      ref: "src/foo.ts:42",
+      disposition: "resolved",
+      source: "review",
+      evidence: "Fixed in the follow-up commit.",
+    });
+
+    const { data } = prisma._createCalls[0];
+    expect(data.agentId).toBe(null);
+  });
 });

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -632,7 +632,7 @@ export function createPrsRoutes(
   // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
   app.openapi(findingsRoute, async (c): Promise<any> => {
     const body = await readJson(c);
-    const { ref, evidence, at } = body;
+    const { ref, evidence, at, agentId } = body;
 
     // disposition/source are already constrained to their valid enum values
     // by CreateFindingBodySchema's z.enum() — the OpenAPIHono request
@@ -658,6 +658,7 @@ export function createPrsRoutes(
     }
 
     const resolvedAt = typeof at === "string" && at ? at : undefined;
+    const resolvedAgentId = typeof agentId === "string" && agentId ? agentId : undefined;
 
     const finding = await prService.appendFinding(c.req.param("id"), {
       ref,
@@ -665,6 +666,7 @@ export function createPrsRoutes(
       source,
       evidence,
       at: resolvedAt,
+      agentId: resolvedAgentId,
     });
     return c.json(finding, 201);
   });


### PR DESCRIPTION
## Summary
- Add a nullable `agentId` column to `PrFinding` so every recorded review/patch finding can capture which agent instance triaged it
- Thread `agentId` through `CreateFindingBodySchema`, `AppendFindingInput`, and `appendFinding()` — optional on write, defaults to `null`
- `patch.md`'s POST to `/prs/:id/findings` now includes `"agentId": "$SHIPWRIGHT_AGENT_ID"` in the request body

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | PrFinding.agentId String? added via migration; no backfill needed | MET | schema.prisma: `agentId String?` added to PrFinding; migration `20260818000000_add_pr_finding_agent_id` does a plain nullable `ALTER TABLE ADD COLUMN` |
| 2 | CreateFindingBodySchema and AppendFindingInput accept optional agentId; appendFinding() stores it | MET | openapi-schemas.ts CreateFindingBodySchema `+agentId` optional; AppendFindingInput `+agentId?`; appendFinding() passes `agentId: data.agentId ?? null` to prisma create |
| 3 | patch.md POST includes "agentId": "$SHIPWRIGHT_AGENT_ID" | MET | patch.md Step 5c.5 findings POST body now includes `\"agentId\": \"$SHIPWRIGHT_AGENT_ID\"` |
| 4 | Test decision: extend appendFinding + findings-route smoke coverage; no existing tests retired | MET | 2 new unit tests, 2 new smoke tests, 1 new content test added; no tests removed |
| 5 | Safe to deploy standalone: yes | MET | Purely additive: nullable DB column, optional schema fields, backward-compatible route/service changes |

## Test Plan
- `pull-request-service.unit.test.ts`: agentId round-trips into the `prFinding.create()` call when provided, defaults to `null` when omitted
- `prs.smoke.test.ts`: `POST /prs/:id/findings` returns `agentId` in the response when provided, and succeeds unaffected when omitted
- `patch.content.test.ts`: asserts patch.md's findings POST body includes `agentId: $SHIPWRIGHT_AGENT_ID`
- `docs/task-store.md` refreshed to document the new field
- [x] Pre-commit checks passing (task-store full suite: 572 pass / 0 fail; one pre-existing `extraAllowedTools` flake in `agent/src/claude.unit.test.ts` reproduces on clean main, unrelated to this diff)

Generated with [Claude Code](https://claude.com/claude-code)
