### PR TITLE
feat: enforce Slack membership check across message, mention, and reaction handlers

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -67,7 +67,7 @@ import { ensureAgentHome, installPlugins, runMiseStartup } from "./setup.ts";
 import { HttpShipwrightRuntimeClient } from "./shipwright-runtime-client.ts";
 import { createSlackApp, hasSlackCredentials } from "./slack.ts";
 import { sendBackOnlineDm } from "./startup-dm.ts";
-import { resolveDisplayName } from "./users.ts";
+import { resolveDisplayName, resolveUserEmail } from "./users.ts";
 import { synthesizeSpeech } from "./voice.ts";
 import {
   HttpWorkQueueReporter,
@@ -565,6 +565,8 @@ if (hasSlackCredentials(slackAppConfig)) {
     (key) => sessions.get(key),
     undefined, // blocksConverter — default
     chatTokenReporter,
+    (userId, client) => resolveUserEmail(userId, client),
+    agentSlackMembershipRef,
   );
 
   await app.start();

--- a/agent/src/slack-chat-conversation.integration.test.ts
+++ b/agent/src/slack-chat-conversation.integration.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createAgentSlackMembershipRef } from "./agent-slack-membership-ref.ts";
 import type { ModelUsage, TokenUsage } from "./claude.ts";
 import { threadKey } from "./sessions.ts";
 import { createSlackApp as _createSlackApp } from "./slack.ts";
@@ -90,6 +91,13 @@ function createSlackApp(
     "UBOT123", // botUserId
     async () => ({ messages: [] }), // conversationsRepliesFn
     getSessionFn,
+    undefined, // blocksConverter — default
+    undefined, // chatTokenReporter — default noop
+    async () => undefined, // resolveUserEmailFn
+    // A fresh, unsynced ref — never the process-wide agentSlackMembershipRef
+    // singleton, which agent-slack-membership-ref.unit.test.ts mutates
+    // directly (see slack.integration.test.ts's identical fix).
+    createAgentSlackMembershipRef(),
   );
 }
 

--- a/agent/src/slack.integration.test.ts
+++ b/agent/src/slack.integration.test.ts
@@ -17,6 +17,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import {
+  type AgentSlackMembershipRef,
+  createAgentSlackMembershipRef,
+} from "./agent-slack-membership-ref.ts";
+import {
   type ChatTokenReporter,
   NoopChatTokenReporter,
 } from "./chat-token-reporter.ts";
@@ -144,6 +148,11 @@ function createSlackApp(
     blocksConverter?: typeof markdownToBlocks;
     chatTokenReporter?: ChatTokenReporter;
     sentryClient?: ErrorCapturingClient;
+    resolveUserEmailFn?: (
+      userId: string,
+      client: unknown,
+    ) => Promise<string | undefined>;
+    membershipRef?: AgentSlackMembershipRef;
   } = {},
 ) {
   capturedErrors = [];
@@ -165,6 +174,14 @@ function createSlackApp(
     overrides.getSessionFn ?? (async () => undefined),
     overrides.blocksConverter,
     overrides.chatTokenReporter ?? new NoopChatTokenReporter(),
+    overrides.resolveUserEmailFn ?? (async () => undefined),
+    // A fresh, unsynced ref per call — never the process-wide
+    // agentSlackMembershipRef singleton, which other test files (e.g.
+    // agent-slack-membership-ref.unit.test.ts) mutate directly. Falling
+    // through to that shared singleton would make this suite's outcome
+    // depend on bun test's file execution order (see CLAUDE.md's test
+    // isolation hard rule).
+    overrides.membershipRef ?? createAgentSlackMembershipRef(),
   );
 }
 

--- a/agent/src/slack.integration.test.ts
+++ b/agent/src/slack.integration.test.ts
@@ -3036,6 +3036,11 @@ describe("thread resume after timeout — real createRunClaude wired as runner",
       async (key: string) => realSessions.get(key),
       undefined,
       new NoopChatTokenReporter(),
+      async () => undefined, // resolveUserEmailFn
+      // A fresh, unsynced ref — never the process-wide agentSlackMembershipRef
+      // singleton, which agent-slack-membership-ref.unit.test.ts mutates
+      // directly (see the createSlackApp wrapper above for the identical fix).
+      createAgentSlackMembershipRef(),
     );
     expect(app).toBeInstanceOf(MockApp);
 

