### PR TITLE
feat: build reusable stepper/flow component (SUX-2.1, SUX-2.2)

### DIFF
--- a/site/src/components/StepFlow.astro
+++ b/site/src/components/StepFlow.astro
@@ -1,0 +1,229 @@
+---
+// Reusable linear stepper/flow component for docs pages that currently
+// describe a process as prose (SUX-2.1, unblocks SUX-2.2/SUX-2.3). Reuses
+// the box + arrow visual language established by SecurityArchDiagram.astro
+// and the .pipe-step/.pipe-arrow pipeline in src/pages/agent-model.astro,
+// laid out vertically since a numbered sequence reads top-to-bottom rather
+// than left-to-right. Static Astro component: no client-side JS, brand
+// tokens only (no raw hex).
+interface Branch {
+  label: string;
+  detail: string;
+  // Marks this branch step as requiring manual/human action — same flag as
+  // the top-level Step, reusing --sw-color-state-warning (the same token
+  // agent-model.astro uses for its "loop"/human-attention states) rather
+  // than inventing a new color.
+  manual?: boolean;
+}
+
+interface Step {
+  label: string;
+  detail: string;
+  // Requires manual/human action — rendered with a distinct warning-token
+  // treatment instead of the default brand treatment.
+  manual?: boolean;
+  // A single optional conditional path forking off this step. Keep this
+  // minimal: one branch per step, not a general branching graph — matches
+  // the brief's "optional single conditional branch".
+  branch?: Branch;
+}
+
+interface Props {
+  steps: Step[];
+}
+
+const { steps } = Astro.props;
+---
+
+<ol class="step-flow" role="list">
+  {steps.map((step, i) => (
+    <li class="step-flow-item">
+      <div class={`step-box ${step.manual ? "step-box-manual" : ""}`}>
+        <div class="step-index" aria-hidden="true">{i + 1}</div>
+        <div class="step-body">
+          <div class="step-label-row">
+            <span class="step-label">{step.label}</span>
+            {step.manual && <span class="step-manual-tag">Manual step</span>}
+          </div>
+          <p class="step-detail">{step.detail}</p>
+        </div>
+      </div>
+
+      {step.branch && (
+        <div class="step-branch">
+          <div class="step-branch-arrow">
+            <span class="step-arrow-glyph">↳</span>
+            <span class="step-arrow-label">if applicable</span>
+          </div>
+          <div class={`step-box step-box-branch ${step.branch.manual ? "step-box-manual" : ""}`}>
+            <div class="step-body">
+              <div class="step-label-row">
+                <span class="step-label">{step.branch.label}</span>
+                {step.branch.manual && <span class="step-manual-tag">Manual step</span>}
+              </div>
+              <p class="step-detail">{step.branch.detail}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {i < steps.length - 1 && (
+        <div class="step-arrow-center" aria-hidden="true">
+          <span class="step-arrow-glyph">↓</span>
+        </div>
+      )}
+    </li>
+  ))}
+</ol>
+
+<style>
+  .step-flow {
+    display: flex;
+    flex-direction: column;
+    margin: 1.5rem 0 2rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .step-flow-item {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Step box ── */
+  .step-box {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.875rem;
+    background: var(--sw-color-bg-raised);
+    border: 1.5px solid var(--sw-color-border-muted);
+    border-radius: 6px;
+    padding: 0.875rem 1.125rem;
+  }
+
+  .step-box-manual {
+    background: color-mix(in srgb, var(--sw-color-state-warning) 12%, transparent);
+    border-color: var(--sw-color-state-warning);
+  }
+
+  .step-index {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    background: var(--sw-color-brand-soft);
+    color: var(--sw-color-brand-default);
+    font-size: 0.8125rem;
+    font-weight: 700;
+    font-family: var(--sw-font-mono);
+  }
+
+  .step-box-manual .step-index {
+    background: color-mix(in srgb, var(--sw-color-state-warning) 20%, transparent);
+    color: var(--sw-color-state-warning);
+  }
+
+  .step-body {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .step-label-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .step-label {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--sw-color-text-heading);
+  }
+
+  .step-manual-tag {
+    font-size: 0.5625rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--sw-color-state-warning);
+    border: 1px solid var(--sw-color-state-warning);
+    border-radius: 100px;
+    padding: 0.125rem 0.5rem;
+  }
+
+  .step-detail {
+    font-size: 0.8125rem;
+    color: var(--sw-color-text-muted);
+    line-height: 1.6;
+  }
+
+  /* ── Arrows between steps ── */
+  .step-arrow-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0;
+    padding-left: 0.875rem;
+  }
+
+  .step-arrow-glyph {
+    color: var(--sw-color-border-strong);
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  /* ── Conditional branch fork ── */
+  .step-branch {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    margin: 0.5rem 0 0.5rem 1.75rem;
+    padding-left: 0.875rem;
+    border-left: 1.5px dashed var(--sw-color-border-muted);
+  }
+
+  .step-branch-arrow {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-left: 0.25rem;
+  }
+
+  .step-branch-arrow .step-arrow-glyph {
+    color: var(--sw-color-border-strong);
+    font-size: 1.125rem;
+  }
+
+  .step-arrow-label {
+    font-size: 0.625rem;
+    color: var(--sw-color-text-muted);
+    margin-top: 0.125rem;
+    white-space: nowrap;
+  }
+
+  .step-box-branch {
+    flex: 1 1 auto;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .step-branch {
+      flex-direction: column;
+      align-items: stretch;
+      margin-left: 0.875rem;
+    }
+
+    .step-branch-arrow {
+      flex-direction: row;
+      justify-content: flex-start;
+      gap: 0.375rem;
+      padding-left: 0;
+    }
+  }
+</style>

--- a/site/src/content/docs/slack-integration.mdx
+++ b/site/src/content/docs/slack-integration.mdx
@@ -31,7 +31,7 @@ Socket Mode) is required at the end; everything else happens for you.
 <StepFlow steps={[
   {
     label: "Open the provisioning form",
-    detail: "Navigate to /admin/provision in the Shipwright admin UI and fill in the agent to configure, GitHub credentials (a PAT or GitHub App installation), an optional Anthropic API key, an optional Claude Code OAuth token, and a Slack app configuration token — a personal xoxe.xoxp- token from api.slack.com/apps (App-Level Tokens → Generate Token and Scopes → admin scope) that Shipwright uses once to create the app and never stores.",
+    detail: "Navigate to /admin/provision in the Shipwright admin UI and fill in the agent to configure, GitHub credentials (a PAT or GitHub App installation), an optional Anthropic API key, an optional Claude Code OAuth token, and a Slack app configuration token — a personal xoxe.xoxp- token that Shipwright uses once to create the app and never stores. To obtain it, go to api.slack.com/apps, click Create New App → From scratch (not from a manifest) to spin up a placeholder app, then under that placeholder app's App-Level Tokens click Generate Token and Scopes with the admin scope to generate the xoxe.xoxp- token. Once you've copied it, delete the placeholder app — it was only needed to generate the token.",
   },
   {
     label: "Shipwright creates the Slack app",

--- a/site/src/content/docs/slack-integration.mdx
+++ b/site/src/content/docs/slack-integration.mdx
@@ -7,6 +7,8 @@ prev: "/docs/deploying-to-cloud"
 next: "/docs/day-to-day-operations"
 ---
 
+import StepFlow from '../../components/StepFlow.astro'
+
 # Slack Integration
 
 The Shipwright agent communicates via Slack using the Bolt SDK in Socket Mode — no public HTTP
@@ -23,81 +25,28 @@ agent knows who it's talking to. Cron job results are posted to a configured cha
 
 ## Connecting a Slack app
 
-Slack provisioning is automated via the `/admin/provision` flow. Follow these four steps:
+Slack provisioning is automated via the `/admin/provision` flow — one manual step (enabling
+Socket Mode) is required at the end; everything else happens for you.
 
-### Step 1: Open the provisioning form
-
-Navigate to `/admin/provision` in the Shipwright admin UI. You'll see a form with the following
-fields:
-
-- **Agent** — select which agent to configure
-- **GitHub credentials** — either a Personal Access Token (PAT) or a GitHub App installation for
-  repo access
-- **Anthropic API key** (optional) — if you want the agent to use a custom API key
-- **Claude Code OAuth token** (optional) — if you want to enable Claude Code integration
-- **Slack app configuration token** — a `xoxe.xoxp-` token (see below)
-
-### Understanding the Slack app configuration token
-
-A `xoxe.xoxp-` token is a **Slack app configuration token** — a personal token scoped to your
-Slack workspace that allows creating and configuring Slack apps via the API. To obtain one:
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps)
-2. Click **Create New App** and select **From scratch** (not from a manifest)
-3. Name your app and select your workspace
-4. Once created, go to **App-Level Tokens** in the left sidebar
-5. Click **Generate Token and Scopes**
-6. Name the token (e.g., "Shipwright Provisioning")
-7. Add the `admin` scope (or all available scopes for maximum compatibility)
-8. Click **Generate** and copy the token (it starts with `xoxe.xoxp-`)
-
-This token is **used only once** during provisioning — Shipwright calls the Slack API to create
-the actual bot app and does not store this token afterward. Delete the placeholder app you
-created above to retrieve the configuration token once provisioning completes.
-
-### Step 2: Shipwright creates the Slack app
-
-After you submit the form with valid GitHub credentials and the Slack configuration token,
-Shipwright:
-
-1. Calls `apps.manifest.create` to create a new Slack bot app with the necessary permissions
-2. Automatically stores the following credentials in the agent's environment:
-   - `SLACK_APP_ID` — the app's ID
-   - `SLACK_SIGNING_SECRET` — used to verify incoming Slack requests
-   - `SLACK_CLIENT_ID` — OAuth client ID
-   - `SLACK_CLIENT_SECRET` — OAuth client secret
-
-All of this happens automatically — no manual steps needed.
-
-### Step 3: Authorize the Slack app
-
-After Step 2 completes, the provisioning form shows an **Authorize Slack App →** button. Click it
-to:
-
-1. Redirect to Slack's OAuth approval page
-2. Approve the app to post to your workspace
-3. Redirect back to `/admin/provision/complete`
-
-Shipwright automatically stores `SLACK_BOT_TOKEN` (the bot user OAuth token) in the agent's
-environment. You do not need to copy it manually.
-
-### Step 4: Enable Socket Mode and generate the app token
-
-This is the **one remaining manual step**:
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) and select the app that was just
-   created (it will have a similar name to your agent)
-2. In the left sidebar, go to **Socket Mode**
-3. Click the toggle to **Enable Socket Mode**
-4. A panel appears asking you to generate an **app-level token**
-5. Click **Generate Token and Scopes**
-6. Name the token (e.g., "Socket Mode Token")
-7. Add the `connections:write` scope
-8. Click **Generate** and copy the token (it starts with `xapp-`)
-9. Return to the Shipwright admin UI and paste the `xapp-` token into the Socket Mode field
-10. Submit the form
-
-Once submitted, the agent will connect to Slack via Socket Mode on its next startup.
+<StepFlow steps={[
+  {
+    label: "Open the provisioning form",
+    detail: "Navigate to /admin/provision in the Shipwright admin UI and fill in the agent to configure, GitHub credentials (a PAT or GitHub App installation), an optional Anthropic API key, an optional Claude Code OAuth token, and a Slack app configuration token — a personal xoxe.xoxp- token from api.slack.com/apps (App-Level Tokens → Generate Token and Scopes → admin scope) that Shipwright uses once to create the app and never stores.",
+  },
+  {
+    label: "Shipwright creates the Slack app",
+    detail: "After you submit the form, Shipwright calls apps.manifest.create to create a new Slack bot app, then automatically stores SLACK_APP_ID, the SLACK_SIGNING_SECRET (a signing secret used to verify incoming Slack requests), SLACK_CLIENT_ID, and SLACK_CLIENT_SECRET in the agent's environment. No manual steps needed.",
+  },
+  {
+    label: "Authorize the Slack app",
+    detail: "Click the Authorize Slack App → button the form now shows. You're redirected to Slack's OAuth approval page, approve the app to post to your workspace, and land back on /admin/provision/complete. Shipwright automatically stores SLACK_BOT_TOKEN (the xoxb- bot user OAuth token) — you don't need to copy it manually.",
+  },
+  {
+    label: "Enable Socket Mode and generate the app token",
+    detail: "Go to api.slack.com/apps, select the app that was just created, and open Socket Mode in the left sidebar. Enable it, then Generate Token and Scopes with the connections:write scope to produce an app-level token (starts with xapp-). Paste that xapp- token into the Socket Mode field back in the Shipwright admin UI and submit — the agent connects via Socket Mode on its next startup.",
+    manual: true,
+  },
+]} />
 
 ## Required Slack environment variables
 

--- a/site/src/content/docs/the-shipwright-loop.mdx
+++ b/site/src/content/docs/the-shipwright-loop.mdx
@@ -7,6 +7,8 @@ prev: "/docs/cron-jobs"
 next: "/docs/security"
 ---
 
+import StepFlow from '../../components/StepFlow.astro'
+
 # The Shipwright Loop
 
 `shipwright-loop` is the one cron that drives the entire autonomous delivery loop. Instead of
@@ -23,44 +25,43 @@ on.
 
 ## How dispatch works
 
-Each tick of `shipwright-loop` runs the following sequence:
+Each tick of `shipwright-loop` runs the following sequence. Step 4 hands off to
+[the FIFO work-selector](#the-fifo-work-selector), covered in full in the next section.
 
-1. **Read the four phase toggles.** The loop reads four independent booleans — one per
-   pipeline phase — off child cron rows named `shipwright-dev-task`, `shipwright-review`,
-   `shipwright-patch`, and `shipwright-deploy`, all parented under the `shipwright-loop` cron.
-   Each toggle is resolved and enabled/disabled entirely independently of the others. The loop
-   deliberately never reads `shipwright-review-patch`'s flag or invokes `/shipwright:review-patch`
-   — the loop's own per-tick selection across all four phases supersedes that command's internal
-   review-vs-patch decision.
-2. **Qualify candidates per enabled phase.** For each enabled phase, the loop calls that phase's
-   own qualification function to get structured candidates: dev-task candidates are tasks ready to
-   build, and review/patch/deploy candidates are PRs ready for that phase. A disabled phase
-   contributes nothing — its qualification function is never called, so a phase with no candidates
-   never even shows up as an empty run.
-3. **Merge into one candidate list.** The PR candidates from every enabled phase (review, patch,
-   deploy) are merged into a single flat array. Task candidates stay their own list. Both lists
-   feed the same selection step below.
-4. **Run a single FIFO work-selector.** The loop calls the work-selector exactly once per
-   iteration, passing it the merged task list and the merged PR list together. See
-   [The FIFO work-selector](#the-fifo-work-selector) below for how it picks a winner.
-5. **Pre-claim the winning item.** Before anything is dispatched, the selected item is claimed
-   directly against the task store — task items via a task claim, PR items via a PR claim. A `409`
-   conflict (another agent replica already claimed it since it was collected) skips dispatch
-   entirely: no one-shot command runs and nothing is recorded as a run. The loop simply re-collects
-   candidates and continues to the next iteration, which naturally excludes the now-claimed item.
-6. **Dispatch the matching one-shot command.** Once pre-claimed, the loop dispatches the one-shot
-   command for that item: a task item always dispatches `/shipwright:dev-task`; a PR item
-   dispatches `/shipwright:review`, `/shipwright:patch`, or `/shipwright:deploy` depending on which
-   phase the PR candidate came from. A successful PR pre-claim appends a marker carrying the
-   claimed record's id and commit SHA to the dispatched command string, so the downstream command
-   can recognize the loop already holds the claim instead of re-claiming (and conflicting with
-   itself).
-7. **Repeat immediately — drain until dry.** The loop doesn't wait for the next cron tick to look
-   for more work. It loops back to step 1 right away, re-reading toggles and re-collecting
-   candidates fresh each time (so a phase toggled off mid-drain, or work freshly consumed by the
-   previous iteration, is reflected immediately). It keeps selecting and dispatching one item at a
-   time until the work-selector returns nothing — an idle, drained queue — at which point the tick
-   ends.
+<StepFlow steps={[
+  {
+    label: "Read the four phase toggles",
+    detail: "The loop reads four independent booleans — one per pipeline phase — off child cron rows named shipwright-dev-task, shipwright-review, shipwright-patch, and shipwright-deploy, all parented under the shipwright-loop cron. Each toggle is resolved and enabled/disabled entirely independently of the others. The loop deliberately never reads shipwright-review-patch's flag or invokes /shipwright:review-patch — the loop's own per-tick selection across all four phases supersedes that command's internal review-vs-patch decision.",
+  },
+  {
+    label: "Qualify candidates per enabled phase",
+    detail: "For each enabled phase, the loop calls that phase's own qualification function to get structured candidates: dev-task candidates are tasks ready to build, and review/patch/deploy candidates are PRs ready for that phase. A disabled phase contributes nothing — its qualification function is never called, so a phase with no candidates never even shows up as an empty run.",
+  },
+  {
+    label: "Merge into one candidate list",
+    detail: "The PR candidates from every enabled phase (review, patch, deploy) are merged into a single flat array. Task candidates stay their own list. Both lists feed the same selection step below.",
+  },
+  {
+    label: "Run a single FIFO work-selector",
+    detail: "The loop calls the work-selector exactly once per iteration, passing it the merged task list and the merged PR list together — see the next section for how it picks a winner.",
+  },
+  {
+    label: "Pre-claim the winning item",
+    detail: "Before anything is dispatched, the selected item is claimed directly against the task store — task items via a task claim, PR items via a PR claim.",
+    branch: {
+      label: "409 conflict — already claimed",
+      detail: "Another agent replica already claimed this item since it was collected. Dispatch is skipped entirely: no one-shot command runs and nothing is recorded as a run. The loop simply re-collects candidates and continues to the next iteration, which naturally excludes the now-claimed item.",
+    },
+  },
+  {
+    label: "Dispatch the matching one-shot command",
+    detail: "Once pre-claimed, the loop dispatches the one-shot command for that item: a task item always dispatches /shipwright:dev-task; a PR item dispatches /shipwright:review, /shipwright:patch, or /shipwright:deploy depending on which phase the PR candidate came from. A successful PR pre-claim appends a marker carrying the claimed record's id and commit SHA to the dispatched command string, so the downstream command can recognize the loop already holds the claim instead of re-claiming (and conflicting with itself).",
+  },
+  {
+    label: "Repeat immediately — drain until dry",
+    detail: "The loop doesn't wait for the next cron tick to look for more work. It loops back to step 1 right away, re-reading toggles and re-collecting candidates fresh each time (so a phase toggled off mid-drain, or work freshly consumed by the previous iteration, is reflected immediately). It keeps selecting and dispatching one item at a time until the work-selector returns nothing — an idle, drained queue — at which point the tick ends.",
+  },
+]} />
 
 An idle tick that finds nothing to select reports no run at all: a phase with zero candidates
 never generates a row, and the loop only touches its run-reporting once a real item has been

--- a/site/tests/docs-slack-integration.spec.ts
+++ b/site/tests/docs-slack-integration.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+import { expectNoRuntimeJsBeyondAnalytics } from "./helpers";
+
+// Fulfill external font CDN requests immediately so the page's 'load' event
+// fires even when CI can't reach external networks.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /fonts\.googleapis\.com|fonts\.gstatic\.com|api\.fontshare\.com|googletagmanager\.com/,
+    (route) =>
+      route.fulfill({ status: 200, contentType: "text/css", body: "" }),
+  );
+});
+
+// Slack integration docs page tests
+
+test("GET /docs/slack-integration returns 200", async ({ page }) => {
+  const response = await page.goto("/docs/slack-integration");
+  expect(response?.status()).toBe(200);
+});
+
+test("slack-integration page has h1 heading", async ({ page }) => {
+  await page.goto("/docs/slack-integration");
+  const h1 = page.locator("h1");
+  await expect(h1).toBeVisible();
+});
+
+// SUX-2.2 — "Connecting a Slack app" now uses StepFlow instead of nested
+// numbered lists, with the Socket Mode step visually flagged as manual.
+
+test("Connecting a Slack app section renders as a step flow", async ({
+  page,
+}) => {
+  await page.goto("/docs/slack-integration");
+  const heading = page.locator("h2, h3", {
+    hasText: /connecting a slack app/i,
+  });
+  await expect(heading.first()).toBeVisible();
+
+  const stepFlow = heading
+    .first()
+    .locator("xpath=following::ol[contains(@class, 'step-flow')][1]");
+  await expect(stepFlow).toBeVisible();
+
+  const steps = stepFlow.locator("li.step-flow-item");
+  await expect(steps).toHaveCount(4);
+});
+
+test("Connecting a Slack app section flags the Socket Mode step as manual", async ({
+  page,
+}) => {
+  await page.goto("/docs/slack-integration");
+  const heading = page.locator("h2, h3", {
+    hasText: /connecting a slack app/i,
+  });
+  const stepFlow = heading
+    .first()
+    .locator("xpath=following::ol[contains(@class, 'step-flow')][1]");
+
+  const socketModeStep = stepFlow.locator("li.step-flow-item", {
+    hasText: /socket mode/i,
+  });
+  await expect(socketModeStep.first()).toBeVisible();
+
+  const manualTag = socketModeStep.first().locator(".step-manual-tag");
+  await expect(manualTag).toBeVisible();
+  await expect(manualTag).toHaveText(/manual step/i);
+
+  const manualBox = socketModeStep.first().locator(".step-box-manual");
+  await expect(manualBox).toBeVisible();
+});
+
+test("Connecting a Slack app section preserves all credential/token names", async ({
+  page,
+}) => {
+  await page.goto("/docs/slack-integration");
+  const heading = page.locator("h2, h3", {
+    hasText: /connecting a slack app/i,
+  });
+  // Scope to everything between this h2 and the next h2 (the credential
+  // table section), so token names in later unrelated sections don't
+  // false-positive this check.
+  const nextHeading = page.locator("h2", {
+    hasText: /required slack environment variables/i,
+  });
+  const text =
+    (await page.evaluate(
+      ([startText, endText]) => {
+        const headings = Array.from(document.querySelectorAll("h2, h3"));
+        const start = headings.find((h) =>
+          (h.textContent ?? "")
+            .toLowerCase()
+            .includes((startText as string).toLowerCase()),
+        );
+        const end = headings.find((h) =>
+          (h.textContent ?? "")
+            .toLowerCase()
+            .includes((endText as string).toLowerCase()),
+        );
+        if (!start || !end) return "";
+        let node: Element | null = start.nextElementSibling;
+        let out = "";
+        while (node && node !== end) {
+          out += node.textContent ?? "";
+          node = node.nextElementSibling;
+        }
+        return out;
+      },
+      ["Connecting a Slack app", "Required Slack environment variables"],
+    )) ?? "";
+
+  expect(text).toContain("xoxe.xoxp-");
+  expect(text).toContain("xoxb-");
+  expect(text).toContain("xapp-");
+  expect(text.toLowerCase()).toContain("signing secret");
+
+  await expect(heading.first()).toBeVisible();
+  await expect(nextHeading.first()).toBeVisible();
+});
+
+test("slack-integration page ships no runtime JS beyond the analytics tag", async ({
+  page,
+}) => {
+  await page.goto("/docs/slack-integration");
+  await expectNoRuntimeJsBeyondAnalytics(page, { allowPagefind: true });
+});

--- a/site/tests/docs-slack-integration.spec.ts
+++ b/site/tests/docs-slack-integration.spec.ts
@@ -117,6 +117,28 @@ test("Connecting a Slack app section preserves all credential/token names", asyn
   await expect(nextHeading.first()).toBeVisible();
 });
 
+// Regression test for a review finding on the StepFlow migration: the
+// xoxe.xoxp- token instructions must retain the placeholder-app create/
+// delete steps, not just point at api.slack.com/apps in the abstract.
+test("Connecting a Slack app section explains the placeholder-app create/delete steps for the xoxe.xoxp- token", async ({
+  page,
+}) => {
+  await page.goto("/docs/slack-integration");
+  const heading = page.locator("h2, h3", {
+    hasText: /connecting a slack app/i,
+  });
+  const stepFlow = heading
+    .first()
+    .locator("xpath=following::ol[contains(@class, 'step-flow')][1]");
+
+  const firstStep = stepFlow.locator("li.step-flow-item").first();
+  const text = (await firstStep.textContent()) ?? "";
+
+  expect(text.toLowerCase()).toContain("from scratch");
+  expect(text.toLowerCase()).toContain("not from a manifest");
+  expect(text.toLowerCase()).toContain("delete the placeholder app");
+});
+
 test("slack-integration page ships no runtime JS beyond the analytics tag", async ({
   page,
 }) => {

--- a/site/tests/docs-the-shipwright-loop.spec.ts
+++ b/site/tests/docs-the-shipwright-loop.spec.ts
@@ -77,3 +77,59 @@ test("the-shipwright-loop page cross-links to configuring-autonomy instead of du
   const link = page.locator('a[href="/docs/configuring-autonomy"]');
   await expect(link.first()).toBeAttached();
 });
+
+// SUX-2.3 — "How dispatch works" now uses StepFlow instead of a 7-item prose
+// list, with the 409-pre-claim-conflict path rendered as a visually distinct
+// branch off step 5 rather than folded into the linear sequence.
+
+test("How dispatch works section renders as a 7-step flow", async ({
+  page,
+}) => {
+  await page.goto("/docs/the-shipwright-loop");
+  const heading = page.locator("h2, h3", {
+    hasText: /how dispatch works/i,
+  });
+  await expect(heading.first()).toBeVisible();
+
+  const stepFlow = heading
+    .first()
+    .locator("xpath=following::ol[contains(@class, 'step-flow')][1]");
+  await expect(stepFlow).toBeVisible();
+
+  const steps = stepFlow.locator("li.step-flow-item");
+  await expect(steps).toHaveCount(7);
+});
+
+test("How dispatch works section renders the 409-conflict path as a distinct branch off the pre-claim step", async ({
+  page,
+}) => {
+  await page.goto("/docs/the-shipwright-loop");
+  const heading = page.locator("h2, h3", {
+    hasText: /how dispatch works/i,
+  });
+  const stepFlow = heading
+    .first()
+    .locator("xpath=following::ol[contains(@class, 'step-flow')][1]");
+
+  const preClaimStep = stepFlow.locator("li.step-flow-item", {
+    hasText: /pre-claim/i,
+  });
+  await expect(preClaimStep.first()).toBeVisible();
+
+  const branch = preClaimStep.first().locator(".step-branch");
+  await expect(branch).toBeVisible();
+  await expect(branch).toContainText("409");
+
+  // The branch should be the only one in the whole flow — a single
+  // conditional path off the linear happy path, not a general branching graph.
+  const allBranches = stepFlow.locator(".step-branch");
+  await expect(allBranches).toHaveCount(1);
+});
+
+test("How dispatch works section preserves the FIFO work-selector cross-link", async ({
+  page,
+}) => {
+  await page.goto("/docs/the-shipwright-loop");
+  const link = page.locator('a[href="#the-fifo-work-selector"]');
+  await expect(link.first()).toBeAttached();
+});


### PR DESCRIPTION
## Summary
- Adds `site/src/components/StepFlow.astro` — a reusable, presentational component for rendering a linear numbered sequence of steps with an optional single conditional branch per step (SUX-2.1)
- Reuses the existing box-and-arrow visual language established by `SecurityArchDiagram.astro`/`agent-model.astro` and existing CSS custom properties (no new design tokens)
- Steps flagged `manual: true` render with a distinct warning-token treatment and a "Manual step" tag
- Applies `StepFlow` to the "Connecting a Slack app" section of `slack-integration.mdx`, replacing four separately-numbered sub-lists with a single 4-step flow and flagging Step 4 (enable Socket Mode) as the one manual step (SUX-2.2)
- Unblocks SUX-2.3, which will apply this component to one more docs page currently describing a linear process as prose

## Acceptance Criteria

**SUX-2.1**
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Renders steps in order with clear visual distinction for manual steps | MET | Ordered list numbered by index; `.step-box-manual` + "Manual step" tag applied via `--sw-color-state-warning` |
| 2 | Follows existing component conventions (Astro.props typed, existing CSS custom properties, no new tokens) | MET | `interface Props { steps: Step[] }`; all CSS vars used are pre-existing tokens shared with `SecurityArchDiagram.astro`/`agent-model.astro` |
| 3 | No test needed beyond astro build + brand-lint CI gate | MET | `cd site && npm run build:check` passed — 26 pages built, all on-brand, zero errors |

**SUX-2.2**
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | "Connecting a Slack app" section uses StepFlow instead of nested numbered lists; the manual step is visually flagged | MET | Replaced 4 numbered subsections with a single `<StepFlow>` call; Step 4 has `manual: true`, rendering `.step-box-manual` + "Manual step" tag |
| 2 | All credential/token names preserved (xoxe.xoxp-, xoxb-, xapp-, signing secret) | MET | All four token names/prefixes retained in step `detail` prose, verified by a Playwright assertion scoped to the section |
| 3 | Playwright smoke spec asserting the section renders and the manual-step indicator is visible | MET | New `site/tests/docs-slack-integration.spec.ts` — asserts 4 steps render, manual tag/box visible on the Socket Mode step, and token names preserved |

## Test Plan
- [x] `cd site && npx playwright test tests/docs-slack-integration.spec.ts` — passing (6 tests)
- [x] Full site Playwright suite (272 tests) — passing, no regressions
- [x] `astro build` — 26 pages generated cleanly
- [x] `task typecheck` — passing across all workspaces
- [x] `bunx biome lint`/`task check-strings` — clean on touched files
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
