### PR TITLE
docs: dedupe manual setup steps in getting-started.mdx

### DIFF
--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -54,29 +54,9 @@ When you run the one-prompt setup, three things happen in sequence:
 
 ## Manual setup
 
-If you prefer to run the steps yourself:
-
-```bash
-git clone https://github.com/app-vitals/shipwright.git
-cd shipwright
-./scripts/quickstart.sh
-```
-
-The quickstart script runs the following commands internally:
-
-```bash
-task setup   # install all workspace dependencies
-task dev     # start the metrics dashboard at http://localhost:3460/dashboard
-```
-
-Once the dashboard is running, install the plugin inside your Claude Code session:
-
-```text
-/plugin install shipwright@app-vitals/shipwright
-```
-
-The dashboard will be available at `http://localhost:3460/dashboard`. It starts in offline mode
-(fixtures), so you can explore without configuring any external services.
+If you prefer to run the steps yourself, or want a metrics-only mode or the full multi-service
+dev stack, see [Running Locally](/docs/running-locally) — it covers the same clone/quickstart/
+plugin-install flow (Option A) plus `task dev` (Option B) and `task stack` (Option C).
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Trimmed getting-started.mdx's "Manual setup" section, which duplicated running-locally.mdx's "Option A — Quickstart" clone/quickstart/plugin-install steps almost verbatim
- Replaced it with a short pointer to running-locally.mdx, which remains the canonical A/B/C setup reference

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | getting-started.mdx no longer duplicates the full step-by-step manual setup; links to running-locally.mdx | MET |
| 2 | running-locally.mdx content is unchanged | MET |
| 3 | No information lost — trimmed content is redundant or preserved as a pointer | MET |
| 4 | No test change needed unless a spec asserts on the trimmed text | MET — checked, no spec asserts on it |

## Test Plan
- `cd site && npm run build` — succeeds, all 26 pages build including getting-started and running-locally
- Verified built `getting-started/index.html` retains a link to `/docs/running-locally`, still has a fenced code block, and still has the "Prerequisites" h2 (covered by existing Playwright specs `docs-platform.spec.ts`)
- `task check-strings` — no banned strings
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
