### PR TITLE
feat: Traefik ingress controller support (CNH-4.1)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -76,6 +76,16 @@ jobs:
                 -schema-location default \
                 -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 
+      - name: kubeconform validate — traefik profile (strict, k8s + CRD + traefik middleware schemas)
+        run: |
+          helm template shipwright charts/shipwright --namespace shipwright \
+              -f charts/shipwright/examples/values-cloud-native-traefik.yaml \
+            | kubeconform \
+                -strict \
+                -summary \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
   # End-to-end gate: spin a kind cluster and `ct install` the chart per ci/ values
   # variant, running `helm test` against each install.
   helm-e2e:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,6 +176,17 @@ tasks:
         -schema-location default
         {{ printf "%s" "-schema-location" }}
         {{ printf "%s" "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" }}
+      # Traefik profile: exercises the traefik dialect (ingress.yaml) plus the
+      # Middleware/http-redirect templates against the traefik.io/v1alpha1
+      # Middleware CRD schema (same datreeio CRDs-catalog schema-location
+      # above already resolves it).
+      - >-
+        helm template shipwright charts/shipwright --namespace shipwright
+        -f charts/shipwright/examples/values-cloud-native-traefik.yaml
+        | kubeconform -strict -summary
+        -schema-location default
+        {{ printf "%s" "-schema-location" }}
+        {{ printf "%s" "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" }}
 
   helm:check:
     desc: "Local-runnable Helm gate: lint → unittest → validate (no cluster)"

--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.14.0] - 2026-08-25
+
+### Added
+
+- Traefik ingress controller support (CNH-4.1): `templates/ingress.yaml` grows a traefik dialect branch (guarded on `shipwright.bundled.traefik`, nothing changes for `controller=nginx`) adding `traefik.ingress.kubernetes.io/router.entrypoints` (`websecure` when TLS is on, else `web`, using the configurable `networking.ingress.traefik.entrypoints` names), `router.tls: "true"` when TLS is on, and `router.middlewares` (`<ns>-<fullname>-task-store-strip@kubernetescrd`) when the task-store route is exposed; traefik paths are always plain `Prefix` (`/dashboard`, the configured `taskStore.expose.pathPrefix`, `/`) with no capture-group regex and no `nginx.ingress.kubernetes.io/rewrite-target` annotation, since prefix-stripping is delegated to a Middleware instead. New `templates/ingress-traefik-middleware.yaml` renders a StripPrefix Middleware (`<fullname>-task-store-strip`) when task-store is exposed and a redirectScheme Middleware (`<fullname>-redirect-https`) when TLS + redirect are on, both `traefik.io/v1alpha1` and controller-gated. New `templates/ingress-http-redirect.yaml` renders a separate plain-HTTP Ingress (`<fullname>-http-redirect`, no `spec.tls`, entrypoint `web`) bound to the redirect-https Middleware, needed because a TLS-enabled Ingress is a TLS-only router in Traefik's model. New `tests/ingress_traefik_test.yaml` and `tests/ingress_traefik_middleware_test.yaml` (helm-unittest) cover the full traefik x {TLS off/on} x {task-store exposed off/on} matrix plus the zero-render cases for nginx/ClusterIP. New `examples/values-cloud-native-traefik.yaml` plus a matching kubeconform CI step (`.github/workflows/helm.yml`) and `Taskfile.yml` `helm:validate` command validate the `traefik.io/v1alpha1` Middleware CRD schema via the existing datreeio CRDs-catalog schema-location. No `values.yaml`/`values.schema.json` changes — this consumes `controller`/`tls`/`traefik.entrypoints` keys already added in CNH-2.1/CNH-3.1. Default-values (nginx) render output is unchanged.
+
 ## [1.13.1] - 2026-08-25
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.13.1
+version: 1.14.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -33,6 +33,8 @@ annotations:
       description: "ingress TLS/cert-manager helpers, validation, and values/schema groundwork (networking.ingress.controller/tls, tls.certManager.issuer) — no render change; nothing new is wired into templates/ingress.yaml yet"
     - kind: added
       description: "wire ingress TLS + cert-manager ingress-shim annotations into templates/ingress.yaml (nginx): renders spec.tls when networking.ingress.tls.enabled or tls.certManager.enabled, adds the nginx.ingress.kubernetes.io/ssl-redirect annotation when TLS + redirect + controller=nginx, and adds cert-manager.io/issuer or cert-manager.io/cluster-issuer keyed by the effective issuer kind/name — no chart-rendered Certificate CR on the ingress path, so TLS works on first install regardless of cert-manager readiness"
