### PR TITLE
feat: cache Slack sender email alongside display name (SMR-2.2)

### DIFF
--- a/agent/src/users.ts
+++ b/agent/src/users.ts
@@ -1,16 +1,25 @@
 /**
- * Generic user display name resolver with in-memory cache.
+ * Generic user display name / email resolver with in-memory cache.
  *
  * Uses a structural UserResolverClient interface instead of importing
  * @slack/web-api directly — keeping the agent package Slack-agnostic.
+ *
+ * A single users.info() call is cached per user id and used to serve both
+ * the display name and the email, avoiding a second API call when a caller
+ * needs both.
  */
+
+interface ResolvedUser {
+  name: string;
+  email?: string;
+}
 
 // In-memory cache — survives for the lifetime of the process.
 // Export clearCache() for test teardown to prevent cross-test leakage
 // when Bun shares the module between test files.
-const cache = new Map<string, string>();
+const cache = new Map<string, ResolvedUser>();
 
-/** Clear the in-memory display name cache. Use in test afterEach teardown. */
+/** Clear the in-memory display name / email cache. Use in test afterEach teardown. */
 export function clearCache(): void {
   cache.clear();
 }
@@ -19,34 +28,63 @@ export interface UserResolverClient {
   users: {
     info(args: { user: string }): Promise<{
       user?: {
-        profile?: { display_name?: string; real_name?: string };
+        profile?: {
+          display_name?: string;
+          real_name?: string;
+          email?: string;
+        };
         name?: string;
       };
     }>;
   };
 }
 
