### PR TITLE
feat: expose restrictSlackToMembers and member emails on the runtime config lookup (SMR-1.2)

### DIFF
--- a/admin/openapi.json
+++ b/admin/openapi.json
@@ -48,6 +48,10 @@
             "type": "string",
             "format": "date-time",
             "example": "2026-01-01T00:00:00.000Z"
+          },
+          "warning": {
+            "type": "string",
+            "example": "this agent has no members — enabling this will block all Slack senders"
           }
         },
         "required": [
@@ -108,6 +112,10 @@
             "example": [
               "octocat"
             ]
+          },
+          "restrictSlackToMembers": {
+            "type": "boolean",
+            "example": false
           }
         },
         "required": [
@@ -228,6 +236,9 @@
               "type": "string"
             }
           },
+          "restrictSlackToMembers": {
+            "type": "boolean"
+          },
           "typeName": {
             "type": "string"
           },
@@ -244,6 +255,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "warning": {
+            "type": "string"
           }
         },
         "required": [
@@ -252,6 +266,7 @@
           "selfHosted",
           "repos",
           "authorAllowlist",
+          "restrictSlackToMembers",
           "typeName",
           "createdAt",
           "updatedAt",
@@ -282,6 +297,10 @@
             "example": [
               "octocat"
             ]
+          },
+          "restrictSlackToMembers": {
+            "type": "boolean",
+            "example": false
           }
         }
       },
@@ -1899,6 +1918,19 @@
             "example": [
               "octocat"
             ]
+          },
+          "restrictSlackToMembers": {
+            "type": "boolean",
+            "example": false
+          },
+          "memberEmails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "dev@example.com"
+            ]
           }
         },
         "required": [
@@ -1906,7 +1938,9 @@
           "allowedTools",
           "plugins",
           "repos",
-          "authorAllowlist"
+          "authorAllowlist",
+          "restrictSlackToMembers",
+          "memberEmails"
         ]
       },
       "RuntimeError": {
@@ -2746,6 +2780,24 @@
             },
             "required": false,
             "name": "offset",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "acme/x#123"
+            },
+            "required": false,
+            "name": "itemId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx1234567890"
+            },
+            "required": false,
+            "name": "phaseId",
             "in": "query"
           }
         ],

--- a/admin/src/agents.ts
+++ b/admin/src/agents.ts
@@ -7,6 +7,7 @@
  */
 
 import type { PrismaClient } from "../prisma/client/index.js";