+    - kind: added
+      description: "Traefik ingress controller support (CNH-4.1): templates/ingress.yaml grows a traefik dialect branch (guarded on shipwright.bundled.traefik, nothing changes for controller=nginx) adding traefik.ingress.kubernetes.io/router.entrypoints (websecure when TLS is on, else web, using the configurable networking.ingress.traefik.entrypoints names), router.tls: \"true\" when TLS is on, and router.middlewares (<ns>-<fullname>-task-store-strip@kubernetescrd) when the task-store route is exposed; traefik paths are always plain Prefix (/dashboard, the configured taskStore.expose.pathPrefix, /) with no capture-group regex and no nginx rewrite-target annotation, since prefix-stripping is delegated to a Middleware instead. New templates/ingress-traefik-middleware.yaml renders a StripPrefix Middleware (<fullname>-task-store-strip) when task-store is exposed and a redirectScheme Middleware (<fullname>-redirect-https) when TLS + redirect are on, both traefik.io/v1alpha1 and controller-gated. New templates/ingress-http-redirect.yaml renders a separate plain-HTTP Ingress (<fullname>-http-redirect, no spec.tls, entrypoint web) bound to the redirect-https Middleware, needed because a TLS-enabled Ingress is a TLS-only router in Traefik's model. New tests/ingress_traefik_test.yaml and tests/ingress_traefik_middleware_test.yaml (helm-unittest) cover the full traefik x {TLS off/on} x {task-store exposed off/on} matrix plus the zero-render cases for nginx/ClusterIP. New examples/values-cloud-native-traefik.yaml plus a matching kubeconform CI step (.github/workflows/helm.yml) and Taskfile.yml helm:validate command validate the traefik.io/v1alpha1 Middleware CRD schema via the existing datreeio CRDs-catalog schema-location. No values.yaml/values.schema.json changes — this consumes controller/tls/traefik.entrypoints keys already added in CNH-2.1/CNH-3.1. Default-values (nginx) render output is unchanged."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/examples/values-cloud-native-traefik.yaml
+++ b/charts/shipwright/examples/values-cloud-native-traefik.yaml
@@ -1,0 +1,73 @@
+# Example: Traefik ingress controller, with TLS termination and HTTP->HTTPS
+# redirect enabled, and the task-store API exposed externally under
+# /task-store.
+#
+# This is NOT a ct-discovered ci/ values variant. The kind cluster `ct install`
+# uses runs the NGINX ingress addon and has NO Traefik CRDs (traefik.io/v1alpha1
+# Middleware) installed, so a values file that sets
+# networking.ingress.controller=traefik would make `ct install` fail (the
+# Middleware resources reference an unknown CRD). Keep this under examples/ so
+# ct never picks it up; the CI kubeconform gate (.github/workflows/helm.yml)
+# renders this file directly (no cluster involved) against the datreeio
+# CRDs-catalog schema for traefik.io/v1alpha1 Middleware, so its schema
+# correctness is still checked on every PR.
+#
+#   helm template shipwright charts/shipwright \
+#     -f charts/shipwright/examples/values-cloud-native-traefik.yaml
+#
+# Prerequisites on a real cluster:
+#   - Traefik installed as the ingress controller, with the
+#     traefik.io/v1alpha1 CRDs (Middleware, IngressRoute, etc.) applied.
+#   - cert-manager installed, with a ClusterIssuer named below (e.g.
+#     letsencrypt-prod), OR bring your own TLS Secret via
+#     networking.ingress.tls.secretName.
+
+networking:
+  # Render an Ingress (templates/ingress.yaml) plus the Traefik-specific
+  # Middleware resources (templates/ingress-traefik-middleware.yaml) and the
+  # plain-HTTP redirect Ingress (templates/ingress-http-redirect.yaml).
+  type: ingress
+  ingress:
+    className: traefik
+    host: shipwright.example.com
+    # Selects the traefik dialect in templates/ingress.yaml: router.entrypoints
+    # / router.tls / router.middlewares annotations, plain Prefix paths (no
+    # nginx rewrite-target capture-group trick).
+    controller: traefik
+    tls:
+      # Terminates TLS on this Ingress — adds router.tls: "true" and the
+      # cert-manager ingress-shim annotation below.
+      enabled: true
+      # Renders the redirect-https Middleware plus the separate plain-HTTP
+      # redirect Ingress (an Ingress with spec.tls is a TLS-only router in
+      # Traefik, so plain-HTTP traffic needs its own Ingress on the "web"
+      # entrypoint to be caught and redirected).
+      redirect: true
+    traefik:
+      entrypoints:
+        web: web
+        websecure: websecure
+
+tls:
+  # Issue a TLS cert via cert-manager. Adds the cert-manager.io/cluster-issuer
+  # ingress-shim annotation, controller-agnostic (see templates/ingress.yaml).
+  certManager:
+    enabled: true
+    issuerRef:
+      # A ClusterIssuer that must already exist in the cluster.
+      name: letsencrypt-prod
+      kind: ClusterIssuer
+
+taskStore:
+  enabled: true
+  expose:
+    enabled: true
+    pathPrefix: /task-store
+
+auth:
+  # Real Google OAuth for a public deployment.
+  mode: google
+  google:
+    clientId: REPLACE_ME
+    clientSecret: REPLACE_ME
+    allowedEmails: you@example.com

