### PR TITLE
feat: Ingress TLS + cert-manager ingress-shim (nginx)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.13.1] - 2026-08-25
+
+### Added
+
+- Wire ingress TLS + cert-manager ingress-shim (nginx) into `templates/ingress.yaml` (CNH-3.1): renders `spec.tls: [{hosts: [host], secretName: <fullname>-tls | override}]` when `networking.ingress.tls.enabled` or `tls.certManager.enabled` is set; adds the `nginx.ingress.kubernetes.io/ssl-redirect: "true"` annotation when TLS is on, `networking.ingress.tls.redirect` is true, and the controller is nginx; adds the cert-manager ingress-shim annotation (`cert-manager.io/issuer` or `cert-manager.io/cluster-issuer`, controller-agnostic) keyed by the effective issuer kind/name (`shipwright.certManager.issuerName`/`issuerKind`) when `tls.certManager.enabled=true`. No chart-rendered Certificate CR on the ingress path — cert-manager itself watches the annotations, so TLS works on first install regardless of cert-manager readiness. Broadened `shipwright.ingress.tlsEnabled` (`_helpers.tpl`) to `networking.ingress.tls.enabled OR tls.certManager.enabled`; this helper had no callers before this change. Existing plain-HTTP Ingress output (nginx, TLS off) is unchanged — the annotations-block predicate keeps `networking.ingress.annotations`/task-store-exposure as its first two disjuncts.
+
 ## [1.13.0] - 2026-08-25
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.13.0
+version: 1.13.1
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -31,6 +31,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "ingress TLS/cert-manager helpers, validation, and values/schema groundwork (networking.ingress.controller/tls, tls.certManager.issuer) — no render change; nothing new is wired into templates/ingress.yaml yet"
+    - kind: added
+      description: "wire ingress TLS + cert-manager ingress-shim annotations into templates/ingress.yaml (nginx): renders spec.tls when networking.ingress.tls.enabled or tls.certManager.enabled, adds the nginx.ingress.kubernetes.io/ssl-redirect annotation when TLS + redirect + controller=nginx, and adds cert-manager.io/issuer or cert-manager.io/cluster-issuer keyed by the effective issuer kind/name — no chart-rendered Certificate CR on the ingress path, so TLS works on first install regardless of cert-manager readiness"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -593,12 +593,15 @@ future controller-specific template logic has one place to read this from.
 {{- end }}
 
 {{/*
-shipwright.ingress.tlsEnabled — true when the Ingress should terminate TLS
-(networking.ingress.tls.enabled). GROUNDWORK: templates/ingress.yaml does not
-yet render a `tls:` stanza; this exists for a follow-up task to gate that on.
+shipwright.ingress.tlsEnabled — true when the Ingress should terminate TLS:
+either networking.ingress.tls.enabled=true directly, OR
+tls.certManager.enabled=true (enabling cert-manager on the ingress path
+implies wanting TLS — that's the entire point of the ingress-shim annotations
+templates/ingress.yaml renders). Gates the `tls:` stanza on
+templates/ingress.yaml (CNH-3.1).
 */}}
 {{- define "shipwright.ingress.tlsEnabled" -}}
-{{- if .Values.networking.ingress.tls.enabled }}true{{- end }}
+{{- if or .Values.networking.ingress.tls.enabled .Values.tls.certManager.enabled }}true{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/shipwright/templates/ingress.yaml
+++ b/charts/shipwright/templates/ingress.yaml
@@ -3,19 +3,51 @@
        taskStore.enabled avoids a path/annotation pointing at a Service that does
        not exist. */}}
 {{- $exposeTaskStore := and .Values.taskStore.enabled .Values.taskStore.expose.enabled }}
+{{- /* TLS on this Ingress (CNH-3.1): networking.ingress.tls.enabled directly, OR
+       tls.certManager.enabled (cert-manager on the ingress path implies wanting
+       TLS — see shipwright.ingress.tlsEnabled). */}}
+{{- $tlsEnabled := include "shipwright.ingress.tlsEnabled" . }}
+{{- /* ssl-redirect is an nginx-specific annotation key, so only add it for the
+       nginx controller flavor (shipwright.bundled.nginx) — a meaningless
+       annotation on a traefik-controller deployment would be confusing. */}}
+{{- $sslRedirect := and $tlsEnabled .Values.networking.ingress.tls.redirect (include "shipwright.bundled.nginx" .) }}
+{{- /* cert-manager's ingress-shim annotations are controller-agnostic — cert-manager
+       itself watches these on any Ingress regardless of controller — so they are
+       NOT gated on shipwright.bundled.nginx. Only added when tls.certManager is
+       enabled AND an effective issuer name is resolvable (bring-your-own
+       issuerRef.name, or a chart-managed Issuer via issuer.create=true). */}}
+{{- $issuerName := include "shipwright.certManager.issuerName" . }}
+{{- $certManagerAnnotation := and .Values.tls.certManager.enabled $issuerName }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "shipwright.fullname" . }}
   labels:
     {{- include "shipwright.labels" . | nindent 4 }}
