### PR TITLE
fix(admin): relabel the toolbar 'Provision' nav link to 'Slack'

### DIFF
--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -215,7 +215,7 @@ export function renderShipwrightToolbar(
     <a href="${adminBase}/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="${adminBase}/admin/agents" class="vos-nav-link${active("/admin/agents")}">Agents</a>
-      <a href="${adminBase}/admin/provision" class="vos-nav-link${active("/admin/provision")}">Provision</a>
+      <a href="${adminBase}/admin/provision" class="vos-nav-link${active("/admin/provision")}">Slack</a>
       <a href="${adminBase}/admin/tasks?state=ready" class="vos-nav-link${active("/admin/tasks")}">Tasks</a>
       <a href="${adminBase}/admin/prs" class="vos-nav-link${active("/admin/prs")}">PRs</a>
       <a href="${adminBase}/admin/chat" class="vos-nav-link${active("/admin/chat")}">Chat</a>

--- a/lib/web/toolbar.unit.test.ts
+++ b/lib/web/toolbar.unit.test.ts
@@ -30,6 +30,12 @@ describe("renderShipwrightToolbar", () => {
       expect(html).toContain("Metrics");
     });
 
+    test("Slack wizard link is labeled 'Slack' (not the generic 'Provision')", () => {
+      expect(html).toContain('href="/admin/provision"');
+      expect(html).toContain(">Slack</a>");
+      expect(html).not.toContain(">Provision</a>");
+    });
+
     test("active link has active class", () => {
       expect(html).toContain('class="vos-nav-link active"');
     });

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -163,7 +163,7 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Provision</a>
+      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
@@ -656,7 +656,7 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Provision</a>
+      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
@@ -1149,7 +1149,7 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Provision</a>
+      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
@@ -1642,7 +1642,7 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Provision</a>
+      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>


### PR DESCRIPTION
## Problem
The admin toolbar's **"Provision"** nav item points at `/admin/provision` — the **Slack-app bootstrap wizard** (requires an `xoxp` token), not a generic agent-provisioning page. The generic label reads as "create an agent here," funneling dev/no-Slack users into the Slack-only flow.

## Fix
Relabel the nav item **"Provision" → "Slack"** (`lib/web/toolbar.ts`). Link target (`/admin/provision`) and active-state highlighting are unchanged — only the label. Agent creation lives under **Agents → + New agent** (`/admin/agents/new`).

## Tests
- `lib/web/toolbar.unit.test.ts`: asserts the nav link is labeled "Slack" → `/admin/provision` and no longer presents a generic "Provision" item (19 pass).
- Existing `admin-ui-pages.unit.test.ts` active-state assertions match on the href+class substring, so they're unaffected.

## Context
Third of three related fixes for the minikube agent-provisioning flow: #2764 (encryption-key format — the hard 500), #2767 (agents-page primary CTA), and this toolbar relabel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)