### PR TITLE
docs: convert workflow-pattern checkmarks to table

### DIFF
--- a/site/src/content/docs/configuring-autonomy.mdx
+++ b/site/src/content/docs/configuring-autonomy.mdx
@@ -73,6 +73,12 @@ a working `check-deploy` pre-check — so the agent can't merge something broken
 
 ## Common workflow patterns
 
+| Pattern | dev-task | review | patch | deploy | Notes |
+|---------|:--------:|:------:|:-----:|:------:|-------|
+| Hands-off | ✓ | ✗ | ✓ | ✗ | Build and patch CI, skip posting reviews — you review PRs yourself. |
+| Staged reviews | ✓ | ✓ | ✓ | ✗ | `auto_post_reviews: false` — findings held locally until you approve them. |
+| Bring your own PR | ✗ | ✓ | ✓ | ✓ | Skip the task queue; open PRs yourself and let review/patch/deploy take it from there. |
+
 ### Hands-off: build and patch, skip review
 
 Some projects don't need the agent to post PR reviews. You just want it to build tasks and
@@ -80,10 +86,6 @@ fix CI failures while you review PRs yourself.
 
 Enable `shipwright-dev-task` and `shipwright-patch`. Disable `shipwright-review`. The agent
 builds, opens PRs, and patches CI — but never posts a review comment.
-
-```
-dev-task  ✓  patch  ✓  review  ✗  deploy  ✗
-```
 
 ### Staged reviews
 
@@ -96,19 +98,11 @@ With staging on, the agent runs its review pass and writes the findings to a loc
 Nothing is posted to GitHub until you approve it. Once you've confirmed the review looks right,
 post it manually, or set `auto_post_reviews: true` again to go back to automatic posting.
 
-```
-dev-task  ✓  review  ✓  patch  ✓  deploy  ✗   (auto_post_reviews: false)
-```
-
 ### Bring your own PR
 
 You don't have to go through the task queue at all. Open a PR yourself — a quick fix, a hotfix,
 anything — and Shipwright picks it up from there. With `review`, `patch`, and `deploy` enabled,
 the agent will review the PR, patch any CI failures, and merge it once it's clean.
-
-```
-dev-task  ✗  review  ✓  patch  ✓  deploy  ✓
-```
 
 This works and is a reasonable way to get comfortable with the system. That said, bypassing
 `dev-task` means skipping the quality work it does before the PR exists: structured planning,


### PR DESCRIPTION
## Summary
- Replaced the three ad hoc checkmark code blocks in `configuring-autonomy.mdx`'s "Common workflow patterns" section with a single table (Pattern | dev-task | review | patch | deploy | Notes)
- Matches the table convention already used for Stage 1-3 earlier in the same file
- Explanatory prose for each pattern is unchanged — only the ad hoc checkmark-string encoding was replaced

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Three patterns represented as table rows with per-phase on/off state | MET | New table with 3 rows × dev-task/review/patch/deploy columns |
| 2 | Explanatory prose retained under/beside the table | MET | All three `###` subsections and prose kept intact |
| 3 | No test change needed — same-page formatting change only | MET | Only `configuring-autonomy.mdx` touched |

## Test Plan
- Docs-only formatting change; no test change required per acceptance criteria
- `task lint` passes
- `task ci`'s `test:coverage` step has pre-existing unrelated failures (`metrics/src/lib/env.unit.test.ts`, `metrics/src/lib/errors.unit.test.ts`, `task-store/src/routes/prs.openapi.smoke.test.ts`) — confirmed reproducing on `main` at the same commit, unrelated to this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