--- a/charts/shipwright/templates/ingress-http-redirect.yaml
+++ b/charts/shipwright/templates/ingress-http-redirect.yaml
@@ -1,0 +1,37 @@
+{{- /* CNH-4.1: plain-HTTP redirect Ingress, Traefik only. An Ingress with
+       spec.tls set is a TLS-only router in Traefik's model — plaintext
+       requests never reach it — so a SEPARATE Ingress bound to the "web"
+       entrypoint (no spec.tls) is required to catch plain-HTTP traffic and
+       redirect it to HTTPS via the redirect-https Middleware
+       (templates/ingress-traefik-middleware.yaml). Renders only when the
+       controller is traefik, TLS is enabled on the main Ingress, and
+       networking.ingress.tls.redirect is true — the same three-way gate the
+       redirect-https Middleware itself uses. */}}
+{{- $tlsEnabled := include "shipwright.ingress.tlsEnabled" . }}
+{{- if and (eq .Values.networking.type "ingress") (include "shipwright.bundled.traefik" .) $tlsEnabled .Values.networking.ingress.tls.redirect }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "shipwright.fullname" . }}-http-redirect
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: {{ .Values.networking.ingress.traefik.entrypoints.web }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ include "shipwright.fullname" . }}-redirect-https@kubernetescrd
+spec:
+  {{- with .Values.networking.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.networking.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "shipwright.admin.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/shipwright/templates/ingress-traefik-middleware.yaml
+++ b/charts/shipwright/templates/ingress-traefik-middleware.yaml
@@ -1,0 +1,51 @@
+{{- /* CNH-4.1: Traefik Middleware resources. Traefik's per-router behavior
+       (path-prefix stripping, HTTP->HTTPS redirect) is expressed as separate
+       traefik.io/v1alpha1 Middleware CRs referenced from an Ingress via the
+       traefik.ingress.kubernetes.io/router.middlewares annotation
+       (templates/ingress.yaml), rather than nginx's single shared
+       rewrite-target/ssl-redirect annotations. This file renders 0, 1, or 2
+       Middleware documents depending on which features are active — nothing
+       renders at all unless networking.type=ingress AND the controller is
+       traefik. */}}
+{{- if and (eq .Values.networking.type "ingress") (include "shipwright.bundled.traefik" .) }}
+{{- $exposeTaskStore := and .Values.taskStore.enabled .Values.taskStore.expose.enabled }}
+{{- $tlsEnabled := include "shipwright.ingress.tlsEnabled" . }}
+{{- if $exposeTaskStore }}
+# Strips the task-store pathPrefix before traffic reaches the Service (the
+# task-store app serves /tasks, /tokens, /prs, /health at root) — traefik's
+# analogue of nginx's rewrite-target annotation, referenced from
+# templates/ingress.yaml via router.middlewares.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "shipwright.fullname" . }}-task-store-strip
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+spec:
+  stripPrefix:
+    prefixes:
+      - {{ .Values.taskStore.expose.pathPrefix }}
+{{- end }}
+{{- if and $tlsEnabled .Values.networking.ingress.tls.redirect }}
+{{- if $exposeTaskStore }}
+---
+{{- end }}
+# Redirects plain-HTTP requests to HTTPS. Referenced from the separate
+# plain-HTTP redirect Ingress (templates/ingress-http-redirect.yaml) — an
+# Ingress with spec.tls set is a TLS-only router in Traefik's model, so a
+# SEPARATE Ingress on the "web" entrypoint carries this Middleware to catch
+# and redirect plaintext traffic.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "shipwright.fullname" . }}-redirect-https
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+{{- end }}
+{{- end }}

--- a/charts/shipwright/templates/ingress.yaml
+++ b/charts/shipwright/templates/ingress.yaml
@@ -18,24 +18,65 @@
        issuerRef.name, or a chart-managed Issuer via issuer.create=true). */}}
 {{- $issuerName := include "shipwright.certManager.issuerName" . }}
 {{- $certManagerAnnotation := and .Values.tls.certManager.enabled $issuerName }}
