### PR TITLE
fix: use workspace:* for @shipwright/lib deps to resolve Renovate lookup warning

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -18,7 +18,7 @@
     "@prisma/client": "^6.19.2",
     "@sentry/bun": "^10.63.0",
     "@sentry/hono": "^10.63.0",
-    "@shipwright/lib": "*",
+    "@shipwright/lib": "workspace:*",
     "hono": "^4.13.1",
     "yaml": "^2.9.0",
     "zod": "^3",

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "@prisma/client": "^6.19.2",
         "@sentry/bun": "^10.63.0",
         "@sentry/hono": "^10.63.0",
-        "@shipwright/lib": "*",
+        "@shipwright/lib": "workspace:*",
         "hono": "^4.13.1",
         "yaml": "^2.9.0",
         "zod": "^3",
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.194.0",
+      "version": "1.196.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -70,7 +70,7 @@
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@prisma/client": "^6.19.2",
-        "@shipwright/lib": "*",
+        "@shipwright/lib": "workspace:*",
         "hono": "^4.13.1",
       },
       "devDependencies": {
@@ -100,7 +100,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.194.0",
+      "version": "1.196.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -118,7 +118,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.194.0",
+      "version": "1.196.0",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -132,7 +132,7 @@
         "@prisma/client": "^6.19.2",
         "@sentry/bun": "^10.63.0",
         "@sentry/hono": "^10.63.0",
-        "@shipwright/lib": "*",
+        "@shipwright/lib": "workspace:*",
         "hono": "^4.13.1",
         "zod": "^3",
       },

--- a/chat/package.json
+++ b/chat/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@hono/zod-openapi": "^0.18.3",
     "@prisma/client": "^6.19.2",
-    "@shipwright/lib": "*",
+    "@shipwright/lib": "workspace:*",
     "hono": "^4.13.1"
   },
   "devDependencies": {

--- a/metrics/package.json
+++ b/metrics/package.json
@@ -12,7 +12,7 @@
     "@hono/zod-openapi": "^0.18.3",
     "@sentry/bun": "^10.63.0",
     "@sentry/hono": "^10.63.0",
-    "@shipwright/lib": "*",
+    "@shipwright/lib": "workspace:*",
     "hono": "^4.13.1",
     "openapi-fetch": "^0.13",
     "zod": "^3"

--- a/task-store/package.json
+++ b/task-store/package.json
@@ -17,7 +17,7 @@
     "@prisma/client": "^6.19.2",
     "@sentry/bun": "^10.63.0",
     "@sentry/hono": "^10.63.0",
-    "@shipwright/lib": "*",
+    "@shipwright/lib": "workspace:*",
     "hono": "^4.13.1",
     "zod": "^3"
   },


### PR DESCRIPTION
## Summary
- Renovate Dependency Dashboard reported it could not resolve `@shipwright/lib` as an npm package in `admin/package.json`, `chat/package.json`, `metrics/package.json`, and `task-store/package.json` — those four files declared it as a bare wildcard (`"*"`) instead of `"workspace:*"`, so Renovate tried the public npm registry instead of recognizing it as an internal Bun workspace-linked package.
- Changed all four to `"@shipwright/lib": "workspace:*"`, matching the pattern already used by `agent/package.json` for the same dependency.
- Confirmed no other internal `@shipwright/*` dependency has the same bare-wildcard issue repo-wide.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Change bare `"*"` to `"workspace:*"` in the 4 affected package.json files | MET | admin/package.json, chat/package.json, metrics/package.json, task-store/package.json all updated |
| 2 | Verify `workspace:*` doesn't break `bun install` / `task ci` | MET | `bun install` succeeds; lint/check-strings/typecheck/check-config-docs/check-version-sync all pass |
| 3 | Confirm no other internal `@shipwright/*` packages have the same bare-wildcard issue | MET | Repo-wide grep for `"@shipwright/*": "*"` returns zero matches |

## Test Plan
- `bun install` — succeeds, `bun.lock` correctly links `@shipwright/lib` as `workspace:*` for all four packages
- `task ci` (lint, check-strings, typecheck, check-config-docs, check-version-sync) — all pass
- `task test:coverage` — 31 pre-existing failures (confirmed identical with and without this change via checkout-based baseline diff), not introduced by this fix
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
