### PR TITLE
fix: bootstrap consolidation-patrol precheck instead of permanent deadlock

### DIFF
--- a/docs/consolidation.md
+++ b/docs/consolidation.md
@@ -151,7 +151,7 @@ The `consolidation-patrol-maintenance` cron runs `consolidation-scan` and `conso
 |-------|-------|-------|
 | **Schedule** | `0 5 * * 1` | Weekly, Monday at 05:00 UTC. |
 | **Prompt** | `/shipwright:consolidation-scan` → `/shipwright:consolidation-fix` | Runs both skills in sequence; only posts to Slack if `ready_to_propose` findings exist. |
-| **preCheck** | `shipwright:check-consolidation-patrol.ts` | Scans the ledger for candidates worth waking a full Claude session: either already `ready_to_propose`, or still `tracking` but one observation away from the stabilization threshold (`occurrence_count >= 2`). Missing ledger → exits silently (normal first run). |
+| **preCheck** | `shipwright:check-consolidation-patrol.ts` | Scans the ledger for candidates worth waking a full Claude session: either already `ready_to_propose`, or still `tracking` but one observation away from the stabilization threshold (`occurrence_count >= 2`). Missing ledger → exits permissively to bootstrap the initial tracking (one-time unlock). |
 | **Enabled** | `false` | Disabled by default. Recommended to stay disabled after merge until `state/consolidation-ledger.json` has accumulated a few weeks of real signal. |
 
 ### How to enable it
@@ -173,7 +173,7 @@ The same mechanism applies to all opt-in crons — see `docs/agent.md`'s "Defaul
 - Already `ready_to_propose` (met the Rule of Three).
 - Still `tracking` but with `occurrence_count >= 2` — one observation away from the count threshold (note: `occurrence_count` alone doesn't promote a candidate; `consecutive_stable_runs` and suppression checks also apply — the preCheck is just a cheap signal, and `consolidation-scan`/`consolidation-fix` remain authoritative).
 
-Missing ledger → exits silently (normal first run). Ledger present but unparsable → exits permissively (unknown state). Zero interesting candidates → exits silently. At least one → exits with a short summary, which becomes the actual cron prompt, so the cron only spends a Claude turn when there's real signal.
+Missing ledger → exits permissively (one-time bootstrap unlock; the scan that creates the ledger must be allowed to run). Ledger present but unparsable → exits permissively (unknown state). Zero interesting candidates → exits silently. At least one → exits with a short summary, which becomes the actual cron prompt, so the cron only spends a Claude turn when there's real signal.
 
 ## See also
 

--- a/plugins/shipwright/scripts/check-consolidation-patrol.ts
+++ b/plugins/shipwright/scripts/check-consolidation-patrol.ts
@@ -15,8 +15,13 @@
  *     worth surfacing; the consolidation-scan/consolidation-fix skills remain
  *     authoritative on whether there's real work.
  *
- * - A missing ledger is a normal first run (no candidates could possibly
- *   exist yet) → exit 1 (nothing to do).
+ * - A missing ledger → exit 0 (permissive; one-time bootstrap unlock). The
+ *   ledger is only ever written by consolidation-scan, which this precheck
+ *   gates — treating "missing" as "nothing to do" is a permanent deadlock,
+ *   since the scan that would create the ledger never gets a chance to run.
+ *   Once consolidation-scan runs once and writes the ledger, subsequent
+ *   precheck runs correctly gate on occurrence_count/ready_to_propose as
+ *   designed.
  * - A ledger that fails to read/parse → exit 0 (permissive; can't rule out
  *   work exists).
  * - Zero interesting candidates → exit 1 (nothing to do).
@@ -81,9 +86,15 @@ export async function run(deps: Deps): Promise<RunResult> {
     };
   }
 
-  // Missing ledger — normal first run, no candidates could possibly exist yet.
+  // Missing ledger — one-time bootstrap unlock. The ledger is only ever
+  // written by consolidation-scan, which this precheck gates; exiting 1
+  // here would permanently deadlock (the scan that creates the ledger
+  // never gets a chance to run).
   if (ledger === null) {
-    return { exit: 1, output: "" };
+    return {
+      exit: 0,
+      output: "No consolidation ledger yet -- running to bootstrap tracking.",
+    };
   }
 
   const interestingCount = Object.values(ledger.candidates).filter(

--- a/plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts
+++ b/plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts
@@ -53,11 +53,11 @@ function candidate(
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("check-consolidation-patrol", () => {
-  test("exits 1 when the ledger is missing (normal first run — no candidates possible)", async () => {
+  test("exits 0 permissively when the ledger is missing (bootstrap — can't rule out work exists)", async () => {
     const deps = makeDeps({ readLedger: () => null });
     const result = await run(deps);
-    expect(result.exit).toBe(1);
-    expect(result.output).toBe("");
+    expect(result.exit).toBe(0);
+    expect(result.output.length).toBeGreaterThan(0);
   });
 
   test("exits 1 when the ledger has zero candidates", async () => {


### PR DESCRIPTION
## Summary
- `check-consolidation-patrol.ts`'s `ledger === null` branch now returns `{ exit: 0, output: "No consolidation ledger yet -- running to bootstrap tracking." }` instead of `{ exit: 1, output: "" }`, fixing a permanent bootstrap deadlock — the ledger is only ever written by `consolidation-scan`, which this exact precheck gates, so the old exit-1 behavior meant the scan that creates the ledger could never run.
- Docblock comment updated to describe the new permissive-bootstrap behavior; `docs/consolidation.md` refreshed to match.
- The unparseable-ledger (catch) branch and the "zero interesting candidates" branch are untouched.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `ledger === null` branch returns `{ exit: 0, output: ... }` with bootstrap message | MET | Returns `{ exit: 0, output: "No consolidation ledger yet -- running to bootstrap tracking." }` |
| 2 | Docblock updated to describe permissive-bootstrap behavior | MET | Docblock bullet rewritten to explain the deadlock and the fix |
| 3 | Catch branch + zero-candidates branch unchanged | MET | Diff shows no changes to those lines |
| 4 | Existing unit test updated to assert exit 0 with bootstrap output | MET | Test renamed and assertions changed to `exit === 0`, non-empty output |

## Test Plan
- Updated `check-consolidation-patrol.unit.test.ts`'s missing-ledger test to assert exit 0 with non-empty output (TDD: confirmed it failed against the pre-fix code, then passed after the fix).
- `bun test plugins/shipwright/scripts/check-consolidation-patrol.unit.test.ts` — 7/7 pass.
- `task typecheck` — passes across all workspaces.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
