### PR TITLE
feat: add Helm chart support for auth.mode=okta

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,16 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.12.0] - 2026-08-20
+
+### Added
+
+- `auth.mode=okta` — Okta OIDC support mirroring `auth.mode=google` (new
+  `auth.okta.*` values block with `existingSecret` support, `values.schema.json`
+  enum + conditional required fields, `OKTA_ISSUER`/`OKTA_CLIENT_ID`/
+  `OKTA_CLIENT_SECRET`/`SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` wiring in the admin
+  Secret and Deployment, and `NOTES.txt` messaging).
+
 ## [1.11.64] - 2026-08-19
 
 ### Changed

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -14,11 +14,14 @@ independent of `appVersion`. CI enforces this with
 
 ### Added
 
-- `auth.mode=okta` — Okta OIDC support mirroring `auth.mode=google` (new
-  `auth.okta.*` values block with `existingSecret` support, `values.schema.json`
+- `auth.mode=okta` — Okta OIDC **chart-side plumbing** mirroring `auth.mode=google`
+  (new `auth.okta.*` values block with `existingSecret` support, `values.schema.json`
   enum + conditional required fields, `OKTA_ISSUER`/`OKTA_CLIENT_ID`/
   `OKTA_CLIENT_SECRET`/`SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` wiring in the admin
-  Secret and Deployment, and `NOTES.txt` messaging).
+  Secret and Deployment, and `NOTES.txt` messaging). ⚠️ Chart-only — the admin
+  application does not yet implement Okta OIDC login; `auth.mode=okta` will
+  lock deployers out of the admin UI until application-side support ships.
+  Use `auth.mode=google` for a working production login today.
 
 ## [1.11.64] - 2026-08-19
 

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.11.64
+version: 1.12.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.11.64 triggered by release tag agent-v1.170.0"
+    - kind: added
+      description: "auth.mode=okta — Okta OIDC support mirroring auth.mode=google (auth.okta.* block, existingSecret support)"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -30,7 +30,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: added
-      description: "auth.mode=okta — Okta OIDC support mirroring auth.mode=google (auth.okta.* block, existingSecret support)"
+      description: "auth.mode=okta — Okta OIDC chart-side plumbing mirroring auth.mode=google (auth.okta.* block, existingSecret support). Chart-only: admin app has no Okta login handler yet, use auth.mode=google for working production login"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/README.md
+++ b/charts/shipwright/README.md
@@ -156,10 +156,14 @@ environment, set `postgresql.auth.existingSecret` to a pre-created Secret (or se
 | `agent.voice.elevenlabs.apiKey` | `""` | ElevenLabs TTS key → `ELEVENLABS_API_KEY` (voice Secret). Empty = in-pod Piper TTS fallback. |
 | `agent.voice.elevenlabs.voiceId` | `""` | Optional ElevenLabs voice id → `ELEVENLABS_VOICE_ID`. |
 | `agent.voice.groq.apiKey` | `""` | Groq STT key → `GROQ_API_KEY` (voice Secret); used only when `provider=groq`. |
-| `auth.mode` | `open` | Admin auth: `open` (dev auth, **no OAuth — insecure, do not expose publicly**) \| `google` (Google OAuth, `NODE_ENV=production`). |
+| `auth.mode` | `open` | Admin auth: `open` (dev auth, **no OAuth — insecure, do not expose publicly**) \| `google` (Google OAuth, `NODE_ENV=production`) \| `okta` (Okta OIDC, `NODE_ENV=production`). One deployment runs exactly one provider at a time. |
 | `auth.google.clientId` | `""` | Google OAuth client ID (used when `auth.mode=google`). |
 | `auth.google.clientSecret` | `""` | Google OAuth client secret (kept in the chart-managed admin Secret). |
 | `auth.google.allowedEmails` | `""` | Comma-separated allow-list of emails permitted to sign in. |
+| `auth.okta.issuer` | `""` | Okta OIDC issuer URL, e.g. `https://dev-123456.okta.com` (used when `auth.mode=okta`). |
+| `auth.okta.clientId` | `""` | Okta OIDC client ID (used when `auth.mode=okta`). |
+| `auth.okta.clientSecret` | `""` | Okta OIDC client secret (kept in the chart-managed admin Secret). |
+| `auth.okta.allowedEmails` | `""` | Comma-separated allow-list of emails permitted to sign in. |
 | `admin.service.type` | `ClusterIP` | Admin Service type. |
 | `admin.serviceAccount.create` | `true` | Whether to create the admin ServiceAccount. |
 | `admin.serviceAccount.name` | `""` | Admin ServiceAccount name (generated if empty). |

--- a/charts/shipwright/README.md
+++ b/charts/shipwright/README.md
@@ -156,14 +156,25 @@ environment, set `postgresql.auth.existingSecret` to a pre-created Secret (or se
 | `agent.voice.elevenlabs.apiKey` | `""` | ElevenLabs TTS key → `ELEVENLABS_API_KEY` (voice Secret). Empty = in-pod Piper TTS fallback. |
 | `agent.voice.elevenlabs.voiceId` | `""` | Optional ElevenLabs voice id → `ELEVENLABS_VOICE_ID`. |
 | `agent.voice.groq.apiKey` | `""` | Groq STT key → `GROQ_API_KEY` (voice Secret); used only when `provider=groq`. |
-| `auth.mode` | `open` | Admin auth: `open` (dev auth, **no OAuth — insecure, do not expose publicly**) \| `google` (Google OAuth, `NODE_ENV=production`) \| `okta` (Okta OIDC, `NODE_ENV=production`). One deployment runs exactly one provider at a time. |
+| `auth.mode` | `open` | Admin auth: `open` (dev auth, **no OAuth — insecure, do not expose publicly**) \| `google` (Google OAuth, `NODE_ENV=production`) \| `okta` (Okta OIDC env plumbing only, `NODE_ENV=production` — **not yet backed by an admin-app login path, see warning below**). One deployment runs exactly one provider at a time. |
 | `auth.google.clientId` | `""` | Google OAuth client ID (used when `auth.mode=google`). |
 | `auth.google.clientSecret` | `""` | Google OAuth client secret (kept in the chart-managed admin Secret). |
 | `auth.google.allowedEmails` | `""` | Comma-separated allow-list of emails permitted to sign in. |
-| `auth.okta.issuer` | `""` | Okta OIDC issuer URL, e.g. `https://dev-123456.okta.com` (used when `auth.mode=okta`). |
-| `auth.okta.clientId` | `""` | Okta OIDC client ID (used when `auth.mode=okta`). |
+| `auth.okta.issuer` | `""` | Okta OIDC issuer URL, e.g. `https://dev-123456.okta.com` (used when `auth.mode=okta`; chart-only today, see warning below). |
+| `auth.okta.clientId` | `""` | Okta OIDC client ID (used when `auth.mode=okta`; chart-only today, see warning below). |
 | `auth.okta.clientSecret` | `""` | Okta OIDC client secret (kept in the chart-managed admin Secret). |
 | `auth.okta.allowedEmails` | `""` | Comma-separated allow-list of emails permitted to sign in. |
+
+> ⚠️ **`auth.mode=okta` is chart-only today — do not deploy it expecting a working login.**
+> This chart wires `OKTA_ISSUER`/`OKTA_CLIENT_ID`/`OKTA_CLIENT_SECRET`/
+> `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` into the admin Deployment and sets
+> `NODE_ENV=production`, but the admin application (`admin/src/`) has no Okta
+> OIDC client implementation yet — only `auth.mode=google` has a working login
+> path in the app today. Deploying with `auth.mode=okta` sets
+> `NODE_ENV=production` (which blocks the `auth.mode=open` dev-auth escape)
+> with no functioning login route, locking you out of the admin UI. Use
+> `auth.mode=google` or `auth.mode=open` (non-public only) until Okta app
+> support ships.
 | `admin.service.type` | `ClusterIP` | Admin Service type. |
 | `admin.serviceAccount.create` | `true` | Whether to create the admin ServiceAccount. |
 | `admin.serviceAccount.name` | `""` | Admin ServiceAccount name (generated if empty). |

--- a/charts/shipwright/templates/NOTES.txt
+++ b/charts/shipwright/templates/NOTES.txt
@@ -122,6 +122,10 @@ Provision your first agent:
 
   auth.mode=google — Google OAuth is enabled (NODE_ENV=production). Only emails
   in auth.google.allowedEmails ("{{ .Values.auth.google.allowedEmails }}") may sign in.
+{{- else if eq .Values.auth.mode "okta" }}
+
+  auth.mode=okta — Okta OIDC is enabled (NODE_ENV=production). Only emails
+  in auth.okta.allowedEmails ("{{ .Values.auth.okta.allowedEmails }}") may sign in.
 {{- end }}
 
 Minikube tip: with networking.type=ClusterIP, reach a service via

--- a/charts/shipwright/templates/NOTES.txt
+++ b/charts/shipwright/templates/NOTES.txt
@@ -124,8 +124,13 @@ Provision your first agent:
   in auth.google.allowedEmails ("{{ .Values.auth.google.allowedEmails }}") may sign in.
 {{- else if eq .Values.auth.mode "okta" }}
 
-  auth.mode=okta — Okta OIDC is enabled (NODE_ENV=production). Only emails
-  in auth.okta.allowedEmails ("{{ .Values.auth.okta.allowedEmails }}") may sign in.
+  ============================================================================
+  ⚠️  WARNING: auth.mode=okta is CHART-ONLY — the admin app has no Okta login
+      handler yet. NODE_ENV=production is set (blocking dev-auth) with no
+      working login path, which will lock you out of the admin UI. Use
+      auth.mode=google (working today) or auth.mode=open (non-public only)
+      until application-side Okta support ships.
+  ============================================================================
 {{- end }}
 
 Minikube tip: with networking.type=ClusterIP, reach a service via

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -169,7 +169,9 @@ spec:
               value: {{ .Values.auth.google.allowedEmails | quote }}
             {{- end }}
             {{- else if eq .Values.auth.mode "okta" }}
-            # auth.mode=okta — real Okta OIDC. Production hardening on.
+            # auth.mode=okta — Okta OIDC env wiring (chart-only; admin app has
+            # no Okta login handler yet, see values.yaml auth.mode comment).
+            # Production hardening (NODE_ENV=production) on regardless.
             - name: NODE_ENV
               value: "production"
             {{- if .Values.auth.okta.existingSecret }}

--- a/charts/shipwright/templates/admin-deployment.yaml
+++ b/charts/shipwright/templates/admin-deployment.yaml
@@ -168,6 +168,51 @@ spec:
             - name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
               value: {{ .Values.auth.google.allowedEmails | quote }}
             {{- end }}
+            {{- else if eq .Values.auth.mode "okta" }}
+            # auth.mode=okta — real Okta OIDC. Production hardening on.
+            - name: NODE_ENV
+              value: "production"
+            {{- if .Values.auth.okta.existingSecret }}
+            # auth.okta.existingSecret: source all four OIDC vars from caller-managed Secret.
+            - name: OKTA_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.okta.existingSecret }}
+                  key: {{ .Values.auth.okta.issuerRef | default "OKTA_ISSUER" }}
+            - name: OKTA_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.okta.existingSecret }}
+                  key: {{ .Values.auth.okta.clientIdRef | default "OKTA_CLIENT_ID" }}
+            - name: OKTA_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.okta.existingSecret }}
+                  key: {{ .Values.auth.okta.clientSecretRef | default "OKTA_CLIENT_SECRET" }}
+            - name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.okta.existingSecret }}
+                  key: {{ .Values.auth.okta.allowedEmailsRef | default "SHIPWRIGHT_ADMIN_ALLOWED_EMAILS" }}
+            {{- else }}
+            - name: OKTA_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.admin.secretName" . }}
+                  key: OKTA_ISSUER
+            - name: OKTA_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.admin.secretName" . }}
+                  key: OKTA_CLIENT_ID
+            - name: OKTA_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "shipwright.admin.secretName" . }}
+                  key: OKTA_CLIENT_SECRET
+            - name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+              value: {{ .Values.auth.okta.allowedEmails | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.agent.provisioning.enabled }}
             # ── Agent-provisioning env contract (HD-4.2) ──────────────────────

