### PR TITLE
feat: cert-manager bootstrap hook for the bundled cert-manager path

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.17.0] - 2026-08-26
+
+### Added
+
+- cert-manager bootstrap hook for the bundled cert-manager path (CNH-7.1): when cert-manager is bundled in the same release (`cert-manager.enabled=true`), its CRDs are templates in this release and do not exist at first-install apply time, so the chart-managed Issuer/Certificate can no longer be plain inline manifests. New `templates/cert-manager-bootstrap-job.yaml` ships a ConfigMap `<fullname>-cert-manager-bootstrap` (`10-issuer.yaml` if `issuer.create`, `20-certificate.yaml` if `networking.type=gateway` — both from the existing `shipwright.certManager.issuerManifest`/`certificateManifest` helpers) applied by a `post-install,post-upgrade` Job (`hook-weight` `"10"`, after cert-manager's `startupapicheck` at `1` and `db-bootstrap` at `-5`, `hook-delete-policy` `before-hook-creation,hook-succeeded`) whose initContainer `kubectl wait`s for the cert-manager/webhook/cainjector Deployments to be `Available` (300s timeout) before the main container `kubectl apply --server-side --field-manager=shipwright-chart --force-conflicts`s the ConfigMap. A pre-delete cleanup Job (`tls.certManager.bootstrap.cleanupOnDelete`, default `true`) deletes the applied CRs on uninstall, intentionally keeping the issued TLS Secret and ACME account Secret. New `templates/cert-manager-bootstrap-rbac.yaml` adds the ServiceAccount/Role/RoleBinding (regular, non-hook resources so the token survives upgrades) plus a ClusterRole/Binding only when `issuer.kind=ClusterIssuer`. `templates/cert-manager-issuer.yaml` and `templates/certificate.yaml` now render nothing when the new `shipwright.certManager.viaHook` guard is true, so this is the sole render path for those CRs in the bundled-cert-manager case; `helm template` output with default values is byte-identical to before this change.
+
 ## [1.16.3] - 2026-08-26
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.16.3
+version: 1.17.0
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.16.3 triggered by release tag agent-v1.189.0"
+    - kind: added
+      description: "cert-manager bootstrap hook for the bundled cert-manager path (CNH-7.1): when cert-manager is bundled in the same release (cert-manager.enabled=true), its CRDs are templates in this release and do not exist at first-install apply time, so the chart-managed Issuer/Certificate can no longer be plain inline manifests. New templates/cert-manager-bootstrap-job.yaml ships a ConfigMap <fullname>-cert-manager-bootstrap (10-issuer.yaml if issuer.create, 20-certificate.yaml if networking.type=gateway — both from the existing shipwright.certManager.issuerManifest/certificateManifest helpers) applied by a post-install,post-upgrade Job (hook-weight 10, after cert-manager's startupapicheck at 1 and db-bootstrap at -5, hook-delete-policy before-hook-creation,hook-succeeded) whose initContainer kubectl waits for the cert-manager/webhook/cainjector Deployments to be Available before the main container kubectl apply --server-side --force-conflicts's the ConfigMap. A pre-delete cleanup Job (tls.certManager.bootstrap.cleanupOnDelete, default true) deletes the applied CRs on uninstall, intentionally keeping the issued TLS Secret and ACME account Secret. New templates/cert-manager-bootstrap-rbac.yaml adds the ServiceAccount/Role/RoleBinding (regular, non-hook resources so the token survives upgrades) plus a ClusterRole/Binding only when issuer.kind=ClusterIssuer. templates/cert-manager-issuer.yaml and templates/certificate.yaml now render nothing when the new shipwright.certManager.viaHook guard is true, so this is the sole render path for those CRs in the bundled-cert-manager case; `helm template` output with default values is byte-identical to before this change."
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/templates/_helpers.tpl
+++ b/charts/shipwright/templates/_helpers.tpl
@@ -697,18 +697,53 @@ intent. Guards templates/cert-manager-issuer.yaml (CNH-5.1).
 {{- end }}
 
 {{/*
-shipwright.certManager.viaHook — reserved for a FUTURE hook-based-issuance path
-(e.g. a pre-install/pre-upgrade Job that requests a cert out-of-band instead of
-a live cert-manager.io/v1 Certificate resource). No values key backs this
-today — it always renders "" (falsy) — so
-shipwright.certManager.certificateManifest's render guard
-(`tls.certManager.enabled && networking.type == "gateway" && !viaHook`) is
-UNCONDITIONALLY equivalent to today's `tls.certManager.enabled &&
-networking.type == "gateway"` guard. Kept as its own helper (rather than
-inlining `false`) so a follow-up task only has to change this one definition
-to light up the hook path everywhere it is checked.
+shipwright.certManager.viaHook — true when the chart-managed Issuer/Certificate
+must be issued through the post-install/post-upgrade bootstrap hook Job
+(templates/cert-manager-bootstrap-job.yaml, CNH-7.1) instead of as inline
+manifests. This is the case ONLY when cert-manager is BUNDLED in the same
+release (index .Values "cert-manager" "enabled") — on first install its CRDs
+are templates in this very release and do not exist at apply time, so a plain
+cert-manager.io/v1 Issuer/Certificate manifest would fail to apply. The hook
+Job waits for cert-manager to be Available, then `kubectl apply`s the CRs from
+a ConfigMap once the CRDs exist.
+
+Renders "true" when ALL of:
+  - tls.certManager.enabled            (the master cert-manager off-switch), AND
+  - cert-manager.enabled               (the bundled subchart is on), AND
+  - issuer.create OR networking.type=gateway
+                                       (there is actually a chart-managed
+                                       Issuer and/or a gateway Certificate to
+                                       apply — the ingress + bring-your-own-
+                                       Issuer path needs no live CR, it uses
+                                       ingress-shim annotations instead).
+Otherwise renders "" (falsy) and the inline templates/cert-manager-issuer.yaml
+and templates/certificate.yaml render as before.
 */}}
 {{- define "shipwright.certManager.viaHook" -}}
+{{- if and .Values.tls.certManager.enabled (index .Values "cert-manager" "enabled") (or .Values.tls.certManager.issuer.create (eq .Values.networking.type "gateway")) }}true{{- end }}
+{{- end }}
+
+{{/*
+shipwright.certManager.subchartFullname — the fullname the BUNDLED cert-manager
+subchart resolves to, replicating its own cert-manager.fullname helper so the
+bootstrap Job's `kubectl wait` targets the ACTUAL rendered Deployment names
+(<subchartFullname>, <subchartFullname>-webhook, <subchartFullname>-cainjector).
+Honors the cert-manager block's fullnameOverride/nameOverride if a user sets
+them under the `cert-manager:` values key. NOT the parent shipwright.fullname —
+the subchart names off .Release.Name + its own chart name "cert-manager".
+*/}}
+{{- define "shipwright.certManager.subchartFullname" -}}
+{{- $cm := index .Values "cert-manager" | default dict -}}
+{{- if $cm.fullnameOverride -}}
+{{- $cm.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := $cm.nameOverride | default "cert-manager" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/shipwright/templates/cert-manager-bootstrap-job.yaml
+++ b/charts/shipwright/templates/cert-manager-bootstrap-job.yaml
@@ -1,0 +1,211 @@
+{{- if include "shipwright.certManager.viaHook" . }}
+{{- /*
+  cert-manager bootstrap hook (CNH-7.1). Rendered ONLY when
+  shipwright.certManager.viaHook is true — i.e. cert-manager is BUNDLED in the
+  same release (cert-manager.enabled=true), tls.certManager.enabled=true, and
+  there is a chart-managed Issuer (issuer.create) and/or a gateway Certificate
+  to apply.
+
+  WHY THIS EXISTS: when cert-manager ships in the same release, its CRDs
+  (issuers.cert-manager.io, certificates.cert-manager.io, ...) are templates in
+  THIS release and do not exist at first-install apply time. A plain inline
+  cert-manager.io/v1 Issuer/Certificate manifest would therefore fail to apply
+  ("no matches for kind ... in group cert-manager.io"). So the inline templates
+  (templates/cert-manager-issuer.yaml, templates/certificate.yaml) render
+  nothing under viaHook, and their bodies are carried in the ConfigMap below and
+  applied by a post-install/post-upgrade Job that first WAITS for cert-manager
+  (and thus its CRDs + webhook) to be Available.
+
+  Three resources:
+    1. ConfigMap  <fullname>-cert-manager-bootstrap — 10-issuer.yaml (if
+       issuer.create) and 20-certificate.yaml (if gateway), reusing the SAME
+       shipwright.certManager.issuerManifest / certificateManifest helpers the
+       inline templates use, so there is one source of truth for the CR bodies.
+    2. apply Job  <fullname>-cert-manager-bootstrap — post-install,post-upgrade,
+       hook-weight 10 (after cert-manager's own startupapicheck at 1 and the
+       db-bootstrap Job at -5). initContainer `kubectl wait` on the cert-manager
+       Deployments; main container `kubectl apply --server-side` the ConfigMap.
+    3. cleanup Job <fullname>-cert-manager-bootstrap-cleanup — pre-delete hook
+       that deletes the applied CRs on uninstall (issued TLS Secret + ACME
+       account Secret are intentionally KEPT). Gated on
+       tls.certManager.bootstrap.cleanupOnDelete.
+
+  RBAC (ServiceAccount/Role/RoleBinding, and ClusterRole/Binding for a
+  ClusterIssuer) lives in templates/cert-manager-bootstrap-rbac.yaml as REGULAR
+  (non-hook) resources so the SA token stays valid across upgrades.
+*/}}
+{{- $fullname := include "shipwright.fullname" . }}
+{{- $name := printf "%s-cert-manager-bootstrap" $fullname | trunc 63 | trimSuffix "-" }}
+{{- $cmFullname := include "shipwright.certManager.subchartFullname" . }}
+{{- $createIssuer := include "shipwright.certManager.createIssuer" . }}
+{{- $gateway := eq .Values.networking.type "gateway" }}
+{{- $image := include "shipwright.imageRef" (dict "context" $ "repository" "registry.k8s.io/kubectl" "tag" "v1.31.0") }}
+{{- $b := .Values.tls.certManager.bootstrap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  {{- if $createIssuer }}
+  10-issuer.yaml: |
+    {{- include "shipwright.certManager.issuerManifest" . | nindent 4 }}
+  {{- end }}
+  {{- if $gateway }}
+  20-certificate.yaml: |
+    {{- include "shipwright.certManager.certificateManifest" . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ $b.backoffLimit }}
+  activeDeadlineSeconds: {{ $b.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "shipwright.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cert-manager-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ $name }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      initContainers:
+        # Wait for the bundled cert-manager control plane — controller, webhook,
+        # and cainjector — to be Available before applying the CRs. Until the
+        # webhook is up, apply of a cert-manager.io/v1 resource is rejected.
+        - name: wait-cert-manager
+          image: {{ $image | quote }}
+          command:
+            - kubectl
+          args:
+            - wait
+            - --for=condition=Available
+            - --timeout=300s
+            - deployment/{{ $cmFullname }}
+            - deployment/{{ $cmFullname }}-webhook
+            - deployment/{{ $cmFullname }}-cainjector
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          {{- with $b.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      containers:
+        - name: apply
+          image: {{ $image | quote }}
+          command:
+            - kubectl
+          args:
+            - apply
+            - --server-side
+            - --field-manager=shipwright-chart
+            - --force-conflicts
+            - -f
+            - /manifests
+          volumeMounts:
+            - name: manifests
+              mountPath: /manifests
+              readOnly: true
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          {{- with $b.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: manifests
+          configMap:
+            name: {{ $name }}
+{{- if $b.cleanupOnDelete }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-cleanup" $name | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap-cleanup
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ $b.backoffLimit }}
+  activeDeadlineSeconds: {{ $b.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "shipwright.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cert-manager-bootstrap-cleanup
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ $name }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      containers:
+        - name: cleanup
+          image: {{ $image | quote }}
+          # Delete the CRs the apply Job created. --ignore-not-found so an
+          # already-partly-removed release still exits 0. The issued TLS Secret
+          # and the ACME account Secret are INTENTIONALLY not deleted — keeping
+          # them avoids a fresh ACME order / re-issuance on the next install.
+          command:
+            - kubectl
+          args:
+            - delete
+            - --ignore-not-found
+            {{- if $gateway }}
+            - certificate.cert-manager.io/{{ $fullname }}-tls
+            {{- end }}
+            {{- if $createIssuer }}
+            {{- if eq .Values.tls.certManager.issuer.kind "ClusterIssuer" }}
+            - clusterissuer.cert-manager.io/{{ include "shipwright.certManager.issuerName" . }}
+            {{- else }}
+            - issuer.cert-manager.io/{{ include "shipwright.certManager.issuerName" . }}
+            {{- end }}
+            {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          {{- with $b.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/shipwright/templates/cert-manager-bootstrap-rbac.yaml
+++ b/charts/shipwright/templates/cert-manager-bootstrap-rbac.yaml
@@ -1,0 +1,102 @@
+{{- if include "shipwright.certManager.viaHook" . }}
+{{- /*
+  RBAC for the cert-manager bootstrap hook Job (CNH-7.1), rendered ONLY when
+  shipwright.certManager.viaHook is true (cert-manager bundled in the same
+  release AND tls.certManager.enabled AND a chart-managed Issuer and/or gateway
+  Certificate to apply). See templates/cert-manager-bootstrap-job.yaml for the
+  Jobs these back.
+
+  These are REGULAR (non-hook) resources — NOT Helm hooks. If they were hooks
+  they would be recreated on every `helm upgrade`, cycling the ServiceAccount's
+  UID and invalidating already-issued bound tokens (see CLAUDE.md's Debugging
+  note on hook-rendered ServiceAccounts). As regular resources they are applied
+  with the main release, so they exist before the post-install/post-upgrade
+  apply Job (hook-weight 10) fires, and the apply Job's ServiceAccount token
+  stays valid across upgrades.
+
+  Role (namespaced) always renders:
+    - deployments get/list/watch — the apply Job's initContainer runs
+      `kubectl wait --for=condition=Available` on the cert-manager Deployments
+      (needs to read Deployment status).
+    - cert-manager.io issuers/certificates full CRUD — the apply Job
+      `kubectl apply --server-side`s the ConfigMap-sourced Issuer/Certificate,
+      and the cleanup Job deletes them.
+
+  ClusterRole (cluster-scoped) renders ONLY when the chart is creating a
+  ClusterIssuer (createIssuer AND issuer.kind=ClusterIssuer) — a ClusterIssuer
+  is a cluster-scoped resource a namespaced Role cannot reach.
+*/}}
+{{- $name := printf "%s-cert-manager-bootstrap" (include "shipwright.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $clusterScoped := and (include "shipwright.certManager.createIssuer" .) (eq .Values.tls.certManager.issuer.kind "ClusterIssuer") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "certificates"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+{{- if $clusterScoped }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "shipwright.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/shipwright/templates/cert-manager-issuer.yaml
+++ b/charts/shipwright/templates/cert-manager-issuer.yaml
@@ -8,12 +8,16 @@
 # already uses, so issuer.create=true alone (with enabled left at its default
 # false) renders NO Issuer — preserving the documented "disabled by default"
 # behavior instead of silently creating a live Issuer/ClusterIssuer.
-# shipwright.certManager.viaHook is reserved for a FUTURE hook-based-issuance
-# path and always renders falsy today (no values key backs it yet — see
-# _helpers.tpl), so this guard is unconditionally equivalent to
-# `enabled=true && issuer.create=true && !issuerRef.name` for every input that
-# reaches this template today. Disabled by default (enabled=false) → no Issuer
-# renders. Body lives in shipwright.certManager.issuerManifest (_helpers.tpl),
+# shipwright.certManager.viaHook (CNH-7.1) is true when cert-manager is BUNDLED
+# in the same release (cert-manager.enabled) — on first install its CRDs are
+# templates in this release and do not exist at apply time, so an inline Issuer
+# manifest would fail. In that case this template renders NOTHING and the
+# Issuer is instead carried in the cert-manager-bootstrap ConfigMap and applied
+# by the hook Job once cert-manager is Available. For the common
+# bring-your-own-cert-manager path (cert-manager.enabled=false) viaHook is
+# falsy and this template renders the inline Issuer exactly as before.
+# Disabled by default (enabled=false) → no Issuer renders. Body lives in
+# shipwright.certManager.issuerManifest (_helpers.tpl),
 # mirroring the guard-here/body-in-helper split templates/certificate.yaml
 # already uses.
 {{- include "shipwright.validate" . }}

--- a/charts/shipwright/templates/certificate.yaml
+++ b/charts/shipwright/templates/certificate.yaml
@@ -5,12 +5,15 @@
 # setup (networking.type=ingress or ClusterIP), which would produce a
 # Certificate referencing networking.gateway.host (not the ingress host) whose
 # Secret is never mounted or used. Disabled → no Certificate (plain HTTP).
-# shipwright.certManager.viaHook is reserved for a FUTURE hook-based-issuance
-# path and always renders falsy today (no values key backs it yet — see
-# _helpers.tpl), so this guard is UNCONDITIONALLY equivalent to the prior
-# `tls.certManager.enabled && networking.type == "gateway"` guard for every
-# input that reaches this template today (CNH-2.1 groundwork — no render
-# change). cert-manager writes the issued cert into the Secret named here
+# shipwright.certManager.viaHook (CNH-7.1) is true when cert-manager is BUNDLED
+# in the same release (cert-manager.enabled) — on first install its CRDs are
+# templates in this release and do not exist at apply time, so an inline
+# Certificate manifest would fail. In that case this template renders NOTHING
+# and the Certificate is instead carried in the cert-manager-bootstrap
+# ConfigMap and applied by the hook Job once cert-manager is Available. For the
+# common bring-your-own-cert-manager path (cert-manager.enabled=false) viaHook
+# is falsy and this template renders the inline Certificate exactly as before.
+# cert-manager writes the issued cert into the Secret named here
 # ("<fullname>-tls"), which the Gateway's HTTPS listener references via
 # certificateRefs (templates/gateway.yaml). Body lives in
 # shipwright.certManager.certificateManifest (_helpers.tpl) — moved there

--- a/charts/shipwright/tests/cert_manager_bootstrap_job_test.yaml
+++ b/charts/shipwright/tests/cert_manager_bootstrap_job_test.yaml
@@ -1,0 +1,449 @@
+suite: cert-manager bootstrap hook (bundled cert-manager path)
+# CNH-7.1. When cert-manager is bundled in the SAME release
+# (cert-manager.enabled=true), its Issuer/Certificate CRs cannot be plain
+# manifests on first install — the CRDs they depend on are templates in the
+# same release and do not exist at apply time. This suite covers the
+# ConfigMap-carried manifests + the post-install/post-upgrade Job that applies
+# them once cert-manager is Available, the (non-hook) RBAC that backs the Job,
+# and the pre-delete cleanup Job. The `viaHook` guard suppresses the inline
+# Issuer/Certificate whenever this hook path is active.
+#
+# Files under test render nothing unless BOTH cert-manager.enabled=true AND
+# tls.certManager.enabled=true AND (issuer.create OR networking.type=gateway) —
+# see shipwright.certManager.viaHook. Defaults leave both flags false, so the
+# whole feature is off (byte-identical default render — acceptance criterion 3).
+#
+# The cert-manager-bootstrap-job.yaml template renders documents in a stable
+# order: [0] ConfigMap, [1] apply Job, [2] cleanup Job (when cleanupOnDelete).
+# The apply Job and cleanup Job both have kind: Job, so cases assert against a
+# specific documentIndex rather than a kind selector.
+templates:
+  - templates/cert-manager-bootstrap-job.yaml
+  - templates/cert-manager-bootstrap-rbac.yaml
+release:
+  name: r
+  namespace: shipwright
+tests:
+  # ---------------------------------------------------------------------------
+  # Apply Job — hook wiring
+  # ---------------------------------------------------------------------------
+  - it: renders the bootstrap apply Job when cert-manager is bundled + tls.certManager enabled + gateway
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      networking.gateway.host: shipwright.example
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: r-shipwright-cert-manager-bootstrap
+
+  - it: is a post-install AND post-upgrade hook at weight 10 with the right delete policy
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  # ---------------------------------------------------------------------------
+  # Apply Job — init container waits on cert-manager Deployments
+  # ---------------------------------------------------------------------------
+  - it: waits for the cert-manager, webhook, and cainjector Deployments to be Available
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].command[0]
+          value: kubectl
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --for=condition=Available
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: deployment/r-cert-manager
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: deployment/r-cert-manager-webhook
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: deployment/r-cert-manager-cainjector
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --timeout=300s
+
+  - it: uses the registry.k8s.io/kubectl image for the init and main containers
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].image
+          pattern: "^registry\\.k8s\\.io/kubectl:"
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^registry\\.k8s\\.io/kubectl:"
+
+  # ---------------------------------------------------------------------------
+  # Apply Job — main container apply args
+  # ---------------------------------------------------------------------------
+  - it: applies the manifests server-side with a pinned field manager and force-conflicts
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: kubectl
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: apply
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --server-side
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --field-manager=shipwright-chart
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --force-conflicts
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: -f
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: /manifests
+
+  # ---------------------------------------------------------------------------
+  # Apply Job — pod/security/limits
+  # ---------------------------------------------------------------------------
+  - it: restarts OnFailure with the default backoffLimit and activeDeadlineSeconds
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: OnFailure
+      - equal:
+          path: spec.backoffLimit
+          value: 10
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 540
+
+  - it: runs as the non-root distroless kubectl user with a read-only root filesystem
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65532
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: uses the bootstrap ServiceAccount for the apply Job
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: r-shipwright-cert-manager-bootstrap
+
+  - it: applies configured backoffLimit / activeDeadlineSeconds / resources overrides
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 1
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+      tls.certManager.bootstrap.backoffLimit: 4
+      tls.certManager.bootstrap.activeDeadlineSeconds: 123
+      tls.certManager.bootstrap.resources:
+        requests:
+          cpu: 11m
+          memory: 22Mi
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 4
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 123
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 11m
+
+  # ---------------------------------------------------------------------------
+  # ConfigMap contents per networking type ([0] is always the ConfigMap)
+  # ---------------------------------------------------------------------------
+  - it: ships the Issuer AND the Certificate in the bootstrap ConfigMap on the gateway path
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 0
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      networking.gateway.host: shipwright.example
+      tls.certManager.issuer.create: true
+      tls.certManager.issuer.type: selfsigned
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["10-issuer.yaml"]
+      - exists:
+          path: data["20-certificate.yaml"]
+      - matchRegex:
+          path: data["10-issuer.yaml"]
+          pattern: "kind: Issuer"
+      - matchRegex:
+          path: data["20-certificate.yaml"]
+          pattern: "kind: Certificate"
+
+  - it: ships ONLY the Issuer in the ConfigMap on the ingress path (issuer.create, no gateway Certificate)
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentIndex: 0
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: ingress
+      tls.certManager.issuer.create: true
+      tls.certManager.issuer.type: selfsigned
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["10-issuer.yaml"]
+      - notExists:
+          path: data["20-certificate.yaml"]
+
+  # ---------------------------------------------------------------------------
+  # RBAC — SA, Role
+  # ---------------------------------------------------------------------------
+  - it: creates the bootstrap ServiceAccount as a regular (non-hook) resource
+    template: templates/cert-manager-bootstrap-rbac.yaml
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: metadata.name
+          value: r-shipwright-cert-manager-bootstrap
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: grants the Role read on Deployments and full CRUD on cert-manager.io issuers/certificates
+    template: templates/cert-manager-bootstrap-rbac.yaml
+    documentSelector:
+      path: kind
+      value: Role
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - equal:
+          path: metadata.name
+          value: r-shipwright-cert-manager-bootstrap
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["deployments"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cert-manager.io"]
+            resources: ["issuers", "certificates"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # ---------------------------------------------------------------------------
+  # RBAC — ClusterRole only for ClusterIssuer
+  # ---------------------------------------------------------------------------
+  - it: renders a ClusterRole for clusterissuers ONLY when the chart creates a ClusterIssuer
+    template: templates/cert-manager-bootstrap-rbac.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: ingress
+      tls.certManager.issuer.create: true
+      tls.certManager.issuer.kind: ClusterIssuer
+      tls.certManager.issuer.type: selfsigned
+    asserts:
+      - equal:
+          path: metadata.name
+          value: r-shipwright-cert-manager-bootstrap
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cert-manager.io"]
+            resources: ["clusterissuers"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: renders NO ClusterRole when the chart-managed issuer.kind is Issuer (namespaced)
+    template: templates/cert-manager-bootstrap-rbac.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+      skipEmptyTemplates: true
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuer.create: true
+      tls.certManager.issuer.kind: Issuer
+      tls.certManager.issuer.type: selfsigned
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---------------------------------------------------------------------------
+  # Cleanup Job (pre-delete)
+  # ---------------------------------------------------------------------------
+  - it: renders a pre-delete cleanup Job by default (cleanupOnDelete=true)
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentSelector:
+      path: metadata.annotations["helm.sh/hook"]
+      value: pre-delete
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: r-shipwright-cert-manager-bootstrap-cleanup
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: delete
+
+  - it: renders NO cleanup Job when cleanupOnDelete=false
+    template: templates/cert-manager-bootstrap-job.yaml
+    documentSelector:
+      path: metadata.annotations["helm.sh/hook"]
+      value: pre-delete
+      skipEmptyTemplates: true
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+      tls.certManager.bootstrap.cleanupOnDelete: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---------------------------------------------------------------------------
+  # Off switches — cert-manager.enabled=false suppresses EVERYTHING
+  # ---------------------------------------------------------------------------
+  - it: renders no bootstrap Job/ConfigMap when the bundled cert-manager is disabled (even with tls.certManager on + gateway)
+    template: templates/cert-manager-bootstrap-job.yaml
+    set:
+      cert-manager.enabled: false
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no bootstrap RBAC when the bundled cert-manager is disabled
+    template: templates/cert-manager-bootstrap-rbac.yaml
+    set:
+      cert-manager.enabled: false
+      tls.certManager.enabled: true
+      networking.type: gateway
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no bootstrap resources when tls.certManager is disabled (cert-manager subchart alone is not enough)
+    template: templates/cert-manager-bootstrap-job.yaml
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no bootstrap resources on the ingress path with no chart-managed Issuer (viaHook requires issuer.create OR gateway)
+    template: templates/cert-manager-bootstrap-job.yaml
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: ingress
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing at all with default values
+    templates:
+      - templates/cert-manager-bootstrap-job.yaml
+      - templates/cert-manager-bootstrap-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/shipwright/tests/cert_manager_issuer_test.yaml
+++ b/charts/shipwright/tests/cert_manager_issuer_test.yaml
@@ -145,6 +145,23 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: renders NO inline Issuer when the bundled cert-manager hook path is active (CNH-7.1 — it ships inside the bootstrap ConfigMap instead)
+    # Mirrors the certificate_test.yaml viaHook case. When cert-manager is
+    # bundled in the same release and the chart is creating an Issuer, viaHook is
+    # true, so this inline template renders 0 documents — the Issuer is carried
+    # in the r-shipwright-cert-manager-bootstrap ConfigMap and applied by the
+    # hook Job once cert-manager (and its CRDs) is Available.
+    template: templates/cert-manager-issuer.yaml
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: ingress
+      tls.certManager.issuer.create: true
+      tls.certManager.issuer.type: selfsigned
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: fails the render when networking.type=gateway with issuer.create=true and type=letsencrypt (default) — the HTTP-01 solver has no Ingress to target in gateway mode
     template: templates/cert-manager-issuer.yaml
     set:

--- a/charts/shipwright/tests/certificate_test.yaml
+++ b/charts/shipwright/tests/certificate_test.yaml
@@ -54,6 +54,24 @@ tests:
           path: spec.issuerRef.kind
           value: Issuer
 
+  - it: renders NO inline Certificate when the bundled cert-manager hook path is active (CNH-7.1 — it ships inside the bootstrap ConfigMap instead)
+    # When cert-manager is bundled in the same release, its CRDs are templates in
+    # this release and do not exist at first-install apply time, so a plain
+    # inline Certificate would fail to apply. shipwright.certManager.viaHook is
+    # true here (cert-manager.enabled && tls.certManager.enabled && gateway), so
+    # this template must render 0 documents — the Certificate is carried in the
+    # r-shipwright-cert-manager-bootstrap ConfigMap and applied by the hook Job.
+    template: templates/certificate.yaml
+    set:
+      cert-manager.enabled: true
+      tls.certManager.enabled: true
+      networking.type: gateway
+      networking.gateway.host: shipwright.example
+      tls.certManager.issuerRef.name: letsencrypt
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders NO Certificate when certManager is disabled (default — plain HTTP)
     template: templates/certificate.yaml
     asserts:

--- a/charts/shipwright/values.schema.json
+++ b/charts/shipwright/values.schema.json
@@ -127,6 +127,16 @@
                 "email": { "type": "string" },
                 "server": { "type": "string" }
               }
+            },
+            "bootstrap": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cleanupOnDelete": { "type": "boolean" },
+                "backoffLimit": { "type": "integer" },
+                "activeDeadlineSeconds": { "type": "integer" },
+                "resources": { "type": "object" }
+              }
             }
           },
           "if": {

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -176,6 +176,38 @@ tls:
       # Encrypt staging endpoint (https://acme-staging-v02.api.letsencrypt.org/directory)
       # while testing to avoid production rate limits.
       server: ""
+    # -- Bootstrap hook for the BUNDLED cert-manager path (CNH-7.1). When
+    # cert-manager is bundled in the same release (cert-manager.enabled=true),
+    # its CRDs are templates in this release and do not exist at first-install
+    # apply time, so the chart-managed Issuer/Certificate cannot be plain
+    # manifests. Instead they ship inside a ConfigMap applied by a
+    # post-install/post-upgrade Job that waits for cert-manager to be Available.
+    # This block only takes effect when shipwright.certManager.viaHook is true
+    # (tls.certManager.enabled && cert-manager.enabled && (issuer.create ||
+    # networking.type=gateway)); it is inert for the common
+    # bring-your-own-cert-manager path.
+    bootstrap:
+      # -- Render a pre-delete cleanup Job that deletes the applied Issuer/
+      # Certificate CRs on `helm uninstall`. The issued TLS Secret and the ACME
+      # account Secret are intentionally KEPT (deleting them would force a fresh
+      # ACME order / re-issuance on the next install). Set false to leave the
+      # CRs in place on delete.
+      cleanupOnDelete: true
+      # -- backoffLimit for the apply Job. The initContainer waits for
+      # cert-manager to be Available first, so retries here only cover a
+      # cert-manager that is slow to reconcile the applied CRs.
+      backoffLimit: 10
+      # -- Hard wall-clock deadline (seconds) for the apply Job. Slightly under
+      # the initContainer's 300s Available wait plus apply time.
+      activeDeadlineSeconds: 540
+      # -- Compute resources for the bootstrap Job pods (apply + cleanup).
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
 
 # -- ServiceAccount for shipwright workloads.
 serviceAccount:

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -382,8 +382,12 @@ Gateway API, with TLS issued by cert-manager. A ready-to-apply example lives at
   `gke-l7-global-external-managed` GatewayClass ships with GKE's managed gateway
   controller.
 - **cert-manager** installed, with a `ClusterIssuer` already created (e.g.
-  `letsencrypt-prod`). cert-manager's CRDs (`cert-manager.io/v1`) must exist
-  before the chart renders the `Certificate`.
+  `letsencrypt-prod`). If you're bringing your own cert-manager, its CRDs
+  (`cert-manager.io/v1`) must exist before install. **Alternatively,** you can
+  bundle cert-manager in this same Helm release (see [Bundled ingress
+  controllers and cert-manager](#bundled-ingress-controllers-and-cert-manager-optional)
+  below) — the chart will then apply the `Certificate` after cert-manager's
+  CRDs are ready via a post-install Job hook.
 
 > The chart's `ci/` values used by chart-testing do **not** enable the gateway
 > or cert-manager, because the test kind cluster has neither set of CRDs. That's
@@ -465,7 +469,13 @@ certificate management.
 - **AWS Load Balancer Controller** installed in the cluster — it watches
   `Ingress` objects with `ingressClassName: alb` and provisions an ALB. Without
   it, the rendered `Ingress` has no controller and no load balancer appears.
-- **cert-manager** (or AWS Certificate Manager via annotations) for TLS.
+- **TLS management:** use either AWS Certificate Manager (via annotations,
+  requires no cert-manager), or cert-manager (when bundled or pre-installed). If
+  bringing your own cert-manager, its CRDs (`cert-manager.io/v1`) must exist
+  before install. Alternatively, you can bundle cert-manager in this same Helm
+  release (see [Bundled ingress controllers and cert-manager](#bundled-ingress-controllers-and-cert-manager-optional)
+  below) — the chart will then apply any chart-managed `Issuer` after
+  cert-manager's CRDs are ready via a post-install Job hook.
 
 ### Install
 
@@ -594,8 +604,13 @@ Production deployment on any Kubernetes cluster with Traefik as the ingress cont
   API group CRDs (e.g., `traefik.io/v1alpha1` `Middleware`) applied. Most
   Traefik Helm charts include these by default.
 - **cert-manager** installed, with a `ClusterIssuer` already created (e.g.
-  `letsencrypt-prod`). cert-manager's CRDs (`cert-manager.io/v1`) must exist
-  before the chart renders the `Certificate`.
+  `letsencrypt-prod`). If you're bringing your own cert-manager, its CRDs
+  (`cert-manager.io/v1`) must exist before install. **Alternatively,** you can
+  bundle cert-manager in this same Helm release (see [Bundled ingress
+  controllers and cert-manager](#bundled-ingress-controllers-and-cert-manager-optional)
+  below) — the chart will then apply the `Ingress` TLS stanza and any
+  chart-managed `Issuer` after cert-manager's CRDs are ready via a post-install
+  Job hook.
 
 ### Install
 
@@ -1058,11 +1073,32 @@ chart needed per jetstack v1.15+ convention) and runs a startup API check to ens
 the CRDs are ready. When you `helm uninstall`, the CRDs are preserved to avoid
 deleting custom resources (Certificates, Issuers, etc.) cluster-wide.
 
-This is independent of `tls.certManager.enabled` and the chart's own Issuer
-creation (`tls.certManager.issuer.create`). The bundled cert-manager subchart is
-purely the **controller** — the chart's TLS wiring picks up that controller and
-uses it. You can run cert-manager elsewhere and leave this bundled subchart
-disabled; or enable it here to bring both controller and TLS wiring up together.
+#### CRD-bootstrap hook for bundled cert-manager
+
+When cert-manager is bundled in the **same release** (`cert-manager.enabled=true`)
+and `tls.certManager.enabled=true` with a chart-managed `Issuer` and/or `Certificate`
+to apply (`tls.certManager.issuer.create=true` or `networking.type=gateway`), the
+chart uses a **post-install/post-upgrade bootstrap Job** (CNH-7.1) to apply those
+CRs. This is necessary because on first install, cert-manager's CRDs are templates
+in this release and do not exist at apply time — an inline `Issuer` or `Certificate`
+manifest would fail to apply until cert-manager's webhook is up. The bootstrap Job
+waits for cert-manager to be Available, then applies the CRs from a ConfigMap.
+
+A cleanup Job (pre-delete hook) is also rendered by default to delete the applied
+CRs on `helm uninstall`, preserving the issued TLS Secret and ACME account Secret
+so the next install does not force a fresh ACME order. To disable cleanup on
+delete, set `tls.certManager.bootstrap.cleanupOnDelete: false`.
+
+This bootstrap hook is **only** used for the bundled cert-manager path. If you're
+using `cert-manager.enabled=false` and bringing your own cert-manager (which has
+already had its CRDs installed separately), the chart applies CRs as ordinary inline
+manifests.
+
+This is independent of whether you bring your own cert-manager — the bundled
+cert-manager subchart is purely the **controller**. The chart's TLS wiring picks up
+that controller and uses it. You can run cert-manager elsewhere and leave this
+bundled subchart disabled; or enable it here to bring both controller and TLS
+wiring up together with no external dependencies.
 
 ### All three together (self-contained cloud-native setup)
 


### PR DESCRIPTION
## ⚠️ MERGE GATE — DO NOT AUTO-MERGE

This is the highest-complexity task in the cloud-native-helm-chart effort and is flagged for **human oversight** before it reaches the Vitals OS deployment of shipwright. Leave this PR at reviewed/approved + CI green and **stop there** — do not let the standard deploy loop auto-merge or auto-deploy it. The paired HITL task **CNH-7.3** performs the actual merge.

## Summary
- Adds a post-install/post-upgrade bootstrap Job (`<fullname>-cert-manager-bootstrap`) that applies the chart-managed Issuer/Certificate via `kubectl apply --server-side` once the bundled cert-manager subchart's CRDs and webhook are Available — needed because when cert-manager ships in the *same* Helm release, its CRDs are templates too and don't exist at first-install apply time for a plain inline `cert-manager.io/v1` manifest.
- Ships the Issuer/Certificate bodies inside a ConfigMap (reusing the existing `shipwright.certManager.issuerManifest`/`certificateManifest` helpers verbatim — one source of truth), adds RBAC (SA/Role/ClusterRole as regular non-hook resources so the token survives upgrades), and a pre-delete cleanup Job (gated on `tls.certManager.bootstrap.cleanupOnDelete`, default true) that removes the applied CRs while intentionally keeping the issued TLS Secret and ACME account Secret.
- Wires the previously-dead-code `shipwright.certManager.viaHook` helper (`tls.certManager.enabled && cert-manager.enabled && (issuer.create || networking.type=gateway)`) so the existing inline `certificate.yaml`/`cert-manager-issuer.yaml` guards — already wired for this in CNH-2.1/CNH-5.1 — now correctly suppress inline rendering in favor of the hook path.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New `tests/cert_manager_bootstrap_job_test.yaml` (helm-unittest) covering hook annotations/weight/delete-policy, init-container wait targets, apply args, ConfigMap contents per networking type, SA name, Role rules, ClusterRole gating, runAsNonRoot, overrides, cleanup Job gating, zero-docs when disabled | MET | 22 test cases, all passing |
| 2 | `certificate_test.yaml` asserts no inline Certificate when cert-manager.enabled=true + gateway + tls.certManager.enabled=true | MET | New case added, `hasDocuments: count: 0` |
| 3 | `helm template` with default values byte-identical to previous chart version | MET | Verified via diff against parent commit — only random secret bytes differ |
| 4 | PR left open at reviewed/approved + CI green — no auto-merge/auto-deploy; CNH-7.3 (HITL) performs the merge | Enforced by process, see banner above | N/A |

## Test Plan
- [x] `task helm:check` — helm lint + 443/443 helm-unittest tests pass + kubeconform strict validation (default + traefik profiles) clean
- [x] Default-values render confirmed byte-identical to previous chart version (modulo random secret bytes)
- [x] `task ci` lint/check-strings/check-version-sync/check-config-docs/typecheck all green; the 29 `bun test` failures observed locally in `metrics/`/`task-store/` are pre-existing test-process leakage present on `main` too (confirmed via a clean checkout — unrelated to this chart-only diff)
- [x] Docs refreshed (`docs/deploy-kubernetes.md`) to document the new bootstrap Job behavior

Generated with [Claude Code](https://claude.com/claude-code)
