### PR TITLE
feat: add GET /prs/:id/events endpoint

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -350,6 +350,29 @@ GET /prs/:id
 
 Returns `404` if not found.
 
+#### Get PR events
+
+```
+GET /prs/:id/events
+```
+
+Fetch a PR's `PullRequestEvent` audit trail — a complete history of field-level state transitions recorded in append-only order.
+
+Query params:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `limit` | number | Page size. Defaults to `50` when omitted. |
+| `offset` | number | Page offset. Defaults to `0` when omitted. |
+
+Returns `{ events: PullRequestEvent[], total: number, limit: number, offset: number }` where:
+- `events` — the PR's `PullRequestEvent` objects, ordered by `at` ascending (oldest first)
+- `total` — count of all events for this PR (independent of `limit`/`offset`)
+- `limit` — the limit applied (defaults to 50)
+- `offset` — the offset applied (defaults to 0)
+
+Returns `404` if the PR doesn't exist.
+
 #### Update PR
 
 ```

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -1869,6 +1869,128 @@
           }
         }
       }
+    },
+    "/prs/{id}/findings": {
+      "post": {
+        "tags": [
+          "PRs"
+        ],
+        "summary": "Append a review/patch finding to a PR — source:'patch' may only submit disposition:'rejected'",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx0987654321"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFindingBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Finding recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrFinding"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — including the authority violation of source:'patch' submitting a disposition other than 'rejected'",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prs/{id}/events": {
+      "get": {
+        "tags": [
+          "PRs"
+        ],
+        "summary": "Fetch a PR's PullRequestEvent audit trail, ordered by `at` ascending (oldest first)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx0987654321"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Max records to return",
+              "example": "50"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Pagination offset",
+              "example": "0"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PR's event history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrEventsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2566,6 +2688,134 @@
           }
         }
       },
+      "PrFinding": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "clxfinding123456"
+          },
+          "prRecordId": {
+            "type": "string",
+            "example": "clx0987654321"
+          },
+          "ref": {
+            "type": "string",
+            "example": "src/foo.ts:42"
+          },
+          "disposition": {
+            "type": "string",
+            "enum": [
+              "resolved",
+              "superseded",
+              "rejected"
+            ],
+            "example": "resolved"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "review",
+              "patch"
+            ],
+            "example": "review"
+          },
+          "evidence": {
+            "type": "string",
+            "example": "Fixed the null check in the follow-up commit."
+          },
+          "at": {
+            "type": "string",
+            "example": "2026-08-17T12:00:00.000Z"
+          },
+          "agentId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Agent instance that triaged this finding, if any.",
+            "example": "agent-abc123"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-08-17T12:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "prRecordId",
+          "ref",
+          "disposition",
+          "source",
+          "evidence",
+          "at",
+          "agentId",
+          "createdAt"
+        ]
+      },
+      "PullRequestEvent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "clxevent123456"
+          },
+          "prRecordId": {
+            "type": "string",
+            "example": "clx0987654321"
+          },
+          "field": {
+            "type": "string",
+            "example": "reviewState"
+          },
+          "oldValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "pending"
+          },
+          "newValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "in_progress"
+          },
+          "actor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "agent-abc123"
+          },
+          "method": {
+            "type": "string",
+            "example": "claim"
+          },
+          "at": {
+            "type": "string",
+            "example": "2026-08-17T12:00:00.000Z"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-08-17T12:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "prRecordId",
+          "field",
+          "oldValue",
+          "newValue",
+          "actor",
+          "method",
+          "at",
+          "createdAt"
+        ]
+      },
       "PullRequest": {
         "type": "object",
         "properties": {
@@ -2777,6 +3027,20 @@
             "type": "string",
             "format": "date-time",
             "example": "2026-01-06T12:00:00.000Z"
+          },
+          "findings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrFinding"
+            },
+            "description": "Review/patch findings recorded against this PR, if the caller's query included them (GET /prs/:id and list responses always include this array)."
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PullRequestEvent"
+            },
+            "description": "Field-level state transition audit trail for this PR, if the caller's query included them (GET /prs/:id and list responses always include this array)."
           }
         },
         "required": [
@@ -2921,6 +3185,85 @@
             "example": "npm-test-failed-foo.unit.test.ts"
           }
         }
+      },
+      "CreateFindingBody": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "Identifier for the finding (e.g. file:line or a slug).",
+            "example": "src/foo.ts:42"
+          },
+          "disposition": {
+            "type": "string",
+            "enum": [
+              "resolved",
+              "superseded",
+              "rejected"
+            ],
+            "description": "Triage outcome. source:'patch' may only submit 'rejected' — server-enforced (400 otherwise); source:'review' may submit any value.",
+            "example": "resolved"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "review",
+              "patch"
+            ],
+            "description": "Which pipeline phase is recording this finding.",
+            "example": "review"
+          },
+          "evidence": {
+            "type": "string",
+            "example": "Fixed the null check in the follow-up commit."
+          },
+          "at": {
+            "type": "string",
+            "description": "ISO timestamp of when the finding was triaged. Defaults to the current time when omitted.",
+            "example": "2026-08-17T12:00:00.000Z"
+          },
+          "agentId": {
+            "type": "string",
+            "description": "Agent instance that triaged this finding.",
+            "example": "agent-abc123"
+          }
+        },
+        "required": [
+          "ref",
+          "disposition",
+          "source",
+          "evidence"
+        ]
+      },
+      "PrEventsResponse": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PullRequestEvent"
+            },
+            "description": "This PR's PullRequestEvent audit trail, ordered by `at` ascending (oldest first)."
+          },
+          "total": {
+            "type": "integer",
+            "example": 1
+          },
+          "limit": {
+            "type": "integer",
+            "example": 50
+          },
+          "offset": {
+            "type": "integer",
+            "example": 0
+          }
+        },
+        "required": [
+          "events",
+          "total",
+          "limit",
+          "offset"
+        ]
       }
     }
   }

--- a/task-store/src/app.ts
+++ b/task-store/src/app.ts
@@ -69,6 +69,9 @@ const noopPrService: PullRequestServiceLike = {
   async appendFinding(_prId, _data) {
     return {} as never;
   },
+  async getEvents(_prId, _opts?) {
+    return { events: [], total: 0 };
+  },
 };
 
 export interface TaskStoreDeps {

--- a/task-store/src/generate-spec.ts
+++ b/task-store/src/generate-spec.ts
@@ -126,6 +126,9 @@ const stubPrService: PullRequestServiceLike = {
   async appendFinding() {
     return {} as never;
   },
+  async getEvents() {
+    return { events: [], total: 0 };
+  },
 };
 
 // ─── Spec assembly ────────────────────────────────────────────────────────────

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -285,18 +285,9 @@ export const PullRequestEventSchema = z
     id: z.string().openapi({ example: "clxevent123456" }),
     prRecordId: z.string().openapi({ example: "clx0987654321" }),
     field: z.string().openapi({ example: "reviewState" }),
-    oldValue: z
-      .string()
-      .nullable()
-      .openapi({ example: "pending" }),
-    newValue: z
-      .string()
-      .nullable()
-      .openapi({ example: "in_progress" }),
-    actor: z
-      .string()
-      .nullable()
-      .openapi({ example: "agent-abc123" }),
+    oldValue: z.string().nullable().openapi({ example: "pending" }),
+    newValue: z.string().nullable().openapi({ example: "in_progress" }),
+    actor: z.string().nullable().openapi({ example: "agent-abc123" }),
     method: z.string().openapi({ example: "claim" }),
     at: z.string().openapi({ example: "2026-08-17T12:00:00.000Z" }),
     createdAt: z
@@ -427,20 +418,14 @@ export const PullRequestSchema = z
       .string()
       .datetime()
       .openapi({ example: "2026-01-06T12:00:00.000Z" }),
-    findings: z
-      .array(PrFindingSchema)
-      .optional()
-      .openapi({
-        description:
-          "Review/patch findings recorded against this PR, if the caller's query included them (GET /prs/:id and list responses always include this array).",
-      }),
-    events: z
-      .array(PullRequestEventSchema)
-      .optional()
-      .openapi({
-        description:
-          "Field-level state transition audit trail for this PR, if the caller's query included them (GET /prs/:id and list responses always include this array).",
-      }),
+    findings: z.array(PrFindingSchema).optional().openapi({
+      description:
+        "Review/patch findings recorded against this PR, if the caller's query included them (GET /prs/:id and list responses always include this array).",
+    }),
+    events: z.array(PullRequestEventSchema).optional().openapi({
+      description:
+        "Field-level state transition audit trail for this PR, if the caller's query included them (GET /prs/:id and list responses always include this array).",
+    }),
   })
   .openapi("PullRequest");
 
@@ -711,6 +696,33 @@ export const PrListResponseSchema = z
     offset: z.number().int().openapi({ example: 0 }),
   })
   .openapi("PrListResponse");
+
+/** Query params for GET /prs/:id/events */
+export const PrEventsQuerySchema = z
+  .object({
+    limit: z
+      .string()
+      .optional()
+      .openapi({ example: "50", description: "Max records to return" }),
+    offset: z
+      .string()
+      .optional()
+      .openapi({ example: "0", description: "Pagination offset" }),
+  })
+  .openapi("PrEventsQuery");
+
+/** Response for GET /prs/:id/events */
+export const PrEventsResponseSchema = z
+  .object({
+    events: z.array(PullRequestEventSchema).openapi({
+      description:
+        "This PR's PullRequestEvent audit trail, ordered by `at` ascending (oldest first).",
+    }),
+    total: z.number().int().openapi({ example: 1 }),
+    limit: z.number().int().openapi({ example: 50 }),
+    offset: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("PrEventsResponse");
 
 export const ClaimPrBodySchema = z
   .object({

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -27,8 +27,9 @@
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
-import type { PrFinding, PullRequest } from "./index.ts";
+import type { PrFinding, PullRequest, PullRequestEvent } from "./index.ts";
 import type {
+  GetEventsResult,
   PullRequestListFilters,
   PullRequestListResult,
   PullRequestServiceLike,
@@ -93,6 +94,23 @@ function makeFinding(overrides: Partial<PrFinding> = {}): PrFinding {
     createdAt: new Date(),
     ...overrides,
   } as PrFinding;
+}
+
+function makeEvent(
+  overrides: Partial<PullRequestEvent> = {},
+): PullRequestEvent {
+  return {
+    id: "event-1",
+    prRecordId: "pr-1",
+    field: "reviewState",
+    oldValue: "pending",
+    newValue: "in_progress",
+    actor: "agent-abc123",
+    method: "claim",
+    at: "2026-08-17T00:00:00.000Z",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as PullRequestEvent;
 }
 
 /** Admin token service (agentId: null). */
@@ -199,6 +217,11 @@ function fakePrService(
     claimCalls?: CapturedClaimCall[];
     appendFindingCalls?: CapturedAppendFindingCall[];
     appendFindingResult?: PrFinding | Error;
+    eventsResult?: GetEventsResult | Error;
+    getEventsCalls?: Array<{
+      prId: string;
+      opts?: { limit?: number; offset?: number };
+    }>;
   } = {},
 ): PullRequestServiceLike {
   const store = opts.store ?? new Map<string, PullRequest>();
@@ -428,6 +451,19 @@ function fakePrService(
         at: data.at ?? new Date().toISOString(),
         agentId: data.agentId ?? null,
       });
+    },
+
+    async getEvents(
+      prId: string,
+      eventsOpts?: { limit?: number; offset?: number },
+    ): Promise<GetEventsResult> {
+      opts.getEventsCalls?.push({ prId, opts: eventsOpts });
+      if (opts.eventsResult !== undefined) {
+        if (opts.eventsResult instanceof Error) throw opts.eventsResult;
+        return opts.eventsResult;
+      }
+      if (!store.has(prId)) throw new NotFoundError("pr not found");
+      return { events: [], total: 0 };
     },
   };
 }
@@ -1908,5 +1944,146 @@ describe("/prs routes (smoke)", () => {
     expect(body.findings).toHaveLength(2);
     expect(body.findings[0].ref).toBe("src/foo.ts:1");
     expect(body.findings[1].disposition).toBe("rejected");
+  });
+
+  // ─── GET /prs/:id/events ───────────────────────────────────────────────────
+
+  it("GET /prs/:id/events returns 401 without auth", async () => {
+    const app = makeApp();
+    const res = await app.request("/prs/pr-1/events");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /prs/:id/events returns 404 when the PR does not exist", async () => {
+    const app = makeApp({
+      prService: fakePrService({
+        store: new Map(),
+        eventsResult: new NotFoundError("pr not found"),
+      }),
+    });
+
+    const res = await app.request("/prs/missing/events", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /prs/:id/events returns 200 with an events array in ascending `at` order, plus total/limit/offset", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const events = [
+      makeEvent({
+        id: "event-1",
+        field: "reviewState",
+        oldValue: "pending",
+        newValue: "in_progress",
+        method: "claim",
+        at: "2026-08-17T00:00:00.000Z",
+      }),
+      makeEvent({
+        id: "event-2",
+        field: "reviewState",
+        oldValue: "in_progress",
+        newValue: "posted",
+        method: "complete",
+        at: "2026-08-17T01:00:00.000Z",
+      }),
+    ];
+    const app = makeApp({
+      prService: fakePrService({
+        store,
+        eventsResult: { events, total: 2 },
+      }),
+    });
+
+    const res = await app.request("/prs/pr-1/events", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      events: PullRequestEvent[];
+      total: number;
+      limit: number;
+      offset: number;
+    };
+    expect(body.events).toHaveLength(2);
+    expect(body.events[0]?.id).toBe("event-1");
+    expect(body.events[0]?.at).toBe("2026-08-17T00:00:00.000Z");
+    expect(body.events[1]?.id).toBe("event-2");
+    expect(body.events[1]?.at).toBe("2026-08-17T01:00:00.000Z");
+    expect(body.total).toBe(2);
+    expect(typeof body.limit).toBe("number");
+    expect(typeof body.offset).toBe("number");
+  });
+
+  it("GET /prs/:id/events returns 200 with an empty array when the PR has zero events (not 404)", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = makeApp({
+      prService: fakePrService({
+        store,
+        eventsResult: { events: [], total: 0 },
+      }),
+    });
+
+    const res = await app.request("/prs/pr-1/events", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      events: PullRequestEvent[];
+      total: number;
+    };
+    expect(body.events).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it("GET /prs/:id/events?limit=&offset= parses limit/offset and forwards them to the service", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const getEventsCalls: Array<{
+      prId: string;
+      opts?: { limit?: number; offset?: number };
+    }> = [];
+    const app = makeApp({
+      prService: fakePrService({
+        store,
+        eventsResult: { events: [], total: 0 },
+        getEventsCalls,
+      }),
+    });
+
+    const res = await app.request("/prs/pr-1/events?limit=10&offset=5", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    expect(getEventsCalls).toHaveLength(1);
+    expect(getEventsCalls[0]?.prId).toBe("pr-1");
+    expect(getEventsCalls[0]?.opts?.limit).toBe(10);
+    expect(getEventsCalls[0]?.opts?.offset).toBe(5);
+  });
+
+  it("GET /prs/:id/events without limit/offset leaves them undefined (service applies defaults)", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const getEventsCalls: Array<{
+      prId: string;
+      opts?: { limit?: number; offset?: number };
+    }> = [];
+    const app = makeApp({
+      prService: fakePrService({
+        store,
+        eventsResult: { events: [], total: 0 },
+        getEventsCalls,
+      }),
+    });
+
+    const res = await app.request("/prs/pr-1/events", {
+      headers: adminAuth(),
+    });
+    expect(res.status).toBe(200);
+    expect(getEventsCalls).toHaveLength(1);
+    expect(getEventsCalls[0]?.opts?.limit).toBeUndefined();
+    expect(getEventsCalls[0]?.opts?.offset).toBeUndefined();
   });
 });

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -21,13 +21,14 @@ import { DEFAULT_CLAIM_TTL_MS } from "@shipwright/lib/claim-ttl";
 import { type Clock, SystemClock } from "./clock.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
 import {
-  Prisma,
   type PrFinding,
   type PrFindingDisposition,
   type PrFindingSource,
-  type PrismaClient,
   type PrPhase,
+  Prisma,
+  type PrismaClient,
   type PullRequest,
+  type PullRequestEvent,
 } from "./index.ts";
 import { buildRepoOrgWhere } from "./lib/repo-org-filter.ts";
 import { computePrTransitionDiff } from "./pr-transition-diff.ts";
@@ -187,6 +188,12 @@ export interface PullRequestListResult {
   offset: number;
 }
 
+/** Result from PullRequestService.getEvents. */
+export interface GetEventsResult {
+  events: PullRequestEvent[];
+  total: number;
+}
+
 /** Input for PullRequestService.appendFinding. */
 export interface AppendFindingInput {
   ref: string;
@@ -229,6 +236,10 @@ export interface PullRequestServiceLike {
     repos?: string[],
   ): Promise<{ pr: PullRequest; phase: PrPhase } | null>;
   appendFinding(prId: string, data: AppendFindingInput): Promise<PrFinding>;
+  getEvents(
+    prId: string,
+    opts?: { limit?: number; offset?: number },
+  ): Promise<GetEventsResult>;
 }
 
 export class PullRequestService implements PullRequestServiceLike {
@@ -1068,6 +1079,41 @@ export class PullRequestService implements PullRequestServiceLike {
         agentId: data.agentId ?? null,
       },
     });
+  }
+
+  /**
+   * Fetch a PR's PullRequestEvent audit trail (PSA-1.2), ordered by `at`
+   * ascending (oldest first) — uses the (prRecordId, at) index (PSA-1.1).
+   * Existence-checks the PR first (mirrors appendFinding()) so a missing PR
+   * surfaces as a clean NotFoundError rather than an empty result being
+   * indistinguishable from "PR exists but has zero events".
+   */
+  async getEvents(
+    prId: string,
+    opts: { limit?: number; offset?: number } = {},
+  ): Promise<GetEventsResult> {
+    const existing = await this.prisma.pullRequest.findUnique({
+      where: { id: prId },
+      select: { id: true },
+    });
+    if (!existing) {
+      throw new NotFoundError("pr not found");
+    }
+
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+
+    const [events, total] = await this.prisma.$transaction([
+      this.prisma.pullRequestEvent.findMany({
+        where: { prRecordId: prId },
+        orderBy: { at: "asc" },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.pullRequestEvent.count({ where: { prRecordId: prId } }),
+    ]);
+
+    return { events, total };
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/task-store/src/pull-request-service.unit.test.ts
+++ b/task-store/src/pull-request-service.unit.test.ts
@@ -1593,3 +1593,143 @@ describe("PullRequestService.appendFinding()", () => {
     expect(data.agentId).toBe(null);
   });
 });
+
+// ─── getEvents() ────────────────────────────────────────────────────────────
+//
+// Unlike the DB-backed ordering test in pull-request-service.integration.test.ts
+// (which requires DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST and self-skips
+// without it), this exercises getEvents()'s own two code paths — the
+// existence check and the findMany/count $transaction — against a hand-built
+// Prisma double, no real Postgres required. Mirrors makeListPrismaDouble
+// above but scoped to the pullRequestEvent model.
+
+function makeEventsPrismaDouble(
+  prExists: boolean,
+  events: Array<Record<string, unknown>> = [],
+) {
+  const findManyCalls: Array<{
+    where?: unknown;
+    orderBy?: unknown;
+    take?: unknown;
+    skip?: unknown;
+  }> = [];
+
+  const prisma = {
+    pullRequest: {
+      findUnique(_args: unknown): Promise<{ id: string } | null> {
+        return Promise.resolve(prExists ? { id: "pr-1" } : null);
+      },
+    },
+    pullRequestEvent: {
+      findMany(args: {
+        where?: unknown;
+        orderBy?: unknown;
+        take?: unknown;
+        skip?: unknown;
+      }) {
+        findManyCalls.push(args);
+        return Promise.resolve(events);
+      },
+      count() {
+        return Promise.resolve(events.length);
+      },
+    },
+    $transaction(ops: Promise<unknown>[]) {
+      return Promise.all(ops);
+    },
+    _findManyCalls: findManyCalls,
+  };
+
+  return prisma as unknown as {
+    pullRequest: {
+      findUnique: (args: unknown) => Promise<{ id: string } | null>;
+    };
+    pullRequestEvent: {
+      findMany: (args: {
+        where?: unknown;
+        orderBy?: unknown;
+        take?: unknown;
+        skip?: unknown;
+      }) => Promise<unknown[]>;
+      count: () => Promise<number>;
+    };
+    $transaction: (ops: Promise<unknown>[]) => Promise<unknown[]>;
+    _findManyCalls: Array<{
+      where?: unknown;
+      orderBy?: unknown;
+      take?: unknown;
+      skip?: unknown;
+    }>;
+  };
+}
+
+describe("PullRequestService.getEvents()", () => {
+  const NOW = new Date("2026-08-19T00:00:00.000Z");
+  const clock = FixedClock(NOW);
+
+  test("throws NotFoundError and never queries events when the PR does not exist", async () => {
+    const prisma = makeEventsPrismaDouble(false);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await expect(svc.getEvents("missing-pr")).rejects.toThrow(NotFoundError);
+    expect(prisma._findManyCalls).toHaveLength(0);
+  });
+
+  test("queries pullRequestEvent scoped to prRecordId, ordered by `at` ascending", async () => {
+    const prisma = makeEventsPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.getEvents("pr-1");
+
+    expect(prisma._findManyCalls).toHaveLength(1);
+    const call = prisma._findManyCalls[0];
+    expect(call.where).toEqual({ prRecordId: "pr-1" });
+    expect(call.orderBy).toEqual({ at: "asc" });
+  });
+
+  test("defaults limit to 50 and offset to 0 when the caller omits opts", async () => {
+    const prisma = makeEventsPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.getEvents("pr-1");
+
+    const call = prisma._findManyCalls[0];
+    expect(call.take).toBe(50);
+    expect(call.skip).toBe(0);
+  });
+
+  test("forwards caller-supplied limit/offset to the findMany() call", async () => {
+    const prisma = makeEventsPrismaDouble(true);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    await svc.getEvents("pr-1", { limit: 10, offset: 5 });
+
+    const call = prisma._findManyCalls[0];
+    expect(call.take).toBe(10);
+    expect(call.skip).toBe(5);
+  });
+
+  test("returns events and total from the underlying findMany()/count() results", async () => {
+    const events = [
+      { id: "event-1", prRecordId: "pr-1", at: "2026-08-17T00:00:00.000Z" },
+      { id: "event-2", prRecordId: "pr-1", at: "2026-08-17T01:00:00.000Z" },
+    ];
+    const prisma = makeEventsPrismaDouble(true, events);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    const result = await svc.getEvents("pr-1");
+
+    expect(result.events).toEqual(events as never);
+    expect(result.total).toBe(2);
+  });
+
+  test("returns an empty array and total 0 when the PR has no events", async () => {
+    const prisma = makeEventsPrismaDouble(true, []);
+    const svc = new PullRequestService(prisma as never, clock);
+
+    const result = await svc.getEvents("pr-1");
+
+    expect(result.events).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -1848,3 +1848,161 @@ describeOrSkip(
     });
   },
 );
+
+// ─── PSA-2.1: PullRequestService.getEvents() ──────────────────────────────────
+
+describeOrSkip("PullRequestService.getEvents() (integration)", () => {
+  let prisma: PrismaClient;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    // PullRequestEvent's FK is ON DELETE RESTRICT (PSA-1.2) — clear event
+    // rows before their parent PullRequest rows, since claim()/etc. write them.
+    await prisma.pullRequestEvent.deleteMany();
+    await prisma.pullRequest.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("returns events seeded via instrumented service methods (claim, complete, patch) in ascending `at` order", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 9100;
+    const commitSha = "sha-events-1";
+
+    // Seed an existing, unclaimed record so the first claim() below takes the
+    // UPDATE path (existing !== null) — the CREATE path produces zero rows
+    // (see computePrTransitionDiff), so it wouldn't exercise the audit trail.
+    const seeded = await prisma.pullRequest.create({
+      data: {
+        repo,
+        prNumber,
+        commitSha,
+        reviewState: "pending",
+        state: "open",
+      },
+    });
+
+    const t1 = new Date("2026-08-18T10:00:00.000Z");
+    const t2 = new Date("2026-08-18T10:05:00.000Z");
+    const t3 = new Date("2026-08-18T10:10:00.000Z");
+
+    // 1. claim() — reviewState pending -> in_progress.
+    const svc1 = new PullRequestService(prisma, FixedClock(t1));
+    const claimed = await svc1.claim(
+      repo,
+      prNumber,
+      commitSha,
+      "agent-a",
+      undefined,
+      "review",
+    );
+    expect(claimed.status).toBe(200);
+
+    // 2. complete() — reviewState in_progress -> posted.
+    const svc2 = new PullRequestService(prisma, FixedClock(t2));
+    await svc2.complete(seeded.id);
+
+    // 3. patch() — patchCycles 0 -> 1, reviewState -> pending.
+    const svc3 = new PullRequestService(prisma, FixedClock(t3));
+    await svc3.patch(seeded.id);
+
+    const result = await svc3.getEvents(seeded.id);
+
+    expect(result.total).toBeGreaterThanOrEqual(3);
+    expect(result.events.length).toBe(result.total);
+
+    // Ascending `at` order — oldest first.
+    const ats = result.events.map((e) => e.at);
+    const sortedAts = [...ats].sort();
+    expect(ats).toEqual(sortedAts);
+    expect(ats[0]).toBe(t1.toISOString());
+    expect(ats.at(-1)).toBe(t3.toISOString());
+
+    // Every event row belongs to this PR.
+    for (const event of result.events) {
+      expect(event.prRecordId).toBe(seeded.id);
+    }
+
+    // Sanity: the methods that drove each write are represented.
+    const methods = result.events.map((e) => e.method);
+    expect(methods).toContain("claim");
+    expect(methods).toContain("complete");
+    expect(methods).toContain("patch");
+  });
+
+  it("returns an empty array (not a 404-equivalent error) for a PR with zero events", async () => {
+    const created = await prisma.pullRequest.create({
+      data: { repo: "app-vitals/shipwright", prNumber: 9101 },
+    });
+
+    const service = new PullRequestService(prisma);
+    const result = await service.getEvents(created.id);
+    expect(result.events).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("throws NotFoundError when the PR does not exist", async () => {
+    const service = new PullRequestService(prisma);
+    let caught: unknown;
+    try {
+      await service.getEvents("00000000-0000-0000-0000-000000000000");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(NotFoundError);
+  });
+
+  it("respects limit/offset pagination while preserving ascending `at` order", async () => {
+    const repo = "app-vitals/shipwright";
+    const prNumber = 9102;
+    const commitSha = "sha-events-paginate";
+
+    const seeded = await prisma.pullRequest.create({
+      data: {
+        repo,
+        prNumber,
+        commitSha,
+        reviewState: "pending",
+        state: "open",
+      },
+    });
+
+    const times = [
+      new Date("2026-08-18T11:00:00.000Z"),
+      new Date("2026-08-18T11:05:00.000Z"),
+      new Date("2026-08-18T11:10:00.000Z"),
+    ];
+
+    // claim() (pending -> in_progress), complete() (in_progress -> posted),
+    // patch() (posted -> pending) — three distinct auditable transitions.
+    const svcClaim = new PullRequestService(prisma, FixedClock(times[0]));
+    await svcClaim.claim(
+      repo,
+      prNumber,
+      commitSha,
+      "agent-a",
+      undefined,
+      "review",
+    );
+
+    const svcComplete = new PullRequestService(prisma, FixedClock(times[1]));
+    await svcComplete.complete(seeded.id);
+
+    const svcPatch = new PullRequestService(prisma, FixedClock(times[2]));
+    await svcPatch.patch(seeded.id);
+
+    const full = await svcPatch.getEvents(seeded.id);
+    expect(full.total).toBeGreaterThanOrEqual(3);
+
+    const page1 = await svcPatch.getEvents(seeded.id, { limit: 1, offset: 0 });
+    expect(page1.events).toHaveLength(1);
+    expect(page1.total).toBe(full.total);
+    expect(page1.events[0]?.at).toBe(full.events[0]?.at);
+
+    const page2 = await svcPatch.getEvents(seeded.id, { limit: 1, offset: 1 });
+    expect(page2.events).toHaveLength(1);
+    expect(page2.events[0]?.at).toBe(full.events[1]?.at);
+  });
+});

--- a/task-store/src/routes/prs.openapi.smoke.test.ts
+++ b/task-store/src/routes/prs.openapi.smoke.test.ts
@@ -212,6 +212,10 @@ function fakePrService(
     async appendFinding() {
       return {} as never;
     },
+
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 
@@ -471,6 +475,14 @@ describe("createPrsRoutes — OpenAPIHono migration (TSM-1.3)", () => {
     store.set("pr-1", makePr({ id: "pr-1" }));
     const app = createPrsRoutes(fakePrService({ store }));
     const res = await app.request("/pr-1/skip/reset", { method: "POST" });
+    expect(res.status).not.toBe(404);
+  });
+
+  it("GET /:id/events route is registered", async () => {
+    const store = new Map<string, PullRequest>();
+    store.set("pr-1", makePr({ id: "pr-1" }));
+    const app = createPrsRoutes(fakePrService({ store }));
+    const res = await app.request("/pr-1/events");
     expect(res.status).not.toBe(404);
   });
 });

--- a/task-store/src/routes/prs.ts
+++ b/task-store/src/routes/prs.ts
@@ -26,6 +26,8 @@
  *   POST   /prs/:id/findings  append a PrFinding row {ref, disposition, source, evidence, at?}
  *                              — source:"patch" may only submit disposition:"rejected" (400
  *                              otherwise); source:"review" may submit any disposition
+ *   GET    /prs/:id/events    fetch a PR's PullRequestEvent audit trail (?limit, ?offset),
+ *                              ordered by `at` ascending (oldest first)
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
@@ -44,6 +46,8 @@ import {
   CreateFindingBodySchema,
   ErrorSchema,
   PatchPrBodySchema,
+  PrEventsQuerySchema,
+  PrEventsResponseSchema,
   PrFindingSchema,
   PrIdParamSchema,
   PrListQuerySchema,
@@ -336,6 +340,28 @@ const findingsRoute = createRoute({
       content: { "application/json": { schema: ErrorSchema } },
       description:
         "Bad request — including the authority violation of source:'patch' submitting a disposition other than 'rejected'",
+    },
+    404: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Not found",
+    },
+  },
+});
+
+const eventsRoute = createRoute({
+  method: "get",
+  path: "/:id/events",
+  tags: ["PRs"],
+  summary:
+    "Fetch a PR's PullRequestEvent audit trail, ordered by `at` ascending (oldest first)",
+  request: {
+    params: PrIdParamSchema,
+    query: PrEventsQuerySchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: PrEventsResponseSchema } },
+      description: "PR's event history",
     },
     404: {
       content: { "application/json": { schema: ErrorSchema } },
@@ -658,7 +684,8 @@ export function createPrsRoutes(
     }
 
     const resolvedAt = typeof at === "string" && at ? at : undefined;
-    const resolvedAgentId = typeof agentId === "string" && agentId ? agentId : undefined;
+    const resolvedAgentId =
+      typeof agentId === "string" && agentId ? agentId : undefined;
 
     const finding = await prService.appendFinding(c.req.param("id"), {
       ref,
@@ -669,6 +696,36 @@ export function createPrsRoutes(
       agentId: resolvedAgentId,
     });
     return c.json(finding, 201);
+  });
+
+  // ─── Events ────────────────────────────────────────────────────────────────
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(eventsRoute, async (c): Promise<any> => {
+    const limitRaw = c.req.query("limit");
+    const offsetRaw = c.req.query("offset");
+    const limit =
+      limitRaw !== undefined
+        ? Number.parseInt(limitRaw, 10) || undefined
+        : undefined;
+    const offset =
+      offsetRaw !== undefined
+        ? Number.parseInt(offsetRaw, 10) || undefined
+        : undefined;
+
+    const result = await prService.getEvents(c.req.param("id"), {
+      limit,
+      offset,
+    });
+
+    return c.json(
+      {
+        events: result.events,
+        total: result.total,
+        limit: limit ?? 50,
+        offset: offset ?? 0,
+      },
+      200,
+    );
   });
 
   return app;


### PR DESCRIPTION
## Summary
- Adds `GET /prs/:id/events` — returns a PR's `PullRequestEvent` audit-trail history, ordered by `at` ascending (oldest first), using the `(prRecordId, at)` index added in PSA-1.1
- Adds `PrEventsQuerySchema`/`PrEventsResponseSchema` (reusing the existing `PullRequestEventSchema`) and a `PullRequestService.getEvents()` method that mirrors `appendFinding()`'s existence-check pattern, throwing `NotFoundError` for a missing PR (zero events on an existing PR returns `200` with an empty array, not `404`)
- Refreshes `docs/task-store.md` with the new endpoint's contract

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New OpenAPI route GET /prs/:id/events, same auth/ownership model as other PR read routes | MET | `eventsRoute` mirrors `getOneRoute` — no extra repo-scope check, consistent with existing read routes |
| 2 | Returns events ordered by `at` ascending, using the [prRecordId, at] index | MET | `pullRequestEvent.findMany({ where: { prRecordId }, orderBy: { at: "asc" } })` |
| 3 | 404 if the PR record doesn't exist | MET | existence check via `findUnique` before querying events |
| 4 | Smoke test (auth, 404, shape) + integration test seeding real events via instrumented methods | MET | 5 new smoke cases + 4 new integration cases (via `claim`/`complete`/`patch`) |
| 5 | Safe to deploy standalone | MET | additive-only change |

## Test Plan
- `task-store/src/prs.smoke.test.ts` — auth, 404, shape, empty-array, limit/offset param forwarding
- `task-store/src/routes/prs.openapi.smoke.test.ts` — route registration
- `task-store/src/pull-request.integration.test.ts` — real Postgres seeding via `claim()`/`complete()`/`patch()`, ascending order, pagination (requires a test DB; skips gracefully in-sandbox via `describeOrSkip`, runs in CI)
- [x] `task lint` / `task typecheck` / `task check-strings` / `task check-config-docs` / `task check-version-sync` all pass
- [x] `bun test` — 594 pass, 0 fail in task-store + repo-wide (1 pre-existing unrelated flake in `agent/src/claude.unit.test.ts`, doesn't touch this diff)
- Coverage gate reports below the 89% threshold in-sandbox — this is the known sandbox gap where integration tests skip without a test DB, not specific to this diff

Generated with [Claude Code](https://claude.com/claude-code)