--- a/charts/shipwright/templates/admin-secret.yaml
+++ b/charts/shipwright/templates/admin-secret.yaml
@@ -67,4 +67,11 @@ data:
   GOOGLE_CLIENT_ID: {{ .Values.auth.google.clientId | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.auth.google.clientSecret | b64enc | quote }}
 {{- end }}
+{{- if and (eq .Values.auth.mode "okta") (not .Values.auth.okta.existingSecret) }}
+  {{- /* Okta OIDC credentials — omitted when auth.okta.existingSecret is set
+       (the Deployment sources them from the caller-managed Secret via secretKeyRef). */}}
+  OKTA_ISSUER: {{ .Values.auth.okta.issuer | b64enc | quote }}
+  OKTA_CLIENT_ID: {{ .Values.auth.okta.clientId | b64enc | quote }}
+  OKTA_CLIENT_SECRET: {{ .Values.auth.okta.clientSecret | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/shipwright/tests/admin_auth_modes_test.yaml
+++ b/charts/shipwright/tests/admin_auth_modes_test.yaml
@@ -1,9 +1,13 @@
-suite: admin auth modes (open vs google)
+suite: admin auth modes (open vs google vs okta)
 # HD-3.1 auth modes. auth.mode=open → ADMIN_DEV_AUTH=true + NODE_ENV=development
 # (the image bakes NODE_ENV=production, which would hard-block dev auth if the
 # deployment left it to the image default).
 # auth.mode=google → NODE_ENV=production + Google OAuth env (from the admin
 # Secret) + SHIPWRIGHT_ADMIN_ALLOWED_EMAILS.
+# auth.mode=okta → NODE_ENV=production + Okta OIDC env (from the admin
+# Secret) + SHIPWRIGHT_ADMIN_ALLOWED_EMAILS. Mirrors the google mode exactly,
+# with OKTA_ISSUER additionally required (Okta OIDC needs the tenant issuer URL;
+# Google's issuer is implicit/well-known so it has no equivalent field).
 templates:
   - templates/admin-deployment.yaml
 release:
@@ -109,3 +113,95 @@ tests:
           content:
             name: ADMIN_DEV_AUTH
             value: "true"
+
+  - it: okta mode sets NODE_ENV=production
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_ENV
+            value: "production"
+
+  - it: okta mode sources OKTA_ISSUER / OKTA_CLIENT_ID / OKTA_CLIENT_SECRET from the admin Secret
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_ISSUER
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: OKTA_ISSUER
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: OKTA_CLIENT_ID
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: OKTA_CLIENT_SECRET
+
+  - it: okta mode passes SHIPWRIGHT_ADMIN_ALLOWED_EMAILS from values
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: a@example.com,b@example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+            value: a@example.com,b@example.com
+
+  - it: okta mode does NOT set ADMIN_DEV_AUTH (dev auth is off)
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ADMIN_DEV_AUTH
+            value: "true"
+
+  - it: okta mode does NOT set any Google OAuth env
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOOGLE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: GOOGLE_CLIENT_ID

--- a/charts/shipwright/tests/admin_secret_test.yaml
+++ b/charts/shipwright/tests/admin_secret_test.yaml
@@ -105,3 +105,51 @@ tests:
           path: data.GOOGLE_CLIENT_ID
       - notExists:
           path: data.GOOGLE_CLIENT_SECRET
+
+  - it: includes Okta OIDC credentials only in okta mode
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    asserts:
+      - equal:
+          path: data.OKTA_ISSUER
+          decodeBase64: true
+          value: https://dev-123.okta.com
+      - equal:
+          path: data.OKTA_CLIENT_ID
+          decodeBase64: true
+          value: cid
+      - equal:
+          path: data.OKTA_CLIENT_SECRET
+          decodeBase64: true
+          value: csec
+
+  - it: omits Okta OIDC credentials in open mode
+    set:
+      auth.mode: open
+    asserts:
+      - notExists:
+          path: data.OKTA_ISSUER
+      - notExists:
+          path: data.OKTA_CLIENT_ID
+      - notExists:
+          path: data.OKTA_CLIENT_SECRET
+
+  - it: omits OKTA_ISSUER, OKTA_CLIENT_ID and OKTA_CLIENT_SECRET when auth.okta.existingSecret is set
+    set:
+      auth.mode: okta
+      auth.okta.existingSecret: my-okta-secret
+      auth.okta.issuerRef: OKTA_ISSUER
+      auth.okta.clientIdRef: OKTA_CLIENT_ID
+      auth.okta.clientSecretRef: OKTA_CLIENT_SECRET
+      auth.okta.allowedEmailsRef: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+    asserts:
+      - notExists:
+          path: data.OKTA_ISSUER
+      - notExists:
+          path: data.OKTA_CLIENT_ID
+      - notExists:
+          path: data.OKTA_CLIENT_SECRET

--- a/charts/shipwright/tests/admin_workload_test.yaml
+++ b/charts/shipwright/tests/admin_workload_test.yaml
@@ -215,6 +215,94 @@ tests:
             name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
             value: "dev@example.com"
 
+  # ── auth.okta.existingSecret ─────────────────────────────────────────────
+
+  - it: sources OKTA_ISSUER, OKTA_CLIENT_ID, OKTA_CLIENT_SECRET, and SHIPWRIGHT_ADMIN_ALLOWED_EMAILS from existingSecret when set
+    template: templates/admin-deployment.yaml
+    set:
+      auth.mode: okta
+      auth.okta.existingSecret: my-okta-secret
+      auth.okta.issuerRef: OKTA_ISSUER
+      auth.okta.clientIdRef: OKTA_CLIENT_ID
+      auth.okta.clientSecretRef: OKTA_CLIENT_SECRET
+      auth.okta.allowedEmailsRef: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_ISSUER
+            valueFrom:
+              secretKeyRef:
+                name: my-okta-secret
+                key: OKTA_ISSUER
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-okta-secret
+                key: OKTA_CLIENT_ID
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-okta-secret
+                key: OKTA_CLIENT_SECRET
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+            valueFrom:
+              secretKeyRef:
+                name: my-okta-secret
+                key: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+
+  - it: sources Okta OIDC from the chart-managed Secret by default (no existingSecret)
+    template: templates/admin-deployment.yaml
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    release:
+      name: r
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_ISSUER
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: OKTA_ISSUER
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: OKTA_CLIENT_ID
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OKTA_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: r-shipwright-admin
+                key: OKTA_CLIENT_SECRET
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+            value: "dev@example.com"
+
   # ── admin.appBaseUrl ──────────────────────────────────────────────────────
 
   - it: injects SHIPWRIGHT_ADMIN_APP_BASE_URL when admin.appBaseUrl is set

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -202,7 +202,7 @@ tests:
       - failedTemplate:
           errorPattern: "clientId"
 
-  - it: accepts networking.type=okta (new enum member)
+  - it: accepts auth.mode=okta (new enum member)
     set:
       auth.mode: okta
       auth.okta.issuer: https://dev-123.okta.com

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -201,3 +201,54 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "clientId"
+
+  - it: accepts networking.type=okta (new enum member)
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: dev@example.com
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects okta mode with missing required auth.okta.* fields
+    set:
+      auth.mode: okta
+    asserts:
+      - failedTemplate:
+          errorPattern: "issuer"
+
+  - it: rejects okta mode with empty allowedEmails (conditional minLength)
+    set:
+      auth.mode: okta
+      auth.okta.issuer: https://dev-123.okta.com
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "allowedEmails"
+
+  - it: accepts okta mode with existingSecret set and empty clientId (existingSecret bypasses inline-field requirement)
+    set:
+      auth.mode: okta
+      auth.okta.existingSecret: my-okta-secret
+      auth.okta.issuer: ""
+      auth.okta.clientId: ""
+      auth.okta.clientSecret: ""
+      auth.okta.allowedEmails: ""
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects okta mode with existingSecret empty and empty issuer (existing enforcement still holds)
+    set:
+      auth.mode: okta
+      auth.okta.existingSecret: ""
+      auth.okta.issuer: ""
+      auth.okta.clientId: cid
+      auth.okta.clientSecret: csec
+      auth.okta.allowedEmails: user@example.com
+    asserts:
+      - failedTemplate:
+          errorPattern: "issuer"

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -408,7 +408,7 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["open", "google", "none"]
+          "enum": ["open", "google", "okta", "none"]
         },
         "google": {
           "type": "object",
@@ -418,6 +418,21 @@
             "clientIdRef": { "type": "string" },
             "clientSecretRef": { "type": "string" },
             "allowedEmailsRef": { "type": "string" },
+            "clientId": { "type": "string" },
+            "clientSecret": { "type": "string" },
+            "allowedEmails": { "type": "string" }
+          }
+        },
+        "okta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "existingSecret": { "type": "string" },
+            "issuerRef": { "type": "string" },
+            "clientIdRef": { "type": "string" },
+            "clientSecretRef": { "type": "string" },
+            "allowedEmailsRef": { "type": "string" },
+            "issuer": { "type": "string" },
             "clientId": { "type": "string" },
             "clientSecret": { "type": "string" },
             "allowedEmails": { "type": "string" }
