### PR TITLE
fix(agent): match deploy candidate CI/deploy workflow names case-insensitively

### DIFF
--- a/agent/src/check-deploy.ts
+++ b/agent/src/check-deploy.ts
@@ -376,7 +376,7 @@ export async function buildProductionDeps(opts: {
         `repos/${org}/${repo}/actions/runs?status=queued&per_page=10`,
       ]);
       return [...inProgress.workflow_runs, ...queued.workflow_runs]
-        .filter((r) => r.name === "Deploy")
+        .filter((r) => r.name.toLowerCase() === "deploy")
         .map((r) => ({
           name: r.name,
           status: r.status,
@@ -413,7 +413,7 @@ export async function buildProductionDeps(opts: {
         `repos/${org}/${repo}/actions/runs?head_sha=${headSha}&per_page=20`,
       ]);
       return data.workflow_runs
-        .filter((r) => r.name === "CI")
+        .filter((r) => r.name.toLowerCase() === "ci")
         .map((r) => ({ status: r.status, conclusion: r.conclusion }));
     },
     isBundleComplete: createBundleCompleteQuery({ fetchFn: opts.fetchFn }),

--- a/agent/src/check-deploy.unit.test.ts
+++ b/agent/src/check-deploy.unit.test.ts
@@ -1094,7 +1094,7 @@ describe("buildProductionDeps", () => {
     ]);
   });
 
