### PR TITLE
fix: unify default system crons table, add command/skill columns (SUX-1.1)

### DIFF
--- a/plugins/shipwright/test/cron-tables.content.test.ts
+++ b/plugins/shipwright/test/cron-tables.content.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Default system crons table content tests — SUX-1.1
+ *
+ * site/src/content/docs/the-agent.mdx and site/src/content/docs/cron-jobs.mdx used to both
+ * carry a "Default system crons" table, and they had drifted out of sync with each other and
+ * with agent-types/coding/manifest.yaml's `crons:` array (the actual source of truth).
+ *
+ * cron-jobs.mdx is now the single source of truth for this table. This test guards against
+ * re-drift:
+ *   - every cron name declared in the manifest appears exactly once in cron-jobs.mdx's
+ *     "Default system crons" table
+ *   - the-agent.mdx no longer contains any cron names at all (it should only link to
+ *     cron-jobs.mdx instead of re-documenting the table)
+ *   - cron-jobs.mdx's table header includes the new Command and Skill columns
+ *
+ * Content-assertion only: existsSync/readFileSync, no I/O beyond local file reads.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// plugins/shipwright/test/ → repo root
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+const cronJobsDocPath = join(repoRoot, "site", "src", "content", "docs", "cron-jobs.mdx");
+const theAgentDocPath = join(repoRoot, "site", "src", "content", "docs", "the-agent.mdx");
+const manifestPath = join(repoRoot, "agent-types", "coding", "manifest.yaml");
+
+function readCronJobsDoc(): string {
+  return readFileSync(cronJobsDocPath, "utf8");
+}
+
+/**
+ * Isolate the "Default system crons" table's own lines (header + separator + rows), so
+ * assertions about "exactly once" aren't tripped up by legitimate prose mentions of a cron
+ * name elsewhere on the page (e.g. "Loop-driven vs standalone crons").
+ */
+function readCronJobsTableBlock(): string {
+  const doc = readCronJobsDoc();
+  const headingIdx = doc.indexOf("### Default system crons");
+  expect(headingIdx).toBeGreaterThanOrEqual(0);
+
+  const tableStart = doc.indexOf("| Cron", headingIdx);
+  expect(tableStart).toBeGreaterThan(headingIdx);
+
+  const tableEnd = doc.indexOf("\n\n", tableStart);
+  expect(tableEnd).toBeGreaterThan(tableStart);
+
+  return doc.slice(tableStart, tableEnd);
+}
+
+function readTheAgentDoc(): string {
+  return readFileSync(theAgentDocPath, "utf8");
+}
+
+function readManifest(): string {
+  return readFileSync(manifestPath, "utf8");
+}
+
+/**
+ * Extract cron names from the manifest's `crons:` array. The manifest is simple,
+ * asciibetized-by-hand YAML — a line-based `- name: <cron-name>` extraction is sufficient
+ * and matches this repo's existing preference for plain text assertions over adding a YAML
+ * parser dependency for content tests.
+ */
+function getManifestCronNames(): string[] {
+  const manifest = readManifest();
+  const cronsSectionStart = manifest.indexOf("\ncrons:");
+  expect(cronsSectionStart).toBeGreaterThanOrEqual(0);
+
+  const pluginsSectionStart = manifest.indexOf("\nplugins:", cronsSectionStart);
+  expect(pluginsSectionStart).toBeGreaterThan(cronsSectionStart);
+
+  const cronsBlock = manifest.slice(cronsSectionStart, pluginsSectionStart);
+  const nameMatches = [...cronsBlock.matchAll(/^\s*-\s*name:\s*(\S+)/gm)];
+  const names = nameMatches.map((m) => m[1]);
+
+  expect(names.length).toBeGreaterThan(0);
+  return names;
+}
+
+// ── Files exist ───────────────────────────────────────────────────────────────
+
+describe("cron table docs — files", () => {
+  it("agent-types/coding/manifest.yaml exists", () => {
+    expect(existsSync(manifestPath)).toBe(true);
+  });
+
+  it("site/src/content/docs/cron-jobs.mdx exists", () => {
+    expect(existsSync(cronJobsDocPath)).toBe(true);
+  });
+
+  it("site/src/content/docs/the-agent.mdx exists", () => {
+    expect(existsSync(theAgentDocPath)).toBe(true);
+  });
+});
+
+// ── cron-jobs.mdx is the single source of truth ──────────────────────────────
+
+describe("cron-jobs.mdx — Default system crons table", () => {
+  it("contains a 'Default system crons' heading", () => {
+    expect(readCronJobsDoc()).toContain("Default system crons");
+  });
+
+  it("has a table header row with both Command and Skill columns", () => {
+    const tableBlock = readCronJobsTableBlock();
+    const headerLine = tableBlock.split("\n")[0];
+
+    expect(headerLine).toContain("Cron");
+    expect(headerLine).toContain("Schedule");
+    expect(headerLine).toContain("Command");
+    expect(headerLine).toContain("Skill");
+  });
+
+  for (const cronName of getManifestCronNames()) {
+    it(`includes every manifest cron exactly once as a table row: \`${cronName}\``, () => {
+      const tableBlock = readCronJobsTableBlock();
+      // Match the cron name only in the leading "Cron" column of a row, e.g.
+      // "| `shipwright-loop` |" — this avoids over-counting prose mentions of the same
+      // cron name inside other rows' "What it does" cells (e.g. "shipwright-loop" is
+      // referenced by every pipeline-cron row's description).
+      const rowCellPattern = new RegExp(`^\\|\\s*\`${cronName}\`\\s*\\|`, "gm");
+      const occurrences = [...tableBlock.matchAll(rowCellPattern)].length;
+      expect(occurrences).toBe(1);
+    });
+  }
+});
+
+// ── the-agent.mdx no longer documents the table (regression guard) ──────────
+
+describe("the-agent.mdx — no cron table drift", () => {
+  it("does not contain a cron table (no 'Cron | Schedule' header row)", () => {
+    const doc = readTheAgentDoc();
+    const hasCronTableHeader = doc
+      .split("\n")
+      .some((line) => line.includes("| Cron") && line.includes("Schedule"));
+
+    expect(hasCronTableHeader).toBe(false);
+  });
+
+  it("links to cron-jobs.mdx instead of re-documenting crons", () => {
+    expect(readTheAgentDoc()).toContain("cron-jobs");
+  });
+
+  for (const cronName of getManifestCronNames()) {
+    it(`does not mention manifest cron name: \`${cronName}\``, () => {
+      expect(readTheAgentDoc()).not.toContain(cronName);
+    });
+  }
+});

