### PR TITLE
docs: cross-reference self-hosted Sentry in egress controls table

### DIFF
--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -84,7 +84,7 @@ default unless you add your own network policy. The required outbound destinatio
 | Slack API | Bot messaging, Socket Mode event delivery | Required |
 | Anthropic API | The model calls that power agent reasoning and code generation | Required |
 | Your SSO provider (Google or Okta OAuth) | Admin login when `auth.mode=google` or `auth.mode=okta` | Required only when internet-reachable auth is enabled |
-| Sentry | Error/log reporting | Optional — only when `SENTRY_DSN` is set |
+| Sentry | Error/log reporting | Optional — only when `SENTRY_DSN` is set (self-hostable in-cluster — see [Logging, monitoring & observability](#logging-monitoring--observability)) |
 
 Shipwright has no subprocessor relationship of its own — the only third parties that ever sit in
 the data path are whichever of the above you configure yourself, each under your own account and


### PR DESCRIPTION
## Summary
- Extends the Sentry row's "Required/Optional" cell in the "Network & egress controls" table in `site/src/content/docs/security.mdx` to note that Sentry is self-hostable in-cluster, linking to the existing "Logging, monitoring & observability" section.
- Makes the egress-controls section self-contained on this point without duplicating the self-hosting explanation that already lives in the observability section.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Sentry row's Required/Optional cell reads the exact specified text | MET | Line 87 diff matches exactly |
| 2 | Anchor link resolves to `## Logging, monitoring & observability` heading | MET | Verified against the built HTML: heading renders `id="logging-monitoring--observability"`, link renders `href="#logging-monitoring--observability"` |
| 3 | No other content in security.mdx changes | MET | Diff shows exactly one line changed |
| 4 | No test changes needed (e2e test doesn't pin Sentry cell text) | MET | No test files touched; `docs-security.spec.ts` only asserts the GitHub API row is visible |

## Test Plan
- [x] `astro build` succeeds; verified rendered HTML output has matching anchor `id`/`href` pair
- [x] `bunx biome lint` clean on the changed file
- [x] `task check-strings` clean
- [x] No other content changed — single-line diff
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
