### PR TITLE
fix: show literal jq extraction in review.md Step 5.5 GraphQL variables

### DIFF
--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1052,6 +1052,43 @@ describe("review.md — Step 5.5 fetches reviewThreads via GraphQL (RUC-1.1)", (
     expect(threadsBlock).toMatch(/comments\(first:\s*20\)/);
     expect(threadsBlock).toContain("createdAt");
   });
+
+  it("Step 5.5 shows the literal jq extraction assigning REVIEWS_JSON, REVIEW_THREADS_JSON, and COMMENTS_JSON as full { nodes: [...] } connection objects, not bare arrays (RNS-1.1)", () => {
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const step6Idx = content.indexOf("## Step 6: Classify Changes by Domain");
+    expect(step5Idx).toBeGreaterThan(-1);
+    expect(step6Idx).toBeGreaterThan(step5Idx);
+    const step5Section = content.slice(step5Idx, step6Idx);
+
+    const itemIdx = step5Section.indexOf("Existing reviews, comments, and inline review threads");
+    expect(itemIdx).toBeGreaterThan(-1);
+    const itemBlock = step5Section.slice(itemIdx, itemIdx + 3000);
+
+    // The graphql call's response must be captured so the extraction below can read it.
+    expect(itemBlock).toContain("RESPONSE=$(gh api graphql -f query=");
+
+    // Each JSON variable must be built by example from the literal jq extraction, not left
+    // to prose inference -- and must hold the full connection object, not the bare inner
+    // array, since Step 9.5 requires the { nodes: [...] } shape.
+    expect(itemBlock).toContain(
+      "HEAD_REF_OID=$(jq -r '.data.repository.pullRequest.headRefOid' <<< \"$RESPONSE\")",
+    );
+    expect(itemBlock).toContain(
+      "REVIEWS_JSON=$(jq -c '.data.repository.pullRequest.reviews' <<< \"$RESPONSE\")",
+    );
+    expect(itemBlock).toContain(
+      "REVIEW_THREADS_JSON=$(jq -c '.data.repository.pullRequest.reviewThreads' <<< \"$RESPONSE\")",
+    );
+    expect(itemBlock).toContain(
+      "COMMENTS_JSON=$(jq -c '.data.repository.pullRequest.comments' <<< \"$RESPONSE\")",
+    );
+
+    // The prose must describe fields inside the wrapped object, not phrasing that implies
+    // the bare inner array itself is what gets assigned to the variable.
+    expect(itemBlock).toContain("full connection object");
+    expect(itemBlock).toContain("{ nodes: [...] }");
+    expect(itemBlock).not.toMatch(/Extract `reviews\.nodes\[\]`/);
+  });
 });
 
 describe("review.md — Unresolved Comment Check includes unresolved inline threads (RUC-1.1)", () => {

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -223,7 +223,7 @@ back to `'sonnet'`.
    review objects only — blind to inline diff-line review comments and their `isResolved`
    state):
    ```bash
-   gh api graphql -f query='
+   RESPONSE=$(gh api graphql -f query='
    {
      repository(owner: "{org}", name: "{repo}") {
        pullRequest(number: {pr}) {
@@ -261,16 +261,26 @@ back to `'sonnet'`.
          }
        }
      }
-   }'
+   }')
    ```
-   Extract `reviews.nodes[]` (including each review's `commit.oid`, needed by Step 9.5's
-   mechanical gate below to filter reviews at the current `headRefOid`), `reviewThreads.nodes[]`
-   (with `isResolved` and up to 20 comments per thread — `author.login`, `body`, `path`, `line`,
-   and `createdAt` for each, not just the first comment; `createdAt` is what Step 9.5's
-   `isThreadAddressedByAuthorReply` exclusion (URT-1.1) needs to detect a PR-author reply posted
-   after a thread's first, flagging comment), and `comments.nodes[]` — the same shape patch.md's
-   Step 3a extracts. Used below by the Unresolved Comment Check and by the unaddressed-findings
-   gate before Step 10.
+   Extract `HEAD_REF_OID`, `REVIEWS_JSON`, `REVIEW_THREADS_JSON`, and `COMMENTS_JSON` from the
+   response — each of the three JSON variables holds the **full connection object**
+   (`{ nodes: [...] }`), not the bare inner array, since Step 9.5 passes them straight through to
+   `compute-unaddressed-findings.ts`, which requires that shape:
+   ```bash
+   HEAD_REF_OID=$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$RESPONSE")
+   REVIEWS_JSON=$(jq -c '.data.repository.pullRequest.reviews' <<< "$RESPONSE")
+   REVIEW_THREADS_JSON=$(jq -c '.data.repository.pullRequest.reviewThreads' <<< "$RESPONSE")
+   COMMENTS_JSON=$(jq -c '.data.repository.pullRequest.comments' <<< "$RESPONSE")
+   ```
+   `REVIEWS_JSON.nodes[]` holds each review (including `commit.oid`, needed by Step 9.5's
+   mechanical gate below to filter reviews at the current `headRefOid`),
+   `REVIEW_THREADS_JSON.nodes[]` holds each thread (with `isResolved` and up to 20 comments per
+   thread — `author.login`, `body`, `path`, `line`, and `createdAt` for each, not just the first
+   comment; `createdAt` is what Step 9.5's `isThreadAddressedByAuthorReply` exclusion (URT-1.1)
+   needs to detect a PR-author reply posted after a thread's first, flagging comment), and
+   `COMMENTS_JSON.nodes[]` holds each comment — the same shape patch.md's Step 3a extracts. Used
+   below by the Unresolved Comment Check and by the unaddressed-findings gate before Step 10.
 
    #### Prior Qualifying Reviews for Subagent Attestation (PVD-1.2)
 


### PR DESCRIPTION
## Summary
- Step 5.5 in `review.md` previously described the GraphQL response only in prose ("extract `reviews.nodes[]`..."), with no literal shell assignment for `REVIEWS_JSON`, `REVIEW_THREADS_JSON`, and `COMMENTS_JSON` — the variables Step 9.5 later passes to `compute-unaddressed-findings.ts`, which requires the full `{ nodes: [...] }` connection shape.
- Added the literal `jq` extraction (`RESPONSE=$(gh api graphql ...)` then `HEAD_REF_OID`/`REVIEWS_JSON`/`REVIEW_THREADS_JSON`/`COMMENTS_JSON=$(jq -c ...)`) immediately after the GraphQL call, and reworded the "Extract..." paragraph to describe fields inside the wrapped object (e.g. `REVIEWS_JSON.nodes[]`) instead of implying the bare inner array is what gets assigned.
- `patch.md`'s similar prose is left untouched per the task's scope note — it has no shape-validating consumer.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 5.5 shows literal jq extraction for HEAD_REF_OID/REVIEWS_JSON/REVIEW_THREADS_JSON/COMMENTS_JSON, each holding `{ nodes: [...] }` | MET |
| 2 | "Extract reviews.nodes[]..." prose reworded to describe fields inside the wrapped object | MET |
| 3 | Step 9.5's existing wording/behavior unchanged | MET |
| 4 | patch.md not modified | MET |
| 5 | Existing content-test assertions still pass; new assertion added pinning the literal extraction | MET |

## Test Plan
- [x] `bun test plugins/shipwright/commands/review.content.test.ts` — 146 pass, 0 fail (including new test)
- [x] `bun test plugins/shipwright/commands/` — 697 pass, 0 fail
- [x] `task typecheck` — passes across all workspaces
- [x] `task lint` — no issues
- Markdown/prompt-content-only change, no runtime code path — no unit/integration/smoke tests needed per task acceptance criteria

Generated with [Claude Code](https://claude.com/claude-code)
