### PR TITLE
fix(review): clarify Step 7 dispatch synchronicity; guard against ScheduleWakeup

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1754,3 +1754,30 @@ describe("review.md — findings ledger persistence (PFL-2.1)", () => {
     expect(step11bSection).toContain("must already have completed");
   });
 });
+
+describe("review.md — Step 7 dispatch is synchronous, no ScheduleWakeup/Monitor (RVS-1.1)", () => {
+  function extractStep7Section(md: string): string {
+    const step7Idx = md.indexOf("## Step 7: Deep Review");
+    const step8Idx = md.indexOf("## Step 8: Score and Classify Findings");
+    expect(step7Idx).toBeGreaterThan(-1);
+    expect(step8Idx).toBeGreaterThan(step7Idx);
+    return md.slice(step7Idx, step8Idx);
+  }
+
+  it("explicitly states the Agent dispatch blocks and returns the subagent's JSON response directly", () => {
+    const step7Section = extractStep7Section(content);
+    const lower = step7Section.toLowerCase().replace(/\s+/g, " ");
+    expect(lower).toContain("synchronous");
+    expect(lower).toContain("blocking");
+    expect(lower).toContain("returns the subagent's full json response");
+  });
+
+  it("does NOT instruct a ScheduleWakeup/Monitor call or background-wait phrasing for the Step 7 dispatch", () => {
+    const step7Section = extractStep7Section(content);
+    expect(step7Section).not.toContain("ScheduleWakeup");
+    expect(step7Section).not.toContain("Monitor");
+    const lower = step7Section.toLowerCase();
+    expect(lower).not.toContain("running in the background");
+    expect(lower).not.toContain("wait for it to complete");
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -485,6 +485,11 @@ Dispatch via the Agent tool with `subagent_type: "shipwright:code-reviewer"`, pa
 falling back to `'sonnet'` when no task is linked or the lookup failed), and pass
 a single prompt block containing:
 
+**This call is synchronous and blocking** — the Agent tool result returns the subagent's
+full JSON response directly, so Step 7 continues straight to parsing it into Step 8 and
+Step 9. No wait/poll step is needed here: do not schedule a wakeup or background monitor
+for this dispatch.
+
 - **PR metadata** — `number`, `title`, `author`, `headRefName`, `baseRefName`, `headRefOid`
 - **Full diff** — the `git diff "origin/$base"...HEAD` output from Step 5.2
 - **Changed files** — the list extracted in Step 5.3


### PR DESCRIPTION
## Summary
- Clarifies Step 7 of `review.md` — the Agent dispatch to `shipwright:code-reviewer` is synchronous and blocking; the tool result returns the subagent's full JSON response directly, so Step 7 continues straight into parsing (no wait/poll step needed).
- Prevents Claude from mistakenly treating this dispatch as backgrounded and calling `ScheduleWakeup` (which throws, since it requires `prompt`/`delaySeconds`/`reason`/`noop` unless `stop: true`).
- Adds a regression-guard content test mirroring `deploy.content.test.ts`'s existing pattern, asserting Step 7's section contains neither `ScheduleWakeup` nor background-wait phrasing.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 7's prose explicitly states the dispatch blocks and returns JSON directly, disclaiming ScheduleWakeup/Monitor | MET |
| 2 | review.content.test.ts gains a new assertion mirroring deploy.content.test.ts's guard | MET |
| 3 | One net-new content test added, no existing tests modified/retired | MET |
| 4 | `bun test review.content.test.ts` passes, `task lint` passes | MET |

## Test Plan
- `bun test plugins/shipwright/commands/review.content.test.ts` — 142 pass / 0 fail
- `bunx biome lint` on the touched test file — no issues
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
