### PR TITLE
docs: convert admins-vs-members and one-agent-per-user bullets to tables (SDH-2.2)

### DIFF
--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -270,8 +270,8 @@ Access control is layered around two roles:
 
 | Role | Grant mechanism | Scope/Visibility |
 |---|---|---|
-| **Admin** | Listed in `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, or holding an admin API key | Can see and manage every agent in the deployment: provisioning, env vars, crons, tools, tokens, and deletion |
-| **Agent Member** | Added as an `AgentMember` (by email) to one specific agent | Can see that agent's detail page and, if Slack access is restricted to members, message it — without any visibility into or control over the rest of the fleet |
+| Admin | Listed in `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, or holding an admin API key | Can see and manage every agent in the deployment: provisioning, env vars, crons, tools, tokens, and deletion |
+| Agent Member | Added as an `AgentMember` (by email) to one specific agent | Can see that agent's detail page and, if Slack access is restricted to members, message it — without any visibility into or control over the rest of the fleet |
 
 This lets you grant a teammate scoped visibility into "their" agent without making them an admin
 over every agent in the deployment.

--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -259,22 +259,19 @@ bot identity across many humans makes attribution ambiguous.
 
 Two independent, optional scoping controls narrow an agent's exposure further:
 
-- **`restrictSlackToMembers`** (default `false`) — when `true`, only Slack users registered as that
-  agent's members can DM or mention it; when `false`, any user in the Slack workspace can.
-- **`authorAllowlist`** (default empty, meaning anyone) — a list of GitHub logins whose pull
-  requests the agent will act on. An empty allowlist means any authenticated GitHub user's PRs are
-  eligible.
+| Control | Default | Effect |
+|---|---|---|
+| `restrictSlackToMembers` | `false` | When `true`, only Slack users registered as that agent's members can DM or mention it; when `false`, any user in the Slack workspace can |
+| `authorAllowlist` | empty (anyone) | A list of GitHub logins whose pull requests the agent will act on. An empty allowlist means any authenticated GitHub user's PRs are eligible |
 
 ## Admins vs. agent members
 
 Access control is layered around two roles:
 
-- **Admins** — anyone on `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, or holding an admin API key, can see
-  and manage every agent in the deployment: provisioning, env vars, crons, tools, tokens, and
-  deletion.
-- **Agent members** — a non-admin human, added as an `AgentMember` (by email) to one specific
-  agent, can see that agent's detail page and, if Slack access is restricted to members, message it
-  — without any visibility into or control over the rest of the fleet.
+| Role | Grant mechanism | Scope/Visibility |
+|---|---|---|
+| **Admin** | Listed in `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS`, or holding an admin API key | Can see and manage every agent in the deployment: provisioning, env vars, crons, tools, tokens, and deletion |
+| **Agent Member** | Added as an `AgentMember` (by email) to one specific agent | Can see that agent's detail page and, if Slack access is restricted to members, message it — without any visibility into or control over the rest of the fleet |
 
 This lets you grant a teammate scoped visibility into "their" agent without making them an admin
 over every agent in the deployment.

--- a/site/tests/docs-security.spec.ts
+++ b/site/tests/docs-security.spec.ts
@@ -157,3 +157,27 @@ test("security page shows secrets/token table under Secrets & service-to-service
   });
   await expect(cell.first()).toBeVisible();
 });
+
+test("security page shows one agent per user scoping controls table", async ({
+  page,
+}) => {
+  await page.goto("/docs/security");
+  const heading = page.locator("h2, h3", { hasText: /one agent per user/i });
+  await expect(heading.first()).toBeVisible();
+  const table = heading.first().locator("xpath=following::table[1]");
+  const row = table.locator("tr", { hasText: /restrictSlackToMembers/i });
+  await expect(row.first()).toBeVisible();
+});
+
+test("security page shows admins vs agent members table", async ({
+  page,
+}) => {
+  await page.goto("/docs/security");
+  const heading = page.locator("h2, h3", {
+    hasText: /admins.*members|agent members/i,
+  });
+  await expect(heading.first()).toBeVisible();
+  const table = heading.first().locator("xpath=following::table[1]");
+  const row = table.locator("tr", { hasText: /admin/i });
+  await expect(row.first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Converts the "Admins vs. agent members" bullet list in `site/src/content/docs/security.mdx` into a `Role | Grant mechanism | Scope/Visibility` pipe-table, consistent with the existing K8s RBAC table pattern on the same page.
- Converts the two scoping-control bullets (`restrictSlackToMembers`, `authorAllowlist`) under "One agent per user" into a `Control | Default | Effect` pipe-table, leaving the surrounding narrative prose untouched.
- Adds two new Playwright assertions to `site/tests/docs-security.spec.ts` confirming each new table renders, following the existing heading→table locator pattern used elsewhere in the file.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Admins vs. agent members → Role \| Grant mechanism \| Scope/Visibility table | MET | security.mdx, one row each for Admin and Agent Member, using only facts already in the prior bullets |
| 2 | One agent per user scoping controls → Control \| Default \| Effect table, prose untouched | MET | security.mdx, exact defaults preserved (`restrictSlackToMembers`=false, `authorAllowlist`=empty/anyone); surrounding narrative unchanged |
| 3 | Existing heading-presence assertions still pass | MET | `MAJOR_SECTIONS` entries for both sections unmodified |
| 4 | Two new Playwright assertions added, no tests retired | MET | Two new tests added following the existing `xpath=following::table[1]` locator pattern |

## Test Plan
- `cd site && npm run build` — Astro build succeeds, MDX compiles cleanly (25 pages built)
- `bunx biome lint .` — clean, no errors
- Playwright (`cd site && npm test`) could not execute locally in this sandbox (Chromium requires system libs unavailable without root) — verified correctness instead via built HTML output (`dist/docs/security/index.html`) showing both tables render with expected `<table>`/`<thead>`/`<tbody>` structure and content. CI's Playwright job will run the real e2e suite.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
