### PR TITLE
docs: add forward-pointer note to running-locally.mdx

### DIFF
--- a/site/src/content/docs/running-locally.mdx
+++ b/site/src/content/docs/running-locally.mdx
@@ -9,6 +9,9 @@ next: "/docs/agent-skills"
 
 # Running Locally
 
+> **New here?** Read [The Agent](/docs/the-agent) first if you want the concept explained
+> before running the stack.
+
 Shipwright has two local run modes: a lightweight metrics-only mode (`task dev`) that requires no
 secrets, and a full six-pane dev stack (`task stack`) that brings up every service together. Both
 are driven by the `task` command runner.


### PR DESCRIPTION
## Summary
- Adds a one-line forward-pointer note near the top of `running-locally.mdx`, pointing readers to `/docs/the-agent` for a concept explainer before diving into the full-stack setup.
- Scoped to the content pointer only — sidebar order/prev/next frontmatter is unchanged, per the task's explicit scope boundary (a full reorder would touch 4 files' frontmatter and their spec assertions).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | A one-line forward-pointer to /docs/the-agent is added near the top of running-locally.mdx | MET | Blockquote note added directly after the H1 heading |
| 2 | No frontmatter (order/prev/next) changes | MET | Diff touches only body content, lines 9+ |
| 3 | No test change needed | MET | No test files modified; existing nav/heading specs in `docs-platform.spec.ts` are unaffected |

## Test Plan
- Ran `npm run build` in `site/` — Astro build succeeds, `/docs/running-locally` page renders with the new blockquote note linking to `/docs/the-agent`.
- Verified rendered HTML output contains the expected link markup.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
