### PR TITLE
fix: suppress confirmed false-positive gitleaks findings (security-gitleaks-secret-shipwright-2026-W32)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,14 @@
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+4cbdfab16db1e5bb80d6f202cf237235877e54d0:docs/test-readiness/test-system.md:generic-api-key:12
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+4cbdfab16db1e5bb80d6f202cf237235877e54d0:docs/test-readiness/test-system.md:generic-api-key:215
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+d36760ea08f97070d42d1c071c4a33f6064e4fb1:docs/test-readiness/test-system.md:generic-api-key:12
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+d36760ea08f97070d42d1c071c4a33f6064e4fb1:docs/test-readiness/test-system.md:generic-api-key:215
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+1f46b4399ed270a74e082d1b97bf99c6db31c8b2:agent/src/setup-github-auth.integration.test.ts:private-key:83
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+6740dc2794c2c7351ad859b1c979f78a3126e461:agent/src/fixtures/slack-provision-cassette.json:generic-api-key:8
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
+6740dc2794c2c7351ad859b1c979f78a3126e461:agent/src/admin-ui.smoke.test.ts:generic-api-key:95


### PR DESCRIPTION
## Summary
- Confirmed all 7 full-history gitleaks findings from HITL task `security-gitleaks-secret-shipwright-2026-W32` are false positives — recorded test fixtures / doc prose, not live credentials.
- Verified locally: full-history `gitleaks detect` goes from 7 leaks → 0 leaks with this `.gitleaksignore` in place.

## Findings suppressed (7 fingerprints)
1. `docs/test-readiness/test-system.md:12` (2 commits) — doc prose mentioning "Groq/ElevenLabs" as a service name, matched by generic-api-key heuristic. No literal secret.
2. `docs/test-readiness/test-system.md:215` (2 commits) — same false-positive pattern, doc prose about OAuth client secret handling.
3. `agent/src/setup-github-auth.integration.test.ts:83` — literal string `-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----`, a hardcoded test double.
4. `agent/src/fixtures/slack-provision-cassette.json:8` — `recorded-signing-secret-abc123`, a `RecordedSlackClient` cassette value (introduced in #she-3.2, "Recorded fixture doubles — never live" per commit message).
5. `agent/src/admin-ui.smoke.test.ts:95` (now `admin/src/admin-ui.smoke.test.ts`) — `abc123signingsecret`, same recorded-fixture test data.

Confirmed with Dan (App Vitals) that none require credential rotation.

## Test plan
- [x] `gitleaks detect --source . --log-opts="--all"` on this branch reports "no leaks found" (was 7 before the change)
- [x] `.gitleaksignore` fingerprints verified against `gitleaks version 8.27.2` (matches repo's `ci.yml` pinned version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)