### PR TITLE
feat: re-fetch headRefOid immediately before review POST to abort on stale head

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -965,7 +965,32 @@ bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
 
 ### If `auto_post_reviews` is true (default):
 
-1. Submit via GitHub API, writing the response to a temp file (NOT a shell variable —
+1. **Re-check freshness immediately before posting** (RHR-1.1). Time has passed since
+   `headRefOid` was captured at claim time (Step 4 or Step 14's Pre-Claim Fast Path) — the
+   review-writing phase (Steps 5-10.5) can take long enough for the author to push a new
+   commit in the meantime. Re-fetch the live head into a new variable and compare against
+   the canonical `headRefOid` captured earlier — do not overwrite `headRefOid` itself, and
+   do not introduce any other new source of truth for it:
+   ```bash
+   currentHeadRefOid=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid')
+   ```
+   - **Match** (`"$currentHeadRefOid" = "$headRefOid"`): head hasn't moved since claim.
+     Continue to step 2 below, unchanged.
+   - **Mismatch** (`"$currentHeadRefOid" != "$headRefOid"`): the review body and inline
+     comments were built against a commit that's no longer HEAD — some other change (often
+     the very fix the review was about to flag) landed in the gap between claim and post.
+     Do not POST. Release the claim so the record returns to `reviewState: "pending"` and
+     the PR gets picked up fresh next pass:
+     ```bash
+     curl -s -o /dev/null -X POST \
+       -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+       "$SHIPWRIGHT_TASK_STORE_URL/prs/${PR_RECORD_ID}/release"
+     ```
+     Print: `Aborted stale review for #{pr} -- head moved ({headRefOid[0..7]} -> {currentHeadRefOid[0..7]}) since claim; releasing for re-review.`
+     Stop here — do not proceed to step 2 below, and do not run the record-completion
+     step further down in this Step 11 (see "Mark PullRequest Record Posted"). No review
+     was posted, so `reviewState` must never transition to posted/approved for this pass.
+2. Submit via GitHub API, writing the response to a temp file (NOT a shell variable —
    the response JSON contains embedded newlines that corrupt `echo "$var" | jq` parsing):
    ```bash
    POST_EXIT=0
@@ -976,12 +1001,12 @@ bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
    **Never re-execute this POST.** If parsing fails, re-parse the temp file — do not
    re-run `gh api -X POST`, which submits a duplicate review that cannot be deleted or
    dismissed (GitHub does not allow deleting/dismissing COMMENTED reviews via the API).
-2. Capture `html_url` from the temp file:
+3. Capture `html_url` from the temp file:
    ```bash
    REVIEW_URL=$(jq -r '.html_url // empty' "/tmp/pr_post_{pr}.json")
    ```
-3. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `REVIEW_URL` both count as failure:
-   - **Success** (`POST_EXIT == 0` and `REVIEW_URL` present): continue to steps 4-5 below.
+4. **Check the post succeeded** before doing anything else — non-zero exit and/or a missing/empty `REVIEW_URL` both count as failure:
+   - **Success** (`POST_EXIT == 0` and `REVIEW_URL` present): continue to steps 5-6 below.
    - **Failure**: the GitHub post did not land, so nothing was actually reviewed at HEAD.
      Do not run Step 11b — marking the record posted here would let
      `check-review.ts`'s `commitSha`/`reviewState` dedup permanently hide this PR from
@@ -994,8 +1019,8 @@ bun run "${CLAUDE_PLUGIN_ROOT}/scripts/compute-review-verdict.ts" \
         ```
      2. Print a warning: `Warning: review post for #{pr} failed (exit {POST_EXIT}) — released claim, will retry next pass.`
      3. Stop — do not proceed to Step 11b.
-4. Run Step 11b to mark the PR record posted.
-5. Print: `Posted review for #{pr}: {REVIEW_URL}`
+5. Run Step 11b to mark the PR record posted.
+6. Print: `Posted review for #{pr}: {REVIEW_URL}`
 
 ### If `auto_post_reviews` is false (staged):
 

--- a/plugins/shipwright/commands/review.unit.test.ts
+++ b/plugins/shipwright/commands/review.unit.test.ts
@@ -151,7 +151,10 @@ describe("review.md — RPF-1.4 verify review post before complete", () => {
   it("on post failure, does not proceed to Step 11b", () => {
     const failureIdx = autoPostSection.toLowerCase().indexOf("**failure**");
     expect(failureIdx).toBeGreaterThan(-1);
-    const releaseIdx = autoPostSection.indexOf("/release");
+    // Scope the release-call search to after the failure marker: RHR-1.1 added an
+    // earlier, unrelated /release call (freshness-abort path) before this branch, so a
+    // plain autoPostSection-wide indexOf would find that one instead of this branch's.
+    const releaseIdx = autoPostSection.indexOf("/release", failureIdx);
     expect(releaseIdx).toBeGreaterThan(-1);
     expect(releaseIdx).toBeGreaterThan(failureIdx);
     // The failure branch must explicitly say to stop instead of running Step 11b
@@ -163,6 +166,98 @@ describe("review.md — RPF-1.4 verify review post before complete", () => {
     expect(autoPostSection.includes("Run Step 11b to mark the PR record posted")).toBe(
       true,
     );
+  });
+});
+
+describe("review.md — RHR-1.1 review-post freshness re-check", () => {
+  let autoPostSection: string;
+
+  beforeAll(() => {
+    const startIdx = content.indexOf("### If `auto_post_reviews` is true (default):");
+    const endIdx = content.indexOf("### If `auto_post_reviews` is false (staged):");
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    autoPostSection = content.slice(startIdx, endIdx);
+  });
+
+  it("re-fetches headRefOid and compares against the canonical headRefOid variable before the POST call", () => {
+    const postIdx = autoPostSection.indexOf("gh api -X POST");
+    expect(postIdx).toBeGreaterThan(-1);
+    const beforePost = autoPostSection.slice(0, postIdx);
+
+    // Must re-fetch via gh pr view ... headRefOid before the POST call.
+    expect(beforePost).toMatch(/gh pr view [^\n]*headRefOid/);
+    // Must compare the fresh value against the existing canonical `headRefOid`
+    // variable — not a newly-named variable standing in as a second source of truth.
+    expect(beforePost).toContain("$headRefOid");
+  });
+
+  it("comes after the hard-gate validation (Step 10.5) and before the POST call", () => {
+    const step105Idx = content.indexOf("### Step 10.5: Hard-Gate Validation (Before Posting)");
+    const postIdx = content.indexOf("gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews");
+    const refetchIdx = content.indexOf("currentHeadRefOid");
+    expect(step105Idx).toBeGreaterThan(-1);
+    expect(postIdx).toBeGreaterThan(-1);
+    expect(refetchIdx).toBeGreaterThan(-1);
+    expect(refetchIdx).toBeGreaterThan(step105Idx);
+    expect(refetchIdx).toBeLessThan(postIdx);
+  });
+
+  it("on mismatch, does not POST, releases the claim via /prs/{id}/release, and prints an abort message naming both SHAs", () => {
+    const refetchIdx = autoPostSection.indexOf("currentHeadRefOid");
+    expect(refetchIdx).toBeGreaterThan(-1);
+    const postIdx = autoPostSection.indexOf("gh api -X POST");
+    expect(postIdx).toBeGreaterThan(refetchIdx);
+
+    const mismatchSection = autoPostSection.slice(refetchIdx, postIdx);
+    expect(mismatchSection).toContain("/release");
+    expect(mismatchSection).toContain("Aborted stale review for");
+  });
+
+  it("the abort message references both the old and new short SHAs", () => {
+    const messageIdx = autoPostSection.indexOf("Aborted stale review for");
+    expect(messageIdx).toBeGreaterThan(-1);
+    const messageLine = autoPostSection.slice(messageIdx, messageIdx + 200);
+    expect(messageLine).toMatch(/head moved/i);
+  });
+
+  it("the freshness re-check precedes Step 11b in file order", () => {
+    const refetchIdx = content.indexOf("currentHeadRefOid");
+    const step11bIdx = content.indexOf("## Step 11b: Mark PullRequest Record Posted");
+    expect(refetchIdx).toBeGreaterThan(-1);
+    expect(step11bIdx).toBeGreaterThan(-1);
+    expect(refetchIdx).toBeLessThan(step11bIdx);
+  });
+
+  it("explicitly stops before the record-completion step on mismatch", () => {
+    const refetchIdx = autoPostSection.indexOf("currentHeadRefOid");
+    expect(refetchIdx).toBeGreaterThan(-1);
+    const postIdx = autoPostSection.indexOf("gh api -X POST");
+    const mismatchSection = autoPostSection.slice(refetchIdx, postIdx);
+    expect(mismatchSection).toMatch(/stop/i);
+    expect(mismatchSection).toContain("record-completion");
+  });
+
+  it("on match, the flow continues unmodified into the existing POST step", () => {
+    // The existing POST call, its exit-code capture, and its comment about never
+    // re-executing the POST must still be present and reachable on the match branch.
+    expect(autoPostSection.includes("gh api -X POST /repos/{org}/{repo}/pulls/{pr}/reviews")).toBe(
+      true,
+    );
+    expect(autoPostSection.includes("Never re-execute this POST.")).toBe(true);
+    expect(autoPostSection.includes("POST_EXIT=0")).toBe(true);
+  });
+
+  it("does not introduce a second canonical headRefOid capture point — Step 4 and Step 14 remain the sole capture sites", () => {
+    // The canonical variable is captured via `gh pr view ... --json headRefOid -q '.headRefOid'`.
+    // Count occurrences of this exact capture pattern across the whole file; RHR-1.1's
+    // addition must reuse a differently-named variable (currentHeadRefOid) for its own
+    // re-fetch rather than reassigning `headRefOid` a third time via the same pattern.
+    const captureRegex = /headRefOid=\$\(gh pr view [^\n]*--json headRefOid -q '\.headRefOid'\)/g;
+    const matches = content.match(captureRegex) ?? [];
+    // Step 4 and Step 14's Pre-Claim Fast Path both use this exact pattern already;
+    // RHR-1.1 must not add a third occurrence assigning to `headRefOid` itself.
+    expect(matches.length).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a freshness re-check to `/shipwright:review` Step 11's auto-post branch: immediately before the `gh api -X POST .../reviews` call, re-fetches `headRefOid` via `gh pr view` and compares it against the canonical `headRefOid` captured once at claim time (Step 4 / Step 14's Pre-Claim Fast Path).
- On mismatch (head moved since claim — e.g. the very fix the review was about to flag landed in the gap between claim and post), skips the POST, releases the claim via the existing `/prs/{id}/release` endpoint, prints an abort message naming both SHAs, and stops before Step 11b so `reviewState` never transitions to posted/approved for a review that wasn't actually posted at current head.
- On match, behavior is unchanged — closes the one staleness window (claim → post, within a single review run) that the two existing entry-time-only re-checks (Step 14 Pre-Claim Fast Path, staged-record refresh check) didn't cover. Root cause confirmed on app-vitals/shipwright PR #2728.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 11 auto-post branch re-fetches headRefOid via `gh pr view` immediately before the POST call, comparing against canonical Step 4/14 variable, no new capture point | MET | New step 1 adds `currentHeadRefOid=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid -q '.headRefOid')`, compared against existing `$headRefOid`; test confirms exactly 2 canonical capture-pattern occurrences remain (Step 4 + Step 14) |
| 2 | On mismatch: no POST, `/prs/{id}/release` called, warning names both SHAs, flow stops before Step 11b | MET | Mismatch branch calls `/prs/${PR_RECORD_ID}/release`, prints `Aborted stale review for #{pr} -- head moved (...) since claim...`, explicitly stops before step 2 (POST) and before Step 11b |
| 3 | On match: existing POST behavior unchanged, verified by content test | MET | Match branch says "Continue to step 2 below, unchanged"; original POST/exit-check/comment text preserved verbatim |
| 4 | review.unit.test.ts extended with (a) re-fetch+comparison placement, (b) release/abort-message mismatch path, (c) abort precedes Step 11b; no existing tests retired | MET | New describe block with 8 tests covers all three; existing RPF-1.4 tests all still pass (one line adjusted to scope a search past the new earlier `/release` occurrence, not removed) |
| 5 | No task-store service changes — reuses `/prs/{id}/release` verbatim | MET | Uses the exact same curl pattern already present in the Step 11 failure branch; no endpoint changes |

## Test Plan
- `bun test plugins/shipwright/commands/review.unit.test.ts` — 28/28 pass
- `bun test plugins/shipwright/commands/` — 676/676 pass
- `task lint`, `task typecheck`, `task check-strings`, `task check-config-docs`, `task check-version-sync`, `task secret-scan` all pass
- Full-repo coverage gate (`bun scripts/check-coverage.ts`) fails at 83.91%/84.59% vs 90%/89% thresholds — confirmed this is a pre-existing sandbox gap by reproducing the identical failure on a clean `main` checkout, unrelated to this change (this PR touches only markdown/prompt content and its own test file)
- `agent/src/claude.unit.test.ts`'s `extraAllowedTools` test fails in-sandbox — confirmed pre-existing flake, reproduces on clean main
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
