### PR TITLE
feat: add Okta OIDC auth client

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -20,7 +20,6 @@
     "@sentry/hono": "^10.63.0",
     "@shipwright/lib": "*",
     "hono": "^4.13.1",
-    "openid-client": "^6.8.1",
     "yaml": "^2.9.0",
     "zod": "^3",
     "zod-to-json-schema": "^3.25.2"

--- a/admin/package.json
+++ b/admin/package.json
@@ -20,6 +20,7 @@
     "@sentry/hono": "^10.63.0",
     "@shipwright/lib": "*",
     "hono": "^4.13.1",
+    "openid-client": "^6.8.1",
     "yaml": "^2.9.0",
     "zod": "^3",
     "zod-to-json-schema": "^3.25.2"

--- a/admin/src/fixtures/okta-auth-cassette.json
+++ b/admin/src/fixtures/okta-auth-cassette.json
@@ -1,0 +1,36 @@
+{
+  "exchangeCode_success": {
+    "status": 200,
+    "body": {
+      "access_token": "okta.test-access-token",
+      "refresh_token": "okta.test-refresh-token",
+      "id_token": "okta.test-id-token-jwt",
+      "expires_in": 3600
+    }
+  },
+  "exchangeCode_success_no_optional_fields": {
+    "status": 200,
+    "body": {
+      "access_token": "okta.test-access-token-minimal",
+      "expires_in": 3600
+    }
+  },
+  "exchangeCode_400": {
+    "status": 400,
+    "body": "{\"error\":\"invalid_grant\",\"error_description\":\"The authorization code is invalid or has expired.\"}"
+  },
+  "getUserInfo_success": {
+    "status": 200,
+    "body": {
+      "sub": "00u1a2b3c4d5e6f7g8h9",
+      "email": "user@example.com",
+      "email_verified": true,
+      "name": "Test User",
+      "picture": "https://example.com/photo.jpg"
+    }
+  },
+  "getUserInfo_401": {
+    "status": 401,
+    "body": "{\"error\":\"invalid_token\"}"
+  }
+}

