### PR TITLE
feat: add explicit chaining instruction to error-patrol-maintenance cron prompt

### DIFF
--- a/admin/src/agent-cron-jobs.integration.test.ts
+++ b/admin/src/agent-cron-jobs.integration.test.ts
@@ -144,7 +144,8 @@ const GOLDEN_CODING_CRONS: GoldenCron[] = [
     name: "error-patrol-maintenance",
     schedule: "0 4 * * *",
     prompt:
-      '/shipwright:error-scan\n/shipwright:error-fix\n/shipwright:error-resolve\nAfter the chain completes, write state/error-patrol-ledger.json\'s lastRun field: "<ISO timestamp>". Use [silent] if no new or regressed issues are found.',
+      "/shipwright:error-scan\n/shipwright:error-fix\n/shipwright:error-resolve\nThese three commands are not independent suggestions -- invoke each one immediately after the previous one finishes, in this same session, using the Skill tool. Do not stop after a command's own output tells you to 'run /X next' (e.g. error-scan's summary) -- that phrasing is written for a standalone manual invocation, not this chained cron session. Continue automatically through all three commands before doing anything else.\n" +
+      'After the chain completes, write state/error-patrol-ledger.json\'s lastRun field: "<ISO timestamp>". Use [silent] if no new or regressed issues are found.',
     silent: true,
     preCheck: "shipwright:check-error-patrol.ts",
     enabled: false,

--- a/agent-types/coding/manifest.content.test.ts
+++ b/agent-types/coding/manifest.content.test.ts
@@ -202,3 +202,29 @@ describe("agent-types/coding/manifest.yaml — env contract", () => {
     expect(new Set(allKeys).size).toBe(allKeys.length);
   });
 });
+
+// ─── error-patrol-maintenance cron — chaining instruction ──────────────────
+
+describe("agent-types/coding/manifest.yaml — error-patrol-maintenance chaining", () => {
+  it("error-patrol-maintenance prompt contains explicit chaining instruction", () => {
+    const manifest = parseAgentTypeManifest(rawContent);
+    const errorPatrol = manifest.crons.find(
+      (c) => c.name === "error-patrol-maintenance",
+    );
+    expect(errorPatrol).toBeDefined();
+
+    // The prompt should explicitly instruct the model to invoke each command
+    // immediately after the previous one finishes, and not to treat a
+    // command's own "run /X next" output as a stop signal.
+    const chainingKeywords = [
+      "invoke each one immediately",
+      "Do not stop after",
+      "Continue automatically",
+    ];
+
+    const hasAllKeywords = chainingKeywords.every((keyword) =>
+      errorPatrol?.prompt.includes(keyword),
+    );
+    expect(hasAllKeywords).toBe(true);
+  });
+});

--- a/agent-types/coding/manifest.yaml
+++ b/agent-types/coding/manifest.yaml
@@ -123,6 +123,7 @@ crons:
       /shipwright:error-scan
       /shipwright:error-fix
       /shipwright:error-resolve
+      These three commands are not independent suggestions -- invoke each one immediately after the previous one finishes, in this same session, using the Skill tool. Do not stop after a command's own output tells you to 'run /X next' (e.g. error-scan's summary) -- that phrasing is written for a standalone manual invocation, not this chained cron session. Continue automatically through all three commands before doing anything else.
       After the chain completes, write state/error-patrol-ledger.json's lastRun field: "<ISO timestamp>". Use [silent] if no new or regressed issues are found.
     silent: true
     preCheck: shipwright:check-error-patrol.ts


### PR DESCRIPTION
## Summary
- Insert an explicit continuation instruction into `error-patrol-maintenance`'s `prompt:` block in `agent-types/coding/manifest.yaml`, between the three `/shipwright:X` command lines and the "After the chain completes..." line
- The instruction tells the model to invoke each command immediately after the previous one finishes, in the same session, and to disregard a command's own "run /X next" output as a stop signal
- Adds a content-assertion test to `agent-types/coding/manifest.content.test.ts` guarding against a future edit silently dropping the instruction

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `error-patrol-maintenance` prompt block contains an explicit continuation instruction | MET |
| 2 | YAML still parses via `parseAgentTypeManifest`, no structural schema changes | MET |
| 3 | New content-assertion test added to `manifest.content.test.ts` | MET |

## Test Plan
- [x] New content-assertion test in `manifest.content.test.ts` fails before the fix, passes after
- [x] All 24 tests in `manifest.content.test.ts` pass (23 pre-existing + 1 new)
- [x] `task ci` run — 30 pre-existing failures confirmed unrelated (present on `main` too, in unrelated files: `metrics/src/lib/env.unit.test.ts`, `task-store-provider.integration.test.ts`, `prs.openapi.smoke.test.ts`); no regressions introduced by this change

Generated with [Claude Code](https://claude.com/claude-code)