+{{- /* Traefik dialect (CNH-4.1): traefik reads TLS/entrypoint/middleware
+       config from annotations rather than the nginx-specific
+       rewrite-target/ssl-redirect keys above. Guarded on
+       shipwright.bundled.traefik so nothing here renders for nginx (or any
+       other controller value) — the nginx branch above is untouched. */}}
+{{- $isTraefik := include "shipwright.bundled.traefik" . }}
+{{- $traefikEntrypoint := .Values.networking.ingress.traefik.entrypoints.web }}
+{{- if $tlsEnabled }}
+{{- $traefikEntrypoint = .Values.networking.ingress.traefik.entrypoints.websecure }}
+{{- end }}
+{{- $traefikMiddlewares := and $isTraefik $exposeTaskStore }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "shipwright.fullname" . }}
   labels:
     {{- include "shipwright.labels" . | nindent 4 }}
-  {{- if or .Values.networking.ingress.annotations $exposeTaskStore $sslRedirect $certManagerAnnotation }}
+  {{- if or .Values.networking.ingress.annotations $exposeTaskStore $sslRedirect $certManagerAnnotation $isTraefik }}
   annotations:
     {{- if $exposeTaskStore }}
     # Strip the task-store path prefix before traffic reaches the Service (the
     # task-store app serves /tasks, /tokens, /prs, /health at root). Only set when
     # the task-store route is exposed, so non-exposed installs are unaffected.
+    # nginx-only: traefik's equivalent path-stripping is a StripPrefix
+    # Middleware attached via router.middlewares below (see
+    # templates/ingress-traefik-middleware.yaml).
+    {{- if include "shipwright.bundled.nginx" . }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
     {{- end }}
     {{- if $sslRedirect }}
     # HTTP->HTTPS redirect once TLS is on — nginx-specific, so gated on the
     # nginx controller flavor (networking.ingress.controller=nginx).
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
+    {{- if $isTraefik }}
+    # Traefik reads routing/TLS config from annotations on the same Ingress
+    # object (rather than a separate CRD) when using the annotation-based
+    # provider. router.entrypoints selects which Traefik entrypoint serves
+    # this Ingress — websecure once TLS terminates here, else web. Entrypoint
+    # NAMES are configurable (networking.ingress.traefik.entrypoints), not
+    # hardcoded, since they're operator-defined on the Traefik install itself.
+    traefik.ingress.kubernetes.io/router.entrypoints: {{ $traefikEntrypoint }}
+    {{- if $tlsEnabled }}
+    # Tells Traefik's router to terminate TLS for this Ingress. Distinct from
+    # (and additive to) the controller-agnostic cert-manager ingress-shim
+    # annotations below, which only control certificate issuance.
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    {{- end }}
+    {{- if $traefikMiddlewares }}
+    # Attaches the StripPrefix Middleware (templates/ingress-traefik-middleware.yaml)
+    # to this router so task-store sees its root paths (/tasks, /tokens, /prs,
+    # /health) after the pathPrefix is stripped — traefik's analogue of the
+    # nginx rewrite-target annotation above, but as a proper namespaced
+    # resource reference rather than a shared per-Ingress rewrite. Format is
+    # traefik's required "<namespace>-<name>@kubernetescrd" cross-provider
+    # middleware reference.
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ include "shipwright.fullname" . }}-task-store-strip@kubernetescrd
+    {{- end }}
     {{- end }}
     {{- if $certManagerAnnotation }}
     # cert-manager ingress-shim: cert-manager watches for this annotation and
@@ -86,8 +127,13 @@ spec:
           # entire matched suffix, making "/$2" a no-op rewrite. Ordinary
           # "/dashboard" is fine, and simpler, when task-store isn't exposed and
           # no rewrite-target exists to interact with.
-          - path: {{ if $exposeTaskStore }}/()(dashboard.*){{ else }}/dashboard{{ end }}
-            pathType: {{ if $exposeTaskStore }}ImplementationSpecific{{ else }}Prefix{{ end }}
+          #
+          # Traefik never uses the capture-group trick — it has no shared
+          # per-Ingress rewrite annotation, so its paths stay plain Prefix
+          # regardless of task-store exposure (stripping is done per-router via
+          # the StripPrefix Middleware instead, see router.middlewares above).
+          - path: {{ if $isTraefik }}/dashboard{{ else if $exposeTaskStore }}/()(dashboard.*){{ else }}/dashboard{{ end }}
+            pathType: {{ if or $isTraefik (not $exposeTaskStore) }}Prefix{{ else }}ImplementationSpecific{{ end }}
             backend:
               service:
                 name: {{ include "shipwright.metrics.fullname" . }}
@@ -98,9 +144,11 @@ spec:
           # Task-store API (opt-in). Declared BEFORE the admin "/" catch-all so the
           # more-specific task-store prefix wins. The nginx rewrite-target
           # annotation above strips the prefix (capture group $2) so the app sees