+import { AgentMemberService } from "./agent-members.ts";
 import {
   type AgentTypeManifestResolver,
   AgentTypeRegistry,
@@ -83,6 +84,8 @@ export interface AgentIdAndRepos {
   id: string;
   repos: string[];
   authorAllowlist: string[];
+  restrictSlackToMembers: boolean;
+  memberEmails: string[];
 }
 
 export interface AgentOption {
@@ -127,6 +130,10 @@ export class AgentService {
   constructor(
     private prisma: PrismaClient,
     private agentTypeRegistry: AgentTypeManifestResolver = new AgentTypeRegistry(),
+    private agentMemberService: Pick<
+      AgentMemberService,
+      "listByAgentId"
+    > = new AgentMemberService(prisma),
   ) {}
 
   /**
@@ -274,14 +281,25 @@ export class AgentService {
   }
 
   /**
-   * Get {id, repos, authorAllowlist} for a single agent — used by the runtime
-   * config/crons routes. Returns null if not found.
+   * Get {id, repos, authorAllowlist, restrictSlackToMembers, memberEmails}
+   * for a single agent — used by the runtime config/crons routes. Returns
+   * null if not found.
    */
   async getById(id: string): Promise<AgentIdAndRepos | null> {
-    return this.prisma.agent.findUnique({
+    const row = await this.prisma.agent.findUnique({
       where: { id },
-      select: { id: true, repos: true, authorAllowlist: true },
+      select: {
+        id: true,
+        repos: true,
+        authorAllowlist: true,
+        restrictSlackToMembers: true,
+      },
     });
+    if (!row) return null;
+
+    const members = await this.agentMemberService.listByAgentId(id);
+    const memberEmails = members.map((m) => m.email);
+    return { ...row, memberEmails };
   }
 
   /**

--- a/admin/src/agents.unit.test.ts
+++ b/admin/src/agents.unit.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import type { AgentMemberService } from "./agent-members.ts";
 import type { AgentTypeManifestResolver } from "./agent-type-manifest-loader.ts";
 import type { AgentTypeManifest } from "./agent-type-registry.ts";
 import { AgentService } from "./agents.ts";
@@ -46,6 +47,10 @@ function applySelect<T extends object>(
 function makeFakePrisma(
   seed: FakeAgentRow[] = [],
   envSeed: Record<string, string[]> = {},
+  memberSeed: Record<
+    string,
+    { id: string; agentId: string; email: string; createdAt: Date }[]
+  > = {},
 ) {
   const rows = new Map<string, FakeAgentRow>(seed.map((r) => [r.id, r]));
   let nextId = 1;
@@ -182,7 +187,17 @@ function makeFakePrisma(
     },
   };
 
-  return { agent, agentEnv, __rows: rows };
+  const agentMember = {
+    async findMany({
+      where,
+    }: {
+      where: { agentId: string };
+    }): Promise<{ id: string; agentId: string; email: string; createdAt: Date }[]> {
+      return memberSeed[where.agentId] ?? [];
+    },
+  };
+
+  return { agent, agentEnv, agentMember, __rows: rows };
 }
 
 type FakePrisma = ReturnType<typeof makeFakePrisma>;
@@ -588,6 +603,8 @@ describe("AgentService.getById", () => {
       id: "a1",
       repos: ["org/repo1", "org/repo2"],
       authorAllowlist: [],
+      restrictSlackToMembers: false,
+      memberEmails: [],
     });
   });
 
@@ -611,7 +628,57 @@ describe("AgentService.getById", () => {
       id: "a1",
       repos: ["org/repo1"],
       authorAllowlist: ["octocat", "hubot"],
+      restrictSlackToMembers: false,
+      memberEmails: [],
     });
+  });
+
+  it("includes memberEmails scoped to the agent, excluding other agents' members", async () => {
+    const row = seedRow({ id: "a1", repos: ["org/repo1"] });
+    const otherRow = seedRow({ id: "a2", repos: [] });
+    const prisma = makeFakePrisma([row, otherRow], undefined, {
+      a1: [
+        {
+          id: "member-1",
+          agentId: "a1",
+          email: "dev@example.com",
+          createdAt: new Date("2024-01-01"),
+        },
+        {
+          id: "member-2",
+          agentId: "a1",
+          email: "ops@example.com",
+          createdAt: new Date("2024-01-01"),
+        },
+      ],
+      a2: [
+        {
+          id: "member-3",
+          agentId: "a2",
+          email: "other@example.com",
+          createdAt: new Date("2024-01-01"),
+        },
+      ],
+    }) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.getById("a1");
+
+    expect(result?.memberEmails).toEqual(["dev@example.com", "ops@example.com"]);
+  });
+
+  it("returns restrictSlackToMembers: true when set on the seeded row", async () => {
+    const row = seedRow({
+      id: "a1",
+      repos: ["org/repo1"],
+      restrictSlackToMembers: true,
+    });
+    const prisma = makeFakePrisma([row]) as unknown as FakePrisma;
+    const service = new AgentService(prisma as never);
+
+    const result = await service.getById("a1");
+
+    expect(result?.restrictSlackToMembers).toBe(true);
   });
 });
 

--- a/admin/src/api.smoke.test.ts
+++ b/admin/src/api.smoke.test.ts
@@ -36,6 +36,8 @@ interface MockAgent {
   name: string;
   repos: string[];
   authorAllowlist: string[];
+  restrictSlackToMembers: boolean;
+  memberEmails: string[];
 }
 
 // ─── Mock factories ───────────────────────────────────────────────────────────
@@ -81,6 +83,8 @@ function makeMockAgentService(agents: Map<string, MockAgent>): {
     id: string;
     repos: string[];
     authorAllowlist: string[];
+    restrictSlackToMembers: boolean;
+    memberEmails: string[];
   } | null>;
 } {
   return {
@@ -90,6 +94,8 @@ function makeMockAgentService(agents: Map<string, MockAgent>): {
       id: string;
       repos: string[];
       authorAllowlist: string[];
+      restrictSlackToMembers: boolean;
+      memberEmails: string[];
     } | null> {
       const agent = agents.get(agentId);
       return agent
@@ -97,6 +103,8 @@ function makeMockAgentService(agents: Map<string, MockAgent>): {
             id: agent.id,
             repos: agent.repos,
             authorAllowlist: agent.authorAllowlist,
+            restrictSlackToMembers: agent.restrictSlackToMembers,
+            memberEmails: agent.memberEmails,
           }
         : null;
     },
@@ -164,6 +172,8 @@ function buildApp(opts?: {
   crons?: AgentCronJob[];
   repos?: string[];
   authorAllowlist?: string[];
+  restrictSlackToMembers?: boolean;
+  memberEmails?: string[];
 }) {
   const hasAgent = opts?.hasAgent ?? true;
   const bundle: AgentEnvBundle | null =
@@ -180,6 +190,8 @@ function buildApp(opts?: {
   const crons = opts?.crons ?? [makeCron(KNOWN_AGENT_ID, "cron-1")];
   const repos = opts?.repos ?? ["org/repo1", "org/repo2"];
   const authorAllowlist = opts?.authorAllowlist ?? [];
+  const restrictSlackToMembers = opts?.restrictSlackToMembers ?? false;
+  const memberEmails = opts?.memberEmails ?? [];
 
   const agents = new Map<string, MockAgent>();
   const bundles = new Map<string, AgentEnvBundle | null>();
@@ -192,6 +204,8 @@ function buildApp(opts?: {
       name: "Test Agent",
       repos,
       authorAllowlist,
+      restrictSlackToMembers,
+      memberEmails,
     });
     bundles.set(KNOWN_AGENT_ID, bundle);
     pluginMap.set(KNOWN_AGENT_ID, plugins);
@@ -262,6 +276,33 @@ describe("GET /:id/config (mounted as GET /agents/:id/config from root)", () => 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.authorAllowlist).toEqual([]);
+  });
+
+  test("200 returns restrictSlackToMembers and memberEmails exactly as stored on the agent", async () => {
+    const app = buildApp({
+      restrictSlackToMembers: true,
+      memberEmails: ["dev@example.com", "ops@example.com"],
+    });
+    const res = await app.request(`/${KNOWN_AGENT_ID}/config`, {
+      headers: { Authorization: `Bearer ${VALID_ADMIN_KEY}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.restrictSlackToMembers).toBe(true);
+    expect(body.memberEmails).toEqual(["dev@example.com", "ops@example.com"]);
+  });
+
+  test("200 returns restrictSlackToMembers false and memberEmails empty when the agent has no members", async () => {
+    const app = buildApp({ restrictSlackToMembers: false, memberEmails: [] });
+    const res = await app.request(`/${KNOWN_AGENT_ID}/config`, {
+      headers: { Authorization: `Bearer ${VALID_ADMIN_KEY}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.restrictSlackToMembers).toBe(false);
+    expect(body.memberEmails).toEqual([]);
   });
 
   test("parses the canonical plugin@marketplace spec, defaulting bare names to shipwright", async () => {
@@ -434,7 +475,13 @@ function buildCombinedApp() {
     },
     agentService: {
       async getById() {
-        return { id: COMBINED_AGENT_ID, repos: [], authorAllowlist: [] };
+        return {
+          id: COMBINED_AGENT_ID,
+          repos: [],
+          authorAllowlist: [],
+          restrictSlackToMembers: false,
+          memberEmails: [],
+        };
       },
     },
     agentPluginService: {

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -44,6 +44,8 @@ export interface AgentConfigResponse {
   plugins: AgentPlugin[];
   repos: string[];
   authorAllowlist: string[];
+  restrictSlackToMembers: boolean;
+  memberEmails: string[];
 }
 
 interface AgentEnvServiceLike {
@@ -68,9 +70,13 @@ interface AgentCronJobServiceLike {
 }
 
 interface AgentServiceLike {
-  getById(
-    agentId: string,
-  ): Promise<{ id: string; repos: string[]; authorAllowlist: string[] } | null>;
+  getById(agentId: string): Promise<{
+    id: string;
+    repos: string[];
+    authorAllowlist: string[];
+    restrictSlackToMembers: boolean;
+    memberEmails: string[];
+  } | null>;
 }
 
 interface AgentPluginServiceLike {
@@ -205,6 +211,8 @@ export function createAgentRuntimeApp(deps: AgentRuntimeDeps): OpenAPIHono {
       }),
       repos: agent.repos,
       authorAllowlist: agent.authorAllowlist,
+      restrictSlackToMembers: agent.restrictSlackToMembers ?? false,
+      memberEmails: agent.memberEmails ?? [],
     };
 
     return c.json(response, 200);

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -895,6 +895,8 @@ export const AgentConfigResponseSchema = z
     plugins: z.array(AgentConfigPluginSchema),
     repos: z.array(z.string()).openapi({ example: ["org/repo1", "org/repo2"] }),
     authorAllowlist: z.array(z.string()).openapi({ example: ["octocat"] }),
+    restrictSlackToMembers: z.boolean().openapi({ example: false }),
+    memberEmails: z.array(z.string()).openapi({ example: ["dev@example.com"] }),
   })
   .openapi("AgentConfigResponse");
 

--- a/agent/src/cutover-validate.integration.test.ts
+++ b/agent/src/cutover-validate.integration.test.ts
@@ -36,7 +36,15 @@ function makeCron(id: string): AgentCronJob {
 }
 
 function makeConfig(env: Record<string, string>): AgentConfigResponse {
-  return { env, allowedTools: [], plugins: [], repos: [], authorAllowlist: [] };
+  return {
+    env,
+    allowedTools: [],
+    plugins: [],
+    repos: [],
+    authorAllowlist: [],
+    restrictSlackToMembers: false,
+    memberEmails: [],
+  };
 }
 
 // ─── Recorded double ──────────────────────────────────────────────────────────

--- a/agent/src/entrypoint.integration.test.ts
+++ b/agent/src/entrypoint.integration.test.ts
@@ -26,6 +26,8 @@ const SAMPLE_CONFIG: AgentConfigResponse = {
   plugins: [{ marketplace: "my-market", plugin: "my-plugin" }],
   repos: [],
   authorAllowlist: [],
+  restrictSlackToMembers: false,
+  memberEmails: [],
 };
 
 // ─── Temp dir helpers ──────────────────────────────────────────────────────────
@@ -251,6 +253,8 @@ describe("runEntrypoint — config with empty env", () => {
       plugins: [],
       repos: [],
       authorAllowlist: [],
+      restrictSlackToMembers: false,
+      memberEmails: [],
     };
     const configClient = new RecordedShipwrightConfigClient(emptyConfig);
     const { deps, exitCodes, spawnCalls } = makeDeps(configClient);

--- a/agent/src/shipwright-runtime-client.integration.test.ts
+++ b/agent/src/shipwright-runtime-client.integration.test.ts
@@ -24,6 +24,8 @@ const SAMPLE_CONFIG: AgentConfigResponse = {
   plugins: [{ marketplace: "shipwright", plugin: "my-plugin" }],
   repos: [],
   authorAllowlist: [],
+  restrictSlackToMembers: false,
+  memberEmails: [],
 };
 
 const SAMPLE_CRONS: AgentCronJob[] = [

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.177.0",
+      "version": "1.178.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -100,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.177.0",
+      "version": "1.178.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.177.0",
+      "version": "1.178.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.178.0",
+      "version": "1.179.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -100,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.178.0",
+      "version": "1.179.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.178.0",
+      "version": "1.179.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -533,5 +533,7 @@ Used by the agent harness on startup and during the config sync loop. Returns th
 - `plugins` — installed plugins with derived marketplace URLs
 - `repos` — array of `org/repo` strings (scoped repositories this agent may access)
 - `authorAllowlist` — array of GitHub login strings (authors permitted to file pull requests scoped to this agent; empty array = all authenticated users allowed)
+- `restrictSlackToMembers` — boolean flag controlling Slack message access. When `true`, only users in the agent's `AgentMember` rows can send messages. Defaults to `false` (unrestricted). Used by runtime to enforce membership-based access control.
+- `memberEmails` — array of member email addresses (derived from agent's `AgentMember` rows). Empty when `restrictSlackToMembers` is `false` or no members are configured.
 
 Returns `404` if the agent doesn't exist.

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -744,6 +744,8 @@ export interface paths {
                 query?: {
                     limit?: string;
                     offset?: string;
+                    itemId?: string;
+                    phaseId?: string;
                 };
                 header?: never;
                 path: {
@@ -1596,6 +1598,8 @@ export interface components {
              * @example 2026-01-01T00:00:00.000Z
              */
             updatedAt: string;
+            /** @example this agent has no members — enabling this will block all Slack senders */
+            warning?: string;
         };
         Error: {
             /** @example not found */
@@ -1622,6 +1626,8 @@ export interface components {
              *     ]
              */
             authorAllowlist?: string[];
+            /** @example false */
+            restrictSlackToMembers?: boolean;
         };
         ReconcileAgentsResult: {
             recreated: string[];
@@ -1649,12 +1655,14 @@ export interface components {
             selfHosted: boolean;
             repos: string[];
             authorAllowlist: string[];
+            restrictSlackToMembers: boolean;
             typeName: string;
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
             missingRequiredEnv: string[];
+            warning?: string;
         };
         PatchAgentBody: {
             /** @example false */
@@ -1671,6 +1679,8 @@ export interface components {
              *     ]
              */
             authorAllowlist?: string[];
+            /** @example false */
+            restrictSlackToMembers?: boolean;
         };
         FailedStep: {
             /** @example k8s */
@@ -1932,6 +1942,11 @@ export interface components {
             /** @example 10 */
             cacheCreationTokens: number | null;
             /**
+             * @description Agent session id this run was executed under. Null for runs with no recorded session.
+             * @example session-abc-123
+             */
+            sessionId: string | null;
+            /**
              * Format: date-time
              * @example 2026-01-01T08:00:00.000Z
              */
@@ -2010,6 +2025,11 @@ export interface components {
             cacheReadTokens?: number | null;
             /** @example 10 */
             cacheCreationTokens?: number | null;
+            /**
+             * @description Agent session id this run was executed under.
+             * @example session-abc-123
+             */
+            sessionId?: string | null;
             /** @description Per-model token breakdown for this run */
             modelBreakdown?: components["schemas"]["ModelBreakdownEntry"][];
         };
@@ -2290,6 +2310,14 @@ export interface components {
              *     ]
              */
             authorAllowlist: string[];
+            /** @example false */
+            restrictSlackToMembers: boolean;
+            /**
+             * @example [
+             *       "dev@example.com"
+             *     ]
+             */
+            memberEmails: string[];
         };
         RuntimeError: {
             /** @example Not found */


### PR DESCRIPTION
## Summary
- Extend `AgentService.getById()` to join `AgentMember` rows (via `AgentMemberService.listByAgentId`) and return `restrictSlackToMembers` + `memberEmails` alongside the existing `id`/`repos`/`authorAllowlist` fields.
- Thread both new fields through the runtime config bundle HTTP response (`GET /:id/config`) so `agent/src/index.ts`'s config-sync tick can consume them in SMR-3.1.
- Regenerate `admin/openapi.json` / `lib/admin-types.ts` from the updated Zod schema.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | getById() return type includes restrictSlackToMembers and memberEmails | MET | admin/src/agents.ts AgentIdAndRepos interface + getById() joins AgentMemberService.listByAgentId |
| 2 | Runtime config bundle response includes both fields for agents with/without members | MET | admin/src/api.ts config route emits both fields; api.smoke.test.ts covers both cases |
| 3 | Defaults: restrictSlackToMembers=false, memberEmails=[] matching authorAllowlist null-guard pattern | MET | admin/src/api.ts: agent.restrictSlackToMembers ?? false, agent.memberEmails ?? [] |
| 4 | Test decision: extend existing runtime config route tests, no tests retired | MET | agents.unit.test.ts + api.smoke.test.ts extended; agent/src integration test fixtures updated; 0 tests removed |

## Test Plan
- `bun test admin/src/agents.unit.test.ts admin/src/api.smoke.test.ts` — 65 pass
- `bun test agent/src/cutover-validate.integration.test.ts agent/src/entrypoint.integration.test.ts agent/src/shipwright-runtime-client.integration.test.ts` — 40 pass
- `task typecheck` — clean across all workspaces
- 100% line/function coverage on both changed source files (`admin/src/agents.ts`, `admin/src/api.ts`)
- [x] Pre-commit checks passing

Note: `task ci`'s full `test:coverage` run reports 29 unrelated failures — verified pre-existing on unmodified `main` (a Bun `process.env.X = undefined` quirk in `agent/src/config.unit.test.ts` plus this shell's real `SLACK_BOT_TOKEN`/`ANTHROPIC_MODEL` env vars polluting "unset" assertions, and a pre-existing bug in `task-store/src/routes/prs.ts`'s `validateRepo`). None touch files changed by this PR.

Generated with [Claude Code](https://claude.com/claude-code)
