### PR TITLE
docs: fix stale Slack App manifest claim in security docs

### DIFF
--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -186,11 +186,37 @@ OAuth token), `SLACK_APP_TOKEN` (Socket Mode app-level token), and `SLACK_SIGNIN
 inbound request signatures) — plus optional vars (`SLACK_ADMIN_TOKEN` for privileged operations,
 `SLACK_ALERT_CHANNEL`, `SLACK_OWNER_USER`).
 
-There is no single, centrally codified Slack app manifest shipped with the project. Each operator
-provisions their own Slack app — the admin console's provisioning wizard automates app creation and
-OAuth — and supplies the resulting tokens as env vars. Permissions are implied by how those tokens
-are used (Socket Mode connection, bot messaging, DM/mention handling), not enumerated in a single
-static scope list.
+Shipwright's Slack app manifest is **centrally codified** in the codebase at `admin/src/slack-provisioning-client.ts`.
+The `buildAgentManifest()` function constructs a Slack App Manifest object with configured
+display_information, bot_user, app_home, and assistant_view. Bot permissions are centrally defined
+in the exported `AGENT_BOT_SCOPES` array, which is embedded into the manifest's `oauth_config.scopes.bot`.
+This manifest-driven approach ensures consistent provisioning: `apps.manifest.create` provisions new
+apps during initial setup, and `apps.manifest.update` keeps the manifest in sync during agent
+lifecycle management.
+
+**Bot scopes** — the following table enumerates every permission the agent's bot user holds:
+
+| Scope | Grants |
+|---|---|
+| **Messaging** | |
+| chat:write | Send messages to channels, DMs, and group conversations |
+| im:write | Send direct messages to users |
+| files:read | Read file metadata and contents |
+| files:write | Upload and modify files |
+| reactions:write | Add and remove emoji reactions |
+| assistant:write | Post messages to Slack Assistant threads |
+| **History-read** | |
+| channels:history | Read message history from public channels |
+| groups:history | Read message history from private channels |
+| im:history | Read direct message history |
+| mpim:history | Read group DM message history |
+| **Directory-read** | |
+| channels:read | List public channels and channel information |
+| users:read | List and read user information |
+| users:read.email | Access user email addresses |
+| **Mention & misc.** | |
+| app_mentions:read | Receive notifications when the agent is mentioned |
+| reactions:read | Read emoji reactions on messages |
 
 ## Pull request review & merge
 

--- a/site/tests/docs-security.spec.ts
+++ b/site/tests/docs-security.spec.ts
@@ -67,6 +67,15 @@ test("security page shows an AWS vs GCP comparison table", async ({
   await expect(cell.first()).toBeVisible();
 });
 
+test("security page shows Slack bot scopes table", async ({ page }) => {
+  await page.goto("/docs/security");
+  const heading = page.locator("h2, h3", { hasText: /slack app/i });
+  await expect(heading.first()).toBeVisible();
+  const table = heading.locator("xpath=following::table[1]");
+  const row = table.locator("tr");
+  await expect(row.first()).toBeVisible();
+});
+
 // One heading-presence check per major section the brief requires coverage
 // for.
 const MAJOR_SECTIONS: Array<[string, RegExp]> = [


### PR DESCRIPTION
## Summary
- Fixed the false "no single, centrally codified Slack app manifest" claim in `site/src/content/docs/security.mdx`'s "Slack App integration" section — replaced it with an accurate description of the `buildAgentManifest()`/`AGENT_BOT_SCOPES`-driven provisioning flow (`admin/src/slack-provisioning-client.ts`), citing `apps.manifest.create`/`apps.manifest.update`.
- Added a new Scope | Grants pipe-table listing every scope in the current `AGENT_BOT_SCOPES` array, grouped into Messaging, History-read, Directory-read, and Mention & misc. categories — mirroring the shape of the existing GitHub App integration section's permissions table.
- Added a new Playwright assertion in `site/tests/docs-security.spec.ts` confirming the Slack scopes table renders near the "Slack App integration" heading.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | False manifest sentence removed, replaced with accurate buildAgentManifest()/AGENT_BOT_SCOPES description citing admin/src/slack-provisioning-client.ts | MET | security.mdx:189-195 |
| 2 | New pipe-table added, grouped messaging/history-read/directory-read/mention-misc, mirroring GitHub table shape | MET | security.mdx:199-219 |
| 3 | Scope list matches AGENT_BOT_SCOPES exactly, re-verified against live source | MET | Verified against admin/src/slack-provisioning-client.ts:123-139 — all 15 scopes match |
| 4 | Existing "Slack App integration" heading assertion still passes | MET | Full suite run — 22/22 passed |
| 5 | New Playwright assertion for Slack scopes table added, no existing tests retired | MET | docs-security.spec.ts:70-77 |

## Test Plan
- `cd site && SKIP_PAGEFIND=1 npm test -- docs-security.spec.ts` — 22/22 passed, including the new Slack scopes table test
- `task typecheck` — all 7 packages pass
- `bunx biome lint` on changed files — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
