### PR TITLE
docs: convert observability captured/redacted lists to a scan table

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,19 +12,20 @@ All services share the same init options and scrub hooks via `buildSentryInitOpt
 
 ## What is collected
 
-When `SENTRY_DSN` is set, a service reports:
+When `SENTRY_DSN` is set, a service reports to Sentry. Below is a summary of what data is captured and what is redacted:
 
-- **Unhandled exceptions and 5xx errors**, with stack traces, after scrubbing (see below).
-- **`console.log` / `console.warn` / `console.error` calls**, forwarded as structured Sentry Logs via `consoleLoggingIntegration`.
-- **Request path and method** for errors that occur inside an HTTP handler (via `@sentry/hono`'s `sentry()` middleware, or the app's own `onError` hook).
-- **Caller identity** (admin or agent token) in error logs from admin, metrics, and task-store, for tracing which token triggered an unhandled error.
-- **Tags** — structured key-value metadata attached to every event: `service` (the reporting service name, always present), and `agent_id` (when initializing Sentry for an agent runner with an `agentId`). These process-wide tags are set once at init time via `buildSentryInitOptions()`'s static `initialScope`. The agent additionally tags `item_type`/`item_id` (`"task"` or `"pr"`, plus that item's id) on any Sentry event captured during `loop-orchestrator.ts`'s `dispatch()` — its per-item execution runs inside a forked Sentry scope (`sentryClient.withScope(...)`, not a bare `Sentry.setTag()` global mutation) so the tags are scoped to that single dispatch and never leak across concurrent or sequential dispatches. This lets a Sentry Issue or Log be attributed to the specific task/PR that was in flight, not just "which service/agent" — see `lib/sentry.ts`'s `ErrorCapturingClient.withScope` and `loop-orchestrator.ts`'s `dispatch()`.
+| Data | Captured by Sentry? |
+|---|---|
+| Unhandled exceptions and 5xx errors, with stack traces | Yes |
+| `console.log` / `console.warn` / `console.error` calls, forwarded as structured logs | Yes |
+| Request path and method for HTTP errors | Yes |
+| Caller identity — which admin or agent token triggered an error | Yes |
+| Tags (structured key-value metadata: `service`, `agent_id`, `item_type`, `item_id`) | Yes |
+| `Authorization` and `Cookie` header values | Redacted — replaced with `[Filtered]` regardless of configuration |
+| Request or response bodies | No — never attached to an event |
+| The live value of any secret-shaped env var | Redacted — scrubbed wherever it appears, including nested inside longer strings |
 
-## What is never collected
-
-- **Request headers** — `Authorization` and `Cookie` header **values** are unconditionally redacted to `[Filtered]` in every event before it leaves the process, regardless of whether any secret env var is set. (The header keys remain; only the values are scrubbed.)
-- **Request bodies** — request/response bodies are never attached to Sentry events.
-- **Secret values** — any currently-set value of a secret-shaped env var (`ANTHROPIC_API_KEY`, `GH_TOKEN`, `SHIPWRIGHT_SESSION_SECRET`, etc. — see `SECRET_ENV_VARS` in `lib/secret-env-vars.ts` for the full list) is redacted to `[Filtered]` wherever it appears in an event or log, including nested inside longer strings. This scrub runs on both error events (`scrubEvent`) and console-derived logs (`scrubLog`).
+**Tags** are structured key-value metadata attached to every event: `service` (the reporting service name, always present), and `agent_id` (when initializing Sentry for an agent runner with an `agentId`). These process-wide tags are set once at init time via `buildSentryInitOptions()`'s static `initialScope`. The agent additionally tags `item_type`/`item_id` (`"task"` or `"pr"`, plus that item's id) on any Sentry event captured during `loop-orchestrator.ts`'s `dispatch()` — its per-item execution runs inside a forked Sentry scope (`sentryClient.withScope(...)`, not a bare `Sentry.setTag()` global mutation) so the tags are scoped to that single dispatch and never leak across concurrent or sequential dispatches. This lets a Sentry Issue or Log be attributed to the specific task/PR that was in flight, not just "which service/agent" — see `lib/sentry.ts`'s `ErrorCapturingClient.withScope` and `loop-orchestrator.ts`'s `dispatch()`.
 
 ## Disabling Sentry
 

--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -281,19 +281,15 @@ over every agent in the deployment.
 Sentry integration is opt-in and inert by default — zero telemetry is sent unless `SENTRY_DSN` is
 set, independently, on each service (admin, metrics, task-store, agent).
 
-**What's captured**, when enabled:
-
-- Unhandled exceptions and 5xx errors, with stack traces
-- `console.log` / `console.warn` / `console.error` calls, forwarded as structured logs
-- Request path and method for HTTP errors
-- Caller identity — which admin or agent token triggered an error — for tracing
-
-**What's never captured**, unconditionally:
-
-- `Authorization` and `Cookie` header values — redacted to `[Filtered]` regardless of configuration
-- Request or response bodies — never attached to an event
-- The live value of any secret-shaped env var — redacted wherever it appears, including nested
-  inside longer strings
+| Data | Captured by Sentry? |
+|---|---|
+| Unhandled exceptions and 5xx errors, with stack traces | Yes |
+| `console.log` / `console.warn` / `console.error` calls, forwarded as structured logs | Yes |
+| Request path and method for HTTP errors | Yes |
+| Caller identity — which admin or agent token triggered an error | Yes |
+| `Authorization` and `Cookie` header values | Redacted — replaced with `[Filtered]` regardless of configuration |
+| Request or response bodies | No — never attached to an event |
+| The live value of any secret-shaped env var | Redacted — scrubbed wherever it appears, including nested inside longer strings |
 
 Self-hosted Sentry is fully supported: point `SENTRY_DSN` at your own instance and everything above
 applies the same way.

--- a/site/tests/docs-security.spec.ts
+++ b/site/tests/docs-security.spec.ts
@@ -181,3 +181,26 @@ test("security page shows admins vs agent members table", async ({
   const row = table.locator("tr", { hasText: /admin/i });
   await expect(row.first()).toBeVisible();
 });
+
+// SDH-2.3 — captured/redacted scan table replacing the two separate
+// "What's captured" / "What's never captured" bullet lists under
+// Logging, monitoring & observability.
+
+test("security page shows captured/redacted scan table under Logging, monitoring & observability", async ({
+  page,
+}) => {
+  await page.goto("/docs/security");
+  const heading = page.locator("h2, h3", { hasText: /observability|logging/i });
+  await expect(heading.first()).toBeVisible();
+  const table = heading.first().locator("xpath=following::table[1]");
+  const row = table.locator("tr");
+  await expect(row.first()).toBeVisible();
+  for (const label of [
+    /5xx/i,
+    /console\.(log|warn|error)/i,
+    /Authorization/i,
+  ]) {
+    const cell = table.locator("td, th", { hasText: label });
+    await expect(cell.first()).toBeVisible();
+  }
+});


### PR DESCRIPTION
## Summary
- Replace the two separate "What's captured"/"What's never captured" bullet lists under "Logging, monitoring & observability" in `site/src/content/docs/security.mdx` with a single `Data | Captured by Sentry?` pipe-table (Yes/No/Redacted per current prose), keeping the opt-in/inert-by-default and self-hosted-Sentry sentences as prose.
- Add a new Playwright assertion to `site/tests/docs-security.spec.ts` confirming the new table renders under the observability heading.
- Refresh `docs/observability.md`'s equivalent bullet lists to the same table format for consistency (auto-docs-refresher).

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Single Data \| Captured by Sentry? table replaces both bullet lists, accurate Yes/No/Redacted values | MET |
| 2 | Framing sentences remain as prose outside the table | MET |
| 3 | Existing observability heading assertion still passes | MET |
| 4 | One new Playwright assertion added, no existing tests retired | MET |

## Test Plan
- `cd site && npx playwright test docs-security.spec.ts` — 28/28 passing, including the new table-assertion test and the pre-existing heading-presence test.
- `cd site && npm run build` — succeeds.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
