### PR TITLE
feat: add principles.md override check + security domain citation to plan-session

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -61,12 +61,16 @@ This is the mechanism for repo-specific scheduled/autonomous behavior — a nigh
 
 ## Lightweight customization without a companion plugin
 
-If all you need is to tweak config or data — not add a new command or skill — a full companion plugin is overkill. The `entropy-scan` skill supports a local override file under `.claude/shipwright/` in the target repo, checked before falling back to the plugin's shipped default — the reference pattern for this kind of lightweight customization:
+If all you need is to tweak config or data — not add a new command or skill — a full companion plugin is overkill. The `entropy-scan` skill and the `plan-session` command support a local override file under `.claude/shipwright/` in the target repo, checked before falling back to the plugin's shipped default — the reference pattern for this kind of lightweight customization:
 
 - Default: `<plugin-dir>/references/principles.md`
 - Override: `.claude/shipwright/principles.md` (project-local, used in its entirety when present — no merging with the default)
 
-Run `/entropy-scan --init` to seed the override file from the plugin default, then edit it to match your project's norms (disable entries, change severity, add project-specific checks). See [`skills/entropy-scan/references/customization.md`](../plugins/shipwright/skills/entropy-scan/references/customization.md) for the full pattern.
+**For `entropy-scan`:** Run `/entropy-scan --init` to seed the override file from the plugin default, then edit it to match your project's norms (disable entries, change severity, add project-specific checks).
+
+**For `plan-session`:** Step 5 (Task Breakdown) automatically checks for a project-level override before loading the default principles file. If `.claude/shipwright/principles.md` exists, it loads and uses that; otherwise, it loads the default. This lets teams define project-specific principles to inform task scope and acceptance criteria.
+
+See [`skills/entropy-scan/references/customization.md`](../plugins/shipwright/skills/entropy-scan/references/customization.md) for the full pattern.
 
 Reach for this first if you just need different data or thresholds; reach for a companion plugin when you need genuinely new commands, skills, or scheduled behavior that doesn't fit inside shipwright's existing commands.
 

--- a/plugins/shipwright/commands/plan-session.content.test.ts
+++ b/plugins/shipwright/commands/plan-session.content.test.ts
@@ -108,3 +108,34 @@ describe("plan-session.md — Step 6b template omits requiresHumanApproval (RHA-
     expect(section).not.toContain("Type B");
   });
 });
+
+describe("plan-session.md — Step 5 principles override check + security domain (PCO-1.1)", () => {
+  function extractStep5Section(md: string): string {
+    const match = md.match(/## Step 5: Task Breakdown[\s\S]*?(?=\n### Complexity and Model Scoring)/);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("Step 5 preamble checks .claude/shipwright/principles.md before falling back", () => {
+    const section = extractStep5Section(content);
+    expect(section).toContain(".claude/shipwright/principles.md");
+  });
+
+  it("Step 5 preamble mentions fallback to references/principles.md", () => {
+    const section = extractStep5Section(content);
+    expect(section).toContain("references/principles.md");
+  });
+
+  it("Step 5 preamble describes checking/loading project override before falling back", () => {
+    const section = extractStep5Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toMatch(/check.*project|project.*override|override.*check/);
+  });
+
+  it("Step 5 preamble cites security as one of the domains alongside architecture and testing", () => {
+    const section = extractStep5Section(content);
+    expect(section).toContain("security");
+    expect(section).toContain("architecture");
+    expect(section).toContain("testing");
+  });
+});

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -167,7 +167,13 @@ Iterate on feedback. Do not move to task breakdown until the design is approved.
 
 Break the approved design into tasks. Each task should be independently shippable (its own PR) unless they are explicitly bundled (see Bundles below).
 
-Before writing tasks, skim `plugins/shipwright/references/principles.md` — the shared architecture/testing principles file `dev-task` and `review` also read from. Let its `architecture` and `testing` domain entries inform each task's scope and acceptance criteria (e.g. respecting `architecture_layering` when splitting a task across layers, or citing the relevant `t*` testing entry when writing the test decision bullet below).
+Before writing tasks, load the principles file:
+
+1. Check for a project-level override: `.claude/shipwright/principles.md` in the project root.
+2. If it exists, load it and print: "Using project config: `.claude/shipwright/principles.md`"
+3. If it does not exist, load the default: `plugins/shipwright/references/principles.md` and print: "No project config found. Using default principles."
+
+Let its `architecture`, `testing`, and `security` domain entries inform each task's scope and acceptance criteria (e.g. respecting `architecture_layering` when splitting a task across layers, citing a relevant `security_*` principle entry when writing security-specific acceptance criteria, or citing the relevant `t*` testing entry when writing the test decision bullet below).
 
 For each task:
 - **ID**: `{PREFIX}-{N}.{M}` — prefix is 2-3 letters from the feature name


### PR DESCRIPTION
## Summary
- `plan-session.md` Step 5 now checks `.claude/shipwright/principles.md` for a project-level override before falling back to `plugins/shipwright/references/principles.md`, mirroring the check-then-fallback-then-print pattern already proven in `entropy-scan/SKILL.md` Step 2.
- Extended the cited principles domains from `architecture`/`testing` to also include `security`.
- Refreshed `docs/extending.md` to document that `plan-session` (not just `entropy-scan`) now supports the `.claude/shipwright/` override pattern.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5's preamble checks `.claude/shipwright/principles.md` before falling back to `references/principles.md`, matching entropy-scan/SKILL.md Step 2's check-then-fallback-then-print pattern | MET |
| 2 | Cited domains list includes `security` alongside `architecture` and `testing` | MET |
| 3 | Test decision: extend `plan-session.content.test.ts` to assert the override-check text and `security` domain citation, purely additive | MET |

## Test Plan
- Added a new `describe` block in `plugins/shipwright/commands/plan-session.content.test.ts` asserting the override-check text and `security` domain citation; all 10 pre-existing tests in that file remain untouched and green.
- `bun test plugins/shipwright/commands/plan-session.content.test.ts` — 14/14 pass.
- `bun run --filter='@shipwright/plugin' typecheck` — passes.
- `bunx biome lint` on changed files — clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