@@ -445,6 +460,39 @@
                 "clientId": { "type": "string", "minLength": 1 },
                 "clientSecret": { "type": "string", "minLength": 1 },
                 "allowedEmails": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        }
+      },
+      "else": {
+        "if": {
+          "properties": { "mode": { "const": "okta" } },
+          "required": ["mode"]
+        },
+        "then": {
+          "properties": {
+            "okta": {
+              "if": {
+                "properties": {
+                  "existingSecret": { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret"]
+              },
+              "then": {},
+              "else": {
+                "required": [
+                  "issuer",
+                  "clientId",
+                  "clientSecret",
+                  "allowedEmails"
+                ],
+                "properties": {
+                  "issuer": { "type": "string", "minLength": 1 },
+                  "clientId": { "type": "string", "minLength": 1 },
+                  "clientSecret": { "type": "string", "minLength": 1 },
+                  "allowedEmails": { "type": "string", "minLength": 1 }
+                }
               }
             }
           }

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -432,8 +432,13 @@ auth:
   #               Minikube/dev default. Do NOT expose publicly.
   #    "google" — real Google OAuth (NODE_ENV=production). Requires
   #               auth.google.{clientId,clientSecret,allowedEmails}.
-  #    "okta"   — real Okta OIDC (NODE_ENV=production). Requires
+  #    "okta"   — Okta OIDC env wiring only (NODE_ENV=production). Requires
   #               auth.okta.{issuer,clientId,clientSecret,allowedEmails}.
+  #               ⚠️ CHART-ONLY TODAY: the admin app (admin/src/) has no Okta
+  #               login handler yet, so this mode sets NODE_ENV=production
+  #               (blocking dev-auth) with no working login path. Do not use
+  #               in a real deployment until application-side Okta support
+  #               ships — use "google" or "open" (non-public) instead.
   # One Helm deployment runs exactly one provider at a time — this stays a
   # single-value enum rather than a list of enabled providers.
   mode: open
@@ -459,6 +464,7 @@ auth:
   # -- Okta OIDC settings (used only when auth.mode=okta). Mirrors auth.google
   # exactly, plus an issuer (Okta's OIDC issuer URL is tenant-specific and has
   # no well-known default the way Google's does).
+  # ⚠️ Chart-only today — see the auth.mode comment above.
   okta:
     # -- Name of an existing Secret holding Okta OIDC credentials and the
     # allowed-emails list. When set, issuer/clientId/clientSecret/allowedEmails

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -432,6 +432,10 @@ auth:
   #               Minikube/dev default. Do NOT expose publicly.
   #    "google" — real Google OAuth (NODE_ENV=production). Requires
   #               auth.google.{clientId,clientSecret,allowedEmails}.
+  #    "okta"   — real Okta OIDC (NODE_ENV=production). Requires
+  #               auth.okta.{issuer,clientId,clientSecret,allowedEmails}.
+  # One Helm deployment runs exactly one provider at a time — this stays a
+  # single-value enum rather than a list of enabled providers.
   mode: open
   # -- Google OAuth settings (used only when auth.mode=google).
   google:
@@ -449,6 +453,32 @@ auth:
     # -- Google OAuth client ID (used when existingSecret is empty).
     clientId: ""
     # -- Google OAuth client secret (kept in the chart-managed admin Secret).
+    clientSecret: ""
+    # -- Comma-separated allow-list of emails permitted to sign in.
+    allowedEmails: ""
+  # -- Okta OIDC settings (used only when auth.mode=okta). Mirrors auth.google
+  # exactly, plus an issuer (Okta's OIDC issuer URL is tenant-specific and has
+  # no well-known default the way Google's does).
+  okta:
+    # -- Name of an existing Secret holding Okta OIDC credentials and the
+    # allowed-emails list. When set, issuer/clientId/clientSecret/allowedEmails
+    # below are ignored and the Deployment sources those four vars via
+    # secretKeyRef from this Secret. Leave empty to use the inline values below.
+    existingSecret: ""
+    # -- Key in existingSecret for OKTA_ISSUER.
+    issuerRef: OKTA_ISSUER
+    # -- Key in existingSecret for OKTA_CLIENT_ID.
+    clientIdRef: OKTA_CLIENT_ID
+    # -- Key in existingSecret for OKTA_CLIENT_SECRET.
+    clientSecretRef: OKTA_CLIENT_SECRET
+    # -- Key in existingSecret for SHIPWRIGHT_ADMIN_ALLOWED_EMAILS.
+    allowedEmailsRef: SHIPWRIGHT_ADMIN_ALLOWED_EMAILS
+    # -- Okta OIDC issuer URL, e.g. "https://dev-123456.okta.com" (used when
+    # existingSecret is empty).
+    issuer: ""
+    # -- Okta OIDC client ID (used when existingSecret is empty).
+    clientId: ""
+    # -- Okta OIDC client secret (kept in the chart-managed admin Secret).
     clientSecret: ""
     # -- Comma-separated allow-list of emails permitted to sign in.
     allowedEmails: ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,9 +146,9 @@ Provide either the GitHub App vars (recommended) or `GH_TOKEN` (PAT). App auth i
 | `METRICS_ADMIN_APP_URL` | `string` | `""` | The reverse of `METRICS_DASHBOARD_URL`: base URL of the admin console for the metrics **dashboard** toolbar's Agents/Tasks/PRs links. Defaults to empty (same-host relative links, suitable for single-host ingress). Set to an absolute URL when the admin console runs on a different origin than the metrics dashboard (e.g. in local `task stack`: `http://localhost:3001`), otherwise those links 404 on the metrics origin. Distinct from the server-to-server `METRICS_ADMIN_URL`. |
 | `GOOGLE_CLIENT_ID` | `string` | — | Google OAuth 2.0 client ID. Required for the admin UI login flow. |
 | `GOOGLE_CLIENT_SECRET` | `string` | — | Google OAuth 2.0 client secret. Required for the admin UI login flow. |
-| `OKTA_ISSUER` | `string` | — | Okta OIDC issuer URL (e.g. `https://dev-123456.okta.com`). Required for the admin UI login flow when `auth.mode=okta`. |
-| `OKTA_CLIENT_ID` | `string` | — | Okta OIDC client ID. Required for the admin UI login flow when `auth.mode=okta`. |
-| `OKTA_CLIENT_SECRET` | `string` | — | Okta OIDC client secret. Required for the admin UI login flow when `auth.mode=okta`. |
+| `OKTA_ISSUER` | `string` | — | Okta OIDC issuer URL (e.g. `https://dev-123456.okta.com`). Wired into the admin Deployment by the Helm chart's `auth.mode=okta`, but **not yet read by the admin app** — no Okta login handler exists in `admin/src/` today. Chart-only plumbing ahead of application support. |
+| `OKTA_CLIENT_ID` | `string` | — | Okta OIDC client ID. Same chart-only caveat as `OKTA_ISSUER` above — not yet consumed by the admin app. |
+| `OKTA_CLIENT_SECRET` | `string` | — | Okta OIDC client secret. Same chart-only caveat as `OKTA_ISSUER` above — not yet consumed by the admin app. |
 
 ### Agent provisioning (admin service)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,9 @@ Provide either the GitHub App vars (recommended) or `GH_TOKEN` (PAT). App auth i
 | `METRICS_ADMIN_APP_URL` | `string` | `""` | The reverse of `METRICS_DASHBOARD_URL`: base URL of the admin console for the metrics **dashboard** toolbar's Agents/Tasks/PRs links. Defaults to empty (same-host relative links, suitable for single-host ingress). Set to an absolute URL when the admin console runs on a different origin than the metrics dashboard (e.g. in local `task stack`: `http://localhost:3001`), otherwise those links 404 on the metrics origin. Distinct from the server-to-server `METRICS_ADMIN_URL`. |
 | `GOOGLE_CLIENT_ID` | `string` | — | Google OAuth 2.0 client ID. Required for the admin UI login flow. |
 | `GOOGLE_CLIENT_SECRET` | `string` | — | Google OAuth 2.0 client secret. Required for the admin UI login flow. |
+| `OKTA_ISSUER` | `string` | — | Okta OIDC issuer URL (e.g. `https://dev-123456.okta.com`). Required for the admin UI login flow when `auth.mode=okta`. |
+| `OKTA_CLIENT_ID` | `string` | — | Okta OIDC client ID. Required for the admin UI login flow when `auth.mode=okta`. |
+| `OKTA_CLIENT_SECRET` | `string` | — | Okta OIDC client secret. Required for the admin UI login flow when `auth.mode=okta`. |
 
 ### Agent provisioning (admin service)
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -725,6 +725,26 @@ Only emails on `allowedEmails` may sign in. The client secret is kept in the
 chart-managed admin Secret, never in plaintext Deployment env. This is the
 required mode for the GKE and EKS targets above.
 
+### `auth.mode=okta` — Okta OIDC (production)
+
+Sets `NODE_ENV=production` (which also hard-blocks the dev-only escapes like
+`ADMIN_DEV_AUTH`) and enables real Okta OIDC. Requires:
+
+```yaml
+auth:
+  mode: okta
+  okta:
+    issuer: https://your-tenant.okta.com      # your Okta tenant's OIDC issuer URL
+    clientId: <your-okta-client-id>
+    clientSecret: <your-okta-client-secret>   # stored in the chart-managed admin Secret
+    allowedEmails: you@your-domain.example,teammate@your-domain.example   # comma-separated allow-list
+```
+
+Only emails on `allowedEmails` may sign in. The client secret is kept in the
+chart-managed admin Secret, never in plaintext Deployment env. This is an
+alternative to `auth.mode=google` for deployments where Okta is the identity
+provider.
+
 ---
 
 ## Bringing your own PostgreSQL / Bitnami registry fallback

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -725,10 +725,21 @@ Only emails on `allowedEmails` may sign in. The client secret is kept in the
 chart-managed admin Secret, never in plaintext Deployment env. This is the
 required mode for the GKE and EKS targets above.
 
-### `auth.mode=okta` — Okta OIDC (production)
+### `auth.mode=okta` — Okta OIDC (chart-only, not yet a working login path)
 
-Sets `NODE_ENV=production` (which also hard-blocks the dev-only escapes like
-`ADMIN_DEV_AUTH`) and enables real Okta OIDC. Requires:
+> ⚠️ **Do not deploy this expecting a working login.** This mode wires the
+> `OKTA_ISSUER`/`OKTA_CLIENT_ID`/`OKTA_CLIENT_SECRET`/
+> `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` env vars into the admin Deployment and sets
+> `NODE_ENV=production` (which also hard-blocks the dev-only escapes like
+> `ADMIN_DEV_AUTH`), but the admin application does not yet have an Okta OIDC
+> client — only `auth.mode=google` has a working login path in the app today.
+> Deploying with `auth.mode=okta` as-is will lock you out of the admin UI:
+> `NODE_ENV=production` blocks dev auth, and there is no Okta handler to log
+> in with. Use `auth.mode=google` (production) or `auth.mode=open`
+> (non-public only) until application-side Okta support ships.
+
+The values below are accepted and validated by the chart so that
+`auth.okta.*` config can be prepared ahead of application support landing:
 
 ```yaml
 auth:
@@ -739,11 +750,6 @@ auth:
     clientSecret: <your-okta-client-secret>   # stored in the chart-managed admin Secret
     allowedEmails: you@your-domain.example,teammate@your-domain.example   # comma-separated allow-list
 ```
-
-Only emails on `allowedEmails` may sign in. The client secret is kept in the
-chart-managed admin Secret, never in plaintext Deployment env. This is an
-alternative to `auth.mode=google` for deployments where Okta is the identity
-provider.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `auth.mode=okta` support to the shipwright Helm chart, mirroring the existing `auth.mode=google` implementation field-for-field
- Adds an `auth.okta` values block (issuer/clientId/clientSecret/allowedEmails + `existingSecret` support), a `values.schema.json` conditional requiring those fields when `existingSecret` is unset, and template wiring in `admin-deployment.yaml`/`admin-secret.yaml`/`NOTES.txt`
- `auth.mode` remains a single-value enum (`open`/`google`/`okta`) — one Helm deployment runs exactly one provider at a time; `google` behavior is untouched

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | helm template with auth.mode=okta renders OKTA_ISSUER/OKTA_CLIENT_ID/OKTA_CLIENT_SECRET/SHIPWRIGHT_ADMIN_ALLOWED_EMAILS correctly from both inline values and existingSecret | MET |
| 2 | values.schema.json rejects auth.mode=okta without required auth.okta.* fields | MET |
| 3 | extend tests/admin_auth_modes_test.yaml with okta-mode cases mirroring google-mode cases, no tests retired | MET |

## Test Plan
- `helm unittest charts/shipwright` — 344/344 passing (15 new okta cases added, zero retired)
- `helm lint charts/shipwright` — clean
- `bun scripts/check-config-docs.ts` — 39/39 env vars documented
- Manual `helm template` renders verified for both inline-values and `existingSecret` paths
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