--- a/admin/src/okta-auth-client.integration.test.ts
+++ b/admin/src/okta-auth-client.integration.test.ts
@@ -1,0 +1,263 @@
+/**
+ * admin/src/okta-auth-client.integration.test.ts
+ * Integration tests for HttpOktaAuthClient against recorded Okta OIDC
+ * API fixtures.
+ *
+ * Drives the client through an INJECTED fetchFn that replays canned Responses
+ * from a cassette keyed by scenario — no live API server, no global.fetch
+ * override, no mock.module(). Mirrors the pattern in
+ * google-auth-client.integration.test.ts.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { HttpOktaAuthClient } from "./okta-auth-client.ts";
+
+// ─── Cassette ───────────────────────────────────────────────────────────────
+
+interface CassetteEntry {
+  status: number;
+  body: unknown;
+}
+
+const CASSETTE_PATH = new URL(
+  "./fixtures/okta-auth-cassette.json",
+  import.meta.url,
+).pathname;
+
+const cassette: Record<string, CassetteEntry> = JSON.parse(
+  readFileSync(CASSETTE_PATH, "utf-8"),
+);
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+/**
+ * Build an injected fetchFn that returns the cassette entry for `key`.
+ * Records the last request so tests can assert URL/method/headers/body.
+ */
+function cassetteFetch(key: string): {
+  fetchFn: typeof fetch;
+  lastRequest: () => RecordedRequest;
+} {
+  let last: RecordedRequest | undefined;
+  const entry = cassette[key];
+  if (!entry) throw new Error(`cassette key not found: ${key}`);
+
+  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    last = {
+      url,
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body:
+        typeof init?.body === "string"
+          ? init.body
+          : init?.body instanceof URLSearchParams
+            ? init.body.toString()
+            : undefined,
+    };
+    // A string body is replayed verbatim (e.g. a raw error payload) so the
+    // client sees genuinely non-JSON-object bytes when relevant; here all
+    // cassette bodies are either objects (JSON-encoded) or raw strings.
+    const isRaw = typeof entry.body === "string";
+    return new Response(
+      isRaw ? (entry.body as string) : JSON.stringify(entry.body),
+      {
+        status: entry.status,
+        headers: { "Content-Type": isRaw ? "text/plain" : "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  return {
+    fetchFn,
+    lastRequest: () => {
+      if (!last) throw new Error("fetchFn was not called");
+      return last;
+    },
+  };
+}
+
+const TEST_ISSUER = "https://example.okta.com/oauth2/default";
+
+function makeClient(
+  key: string,
+  issuer: string = TEST_ISSUER,
+): {
+  client: HttpOktaAuthClient;
+  lastRequest: () => RecordedRequest;
+} {
+  const { fetchFn, lastRequest } = cassetteFetch(key);
+  const client = new HttpOktaAuthClient({ issuer, fetchFn });
+  return { client, lastRequest };
+}
+
+// ─── getAuthorizationUrl ─────────────────────────────────────────────────────
+
+describe("HttpOktaAuthClient — getAuthorizationUrl", () => {
+  it("builds the authorize URL with standard OIDC query params (pure, no network call)", () => {
+    const client = new HttpOktaAuthClient({ issuer: TEST_ISSUER });
+    const url = client.getAuthorizationUrl({
+      clientId: "client-id-abc",
+      redirectUri: "https://example.com/callback",
+      state: "state-xyz",
+      scope: "openid profile email",
+    });
+
+    const parsed = new URL(url);
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(
+      `${TEST_ISSUER}/v1/authorize`,
+    );
+    expect(parsed.searchParams.get("client_id")).toBe("client-id-abc");
+    expect(parsed.searchParams.get("redirect_uri")).toBe(
+      "https://example.com/callback",
+    );
+    expect(parsed.searchParams.get("response_type")).toBe("code");
+    expect(parsed.searchParams.get("scope")).toBe("openid profile email");
+    expect(parsed.searchParams.get("state")).toBe("state-xyz");
+  });
+
+  it("defaults scope to 'openid profile email' when not provided", () => {
+    const client = new HttpOktaAuthClient({ issuer: TEST_ISSUER });
+    const url = client.getAuthorizationUrl({
+      clientId: "client-id-abc",
+      redirectUri: "https://example.com/callback",
+      state: "state-xyz",
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("scope")).toBe("openid profile email");
+  });
+
+  it("normalizes an issuer with a trailing slash to avoid a double slash", () => {
+    const client = new HttpOktaAuthClient({
+      issuer: "https://example.okta.com/oauth2/default/",
+    });
+    const url = client.getAuthorizationUrl({
+      clientId: "client-id-abc",
+      redirectUri: "https://example.com/callback",
+      state: "state-xyz",
+    });
+
+    expect(url.startsWith(`${TEST_ISSUER}/v1/authorize?`)).toBe(true);
+    expect(url.includes("//v1/authorize")).toBe(false);
+  });
+});
+
+// ─── exchangeCode ────────────────────────────────────────────────────────────
+
+describe("HttpOktaAuthClient — exchangeCode", () => {
+  it("POSTs form-encoded params to the Okta token endpoint and maps the response", async () => {
+    const { client, lastRequest } = makeClient("exchangeCode_success");
+    const result = await client.exchangeCode({
+      code: "auth-code-123",
+      clientId: "client-id-abc",
+      clientSecret: "client-secret-xyz",
+      redirectUri: "https://example.com/callback",
+    });
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe(`${TEST_ISSUER}/v1/token`);
+    expect(req.headers.get("content-type")).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const params = new URLSearchParams(req.body);
+    expect(params.get("code")).toBe("auth-code-123");
+    expect(params.get("client_id")).toBe("client-id-abc");
+    expect(params.get("client_secret")).toBe("client-secret-xyz");
+    expect(params.get("redirect_uri")).toBe("https://example.com/callback");
+    expect(params.get("grant_type")).toBe("authorization_code");
+
+    expect(result).toEqual({
+      accessToken: "okta.test-access-token",
+      refreshToken: "okta.test-refresh-token",
+      idToken: "okta.test-id-token-jwt",
+      expiresIn: 3600,
+    });
+  });
+
+  it("maps a response missing optional fields (no refresh/id token)", async () => {
+    const { client } = makeClient("exchangeCode_success_no_optional_fields");
+    const result = await client.exchangeCode({
+      code: "auth-code-123",
+      clientId: "client-id-abc",
+      clientSecret: "client-secret-xyz",
+      redirectUri: "https://example.com/callback",
+    });
+
+    expect(result.accessToken).toBe("okta.test-access-token-minimal");
+    expect(result.refreshToken).toBeUndefined();
+    expect(result.idToken).toBeUndefined();
+    expect(result.expiresIn).toBe(3600);
+  });
+
+  it("throws on a non-ok response, including the status and body text", async () => {
+    const { client } = makeClient("exchangeCode_400");
+    await expect(
+      client.exchangeCode({
+        code: "bad-code",
+        clientId: "client-id-abc",
+        clientSecret: "client-secret-xyz",
+        redirectUri: "https://example.com/callback",
+      }),
+    ).rejects.toThrow(/Token exchange failed: 400/);
+  });
+
+  it("normalizes an issuer with a trailing slash for the token endpoint", async () => {
+    const { client, lastRequest } = makeClient(
+      "exchangeCode_success",
+      "https://example.okta.com/oauth2/default/",
+    );
+    await client.exchangeCode({
+      code: "auth-code-123",
+      clientId: "client-id-abc",
+      clientSecret: "client-secret-xyz",
+      redirectUri: "https://example.com/callback",
+    });
+
+    expect(lastRequest().url).toBe(`${TEST_ISSUER}/v1/token`);
+  });
+});
+
+// ─── getUserInfo ─────────────────────────────────────────────────────────────
+
+describe("HttpOktaAuthClient — getUserInfo", () => {
+  it("GETs the userinfo endpoint with a Bearer token and returns the profile", async () => {
+    const { client, lastRequest } = makeClient("getUserInfo_success");
+    const result = await client.getUserInfo("test-access-token");
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.url).toBe(`${TEST_ISSUER}/v1/userinfo`);
+    expect(req.headers.get("authorization")).toBe("Bearer test-access-token");
+
+    expect(result).toEqual({
+      sub: "00u1a2b3c4d5e6f7g8h9",
+      email: "user@example.com",
+      email_verified: true,
+      name: "Test User",
+      picture: "https://example.com/photo.jpg",
+    });
+  });
+
+  it("throws on a non-ok response", async () => {
+    const { client } = makeClient("getUserInfo_401");
+    await expect(client.getUserInfo("bad-token")).rejects.toThrow(
+      /Userinfo fetch failed: 401/,
+    );
+  });
+});
+
+// ─── Default construction ───────────────────────────────────────────────────
+
+describe("HttpOktaAuthClient — default construction", () => {
+  it("can be constructed with just an issuer (defaults fetchFn to global fetch, no network call)", () => {
+    expect(() => new HttpOktaAuthClient({ issuer: TEST_ISSUER })).not.toThrow();
+  });
+});

--- a/admin/src/okta-auth-client.ts
+++ b/admin/src/okta-auth-client.ts
@@ -1,0 +1,152 @@
+/**
+ * admin/src/okta-auth-client.ts
+ * Typed client for Okta OIDC authorization, token exchange, and user profile
+ * lookup.
+ *
+ * Interface + HTTP implementation following the project's client DI pattern
+ * (mirrors google-auth-client.ts). Endpoints are derived from a
+ * caller-supplied issuer URL using Okta's well-known endpoint conventions
+ * ({issuer}/v1/authorize, /v1/token, /v1/userinfo) — no live
+ * `Issuer.discover()` `.well-known` network call happens, so construction is
+ * fully synchronous and side-effect free. Tests inject a mock fetchFn;
+ * production uses HttpOktaAuthClient with the real global fetch.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface OktaTokenResponse {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  expiresIn: number;
+}
+
+export interface OktaUserInfo {
+  sub: string;
+  email?: string;
+  email_verified?: boolean;
+  name: string;
+  picture?: string;
+}
+
+// ─── Interface ──────────────────────────────────────────────────────────────
+
+export interface OktaAuthClient {
+  getAuthorizationUrl(params: {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    scope?: string;
+  }): string;
+
+  exchangeCode(params: {
+    code: string;
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+  }): Promise<OktaTokenResponse>;
+
+  getUserInfo(accessToken: string): Promise<OktaUserInfo>;
+}
+
+// ─── Error ──────────────────────────────────────────────────────────────────
+
+class OktaAuthClientError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "OktaAuthClientError";
+  }
+}
+
+// ─── HTTP implementation ────────────────────────────────────────────────────
+
+const DEFAULT_SCOPE = "openid profile email";
+
+export class HttpOktaAuthClient implements OktaAuthClient {
+  private readonly issuer: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(opts: { issuer: string; fetchFn?: typeof fetch }) {
+    // Normalize away a trailing slash so `${issuer}/v1/...` never produces a
+    // double slash, regardless of how the issuer was configured.
+    this.issuer = opts.issuer.replace(/\/+$/, "");
+    this.fetchFn = opts.fetchFn ?? fetch;
+  }
+
+  getAuthorizationUrl(params: {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    scope?: string;
+  }): string {
+    const query = new URLSearchParams({
+      client_id: params.clientId,
+      redirect_uri: params.redirectUri,
+      response_type: "code",
+      scope: params.scope ?? DEFAULT_SCOPE,
+      state: params.state,
+    });
+
+    return `${this.issuer}/v1/authorize?${query.toString()}`;
+  }
+
+  async exchangeCode(params: {
+    code: string;
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+  }): Promise<OktaTokenResponse> {
+    const res = await this.fetchFn(`${this.issuer}/v1/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        code: params.code,
+        client_id: params.clientId,
+        client_secret: params.clientSecret,
+        redirect_uri: params.redirectUri,
+        grant_type: "authorization_code",
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new OktaAuthClientError(
+        `Token exchange failed: ${res.status} ${body}`,
+        res.status,
+      );
+    }
+
+    const data = (await res.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_in: number;
+    };
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      idToken: data.id_token,
+      expiresIn: data.expires_in,
+    };
+  }
+
+  async getUserInfo(accessToken: string): Promise<OktaUserInfo> {
+    const res = await this.fetchFn(`${this.issuer}/v1/userinfo`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new OktaAuthClientError(
+        `Userinfo fetch failed: ${res.status} ${body}`,
+        res.status,
+      );
+    }
+
+    return (await res.json()) as OktaUserInfo;
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "@sentry/hono": "^10.63.0",
         "@shipwright/lib": "*",
         "hono": "^4.13.1",
-        "openid-client": "^6.8.1",
         "yaml": "^2.9.0",
         "zod": "^3",
         "zod-to-json-schema": "^3.25.2",
@@ -722,7 +721,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
@@ -842,8 +841,6 @@
 
     "nypm": ["nypm@0.6.8", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.2.4" }, "bin": { "nypm": "./dist/cli.mjs" } }, "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw=="],
 
-    "oauth4webapi": ["oauth4webapi@3.8.7", "", {}, "sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw=="],
-
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -863,8 +860,6 @@
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
     "openapi3-ts": ["openapi3-ts@4.6.0", "", { "dependencies": { "yaml": "^2.9.0" } }, "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg=="],
-
-    "openid-client": ["openid-client@6.8.6", "", { "dependencies": { "jose": "^6.2.8", "oauth4webapi": "^3.8.7" } }, "sha512-lsfMRH/GCgMiGCRnBRY3e70uogkgOessPaTOhP3rw/dxqNOZHwOazWx+m6jt5EVk3ecRFULl0TwWpk9Qnw3RKQ=="],
 
     "p-each-series": ["p-each-series@3.0.0", "", {}, "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="],
 
@@ -1149,8 +1144,6 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@actions/http-client/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
-
-    "@modelcontextprotocol/sdk/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@sentry/hono": "^10.63.0",
         "@shipwright/lib": "*",
         "hono": "^4.13.1",
+        "openid-client": "^6.8.1",
         "yaml": "^2.9.0",
         "zod": "^3",
         "zod-to-json-schema": "^3.25.2",
@@ -46,7 +47,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.168.0",
+      "version": "1.170.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -100,7 +101,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.168.0",
+      "version": "1.170.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +119,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.168.0",
+      "version": "1.170.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -721,7 +722,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+    "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
@@ -841,6 +842,8 @@
 
     "nypm": ["nypm@0.6.8", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.2.4" }, "bin": { "nypm": "./dist/cli.mjs" } }, "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw=="],
 
+    "oauth4webapi": ["oauth4webapi@3.8.7", "", {}, "sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -860,6 +863,8 @@
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
     "openapi3-ts": ["openapi3-ts@4.6.0", "", { "dependencies": { "yaml": "^2.9.0" } }, "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg=="],
+
+    "openid-client": ["openid-client@6.8.6", "", { "dependencies": { "jose": "^6.2.8", "oauth4webapi": "^3.8.7" } }, "sha512-lsfMRH/GCgMiGCRnBRY3e70uogkgOessPaTOhP3rw/dxqNOZHwOazWx+m6jt5EVk3ecRFULl0TwWpk9Qnw3RKQ=="],
 
     "p-each-series": ["p-each-series@3.0.0", "", {}, "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="],
 
@@ -1144,6 +1149,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@actions/http-client/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+
+    "@modelcontextprotocol/sdk/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 


### PR DESCRIPTION
## Summary
- Add `admin/src/okta-auth-client.ts` — `OktaAuthClient` interface + `HttpOktaAuthClient` implementation, mirroring `HttpGoogleAuthClient`'s fetchFn-DI pattern
- Endpoints (`/v1/authorize`, `/v1/token`, `/v1/userinfo`) are derived from a caller-supplied static `issuer` config — no live `Issuer.discover()` `.well-known` call, so construction is synchronous and side-effect free
- Add `openid-client` to `admin/package.json` dependencies

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | OktaAuthClient exposes getAuthorizationUrl, exchangeCode, getUserInfo, matching GoogleAuthClient shape | MET | Interface + `HttpOktaAuthClient` implement all three methods |
| 2 | No live network call during construction (static config, not Issuer.discover()) | MET | Constructor only normalizes the issuer string synchronously |
| 3 | Integration test with injected fetchFn + recorded fixtures, mirroring google-auth-client pattern, no existing tests retired | MET | `okta-auth-client.integration.test.ts` + `fixtures/okta-auth-cassette.json` added; `google-auth-client.integration.test.ts` untouched |

## Test Plan
- `NODE_ENV=test bun test admin/src/okta-auth-client.integration.test.ts` — 10/10 pass
- `bunx biome lint` on new files — clean
- `bun run typecheck` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
