### PR TITLE
fix(chat): make the reply heartbeat interval-driven and owner-scoped

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -4441,10 +4441,13 @@ export function renderChatThreadPage(
       .then(function(r) { return r.json(); })
       .then(function(data) {
         var msgs = data.messages || [];
+        // Guard the null cutoff: comparing a Date against null coerces to a
+        // compare against 0, which would treat every assistant message in the
+        // thread as a new reply.
         var cutoff = lastUserMessageTime;
-        var replies = msgs.filter(function(m) {
+        var replies = cutoff ? msgs.filter(function(m) {
           return m.role === 'assistant' && new Date(m.createdAt) > cutoff;
-        });
+        }) : [];
         if (replies.length > 0) {
           stopPolling();
           removeThinkingIndicator();
@@ -4478,7 +4481,13 @@ export function renderChatThreadPage(
             lastProgressPollCount = pollCount;
           }
           if (pending.claimedAt) {
-            var elapsedSec = Math.round((Date.now() - lastUserMessageTime.getTime()) / 1000);
+            // Prefer the server's createdAt so elapsed survives a reload and
+            // never depends on lastUserMessageTime, which is null on a fresh
+            // page load and would throw here.
+            var startedAt = pending.createdAt
+              ? new Date(pending.createdAt).getTime()
+              : (lastUserMessageTime ? lastUserMessageTime.getTime() : Date.now());
+            var elapsedSec = Math.round((Date.now() - startedAt) / 1000);
             setThinkingText('still working… (' + elapsedSec + 's)');
           }
         }

--- a/admin/src/http-chat-client.ts
+++ b/admin/src/http-chat-client.ts
@@ -31,6 +31,8 @@ export interface ChatMessage {
   body: string;
   createdAt: string;
   claimedBy: string | null;
+  claimed?: boolean;
+  claimedAt?: string | null;
   heartbeatAt?: string | null;
   repliedAt: string | null;
   tokens: MessageTokens | null;

--- a/agent/src/chat-poller.ts
+++ b/agent/src/chat-poller.ts
@@ -28,24 +28,33 @@ export type ChatRunner = (
 ) => Promise<ClaudeRunResult>;
 
 /**
- * Minimum time between heartbeat() calls for a single claimed message.
- * ProgressCallback fires once per Claude turn, which can be much more
- * frequent than this — throttling keeps a chatty run from hammering the
- * chat service while still giving pollers proof of life well inside the
- * admin UI's 3s poll interval.
+ * Heartbeat cadence while a reply is in flight.
+ *
+ * Interval-driven, NOT progress-driven. A single long-running tool call (a
+ * multi-minute `Bash`, say) emits one stream event and then nothing at all
+ * until it returns, so a heartbeat tied to Claude turns goes silent during
+ * exactly the long wait it exists to cover. Liveness is a property of the
+ * agent process, not of the model's output cadence — so it gets its own
+ * timer. 3s keeps proof of life well inside the admin UI's poll interval.
  */
-const HEARTBEAT_MIN_INTERVAL_MS = 3_000;
+const HEARTBEAT_INTERVAL_MS = 3_000;
 
 export interface ChatPollerOptions {
   client: ChatServiceClient;
   runner: ChatRunner;
   /** Poll interval in ms. Default: 5000 */
   intervalMs?: number;
+  /** Heartbeat cadence in ms while a reply is in flight. Default: 3000 */
+  heartbeatIntervalMs?: number;
   /**
    * Agent workspace directory. When set, attachments on claimed messages are
    * pulled into `<workspaceDir>/uploads/` so Claude can Read them.
    */
   workspaceDir?: string;
+  /** Injected for tests so timer behavior is deterministic. */
+  setIntervalFn?: typeof setInterval;
+  /** Injected for tests so timer behavior is deterministic. */
+  clearIntervalFn?: typeof clearInterval;
 }
 
 export interface ChatPoller {
@@ -60,9 +69,19 @@ export interface ChatPoller {
 // ─── createChatPoller ─────────────────────────────────────────────────────────
 
 export function createChatPoller(opts: ChatPollerOptions): ChatPoller {
-  const { client, runner, intervalMs = 5_000, workspaceDir } = opts;
+  const {
+    client,
+    runner,
+    intervalMs = 5_000,
+    heartbeatIntervalMs = HEARTBEAT_INTERVAL_MS,
+    workspaceDir,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+  } = opts;
 
   let timer: ReturnType<typeof setInterval> | undefined;
+  /** Guards against a slow poll overlapping the next interval tick. */
+  let pollInFlight = false;
 
   async function processThread(threadId: string): Promise<void> {
     const message = await client.claimMessage(threadId);
@@ -94,14 +113,10 @@ export function createChatPoller(opts: ChatPollerOptions): ChatPoller {
       }
     }
 
-    // Best-effort heartbeat while the run is in progress, throttled so a
-    // chatty multi-turn run doesn't hammer the chat service. Failures are
-    // swallowed — a missed heartbeat must never abort the reply itself.
-    let lastHeartbeatSentAt = 0;
-    const onProgress: ProgressCallback = () => {
-      const now = Date.now();
-      if (now - lastHeartbeatSentAt < HEARTBEAT_MIN_INTERVAL_MS) return;
-      lastHeartbeatSentAt = now;
+    // Best-effort liveness heartbeat, running for the whole duration of the
+    // reply. Failures are swallowed — a missed heartbeat must never abort the
+    // reply itself.
+    const sendHeartbeat = () => {
       client.heartbeat(threadId, message.id).catch((err) => {
         console.error(
           `[chat-poller] heartbeat failed for thread ${threadId} message ${message.id}:`,
@@ -111,14 +126,17 @@ export function createChatPoller(opts: ChatPollerOptions): ChatPoller {
     };
 
     let runResult: Awaited<ReturnType<ChatRunner>>;
+    const heartbeatTimer = setIntervalFn(sendHeartbeat, heartbeatIntervalMs);
     try {
-      runResult = await runner(runnerMessage, sessionKey, onProgress);
+      runResult = await runner(runnerMessage, sessionKey);
     } catch (err) {
       console.error(
         `[chat-poller] runner failed for thread ${threadId}:`,
         err instanceof Error ? err.message : String(err),
       );
       return;
+    } finally {
+      clearIntervalFn(heartbeatTimer);
     }
 
     try {
@@ -165,11 +183,20 @@ export function createChatPoller(opts: ChatPollerOptions): ChatPoller {
   return {
     start() {
       if (timer) return; // already running
-      timer = setInterval(() => void pollOnce(), intervalMs);
+      // Skip a tick when the previous iteration is still running. A poll that
+      // outlives its interval (a long claim + reply cycle always does) would
+      // otherwise stack concurrent iterations for as long as it runs.
+      timer = setIntervalFn(() => {
+        if (pollInFlight) return;
+        pollInFlight = true;
+        void pollOnce().finally(() => {
+          pollInFlight = false;
+        });
+      }, intervalMs);
     },
     stop() {
       if (timer) {
-        clearInterval(timer);
+        clearIntervalFn(timer);
         timer = undefined;
       }
     },

--- a/agent/src/chat-poller.unit.test.ts
+++ b/agent/src/chat-poller.unit.test.ts
@@ -167,11 +167,7 @@ describe("createChatPoller poll: claim then reply", () => {
 
     // Runner called with the message body and correct session key
     expect(runner).toHaveBeenCalledTimes(1);
-    expect(runner).toHaveBeenCalledWith(
-      message.body,
-      `chat:${threadId}`,
-      expect.any(Function),
-    );
+    expect(runner).toHaveBeenCalledWith(message.body, `chat:${threadId}`);
 
     // Reply posted with runner output
     expect(replyToMessage).toHaveBeenCalledTimes(1);
@@ -216,11 +212,7 @@ describe("createChatPoller poll: claim then reply", () => {
     await poller.pollOnce();
 
     // Runner must receive the stable session key so it can resume the session
-    expect(runner).toHaveBeenCalledWith(
-      message.body,
-      `chat:${threadId}`,
-      expect.any(Function),
-    );
+    expect(runner).toHaveBeenCalledWith(message.body, `chat:${threadId}`);
   });
 });
 
@@ -337,8 +329,29 @@ describe("createChatPoller poll: listThreads failure", () => {
 
 // ─── poll: heartbeat during a long-running reply ───────────────────────────────
 
+/**
+ * Deterministic stand-in for setInterval/clearInterval. Registered callbacks
+ * fire only when `tick()` is called, so tests never depend on wall time.
+ */
+function makeFakeInterval() {
+  let nextId = 1;
+  const active = new Map<number, () => void>();
+  const setIntervalFn = ((fn: () => void) => {
+    const id = nextId++;
+    active.set(id, fn);
+    return id;
+  }) as unknown as typeof setInterval;
+  const clearIntervalFn = ((id: number) => {
+    active.delete(id);
+  }) as unknown as typeof clearInterval;
+  const tick = (times = 1) => {
+    for (let i = 0; i < times; i++) for (const fn of [...active.values()]) fn();
+  };
+  return { setIntervalFn, clearIntervalFn, tick, activeCount: () => active.size };
+}
+
 describe("createChatPoller poll: heartbeat during a long-running reply", () => {
-  it("sends a heartbeat when the runner reports progress", async () => {
+  it("beats on an interval even when the run emits no progress at all", async () => {
     const threadId = "thread-hb";
     const messageId = "msg-hb";
     const thread = makeThread(threadId);
@@ -358,25 +371,32 @@ describe("createChatPoller poll: heartbeat during a long-running reply", () => {
       heartbeat,
     });
 
-    // Simulate a multi-turn Claude run by invoking the onProgress callback
-    // the poller passes in before resolving.
-    const runner = mock(
-      async (_msg: string, _key?: string, onProgress?: ProgressCallback) => {
-        onProgress?.({});
-        return { result: "ok" };
-      },
-    );
+    const fake = makeFakeInterval();
 
-    const poller = createChatPoller({ client, runner });
+    // The regression this guards: a single long tool call emits ONE stream
+    // event and then nothing until it returns. A progress-driven heartbeat
+    // goes silent here — exactly during the wait it exists to cover. This
+    // runner never reports progress, and the heartbeat must still fire.
+    const runner = mock(async () => {
+      fake.tick(3);
+      return { result: "ok" };
+    });
+
+    const poller = createChatPoller({
+      client,
+      runner,
+      setIntervalFn: fake.setIntervalFn,
+      clearIntervalFn: fake.clearIntervalFn,
+    });
     await poller.pollOnce();
 
-    expect(heartbeat).toHaveBeenCalledTimes(1);
+    expect(heartbeat).toHaveBeenCalledTimes(3);
     expect(heartbeat).toHaveBeenCalledWith(threadId, messageId);
   });
 
-  it("throttles heartbeats within the minimum interval", async () => {
-    const threadId = "thread-hb-throttle";
-    const message = makeMessage(threadId, "msg-hb-throttle");
+  it("stops beating once the run completes", async () => {
+    const threadId = "thread-hb-stop";
+    const message = makeMessage(threadId, "msg-hb-stop");
     const replyResult = makeReplyResult(message);
 
     const heartbeat = mock(async () => {});
@@ -392,19 +412,52 @@ describe("createChatPoller poll: heartbeat during a long-running reply", () => {
       heartbeat,
     });
 
-    // Fire onProgress many times back-to-back — well within the throttle
-    // window, only the first call should reach the chat service.
-    const runner = mock(
-      async (_msg: string, _key?: string, onProgress?: ProgressCallback) => {
-        for (let i = 0; i < 5; i++) onProgress?.({});
-        return { result: "ok" };
-      },
-    );
+    const fake = makeFakeInterval();
+    const runner = mock(async () => ({ result: "ok" }));
 
-    const poller = createChatPoller({ client, runner });
+    const poller = createChatPoller({
+      client,
+      runner,
+      setIntervalFn: fake.setIntervalFn,
+      clearIntervalFn: fake.clearIntervalFn,
+    });
     await poller.pollOnce();
 
-    expect(heartbeat).toHaveBeenCalledTimes(1);
+    expect(fake.activeCount()).toBe(0);
+    fake.tick(5);
+    expect(heartbeat).not.toHaveBeenCalled();
+  });
+
+  it("stops beating when the run throws", async () => {
+    const threadId = "thread-hb-throw";
+    const message = makeMessage(threadId, "msg-hb-throw");
+
+    const heartbeat = mock(async () => {});
+    const client = makeFakeClient({
+      listThreads: async () => ({
+        threads: [makeThread(threadId)],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      }),
+      claimMessage: async () => message,
+      heartbeat,
+    });
+
+    const fake = makeFakeInterval();
+    const runner = mock(async () => {
+      throw new Error("runner exploded");
+    });
+
+    const poller = createChatPoller({
+      client,
+      runner,
+      setIntervalFn: fake.setIntervalFn,
+      clearIntervalFn: fake.clearIntervalFn,
+    });
+    await poller.pollOnce();
+
+    expect(fake.activeCount()).toBe(0);
   });
 
   it("does not let a heartbeat failure abort the reply", async () => {
@@ -660,5 +713,47 @@ describe("createChatPoller poll: attachment handling", () => {
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ─── start: overlap guard ─────────────────────────────────────────────────────
+
+describe("createChatPoller start: overlap guard", () => {
+  it("skips interval ticks while the previous poll is still in flight", async () => {
+    let releaseList: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    const listThreads = mock(async () => {
+      await gate;
+      return { threads: [], total: 0, limit: 50, offset: 0 };
+    });
+
+    const client = makeFakeClient({ listThreads });
+    const runner = mock(async () => ({ result: "ok" }));
+    const fake = makeFakeInterval();
+
+    const poller = createChatPoller({
+      client,
+      runner,
+      setIntervalFn: fake.setIntervalFn,
+      clearIntervalFn: fake.clearIntervalFn,
+    });
+    poller.start();
+
+    // A poll that outlives its interval would otherwise stack concurrent
+    // iterations for as long as it runs.
+    fake.tick(); // starts poll #1, which blocks on the gate
+    fake.tick(); // must be skipped
+    fake.tick(); // must be skipped
+    expect(listThreads).toHaveBeenCalledTimes(1);
+
+    releaseList();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    fake.tick(); // previous poll settled — free to run again
+    expect(listThreads).toHaveBeenCalledTimes(2);
+
+    poller.stop();
   });
 });

--- a/chat/openapi.json
+++ b/chat/openapi.json
@@ -877,6 +877,47 @@
         }
       }
     },
+    "/threads/{threadId}/messages/{id}/heartbeat": {
+      "post": {
+        "tags": [
+          "messages"
+        ],
+        "summary": "Bump a claimed message's heartbeatAt (proof of life for a long-running reply)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clxmessage123456"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Thread or message not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/threads/{threadId}/messages/{id}/reply": {
       "post": {
         "tags": [
@@ -1246,6 +1287,14 @@
               "null"
             ],
             "example": "agent-id-123"
+          },
+          "heartbeatAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": null
           },
           "repliedAt": {
             "type": [

--- a/chat/src/message-service.integration.test.ts
+++ b/chat/src/message-service.integration.test.ts
@@ -377,15 +377,39 @@ describeOrSkip("MessageService (integration)", () => {
       });
       expect(claimed.heartbeatAt).toBeNull();
 
-      const updated = await svc.heartbeat(claimed.id);
+      const updated = await svc.heartbeat(claimed.id, "worker-1");
 
       expect(updated?.heartbeatAt).toEqual(new Date("2026-05-01T10:00:00Z"));
     });
 
     it("returns null when the message does not exist", async () => {
       const svc = new MessageService(prisma);
-      const updated = await svc.heartbeat("does-not-exist");
+      const updated = await svc.heartbeat("does-not-exist", "worker-1");
       expect(updated).toBeNull();
+    });
+
+    it("returns null when another worker owns the claim", async () => {
+      const threadId = await createThread(prisma);
+      const svc = new MessageService(prisma);
+
+      const claimed = await prisma.message.create({
+        data: {
+          threadId,
+          role: "user",
+          body: "long question",
+          claimed: true,
+          claimedAt: new Date("2026-05-01T09:59:00Z"),
+          claimedBy: "worker-1",
+        },
+      });
+
+      const updated = await svc.heartbeat(claimed.id, "worker-2");
+
+      expect(updated).toBeNull();
+      const reread = await prisma.message.findUnique({
+        where: { id: claimed.id },
+      });
+      expect(reread?.heartbeatAt).toBeNull();
     });
 
     it("returns null and does not bump heartbeatAt for an unclaimed message", async () => {
@@ -396,7 +420,7 @@ describeOrSkip("MessageService (integration)", () => {
         data: { threadId, role: "user", body: "not claimed yet" },
       });
 
-      const updated = await svc.heartbeat(unclaimed.id);
+      const updated = await svc.heartbeat(unclaimed.id, "worker-1");
       expect(updated).toBeNull();
 
       const reloaded = await prisma.message.findUnique({
@@ -421,7 +445,7 @@ describeOrSkip("MessageService (integration)", () => {
         },
       });
 
-      const updated = await svc.heartbeat(replied.id);
+      const updated = await svc.heartbeat(replied.id, "worker-1");
       expect(updated).toBeNull();
 
       const reloaded = await prisma.message.findUnique({

--- a/chat/src/message-service.ts
+++ b/chat/src/message-service.ts
@@ -66,10 +66,10 @@ export interface MessageServiceLike {
 
   /**
    * Bump a claimed message's heartbeatAt to now — proof of life for a
-   * long-running reply. Returns the updated message, or null if not found,
-   * not claimed, or already replied.
+   * long-running reply. Scoped to the claim's owner: returns null unless the
+   * message is an unreplied user message currently claimed by `claimedBy`.
    */
-  heartbeat(id: string): Promise<Message | null>;
+  heartbeat(id: string, claimedBy: string): Promise<Message | null>;
 
   /**
    * Post an agent reply to a claimed message.
@@ -215,14 +215,19 @@ export class MessageService implements MessageServiceLike {
     }
   }
 
-  async heartbeat(id: string): Promise<Message | null> {
+  async heartbeat(id: string, claimedBy: string): Promise<Message | null> {
     try {
+      // Scoped to the current owner of an in-flight claim: only the agent that
+      // actually claimed this message, and only while the reply is still
+      // outstanding. An unscoped update would let any caller authorized for
+      // the thread keep an arbitrary message looking alive.
       return await this.prisma.message.update({
-        where: { id, claimed: true, repliedAt: null },
+        where: { id, role: "user", claimed: true, repliedAt: null, claimedBy },
         data: { heartbeatAt: this.clock.now() },
       });
     } catch (err: unknown) {
-      // Not found, unclaimed, or already replied — all surface as P2025.
+      // Not found, unclaimed, already replied, or owned by another worker —
+      // all surface as P2025.
       if (isPrismaNotFound(err)) return null;
       throw err;
     }

--- a/chat/src/messages.smoke.test.ts
+++ b/chat/src/messages.smoke.test.ts
@@ -322,7 +322,9 @@ describe("POST /threads/:id/messages/:msgId/heartbeat", () => {
       role: "user",
       body: "Long-running question",
     });
-    await ms.claim(thread.id, "worker-1");
+    // The route derives claimedBy from the caller's token — an admin token
+    // resolves to "admin", so the claim must be owned by "admin" to beat it.
+    await ms.claim(thread.id, "admin");
     const app = buildApp(ts, ms);
 
     const res = await app.request(
@@ -332,6 +334,26 @@ describe("POST /threads/:id/messages/:msgId/heartbeat", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Message;
     expect(body.heartbeatAt).toBeTruthy();
+  });
+
+  it("returns 404 when another worker owns the claim", async () => {
+    const ts = fakeThreadService();
+    const ms = fakeMessageService();
+    const thread = await ts.create({ agentId: "a1" });
+    const userMsg = await ms.create(thread.id, {
+      role: "user",
+      body: "Long-running question",
+    });
+    await ms.claim(thread.id, "worker-1");
+    const app = buildApp(ts, ms);
+
+    // Caller is admin, but worker-1 holds the claim — keeping someone else's
+    // in-flight message looking alive is not the caller's to do.
+    const res = await app.request(
+      `/threads/${thread.id}/messages/${userMsg.id}/heartbeat`,
+      { method: "POST", headers: H.get },
+    );
+    expect(res.status).toBe(404);
   });
 
   it("returns 404 when the message has not been claimed", async () => {
@@ -359,7 +381,7 @@ describe("POST /threads/:id/messages/:msgId/heartbeat", () => {
       role: "user",
       body: "Long-running question",
     });
-    await ms.claim(thread.id, "worker-1");
+    await ms.claim(thread.id, "admin");
     await ms.reply(userMsg.id, { body: "the answer" });
     const app = buildApp(ts, ms);
 

--- a/chat/src/routes/messages.ts
+++ b/chat/src/routes/messages.ts
@@ -545,7 +545,14 @@ export function createMessagesRoutes(
     if (!existing || existing.threadId !== threadId)
       throw new NotFoundError("message not found");
 
-    const updated = await messageService.heartbeat(c.req.param("id"));
+    // Same identity derivation as claim — only the claim's owner may beat it.
+    const callerAgentId = c.get("agentId");
+    const claimedBy = callerAgentId ?? "admin";
+
+    const updated = await messageService.heartbeat(
+      c.req.param("id"),
+      claimedBy,
+    );
     if (!updated) throw new NotFoundError("message not found");
     return c.json(updated, 200);
   });

--- a/chat/src/test-fakes.ts
+++ b/chat/src/test-fakes.ts
@@ -245,9 +245,16 @@ export function fakeMessageService(
       msg.claimedBy = claimedBy;
       return msg;
     },
-    async heartbeat(id) {
+    async heartbeat(id, claimedBy) {
       const msg = store.find((m) => m.id === id);
-      if (!msg || !msg.claimed || msg.repliedAt !== null) return null;
+      if (
+        !msg ||
+        msg.role !== "user" ||
+        !msg.claimed ||
+        msg.repliedAt !== null ||
+        msg.claimedBy !== claimedBy
+      )
+        return null;
       msg.heartbeatAt = new Date();
       return msg;
     },


### PR DESCRIPTION
Follow-up to #2899. The heartbeat landed there stops during exactly the silence it was built to cover.

## The defect

The heartbeat was driven by `onProgress`, which fires only when a new assistant `message.id` is seen (`claude.ts:362` dedupes on it). A long-running tool call — a multi-minute `Bash`, say — emits one `tool_use` line and then nothing until it returns. So the heartbeat goes quiet and the UI declares a stall on a perfectly healthy run.

Liveness is a property of the agent process, not of the model's output cadence, so it now gets its own timer.

## Changes

- **Interval-driven heartbeat** (`agent/src/chat-poller.ts`) — a 3s timer running for the whole reply, cleared in a `finally` so it stops on success, throw, or early return. Replaces the progress-driven throttle.
- **Owner-scoped `heartbeat()`** (`chat/src/message-service.ts`) — extends #2899's guard with `claimedBy` and `role: "user"`. Previously any caller authorized for the thread could keep *any* claimed message looking alive; now only the worker holding the claim can. The route derives `claimedBy` exactly as `claim` does.
- **Overlap guard on `start()`** — `setInterval` fired regardless of whether the previous `pollOnce` was still running, stacking concurrent iterations for as long as a slow poll ran. The existing `if (timer) return` only guarded double-`start()`.
- **Null-deref in the poll loop** (`admin/src/admin-ui-pages.ts`) — `lastUserMessageTime.getTime()` throws when it is null on a fresh page load, and the `> null` cutoff coerces to `> 0`, treating every assistant message as a new reply. Elapsed now reads the server's `createdAt`, so it also survives a reload.
- **Regenerated `chat/openapi.json`** — #2899 added the route and schema field but not the spec.
- **`ChatMessage.claimed` / `.claimedAt`** (`admin/src/http-chat-client.ts`) — the UI reads `pending.claimedAt`, which was never declared on the interface.

## Testing

- Interval heartbeat covered by a fake `setInterval`/`clearInterval` pair (injected, no wall-clock waits). The key regression test uses a runner that reports **no** progress at all and asserts the heartbeat still fires.
- Ownership rejection covered at both the service layer (integration, real Postgres) and the route layer (smoke).
- Deduped two of my integration tests in favour of #2899's stronger versions, which also assert `heartbeatAt` stays null.
- `chat/` 168 pass against real Postgres; `chat/ agent/ admin/` 3398 pass. The one failure, `check-deploy.unit.test.ts > repos reflects an empty scan`, is pre-existing and environmental — it fails identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzZcAciAPGjwcVxXoz7TvL