### PR TITLE
test: reset agentSlackMembershipRef singleton after test (T-084)

### DIFF
--- a/agent/src/agent-slack-membership-ref.unit.test.ts
+++ b/agent/src/agent-slack-membership-ref.unit.test.ts
@@ -4,7 +4,7 @@
  * Unit tests for createAgentSlackMembershipRef() — pure logic, no I/O.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import {
   agentSlackMembershipRef,
   createAgentSlackMembershipRef,
@@ -86,6 +86,10 @@ describe("createAgentSlackMembershipRef", () => {
 });
 
 describe("agentSlackMembershipRef (process-wide singleton)", () => {
+  afterEach(() => {
+    agentSlackMembershipRef.set({ restrict: false, emails: [] });
+  });
+
   it("is a working ref that reflects set() through get(), independent of createAgentSlackMembershipRef() instances", () => {
     const independent = createAgentSlackMembershipRef();
     independent.set({


### PR DESCRIPTION
## Summary
- Adds an `afterEach` to the `agentSlackMembershipRef (process-wide singleton)` describe block in `agent/src/agent-slack-membership-ref.unit.test.ts`, resetting the shared singleton back to its fail-open default (`{restrict: false, emails: []}`) after the test runs
- Closes the cross-suite leak risk flagged in `docs/test-readiness/test-migration.md`'s Method note step 1 — the test previously mutated the process-wide singleton with no cleanup

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Singleton describe block resets `agentSlackMembershipRef` to its fail-open default after its test runs | MET | `afterEach` added, calls `agentSlackMembershipRef.set({ restrict: false, emails: [] })` |
| 2 | No other test file observes a leaked `restrict:true`/non-empty-emails state from this singleton | MET | No other file in the repo imports `agentSlackMembershipRef` in a test context (verified via grep) |
| 3 | Verification command `bun test agent/src/agent-slack-membership-ref.unit.test.ts` passes | MET | 16 pass, 0 fail |

## Test Plan
- `bun test agent/src/agent-slack-membership-ref.unit.test.ts` — 16 pass, 0 fail
- `bun run --filter='*' --sequential typecheck` — all workspaces pass
- `bunx biome lint .` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
