### PR TITLE
docs: link security FAQ answers to their source tables

### DIFF
--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -337,8 +337,8 @@ Via GitHub private security advisories, not a public issue:
 [github.com/app-vitals/shipwright/security/advisories/new](https://github.com/app-vitals/shipwright/security/advisories/new).
 A maintainer will acknowledge the report within 7 days and work with you on a fix and coordinated
 disclosure — see [SECURITY.md](https://github.com/app-vitals/shipwright/blob/main/SECURITY.md) for
-the full policy. See the [Compliance posture table](#compliance-posture) above for more on vulnerability
-disclosure procedures.
+the full policy. See the [Compliance posture table](#compliance-posture) above for more on
+vulnerability disclosure procedures.
 
 **What happens if `SHIPWRIGHT_ENCRYPTION_KEY` is never set?**
 Secrets (env values, Slack tokens, API keys) are stored in plain text in the database, with a
@@ -349,28 +349,33 @@ something you need to set deliberately before any production use.
 Voice can: self-hosted Whisper for speech-to-text plus the default Piper text-to-speech engine make
 zero outbound calls. Every other Shipwright service assumes outbound internet access by default (to
 reach Anthropic, GitHub, and Slack). Restricting egress further is your responsibility, via your
-own Kubernetes `NetworkPolicy` or cloud firewall rules. See the [Network & egress controls table](#network--egress-controls) above
-for the required and optional external destinations.
+own Kubernetes `NetworkPolicy` or cloud firewall rules. See the
+[Network & egress controls table](#network--egress-controls) above for the required and
+optional external destinations.
 
 **Is there an audit log of every action an agent takes?**
 Not a tool-call-level one, today. Sentry (when enabled) captures caller identity on the error path,
-but that's not a full audit trail of every tool invocation. See the [Compliance posture table](#compliance-posture) above
-for the current status of tool-call-level audit logging.
+but that's not a full audit trail of every tool invocation. See the
+[Compliance posture table](#compliance-posture) above for the current status of
+tool-call-level audit logging.
 
 **Does Shipwright have SOC 2 or similar certifications?**
-No, not currently. See the [Compliance posture table](#compliance-posture) above for details on current certification status.
+No, not currently. See the [Compliance posture table](#compliance-posture) above for details
+on current certification status.
 
 **Do I need to expose the admin service to the public internet?**
 No. `networking.type=ClusterIP` (the default) keeps every service reachable only via
 `kubectl port-forward` inside the cluster. Public exposure via Ingress or Gateway API is a choice
 you make when you're ready for it, and `auth.mode=google` or `auth.mode=okta` is required the
-moment you do. See the [Human access table](#human-access) above for authentication mode requirements.
+moment you do. See the [Human access table](#human-access) above for authentication mode
+requirements.
 
 **Does Shipwright support SCIM provisioning?**
 No, not today. There is no SCIM code in the codebase — user access is managed via the
 `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` allowlist and `AgentMember` records described above, not an
-automated identity-provider sync. See the [Admins vs. agent members table](#admins-vs-agent-members) above for how access control is currently
-managed.
+automated identity-provider sync. See the
+[Admins vs. agent members table](#admins-vs-agent-members) above for how access control is
+currently managed.
 
 **Can I IP-allowlist the admin service?**
 There's no built-in IP-allowlist feature. The substitute is keeping `networking.type=ClusterIP`

--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -337,7 +337,8 @@ Via GitHub private security advisories, not a public issue:
 [github.com/app-vitals/shipwright/security/advisories/new](https://github.com/app-vitals/shipwright/security/advisories/new).
 A maintainer will acknowledge the report within 7 days and work with you on a fix and coordinated
 disclosure — see [SECURITY.md](https://github.com/app-vitals/shipwright/blob/main/SECURITY.md) for
-the full policy.
+the full policy. See the [Compliance posture table](#compliance-posture) above for more on vulnerability
+disclosure procedures.
 
 **What happens if `SHIPWRIGHT_ENCRYPTION_KEY` is never set?**
 Secrets (env values, Slack tokens, API keys) are stored in plain text in the database, with a
@@ -348,25 +349,28 @@ something you need to set deliberately before any production use.
 Voice can: self-hosted Whisper for speech-to-text plus the default Piper text-to-speech engine make
 zero outbound calls. Every other Shipwright service assumes outbound internet access by default (to
 reach Anthropic, GitHub, and Slack). Restricting egress further is your responsibility, via your
-own Kubernetes `NetworkPolicy` or cloud firewall rules.
+own Kubernetes `NetworkPolicy` or cloud firewall rules. See the [Network & egress controls table](#network--egress-controls) above
+for the required and optional external destinations.
 
 **Is there an audit log of every action an agent takes?**
 Not a tool-call-level one, today. Sentry (when enabled) captures caller identity on the error path,
-but that's not a full audit trail of every tool invocation.
+but that's not a full audit trail of every tool invocation. See the [Compliance posture table](#compliance-posture) above
+for the current status of tool-call-level audit logging.
 
 **Does Shipwright have SOC 2 or similar certifications?**
-No, not currently.
+No, not currently. See the [Compliance posture table](#compliance-posture) above for details on current certification status.
 
 **Do I need to expose the admin service to the public internet?**
 No. `networking.type=ClusterIP` (the default) keeps every service reachable only via
 `kubectl port-forward` inside the cluster. Public exposure via Ingress or Gateway API is a choice
 you make when you're ready for it, and `auth.mode=google` or `auth.mode=okta` is required the
-moment you do.
+moment you do. See the [Human access table](#human-access) above for authentication mode requirements.
 
 **Does Shipwright support SCIM provisioning?**
 No, not today. There is no SCIM code in the codebase — user access is managed via the
 `SHIPWRIGHT_ADMIN_ALLOWED_EMAILS` allowlist and `AgentMember` records described above, not an
-automated identity-provider sync.
+automated identity-provider sync. See the [Admins vs. agent members table](#admins-vs-agent-members) above for how access control is currently
+managed.
 
 **Can I IP-allowlist the admin service?**
 There's no built-in IP-allowlist feature. The substitute is keeping `networking.type=ClusterIP`


### PR DESCRIPTION
## Summary
- Add anchor links from 6 security FAQ answers back to the table earlier on the page that already contains the same fact (Compliance posture, Network & egress controls, Human access, Admins vs. agent members), so the FAQ and the tables don't silently drift apart the way the cron tables did in SUX-1.1
- All FAQ prose left fully intact — links are appended as an additive pointer, not a replacement
- Rewrapped the touched lines to match the page's existing ~100-char prose width

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Every FAQ answer that duplicates a table fact links to that table's section anchor | MET | 6 FAQ answers now link to `#compliance-posture`, `#network--egress-controls`, or `#human-access`/`#admins-vs-agent-members`; anchors verified against the built HTML |
| 2 | FAQ answers additive, not shortened/deleted | MET | Diff is purely additive — every original sentence preserved |
| 3 | No test change needed; no heading/anchor rename | MET | Zero test files touched; headings unchanged |

## Test Plan
- [x] `cd site && npm run build` — Astro build succeeds, no broken MDX/anchors
- [x] Verified all 4 new anchor targets (`#compliance-posture`, `#network--egress-controls`, `#human-access`, `#admins-vs-agent-members`) exist in the built HTML via `grep -oE 'id="[a-z0-9-]*"'`
- [x] `npx playwright test tests/docs-security.spec.ts` — all 28 tests pass
- [x] `task typecheck` — passes across all workspaces
- Note: `task ci`'s `test:coverage` step has 31 pre-existing failures (metrics env/errors unit tests, task-store prs smoke test) reproduced identically on `main` at the same commit — unrelated to this docs-only change.

Generated with [Claude Code](https://claude.com/claude-code)