-          # its root paths (/tasks, /tokens, /prs, /health).
-          - path: {{ .Values.taskStore.expose.pathPrefix }}(/|$)(.*)
-            pathType: ImplementationSpecific
+          # its root paths (/tasks, /tokens, /prs, /health). Traefik strips the
+          # prefix via a StripPrefix Middleware instead (router.middlewares
+          # above), so its path stays a plain Prefix match with no regex.
+          - path: {{ if $isTraefik }}{{ .Values.taskStore.expose.pathPrefix }}{{ else }}{{ .Values.taskStore.expose.pathPrefix }}(/|$)(.*){{ end }}
+            pathType: {{ if $isTraefik }}Prefix{{ else }}ImplementationSpecific{{ end }}
             backend:
               service:
                 name: {{ include "shipwright.taskStore.fullname" . }}
@@ -111,9 +159,10 @@ spec:
           # path above is routed to the admin service. Same no-op-rewrite
           # treatment as metrics above, and for the same reason: the admin app
           # serves real routes below "/" (e.g. /admin/agents/new) and expects
-          # them verbatim, not collapsed by the shared rewrite-target.
-          - path: {{ if $exposeTaskStore }}/()(.*){{ else }}/{{ end }}
-            pathType: {{ if $exposeTaskStore }}ImplementationSpecific{{ else }}Prefix{{ end }}
+          # them verbatim, not collapsed by the shared rewrite-target. Traefik
+          # again stays a plain "/" Prefix match — no shared rewrite to round-trip.
+          - path: {{ if $isTraefik }}/{{ else if $exposeTaskStore }}/()(.*){{ else }}/{{ end }}
+            pathType: {{ if or $isTraefik (not $exposeTaskStore) }}Prefix{{ else }}ImplementationSpecific{{ end }}
             backend:
               service:
                 name: {{ include "shipwright.admin.fullname" . }}

