### PR TITLE
chore(chart): bump chart version to 1.18.2

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.18.2] - 2026-08-27
+
+### Changed
+
+- auto-bump to chart v1.18.2 triggered by release tag(s): `agent-v1.196.0`
+
 ## [1.18.1] - 2026-08-27
 
 ### Added

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.18.1
+version: 1.18.2
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,8 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: added
-      description: "Minikube cloud-native profile examples (CNH-8.2): new examples/values-minikube-cloud-native-nginx.yaml (bundles ingress-nginx + cert-manager with a selfsigned Issuer, auth.mode: open, admin.appBaseUrl on https://shipwright.local:8443) and examples/values-minikube-cloud-native-traefik.yaml (bundles Traefik, plain HTTP on http://shipwright.local:8080, no cert-manager) — dev-friendly variants of values-cloud-native.yaml/values-cloud-native-traefik.yaml tuned to run standalone on a fresh local Minikube VM with no external OAuth creds or pre-existing ClusterIssuer required."
+    - kind: changed
+      description: "auto-bump to chart v1.18.2 triggered by release tag agent-v1.196.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -407,7 +407,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.195.0
+    tag: agent-v1.196.0
     pullPolicy: ""
   service:
     port: 3000
@@ -430,7 +430,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.195.0
+      tag: agent-v1.196.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.18.1 → 1.18.2

**Triggering tags:**
- `agent-v1.196.0`

**New chart version:** `1.18.2`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v1.196.0`
- `agent.provisioning.image.tag`: `agent-v1.196.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.18.2 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._