### PR TITLE
docs: refresh stale references (2026-08-25)

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"4d948eaf276ff0b0f042ddea40a4ebd2d1230036","timestamp":"2026-08-23T07:02:03Z"}
+{"sha":"988c566f48bc189129197eff1bbf23609e568a35","timestamp":"2026-08-25T07:05:29Z"}


### PR DESCRIPTION
## Summary

Routine `research-docs --auto` docs-freshness audit for the `shipwright` repo, scoped to commits since the last sync anchor (`4d948eaf` → `988c566f`, 24 changed source files).

- Checked candidate docs: `docs/agent-types.md`, `docs/agent.md`, `docs/helm-repo.md`, `docs/deploy-kubernetes.md`, `docs/extending.md`, `docs/consolidation.md`, `docs/testing.md`.
- **No content changes needed.** Every candidate is current:
  - Chart/plugin version bumps (`charts/shipwright/{Chart.yaml,values.yaml,CHANGELOG.md}`, `.claude-plugin/{marketplace,plugin}.json`, `agent/package.json`, `bun.lock`) don't affect any documented fact — the docs describe mechanism/structure, not pinned version numbers.
  - The `error-patrol-maintenance` cron-prompt wording tweak (chained-invocation emphasis) isn't reflected in prose in any doc, and doesn't need to be.
  - `code-reviewer.md`'s principles-source wording change is already accurately described in `docs/extending.md` ("checks for a project-level override... otherwise, it loads the default").
  - `check-consolidation-patrol.ts`'s missing-ledger fix (exit 1 → exit 0, bootstrap-deadlock fix) is already accurately described in `docs/consolidation.md` ("exits permissively to bootstrap the initial tracking (one-time unlock)").
  - `docs/test-readiness/test-system.md` changed but its own delta note confirms no design-affecting change this cycle, so `docs/testing.md`'s digest doesn't need re-generation.
- No new modules without docs — nothing filed to the task store.
- `CLAUDE.md` not touched (no doc set changed).
- Advanced `state/docs-last-synced.json` to HEAD since it's tracked in git and the anchor had drifted forward.

## Test plan

- N/A — anchor-only change, no code or doc content modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)