### PR TITLE
feat: add users:read.email Slack scope

### DIFF
--- a/admin/src/slack-provisioning-client.ts
+++ b/admin/src/slack-provisioning-client.ts
@@ -135,6 +135,7 @@ export const AGENT_BOT_SCOPES: string[] = [
   "reactions:read",
   "reactions:write",
   "users:read",
+  "users:read.email",
 ];
 
 export function buildAgentManifest(

--- a/admin/src/slack-provisioning-client.unit.test.ts
+++ b/admin/src/slack-provisioning-client.unit.test.ts
@@ -48,6 +48,7 @@ describe("buildAgentManifest", () => {
       expect(scopes).toContain("channels:history");
       expect(scopes).toContain("groups:history");
       expect(scopes).toContain("chat:write");
+      expect(scopes).toContain("users:read.email");
     });
 
     it("omits redirect_urls when no redirectUri provided", () => {


### PR DESCRIPTION
## Summary
- Adds `users:read.email` to `AGENT_BOT_SCOPES` in `admin/src/slack-provisioning-client.ts`
- Purely additive — existing already-provisioned agents won't pick up the new scope automatically; a human must click "Sync Manifest" per agent in the admin UI (covered separately by SMR-5.1)

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | AGENT_BOT_SCOPES includes `users:read.email` alongside the existing `users:read` | MET | `admin/src/slack-provisioning-client.ts`: new entry added to the array |
| 2 | Existing unit test updated to assert the new scope; no new test scenario, no tests retired | MET | `admin/src/slack-provisioning-client.unit.test.ts`: added assertion to the existing "includes required scopes" test block |

## Test Plan
- `bun test admin/src/slack-provisioning-client.unit.test.ts` — 10/10 pass
- `bun test admin/src/slack-provisioning-client.unit.test.ts admin/src/slack-provisioning-client.integration.test.ts admin/src/slack-provisioning.integration.test.ts` — 30/30 pass
- `task lint` and `task typecheck` — clean
- `task ci` — 28 pre-existing failures unrelated to this change (metrics env/error-handler tests and a task-store PR-validation smoke test), reproduced identically at the branch's base commit (`74b2f8fc5`) on `main`, unrelated to `slack-provisioning-client.ts`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
