### PR TITLE
docs: fold entrypoint detail into run-modes table

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -12,11 +12,11 @@ The agent owns eleven first-class Prisma models (`Agent` and its `Env` / `CronJo
 
 There are three ways to run the agent process, depending on the deployment context:
 
-| Mode | Entry point | Transport | Use when |
-|---|---|---|---|
-| Pi / bare-metal | `agent/src/index.ts` | Slack Socket Mode | Running directly on a host with a local `.env` file |
-| K8s container | `agent/src/entrypoint-main.ts` | Slack Socket Mode | Deployed via the Dockerfile — validates required vars, fetches config from the admin API, applies env, symlinks `~/.claude`, sets up GitHub auth, runs mise, installs plugins, then spawns `index.ts` |
-| Local dev (no Slack) | `task stack` (Docker agent pane) | Chat poll loop → admin Chat UI | Testing Claude locally without a Slack workspace — chat via the admin console's Chat tab (`/admin/chat`) |
+| Mode | Entry point | Transport | Entrypoint behavior | When to use |
+|---|---|---|---|---|
+| Pi / bare-metal | `agent/src/index.ts` | Slack Socket Mode | Runs directly on the host | Running directly on a host with a local `.env` file |
+| K8s container | `agent/src/entrypoint-main.ts` | Slack Socket Mode | Dockerfile `ENTRYPOINT` is `bun run agent/src/entrypoint-main.ts`, which starts the health server in-process on `SHIPWRIGHT_HEALTH_PORT` (default `3459`) before the startup sequence so Kubernetes liveness probes are reachable during init | Deployed via the Dockerfile (validates vars, fetches config, installs plugins, spawns runner) |
+| Local dev (no Slack) | `task stack` (Docker agent pane) | Chat poll loop → admin Chat UI | Runs the agent in Docker via the agent pane | Testing Claude locally without a Slack workspace — chat via the admin console's Chat tab (`/admin/chat`) |
 
 `agent/src/index.ts` is the production agent entrypoint in all transport modes — it wires the health server, config sync loop, cron sync loop, chat poll loop, Slack Bolt app, and graceful shutdown.
 

--- a/site/src/content/docs/the-agent.mdx
+++ b/site/src/content/docs/the-agent.mdx
@@ -18,17 +18,14 @@ a human-facing admin CRUD API, a server-rendered admin UI, and a public read-onl
 
 There are three ways to run the agent depending on your context:
 
-| Mode | Entry point | Transport | When to use |
-|------|-------------|-----------|-------------|
-| Pi / bare-metal | `agent/src/index.ts` | Slack Socket Mode | Running directly on a host with a local `.env` file |
-| K8s container | `agent/src/entrypoint-main.ts` | Slack Socket Mode | Deployed via the Dockerfile (validates vars, fetches config, installs plugins, spawns runner) |
-| Local dev | `task stack` (Docker agent pane) | Chat poll loop → admin Chat UI | Testing Claude locally without a Slack workspace — chat via the admin console's Chat tab |
+| Mode | Entry point | Transport | Entrypoint behavior | When to use |
+|------|-------------|-----------|---------------------|-------------|
+| Pi / bare-metal | `agent/src/index.ts` | Slack Socket Mode | Runs directly on the host | Running directly on a host with a local `.env` file |
+| K8s container | `agent/src/entrypoint-main.ts` | Slack Socket Mode | Dockerfile `ENTRYPOINT` is `bun run agent/src/entrypoint-main.ts`, which starts the health server in-process on `SHIPWRIGHT_HEALTH_PORT` (default `3459`) before the startup sequence so Kubernetes liveness probes are reachable during init | Deployed via the Dockerfile (validates vars, fetches config, installs plugins, spawns runner) |
+| Local dev | `task stack` | Chat poll loop → admin Chat UI | Runs the agent in Docker via the agent pane | Testing Claude locally without a Slack workspace — chat via the admin console's Chat tab |
 
 The admin service Dockerfile (`admin/Dockerfile`) `ENTRYPOINT` is `bun run admin/src/main.ts`,
-which runs migrations, constructs all services, and mounts all admin and runtime routes. The agent
-container Dockerfile (`agent/Dockerfile`) `ENTRYPOINT` is `bun run agent/src/entrypoint-main.ts`,
-which starts the health server in-process on `SHIPWRIGHT_HEALTH_PORT` (default `3459`) before the
-startup sequence so Kubernetes liveness probes are reachable during init.
+which runs migrations, constructs all services, and mounts all admin and runtime routes.
 
 ## Running the agent locally
 


### PR DESCRIPTION
## Summary
- Folded the trailing paragraph's Dockerfile/entrypoint detail into a new "Entrypoint behavior" column on `the-agent.mdx`'s "Run modes" table, instead of restating it in prose right after the table.
- Refreshed the mirrored "Run modes" table in `docs/agent.md` to match, keeping the two docs in sync.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | 'Run modes' table gains an Entrypoint (or similar) column covering the detail currently in the trailing paragraph; the paragraph is removed once its content is represented in the table | MET |
| 2 | docs-platform.spec.ts's existing assertion that a 'Run modes' h2 heading is visible on this page continues to pass unmodified (heading text/level unchanged) | MET |

## Test Plan
- Verified `## Run modes` heading text/level is unchanged in the source `.mdx`.
- Ran `cd site && npm run build` (Astro static build) — compiled cleanly; confirmed via the built HTML that `<h2 id="run-modes">Run modes</h2>` renders and the new "Entrypoint behavior" column is present.
- Playwright itself could not launch in this sandbox (no root / missing system libs, a known pre-existing environment limitation) — relying on CI's site job for the live e2e run.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