--- a/site/src/content/docs/cron-jobs.mdx
+++ b/site/src/content/docs/cron-jobs.mdx
@@ -113,14 +113,14 @@ scanning repos for stale docs, or querying Sentry for unresolved errors), with n
 
 | Cron | Schedule | Command | Skill | Default | What it does |
 |---|---|---|---|---|---|
-| `shipwright-dev-task` | every minute | `/shipwright:dev-task` | dev-task | **on** | Builds and ships a PR for the task `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-review` | every minute | `/shipwright:review` | review | **on** | Reviews the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-patch` | every minute | `/shipwright:patch` | patch | **on** | Patches the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-deploy` | every minute | `/shipwright:deploy` | deploy | off | Merges and deploys the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-dev-task` | every minute | `/shipwright:dev-task` | — | **on** | Builds and ships a PR for the task `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-review` | every minute | `/shipwright:review` | — | **on** | Reviews the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-patch` | every minute | `/shipwright:patch` | — | **on** | Patches the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-deploy` | every minute | `/shipwright:deploy` | — | off | Merges and deploys the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
 | `shipwright-loop` | every minute | internal | — | off | Drives the four phases above — merges their candidates and dispatches exactly one winning item per phase, per tick, until the queue is dry. |
 | `shipwright-test-readiness` | daily 06:00 | `/shipwright:test-readiness --full --publish` | test-readiness | off | Full test-readiness audit for repos with stale or missing artifacts. |
-| `shipwright-docs-freshness` | daily 07:00 | `/shipwright:research-docs --auto` | research-docs | off | Refreshes docs that have drifted from the code. |
-| `learn-dream` | daily 03:00 | `/shipwright:learn-dream --since 1d --review` | learn-dream | off | Mines the last day of merged PRs for durable learnings. |
+| `shipwright-docs-freshness` | daily 07:00 | `/shipwright:research-docs --auto` | — | off | Refreshes docs that have drifted from the code. |
+| `learn-dream` | daily 03:00 | `/shipwright:learn-dream --since 1d --review` | — | off | Mines the last day of merged PRs for durable learnings. |
 | `dependabot-triage` | daily 08:00 | `/shipwright:triage-dependabot-prs` | triage-dependabot-prs | off | Reviews and triages open Dependabot PRs. |
 | `entropy-patrol-maintenance` | weekly Mon 04:00 | `/shipwright:entropy-scan` → `/shipwright:entropy-fix` | entropy-scan, entropy-fix | off | Scans for code entropy and fixes what's PR-worthy. |
 | `error-patrol-maintenance` | daily 04:00 | `/shipwright:error-scan` → `/shipwright:error-fix` → `/shipwright:error-resolve` | error-scan, error-fix, error-resolve | off | Scans for unresolved Sentry errors and fixes what's PR-worthy. |

--- a/site/src/content/docs/cron-jobs.mdx
+++ b/site/src/content/docs/cron-jobs.mdx
@@ -111,21 +111,21 @@ scanning repos for stale docs, or querying Sentry for unresolved errors), with n
 
 ### Default system crons
 
-| Cron | Schedule | Default | What it does |
-|---|---|---|---|
-| `shipwright-dev-task` | every minute | **on** | Builds and ships a PR for the task `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-review` | every minute | **on** | Reviews the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-patch` | every minute | **on** | Patches the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-deploy` | every minute | off | Merges and deploys the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
-| `shipwright-loop` | every minute | off | Drives the four phases above — merges their candidates and dispatches exactly one winning item per phase, per tick, until the queue is dry. |
-| `shipwright-test-readiness` | daily 06:00 | off | Full test-readiness audit for repos with stale or missing artifacts. |
-| `shipwright-docs-freshness` | daily 07:00 | off | Refreshes docs that have drifted from the code. |
-| `learn-dream` | daily 03:00 | off | Mines the last day of merged PRs for durable learnings. |
-| `dependabot-triage` | daily 08:00 | off | Reviews and triages open Dependabot PRs. |
-| `entropy-patrol-maintenance` | weekly Mon 04:00 | off | Scans for code entropy and fixes what's PR-worthy. |
-| `error-patrol-maintenance` | daily 04:00 | off | Scans for unresolved Sentry errors and fixes what's PR-worthy. |
-| `security-patrol-maintenance` | weekly Mon 06:00 | off | Scans for security vulnerabilities and fixes what's PR-worthy. |
-| `consolidation-patrol-maintenance` | weekly Mon 05:00 | off | Proposes consolidation for duplicate patterns that have stabilized over time. |
+| Cron | Schedule | Command | Skill | Default | What it does |
+|---|---|---|---|---|---|
+| `shipwright-dev-task` | every minute | `/shipwright:dev-task` | dev-task | **on** | Builds and ships a PR for the task `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-review` | every minute | `/shipwright:review` | review | **on** | Reviews the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-patch` | every minute | `/shipwright:patch` | patch | **on** | Patches the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-deploy` | every minute | `/shipwright:deploy` | deploy | off | Merges and deploys the PR `shipwright-loop` selects. Inert if `shipwright-loop` is disabled. |
+| `shipwright-loop` | every minute | internal | — | off | Drives the four phases above — merges their candidates and dispatches exactly one winning item per phase, per tick, until the queue is dry. |
+| `shipwright-test-readiness` | daily 06:00 | `/shipwright:test-readiness --full --publish` | test-readiness | off | Full test-readiness audit for repos with stale or missing artifacts. |
+| `shipwright-docs-freshness` | daily 07:00 | `/shipwright:research-docs --auto` | research-docs | off | Refreshes docs that have drifted from the code. |
+| `learn-dream` | daily 03:00 | `/shipwright:learn-dream --since 1d --review` | learn-dream | off | Mines the last day of merged PRs for durable learnings. |
+| `dependabot-triage` | daily 08:00 | `/shipwright:triage-dependabot-prs` | triage-dependabot-prs | off | Reviews and triages open Dependabot PRs. |
+| `entropy-patrol-maintenance` | weekly Mon 04:00 | `/shipwright:entropy-scan` → `/shipwright:entropy-fix` | entropy-scan, entropy-fix | off | Scans for code entropy and fixes what's PR-worthy. |
+| `error-patrol-maintenance` | daily 04:00 | `/shipwright:error-scan` → `/shipwright:error-fix` → `/shipwright:error-resolve` | error-scan, error-fix, error-resolve | off | Scans for unresolved Sentry errors and fixes what's PR-worthy. |
+| `security-patrol-maintenance` | weekly Mon 06:00 | `/shipwright:security-scan` → `/shipwright:security-fix` | security-scan, security-fix | off | Scans for security vulnerabilities and fixes what's PR-worthy. |
+| `consolidation-patrol-maintenance` | weekly Mon 05:00 | `/shipwright:consolidation-scan` → `/shipwright:consolidation-fix` | consolidation-scan, consolidation-fix | off | Proposes consolidation for duplicate patterns that have stabilized over time. |
 
 Only three ship enabled by default: `shipwright-dev-task`, `shipwright-review`, and
 `shipwright-patch`. Everything else — including `shipwright-loop` itself — is opt-in, toggled from

--- a/site/src/content/docs/the-agent.mdx
+++ b/site/src/content/docs/the-agent.mdx
@@ -84,24 +84,8 @@ unset, secrets are stored in plain text with a logged warning.
 
 ## Default system crons
 
-Every new agent is seeded with eleven system crons. Three are enabled by default; the rest are opt-in
-and can be toggled in the admin UI or via `PATCH /agents/:id/crons/:cronId`.
-
-| Cron | Schedule | Default | What it does |
-|------|----------|---------|--------------|
-| `shipwright-dev-task` | every 30 min | **on** | Pick next ready task, build with tests, open PR |
-| `shipwright-review` | every 30 min | **on** | Review-only pass over open PRs |
-| `shipwright-patch` | every 30 min | **on** | Fix failing CI and unresolved review findings |
-| `shipwright-deploy` | every 30 min | off | Merge approved PRs and deploy |
-| `shipwright-test-readiness` | daily 06:00 | off | Full test-readiness audit |
-| `shipwright-docs-freshness` | daily 07:00 | off | Refresh docs that drifted from the code |
-| `learn-dream` | daily 03:00 | off | Mine merged PRs for durable learnings |
-| `dependabot-triage` | daily 08:00 | off | Review and triage open Dependabot PRs |
-| `entropy-patrol-maintenance` | weekly Mon 04:00 | off | Scan for code entropy and fix what's PR-worthy |
-
-Crons run `silent` by default — they post to Slack only when there is a result worth surfacing or
-on error. Most carry a `preCheck` script whose stdout becomes the actual prompt, so a cron only
-spends a Claude turn when there is real work ready.
+See [Cron Jobs](/docs/cron-jobs#default-system-crons) for the full list of default system crons,
+their schedules, and what each one does.
 
 ## Required environment variables
 


### PR DESCRIPTION
## Summary
- `site/src/content/docs/the-agent.mdx` had a stale "Default system crons" table (9 rows, wrong "every 30 min" schedules, missing `shipwright-loop` and 3 patrol crons) that disagreed with `cron-jobs.mdx`. Replaced it with a one-line pointer to `/docs/cron-jobs#default-system-crons`, making `cron-jobs.mdx` the single source of truth.
- `site/src/content/docs/cron-jobs.mdx`'s table (already accurate against `agent-types/coding/manifest.yaml`, 13 rows) now also carries **Command** and **Skill** columns so it answers "what runs when I enable `shipwright-deploy`?" in one place, without needing to cross-reference `commands-reference.mdx`/`agent-skills.mdx`.
- Added `plugins/shipwright/test/cron-tables.content.test.ts`, a regression guard that reads the manifest's `crons:` list and asserts every cron name appears exactly once in `cron-jobs.mdx`'s table and zero times in `the-agent.mdx`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | the-agent.mdx no longer contains a 'Default system crons' table or cron schedule/enabled data; links to cron-jobs.mdx instead | MET |
| 2 | cron-jobs.mdx's table gains Command and Skill columns, verified against manifest.yaml + commands-reference.mdx/agent-skills.mdx | MET |
| 3 | New content test asserts every manifest cron appears exactly once in cron-jobs.mdx and zero times in the-agent.mdx | MET |
| 4 | No Playwright spec update needed (docs-platform.spec.ts / docs-cron-jobs.spec.ts don't assert on table rows) | MET |

## Test Plan
- `bun test plugins/shipwright/test/cron-tables.content.test.ts` — 33 tests, all pass
- `task lint`, `task typecheck` (all 7 workspaces) — pass
- `task check-strings`, `task check-config-docs`, `task check-version-sync` — pass
- Full `task test` shows 31 pre-existing failures in unrelated packages (`metrics/`, `task-store/`) that are order-dependent full-suite flakes — confirmed they pass in isolation and reproduce identically on unmodified `main`, unrelated to this diff
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
