### PR TITLE
docs: update public security.mdx merge description

### DIFF
--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -238,17 +238,24 @@ reviewing its own open PRs. Automated merging is disabled by default too — the
 cron ships off, so nothing merges without a human clicking merge in the GitHub UI.
 
 If Shipwright itself performs a merge — because you've enabled `shipwright-deploy`, or a human
-runs the merge command directly — it uses an administrator-level override (`gh pr merge --admin`)
-that bypasses branch protection's required-approval rule, on the premise that Shipwright's own
-review-and-CI gate substitutes for it.
+runs the merge command directly — it squash-merges the PR as a normal merge (`gh pr merge --squash`,
+no admin override), which defers to GitHub's branch protection natively rather than bypassing it.
+In practice this rarely blocks, because most repos either have no review requirement configured or
+have the merging identity listed as a **bypass actor** on the active ruleset. If a repo *does* have
+a required-review rule that the merging identity can't bypass, the merge command fails with GitHub's
+native "base branch policy prohibits the merge" error; Shipwright detects that specific failure,
+releases its claim on the task, and marks the task/PR **blocked** with a note explaining that a
+self-review approval doesn't satisfy a native required-review rule — a human then needs to add a
+real approval or configure the identity as a ruleset bypass actor.
 
 For environments that need a specific, named human to be the actual approver — not just "not the
 same agent," but a person you've designated (SOC 2-style segregation of duties) — add your
 reviewers as GitHub **CODEOWNERS** for the repository, or at minimum for `.github/workflows/**`,
-and require review from Code Owners in branch protection. Neither self-review nor another agent's
-review satisfies a Code Owners requirement; only a human on that list does. Keep
-`shipwright-deploy` disabled in this configuration (its default state) so every merge stays an
-explicit human action.
+require review from Code Owners in branch protection, and do **not** list the agent identity as a
+bypass actor on that ruleset. Neither self-review nor another agent's review satisfies a Code
+Owners requirement; only a human on that list does, and with no bypass actor configured, Shipwright's
+merge will correctly block until a human approves. Keep `shipwright-deploy` disabled in this
+configuration (its default state) so every merge stays an explicit human action.
 
 ## One agent per user
 


### PR DESCRIPTION
## Summary
- Rewrites the "Pull request review & merge" section of the public `site/src/content/docs/security.mdx` to describe Shipwright's current merge behavior (squash-merge deferring to GitHub's native branch protection) instead of the old `gh pr merge --admin` unconditional bypass, which was removed in RDA-1.1 (#2834).
- Documents the branch-protection-block detection path (release claim + mark task/PR blocked with a human-actionable note) as the defensive backstop for the rare case where a required review isn't satisfied.
- Retains and slightly sharpens the CODEOWNERS/segregation-of-duties guidance, since ruleset-enforced review requirements are exactly what now gets enforced natively.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Section no longer describes `gh pr merge --admin` as bypassing required-approval unconditionally | MET | Old `--admin` bypass language fully removed; replaced with `gh pr merge --squash` deferring to native branch protection, plus the branch-protection-block detection path |
| 2 | Retains guidance that self-review/other-agent review don't satisfy Code Owners requirement | MET | Sentence retained verbatim: "Neither self-review nor another agent's review satisfies a Code Owners requirement; only a human on that list does." |
| 3 | No test change needed (heading-only regex assertion) | MET | Confirmed by reading `site/tests/docs-security.spec.ts` directly — no prose assertions on this section; no test file touched |

## Test Plan
- Docs-only prose change; verified `site/tests/docs-security.spec.ts` asserts heading presence only, not prose content — no test changes required.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