--- a/agent/src/slack.ts
+++ b/agent/src/slack.ts
@@ -14,6 +14,10 @@ import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import type { App } from "@slack/bolt";
 import type { WebAPIPlatformError } from "@slack/web-api";
 import {
+  type AgentSlackMembershipRef,
+  agentSlackMembershipRef,
+} from "./agent-slack-membership-ref.ts";
+import {
   type ChatTokenReporter,
   NoopChatTokenReporter,
 } from "./chat-token-reporter.ts";
@@ -145,6 +149,35 @@ export type ResolveUserFn = (
   // biome-ignore lint/suspicious/noExplicitAny: Bolt client is complex
   client: any,
 ) => Promise<string>;
+
+export type ResolveUserEmailFn = (
+  userId: string,
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt client is complex
+  client: any,
+) => Promise<string | undefined>;
+
+/**
+ * The single shared Slack membership gate used by all three event handlers
+ * (message, app_mention, reaction_added) — SMR-4.1.
+ *
+ * Fails OPEN (allow) while the membership ref has never synced, or when
+ * restrict is false, so a persistent config-sync failure or a deliberately
+ * unrestricted config never blocks Slack access. Once restrict is true and
+ * the ref has synced, only a case-insensitive match against the synced
+ * member email list is allowed — an undefined email (resolution failed or
+ * absent) is rejected, never treated as a wildcard.
+ */
+export function isAllowedSlackSender(
+  email: string | undefined,
+  membershipRef: AgentSlackMembershipRef,
+): boolean {
+  if (!membershipRef.hasSynced()) return true;
+  const { restrict, emails } = membershipRef.get();
+  if (!restrict) return true;
+  if (!email) return false;
+  const lowered = email.toLowerCase();
+  return emails.some((e) => e.toLowerCase() === lowered);
+}
 
 // Normalizes text for the speak-marker fallback's duplicate-content check:
 // lowercased, trimmed, trailing punctuation stripped, internal whitespace