-export async function resolveDisplayName(
+async function resolveUser(
   userId: string,
   client: UserResolverClient,
-): Promise<string> {
+): Promise<ResolvedUser> {
   const cached = cache.get(userId);
   if (cached !== undefined) return cached;
 
   try {
     const res = await client.users.info({ user: userId });
-    const name =
-      res.user?.profile?.display_name ||
-      res.user?.profile?.real_name ||
-      res.user?.name ||
-      userId;
-    cache.set(userId, name);
-    return name;
+    const resolved: ResolvedUser = {
+      name:
+        res.user?.profile?.display_name ||
+        res.user?.profile?.real_name ||
+        res.user?.name ||
+        userId,
+      email: res.user?.profile?.email || undefined,
+    };
+    cache.set(userId, resolved);
+    return resolved;
   } catch (err) {
     console.warn(
-      `[users] failed to resolve display name for ${userId}:`,
+      `[users] failed to resolve user ${userId}:`,
       err instanceof Error ? err.message : String(err),
     );
-    return userId;
+    return { name: userId, email: undefined };
   }
+}
+
+export async function resolveDisplayName(
+  userId: string,
+  client: UserResolverClient,
+): Promise<string> {
+  const { name } = await resolveUser(userId, client);
+  return name;
+}
+
+/**
+ * Resolve the Slack user's email from the same cached users.info() lookup
+ * used by resolveDisplayName. Returns undefined if the email is absent —
+ * e.g. the users:read.email scope hasn't been granted yet, or the user
+ * genuinely has no email on file — never throws.
+ */
+export async function resolveUserEmail(
+  userId: string,
+  client: UserResolverClient,
+): Promise<string | undefined> {
+  const { email } = await resolveUser(userId, client);
+  return email;
 }

--- a/agent/src/users.unit.test.ts
+++ b/agent/src/users.unit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { clearCache, resolveDisplayName } from "./users.ts";
+import { clearCache, resolveDisplayName, resolveUserEmail } from "./users.ts";
 
 const makeClient = (profile: Record<string, string | undefined>) => ({
   users: {
@@ -56,5 +56,53 @@ describe("resolveDisplayName", () => {
     clearCache();
     await resolveDisplayName("U_CLR", client as never);
     expect(client.users.info).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("resolveUserEmail", () => {
+  afterEach(() => {
+    clearCache();
+  });
+
+  it("returns profile.email when present", async () => {
+    const client = makeClient({
+      display_name: "Dan",
+      email: "dan@example.com",
+    });
+    expect(await resolveUserEmail("U_EMAIL1", client as never)).toBe(
+      "dan@example.com",
+    );
+  });
+
+  it("returns undefined when profile.email is absent (missing scope)", async () => {
+    const client = makeClient({ display_name: "Dan" });
+    expect(
+      await resolveUserEmail("U_NOEMAIL", client as never),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when Slack call throws", async () => {
+    const badClient = {
+      users: {
+        info: mock(async () => {
+          throw new Error("missing_scope");
+        }),
+      },
+    };
+    expect(
+      await resolveUserEmail("U_ERR2", badClient as never),
+    ).toBeUndefined();
+  });
+
+  it("shares the cache with resolveDisplayName — only one API call for both name and email", async () => {
+    const client = makeClient({
+      display_name: "Dan",
+      email: "dan@example.com",
+    });
+    const name = await resolveDisplayName("U_SHARED", client as never);
+    const email = await resolveUserEmail("U_SHARED", client as never);
+    expect(name).toBe("Dan");
+    expect(email).toBe("dan@example.com");
+    expect(client.users.info).toHaveBeenCalledTimes(1);
   });
 });

--- a/docs/test-readiness/test-inventory.md
+++ b/docs/test-readiness/test-inventory.md
@@ -134,7 +134,7 @@ Not declared in CLAUDE.md but observed since 2026-08-06: `.github/workflows/test
 | `agent/src/analytics.ts` (file-backed JSON event store) | 2. Service-boundary code | integration | medium | n/a |
 | `agent/src/cutover-validate.ts` | 4. Error/failure-path (validation gate) | unit | medium | n/a |
 | `agent/src/http-chat-service-client.ts`, `shipwright-config-client.ts`, `shipwright-runtime-client.ts` | 2. Service-boundary code | integration (recorded fixture) | high | n/a |
-| `agent/src/sessions.ts`, `users.ts` | 2. Service-boundary code | integration | medium | n/a |
+| `agent/src/sessions.ts`, `users.ts` (user display name and email resolver with unified cache, SMR-2.2) | 2. Service-boundary code | integration | medium | n/a |
 | `agent/src/config.ts`, `cli-args.ts`, `test-env.ts` | 1. Pure business logic | unit | medium | n/a |
 | `agent/src/index.ts` (composition entrypoint) | 2. Service-boundary code (composition + sync wiring) | integration | critical | n/a |
 | `admin/src/agents-api.ts` (CRUD API for Agent/Env/Cron/Tool/Token/Plugin/Member) | 3. HTTP route | smoke | critical | n/a |


### PR DESCRIPTION
## Summary
- Extends `agent/src/users.ts`'s existing `users.info()`-based lookup to also extract and cache `profile.email` from the same Slack API response, sharing one cache/API call with the existing display-name resolution.
- Adds a new `resolveUserEmail(userId, client)` function returning `Promise<string | undefined>`; `resolveDisplayName`'s signature and behavior are unchanged, so the existing caller (`agent/src/index.ts`) and `agent/src/slack.ts`'s `ResolveUserFn`/`[Name]: ` prefix flow needed no changes.
- Absent/missing email (scope not yet granted, or user has none) resolves to `undefined` without throwing — same for Slack API errors.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Single cached lookup returns both name and email | MET |
| 2 | Absent/missing email resolves to undefined, no throw | MET |
| 3 | All internal callers updated, no old signature left | MET |
| 4 | Tests extended per spec, none retired | MET |

## Test Plan
- Extended `agent/src/users.unit.test.ts` with cases: email present, email absent (missing scope), Slack API error, and a shared-cache assertion (one `users.info()` call serves both name and email lookups).
- All existing `resolveDisplayName` tests unchanged and passing.
- `task typecheck` — all 7 workspaces pass.
- `task lint` — clean.
- Coverage on `agent/src/users.ts`: 100% funcs / 100% lines.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
