### PR TITLE
chore(chart): bump chart version to 1.17.1

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.17.1] - 2026-08-26
+
+### Changed
+
+- auto-bump to chart v1.17.1 triggered by release tag(s): `agent-v1.190.0`
+
 ## [1.17.0] - 2026-08-26
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.17.0
+version: 1.17.1
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "cert-manager bootstrap hook for the bundled cert-manager path (CNH-7.1): when cert-manager is bundled in the same release (cert-manager.enabled=true), its CRDs are templates in this release and do not exist at first-install apply time, so the chart-managed Issuer/Certificate can no longer be plain inline manifests. New templates/cert-manager-bootstrap-job.yaml ships a ConfigMap <fullname>-cert-manager-bootstrap (10-issuer.yaml if issuer.create, 20-certificate.yaml if networking.type=gateway — both from the existing shipwright.certManager.issuerManifest/certificateManifest helpers) applied by a post-install,post-upgrade Job (hook-weight 10, after cert-manager's startupapicheck at 1 and db-bootstrap at -5, hook-delete-policy before-hook-creation,hook-succeeded) whose initContainer kubectl waits for the cert-manager/webhook/cainjector Deployments to be Available before the main container kubectl apply --server-side --force-conflicts's the ConfigMap. A pre-delete cleanup Job (tls.certManager.bootstrap.cleanupOnDelete, default true) deletes the applied CRs on uninstall, intentionally keeping the issued TLS Secret and ACME account Secret. New templates/cert-manager-bootstrap-rbac.yaml adds the ServiceAccount/Role/RoleBinding (regular, non-hook resources so the token survives upgrades) plus a ClusterRole/Binding only when issuer.kind=ClusterIssuer. templates/cert-manager-issuer.yaml and templates/certificate.yaml now render nothing when the new shipwright.certManager.viaHook guard is true, so this is the sole render path for those CRs in the bundled-cert-manager case; `helm template` output with default values is byte-identical to before this change."
+    - kind: changed
+      description: "auto-bump to chart v1.17.1 triggered by release tag agent-v1.190.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -407,7 +407,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.189.0
+    tag: agent-v1.190.0
     pullPolicy: ""
   service:
     port: 3000
@@ -430,7 +430,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.189.0
+      tag: agent-v1.190.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.17.0 → 1.17.1

**Triggering tags:**
- `agent-v1.190.0`

**New chart version:** `1.17.1`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v1.190.0`
- `agent.provisioning.image.tag`: `agent-v1.190.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.17.1 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._