### PR TITLE
feat(site): build zero-JS architecture diagram component for security docs

### DIFF
--- a/site/src/components/SecurityArchDiagram.astro
+++ b/site/src/components/SecurityArchDiagram.astro
@@ -1,0 +1,197 @@
+---
+// Deployment architecture diagram for the security docs page (SDH-1.1).
+// Static Astro component: no client-side JS, brand tokens only (no raw hex).
+// Mirrors the box + arrow visual language of src/pages/agent-model.astro and
+// src/pages/service-architecture.astro.
+---
+
+<div class="sec-diagram" role="img" aria-label="Deployment architecture: Ingress fans out to Admin, Metrics, and MCP. Admin provisions Agent(s). MCP proxies to Task store, which Agent(s) reach via a task-store token.">
+
+  <!-- Ingress -->
+  <div class="sec-row sec-row-single">
+    <div class="sec-box sec-box-ingress">
+      <div class="sec-tag">Ingress</div>
+      <div class="sec-title">Gateway API / ALB / nginx / Traefik</div>
+    </div>
+  </div>
+
+  <div class="sec-arrow-center">
+    <span class="sec-arrow-glyph">↓</span>
+    <span class="sec-arrow-label">HTTPS</span>
+  </div>
+
+  <!-- Fan-out: Admin / Metrics / MCP -->
+  <div class="sec-row sec-row-three">
+    <div class="sec-box sec-box-service">
+      <div class="sec-tag">Admin</div>
+      <div class="sec-title">:3001</div>
+    </div>
+    <div class="sec-box sec-box-service">
+      <div class="sec-tag">Metrics</div>
+      <div class="sec-title">:3460</div>
+    </div>
+    <div class="sec-box sec-box-service">
+      <div class="sec-tag">MCP</div>
+      <div class="sec-title">:3010</div>
+    </div>
+  </div>
+
+  <!-- Arrows down from Admin and MCP (Metrics is a leaf, no downstream box) -->
+  <div class="sec-row sec-row-three">
+    <div class="sec-arrow-center">
+      <span class="sec-arrow-glyph">↓</span>
+      <span class="sec-arrow-label">provisions</span>
+    </div>
+    <div class="sec-arrow-spacer" aria-hidden="true"></div>
+    <div class="sec-arrow-center">
+      <span class="sec-arrow-glyph">↓</span>
+      <span class="sec-arrow-label">proxies</span>
+    </div>
+  </div>
+
+  <!-- Leaves: Agent(s) / (empty) / Task store, with a token link between them -->
+  <div class="sec-row sec-row-three">
+    <div class="sec-box sec-box-leaf">
+      <div class="sec-tag">Agent(s)</div>
+      <div class="sec-title">per-user Deployment</div>
+    </div>
+    <div class="sec-token-link" aria-hidden="true">
+      <span class="sec-token-glyph">←</span>
+      <span class="sec-token-label">task-store token</span>
+    </div>
+    <div class="sec-box sec-box-leaf">
+      <div class="sec-tag">Task store</div>
+      <div class="sec-title">:3000</div>
+    </div>
+  </div>
+
+</div>
+
+<style>
+  .sec-diagram {
+    margin: 1.5rem 0 2rem;
+  }
+
+  .sec-row {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .sec-row-single {
+    grid-template-columns: 1fr;
+  }
+
+  .sec-row-three {
+    grid-template-columns: 1fr 1fr 1fr;
+    align-items: start;
+  }
+
+  /* ── Boxes ── */
+  .sec-box {
+    border-radius: 6px;
+    border-width: 1.5px;
+    border-style: solid;
+    padding: 0.875rem 1rem;
+    text-align: center;
+  }
+
+  .sec-box-ingress {
+    max-width: 20rem;
+    margin: 0 auto;
+    background: var(--sw-color-brand-soft);
+    border-color: var(--sw-color-brand-default);
+  }
+
+  .sec-box-service {
+    background: var(--sw-color-bg-raised);
+    border-color: var(--sw-color-border-muted);
+  }
+
+  .sec-box-leaf {
+    background: color-mix(in srgb, var(--sw-color-support-cyan) 10%, transparent);
+    border-color: var(--sw-color-support-cyan);
+  }
+
+  .sec-tag {
+    font-size: 0.6875rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--sw-color-text-heading);
+    margin-bottom: 0.25rem;
+  }
+
+  .sec-title {
+    font-size: 0.75rem;
+    font-family: var(--sw-font-mono);
+    color: var(--sw-color-text-muted);
+  }
+
+  /* ── Arrows ── */
+  .sec-arrow-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0;
+  }
+
+  .sec-arrow-glyph {
+    color: var(--sw-color-border-strong);
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  .sec-arrow-label {
+    font-size: 0.625rem;
+    color: var(--sw-color-text-muted);
+    margin-top: 0.125rem;
+  }
+
+  .sec-arrow-spacer {
+    visibility: hidden;
+  }
+
+  /* ── Token link between Agent(s) and Task store ── */
+  .sec-token-link {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding-top: 1rem;
+  }
+
+  .sec-token-glyph {
+    color: var(--sw-color-support-cyan);
+    font-size: 1.125rem;
+    line-height: 1;
+  }
+
+  .sec-token-label {
+    font-size: 0.625rem;
+    color: var(--sw-color-text-muted);
+    margin-top: 0.125rem;
+    text-align: center;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .sec-row-three {
+      grid-template-columns: 1fr;
+    }
+
+    .sec-arrow-spacer {
+      display: none;
+    }
+
+    .sec-token-link {
+      flex-direction: row;
+      gap: 0.375rem;
+      padding: 0.25rem 0;
+    }
+
+    .sec-token-glyph {
+      transform: rotate(90deg);
+    }
+  }
+</style>

--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -7,6 +7,8 @@ prev: "/docs/the-shipwright-loop"
 next: "/docs/reference"
 ---
 
+import SecurityArchDiagram from '../../components/SecurityArchDiagram.astro'
+
 # Security
 
 This page is a security architecture overview for anyone evaluating Shipwright before deploying it
@@ -38,24 +40,14 @@ Task store, chat, and the MCP server are disabled by default. Per-agent Deployme
 created when `agent.provisioning.enabled=true`; each provisioned agent gets its own Secret and
 PersistentVolumeClaim.
 
-```text
-                          ┌─────────────┐
-                          │   Ingress   │  (Gateway API / ALB / nginx / Traefik)
-                          └──────┬──────┘
-                                 │ HTTPS
-              ┌──────────────────┼──────────────────┐
-              │                  │                   │
-        ┌─────▼─────┐      ┌─────▼─────┐       ┌─────▼─────┐
-        │   Admin   │      │  Metrics  │       │    MCP    │
-        │  :3001    │      │  :3460    │       │  :3010    │
-        └─────┬─────┘      └───────────┘       └─────┬─────┘
-              │ provisions                           │ proxies
-        ┌─────▼─────┐                           ┌─────▼─────┐
-        │  Agent(s) │                           │ Task store│
-        │ (per-user │◄──────────────────────────┤  :3000    │
-        │ Deployment)│      task-store token     └───────────┘
-        └───────────┘
-```
+<SecurityArchDiagram />
+
+| Aspect | AWS (EKS) | GCP (GKE) |
+|---|---|---|
+| Ingress | AWS Load Balancer Controller provisions an ALB from the chart's `Ingress` resource (`ingressClassName: alb`) | Gateway API — the chart renders a `Gateway` and `HTTPRoute`s targeting the `gke-l7-global-external-managed` GatewayClass |
+| TLS | Terminates at the ALB, via an ACM certificate annotation or cert-manager | cert-manager issues TLS via a `ClusterIssuer`, plus an HTTP→HTTPS redirect route |
+| Database | Optional bundled PostgreSQL (Bitnami subchart), off by default — bring your own | Optional bundled PostgreSQL (Bitnami subchart), off by default — bring your own |
+| Storage | Chart-managed PersistentVolumeClaim per provisioned agent, same on both targets | Chart-managed PersistentVolumeClaim per provisioned agent, same on both targets |
 
 ### AWS (EKS)
 

--- a/site/tests/docs-security.spec.ts
+++ b/site/tests/docs-security.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
 
 // Fulfill external font CDN requests immediately so the page's 'load' event
 // fires even when CI can't reach external networks.
@@ -27,6 +28,43 @@ test("security sidebar is present", async ({ page }) => {
   await page.goto("/docs/security");
   const sidebar = page.locator("nav[aria-label='Docs navigation']");
   await expect(sidebar).toBeVisible();
+});
+
+// Architecture diagram component (SDH-1.1) — zero-JS, brand-token diagram
+// replacing the old fenced ```text ASCII block.
+
+test("security page shows all architecture diagram labels", async ({
+  page,
+}) => {
+  await page.goto("/docs/security");
+  const text = (await page.locator("main").textContent()) ?? "";
+  for (const label of [
+    "Ingress",
+    "Admin",
+    "Metrics",
+    "MCP",
+    "Agent(s)",
+    "Task store",
+  ]) {
+    expect(text, `expected label "${label}" to be visible`).toContain(label);
+  }
+});
+
+test("security page ships no runtime JS beyond the analytics tag", async ({
+  page,
+}) => {
+  await page.goto("/docs/security");
+  await expectNoRuntimeJsBeyondAnalytics(page, { allowPagefind: true });
+});
+
+test("security page shows an AWS vs GCP comparison table", async ({
+  page,
+}) => {
+  await page.goto("/docs/security");
+  const row = page.locator("main table tr", { hasText: /ingress/i });
+  await expect(row.first()).toBeVisible();
+  const cell = page.locator("main table td", { hasText: /ALB|Gateway API/i });
+  await expect(cell.first()).toBeVisible();
 });
 
 // One heading-presence check per major section the brief requires coverage


### PR DESCRIPTION
## Summary
- Replace the security docs page's fenced ASCII-art deployment-architecture diagram with `SecurityArchDiagram.astro`, a zero-client-JS component using `--sw-color-*` brand tokens, matching the visual language of `service-architecture.astro`/`agent-model.astro`.
- Add a compact AWS (EKS) vs GCP (GKE) quick-reference table (Ingress/TLS/Database/Storage) directly under the diagram, summarizing the existing prose subsections — no new claims, prose left intact.
- Add Playwright e2e coverage for the new diagram labels, no-runtime-JS guarantee, and the comparison table, without touching the 13 pre-existing heading-presence assertions.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `SecurityArchDiagram.astro` renders a static boxes+arrows diagram via `--sw-color-*` tokens and scoped CSS only, zero client-JS | MET |
| 2 | `security.mdx`'s ASCII block removed, replaced with `<SecurityArchDiagram />`, imported at top | MET |
| 3 | AWS (EKS) vs GCP (GKE) comparison table added under diagram, matching existing prose, prose subsections left intact | MET |
| 4 | All 13 existing heading-presence assertions in `docs-security.spec.ts` pass unmodified | MET |
| 5 | New Playwright e2e assertions added (diagram labels, no-runtime-JS, table renders), additive only | MET |

## Test Plan
- `cd site && npx playwright test docs-security` — 21/21 passed (13 pre-existing heading tests unmodified, 5 pre-existing smoke tests, 3 new tests — labels, no-JS, table)
- `cd site && npx playwright test` (full site suite) — 249/249 passed, no regressions
- `cd site && npx astro build` — succeeds, typechecks templates/MDX
- `task lint` / `task check-strings` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
