### PR TITLE
fix: scope isAddressedByAuthorReply to the real PR author, not currentUser

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1173,6 +1173,12 @@ describe("review.md — Step 9.5 invokes compute-unaddressed-findings.ts mechani
     expect(step95Section).toContain("do not re-fetch or re-shape");
   });
 
+  it("passes the PR's real author login as prAuthor, not CURRENT_USER (RAS-1.1 — third-party review scope)", () => {
+    expect(step95Section).toContain("PR_AUTHOR");
+    expect(step95Section).toContain("prAuthor");
+    expect(step95Section).toContain('--arg prAuthor "$PR_AUTHOR"');
+  });
+
   it("assigns the script's boolean output to UNADDRESSED_FINDINGS for Step 10 to consume", () => {
     expect(step95Section).toContain("UNADDRESSED_FINDINGS=");
     expect(step95Section).toContain('{"unaddressedFindings":true|false}');

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -182,6 +182,12 @@ back to `'sonnet'`.
      --json number,title,author,headRefName,baseRefName,headRefOid,additions,deletions,changedFiles,body
    ```
 
+   Capture the PR's author login from this response as `PR_AUTHOR` — used by both Step 9.5
+   (as `prAuthor`, RAS-1.1) and Step 10 (to derive `selfReview`):
+   ```bash
+   PR_AUTHOR={the .author.login from the metadata above}
+   ```
+
 2. **Diff against the correct base branch** (not always main):
    ```bash
    base=$(gh pr view {pr} --repo {org}/{repo} --json baseRefName -q '.baseRefName')
@@ -675,8 +681,7 @@ subsection when there was nothing to check.
 Immediately before Step 10 finalizes the verdict, this step determines whether this PR has
 **unaddressed findings**, using the exact definition `/shipwright:patch`'s `### Step 3a: Check
 for Unaddressed Review Findings` (`commands/patch.md`) already applies — reuse that definition
-rather than re-deriving it in different language here (a fourth divergent copy of this logic
-is exactly the drift PRB-2.1 previously fixed between `check-deploy.ts` and
+rather than re-deriving it (the drift PRB-2.1 previously fixed between `check-deploy.ts` and
 `check-patch.ts`/`check-review.ts`).
 
 **This is computed mechanically, not freehand.** `compute-unaddressed-findings.ts`
@@ -684,7 +689,8 @@ is exactly the drift PRB-2.1 previously fixed between `check-deploy.ts` and
 helpers — extracted from `agent/src/check-patch.ts`'s List A qualification logic, mirroring
 `compute-review-verdict.ts`'s CLI pattern (DRO-1.1). Invoke it with the `reviews`,
 `reviewThreads`, `comments`, and `headRefOid` fetched in Step 5.5, plus `CURRENT_USER`
-resolved in Step 3 — do not decide `unaddressedFindings` by narrative judgment:
+resolved in Step 3 — do not decide `unaddressedFindings` by narrative judgment. Pass
+`PR_AUTHOR` as `prAuthor`, not `CURRENT_USER` (RAS-1.1):
 
 ```bash
 CURRENT_USER={the login resolved in Step 3}
@@ -693,12 +699,13 @@ CURRENT_USER={the login resolved in Step 3}
 ```bash
 bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-unaddressed-findings.ts" \
   "$(jq -n --arg currentUser "$CURRENT_USER" \
+    --arg prAuthor "$PR_AUTHOR" \
     --argjson headRefOid "$(jq -Rs . <<< "$HEAD_REF_OID")" \
     --argjson reviews "$REVIEWS_JSON" \
     --argjson reviewThreads "$REVIEW_THREADS_JSON" \
     --argjson comments "$COMMENTS_JSON" \
     --argjson priorFindingsStatus "$PRIOR_FINDINGS_STATUS_JSON" \
-    '{currentUser: $currentUser, headRefOid: $headRefOid, reviews: $reviews, reviewThreads: $reviewThreads, comments: $comments, priorFindingsStatus: $priorFindingsStatus}')"
+    '{currentUser: $currentUser, prAuthor: $prAuthor, headRefOid: $headRefOid, reviews: $reviews, reviewThreads: $reviewThreads, comments: $comments, priorFindingsStatus: $priorFindingsStatus}')"
 # -> {"unaddressedFindings":true|false}
 ```
 
@@ -793,7 +800,8 @@ Follow `references/post-review-guide.md` for the full mechanics.
 
 **The event/verdict decision is mechanical, not freehand.** Three inputs are already computed
 by this point in the procedure:
-- `selfReview` = `true` if the PR's `author.login == CURRENT_USER`, else `false`.
+- `selfReview` = `true` if `PR_AUTHOR == CURRENT_USER` (captured in Step 5 from the PR
+  metadata's `author.login`), else `false`.
 - `unaddressedFindings` = the boolean Step 9.5's hard gate computed (real unresolved findings
   from BEFORE this review pass — unresolved prior GitHub review threads/comments — present at
   head, per that step's exact definition).

--- a/plugins/shipwright/scripts/compute-unaddressed-findings.ts
+++ b/plugins/shipwright/scripts/compute-unaddressed-findings.ts
@@ -23,7 +23,8 @@
 // any of five exclusions:
 //   1. isSelfCleanApprove (CPF-2.1) — a self-authored clean-APPROVE review.
 //   2. isAddressedByAuthorReply (CPF-2.3) — a third-party review addressed by a
-//      subsequent PR-author reply.
+//      subsequent PR-author reply. Scoped to the real PR author via `prAuthor`
+//      (RAS-1.1), which defaults to `currentUser` when absent.
 //   3. isSupersededBySelfReview (DRO-1.2) — an earlier self-review superseded by
 //      a later, genuinely clean self-review.
 //   4. isResolvedByPriorFindingsStatus (PVD-1.3) — a prior self-authored review
@@ -40,9 +41,12 @@
 //      exclusion applies to third-party reviews too.
 //
 // CLI:
-//   bun run plugins/shipwright/scripts/compute-unaddressed-findings.ts '{"currentUser":"the-agent","headRefOid":"abc123","reviews":{"nodes":[...]},"reviewThreads":{"nodes":[...]},"comments":{"nodes":[...]},"priorFindingsStatus":[...],"findings":[...]}'
+//   bun run plugins/shipwright/scripts/compute-unaddressed-findings.ts '{"currentUser":"the-agent","headRefOid":"abc123","reviews":{"nodes":[...]},"reviewThreads":{"nodes":[...]},"comments":{"nodes":[...]},"priorFindingsStatus":[...],"findings":[...],"prAuthor":"pr-author-login"}'
 // or pipe the same JSON blob via stdin. `priorFindingsStatus` and `findings`
-// are both optional and default to [] when absent.
+// are both optional and default to [] when absent. `prAuthor` is optional and
+// defaults to `currentUser` when absent (RAS-1.1) — pass it explicitly when
+// `currentUser` is not the PR's author (e.g. review.md's Step 9.5, which
+// gates verdicts on any PR the bot reviews, including third-party PRs).
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 //
@@ -135,6 +139,21 @@ export interface PrReviewData {
    * this field keep their current behavior exactly.
    */
   findings?: PrFinding[];
+  /**
+   * The PR's actual author login, used by `isAddressedByAuthorReply` (CPF-2.3)
+   * to recognize a reply as addressing a finding (RAS-1.1). Optional —
+   * defaults to `currentUser` when absent, preserving check-patch.ts's own-PR
+   * call sites exactly (there, `currentUser` IS the PR author, since `patch`
+   * only ever acts on the authenticated user's own open PRs). review.md's
+   * Step 9.5 reuses this same function to gate review verdicts on ANY PR the
+   * bot reviews, including third-party PRs — there, `currentUser` is the
+   * reviewer, not the author, so `prAuthor` must be passed explicitly with
+   * the PR's real `author.login` for the reply exclusion to mean anything
+   * (root-caused from the ok-wow-agency PR #80 incident, where a third-party
+   * PR author's reply never matched `currentUser` and forced the verdict to
+   * COMMENT despite zero remaining findings).
+   */
+  prAuthor?: string;
 }
 
 // ─── Self-review body matching ────────────────────────────────────────────────
@@ -197,16 +216,23 @@ export function isSelfCleanApprove(
  * top-level PR comment posted after the review) is the only available
  * signal in that case, so we treat it as evidence the finding was addressed
  * (fixed or rebutted) even though the review body itself never changes.
+ *
+ * `prAuthor` is the PR's actual author login — NOT necessarily `currentUser`
+ * (RAS-1.1). check-patch.ts's own-PR call sites pass `currentUser` here
+ * (correct there, since `currentUser` IS the PR author), but review.md's
+ * Step 9.5 gates verdicts on any PR the bot reviews, including third-party
+ * PRs where `currentUser` is the reviewer, not the author — only the PR's
+ * actual author can "address" a finding via reply.
  */
 export function isAddressedByAuthorReply(
   review: Pick<ReviewNode, "submittedAt">,
   comments: IssueCommentNode[],
-  currentUser: string,
+  prAuthor: string,
 ): boolean {
   const reviewedAt = new Date(review.submittedAt).getTime();
   return comments.some(
     (c) =>
-      c.author.login === currentUser &&
+      c.author.login === prAuthor &&
       new Date(c.createdAt).getTime() > reviewedAt,
   );
 }
@@ -369,7 +395,10 @@ export function isResolvedByLedger(ref: string, findings: PrFinding[]): boolean 
  * threads AND the PR author has replied after the review (see
  * isAddressedByAuthorReply, CPF-2.3) — the only way to mark a third-party
  * review's finding as addressed, since only the review's own author can edit
- * its body.
+ * its body. The PR author's identity for this check is `data.prAuthor`,
+ * defaulting to `currentUser` when absent (RAS-1.1) — preserving
+ * check-patch.ts's own-PR behavior exactly, while letting review.md's
+ * Step 9.5 pass the PR's real author for third-party PRs the bot reviews.
  *
  * A prior self-authored review is excluded when the current pass's
  * `priorFindingsStatus[]` attests it resolved with evidence (see
@@ -393,6 +422,7 @@ export function hasUnaddressedFindings(
   const { headRefOid, reviews, reviewThreads, comments } = data;
   const priorFindingsStatus = data.priorFindingsStatus ?? [];
   const findings = data.findings ?? [];
+  const prAuthor = data.prAuthor ?? currentUser;
 
   // Find qualifying reviews: state COMMENTED or CHANGES_REQUESTED at current HEAD,
   // excluding self-authored clean-APPROVE reviews (CPF-2.1), self-reviews
@@ -421,7 +451,7 @@ export function hasUnaddressedFindings(
   return qualifyingReviews.some(
     (r) =>
       r.body.trim().length > 0 &&
-      !isAddressedByAuthorReply(r, comments.nodes, currentUser),
+      !isAddressedByAuthorReply(r, comments.nodes, prAuthor),
   );
 }
 
@@ -473,6 +503,15 @@ export function parseCliInput(raw: string): CliInput {
       'Input JSON "findings" field, when present, must be an array',
     );
   }
+  // prAuthor is optional (RAS-1.1) — absent for callers (e.g. check-patch.ts's
+  // own-PR scope, via agent/src, not this CLI) that don't need to distinguish
+  // the PR author from currentUser. When present it must be a string;
+  // hasUnaddressedFindings defaults it to currentUser when absent.
+  if (parsed.prAuthor !== undefined && typeof parsed.prAuthor !== "string") {
+    throw new Error(
+      'Input JSON "prAuthor" field, when present, must be a string',
+    );
+  }
   return {
     currentUser: parsed.currentUser,
     headRefOid: parsed.headRefOid,
@@ -481,6 +520,7 @@ export function parseCliInput(raw: string): CliInput {
     comments: parsed.comments,
     priorFindingsStatus: parsed.priorFindingsStatus ?? [],
     findings: parsed.findings ?? [],
+    prAuthor: parsed.prAuthor,
   };
 }
 
@@ -497,6 +537,7 @@ if (import.meta.main) {
       comments: input.comments,
       priorFindingsStatus: input.priorFindingsStatus,
       findings: input.findings,
+      prAuthor: input.prAuthor,
     },
     input.currentUser,
   );

--- a/plugins/shipwright/scripts/compute-unaddressed-findings.unit.test.ts
+++ b/plugins/shipwright/scripts/compute-unaddressed-findings.unit.test.ts
@@ -833,6 +833,73 @@ describe("hasUnaddressedFindings", () => {
     expect(hasUnaddressedFindings(data, "the-agent")).toBe(true);
   });
 
+  // ─── prAuthor scoping (RAS-1.1, ok-wow-agency PR #80 incident) ─────────────
+  //
+  // Before RAS-1.1, isAddressedByAuthorReply always compared a reply's author
+  // against currentUser (the bot) — correct for check-patch.ts's own-PR scope
+  // (currentUser IS the PR author there), but wrong for review.md's Step 9.5,
+  // which reuses hasUnaddressedFindings for third-party PRs the bot reviews.
+  // On ok-wow-agency PR #80, round-3 automated review was forced to COMMENT
+  // despite zero findings and both prior issues confirmed fixed, because the
+  // reply came from the real PR author (zayyen-p), not currentUser (the-agent)
+  // — the reply never matched. These tests mirror that incident directly.
+
+  test("excludes a third-party review's finding when the real PR author (not currentUser) replies after it, given explicit prAuthor (mirrors ok-wow-agency PR #80)", () => {
+    const data = makeData({
+      prAuthor: "zayyen-p",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "some-reviewer" },
+            state: "COMMENTED",
+            submittedAt: "2026-08-19T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Two issues found in round 2.",
+          },
+        ],
+      },
+      comments: {
+        nodes: [
+          {
+            author: { login: "zayyen-p" },
+            body: "Both issues fixed in this round.",
+            createdAt: "2026-08-19T11:00:00Z", // after the review's submittedAt
+          },
+        ],
+      },
+    });
+    expect(hasUnaddressedFindings(data, "the-agent")).toBe(false);
+  });
+
+  test("does NOT exclude a third-party review's finding when currentUser (not the explicit prAuthor) replies after it — proves prAuthor actually changes behavior", () => {
+    const data = makeData({
+      prAuthor: "zayyen-p",
+      reviews: {
+        nodes: [
+          {
+            author: { login: "some-reviewer" },
+            state: "COMMENTED",
+            submittedAt: "2026-08-19T10:00:00Z",
+            commit: { oid: "current-head-sha" },
+            body: "Two issues found in round 2.",
+          },
+        ],
+      },
+      comments: {
+        nodes: [
+          {
+            // currentUser replies, but the real PR author (zayyen-p) never
+            // did — this must NOT count as the author addressing the finding.
+            author: { login: "the-agent" },
+            body: "Investigating.",
+            createdAt: "2026-08-19T11:00:00Z", // after the review's submittedAt
+          },
+        ],
+      },
+    });
+    expect(hasUnaddressedFindings(data, "the-agent")).toBe(true);
+  });
+
   test("returns true when a third-party review has a non-empty body, no unresolved threads, and no PR-author reply at all", () => {
     const data = makeData({
       reviews: {

--- a/plugins/shipwright/scripts/compute-unaddressed-findings.unit.test.ts
+++ b/plugins/shipwright/scripts/compute-unaddressed-findings.unit.test.ts
@@ -1398,6 +1398,23 @@ describe("parseCliInput", () => {
       'Input JSON "findings" field, when present, must be an array',
     );
   });
+
+  test("throws when prAuthor is present but not a string (RAS-1.1)", () => {
+    const input = validInput({ prAuthor: 123 });
+    expect(() => parseCliInput(JSON.stringify(input))).toThrow(
+      'Input JSON "prAuthor" field, when present, must be a string',
+    );
+  });
+
+  test("passes prAuthor through when present, and leaves it undefined when absent (RAS-1.1)", () => {
+    const withPrAuthor = parseCliInput(
+      JSON.stringify(validInput({ prAuthor: "zayyen-p" })),
+    );
+    expect(withPrAuthor.prAuthor).toBe("zayyen-p");
+
+    const withoutPrAuthor = parseCliInput(JSON.stringify(validInput()));
+    expect(withoutPrAuthor.prAuthor).toBeUndefined();
+  });
 });
 
 // ─── CLI entrypoint (argv/stdin JSON parsing) ──────────────────────────────


### PR DESCRIPTION
## Summary
- `isAddressedByAuthorReply` in `compute-unaddressed-findings.ts` no longer hardcodes `currentUser` as the identity whose reply "addresses" a finding — it now accepts an optional `prAuthor` field on `PrReviewData`, defaulting to `currentUser` for backward compatibility.
- `review.md`'s Step 9.5 now threads the PR's real `author.login` (captured in Step 5, also reused for Step 10's `selfReview`) into the CLI call as `prAuthor`, instead of relying on `currentUser` as a stand-in for the PR author on third-party PRs.
- Root-caused from the ok-wow-agency PR #80 incident (2026-08-19): round-3 automated review was forced to `COMMENT` despite zero findings and both prior issues confirmed fixed, because the PR author's (zayyen-p's) reply never matched `currentUser` (the bot). Dan had to approve manually.
- `check-patch.ts`'s own-PR call sites are unaffected — `prAuthor` is never set there, so it defaults to `currentUser`, which is correct for that scope (the authenticated user's own PRs).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `PrReviewData` gains optional `prAuthor` field; `hasUnaddressedFindings` defaults it to `currentUser` when absent | MET |
| 2 | `isAddressedByAuthorReply`'s third parameter renamed `currentUser` -> `prAuthor`, comparing `c.author.login === prAuthor` | MET |
| 3 | `review.md` Step 9.5 threads the PR's real `author.login` into the CLI call as `prAuthor` | MET |
| 4 | Unit test mirroring the ok-wow-agency #80 incident added; `review.content.test.ts`'s Step 9.5 assertion updated; `check-patch.ts`/`patch.content.test.ts` left unchanged | MET |

## Test Plan
- Two new unit tests in `compute-unaddressed-findings.unit.test.ts` mirror the ok-wow-agency #80 incident: one proving a real-author reply (via explicit `prAuthor`) excludes the finding, one proving a `currentUser` reply no longer counts when `prAuthor` is set to someone else (proves the fix actually changes behavior).
- `review.content.test.ts` asserts `PR_AUTHOR`/`prAuthor` now appear in Step 9.5's markdown.
- `bun test agent/src/check-patch.unit.test.ts` — 63/63 pass, confirming own-PR behavior is unchanged.
- `task typecheck`, `task lint`, `task check-strings` all clean.
- `task ci` full suite: 6600 pass, 1 pre-existing unrelated flake (`agent/src/claude.unit.test.ts` — `extraAllowedTools`, documented pre-existing sandbox flake unrelated to this diff).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
