### PR TITLE
feat: wire GitHub App manifest-flow routes and provision-form UI

### DIFF
--- a/admin/src/admin-dev-login.smoke.test.ts
+++ b/admin/src/admin-dev-login.smoke.test.ts
@@ -200,6 +200,15 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       updateAppManifest: async () => {},
       exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
     },
+    githubAppClient: {
+      exchangeManifestCode: async () => ({
+        appId: "999111",
+        slug: "test-shipwright-agent",
+        pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+        clientId: "gh-app-client-id",
+        clientSecret: "gh-app-client-secret",
+      }),
+    },
     provisioner: {
       canProvision: false,
       provision: async () => ({

--- a/admin/src/admin-local-agent.smoke.test.ts
+++ b/admin/src/admin-local-agent.smoke.test.ts
@@ -14,7 +14,11 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
 import { createAdminUIApp } from "./admin-ui.ts";
-import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
+import type {
+  AdminUIDeps,
+  AdminUIGithubAppClient,
+  AdminUISlackClient,
+} from "./admin-ui.ts";
 import type {
   GoogleAuthClient,
   GoogleTokenResponse,
@@ -79,6 +83,16 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     }),
     updateAppManifest: async () => {},
     exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
+  };
+
+  const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {
+    exchangeManifestCode: async () => ({
+      appId: "999111",
+      slug: "test-shipwright-agent",
+      pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+      clientId: "gh-app-client-id",
+      clientSecret: "gh-app-client-secret",
+    }),
   };
 
   const defaults: AdminUIDeps = {
@@ -257,6 +271,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     adminAllowedEmails: ADMIN_ALLOWED_EMAILS,
     googleClient: makeGoogleClient(),
     slackClient: BASE_SLACK_CLIENT,
+    githubAppClient: BASE_GITHUB_APP_CLIENT,
     provisioner: {
       canProvision: false,
       provision: async () => ({

--- a/admin/src/admin-tokens.smoke.test.ts
+++ b/admin/src/admin-tokens.smoke.test.ts
@@ -9,7 +9,11 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
 import { createAdminUIApp } from "./admin-ui.ts";
-import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
+import type {
+  AdminUIDeps,
+  AdminUIGithubAppClient,
+  AdminUISlackClient,
+} from "./admin-ui.ts";
 import type { GoogleAuthClient } from "./google-auth-client.ts";
 import { resolveTaskStoreBaseUrl } from "./main.ts";
 
@@ -50,6 +54,16 @@ const BASE_SLACK_CLIENT: AdminUISlackClient = {
   }),
   updateAppManifest: async () => {},
   exchangeOAuthCode: async () => ({ botToken: "xoxb-mock" }),
+};
+
+const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {
+  exchangeManifestCode: async () => ({
+    appId: "999111",
+    slug: "test-shipwright-agent",
+    pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+    clientId: "gh-app-client-id",
+    clientSecret: "gh-app-client-secret",
+  }),
 };
 
 function makeGoogleClient(): GoogleAuthClient {
@@ -310,6 +324,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     adminAllowedEmails: ["admin@example.com"],
     googleClient: makeGoogleClient(),
     slackClient: BASE_SLACK_CLIENT,
+    githubAppClient: BASE_GITHUB_APP_CLIENT,
     appBaseUrl: "https://example.com",
     ...overrides,
   };

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1556,18 +1556,41 @@ export function renderProvisionStartPage(
             </div>
           </div>
           <div id="gh-app-fields" style="display:none">
-            <div class="form-group">
-              <label class="form-label" for="ghAppId">App ID</label>
-              <input id="ghAppId" name="ghAppId" type="text" class="form-input" placeholder="123456" />
+            <div class="form-group" style="margin-bottom:12px">
+              <label style="font-size:13px;font-weight:500;margin-right:16px">
+                <input type="radio" name="ghAppMode" value="manual" checked
+                  onchange="document.getElementById('gh-app-manual-fields').style.display='block';document.getElementById('gh-app-auto-fields').style.display='none'"
+                /> Paste manually
+              </label>
+              <label style="font-size:13px;font-weight:500">
+                <input type="radio" name="ghAppMode" value="auto"
+                  onchange="document.getElementById('gh-app-manual-fields').style.display='none';document.getElementById('gh-app-auto-fields').style.display='block'"
+                /> Auto-provision (recommended)
+              </label>
             </div>
-            <div class="form-group">
-              <label class="form-label" for="ghAppInstallationId">Installation ID</label>
-              <input id="ghAppInstallationId" name="ghAppInstallationId" type="text" class="form-input" placeholder="987654" />
+            <div id="gh-app-manual-fields">
+              <div class="form-group">
+                <label class="form-label" for="ghAppId">App ID</label>
+                <input id="ghAppId" name="ghAppId" type="text" class="form-input" placeholder="123456" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="ghAppInstallationId">Installation ID</label>
+                <input id="ghAppInstallationId" name="ghAppInstallationId" type="text" class="form-input" placeholder="987654" />
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="ghAppPrivateKey">Private Key (PEM)</label>
+                <textarea id="ghAppPrivateKey" name="ghAppPrivateKey" class="form-input" rows="6"
+                  placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"></textarea>
+              </div>
             </div>
-            <div class="form-group">
-              <label class="form-label" for="ghAppPrivateKey">Private Key (PEM)</label>
-              <textarea id="ghAppPrivateKey" name="ghAppPrivateKey" class="form-input" rows="6"
-                placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"></textarea>
+            <div id="gh-app-auto-fields" style="display:none">
+              <div class="form-group">
+                <label class="form-label" for="githubOrg">GitHub org</label>
+                <input id="githubOrg" name="githubOrg" type="text" class="form-input" placeholder="my-org" required />
+                <p style="font-size:12px;color:#6b7280;margin-top:4px">
+                  You'll be redirected to GitHub to create the App under this organization from a manifest.
+                </p>
+              </div>
             </div>
           </div>
         </fieldset>
@@ -1623,6 +1646,140 @@ export function renderProvisionStartPage(
     <div class="card">
       ${errorHtml}
       ${oauthSection}
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * Auto-submitting POST-redirect page for the GitHub "create a GitHub App
+ * from a manifest" flow: https://docs.github.com/apps/creating-github-apps/setting-up-a-github-app/creating-a-github-app-from-a-manifest
+ *
+ * `githubOrg` must already be validated by the caller against the org-name
+ * pattern before this function is called — it's interpolated directly into
+ * the form's `action` URL.
+ */
+export function renderGithubAppManifestRedirectPage(
+  userName: string,
+  opts: { githubOrg: string; manifest: unknown },
+): string {
+  const actionUrl = `https://github.com/organizations/${encodeURIComponent(opts.githubOrg)}/settings/apps/new`;
+  const manifestJson = JSON.stringify(opts.manifest);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Provision Agent — Shipwright Admin</title>
+  <style>${baseStyles()}</style>
+</head>
+<body>
+  ${renderAdminToolbar(userName, "/admin/provision")}
+  <div class="vos-page">
+    <div class="page-header">
+      <h1 class="page-title">Provision Agent</h1>
+    </div>
+    <div class="provision-steps">
+      <span class="provision-step active">1. Create Slack App</span>
+      <span class="provision-step">2. Authorize</span>
+      <span class="provision-step">3. Complete</span>
+    </div>
+    <div class="card">
+      <p style="font-size:14px;margin-bottom:16px;color:#6b7280">
+        Redirecting to GitHub to create the GitHub App under <strong>${escapeHtml(opts.githubOrg)}</strong>…
+      </p>
+      <form id="github-app-manifest-form" method="POST" action="${escapeHtml(actionUrl)}">
+        <input type="hidden" name="manifest" value="${escapeHtml(manifestJson)}" />
+        <button type="submit" class="btn btn-primary">Continue to GitHub →</button>
+      </form>
+      <script>
+        document.getElementById('github-app-manifest-form').submit();
+      </script>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * Shown after GET /admin/provision/github-app/complete succeeds — links the
+ * operator to GitHub's installations/new page for the newly created app.
+ */
+export function renderGithubAppInstallPage(
+  userName: string,
+  opts: { installUrl: string },
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Provision Agent — Shipwright Admin</title>
+  <style>${baseStyles()}</style>
+</head>
+<body>
+  ${renderAdminToolbar(userName, "/admin/provision")}
+  <div class="vos-page">
+    <div class="page-header">
+      <h1 class="page-title">Provision Agent</h1>
+    </div>
+    <div class="provision-steps">
+      <span class="provision-step">1. Create Slack App</span>
+      <span class="provision-step active">2. Install GitHub App</span>
+      <span class="provision-step">3. Complete</span>
+    </div>
+    <div class="card">
+      <div class="alert alert-success">
+        <strong>GitHub App created!</strong> Click the link below to install it.
+      </div>
+      <a href="${escapeHtml(opts.installUrl)}" class="btn btn-primary" rel="noopener noreferrer">
+        Install GitHub App →
+      </a>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * Shown after GET /admin/provision/github-app/installed succeeds or fails —
+ * the manifest flow's `setup_url` target.
+ */
+export function renderGithubAppInstalledPage(
+  userName: string,
+  opts: { success: boolean; error?: string },
+): string {
+  const bodyHtml = opts.success
+    ? `<div class="alert alert-success">
+        <strong>GitHub App installed!</strong> — installation ID stored.
+      </div>
+      <a href="/admin/provision" class="btn btn-secondary">Back to Provisioning</a>`
+    : `<div class="alert alert-error">${escapeHtml(opts.error ?? "GitHub App installation failed.")}</div>
+      <a href="/admin/provision" class="btn btn-secondary">Try again</a>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Provision Agent — Shipwright Admin</title>
+  <style>${baseStyles()}</style>
+</head>
+<body>
+  ${renderAdminToolbar(userName, "/admin/provision")}
+  <div class="vos-page">
+    <div class="page-header">
+      <h1 class="page-title">Provision Agent</h1>
+    </div>
+    <div class="provision-steps">
+      <span class="provision-step">1. Create Slack App</span>
+      <span class="provision-step">2. Install GitHub App</span>
+      <span class="provision-step active">3. Complete</span>
+    </div>
+    <div class="card">
+      ${bodyHtml}
     </div>
   </div>
 </body>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -1672,6 +1672,62 @@ describe("renderProvisionStartPage", () => {
     expect(selectMatch).toBeTruthy();
     expect(selectMatch?.[0]).not.toContain("required");
   });
+
+  // ── new tests for ghAppMode sub-toggle (manual paste vs. auto-provision) ─
+
+  test("renders ghAppMode radio buttons (manual and auto)", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    expect(html).toContain('name="ghAppMode"');
+    expect(html).toContain('value="manual"');
+    expect(html).toContain('value="auto"');
+  });
+
+  test("ghAppMode=manual is checked by default (preserves current behavior)", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    const manualMatch = html.match(
+      /<input type="radio" name="ghAppMode" value="manual"[^>]*>/,
+    );
+    expect(manualMatch).toBeTruthy();
+    expect(manualMatch?.[0]).toContain("checked");
+  });
+
+  test("ghAppMode=auto is NOT checked by default", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    const autoMatch = html.match(
+      /<input type="radio" name="ghAppMode" value="auto"[^>]*>/,
+    );
+    expect(autoMatch).toBeTruthy();
+    expect(autoMatch?.[0]).not.toContain("checked");
+  });
+
+  test("manual fields (ghAppId, ghAppInstallationId, ghAppPrivateKey) still render unchanged", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    expect(html).toContain('id="ghAppId" name="ghAppId"');
+    expect(html).toContain(
+      'id="ghAppInstallationId" name="ghAppInstallationId"',
+    );
+    expect(html).toContain('id="ghAppPrivateKey" name="ghAppPrivateKey"');
+  });
+
+  test("renders a required githubOrg text field for auto-provision", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    expect(html).toContain('name="githubOrg"');
+    const orgMatch = html.match(/<input id="githubOrg"[^>]*>/);
+    expect(orgMatch).toBeTruthy();
+    expect(orgMatch?.[0]).toContain("required");
+  });
+
+  test("gh-app-manual-fields container wraps the three manual fields", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    expect(html).toContain('id="gh-app-manual-fields"');
+  });
+
+  test("gh-app-auto-fields container wraps the githubOrg field and is hidden by default", () => {
+    const html = renderProvisionStartPage(USER_NAME, []);
+    const containerMatch = html.match(/<div id="gh-app-auto-fields"[^>]*>/);
+    expect(containerMatch).toBeTruthy();
+    expect(containerMatch?.[0]).toContain("display:none");
+  });
 });
 
 // ─── renderProvisionPasteForm ─────────────────────────────────────────────────

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -10,7 +10,11 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
 import type { PrListItem, PullRequestItem } from "./admin-ui-pages.ts";
 import { createAdminUIApp } from "./admin-ui.ts";
-import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
+import type {
+  AdminUIDeps,
+  AdminUIGithubAppClient,
+  AdminUISlackClient,
+} from "./admin-ui.ts";
 import type {
   GoogleAuthClient,
   GoogleTokenResponse,
@@ -180,12 +184,27 @@ const BASE_SLACK_CLIENT: AdminUISlackClient = {
   exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
 };
 
+const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {
+  exchangeManifestCode: async () => ({
+    appId: "999111",
+    slug: "test-shipwright-agent",
+    pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+    clientId: "gh-app-client-id",
+    clientSecret: "gh-app-client-secret",
+  }),
+};
+
 function makeMockDeps(
-  overrides?: Partial<Omit<AdminUIDeps, "slackClient">> & {
+  overrides?: Partial<Omit<AdminUIDeps, "slackClient" | "githubAppClient">> & {
     slackClient?: Partial<AdminUISlackClient>;
+    githubAppClient?: Partial<AdminUIGithubAppClient>;
   },
 ): AdminUIDeps {
-  const { slackClient: slackClientOverride, ...rest } = overrides ?? {};
+  const {
+    slackClient: slackClientOverride,
+    githubAppClient: githubAppClientOverride,
+    ...rest
+  } = overrides ?? {};
   return {
     prisma: {
       agent: {
@@ -392,6 +411,7 @@ function makeMockDeps(
     oktaIssuer: OKTA_ISSUER,
     oktaClient: makeOktaClient(),
     slackClient: { ...BASE_SLACK_CLIENT, ...slackClientOverride },
+    githubAppClient: { ...BASE_GITHUB_APP_CLIENT, ...githubAppClientOverride },
     provisioner: {
       canProvision: false,
       provision: async () => ({
@@ -897,7 +917,9 @@ describe("admin UI — authenticated pages", () => {
     // agentTypeRegistry) caused this route to throw on `provisioner.canProvision`
     // — a 500 that left the type picker (and its "required" select[name=type])
     // missing entirely rather than merely disabled.
-    expect(html).toContain('<select id="type" name="type" class="form-input" required>');
+    expect(html).toContain(
+      '<select id="type" name="type" class="form-input" required>',
+    );
     expect(html).toContain('<option value="coding">Coding Agent</option>');
   });
 
@@ -2862,6 +2884,409 @@ describe("admin UI — provision start form", () => {
     const html = await res.text();
     expect(html).toContain("alert-error");
     expect(html).not.toContain('href="https://slack.com');
+  });
+});
+
+// ─── GitHub App manifest-flow provisioning ─────────────────────────────────
+
+describe("admin UI — GitHub App auto-provision (POST /admin/provision/start)", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  it("ghAuthMode=app + ghAppMode=auto + invalid githubOrg returns a form error before any Slack/GitHub call", async () => {
+    let slackCalled = false;
+    const deps = makeMockDeps({
+      slackClient: {
+        createAppManifest: async () => {
+          slackCalled = true;
+          throw new Error("should not be called");
+        },
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const body = new URLSearchParams({
+      agentId: AGENT_ID,
+      xoxpToken: "xoxe.xoxp-valid",
+      ghAuthMode: "app",
+      ghAppMode: "auto",
+      githubOrg: "-not-valid-!!",
+    });
+    const res = await app.request("/admin/provision/start", {
+      method: "POST",
+      body: body.toString(),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+    expect(slackCalled).toBe(false);
+  });
+
+  it("ghAuthMode=app + ghAppMode=auto happy path: renders auto-submitting manifest redirect page targeting the org, with manifest hidden field, and sets state cookie with githubOrg", async () => {
+    const deps = makeMockDeps();
+    const app = createAdminUIApp(deps);
+    const body = new URLSearchParams({
+      agentId: AGENT_ID,
+      xoxpToken: "xoxe.xoxp-valid",
+      ghAuthMode: "app",
+      ghAppMode: "auto",
+      githubOrg: "my-org",
+    });
+    const res = await app.request("/admin/provision/start", {
+      method: "POST",
+      body: body.toString(),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      'action="https://github.com/organizations/my-org/settings/apps/new"',
+    );
+    expect(html).toContain('name="manifest"');
+
+    const setCookieHeader = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookieHeader).toContain("slack_provision_state=");
+    const match = setCookieHeader.match(/slack_provision_state=([^;]+)/);
+    expect(match).toBeTruthy();
+    const jwtToken = decodeURIComponent(match?.[1] ?? "");
+    const parts = jwtToken.split(".");
+    expect(parts).toHaveLength(3);
+    const payload = JSON.parse(
+      Buffer.from(parts[1] ?? "", "base64url").toString("utf-8"),
+    );
+    expect(payload.githubOrg).toBe("my-org");
+  });
+
+  it("ghAuthMode=app + ghAppMode=manual (default) leaves the existing App-paste behavior fully unchanged (no manifest redirect page)", async () => {
+    const deps = makeMockDeps();
+    const app = createAdminUIApp(deps);
+    const body = new URLSearchParams({
+      agentId: AGENT_ID,
+      xoxpToken: "xoxe.xoxp-valid",
+      ghAuthMode: "app",
+      ghAppMode: "manual",
+      ghAppId: "12345",
+      ghAppInstallationId: "67890",
+      ghAppPrivateKey:
+        "-----BEGIN RSA PRIVATE KEY-----\nfoo\n-----END RSA PRIVATE KEY-----",
+    });
+    const res = await app.request("/admin/provision/start", {
+      method: "POST",
+      body: body.toString(),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain("github.com/organizations/");
+    expect(html).toContain("Authorize Slack App");
+  });
+});
+
+describe("admin UI — GET /admin/provision/github-app/complete", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  async function makeValidStateCookie(
+    overrides?: Record<string, unknown>,
+  ): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return sign(
+      {
+        agentId: AGENT_ID,
+        clientId: "cid",
+        clientSecret: "csec",
+        signingSecret: "ssec",
+        appId: "A123",
+        githubOrg: "my-org",
+        iat: now,
+        exp: now + 300,
+        ...overrides,
+      },
+      SESSION_SECRET,
+      "HS256",
+    );
+  }
+
+  it("happy path: exchanges code, writes GH_APP_ID + GH_APP_PRIVATE_KEY, renders installations/new link", async () => {
+    let patchArgs: [string, Record<string, string>, Set<string>?] | null = null;
+    const stateCookie = await makeValidStateCookie();
+    const deps = makeMockDeps({
+      githubAppClient: {
+        exchangeManifestCode: async (code: string) => {
+          expect(code).toBe("valid-code-123");
+          return {
+            appId: "999111",
+            slug: "my-shipwright-agent",
+            pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+            clientId: "gh-client-id",
+            clientSecret: "gh-client-secret",
+          };
+        },
+      },
+      agentEnvService: {
+        getByAgentId: async () => ({ env: {}, secretKeys: [] }),
+        upsert: async () => {},
+        patch: async (
+          agentId: string,
+          envVars: Record<string, string>,
+          secretKeys?: Set<string>,
+        ) => {
+          patchArgs = [agentId, envVars, secretKeys];
+        },
+        deleteKey: async () => {},
+        getConfigBundle: async () => null,
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const res = await app.request(
+      "/admin/provision/github-app/complete?code=valid-code-123",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      "https://github.com/apps/my-shipwright-agent/installations/new",
+    );
+
+    expect(patchArgs).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: guarded by expect(patchArgs).not.toBeNull() above
+    const [patchedAgentId, envVars, secretKeys] = patchArgs!;
+    expect(patchedAgentId).toBe(AGENT_ID);
+    expect(envVars.GH_APP_ID).toBe("999111");
+    expect(envVars.GH_APP_PRIVATE_KEY).toContain("BEGIN RSA PRIVATE KEY");
+    expect(secretKeys?.has("GH_APP_PRIVATE_KEY")).toBe(true);
+  });
+
+  it("missing state cookie renders an error page rather than throwing", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      "/admin/provision/github-app/complete?code=some-code",
+      {
+        headers: { Cookie: `admin_session=${cookie}` },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+
+  it("invalid/tampered state cookie renders an error page rather than throwing", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      "/admin/provision/github-app/complete?code=some-code",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=not-a-real-jwt`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+
+  it("state cookie missing githubOrg renders an error page (not a GitHub-App-flow session)", async () => {
+    const stateCookie = await makeValidStateCookie({ githubOrg: undefined });
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      "/admin/provision/github-app/complete?code=some-code",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+
+  it("missing code query param renders an error page", async () => {
+    const stateCookie = await makeValidStateCookie();
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/provision/github-app/complete", {
+      headers: {
+        Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+
+  it("exchangeManifestCode rejecting renders an error page rather than throwing", async () => {
+    const stateCookie = await makeValidStateCookie();
+    const deps = makeMockDeps({
+      githubAppClient: {
+        exchangeManifestCode: async () => {
+          throw new Error("GitHub conversion failed");
+        },
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const res = await app.request(
+      "/admin/provision/github-app/complete?code=bad-code",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+});
+
+describe("admin UI — GET /admin/provision/github-app/installed", () => {
+  let cookie: string;
+
+  beforeAll(async () => {
+    cookie = await makeSessionCookie();
+  });
+
+  async function makeValidStateCookie(
+    overrides?: Record<string, unknown>,
+  ): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return sign(
+      {
+        agentId: AGENT_ID,
+        clientId: "cid",
+        clientSecret: "csec",
+        signingSecret: "ssec",
+        appId: "A123",
+        githubOrg: "my-org",
+        iat: now,
+        exp: now + 300,
+        ...overrides,
+      },
+      SESSION_SECRET,
+      "HS256",
+    );
+  }
+
+  it("happy path: writes GH_APP_INSTALLATION_ID, renders success", async () => {
+    let patchArgs: [string, Record<string, string>] | null = null;
+    const stateCookie = await makeValidStateCookie();
+    const deps = makeMockDeps({
+      agentEnvService: {
+        getByAgentId: async () => ({ env: {}, secretKeys: [] }),
+        upsert: async () => {},
+        patch: async (agentId: string, envVars: Record<string, string>) => {
+          patchArgs = [agentId, envVars];
+        },
+        deleteKey: async () => {},
+        getConfigBundle: async () => null,
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const res = await app.request(
+      "/admin/provision/github-app/installed?installation_id=778899",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-success");
+
+    expect(patchArgs).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: guarded by expect(patchArgs).not.toBeNull() above
+    const [patchedAgentId, envVars] = patchArgs!;
+    expect(patchedAgentId).toBe(AGENT_ID);
+    expect(envVars.GH_APP_INSTALLATION_ID).toBe("778899");
+  });
+
+  it("non-numeric installation_id renders an error page and does not patch env", async () => {
+    let patchCalled = false;
+    const stateCookie = await makeValidStateCookie();
+    const deps = makeMockDeps({
+      agentEnvService: {
+        getByAgentId: async () => ({ env: {}, secretKeys: [] }),
+        upsert: async () => {},
+        patch: async () => {
+          patchCalled = true;
+        },
+        deleteKey: async () => {},
+        getConfigBundle: async () => null,
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const res = await app.request(
+      "/admin/provision/github-app/installed?installation_id=not-a-number",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+    expect(patchCalled).toBe(false);
+  });
+
+  it("missing state cookie renders an error page rather than throwing", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      "/admin/provision/github-app/installed?installation_id=123",
+      {
+        headers: { Cookie: `admin_session=${cookie}` },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+
+  it("invalid/tampered state cookie renders an error page rather than throwing", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request(
+      "/admin/provision/github-app/installed?installation_id=123",
+      {
+        headers: {
+          Cookie: `admin_session=${cookie}; slack_provision_state=garbage`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
+  });
+
+  it("missing installation_id query param renders an error page", async () => {
+    const stateCookie = await makeValidStateCookie();
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/provision/github-app/installed", {
+      headers: {
+        Cookie: `admin_session=${cookie}; slack_provision_state=${stateCookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("alert-error");
   });
 });
 
@@ -5654,8 +6079,7 @@ describe("admin UI — Slack access settings route (restrictSlackToMembers)", ()
     const deps = makeMockDeps();
     deps.agentMemberService = {
       ...deps.agentMemberService,
-      exists: async (_agentId: string, email: string) =>
-        email === MEMBER_EMAIL,
+      exists: async (_agentId: string, email: string) => email === MEMBER_EMAIL,
     };
     const app = createAdminUIApp(deps);
     const body = new URLSearchParams({ restrictSlackToMembers: "true" });

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -43,6 +43,9 @@ import {
   renderChatPage,
   renderChatThreadPage,
   renderCronLogsPage,
+  renderGithubAppInstallPage,
+  renderGithubAppInstalledPage,
+  renderGithubAppManifestRedirectPage,
   renderLoginPage,
   renderNewLocalAgentPage,
   renderPrDetailPage,
@@ -76,6 +79,7 @@ import type { AgentService } from "./agents.ts";
 import { publicNoAuthMiddleware } from "./api-auth.ts";
 import { validateAttachment } from "./attachment-validation.ts";
 import { ForbiddenError, UnprocessableEntityError } from "./errors.ts";
+import { buildAgentAppManifest } from "./github-app-provisioning-client.ts";
 import type { GoogleAuthClient } from "./google-auth-client.ts";
 import type { ChatClient, ChatThread } from "./http-chat-client.ts";
 import type { OktaAuthClient } from "./okta-auth-client.ts";
@@ -116,6 +120,21 @@ export interface AdminUISlackClient {
     clientSecret: string,
     redirectUri: string,
   ): Promise<{ botToken: string }>;
+}
+
+/**
+ * Narrow interface for the admin UI's GitHub App provisioning dependency.
+ * Mirrors AdminUISlackClient's DI pattern — deliberately narrower than the
+ * full GithubAppProvisioningClient in github-app-provisioning-client.ts.
+ */
+export interface AdminUIGithubAppClient {
+  exchangeManifestCode(code: string): Promise<{
+    appId: string;
+    slug: string;
+    pem: string;
+    clientId: string;
+    clientSecret: string;
+  }>;
 }
 
 interface PrismaAgentLike {
@@ -284,6 +303,12 @@ export interface AdminUIDeps {
   oktaIssuer?: string;
   adminAllowedEmails: string[];
   slackClient: AdminUISlackClient;
+  /**
+   * GitHub App manifest-flow provisioning client, used by the auto-provision
+   * sub-flow under ghAuthMode=app: GET /admin/provision/github-app/complete
+   * exchanges the manifest-flow code via exchangeManifestCode().
+   */
+  githubAppClient: AdminUIGithubAppClient;
   appBaseUrl: string;
   /** Enable the /admin/dev-login route. Hard-blocked in production regardless of this value. */
   devAuthEnabled?: boolean;
@@ -544,6 +569,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     oktaIssuer = "",
     adminAllowedEmails,
     slackClient,
+    githubAppClient,
     appBaseUrl,
     devAuthEnabled = false,
     fetchTaskStoreTasks,
@@ -1085,10 +1111,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     try {
       await agentCronJobService.reconcileSystemCrons(agent.id);
     } catch (err) {
-      console.error(
-        "[admin-ui] failed to seed system crons (non-fatal):",
-        err,
-      );
+      console.error("[admin-ui] failed to seed system crons (non-fatal):", err);
     }
     return redirectWithMembersWarning(
       c,
@@ -1745,6 +1768,13 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
   const PROVISION_STATE_COOKIE = "slack_provision_state";
   const PROVISION_STATE_TTL_SECONDS = 300; // 5 min
 
+  // GitHub org login name pattern (matches GitHub's own username/org-name
+  // rules: alphanumeric, single hyphens, no leading/trailing hyphen, max 39
+  // chars). Operator-supplied `githubOrg` is validated against this at every
+  // point it's about to be string-interpolated into a github.com redirect
+  // URL — an open-redirect/injection boundary, not defensive-for-no-reason.
+  const GITHUB_ORG_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]){0,38}$/;
+
   // ─── Manifest sync ────────────────────────────────────────────────────────
 
   app.post("/admin/agents/:id/sync-manifest", requireAuth, async (c) => {
@@ -1865,9 +1895,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     let xoxpToken: string | undefined;
     let ghAuthMode: string | undefined;
     let ghPat: string | undefined;
+    let ghAppMode: string | undefined;
     let ghAppId: string | undefined;
     let ghAppInstallationId: string | undefined;
     let ghAppPrivateKey: string | undefined;
+    let githubOrg: string | undefined;
     let anthropicApiKey: string | undefined;
     let claudeCodeOauthToken: string | undefined;
 
@@ -1880,9 +1912,11 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       xoxpToken = formData.get("xoxpToken")?.toString();
       ghAuthMode = formData.get("ghAuthMode")?.toString() ?? "pat";
       ghPat = formData.get("ghPat")?.toString();
+      ghAppMode = formData.get("ghAppMode")?.toString() ?? "manual";
       ghAppId = formData.get("ghAppId")?.toString();
       ghAppInstallationId = formData.get("ghAppInstallationId")?.toString();
       ghAppPrivateKey = formData.get("ghAppPrivateKey")?.toString();
+      githubOrg = formData.get("githubOrg")?.toString()?.trim();
       anthropicApiKey = formData.get("anthropicApiKey")?.toString();
       claudeCodeOauthToken = formData.get("claudeCodeOauthToken")?.toString();
     } catch {
@@ -1910,20 +1944,30 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         return formError("GitHub Personal Access Token is required.");
       }
     } else if (ghAuthMode === "app") {
-      if (!ghAppId || !/^\d+$/.test(ghAppId)) {
-        return formError("GitHub App ID must be a numeric value.");
-      }
-      if (!ghAppInstallationId || !/^\d+$/.test(ghAppInstallationId)) {
-        return formError("GitHub App Installation ID must be a numeric value.");
-      }
-      if (
-        !ghAppPrivateKey ||
-        !ghAppPrivateKey.includes("BEGIN") ||
-        !ghAppPrivateKey.includes("PRIVATE KEY")
-      ) {
-        return formError(
-          "GitHub App Private Key must be a valid PEM-encoded key.",
-        );
+      if (ghAppMode === "auto") {
+        if (!githubOrg || !GITHUB_ORG_PATTERN.test(githubOrg)) {
+          return formError(
+            "GitHub org must be a valid GitHub organization name.",
+          );
+        }
+      } else {
+        if (!ghAppId || !/^\d+$/.test(ghAppId)) {
+          return formError("GitHub App ID must be a numeric value.");
+        }
+        if (!ghAppInstallationId || !/^\d+$/.test(ghAppInstallationId)) {
+          return formError(
+            "GitHub App Installation ID must be a numeric value.",
+          );
+        }
+        if (
+          !ghAppPrivateKey ||
+          !ghAppPrivateKey.includes("BEGIN") ||
+          !ghAppPrivateKey.includes("PRIVATE KEY")
+        ) {
+          return formError(
+            "GitHub App Private Key must be a valid PEM-encoded key.",
+          );
+        }
       }
     } else {
       return formError("Invalid GitHub auth mode.");
@@ -2026,6 +2070,13 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     const { appId, oauthRedirectUrl, clientId, clientSecret, signingSecret } =
       slackResult;
 
+    // GitHub App auto-provision (ghAuthMode=app, ghAppMode=auto): the manifest
+    // flow's own state (githubOrg) rides along in the same signed cookie used
+    // for the Slack OAuth exchange — this flow is strictly additive and never
+    // touches the PAT or manual-App-paste behavior below.
+    const isGithubAppAutoProvision =
+      ghAuthMode === "app" && ghAppMode === "auto";
+
     // ── Sign provision-state cookie ───────────────────────────────────────
 
     const now = Math.floor(Date.now() / 1000);
@@ -2038,6 +2089,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         appId,
         iat: now,
         exp: now + PROVISION_STATE_TTL_SECONDS,
+        ...(isGithubAppAutoProvision ? { githubOrg } : {}),
       },
       sessionSecret,
       "HS256",
@@ -2065,11 +2117,15 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
 
     if (ghAuthMode === "pat") {
       newEnv.GH_TOKEN = ghPat ?? "";
-    } else {
+    } else if (!isGithubAppAutoProvision) {
+      // Manual GitHub App paste — unchanged from prior behavior.
       newEnv.GH_APP_ID = ghAppId ?? "";
       newEnv.GH_APP_INSTALLATION_ID = ghAppInstallationId ?? "";
       newEnv.GH_APP_PRIVATE_KEY = ghAppPrivateKey ?? "";
     }
+    // isGithubAppAutoProvision: GH_APP_ID/GH_APP_PRIVATE_KEY/GH_APP_INSTALLATION_ID
+    // are written later by the github-app/complete and github-app/installed
+    // routes, once the manifest-flow code and installation_id are known.
 
     if (anthropicApiKey) {
       newEnv.ANTHROPIC_API_KEY = anthropicApiKey;
@@ -2083,6 +2139,22 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       newEnv,
       new Set(SECRET_ENV_VARS),
     );
+
+    if (isGithubAppAutoProvision) {
+      // biome-ignore lint/style/noNonNullAssertion: validated above (ghAppMode === "auto" requires a GITHUB_ORG_PATTERN-valid githubOrg)
+      const org = githubOrg!;
+      const manifest = buildAgentAppManifest(agent.name, {
+        redirectUri: `${appBaseUrl}/admin/provision/github-app/complete`,
+        setupUrl: `${appBaseUrl}/admin/provision/github-app/installed`,
+      });
+      // Use c.html() so the Set-Cookie header from setCookie() is included
+      return c.html(
+        renderGithubAppManifestRedirectPage(c.var.userEmail, {
+          githubOrg: org,
+          manifest,
+        }),
+      );
+    }
 
     // Use c.html() so the Set-Cookie header from setCookie() is included
     return c.html(
@@ -2220,6 +2292,158 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
   // POST /admin/provision/complete — removed; returns 404
   app.post("/admin/provision/complete", (c) => {
     return new Response("Not Found", { status: 404 });
+  });
+
+  /**
+   * Reads and verifies the slack_provision_state cookie for the GitHub App
+   * manifest-flow routes below. Unlike GET /admin/provision/complete, these
+   * routes only make sense mid-GitHub-App-flow, so a valid githubOrg
+   * (re-validated against GITHUB_ORG_PATTERN — never trust round-tripped
+   * input blindly, even though the JWT is signed) is required in the payload
+   * shape, not just the base Slack fields.
+   */
+  async function readGithubAppProvisionState(c: Context<AdminUIEnv>): Promise<
+    | {
+        agentId: string;
+        githubOrg: string;
+      }
+    | { error: string }
+  > {
+    const rawStateCookie = getCookie(c, PROVISION_STATE_COOKIE);
+    if (!rawStateCookie) {
+      deleteCookie(c, PROVISION_STATE_COOKIE);
+      return {
+        error:
+          "Provision session expired or missing. Please start the provisioning flow again.",
+      };
+    }
+    try {
+      const payload = (await verify(
+        rawStateCookie,
+        sessionSecret,
+        "HS256",
+      )) as Record<string, unknown>;
+      if (
+        typeof payload.agentId !== "string" ||
+        typeof payload.githubOrg !== "string" ||
+        !GITHUB_ORG_PATTERN.test(payload.githubOrg)
+      ) {
+        throw new Error("invalid payload shape");
+      }
+      return { agentId: payload.agentId, githubOrg: payload.githubOrg };
+    } catch {
+      deleteCookie(c, PROVISION_STATE_COOKIE);
+      return {
+        error:
+          "Provision session expired or invalid. Please start the provisioning flow again.",
+      };
+    }
+  }
+
+  // GET — manifest-flow redirect target: exchange the one-time code for App
+  // credentials, store them, and link the operator to the install page.
+  app.get("/admin/provision/github-app/complete", requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    const userEmail = c.var.userEmail;
+
+    const state = await readGithubAppProvisionState(c);
+    if ("error" in state) {
+      return html(
+        renderGithubAppInstalledPage(userEmail, {
+          success: false,
+          error: state.error,
+        }),
+      );
+    }
+
+    // Read the code param before consuming the cookie — if code is absent the
+    // cookie must remain intact so the user can restart the provisioning flow.
+    const code = c.req.query("code");
+    if (!code) {
+      return html(
+        renderGithubAppInstalledPage(userEmail, {
+          success: false,
+          error:
+            "GitHub did not return a manifest code. Please restart the provisioning flow from the beginning.",
+        }),
+      );
+    }
+
+    deleteCookie(c, PROVISION_STATE_COOKIE);
+
+    let exchangeResult: {
+      appId: string;
+      slug: string;
+      pem: string;
+      clientId: string;
+      clientSecret: string;
+    };
+    try {
+      exchangeResult = await githubAppClient.exchangeManifestCode(code);
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : "Unknown error exchanging GitHub App manifest code.";
+      return html(
+        renderGithubAppInstalledPage(userEmail, {
+          success: false,
+          error: `GitHub App creation failed: ${msg}`,
+        }),
+      );
+    }
+
+    await agentEnvService.patch(
+      state.agentId,
+      {
+        GH_APP_ID: exchangeResult.appId,
+        GH_APP_PRIVATE_KEY: exchangeResult.pem,
+      },
+      new Set(SECRET_ENV_VARS),
+    );
+
+    return html(
+      renderGithubAppInstallPage(userEmail, {
+        installUrl: `https://github.com/apps/${exchangeResult.slug}/installations/new`,
+      }),
+    );
+  });
+
+  // GET — the manifest's setup_url target, reached after the operator installs
+  // the newly-created App. Stores GH_APP_INSTALLATION_ID.
+  app.get("/admin/provision/github-app/installed", requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    const userEmail = c.var.userEmail;
+
+    const state = await readGithubAppProvisionState(c);
+    if ("error" in state) {
+      return html(
+        renderGithubAppInstalledPage(userEmail, {
+          success: false,
+          error: state.error,
+        }),
+      );
+    }
+
+    const installationId = c.req.query("installation_id");
+    if (!installationId || !/^\d+$/.test(installationId)) {
+      deleteCookie(c, PROVISION_STATE_COOKIE);
+      return html(
+        renderGithubAppInstalledPage(userEmail, {
+          success: false,
+          error:
+            "GitHub did not return a valid installation ID. Please restart the provisioning flow from the beginning.",
+        }),
+      );
+    }
+
+    deleteCookie(c, PROVISION_STATE_COOKIE);
+
+    await agentEnvService.patch(state.agentId, {
+      GH_APP_INSTALLATION_ID: installationId,
+    });
+
+    return html(renderGithubAppInstalledPage(userEmail, { success: true }));
   });
 
   // POST /admin/provision/xapp-token — save xapp token, create scoped token, seed crons

--- a/admin/src/chat.smoke.test.ts
+++ b/admin/src/chat.smoke.test.ts
@@ -9,7 +9,11 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
 import { createAdminUIApp } from "./admin-ui.ts";
-import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
+import type {
+  AdminUIDeps,
+  AdminUIGithubAppClient,
+  AdminUISlackClient,
+} from "./admin-ui.ts";
 import type {
   GoogleAuthClient,
   GoogleTokenResponse,
@@ -218,6 +222,16 @@ const BASE_SLACK_CLIENT: AdminUISlackClient = {
   exchangeOAuthCode: async () => ({ botToken: "xoxb-mock" }),
 };
 
+const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {
+  exchangeManifestCode: async () => ({
+    appId: "999111",
+    slug: "test-shipwright-agent",
+    pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+    clientId: "gh-app-client-id",
+    clientSecret: "gh-app-client-secret",
+  }),
+};
+
 function makeBaseDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
   return {
     prisma: {
@@ -377,6 +391,7 @@ function makeBaseDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     adminAllowedEmails: ADMIN_ALLOWED_EMAILS,
     googleClient: makeGoogleClient(),
     slackClient: BASE_SLACK_CLIENT,
+    githubAppClient: BASE_GITHUB_APP_CLIENT,
     appBaseUrl: "http://localhost:3001",
     ...overrides,
   };

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -50,6 +50,7 @@ import {
   NoopChatServiceProvisioningClient,
 } from "./chat-service-provisioning-client.ts";
 import { isDevAuthAllowed } from "./dev-auth-guard.ts";
+import { HttpGithubAppProvisioningClient } from "./github-app-provisioning-client.ts";
 import { HttpGoogleAuthClient } from "./google-auth-client.ts";
 import { HttpChatClient } from "./http-chat-client.ts";
 import { HttpKubernetesClient } from "./kubernetes-client.ts";
@@ -389,6 +390,7 @@ async function startServer(): Promise<void> {
     ? new HttpOktaAuthClient({ issuer: oktaIssuer })
     : undefined;
   const slackClient = new HttpSlackProvisioningClient();
+  const githubAppClient = new HttpGithubAppProvisioningClient();
 
   // Task-store + chat-service clients for deleteAgentFully() cleanup, shared
   // by both delete entry points (DELETE /agents/:id and the admin-ui danger
@@ -637,6 +639,7 @@ async function startServer(): Promise<void> {
     oktaIssuer,
     ...(oktaClient ? { oktaClient } : {}),
     slackClient,
+    githubAppClient,
     appBaseUrl,
     publicRepo,
     devAuthEnabled: isDevAuthAllowed(process.env),

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -9,7 +9,11 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { sign } from "hono/jwt";
 import { createAdminUIApp } from "./admin-ui.ts";
-import type { AdminUIDeps, AdminUISlackClient } from "./admin-ui.ts";
+import type {
+  AdminUIDeps,
+  AdminUIGithubAppClient,
+  AdminUISlackClient,
+} from "./admin-ui.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -98,6 +102,18 @@ function makeMockSlackClient(opts?: {
     exchangeOAuthCode:
       opts?.exchangeOAuthCode ??
       (async () => ({ botToken: "xoxb-mock-bot-token" })),
+  };
+}
+
+function makeMockGithubAppClient(): AdminUIGithubAppClient {
+  return {
+    exchangeManifestCode: async () => ({
+      appId: "999111",
+      slug: "test-shipwright-agent",
+      pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+      clientId: "gh-app-client-id",
+      clientSecret: "gh-app-client-secret",
+    }),
   };
 }
 
@@ -286,6 +302,7 @@ function makeMockDeps(
       }),
     },
     slackClient: makeMockSlackClient(),
+    githubAppClient: makeMockGithubAppClient(),
     provisioner: {
       canProvision: false,
       provision: async () => ({

--- a/admin/src/server.smoke.test.ts
+++ b/admin/src/server.smoke.test.ts
@@ -219,6 +219,9 @@ function buildComposedApp() {
       updateAppManifest: notImplemented,
       exchangeOAuthCode: notImplemented,
     },
+    githubAppClient: {
+      exchangeManifestCode: notImplemented,
+    },
     appBaseUrl: "http://localhost:3000",
   });
   root.route("/", adminUIApp);

--- a/admin/src/slack-provisioning.integration.test.ts
+++ b/admin/src/slack-provisioning.integration.test.ts
@@ -263,6 +263,15 @@ function makeMockDeps(
       }),
     },
     slackClient,
+    githubAppClient: {
+      exchangeManifestCode: async () => ({
+        appId: "999111",
+        slug: "test-shipwright-agent",
+        pem: "-----BEGIN RSA PRIVATE KEY-----\nmock\n-----END RSA PRIVATE KEY-----",
+        clientId: "gh-app-client-id",
+        clientSecret: "gh-app-client-secret",
+      }),
+    },
     provisioner: {
       canProvision: false,
       provision: async () => ({


### PR DESCRIPTION
## Summary
- Extends the `slack_provision_state` JWT cookie with an optional `githubOrg` field, set only for the GitHub App auto-provision path
- Adds `GET /admin/provision/github-app/complete` (exchanges the manifest-flow code, writes `GH_APP_ID`/`GH_APP_PRIVATE_KEY`, links to `installations/new`) and `GET /admin/provision/github-app/installed` (the manifest's `setup_url` target, validates and stores `GH_APP_INSTALLATION_ID`)
- Adds a "Auto-provision (recommended)" vs "Paste manually" sub-toggle to the provision form under `ghAuthMode=app`; auto-provision is purely additive, defaults off, and renders GitHub's documented manifest-flow auto-submitting POST-redirect page
- Wires `HttpGithubAppProvisioningClient` into `main.ts` alongside the existing `slackClient`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `githubOrg` validated against `^[A-Za-z0-9](?:[A-Za-z0-9-]){0,38}$` before ever being interpolated into a redirect URL | MET |
| 2 | `installation_id` from the setup_url callback validated as numeric before being stored | MET |
| 3 | Manual-paste GitHub App fields and PAT path completely unchanged; auto-provision purely additive, defaults off | MET |
| 4 | Smoke tests for both new routes (happy path + invalid-state-cookie/invalid-code) + unit tests for the new form toggle markup | MET |

## Test Plan
- `admin-ui.smoke.test.ts`: new describe blocks for `POST /admin/provision/start` auto-provision branch, `GET /admin/provision/github-app/complete`, and `GET /admin/provision/github-app/installed` — happy path, invalid org, invalid/missing state cookie, invalid code, non-numeric installation_id
- `admin-ui-pages.unit.test.ts`: new assertions on the `ghAppMode` toggle markup, default-checked state, and the `githubOrg` field
- `bun test` — 928 admin tests pass
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