--- a/charts/shipwright/tests/ingress_traefik_middleware_test.yaml
+++ b/charts/shipwright/tests/ingress_traefik_middleware_test.yaml
@@ -1,0 +1,321 @@
+suite: Traefik Middleware + plain-HTTP redirect Ingress (CNH-4.1)
+# Covers templates/ingress-traefik-middleware.yaml (task-store-strip and
+# redirect-https Middleware resources) and templates/ingress-http-redirect.yaml
+# (the plain-HTTP redirect Ingress). Each renders only under its own exact
+# condition set; every other combination must render zero documents.
+tests:
+  # ---- task-store-strip Middleware ----
+  - it: renders the task-store-strip Middleware when controller=traefik and task-store is exposed
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Middleware
+      - equal:
+          path: apiVersion
+          value: traefik.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: r-shipwright-task-store-strip
+      - equal:
+          path: metadata.namespace
+          value: shipwright
+      - equal:
+          path: spec.stripPrefix.prefixes[0]
+          value: /task-store
+
+  - it: honors a configured taskStore.expose.pathPrefix in the StripPrefix spec
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+      taskStore.expose.pathPrefix: /tasks-api
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: spec.stripPrefix.prefixes[0]
+          value: /tasks-api
+
+  - it: renders zero documents when task-store is not exposed
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero documents when taskStore.expose.enabled but taskStore.enabled=false
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: false
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero documents for the nginx controller even with task-store exposed
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: nginx
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero documents for ClusterIP even with controller=traefik and task-store exposed
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ClusterIP
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---- redirect-https Middleware ----
+  - it: renders the redirect-https Middleware when controller=traefik, TLS enabled, and redirect=true
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Middleware
+      - equal:
+          path: metadata.name
+          value: r-shipwright-redirect-https
+      - equal:
+          path: metadata.namespace
+          value: shipwright
+      - equal:
+          path: spec.redirectScheme.scheme
+          value: https
+      - equal:
+          path: spec.redirectScheme.permanent
+          value: true
+
+  - it: renders BOTH Middlewares (2 documents) when task-store is exposed AND TLS+redirect are on
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: renders zero documents when TLS is off (redirect has nothing to redirect to)
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero documents when redirect=false even though TLS is on
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: false
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero documents for the nginx controller even with TLS+redirect on
+    template: templates/ingress-traefik-middleware.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: nginx
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---- plain-HTTP redirect Ingress ----
+  - it: renders the http-redirect Ingress only under the traefik+TLS+redirect three-way gate
+    template: templates/ingress-http-redirect.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: r-shipwright-http-redirect
+      - equal:
+          path: metadata.namespace
+          value: shipwright
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: web
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: shipwright-r-shipwright-redirect-https@kubernetescrd
+      - notExists:
+          path: spec.tls
+      - equal:
+          path: spec.ingressClassName
+          value: traefik
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: r-shipwright-admin
+
+  - it: uses the configured web entrypoint name on the http-redirect Ingress
+    template: templates/ingress-http-redirect.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+      networking.ingress.traefik.entrypoints.web: custom-web
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: custom-web
+
+  - it: renders zero http-redirect documents for the nginx controller
+    template: templates/ingress-http-redirect.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: nginx
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero http-redirect documents for ClusterIP (networking.type != ingress)
+    template: templates/ingress-http-redirect.yaml
+    set:
+      networking.type: ClusterIP
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero http-redirect documents for traefik without TLS
+    template: templates/ingress-http-redirect.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.redirect: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders zero http-redirect documents for traefik with TLS but redirect=false
+    template: templates/ingress-http-redirect.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.tls.redirect: false
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/tests/ingress_traefik_test.yaml
+++ b/charts/shipwright/tests/ingress_traefik_test.yaml
@@ -1,0 +1,272 @@
+suite: Ingress traefik dialect (CNH-4.1)
+# templates/ingress.yaml's traefik branch: router.entrypoints/router.tls/
+# router.middlewares annotations, plain Prefix paths (no nginx rewrite-target
+# capture-group trick). Covers the traefik x {TLS off,on} x {task-store
+# exposed off,on} matrix. release.namespace is pinned to "shipwright" (rather
+# than helm-unittest's own default "NAMESPACE") so the router.middlewares
+# assertion matches the literal acceptance-criteria string.
+tests:
+  # ---- entrypoints + router.tls, TLS off / on ----
+  - it: uses the web entrypoint and omits router.tls when TLS is off
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: web
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+
+  - it: uses the websecure entrypoint and sets router.tls=true when TLS is on
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: websecure
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+          value: "true"
+
+  - it: honors configured (non-default) traefik entrypoint names
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      networking.ingress.traefik.entrypoints.web: custom-web
+      networking.ingress.traefik.entrypoints.websecure: custom-websecure
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: custom-websecure
+
+  # ---- router.middlewares, task-store exposed off / on ----
+  - it: omits router.middlewares when task-store is not exposed
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+
+  - it: sets router.middlewares to the namespaced task-store-strip middleware reference when task-store is exposed
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: shipwright-r-shipwright-task-store-strip@kubernetescrd
+
+  - it: omits router.middlewares when taskStore.expose.enabled but taskStore.enabled=false (guarded, no dangling middleware ref)
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: false
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+
+  # ---- full 2x2 matrix: TLS off/on x task-store exposed off/on ----
+  - it: "matrix: TLS off, task-store not exposed"
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: web
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 2
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /dashboard
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
+
+  - it: "matrix: TLS off, task-store exposed"
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: web
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: shipwright-r-shipwright-task-store-strip@kubernetescrd
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 3
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /dashboard
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /task-store
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[2].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[2].pathType
+          value: Prefix
+
+  - it: "matrix: TLS on, task-store not exposed"
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: websecure
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+          value: "true"
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 2
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
+
+  - it: "matrix: TLS on, task-store exposed (with configured pathPrefix override)"
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      networking.ingress.controller: traefik
+      networking.ingress.className: traefik
+      networking.ingress.tls.enabled: true
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+      taskStore.expose.pathPrefix: /tasks-api
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: websecure
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: shipwright-r-shipwright-task-store-strip@kubernetescrd
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 3
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /tasks-api
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
+
+  # ---- nginx unaffected ----
+  - it: renders none of the traefik annotations for the default (nginx) controller
+    template: templates/ingress.yaml
+    set:
+      networking.type: ingress
+      taskStore.enabled: true
+      taskStore.expose.enabled: true
+      networking.ingress.tls.enabled: true
+    release:
+      name: r
+      namespace: shipwright
+    asserts:
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: /$2

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -2,7 +2,7 @@
 
 > How to deploy the Shipwright services (admin, metrics, agent, task-store, chat, and
 > MCP server) to Kubernetes with the `shipwright` Helm chart — local on Minikube, and in
