### PR TITLE
feat: add Sign in with Okta button to login page

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -475,6 +475,7 @@ function applyInline(s: string): string {
 export function renderLoginPage(opts?: {
   error?: string;
   returnTo?: string;
+  oktaEnabled?: boolean;
 }): string {
   const errorHtml = opts?.error
     ? `<div class="alert alert-error">${escapeHtml(opts.error)}</div>`
@@ -483,6 +484,14 @@ export function renderLoginPage(opts?: {
   const googleHref = opts?.returnTo
     ? `/admin/auth/google?returnTo=${encodeURIComponent(opts.returnTo)}`
     : "/admin/auth/google";
+
+  const oktaHref = opts?.returnTo
+    ? `/admin/auth/okta?returnTo=${encodeURIComponent(opts.returnTo)}`
+    : "/admin/auth/okta";
+
+  const oktaButtonHtml = opts?.oktaEnabled
+    ? `<a href="${oktaHref}" class="btn btn-primary" style="width:100%;justify-content:center;text-decoration:none">Sign in with Okta</a>`
+    : "";
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -499,6 +508,7 @@ export function renderLoginPage(opts?: {
       <p class="login-subtitle">Sign in to manage your agents.</p>
       ${errorHtml}
       <a href="${googleHref}" class="btn btn-primary" style="width:100%;justify-content:center;text-decoration:none">Sign in with Google</a>
+      ${oktaButtonHtml}
     </div>
   </div>
 </body>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -189,6 +189,34 @@ describe("renderLoginPage", () => {
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
   });
+
+  test("does not show Sign in with Okta when oktaEnabled is not provided", () => {
+    const html = renderLoginPage();
+    expect(html).not.toContain("Sign in with Okta");
+    expect(html).not.toContain('href="/admin/auth/okta"');
+  });
+
+  test("does not show Sign in with Okta when oktaEnabled is false", () => {
+    const html = renderLoginPage({ oktaEnabled: false });
+    expect(html).not.toContain("Sign in with Okta");
+    expect(html).not.toContain('href="/admin/auth/okta"');
+  });
+
+  test("shows Sign in with Okta when oktaEnabled is true", () => {
+    const html = renderLoginPage({ oktaEnabled: true });
+    expect(html).toContain("Sign in with Okta");
+    expect(html).toContain('href="/admin/auth/okta"');
+  });
+
+  test("includes returnTo query param in Okta href when provided", () => {
+    const html = renderLoginPage({
+      oktaEnabled: true,
+      returnTo: "/admin/agents",
+    });
+    expect(html).toContain(
+      'href="/admin/auth/okta?returnTo=%2Fadmin%2Fagents"',
+    );
+  });
 });
 
 // ─── renderAgentsPage ─────────────────────────────────────────────────────────

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -680,7 +680,8 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
   app.get("/admin/login", (c) => {
     const error = c.req.query("error") ?? undefined;
     const returnTo = c.req.query("returnTo") ?? undefined;
-    return html(renderLoginPage({ error, returnTo }));
+    const oktaEnabled = Boolean(oktaClientId && oktaIssuer && oktaClient);
+    return html(renderLoginPage({ error, returnTo, oktaEnabled }));
   });
 
   app.get("/admin/auth/google", (c) => {

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -744,10 +744,9 @@ auth:
 
 Only emails on `allowedEmails` may sign in. The client secret is kept in the
 chart-managed admin Secret, never in plaintext Deployment env. Okta sign-in is
-available at `/admin/auth/okta`; the login page itself currently only surfaces
-the Google sign-in button — an Okta-configured operator needs to navigate to
-`/admin/auth/okta` directly (no second button is rendered on `/admin/login`
-yet).
+available at `/admin/auth/okta`. When `OKTA_ISSUER`, `OKTA_CLIENT_ID`, and
+`OKTA_CLIENT_SECRET` are set, the login page (`/admin/login`) renders a "Sign in
+with Okta" button alongside the Google sign-in button.
 
 ---
 


### PR DESCRIPTION
## Summary
- `renderLoginPage` gains an `oktaEnabled` flag; renders a "Sign in with Okta" button (with `returnTo` passthrough) only when Okta is configured
- `/admin/login` route computes `oktaEnabled = Boolean(oktaClientId && oktaIssuer && oktaClient)`, matching the existing config-check pattern used elsewhere in `admin-ui.ts`
- Refreshed `docs/deploy-kubernetes.md` to reflect the new login button instead of requiring operators to navigate directly to `/admin/auth/okta`

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Login page shows Sign in with Okta only when Okta is configured | MET | `renderLoginPage` gains `oktaEnabled?: boolean`, conditionally renders the button. `/admin/login` computes `oktaEnabled` from the existing Okta config booleans. |
| 2 | Test decision: add/extend a unit or content test on renderLoginPage asserting conditional rendering. No tests retired. | MET | 4 new tests added covering default (no Okta), explicit false, enabled, and returnTo param passthrough. No existing tests removed. |

## Test Plan
- `bun test admin-ui-pages.unit.test.ts` — 584 pass, 0 fail
- `bun test --coverage` on `admin/src/admin-ui-pages.ts` — 94.37% line coverage (target 90%)
- `tsc --noEmit` typecheck — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
