### PR TITLE
chore(chart): bump chart version to 1.19.3

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.19.3] - 2026-08-28
+
+### Changed
+
+- auto-bump to chart v1.19.3 triggered by release tag(s): `agent-v1.198.0`
+
 ## [1.19.2] - 2026-08-28
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.19.2
+version: 1.19.3
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,11 +30,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "Derive admin.appBaseUrl from the public host (CNH-9.1). New shipwright.admin.appBaseUrl helper: an explicit admin.appBaseUrl value always wins; when empty and networking.type is ingress or gateway, SHIPWRIGHT_ADMIN_APP_BASE_URL is derived as <scheme>://<public host>; otherwise the env var is omitted (ClusterIP/NodePort/LoadBalancer installs unchanged). NOTES.txt and README.md updated to reflect the new precedence."
-    - kind: changed
-      description: "auto-bump to chart v1.19.1 triggered by release tag(s): admin-v1.98.0, agent-v1.197.0, chat-v1.53.0, metrics-v1.56.0, task-store-v1.78.0"
-    - kind: changed
-      description: "Cloud-native docs and release (CNH-8.4). README.md gains Values rows for ingress-nginx.enabled/traefik.enabled/cert-manager.enabled, a Dependencies table listing all four vendored subcharts (postgresql, ingress-nginx, traefik, cert-manager) with versions/repositories/conditions, and a new 'Cloud-native install (single chart)' section with a warning against bundling cert-manager on a cluster that already has it. docs/deploy-kubernetes.md gains a new 'Cloud-native (any cluster)' deployment-target section (install commands for both the ingress-nginx and Traefik bundled variants, the same cert-manager-collision warning, and cross-links to the existing Bundled ingress controllers reference and Minikube profiles). docs/helm-repo.md now states the chart vendors four optional subcharts up front."
+      description: "auto-bump to chart v1.19.3 triggered by release tag agent-v1.198.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -411,7 +411,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.197.0
+    tag: agent-v1.198.0
     pullPolicy: ""
   service:
     port: 3000
@@ -434,7 +434,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.197.0
+      tag: agent-v1.198.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.19.2 → 1.19.3

**Triggering tags:**
- `agent-v1.198.0`

**New chart version:** `1.19.3`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v1.198.0`
- `agent.provisioning.image.tag`: `agent-v1.198.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.19.3 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._