### PR TITLE
fix(admin): make /admin/agents/new the primary agent-create CTA

### DIFF
--- a/admin/src/admin-local-agent.smoke.test.ts
+++ b/admin/src/admin-local-agent.smoke.test.ts
@@ -1,6 +1,6 @@
 /**
  * admin/src/admin-local-agent.smoke.test.ts
- * Smoke tests for the "New local agent" create flow.
+ * Smoke tests for the "New agent" create flow (/admin/agents/new).
  *
  * Tests:
  * - GET /admin/agents/new — admin session returns 200 with form containing name input
@@ -625,27 +625,27 @@ describe("admin UI — new local agent create flow", () => {
     expect(html).toContain("Repo must be in org/repo format");
   });
 
-  // ── /admin/agents list page has "New local agent" button ──────────────────
+  // ── /admin/agents list page has the primary "New agent" button ────────────
 
-  it("GET /admin/agents — admin sees 'New local agent' button", async () => {
+  it("GET /admin/agents — admin sees the '+ New agent' button linking to /admin/agents/new", async () => {
     const app = createAdminUIApp(makeMockDeps());
     const res = await app.request("/admin/agents", {
       headers: { Cookie: `admin_session=${adminCookie}` },
     });
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain("New local agent");
+    expect(html).toContain("+ New agent");
     expect(html).toContain("/admin/agents/new");
   });
 
-  it("GET /admin/agents — non-admin does NOT see 'New local agent' button", async () => {
+  it("GET /admin/agents — non-admin does NOT see the '+ New agent' button", async () => {
     const app = createAdminUIApp(makeMockDeps());
     const res = await app.request("/admin/agents", {
       headers: { Cookie: `admin_session=${nonAdminCookie}` },
     });
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).not.toContain("New local agent");
+    expect(html).not.toContain("+ New agent");
   });
 
   // ── runtime=in-cluster (Slack-free provisioning) ──────────────────────────

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -547,7 +547,7 @@ export function renderAgentsPage(
 
   const rows =
     agents.length === 0
-      ? `<tr><td colspan="4" class="empty-state">${isAdmin ? 'No agents yet. <a href="/admin/provision">Provision one →</a>' : "No agents."}</td></tr>`
+      ? `<tr><td colspan="4" class="empty-state">${isAdmin ? 'No agents yet. <a href="/admin/agents/new">Create one →</a>' : "No agents."}</td></tr>`
       : agents
           .map(
             (a) => `<tr>
@@ -563,9 +563,13 @@ export function renderAgentsPage(
           )
           .join("\n");
 
-  const provisionButton = isAdmin
-    ? `<a href="/admin/provision" class="btn btn-primary">+ Provision agent</a>
-      <a href="/admin/agents/new" class="btn btn-secondary" style="margin-left:8px">+ New local agent</a>`
+  // Primary path is /admin/agents/new — it creates in-cluster or self-hosted
+  // agents and needs no Slack, so it never dead-ends. /admin/provision is the
+  // Slack-app bootstrap wizard (requires an xoxp token), offered as a secondary
+  // action for setups that use Slack.
+  const createAgentButtons = isAdmin
+    ? `<a href="/admin/agents/new" class="btn btn-primary">+ New agent</a>
+      <a href="/admin/provision" class="btn btn-secondary" style="margin-left:8px">Connect Slack app</a>`
     : "";
 
   return `<!DOCTYPE html>
@@ -581,7 +585,7 @@ export function renderAgentsPage(
   <div class="vos-page">
     <div class="page-header">
       <h1 class="page-title">Agents</h1>
-      ${provisionButton}
+      ${createAgentButtons}
     </div>
     ${successHtml}
     ${manualStepsHtml}

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -235,9 +235,22 @@ describe("renderAgentsPage", () => {
     expect(html).toContain("No agents yet");
   });
 
-  test("empty state includes link to /admin/provision", () => {
+  test("empty state links to /admin/agents/new (not the Slack wizard)", () => {
     const html = renderAgentsPage([], USER_NAME, true, "UTC");
-    expect(html).toContain("/admin/provision");
+    expect(html).toContain('href="/admin/agents/new"');
+    expect(html).toContain("Create one");
+  });
+
+  test("admin: primary CTA is '+ New agent' → /admin/agents/new", () => {
+    const html = renderAgentsPage([AGENT_LIST_ITEM], USER_NAME, true, "UTC");
+    expect(html).toContain("+ New agent");
+    expect(html).toContain('href="/admin/agents/new"');
+  });
+
+  test("admin: Slack wizard is offered only as a secondary action", () => {
+    const html = renderAgentsPage([AGENT_LIST_ITEM], USER_NAME, true, "UTC");
+    expect(html).toContain("Connect Slack app");
+    expect(html).toContain('href="/admin/provision"');
   });
 
   test("agent name appears as a link", () => {
@@ -293,15 +306,16 @@ describe("renderAgentsPage", () => {
     expect(html).not.toContain("No agents yet");
   });
 
-  test("non-admin: provision button is hidden", () => {
+  test("non-admin: create buttons are hidden", () => {
     const html = renderAgentsPage([AGENT_LIST_ITEM], USER_NAME, false, "UTC");
-    expect(html).not.toContain("+ Provision agent");
+    expect(html).not.toContain("+ New agent");
+    expect(html).not.toContain("Connect Slack app");
   });
 
-  test("non-admin: empty state shows 'No agents.' without provision link", () => {
+  test("non-admin: empty state shows 'No agents.' without a create link", () => {
     const html = renderAgentsPage([], USER_NAME, false, "UTC");
     expect(html).toContain("No agents.");
-    expect(html).not.toContain("Provision one");
+    expect(html).not.toContain("Create one");
   });
 
   test("createdAt date uses the provided timezone", () => {


### PR DESCRIPTION
## Problem
On a fresh stack (e.g. minikube, `auth.mode=open`), the Agents page funnels admins into `/admin/provision` — the **Slack-app bootstrap wizard**, whose "Slack App Configuration Token" (`xoxp`) field is unconditionally `required`. A dev/no-Slack setup has no such token, so agent creation dead-ends there. The general, Slack-optional path (`/admin/agents/new`) was only offered as a secondary "New local agent" button.

## Fix
Reframe the Agents-page CTAs so the path that never dead-ends is primary:
- Empty state links to `/admin/agents/new` ("Create one →") instead of `/admin/provision`.
- Primary button is **"+ New agent"** → `/admin/agents/new` (creates in-cluster or self-hosted, no Slack needed).
- `/admin/provision` is kept, demoted to a secondary **"Connect Slack app"** action for setups that use Slack.

The Slack wizard and its route are unchanged and still reachable — only the prominence/labeling of the CTA changes.

## Tests
- `admin-ui-pages.unit.test.ts`: empty state + primary CTA now target `/admin/agents/new`; Slack wizard asserted as secondary; non-admin sees neither.
- `admin-local-agent.smoke.test.ts`: admin sees "+ New agent" → `/admin/agents/new`; non-admin does not.
- All 614 tests across the two suites pass; typecheck + lint clean.

## Follow-up
Pairs with #2764 (the encryption-key format fix). Not addressed here: the toolbar "Provision" nav link still points at the Slack wizard — left as a separate consideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)