@@ -405,6 +438,8 @@ export function createSlackApp(
   getSessionFn: GetSessionFn = async () => undefined,
   blocksConverter: typeof markdownToBlocks = markdownToBlocks,
   chatTokenReporter: ChatTokenReporter = new NoopChatTokenReporter(),
+  resolveUserEmailFn: ResolveUserEmailFn = async () => undefined,
+  membershipRef: AgentSlackMembershipRef = agentSlackMembershipRef,
 ): App {
   const app = appFactory({
     token: slackConfig.botToken,
@@ -440,6 +475,16 @@ export function createSlackApp(
       if (!msg.thread_ts) return;
       if (!(await getSessionFn(getThreadKey(msg.channel, msg.thread_ts))))
         return;
+    }
+
+    if (msg.user) {
+      const senderEmail = await resolveUserEmailFn(msg.user, client);
+      if (!isAllowedSlackSender(senderEmail, membershipRef)) {
+        console.log(
+          `[slack] rejected sender (not a member): user=${msg.user}`,
+        );
+        return;
+      }
     }
 
     const sessionKey = getThreadKey(msg.channel, msg.thread_ts ?? msg.ts);
@@ -574,6 +619,16 @@ export function createSlackApp(
     // the message handler covers it and would double-respond otherwise.
     if (ev.thread_ts && (await getSessionFn(sessionKey))) {
       return;
+    }
+
+    if (ev.user) {
+      const senderEmail = await resolveUserEmailFn(ev.user, client);
+      if (!isAllowedSlackSender(senderEmail, membershipRef)) {
+        console.log(
+          `[slack] rejected sender (not a member): user=${ev.user}`,
+        );
+        return;
+      }
     }
 
     const setStatus = async (status: string) => {
@@ -715,6 +770,14 @@ export function createSlackApp(
     if (ev.item.type !== "message") return;
     if (!botUserId || ev.item_user !== botUserId) return;
     if (!ev.item.channel.startsWith("D")) return;
+
+    const senderEmail = await resolveUserEmailFn(ev.user, client).catch(
+      () => undefined,
+    );
+    if (!isAllowedSlackSender(senderEmail, membershipRef)) {
+      console.log(`[slack] rejected sender (not a member): user=${ev.user}`);
+      return;
+    }
 
     const sessionKey = getThreadKey(ev.item.channel, ev.item.ts);
     const name = await resolveUserFn(ev.user, client).catch(() => ev.user);

--- a/agent/src/slack.ts
+++ b/agent/src/slack.ts
@@ -179,6 +179,27 @@ export function isAllowedSlackSender(
   return emails.some((e) => e.toLowerCase() === lowered);
 }
 
+/**
+ * Resolves the sender's email and checks it against isAllowedSlackSender(),
+ * logging a debug line for rejected senders. Returns true when the handler
+ * should return early (reject) — shared by all three event handlers so the
+ * resolve/check/log sequence isn't repeated per handler.
+ */
+async function shouldRejectSlackSender(
+  userId: string,
+  // biome-ignore lint/suspicious/noExplicitAny: Bolt client type is complex
+  client: any,
+  resolveUserEmailFn: ResolveUserEmailFn,
+  membershipRef: AgentSlackMembershipRef,
+): Promise<boolean> {
+  const senderEmail = await resolveUserEmailFn(userId, client).catch(
+    () => undefined,
+  );
+  if (isAllowedSlackSender(senderEmail, membershipRef)) return false;
+  console.log(`[slack] rejected sender (not a member): user=${userId}`);
+  return true;
+}
+
 // Normalizes text for the speak-marker fallback's duplicate-content check:
 // lowercased, trimmed, trailing punctuation stripped, internal whitespace
 // collapsed. Deliberately simple — not fuzzy matching, just enough to catch
@@ -477,14 +498,16 @@ export function createSlackApp(
         return;
     }
 
-    if (msg.user) {
-      const senderEmail = await resolveUserEmailFn(msg.user, client);
-      if (!isAllowedSlackSender(senderEmail, membershipRef)) {
-        console.log(
-          `[slack] rejected sender (not a member): user=${msg.user}`,
-        );
-        return;
-      }
+    if (
+      msg.user &&
+      (await shouldRejectSlackSender(
+        msg.user,
+        client,
+        resolveUserEmailFn,
+        membershipRef,
+      ))
+    ) {
+      return;
     }
 
     const sessionKey = getThreadKey(msg.channel, msg.thread_ts ?? msg.ts);
@@ -621,14 +644,16 @@ export function createSlackApp(
       return;
     }
 
-    if (ev.user) {
-      const senderEmail = await resolveUserEmailFn(ev.user, client);
-      if (!isAllowedSlackSender(senderEmail, membershipRef)) {
-        console.log(
-          `[slack] rejected sender (not a member): user=${ev.user}`,
-        );
-        return;
-      }
+    if (
+      ev.user &&
+      (await shouldRejectSlackSender(
+        ev.user,
+        client,
+        resolveUserEmailFn,
+        membershipRef,
+      ))
+    ) {
+      return;
     }
 
     const setStatus = async (status: string) => {
@@ -771,11 +796,14 @@ export function createSlackApp(
     if (!botUserId || ev.item_user !== botUserId) return;
     if (!ev.item.channel.startsWith("D")) return;
 
-    const senderEmail = await resolveUserEmailFn(ev.user, client).catch(
-      () => undefined,
-    );
-    if (!isAllowedSlackSender(senderEmail, membershipRef)) {
-      console.log(`[slack] rejected sender (not a member): user=${ev.user}`);
+    if (
+      await shouldRejectSlackSender(
+        ev.user,
+        client,
+        resolveUserEmailFn,
+        membershipRef,
+      )
+    ) {
       return;
     }
 

--- a/agent/src/slack.unit.test.ts
+++ b/agent/src/slack.unit.test.ts
@@ -5,10 +5,25 @@
  * Socket Mode throws "Must provide an App-Level Token" when constructed without
  * a non-empty appToken, so the agent must only call createSlackApp when both the
  * bot token and the app-level token are present. Absent creds → offline mode.
+ *
+ * The isAllowedSlackSender + handler-level membership-gating tests below cover
+ * SMR-4.1: a single shared gate, called at the top of message/app_mention/
+ * reaction_added, before runner() is invoked. This file builds its own minimal
+ * MockApp harness (mirroring slack.integration.test.ts's pattern) so these
+ * cases are self-contained and slack.integration.test.ts stays untouched —
+ * its existing "processed as today" assertions continue to exercise the same
+ * default fail-open code path (unsynced ref / restrict=false).
  */
 
-import { describe, expect, test } from "bun:test";
-import { dispatchMarkers, hasSlackCredentials } from "./slack.ts";
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentSlackMembershipRef } from "./agent-slack-membership-ref.ts";
+import { createAgentSlackMembershipRef } from "./agent-slack-membership-ref.ts";
+import {
+  dispatchMarkers,
+  hasSlackCredentials,
+  isAllowedSlackSender,
+  createSlackApp as _createSlackApp,
+} from "./slack.ts";
 
 describe("hasSlackCredentials", () => {
   test("true when both bot and app tokens are non-empty", () => {
@@ -68,5 +83,353 @@ describe("dispatchMarkers — plan marker", () => {
     expect(call.thread_ts).toBe("1700.1");
     expect(JSON.stringify(call.blocks)).toContain("https://example.com/p/abc");
     expect(call.text).toContain("https://example.com/p/abc");
+  });
+});
+
+// ─── isAllowedSlackSender ───────────────────────────────────────────────────
+
+describe("isAllowedSlackSender", () => {
+  test("allows when the membership ref has never synced, regardless of email", () => {
+    const ref = createAgentSlackMembershipRef();
+    expect(isAllowedSlackSender(undefined, ref)).toBe(true);
+    expect(isAllowedSlackSender("nobody@example.com", ref)).toBe(true);
+  });
+
+  test("allows when synced but restrict is false", () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: false, emails: ["dan@example.com"] });
+    expect(isAllowedSlackSender(undefined, ref)).toBe(true);
+    expect(isAllowedSlackSender("someone-else@example.com", ref)).toBe(true);
+  });
+
+  test("allows a matching email (exact case)", () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["dan@example.com"] });
+    expect(isAllowedSlackSender("dan@example.com", ref)).toBe(true);
+  });
+
+  test("allows a matching email case-insensitively", () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["Dan@Example.com"] });
+    expect(isAllowedSlackSender("dan@example.com", ref)).toBe(true);
+    expect(isAllowedSlackSender("DAN@EXAMPLE.COM", ref)).toBe(true);
+  });
+
+  test("rejects a non-matching email", () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["dan@example.com"] });
+    expect(isAllowedSlackSender("stranger@example.com", ref)).toBe(false);
+  });
+
+  test("rejects an undefined email when restrict is true", () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["dan@example.com"] });
+    expect(isAllowedSlackSender(undefined, ref)).toBe(false);
+  });
+});
+
+// ─── Handler-level membership gating ───────────────────────────────────────
+// Self-contained MockApp harness (mirrors slack.integration.test.ts) scoped
+// to this file — captures constructor args + registered handlers so the
+// three gating call sites can be exercised without duplicating the 3000+
+// lines of unrelated setup living in slack.integration.test.ts.
+
+type HandlerFn = (...args: unknown[]) => Promise<void>;
+
+let capturedMessageHandler: HandlerFn | null = null;
+let capturedMentionHandler: HandlerFn | null = null;
+let capturedReactionAddedHandler: HandlerFn | null = null;
+
+class MockApp {
+  constructor(_args: Record<string, unknown>) {
+    capturedMessageHandler = null;
+    capturedMentionHandler = null;
+    capturedReactionAddedHandler = null;
+  }
+
+  message(handler: HandlerFn) {
+    capturedMessageHandler = handler;
+  }
+
+  event(type: string, handler: HandlerFn) {
+    if (type === "app_mention") capturedMentionHandler = handler;
+    if (type === "reaction_added") capturedReactionAddedHandler = handler;
+  }
+}
+
+const mockGatingSlackConfig = {
+  botToken: "xoxb-test-token",
+  appToken: "xapp-test-token",
+  signingSecret: "test-secret",
+};
+
+function makeMockClient() {
+  return {
+    assistant: {
+      threads: {
+        setStatus: mock(async (_args: unknown) => {}),
+      },
+    },
+    reactions: {
+      add: mock(async (_args: unknown) => {}),
+    },
+    files: {
+      uploadV2: mock(async (_args: unknown) => {}),
+    },
+    chat: {
+      postMessage: mock(async (_args: unknown) => ({ ts: "resp.ts.1" })),
+    },
+    users: {
+      info: mock(async (_args: unknown) => ({
+        user: {
+          profile: { display_name: "Test User", email: "member@example.com" },
+          name: "testuser",
+        },
+      })),
+    },
+  };
+}
+
+function makeSay() {
+  return mock(async (_args: unknown) => ({ ts: "reply.ts.1" }));
+}
+
+function setupGatingApp(overrides: {
+  membershipRef: AgentSlackMembershipRef;
+  resolveUserEmailFn: (userId: string, client: unknown) => Promise<string | undefined>;
+  runner?: (message: string, sessionKey?: string) => Promise<{
+    result: string;
+    sessionId?: string;
+    streamIncomplete?: boolean;
+  }>;
+  getSessionFn?: (key: string) => Promise<string | undefined>;
+}) {
+  const runner =
+    overrides.runner ??
+    mock(async (_msg: string, _key?: string) => ({
+      result: "Claude response",
+      sessionId: "sess-1",
+    }));
+
+  _createSlackApp(
+    runner,
+    (text: string) => text,
+    (channel: string, ts: string) => `${channel}:${ts}`,
+    // biome-ignore lint/suspicious/noExplicitAny: mock factory for tests
+    (cfg) => new MockApp(cfg as Record<string, unknown>) as any,
+    mockGatingSlackConfig,
+    undefined, // sentryClient — default noop
+    async () => null, // fileDownloaderFn
+    {}, // voiceConfig
+    async () => null, // transcribeAudioFn
+    async () => null, // synthesizeSpeechFn
+    async (userId: string) => userId, // resolveUserFn (display name) — identity
+    "UBOT123", // botUserId
+    async () => ({ messages: [] }), // conversationsRepliesFn
+    overrides.getSessionFn ?? (async () => undefined), // getSessionFn
+    undefined, // blocksConverter — default
+    undefined, // chatTokenReporter — default noop
+    overrides.resolveUserEmailFn,
+    overrides.membershipRef,
+  );
+
+  return { runner };
+}
+
+describe("membership gating — message handler", () => {
+  async function invokeDM(
+    membershipRef: AgentSlackMembershipRef,
+    resolveUserEmailFn: (
+      userId: string,
+      client: unknown,
+    ) => Promise<string | undefined>,
+  ) {
+    const { runner } = setupGatingApp({ membershipRef, resolveUserEmailFn });
+    const client = makeMockClient();
+    const say = makeSay();
+    const message = {
+      channel: "D123",
+      ts: "111.222",
+      text: "Hello bot",
+      channel_type: "im",
+      user: "U-SENDER",
+    };
+    await capturedMessageHandler?.({ message, say, client });
+    return { runner, say, client };
+  }
+
+  test("unsynced ref: processed as today (runner called)", async () => {
+    const ref = createAgentSlackMembershipRef();
+    const { runner, say } = await invokeDM(ref, async () => undefined);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenCalled();
+  });
+
+  test("restrict=false: processed as today (runner called)", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: false, emails: [] });
+    const { runner, say } = await invokeDM(ref, async () => undefined);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenCalled();
+  });
+
+  test("restrict=true + matching email: processed as today", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, say } = await invokeDM(
+      ref,
+      async () => "member@example.com",
+    );
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenCalled();
+  });
+
+  test("restrict=true + non-member email: runner not called, no reply posted", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, say } = await invokeDM(
+      ref,
+      async () => "stranger@example.com",
+    );
+    expect(runner).not.toHaveBeenCalled();
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  test("restrict=true + undefined email (resolution failed): runner not called", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, say } = await invokeDM(ref, async () => undefined);
+    expect(runner).not.toHaveBeenCalled();
+    expect(say).not.toHaveBeenCalled();
+  });
+});
+
+describe("membership gating — app_mention handler", () => {
+  async function invokeMention(
+    membershipRef: AgentSlackMembershipRef,
+    resolveUserEmailFn: (
+      userId: string,
+      client: unknown,
+    ) => Promise<string | undefined>,
+  ) {
+    const { runner } = setupGatingApp({ membershipRef, resolveUserEmailFn });
+    const client = makeMockClient();
+    const say = makeSay();
+    const event = {
+      text: "<@UBOT> do something",
+      channel: "C999",
+      ts: "222.333",
+      user: "U-SENDER",
+    };
+    await capturedMentionHandler?.({ event, say, client });
+    return { runner, say, client };
+  }
+
+  test("unsynced ref: processed as today (runner called)", async () => {
+    const ref = createAgentSlackMembershipRef();
+    const { runner, say } = await invokeMention(ref, async () => undefined);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenCalled();
+  });
+
+  test("restrict=false: processed as today (runner called)", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: false, emails: [] });
+    const { runner, say } = await invokeMention(ref, async () => undefined);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenCalled();
+  });
+
+  test("restrict=true + matching email: processed as today", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, say } = await invokeMention(
+      ref,
+      async () => "MEMBER@example.com",
+    );
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenCalled();
+  });
+
+  test("restrict=true + non-member email: runner not called, no reply posted", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, say } = await invokeMention(
+      ref,
+      async () => "stranger@example.com",
+    );
+    expect(runner).not.toHaveBeenCalled();
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  test("restrict=true + undefined email (resolution failed): runner not called", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, say } = await invokeMention(ref, async () => undefined);
+    expect(runner).not.toHaveBeenCalled();
+    expect(say).not.toHaveBeenCalled();
+  });
+});
+
+describe("membership gating — reaction_added handler", () => {
+  async function invokeReaction(
+    membershipRef: AgentSlackMembershipRef,
+    resolveUserEmailFn: (
+      userId: string,
+      client: unknown,
+    ) => Promise<string | undefined>,
+  ) {
+    const { runner } = setupGatingApp({ membershipRef, resolveUserEmailFn });
+    const client = makeMockClient();
+    const event = {
+      reaction: "thumbsup",
+      item: { type: "message", channel: "D1", ts: "100.1" },
+      item_user: "UBOT123",
+      user: "U-SENDER",
+    };
+    await capturedReactionAddedHandler?.({ event, client });
+    return { runner, client };
+  }
+
+  test("unsynced ref: processed as today (runner called)", async () => {
+    const ref = createAgentSlackMembershipRef();
+    const { runner } = await invokeReaction(ref, async () => undefined);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test("restrict=false: processed as today (runner called)", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: false, emails: [] });
+    const { runner } = await invokeReaction(ref, async () => undefined);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test("restrict=true + matching email: processed as today", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner } = await invokeReaction(
+      ref,
+      async () => "member@example.com",
+    );
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  test("restrict=true + non-member email: runner not called, no post", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, client } = await invokeReaction(
+      ref,
+      async () => "stranger@example.com",
+    );
+    expect(runner).not.toHaveBeenCalled();
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  test("restrict=true + undefined email (resolution failed): runner not called", async () => {
+    const ref = createAgentSlackMembershipRef();
+    ref.set({ restrict: true, emails: ["member@example.com"] });
+    const { runner, client } = await invokeReaction(ref, async () => undefined);
+    expect(runner).not.toHaveBeenCalled();
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a single shared `isAllowedSlackSender()` / `shouldRejectSlackSender()` gate in `agent/src/slack.ts`, called at the top of `app.message()`, `app.event('app_mention')`, and `app.event('reaction_added')`, before `runner()` is invoked in each
- Fails open (no behavior change) when the membership ref hasn't synced or `restrict` is false; when `restrict` is true, allows only senders whose resolved email case-insensitively matches a synced member email, otherwise returns early with no `runner()` call, no reply, and no session creation
- Logs a `[slack] rejected sender (not a member): user=...` line for rejected senders; nothing is surfaced to the rejected user
- Wires `resolveUserEmail` and `agentSlackMembershipRef` into `createSlackApp()` in `agent/src/index.ts`

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Single shared check used by all three handlers | MET |
| 2 | Unsynced ref or restrict=false: processed as today | MET |
| 3 | restrict=true + matching email (case-insensitive): processed as today | MET |
| 4 | restrict=true + non-match/undefined email: runner not called, no reply, no session | MET |
| 5 | Test coverage extending slack.unit.test.ts, no existing tests retired | MET |

## Test Plan
- `agent/src/slack.unit.test.ts`: 27/27 passing — direct `isAllowedSlackSender()` unit cases plus per-handler (message/app_mention/reaction_added) coverage of unsynced/restrict-off/member-match/non-member/undefined-email scenarios using an injected fake client, runner, and membership ref
- `task typecheck` — clean
- `task lint` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
