### PR TITLE
feat: default PostgreSQL image to the bitnamilegacy mirror

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.12.32] - 2026-08-25
+
+### Changed
+
+- default the bundled PostgreSQL image to the bitnamilegacy mirror so a fresh install with default values pulls successfully
+
 ## [1.12.31] - 2026-08-25
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.12.31
+version: 1.12.32
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,7 +30,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.12.31 triggered by release tag agent-v1.186.0"
+      description: "default the bundled PostgreSQL image to the bitnamilegacy mirror so a fresh install with default values pulls successfully"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/README.md
+++ b/charts/shipwright/README.md
@@ -181,7 +181,7 @@ environment, set `postgresql.auth.existingSecret` to a pre-created Secret (or se
 | `admin.resources` | `50m/64Mi → 250m/256Mi` | Admin container resource requests/limits. |
 | `postgresql.enabled` | `true` | Deploy the bundled Bitnami PostgreSQL subchart. |
 | `postgresql.image.registry` | `docker.io` | PostgreSQL image registry (repoint to a mirror — see below). |
-| `postgresql.image.repository` | `bitnami/postgresql` | PostgreSQL image repository. |
+| `postgresql.image.repository` | `bitnamilegacy/postgresql` | PostgreSQL image repository. |
 | `postgresql.auth.database` | `shipwright_admin` | Default database created on first boot. |
 | `postgresql.auth.username` | `shipwright` | Default application user. |
 | `postgresql.auth.password` | `shipwright` | Default password — **change for any non-throwaway env**, or use `existingSecret`. |
@@ -206,15 +206,25 @@ dependencies:
     condition: postgresql.enabled
 ```
 
-**Why this specific pin?** In **2025 Bitnami changed their catalog and registry.**
+**Why this specific pin and mirror?** In **2025 Bitnami changed their catalog and registry.**
 Many image tags were moved to a `bitnamilegacy` repository, and the newest
 secure/hardened images moved behind **Bitnami Secure** (newer chart lines ship a
 default `image.tag: latest` that no longer resolves to a concrete public tag).
 Chart `16.7.27` is pinned because its **default image tag is concrete**
 (`17.6.0-debian-12-r4`), not `latest`, so it renders deterministically.
+**The chart now defaults to the `bitnamilegacy` mirror** to ensure a fresh
+install pulls successfully from the public registry.
 
-**If the default Bitnami registry tags disappear**, repoint the images without
-changing the chart — pick one:
+**If you need the standard `bitnami` repository** (e.g., you have Bitnami Secure
+access or the legacy mirror is deprecated), override the image explicitly:
+
+```yaml
+postgresql:
+  image:
+    repository: bitnami/postgresql
+```
+
+**For other registry scenarios**, pick one of these alternatives:
 
 1. **Mirror the whole stack** in one place:
 
@@ -223,17 +233,7 @@ changing the chart — pick one:
      imageRegistry: <your-mirror-registry>
    ```
 
-2. **Use the `bitnamilegacy` mirror** for the PostgreSQL image specifically:
-
-   ```yaml
-   postgresql:
-     image:
-       registry: docker.io
-       repository: bitnamilegacy/postgresql
-       tag: 17.6.0-debian-12-r4
-   ```
-
-3. **Bring your own PostgreSQL** — disable the subchart entirely and point the
+2. **Bring your own PostgreSQL** — disable the subchart entirely and point the
    admin service at an external database via the `externalDatabase` block:
 
    ```yaml

--- a/charts/shipwright/ci/eks-values.yaml
+++ b/charts/shipwright/ci/eks-values.yaml
@@ -50,11 +50,6 @@ agent:
 
 postgresql:
   enabled: true
-  # Use the `bitnamilegacy` mirror — the default bitnami/postgresql tag is no
-  # longer publicly pullable (see README "Bitnami registry risk").
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
   auth:
     database: shipwright_admin
     username: shipwright

--- a/charts/shipwright/ci/gke-values.yaml
+++ b/charts/shipwright/ci/gke-values.yaml
@@ -68,11 +68,6 @@ agent:
 
 postgresql:
   enabled: true
-  # Use the `bitnamilegacy` mirror — the default bitnami/postgresql tag is no
-  # longer publicly pullable (see README "Bitnami registry risk").
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
   auth:
     database: shipwright_admin
     username: shipwright

--- a/charts/shipwright/ci/minikube-values.yaml
+++ b/charts/shipwright/ci/minikube-values.yaml
@@ -47,13 +47,6 @@ agent:
 
 postgresql:
   enabled: true
-  # Bitnami moved its public catalog behind "Bitnami Secure" in 2025, so the
-  # default docker.io/bitnami/postgresql tag is no longer publicly pullable.
-  # Point CI installs at the `bitnamilegacy` mirror (the fallback documented in
-  # the chart README "Bitnami registry risk" section) so `ct install` can pull.
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
   # Set an explicit password so the install is deterministic across CI re-runs
   # (a Bitnami auto-generated password is fine for a throwaway cluster, but a
   # fixed value keeps `helm test`/connectivity checks reproducible). This is a

--- a/charts/shipwright/examples/values-minikube.yaml
+++ b/charts/shipwright/examples/values-minikube.yaml
@@ -35,11 +35,6 @@ auth:
 
 postgresql:
   enabled: true
-  image:
-    registry: docker.io
-    # Bitnami's 2025 catalog change moved the public `bitnami/postgresql` tags
-    # behind Bitnami Secure. The `bitnamilegacy` mirror still serves them.
-    repository: bitnamilegacy/postgresql
   auth:
     database: shipwright_admin
     username: shipwright

--- a/charts/shipwright/tests/db_bootstrap_job_test.yaml
+++ b/charts/shipwright/tests/db_bootstrap_job_test.yaml
@@ -111,16 +111,16 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^docker\\.io/bitnami/postgresql:"
+          pattern: "^docker\\.io/bitnamilegacy/postgresql:"
 
-  - it: follows a global postgresql image override to a mirror
+  - it: follows a postgresql image override back to bitnami/postgresql
     set:
       postgresql.image.registry: docker.io
-      postgresql.image.repository: bitnamilegacy/postgresql
+      postgresql.image.repository: bitnami/postgresql
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^docker\\.io/bitnamilegacy/postgresql:"
+          pattern: "^docker\\.io/bitnami/postgresql:"
 
   - it: runs as a non-root user
     asserts:

--- a/charts/shipwright/tests/image_defaults_test.yaml
+++ b/charts/shipwright/tests/image_defaults_test.yaml
@@ -18,14 +18,14 @@ templates:
   - templates/chat-deployment.yaml
   - templates/whisper-deployment.yaml
 tests:
-  - it: renders the bitnami/postgresql image from the docker.io registry
+  - it: renders the bitnamilegacy/postgresql image from the docker.io registry
     template: charts/postgresql/templates/primary/statefulset.yaml
     set:
       postgresql.enabled: true
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^docker\\.io/bitnami/postgresql:"
+          pattern: "^docker\\.io/bitnamilegacy/postgresql:"
 
   - it: pins a concrete PostgreSQL image tag (never `latest`)
     template: charts/postgresql/templates/primary/statefulset.yaml
@@ -53,7 +53,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^my-mirror\\.example\\.com/bitnami/postgresql:"
+          pattern: "^my-mirror\\.example\\.com/bitnamilegacy/postgresql:"
 
   # ── DCC-3.1: global.imageRegistry must NOT double-prefix fully-qualified
   # service repositories, but SHOULD still prefix bare repository names. The

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -495,11 +495,13 @@ auth:
 postgresql:
   # -- Deploy the bundled PostgreSQL subchart.
   enabled: true
-  # -- Image overrides. If Bitnami's default registry tags disappear, repoint
-  # `image.registry` / `image.repository` at a mirror (see README "Bitnami registry risk").
+  # -- Image overrides. The `bitnamilegacy` mirror is now the default (Bitnami's
+  # 2025 catalog change moved public tags to Bitnami Secure). To switch back to
+  # the standard `bitnami` repository, override this value explicitly (or see
+  # README "Bitnami registry risk" for alternative mirror options).
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     # tag intentionally left to the pinned subchart default (concrete, not `latest`).
   auth:
     # -- Default database name created on first boot.


### PR DESCRIPTION
## Summary
- Default `postgresql.image.repository` in `charts/shipwright/values.yaml` to `bitnamilegacy/postgresql` (was `bitnami/postgresql`) so a fresh install with default values actually pulls, per Bitnami's 2025 catalog change.
- Remove the now-redundant `postgresql.image.*` overrides from `charts/shipwright/ci/minikube-values.yaml`, `ci/gke-values.yaml`, `ci/eks-values.yaml`, and `examples/values-minikube.yaml` (they duplicated the new default).
- Update the chart README values table and "Bitnami registry risk" prose — `bitnamilegacy` is now the default; `bitnami/postgresql` is documented as the explicit override to switch back to.
- Bitnami postgresql subchart stays pinned at `16.7.27` — no engine swap.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `helm template` renders StatefulSet + db-bootstrap Job with `docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4` | MET | Verified directly with `helm template shipwright charts/shipwright` |
| 2 | Flip existing unit assertions in `image_defaults_test.yaml` + `db_bootstrap_job_test.yaml`; override cases flip to `bitnami/postgresql`; same commit as values.yaml | MET | Flipped in commit `75fdb1d29` alongside the values.yaml change |
| 3 | `helm template` output under `postgresql.enabled=false` unchanged | MET | Verified with `--set postgresql.enabled=false --set externalDatabase.existingSecret=...` — zero bitnami/bitnamilegacy references |
| 4 | `task helm:check` green; Chart.yaml patch-bumped with a CHANGELOG entry | MET | `task helm:check`: lint 0 failed, unittest 344/344 passed, validate 18/18 resources valid. Chart bumped `1.12.31` → `1.12.32`, CHANGELOG entry added |

## Test Plan
- [x] `task helm:check` (lint → unittest → validate) passing locally
- [x] `helm template shipwright charts/shipwright` — default install renders `docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4`
- [x] `helm template shipwright charts/shipwright --set postgresql.enabled=false` — no bitnami/bitnamilegacy image references
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
