### PR TITLE
fix: parse plain-YAML agent-policy.md booleans in check-helpers

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -99,7 +99,7 @@ export function parseCleanupMergedWorktrees(content: string): boolean {
 
 export function parseCleanupAfterDays(content: string): number {
   const match = content.match(
-    /(?:`cleanup_after_days`\s*\|\s*|\*\*cleanup_after_days\*\*:\s*)(\d+)/,
+    /`?\*{0,2}\bcleanup_after_days\b\*{0,2}`?\s*[:|]\s*\*{0,2}(\d+)\b/i,
   );
   if (!match) return 14; // default 14 if missing
   const parsed = Number.parseInt(match[1], 10);

--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -85,14 +85,14 @@ export interface Task {
 
 export function parseAllowSelfReview(content: string): boolean {
   const match = content.match(
-    /(?:`allow_self_review`\s*\|\s*|\*\*allow_self_review\*\*:\s*)(true|false)/,
+    /`?\*{0,2}\ballow_self_review\b\*{0,2}`?\s*[:|]\s*\*{0,2}(true|false)\b/i,
   );
   return match?.[1] === "true"; // default false if missing/unparseable
 }
 
 export function parseCleanupMergedWorktrees(content: string): boolean {
   const match = content.match(
-    /(?:`cleanup_merged_worktrees`\s*\|\s*|\*\*cleanup_merged_worktrees\*\*:\s*)(true|false)/,
+    /`?\*{0,2}\bcleanup_merged_worktrees\b\*{0,2}`?\s*[:|]\s*\*{0,2}(true|false)\b/i,
   );
   return match?.[1] !== "false"; // default true if missing
 }

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -505,6 +505,14 @@ describe("parseCleanupAfterDays", () => {
     ).toBe(21);
   });
 
+  test("parses numeric value from plain YAML frontmatter style", () => {
+    expect(
+      checkHelpers.parseCleanupAfterDays(
+        "---\ncleanup_merged_worktrees: true\ncleanup_after_days: 30\n---\n",
+      ),
+    ).toBe(30);
+  });
+
   test("defaults to 14 when the field is missing", () => {
     expect(checkHelpers.parseCleanupAfterDays("no policy here")).toBe(14);
   });

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -363,6 +363,22 @@ describe("parseAllowSelfReview", () => {
     ).toBe(true);
   });
 
+  test("returns true for plain YAML frontmatter style true", () => {
+    expect(
+      checkHelpers.parseAllowSelfReview(
+        "---\nauto_post_reviews: true\nallow_self_review: true\nmin_confidence: 75\n---\n",
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false for plain YAML frontmatter style false", () => {
+    expect(
+      checkHelpers.parseAllowSelfReview(
+        "---\nauto_post_reviews: true\nallow_self_review: false\nmin_confidence: 75\n---\n",
+      ),
+    ).toBe(false);
+  });
+
   test("defaults to false when the field is missing entirely", () => {
     expect(checkHelpers.parseAllowSelfReview("no policy here")).toBe(false);
   });
@@ -419,6 +435,22 @@ describe("parseCleanupMergedWorktrees", () => {
   test("returns true for bold-style true", () => {
     expect(
       checkHelpers.parseCleanupMergedWorktrees("**cleanup_merged_worktrees**: true"),
+    ).toBe(true);
+  });
+
+  test("returns false for plain YAML frontmatter style false", () => {
+    expect(
+      checkHelpers.parseCleanupMergedWorktrees(
+        "---\ncleanup_merged_worktrees: false\ncleanup_after_days: 14\n---\n",
+      ),
+    ).toBe(false);
+  });
+
+  test("returns true for plain YAML frontmatter style true", () => {
+    expect(
+      checkHelpers.parseCleanupMergedWorktrees(
+        "---\ncleanup_merged_worktrees: true\ncleanup_after_days: 14\n---\n",
+      ),
     ).toBe(true);
   });
 

--- a/plugins/shipwright/scripts/check-helpers.ts
+++ b/plugins/shipwright/scripts/check-helpers.ts
@@ -73,7 +73,7 @@ export interface Task {
 
 export function parseAllowSelfReview(content: string): boolean {
   const match = content.match(
-    /(?:`allow_self_review`\s*\|\s*|\*\*allow_self_review\*\*:\s*)(true|false)/,
+    /`?\*{0,2}\ballow_self_review\b\*{0,2}`?\s*[:|]\s*\*{0,2}(true|false)\b/i,
   );
   return match?.[1] === "true"; // default false if missing/unparseable
 }


### PR DESCRIPTION
## Summary
- `parseAllowSelfReview`/`parseCleanupMergedWorktrees` in `agent/src/check-helpers.ts` (and `parseAllowSelfReview` in `plugins/shipwright/scripts/check-helpers.ts`) only matched the markdown-table (`` `field` | true ``) and bold-colon (`**field**: true`) formats.
- `state/agent-policy.md` is seeded and documented (`docs/configuration.md`) as plain YAML frontmatter (`field: true`, no backticks/bold) — that format silently failed to match, so `allow_self_review: true` parsed as `false` and self-authored PRs kept getting excluded from `check-review`'s candidacy with `check: "self-review"`.
- Widened both regexes to accept optional backtick/bold wrapping around the key with either `:` or `|` as the separator, covering table, bold, and plain-YAML styles.

## Test plan
- [x] Added unit tests for the plain-YAML case in `agent/src/check-helpers.unit.test.ts` (both `parseAllowSelfReview` and `parseCleanupMergedWorktrees`)
- [x] `bun test agent/src/check-helpers.unit.test.ts` — 153 pass
- [x] `bun test plugins/shipwright/scripts/check-helpers.unit.test.ts agent/src/check-review.unit.test.ts` — 140 pass
- [x] Typecheck clean in both `agent/` and `plugins/shipwright/` workspaces
- [x] Verified against the live `~/.shipwright/workspace/state/agent-policy.md` — `parseAllowSelfReview` now returns `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)