-  {{- if or .Values.networking.ingress.annotations $exposeTaskStore }}
+  {{- if or .Values.networking.ingress.annotations $exposeTaskStore $sslRedirect $certManagerAnnotation }}
   annotations:
     {{- if $exposeTaskStore }}
     # Strip the task-store path prefix before traffic reaches the Service (the
     # task-store app serves /tasks, /tokens, /prs, /health at root). Only set when
     # the task-store route is exposed, so non-exposed installs are unaffected.
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
+    {{- if $sslRedirect }}
+    # HTTP->HTTPS redirect once TLS is on — nginx-specific, so gated on the
+    # nginx controller flavor (networking.ingress.controller=nginx).
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
+    {{- if $certManagerAnnotation }}
+    # cert-manager ingress-shim: cert-manager watches for this annotation and
+    # creates/manages the Certificate itself, so the chart renders NO
+    # Certificate CR on the ingress path (see templates/certificate.yaml, which
+    # only renders for networking.type=gateway). Controller-agnostic — not
+    # gated on shipwright.bundled.nginx.
+    {{- if eq (include "shipwright.certManager.issuerKind" .) "ClusterIssuer" }}
+    cert-manager.io/cluster-issuer: {{ $issuerName }}
+    {{- else }}
+    cert-manager.io/issuer: {{ $issuerName }}
+    {{- end }}
     {{- end }}
     {{- with .Values.networking.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -24,6 +56,12 @@ metadata:
 spec:
   {{- with .Values.networking.ingress.className }}
   ingressClassName: {{ . }}
+  {{- end }}
+  {{- if $tlsEnabled }}
+  tls:
+    - hosts:
+        - {{ .Values.networking.ingress.host | quote }}
+      secretName: {{ include "shipwright.ingress.tlsSecretName" . }}
   {{- end }}
   rules:
     - host: {{ .Values.networking.ingress.host | quote }}

--- a/charts/shipwright/tests/gateway_test.yaml
+++ b/charts/shipwright/tests/gateway_test.yaml
@@ -424,3 +424,16 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: networking.type=ingress with tls.certManager enabled renders the Ingress ingress-shim annotation, not a Gateway/HTTPRoute/Certificate (CNH-3.1)
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt-prod
+    release:
+      name: r
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod

--- a/charts/shipwright/tests/ingress_test.yaml
+++ b/charts/shipwright/tests/ingress_test.yaml
@@ -235,6 +235,94 @@ tests:
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
 
+  # ---- TLS + cert-manager ingress-shim (CNH-3.1) ----
+  - it: renders spec.tls and the cert-manager cluster-issuer ingress-shim annotation when tls.certManager is enabled with a bring-your-own ClusterIssuer
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.host: shipwright.example.com
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt-prod
+      tls.certManager.issuerRef.kind: ClusterIssuer
+    release:
+      name: r
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: r-shipwright-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: shipwright.example.com
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - notExists:
+          path: metadata.annotations["cert-manager.io/issuer"]
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
+          value: "true"
+
+  - it: renders NO Certificate document on the ingress path even when tls.certManager is enabled (ingress-shim — cert-manager watches the annotations itself)
+    template: templates/certificate.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.host: shipwright.example.com
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: letsencrypt-prod
+      tls.certManager.issuerRef.kind: ClusterIssuer
+    release:
+      name: r
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses the cert-manager.io/issuer annotation key (not cluster-issuer) for a chart-managed namespaced Issuer
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: ""
+      tls.certManager.issuer.create: true
+      tls.certManager.issuer.kind: Issuer
+      tls.certManager.issuer.email: admin@example.com
+    release:
+      name: r
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/issuer"]
+          value: r-shipwright-issuer
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+
+  - it: renders spec.tls with an explicit secretName override and no cert-manager annotation when cert-manager is not enabled
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.secretName: my-tls
+    release:
+      name: r
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-tls
+      - notExists:
+          path: metadata.annotations["cert-manager.io/issuer"]
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+
+  - it: omits the ssl-redirect annotation when tls.redirect=false even though TLS is on
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: false
+    release:
+      name: r
+    asserts:
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
+
   - it: renders NO Ingress with the default networking.type (ClusterIP)
     template: templates/ingress.yaml
     asserts:

--- a/charts/shipwright/tests/values_schema_test.yaml
+++ b/charts/shipwright/tests/values_schema_test.yaml
@@ -143,6 +143,23 @@ tests:
     asserts:
       - failedTemplate: {}
 
+  - it: rejects an unknown key under networking.ingress.tls (additionalProperties false, CNH-3.1)
+    set:
+      networking.type: ingress
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.bogus: x
+    asserts:
+      - failedTemplate:
+          errorPattern: "additional properties 'bogus' not allowed"
+
+  - it: rejects an unknown networking.ingress.controller outside the [nginx, traefik] enum (CNH-3.1)
+    set:
+      networking.type: ingress
+      networking.ingress.controller: haproxy
+    asserts:
+      - failedTemplate:
+          errorPattern: "/networking/ingress/controller"
+
   - it: accepts internalKey with key set and existingSecret empty (guard is existingSecret-triggered)
     set:
       metrics.provider.internalKey.key: my-key

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -63,18 +63,14 @@ networking:
     # alb.ingress.kubernetes.io/scheme, /target-type; for NGINX, rewrite/ssl rules.
     annotations: {}
     # -- Which ingress controller flavor networking.ingress.className targets:
-    # "nginx" (the Minikube/NGINX addon default) or "traefik". This is
-    # GROUNDWORK ONLY as of CNH-2.1 — it feeds shipwright.bundled.* /
-    # shipwright.validate helper checks and future controller-specific
-    # annotation/entrypoint wiring, but templates/ingress.yaml does not yet
-    # branch on it. Kept independent from `className` (a free-form string,
-    # e.g. "alb") so validation can flag a className that contradicts this
-    # selector without over-constraining className itself.
+    # "nginx" (the Minikube/NGINX addon default) or "traefik". Feeds
+    # shipwright.bundled.* / shipwright.validate helper checks, and
+    # templates/ingress.yaml gates the nginx-specific ssl-redirect annotation
+    # on this being "nginx" (CNH-3.1). Kept independent from `className` (a
+    # free-form string, e.g. "alb") so validation can flag a className that
+    # contradicts this selector without over-constraining className itself.
     controller: nginx
     # -- TLS settings for the Ingress (used ONLY when networking.type=ingress).
-    # GROUNDWORK ONLY as of CNH-2.1 — templates/ingress.yaml does not yet render
-    # a `tls:` stanza; these values back the new shipwright.ingress.tls* helpers
-    # for a follow-up task to wire in.
     tls:
       # -- Whether the Ingress should terminate TLS. Default false preserves the
       # existing plain-HTTP Ingress behavior.
@@ -123,15 +119,22 @@ networking:
 
 # -- TLS / certificate management for the gateway/ingress host.
 tls:
-  # -- cert-manager integration. When enabled AND networking.type=gateway, renders
-  # a cert-manager.io/v1 Certificate (templates/certificate.yaml) for
-  # networking.gateway.host and the Gateway adds an HTTPS (:443) listener
-  # referencing the issued Secret. An HTTP→HTTPS redirect HTTPRoute is also
-  # rendered on the Gateway's "http" listener so that plaintext traffic is
-  # redirected (301) to HTTPS — the standard expectation for GKE
-  # gke-l7-global-external-managed and any TLS-enabled Gateway deployment.
-  # Has no effect when networking.type is not "gateway". Disabled by default
-  # (Minikube = plain HTTP, no cert-manager installed).
+  # -- cert-manager integration. Behavior depends on networking.type:
+  #    - networking.type=gateway: renders a cert-manager.io/v1 Certificate
+  #      (templates/certificate.yaml) for networking.gateway.host and the
+  #      Gateway adds an HTTPS (:443) listener referencing the issued Secret.
+  #      An HTTP→HTTPS redirect HTTPRoute is also rendered on the Gateway's
+  #      "http" listener so that plaintext traffic is redirected (301) to
+  #      HTTPS — the standard expectation for GKE
+  #      gke-l7-global-external-managed and any TLS-enabled Gateway deployment.
+  #    - networking.type=ingress: renders NO chart-managed Certificate CR.
+  #      Instead, templates/ingress.yaml adds the cert-manager ingress-shim
+  #      annotation (cert-manager.io/issuer or cert-manager.io/cluster-issuer,
+  #      keyed by the effective issuer name/kind) so cert-manager itself
+  #      watches the Ingress and creates/manages the Certificate — this way
+  #      TLS works on first install regardless of cert-manager readiness.
+  #    Has no effect for any other networking.type. Disabled by default
+  #    (Minikube = plain HTTP, no cert-manager installed).
   certManager:
     enabled: false
     # -- Reference to the cert-manager Issuer/ClusterIssuer that signs the cert.

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -45,9 +45,11 @@ served at `/` and the metrics dashboard at `/dashboard`, on a single host:
 | `gateway` | A Gateway API `Gateway` + `HTTPRoute`s | GKE (managed L7) |
 
 `ingress` and `gateway` are mutually exclusive — only one of the two is ever
-rendered. TLS via cert-manager (`tls.certManager.enabled`) currently applies to
-the **gateway** path only; on the ingress path TLS is configured through
-controller-specific annotations (see the EKS section).
+rendered. TLS via cert-manager (`tls.certManager.enabled`) applies to **both**
+the gateway and ingress paths (see the [GKE](#gke-gateway-api--cert-manager)
+and [EKS](#eks-alb-ingress--cert-manager) sections for details on how each
+implements it). On the ingress path, cert-manager is integrated via the
+ingress-shim annotation mechanism rather than a chart-rendered Certificate.
 
 ### Exposing the task-store externally (opt-in)
 
@@ -473,6 +475,8 @@ In practice prefer a values file for the annotations:
 
 ### Key values
 
+The example below uses **AWS Certificate Manager (ACM)** for TLS — the traditional EKS path that requires no cert-manager:
+
 ```yaml
 networking:
   type: ingress
@@ -487,7 +491,7 @@ networking:
       alb.ingress.kubernetes.io/certificate-arn: <your-acm-certificate-arn>
 tls:
   certManager:
-    enabled: false      # ingress-path TLS is via ALB/ACM annotations, not the Gateway Certificate
+    enabled: false      # ACM path: leave cert-manager off
 auth:
   mode: google
   google:
@@ -495,6 +499,39 @@ auth:
     clientSecret: <your-oauth-client-secret>
     allowedEmails: you@your-domain.example
 ```
+
+Alternatively, use **cert-manager** to fully automate certificate provisioning and renewal:
+
+```yaml
+networking:
+  type: ingress
+  ingress:
+    className: alb
+    host: shipwright.example.com
+    controller: nginx              # required by the ingress-shim annotations
+    tls:
+      enabled: true                # render spec.tls on the Ingress
+      redirect: true               # add ssl-redirect annotation (nginx-specific)
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+      # ALB will see the TLS spec rendered by the chart and handle the listener accordingly
+tls:
+  certManager:
+    enabled: true                  # enable cert-manager ingress-shim
+    issuerRef:
+      name: letsencrypt-prod       # a ClusterIssuer that must already exist
+      kind: ClusterIssuer
+auth:
+  mode: google
+  google:
+    clientId: <your-oauth-client-id>
+    clientSecret: <your-oauth-client-secret>
+    allowedEmails: you@your-domain.example
+```
+
+Both paths work on EKS — pick the one that fits your infrastructure. ACM is simpler if you're already using AWS Certificate Manager; cert-manager is more flexible if you prefer a cluster-native certificate controller.
 
 ### Networking
 
@@ -514,14 +551,24 @@ Point your DNS record at the ALB's DNS name once provisioned, then reach:
 
 ### TLS
 
-On the ingress path, TLS is terminated at the ALB via the
-`alb.ingress.kubernetes.io/certificate-arn` annotation (an ACM certificate) and
-`listen-ports`. The chart's cert-manager `Certificate` template applies only to
-the **gateway** path, so leave `tls.certManager.enabled=false` here. If you
-prefer cert-manager-managed certs on EKS, you can still use cert-manager to
-populate a TLS Secret and reference it through the appropriate controller
-annotations, but the chart does not render the `Certificate` for the ingress
-path.
+On the ingress path, TLS can be terminated via two mechanisms:
+
+1. **AWS Certificate Manager (ACM)** — the example above. Requires no
+   cert-manager installation. Set `tls.certManager.enabled=false` and use the
+   `alb.ingress.kubernetes.io/certificate-arn` annotation (an ACM certificate)
+   plus `listen-ports` to configure TLS on the ALB itself. This is the
+   traditional EKS path and requires you to manage the certificate out-of-band.
+
+2. **cert-manager ingress-shim** — when `tls.certManager.enabled=true`, the
+   chart renders the cert-manager ingress-shim annotation
+   (`cert-manager.io/issuer` or `cert-manager.io/cluster-issuer`) on the
+   `Ingress`. cert-manager watches the annotation and automatically creates and
+   manages the TLS Secret. This way the certificate is fully automated and
+   rotated by cert-manager — the `spec.tls` stanza is rendered by the chart, and
+   you only need to configure the Issuer reference via `tls.certManager.issuerRef`
+   (e.g., `letsencrypt-prod`). The chart does **not** render a `Certificate` CR
+   for the ingress path — cert-manager's ingress-shim watches the Ingress
+   annotation and creates it automatically.
 
 ---
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -510,12 +510,16 @@ networking:
     host: shipwright.example.com
     tls:
       enabled: true                # render spec.tls on the Ingress
-      redirect: false              # ALB handles its own HTTP->HTTPS redirect via listen-ports/annotations; this flag only applies to the nginx controller
+      redirect: false              # no-op here — `redirect` only renders the nginx-specific ssl-redirect annotation, so it has no effect on ALB
     annotations:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-      # ALB will see the TLS spec rendered by the chart and handle the listener accordingly
+      # NOTE: listen-ports alone does NOT redirect HTTP->HTTPS on ALB — it only opens
+      # both listeners. To force a redirect, add an actions.ssl-redirect annotation
+      # (protocol: HTTPS, port: "443", statusCode: HTTP_301) plus a matching ingress
+      # rule pointing at the `ssl-redirect` service (servicePort: use-annotation).
+      # Omitted here for brevity; see the AWS Load Balancer Controller docs on SSL redirect.
 tls:
   certManager:
     enabled: true                  # enable cert-manager ingress-shim (controller-agnostic annotation)

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -508,10 +508,9 @@ networking:
   ingress:
     className: alb
     host: shipwright.example.com
-    controller: nginx              # required by the ingress-shim annotations
     tls:
       enabled: true                # render spec.tls on the Ingress
-      redirect: true               # add ssl-redirect annotation (nginx-specific)
+      redirect: false              # ALB handles its own HTTP->HTTPS redirect via listen-ports/annotations; this flag only applies to the nginx controller
     annotations:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/target-type: ip
@@ -519,7 +518,7 @@ networking:
       # ALB will see the TLS spec rendered by the chart and handle the listener accordingly
 tls:
   certManager:
-    enabled: true                  # enable cert-manager ingress-shim
+    enabled: true                  # enable cert-manager ingress-shim (controller-agnostic annotation)
     issuerRef:
       name: letsencrypt-prod       # a ClusterIssuer that must already exist
       kind: ClusterIssuer


### PR DESCRIPTION
## Summary
- Wire `spec.tls` rendering + the `nginx.ingress.kubernetes.io/ssl-redirect` annotation into `templates/ingress.yaml`, gated on TLS being on (either `networking.ingress.tls.enabled` or `tls.certManager.enabled`) and, for ssl-redirect, on the nginx controller flavor
- Add the cert-manager ingress-shim annotation (`cert-manager.io/issuer` or `cert-manager.io/cluster-issuer`, keyed by the effective issuer name/kind) so cert-manager manages the Certificate itself — no chart-rendered Certificate CR on the ingress path, so TLS works on first install regardless of cert-manager readiness
- Broaden the CNH-2.1 `shipwright.ingress.tlsEnabled` helper and refresh stale `values.yaml`/docs comments now that the groundwork is actually wired in

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All existing cases in tests/ingress_test.yaml pass unchanged | MET |
| 2 | New helm-unittest cases for TLS + cert-manager scenarios (ClusterIssuer, chart-managed Issuer, bring-your-own secretName, redirect=false) | MET |
| 3 | Schema cases for tls.certManager+ingress/ClusterIP, missing issuer, unknown tls key, bad controller enum | MET |
| 4 | `helm template` with default values remains byte-identical to the previous chart version | MET |

## Test Plan
- `helm unittest charts/shipwright` — 367/367 tests, 26/26 suites green (including `compat_clusterip_test.yaml` and `certificate_test.yaml` unchanged)
- `helm lint charts/shipwright` — clean
- `helm template charts/shipwright` — default values byte-identical vs. main (modulo intentionally-random secrets)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