-> production on GKE (Gateway API + cert-manager) or EKS (ALB + cert-manager).
+> production on GKE (Gateway API + cert-manager), EKS (ALB + cert-manager), or any cluster with Traefik (ingress + cert-manager).
 
 The chart lives at [`charts/shipwright`](../charts/shipwright) and is also
 published to a Helm repo on every chart version bump (see
@@ -13,12 +13,13 @@ PostgreSQL dependency, with Minikube-friendly defaults throughout. Task-store, c
 MCP server are disabled by default; the agent is provisioned dynamically when
 `agent.provisioning.enabled=true` is set.
 
-This guide covers three deployment targets end-to-end, then the cross-cutting
+This guide covers four deployment targets end-to-end, then the cross-cutting
 concerns shared by all of them:
 
 - [Minikube (local, full stack, HTTP + nginx ingress)](#minikube-local) — `task minikube:up`
 - [GKE (Gateway API + cert-manager)](#gke-gateway-api--cert-manager)
 - [EKS (ALB ingress + cert-manager)](#eks-alb-ingress--cert-manager)
+- [Traefik (ingress + cert-manager)](#traefik-ingress--cert-manager)
 - [Agent runtime provisioning model](#agent-runtime-provisioning-model)
 - [Authentication modes](#authentication-modes)
 - [Bringing your own PostgreSQL / Bitnami registry fallback](#bringing-your-own-postgresql--bitnami-registry-fallback)
@@ -41,7 +42,7 @@ served at `/` and the metrics dashboard at `/dashboard`, on a single host:
 | `ClusterIP` | Services only; reach via `kubectl port-forward` | Default; any cluster |
 | `NodePort` | NodePort Services | Bare-metal / kind |
 | `LoadBalancer` | LoadBalancer Services | Cloud L4 LB |
-| `ingress` | An `Ingress` routing `/dashboard` → metrics, `/` → admin | Minikube (nginx), EKS (ALB) |
+| `ingress` | An `Ingress` routing `/dashboard` → metrics, `/` → admin | Minikube (nginx), EKS (ALB), or any cluster with Traefik |
 | `gateway` | A Gateway API `Gateway` + `HTTPRoute`s | GKE (managed L7) |
 
 `ingress` and `gateway` are mutually exclusive — only one of the two is ever
@@ -78,6 +79,11 @@ configurable via `taskStore.expose.pathPrefix`.
 > `nginx.ingress.kubernetes.io/rewrite-target` annotation. On EKS/ALB, configure
 > path rewriting via ALB actions (`alb.ingress.kubernetes.io/actions.*`) or
 > expose the task-store on a dedicated host instead.
+>
+> **Traefik caveat:** Traefik uses a `StripPrefix` middleware instead of a
+> rewrite-target annotation. The chart renders this middleware automatically
+> when `networking.ingress.controller=traefik` and `taskStore.expose.enabled=true`
+> (see `templates/ingress-traefik-middleware.yaml`); no manual annotation work is needed.
 
 ### Chat service (opt-in)
 
@@ -572,6 +578,109 @@ On the ingress path, TLS can be terminated via two mechanisms:
    (e.g., `letsencrypt-prod`). The chart does **not** render a `Certificate` CR
    for the ingress path — cert-manager's ingress-shim watches the Ingress
    annotation and creates it automatically.
+
+---
+
+## Traefik (ingress + cert-manager)
+
+Production deployment on any Kubernetes cluster with Traefik as the ingress controller, with TLS issued by cert-manager. A ready-to-apply example lives at
+[`charts/shipwright/examples/values-cloud-native-traefik.yaml`](../charts/shipwright/examples/values-cloud-native-traefik.yaml).
+
+### Prerequisites
+
+- **Traefik installed** as the cluster's ingress controller, with the Traefik
+  API group CRDs (e.g., `traefik.io/v1alpha1` `Middleware`) applied. Most
+  Traefik Helm charts include these by default.
+- **cert-manager** installed, with a `ClusterIssuer` already created (e.g.
+  `letsencrypt-prod`). cert-manager's CRDs (`cert-manager.io/v1`) must exist
+  before the chart renders the `Certificate`.
+
+### Install
+
+```bash
+helm install shipwright charts/shipwright \
+  --namespace shipwright --create-namespace \
+  -f charts/shipwright/examples/values-cloud-native-traefik.yaml
+```
+
+### Key values
+
+```yaml
+networking:
+  type: ingress
+  ingress:
+    className: traefik
+    host: shipwright.example.com
+    # Traefik-specific settings: entrypoint names configured on the Traefik
+    # instance itself, plus whether to enable the HTTP→HTTPS redirect route.
+    controller: traefik
+    tls:
+      enabled: true                # render spec.tls on the Ingress
+      redirect: true               # render a separate HTTP redirect Ingress (Traefik TLS-only router pattern)
+    traefik:
+      entrypoints:
+        web: web                   # Traefik's HTTP entrypoint name
+        websecure: websecure       # Traefik's HTTPS entrypoint name
+tls:
+  certManager:
+    enabled: true
+    issuerRef:
+      name: letsencrypt-prod       # a ClusterIssuer that must already exist
+      kind: ClusterIssuer
+auth:
+  mode: google
+  google:
+    clientId: <your-oauth-client-id>
+    clientSecret: <your-oauth-client-secret>
+    allowedEmails: you@your-domain.example
+```
+
+### Networking
+
+`networking.type=ingress` with `className: traefik` and `controller: traefik`
+renders an `Ingress` the Traefik controller watches, plus additional Middleware
+CRs for path stripping (when the task-store is exposed). Unlike nginx and ALB,
+Traefik uses annotations to configure routing behavior:
+
+- `traefik.ingress.kubernetes.io/router.entrypoints` — selects which Traefik
+  entrypoint serves this Ingress (e.g., `web` for HTTP-only, `websecure` for
+  HTTPS). The entrypoint names are operator-defined on the Traefik install
+  itself, so they're configurable via `networking.ingress.traefik.entrypoints`.
+- `traefik.ingress.kubernetes.io/router.tls` — when set to `"true"`, tells
+  Traefik to terminate TLS on this Ingress (distinct from the cert-manager
+  certificate issuance below).
+- `traefik.ingress.kubernetes.io/router.middlewares` — attaches `Middleware`
+  resources (like `StripPrefix`) to the Traefik router; automatically applied
+  when `taskStore.expose.enabled=true`.
+
+When `networking.ingress.tls.enabled=true` and `tls.redirect=true`, the chart
+renders two Ingress objects:
+
+1. A main HTTPS-terminating `Ingress` (on the `websecure` entrypoint) routing
+   traffic to admin and metrics.
+2. A separate HTTP `Ingress` (on the `web` entrypoint) that issues a 301 redirect
+   to HTTPS. This is Traefik's standard pattern because an `Ingress` with
+   `spec.tls` is a TLS-only router and cannot also serve plain HTTP — the
+   separate redirect Ingress bridges that gap.
+
+Point your DNS `A`/`AAAA` record at the Traefik gateway's external address once
+provisioned, then reach:
+
+- Admin UI/API: `https://shipwright.example.com/`
+- Metrics dashboard: `https://shipwright.example.com/dashboard/dashboard`
+  (see the Minikube [Reaching the services](#reaching-the-services) note on
+  why the path is doubled)
+
+### TLS
+
+cert-manager issues the certificate when `tls.certManager.enabled=true`. The
+chart renders the cert-manager ingress-shim annotation
+(`cert-manager.io/cluster-issuer` or `cert-manager.io/issuer`) on the main
+HTTPS-terminating `Ingress`; cert-manager watches the annotation and creates a
+`Certificate` CR automatically. The certificate is stored in the `<release>-tls`
+Secret, which the Ingress's `spec.tls` stanza consumes. This annotation-based
+model is controller-agnostic — it works with Traefik, nginx, ALB, and any other
+ingress controller cert-manager supports.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a Traefik dialect branch to `templates/ingress.yaml`: `router.entrypoints` (web/websecure), `router.tls`, and `router.middlewares` annotations, with plain `Prefix` paths (no nginx capture-group/rewrite-target trick)
- New `templates/ingress-traefik-middleware.yaml` (StripPrefix + redirectScheme `Middleware` CRs) and `templates/ingress-http-redirect.yaml` (plain-HTTP redirect Ingress for Traefik's TLS-only-router model), both gated on `networking.ingress.controller=traefik`
- New `examples/values-cloud-native-traefik.yaml`, plus a traefik-profile kubeconform step in `.github/workflows/helm.yml` and the mirrored `Taskfile.yml` `helm:validate` target
- Refreshes `docs/deploy-kubernetes.md` with a new Traefik section
- Bumps chart version 1.13.1 → 1.14.0 with matching CHANGELOG/annotation entries

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New helm-unittest tests covering traefik x {TLS off,on} x {task-store exposed off,on} matrix, plus zero-render guards for the Middleware/redirect-Ingress templates | MET | `tests/ingress_traefik_test.yaml`, `tests/ingress_traefik_middleware_test.yaml` — 395/395 tests pass across all 28 suites |
| 2 | kubeconform (strict, datreeio traefik.io/middleware_v1alpha1.json) passes against `examples/values-cloud-native-traefik.yaml` | MET | Verified locally: 25 resources, 0 invalid/0 errors |
| 3 | `helm template` with default values stays byte-identical to the previous chart version | MET | Diffed against main — only the chart-version label and per-render random secrets differ |

## Test Plan
- [x] `helm unittest charts/shipwright` — 28/28 suites, 395/395 tests pass
- [x] `helm lint charts/shipwright` — clean
- [x] `task helm:check` (lint → unittest → validate, both default and traefik profiles) — clean
- [x] `task check-strings` / `task check-version-sync` — clean

Generated with [Claude Code](https://claude.com/claude-code)