-  test("fetchCiRuns filters workflow_runs down to name === 'CI' and maps status/conclusion", async () => {
+  test("fetchCiRuns filters workflow_runs down to name 'CI' (case-insensitive) and maps status/conclusion", async () => {
     const deps = await buildProductionDeps({
       ghJson: async <T>(args: string[]) => {
         expect(args[1]).toContain(
@@ -1113,7 +1113,28 @@ describe("buildProductionDeps", () => {
     expect(runs).toEqual([{ status: "completed", conclusion: "success" }]);
   });
 
-  test("fetchActiveDeployRuns merges in_progress and queued runs, filters to name === 'Deploy', and maps created_at", async () => {
+  // Regression test: a repo whose CI workflow's `name:` field is lowercase
+  // `ci` (a valid, common convention — see .github/workflows/ci.yml's `name:`
+  // key) was silently excluded from deploy candidacy forever, since the old
+  // filter did an exact-case match against "CI". isCiGreen() always returned
+  // false for such a repo regardless of actual CI status.
+  test("fetchCiRuns matches a lowercase workflow name ('ci')", async () => {
+    const deps = await buildProductionDeps({
+      ghJson: async <T>() => {
+        return {
+          workflow_runs: [
+            { name: "ci", status: "completed", conclusion: "success" },
+            { name: "build-image", status: "completed", conclusion: "success" },
+          ],
+        } as unknown as T;
+      },
+    });
+
+    const runs = await deps.fetchCiRuns("acme", "widgets", "deadbeef");
+    expect(runs).toEqual([{ status: "completed", conclusion: "success" }]);
+  });
+
+  test("fetchActiveDeployRuns merges in_progress and queued runs, filters to name 'Deploy' (case-insensitive), and maps created_at", async () => {
     const calls: string[][] = [];
     const deps = await buildProductionDeps({
       ghJson: async <T>(args: string[]) => {
@@ -1161,6 +1182,37 @@ describe("buildProductionDeps", () => {
     expect(calls).toHaveLength(2);
     expect(calls[0][1]).toContain("status=in_progress");
     expect(calls[1][1]).toContain("status=queued");
+  });
+
+  // Regression test: a repo whose deploy workflow's `name:` field is
+  // lowercase `deploy` was silently excluded from the busy-repo guard.
+  test("fetchActiveDeployRuns matches a lowercase workflow name ('deploy')", async () => {
+    const deps = await buildProductionDeps({
+      ghJson: async <T>(args: string[]) => {
+        if (args[1]?.includes("status=in_progress")) {
+          return {
+            workflow_runs: [
+              {
+                name: "deploy",
+                status: "in_progress",
+                conclusion: null,
+                created_at: "2026-05-01T00:00:00Z",
+              },
+            ],
+          } as unknown as T;
+        }
+        return { workflow_runs: [] } as unknown as T;
+      },
+    });
+
+    const runs = await deps.fetchActiveDeployRuns("acme", "widgets");
+    expect(runs).toEqual([
+      {
+        name: "deploy",
+        status: "in_progress",
+        createdAt: "2026-05-01T00:00:00Z",
+      },
+    ]);
   });
 
   test("clock returns a parseable ISO string", async () => {

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -171,8 +171,13 @@ Fetch the most recent CI runs on the PR's head commit:
 HEAD_SHA=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid')
 REPO="{org}/{repo}"
 gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
-  --jq '[.workflow_runs[] | select(.name == "CI") | {status, conclusion}]'
+  --jq '[.workflow_runs[] | select(.name | ascii_downcase == "ci") | {status, conclusion}]'
 ```
+
+Matched case-insensitively — a repo's CI workflow `name:` field may be `CI` or `ci` (both are
+common conventions; e.g. `app-vitals/squadron`'s `.github/workflows/ci.yml` uses `name: ci`), and
+an exact-case match here would silently and permanently exclude that repo's PRs from ever
+passing this check.
 
 If no CI run has `conclusion == "success"` (or no CI run exists at all), print and stop:
 ```

--- a/plugins/shipwright/commands/merge.content.test.ts
+++ b/plugins/shipwright/commands/merge.content.test.ts
@@ -142,7 +142,7 @@ describe("merge.md — Step 2: Pre-flight Checks", () => {
   it("verifies CI is green on the PR head commit", () => {
     const section = extractStep2Section(content);
     expect(section).toContain("headRefOid");
-    expect(section).toContain('.name == "CI"');
+    expect(section).toContain('ascii_downcase == "ci"');
     expect(section).toContain('conclusion == "success"');
   });
 

--- a/plugins/shipwright/commands/merge.md
+++ b/plugins/shipwright/commands/merge.md
@@ -164,8 +164,13 @@ Fetch the most recent CI runs on the PR's head commit:
 HEAD_SHA=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid')
 REPO="{org}/{repo}"
 gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
-  --jq '[.workflow_runs[] | select(.name == "CI") | {status, conclusion}]'
+  --jq '[.workflow_runs[] | select(.name | ascii_downcase == "ci") | {status, conclusion}]'
 ```
+
+Matched case-insensitively — a repo's CI workflow `name:` field may be `CI` or `ci` (both are
+common conventions; e.g. `app-vitals/squadron`'s `.github/workflows/ci.yml` uses `name: ci`), and
+an exact-case match here would silently and permanently exclude that repo's PRs from ever
+passing this check.
 
 If no CI run has `conclusion == "success"` (or no CI run exists at all), print and stop:
 ```


### PR DESCRIPTION
## Summary
- `check-deploy.ts`'s deploy-candidate scan filtered CI runs on an exact-case match against `"CI"`, and the busy-repo guard did the same against `"Deploy"`.
- `deploy.md` and `merge.md`'s pre-flight CI checks had the identical hardcoded `.name == "CI"` jq filter.
- Any repo whose workflow `name:` is cased differently (e.g. lowercase `ci` — squadron's `.github/workflows/ci.yml` uses `name: ci`) never qualifies as a deploy candidate, and manual `/shipwright:merge`/`/shipwright:deploy` pre-flight always reads "no CI run exists" even when CI is green. Confirmed via the admin cron-run API: 183 recent deploy dispatches, zero ever for `app-vitals/squadron`, while the review phase (not gated on this filter) dispatched to the same PRs within minutes.
- Fix: match case-insensitively everywhere (`r.name.toLowerCase() === "ci"` / `"deploy"` in TS; `select(.name | ascii_downcase == "ci")` in the jq-based docs) instead of a hardcoded exact case, so this doesn't silently recur for the next repo with a differently-cased workflow name.
- Swept `check-patch.ts`/`check-review.ts` for the same hardcoded-name pattern — clean, neither gates on a workflow name filter.

## Test plan
- [x] `bun test src/check-deploy.unit.test.ts` — 56/56 pass, including two new regression tests (`fetchCiRuns matches a lowercase workflow name ('ci')`, `fetchActiveDeployRuns matches a lowercase workflow name ('deploy')`)
- [x] `bun test plugins/shipwright/commands/deploy.content.test.ts plugins/shipwright/commands/merge.content.test.ts` — 142/142 pass (updated `merge.content.test.ts`'s assertion to match the new jq expression)
- [x] `bun run typecheck` (agent workspace) — clean
- [x] `bunx biome lint` on changed files — clean
- [x] Full `bun test` in `agent/` — 1519 pass, 22 pre-existing unrelated failures (env-var pollution in `config.unit.test.ts`, cron-reporter fixtures), none touching this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)