### PR TITLE
docs: convert per-target URL lists to tables in deploying-to-cloud

### DIFF
--- a/site/src/content/docs/deploying-to-cloud.mdx
+++ b/site/src/content/docs/deploying-to-cloud.mdx
@@ -88,8 +88,10 @@ echo "$(minikube ip) shipwright.local" | sudo tee -a /etc/hosts
 
 Then:
 
-- Admin UI/API: `http://shipwright.local/`
-- Metrics dashboard: `http://shipwright.local/dashboard`
+| Service | URL |
+|---------|-----|
+| Admin UI/API | `http://shipwright.local/` |
+| Metrics dashboard | `http://shipwright.local/dashboard` |
 
 Or skip the ingress and port-forward directly:
 
@@ -164,8 +166,10 @@ The chart renders a `Gateway` plus `HTTPRoute`s: an HTTP listener on `:80`, an H
 `:443` (when TLS is enabled), and an HTTP→HTTPS redirect route. Point your DNS `A`/`AAAA` record
 at the Gateway's external address once provisioned.
 
-- Admin UI/API: `https://shipwright.example.com/`
-- Metrics dashboard: `https://shipwright.example.com/dashboard`
+| Service | URL |
+|---------|-----|
+| Admin UI/API | `https://shipwright.example.com/` |
+| Metrics dashboard | `https://shipwright.example.com/dashboard` |
 
 ## EKS (ALB ingress + cert-manager)
 
@@ -212,8 +216,10 @@ helm install shipwright charts/shipwright \
 
 Point your DNS record at the ALB's DNS name once provisioned.
 
-- Admin UI/API: `https://shipwright.example.com/`
-- Metrics dashboard: `https://shipwright.example.com/dashboard`
+| Service | URL |
+|---------|-----|
+| Admin UI/API | `https://shipwright.example.com/` |
+| Metrics dashboard | `https://shipwright.example.com/dashboard` |
 
 ## Agent runtime provisioning
 


### PR DESCRIPTION
## Summary
- Converts the three "Reach the services" call-outs in `deploying-to-cloud.mdx` (Minikube, GKE, EKS) from loose bullet-list paragraphs to `Service | URL` tables
- Same URLs and content preserved verbatim — pure formatting change, no information dropped

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Three call-outs are tables, same content, nothing dropped | MET | All 3 sections converted to identical Service\|URL tables; URLs preserved verbatim |
| 2 | No test change needed | MET | Diff touches only the .mdx file, no test files |

## Test Plan
- [x] `npm run build` (astro build) succeeds; `deploying-to-cloud` page builds cleanly
- [x] Verified rendered HTML output contains the new tables with correct URLs
- [x] No test change needed — content formatting only

Generated with [Claude Code](https://claude.com/claude-code)
