### PR TITLE
feat: auto-merge minor/patch Renovate PRs on shipwright

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "platformAutomerge": true,
+  "automergeType": "pr",
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
@@ -33,7 +35,8 @@
     {
       "description": "Group routine (non-security) minor/patch bumps to cut down PR noise",
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "routine dependency updates"
+      "groupName": "routine dependency updates",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add top-level `"platformAutomerge": true` and `"automergeType": "pr"` to `renovate.json` so Renovate calls GitHub's native auto-merge instead of merging PRs itself.
- Add `"automerge": true` to the existing `packageRules` entry that groups routine minor/patch bumps (`matchUpdateTypes: ["minor", "patch"]`) — scoped automerge, not a blanket top-level `automerge`. Major version bumps are untouched and still require human review.
- The existing GHCR self-image exclusion rule (`enabled: false`, no `matchUpdateTypes`) runs first in `packageRules` and isn't touched by this change, so it still fully excludes those images from Renovate regardless of update type.

## Context
Renovate PRs are excluded from `/shipwright:review` candidacy (RNV-1.1) and there's no other automated triage/merge path for them, so they were piling up unmerged. This wires minor/patch Renovate PRs into GitHub's native auto-merge. Both `app-vitals/shipwright` and `app-vitals/vitals-os` already have the repo setting `allow_auto_merge=true` (verified via `gh api repos/app-vitals/shipwright --jq .allow_auto_merge`).

**Note:** GitHub native auto-merge only completes once required status checks pass AND the branch is mergeable/up to date per this repo's branch protection rules. Verifying the actual branch-protection required-checks configuration is out of scope for this task — the task-author's token could not read branch protection rules via the API to confirm this ahead of time.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Top-level `platformAutomerge: true` + `automergeType: "pr"` added | MET | `renovate.json` diff |
| 2 | `automerge: true` added to the minor/patch packageRule only (no blanket top-level automerge) | MET | `renovate.json` diff |
| 3 | `renovate.json` still validates (valid JSON + matches renovate-schema.json) | MET | `renovate-config-validator` run locally: "Config validated successfully" |
| 4 | GHCR self-image exclusion packageRule unaffected/still takes precedence | MET | Rule runs first, sets `enabled: false` with no `matchUpdateTypes`; the automerge rule doesn't touch `enabled` |

## Test Plan
- [x] `jq . renovate.json` — valid JSON
- [x] `npx -p renovate renovate-config-validator renovate.json` — "Config validated successfully"
- [x] `task lint`, `task typecheck`, `check-config-docs`, `check-version-sync` — all pass
- [ ] `task test:coverage` — pre-existing failures reproduce identically on unmodified `main` in this environment (nested-worktree module-resolution issues under `repos/shipwright/worktrees/...`), unrelated to this JSON-only config change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
