### PR TITLE
refactor: move chat page inline styles into classes (CFB-1.3)

### DIFF
--- a/admin/e2e/chat-thread-page.e2e.ts
+++ b/admin/e2e/chat-thread-page.e2e.ts
@@ -181,4 +181,30 @@ test.describe("GET /admin/chat/:agentId/threads/:threadId — CFB-1.3 class migr
     expect(ratio).toBeGreaterThan(0.65);
     expect(ratio).toBeLessThanOrEqual(0.71);
   });
+
+  test("at 375px mobile viewport, .chat-bubble-inner computed width is 90% of #messages-container", async ({
+    page,
+    context,
+  }) => {
+    // Regression guard: chatPageStyles's @media (max-width:640px) override
+    // (.chat-bubble-inner { max-width:90% }) must win the cascade over
+    // chatThreadStyles's unconditional base rule (max-width:70%) at mobile
+    // widths — see CFB-1.3 review discussion on concatenation order.
+    await page.setViewportSize({ width: 375, height: 812 });
+    await loadChatThreadPage(page, context);
+
+    const bubbleInner = page.locator(".chat-bubble-inner").first();
+    await expect(bubbleInner).toBeVisible();
+
+    const bubbleWidth = await bubbleInner.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const containerWidth = await page
+      .locator("#messages-container")
+      .evaluate((el) => el.getBoundingClientRect().width);
+
+    const ratio = bubbleWidth / containerWidth;
+    expect(ratio).toBeGreaterThan(0.85);
+    expect(ratio).toBeLessThanOrEqual(0.91);
+  });
 });

--- a/admin/e2e/chat-thread-page.e2e.ts
+++ b/admin/e2e/chat-thread-page.e2e.ts
@@ -1,0 +1,184 @@
+/**
+ * admin/e2e/chat-thread-page.e2e.ts
+ * Admin UI — Chat Thread Page E2E Tests (CFB-1.3)
+ *
+ * Proves the inline-style → class migration produced no visual change: at a
+ * desktop viewport, `.chat-bubble-inner`'s computed width must still be 70%
+ * of its containing block (`#messages-container`), matching the value that
+ * used to be set via an inline `style="max-width:70%"` before the migration
+ * moved it into the `.chat-bubble-inner` CSS class.
+ *
+ * Architecture:
+ *   - Spawns admin/e2e/test-server.ts via Bun as a child process.
+ *   - Uses hono/jwt sign() to mint valid session cookies directly.
+ *   - No real DB or OAuth flow is initiated.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type BrowserContext, type Page, expect, test } from "@playwright/test";
+import { sign } from "hono/jwt";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PORT = 3492;
+const BASE_URL = `http://localhost:${PORT}`;
+const SESSION_SECRET = "e2e-admin-test-secret-32chars!!!";
+const SESSION_COOKIE = "admin_session";
+const AGENT_ID = "agent-e2e-1";
+// Matches MOCK_CHAT_THREAD.id in test-server.ts.
+const THREAD_ID = "thread-e2e-1";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ─── Server lifecycle ─────────────────────────────────────────────────────────
+
+let serverProcess: ChildProcess | null = null;
+
+async function waitForServer(url: string, maxWaitMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Server at ${url} did not start within ${maxWaitMs}ms`);
+}
+
+test.beforeAll(async () => {
+  const serverScript = resolve(__dirname, "test-server.ts");
+
+  serverProcess = spawn("bun", ["run", serverScript], {
+    env: {
+      ...process.env,
+      ADMIN_E2E_PORT: String(PORT),
+      ADMIN_E2E_SESSION_SECRET: SESSION_SECRET,
+    },
+    stdio: "pipe",
+    cwd: resolve(__dirname, "../.."),
+  });
+
+  serverProcess.stderr?.on("data", (data: Buffer) => {
+    const msg = data.toString();
+    if (msg.trim()) console.error("[admin-e2e-chat-thread-server]", msg.trim());
+  });
+
+  serverProcess.stdout?.on("data", (data: Buffer) => {
+    const msg = data.toString();
+    if (msg.trim()) console.log("[admin-e2e-chat-thread-server]", msg.trim());
+  });
+
+  await waitForServer(`${BASE_URL}/health`, 15_000);
+});
+
+test.afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill("SIGTERM");
+    serverProcess = null;
+  }
+});
+
+// ─── Session cookie helper ────────────────────────────────────────────────────
+
+async function mintSession(
+  userId = "google-sub-e2e",
+  email = "admin@example.com",
+): Promise<string> {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return sign(
+    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    SESSION_SECRET,
+    "HS256",
+  );
+}
+
+// ─── Helper: load chat thread page with auth ──────────────────────────────────
+
+async function loadChatThreadPage(
+  page: Page,
+  context: BrowserContext,
+): Promise<void> {
+  const token = await mintSession();
+  await context.addCookies([
+    {
+      name: SESSION_COOKIE,
+      value: token,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+  await page.goto(`${BASE_URL}/admin/chat/${AGENT_ID}/threads/${THREAD_ID}`);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("GET /admin/chat/:agentId/threads/:threadId — CFB-1.3 class migration", () => {
+  test("page renders the fixture message inside a .chat-bubble-inner element", async ({
+    page,
+    context,
+  }) => {
+    await loadChatThreadPage(page, context);
+    await expect(page.locator(".chat-bubble-inner").first()).toBeVisible();
+    await expect(page.locator("body")).toContainText(
+      "Hello from the e2e test suite",
+      { useInnerText: true },
+    );
+  });
+
+  test("no style attribute on the migrated elements (page wrapper, header, messages container, bubble, bubble inner)", async ({
+    page,
+    context,
+  }) => {
+    await loadChatThreadPage(page, context);
+
+    await expect(
+      page.locator(".vos-page.chat-thread-page"),
+    ).not.toHaveAttribute("style", /.+/);
+    await expect(
+      page.locator(".page-header.chat-thread-header"),
+    ).not.toHaveAttribute("style", /.+/);
+    await expect(page.locator("#messages-container")).not.toHaveAttribute(
+      "style",
+      /.+/,
+    );
+    await expect(page.locator(".chat-bubble").first()).not.toHaveAttribute(
+      "style",
+      /.+/,
+    );
+    await expect(
+      page.locator(".chat-bubble-inner").first(),
+    ).not.toHaveAttribute("style", /.+/);
+  });
+
+  test("at 1280px viewport, .chat-bubble-inner computed width is 70% of #messages-container", async ({
+    page,
+    context,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await loadChatThreadPage(page, context);
+
+    const bubbleInner = page.locator(".chat-bubble-inner").first();
+    await expect(bubbleInner).toBeVisible();
+
+    const bubbleWidth = await bubbleInner.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const containerWidth = await page
+      .locator("#messages-container")
+      .evaluate((el) => el.getBoundingClientRect().width);
+
+    const ratio = bubbleWidth / containerWidth;
+    // The bubble inner's max-width:70% caps it at 70% of the container, but
+    // an unconstrained (narrow) message could render narrower still — assert
+    // it's at/near the 70% cap, not merely "less than" some looser bound.
+    expect(ratio).toBeGreaterThan(0.65);
+    expect(ratio).toBeLessThanOrEqual(0.71);
+  });
+});

--- a/admin/e2e/test-server.ts
+++ b/admin/e2e/test-server.ts
@@ -21,6 +21,11 @@ import { Hono } from "hono";
 import { sign } from "hono/jwt";
 import { createAdminUIApp } from "../src/admin-ui.ts";
 import type { AdminUIDeps } from "../src/admin-ui.ts";
+import type {
+  ChatClient,
+  ChatMessage,
+  ChatThread,
+} from "../src/http-chat-client.ts";
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 
@@ -70,6 +75,65 @@ const MOCK_TOKEN = {
   createdAt: new Date("2024-01-01"),
   revokedAt: null,
 };
+
+// ─── Chat fixtures (CFB-1.3 — chat thread page e2e) ──────────────────────────
+
+export const MOCK_CHAT_THREAD: ChatThread = {
+  id: "thread-e2e-1",
+  agentId: ADMIN_E2E_AGENT.id,
+  title: "E2E Test Thread",
+  memberId: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+export const MOCK_CHAT_MESSAGES: ChatMessage[] = [
+  {
+    id: "msg-e2e-1",
+    threadId: MOCK_CHAT_THREAD.id,
+    role: "user",
+    // Long enough to overflow any width well under the 70% max-width cap, so
+    // the e2e computed-width assertion (chat-thread-page.e2e.ts) exercises
+    // the CSS-driven cap rather than content-driven shrink-to-fit.
+    body: "Hello from the e2e test suite — this message body is intentionally long so that its rendered width is capped by the chat-bubble-inner max-width rule rather than shrinking to fit its own content, which lets the e2e test assert a stable 70% width ratio against the messages container.",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    claimedBy: null,
+    repliedAt: null,
+    tokens: null,
+    costUsd: null,
+    errorKind: null,
+    attachmentFilename: null,
+    attachmentSize: null,
+  },
+];
+
+function buildMockChatClient(): ChatClient {
+  return {
+    listThreads: async () => ({
+      threads: [MOCK_CHAT_THREAD],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    }),
+    getThread: async () => MOCK_CHAT_THREAD,
+    createThread: async () => MOCK_CHAT_THREAD,
+    updateThread: async () => MOCK_CHAT_THREAD,
+    deleteThread: async () => {},
+    listMessages: async () => ({
+      messages: MOCK_CHAT_MESSAGES,
+      total: MOCK_CHAT_MESSAGES.length,
+      limit: 50,
+      offset: 0,
+    }),
+    createMessage: async () => MOCK_CHAT_MESSAGES[0],
+    getThreadStats: async () => ({
+      messageCount: MOCK_CHAT_MESSAGES.length,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCostUsd: 0,
+    }),
+  };
+}
 
 // ─── Mock deps factory ────────────────────────────────────────────────────────
 
@@ -263,6 +327,7 @@ function buildMockDeps(): AdminUIDeps {
       }),
     },
     appBaseUrl: `http://localhost:${ADMIN_E2E_PORT}`,
+    chatClient: buildMockChatClient(),
   };
 }
 

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -4485,7 +4485,13 @@ export function renderChatThreadPage(
 
   return renderAdminPage({
     title: `${rawTitle} - Shipwright Admin`,
-    extraStyles: `${threadPaneStyles}${chatPageStyles}${chatThreadStyles}
+    // NOTE: chatThreadStyles must be concatenated before chatPageStyles here —
+    // chatPageStyles's mobile @media (max-width:640px) override for
+    // .chat-bubble-inner has the same specificity as chatThreadStyles's
+    // unconditional base rule, so whichever is concatenated *last* wins the
+    // cascade. Putting chatPageStyles last ensures the mobile override
+    // actually takes effect at ≤640px instead of being silently shadowed.
+    extraStyles: `${threadPaneStyles}${chatThreadStyles}${chatPageStyles}
   `,
     body: `${renderAdminToolbar(userName, activePath)}
   <div class="vos-page chat-thread-page">

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -3874,9 +3874,45 @@ const chatPageStyles = `
       /* chat-thread-layout: flex wrapper for thread+message area; stacks to column on mobile */
       .chat-thread-layout { flex-direction:column }
       .chat-thread-sidebar { display:none }
-      .chat-bubble-inner { max-width:90% !important }
+      .chat-bubble-inner { max-width:90% }
       #message-input { font-size:16px }
     }`;
+
+// ─── Chat thread page — class-driven bubble/composer styling (CFB-1.3) ────────
+// These class names are shared verbatim between the server-rendered HTML
+// (renderMessageBubble()) and the inline JS bubble builder (addBubble()) so
+// the two renderers physically cannot drift apart — see the interpolation of
+// CHAT_BUBBLE_CLASS/CHAT_BUBBLE_INNER_CLASS into `inlineScript` below.
+export const CHAT_BUBBLE_CLASS = "chat-bubble";
+export const CHAT_BUBBLE_INNER_CLASS = "chat-bubble-inner";
+export const CHAT_BUBBLE_INNER_WIDE_CLASS = "chat-bubble-inner--wide";
+
+/** e.g. "chat-bubble--user" — role is attacker-controlled only via server data, never used unescaped in an attribute here since roles are a closed set (user/assistant/system/other). */
+export function chatBubbleRoleClass(role: string): string {
+  return `${CHAT_BUBBLE_CLASS}--${role}`;
+}
+
+const chatThreadStyles = `
+    .chat-thread-page { display:flex;flex-direction:column;height:calc(100vh - 52px);max-width:900px;margin:0 auto;padding:0 24px }
+    .chat-thread-header { padding-top:20px;padding-bottom:16px;flex-shrink:0 }
+    .chat-messages-container { flex:1;overflow-y:auto;padding:8px 0;min-height:0 }
+    .${CHAT_BUBBLE_CLASS} { display:flex;margin-bottom:12px }
+    .${chatBubbleRoleClass("user")} { justify-content:flex-end }
+    .${chatBubbleRoleClass("assistant")} { justify-content:flex-start }
+    .${chatBubbleRoleClass("system")} { justify-content:center }
+    .${chatBubbleRoleClass("other")} { justify-content:flex-start }
+    .${CHAT_BUBBLE_INNER_CLASS} { max-width:70%;border-radius:12px;padding:12px 16px;box-shadow:0 1px 2px rgba(0,0,0,0.06) }
+    .${CHAT_BUBBLE_INNER_CLASS}.${CHAT_BUBBLE_INNER_WIDE_CLASS} { max-width:80% }
+    .${chatBubbleRoleClass("user")} .${CHAT_BUBBLE_INNER_CLASS} { background:#eef2ff }
+    .${chatBubbleRoleClass("assistant")} .${CHAT_BUBBLE_INNER_CLASS} { background:#f0fdf4 }
+    .${chatBubbleRoleClass("system")} .${CHAT_BUBBLE_INNER_CLASS} { background:#fef9c3 }
+    .${chatBubbleRoleClass("other")} .${CHAT_BUBBLE_INNER_CLASS} { background:#f3f4f6 }
+    .chat-composer-form { flex-shrink:0;padding:16px 0;border-top:1px solid #e5e7eb;margin-top:8px }
+    .chat-composer-row { display:flex;gap:8px;align-items:flex-end }
+    .chat-message-input { flex:1;resize:vertical;padding:10px 12px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;font-family:inherit;line-height:1.5;outline:none }
+    .chat-composer-btn { flex-shrink:0;height:44px }
+    .chat-composer-btn--attach { padding:0 16px }
+    .chat-composer-btn--send { padding:0 20px }`;
 
 export function renderChatPage(
   agents: AgentOption[],
@@ -4045,14 +4081,15 @@ export function renderChatThreadPage(
     const isAssistant = m.role === "assistant";
     const isSystem = m.role === "system";
 
-    const align = isUser ? "flex-end" : isSystem ? "center" : "flex-start";
-    const bubbleBg = isUser
-      ? "#eef2ff"
-      : isAssistant
-        ? "#f0fdf4"
-        : isSystem
-          ? "#fef9c3"
-          : "#f3f4f6";
+    const bubbleRoleClass = chatBubbleRoleClass(
+      isUser
+        ? "user"
+        : isAssistant
+          ? "assistant"
+          : isSystem
+            ? "system"
+            : "other",
+    );
     const bubbleColor = isUser
       ? "#4f46e5"
       : isAssistant
@@ -4060,7 +4097,9 @@ export function renderChatThreadPage(
         : isSystem
           ? "#854d0e"
           : "#374151";
-    const maxWidth = isSystem ? "80%" : "70%";
+    const bubbleInnerClass = isSystem
+      ? `${CHAT_BUBBLE_INNER_CLASS} ${CHAT_BUBBLE_INNER_WIDE_CLASS}`
+      : CHAT_BUBBLE_INNER_CLASS;
 
     // Render error badge if errorKind is set
     let errorBadge = "";
@@ -4121,8 +4160,8 @@ export function renderChatThreadPage(
       tokenBadge = `<div style="font-size:11px;color:#6b7280;margin-top:4px">${escapeHtml(`${inTok} in / ${outTok} out${costPart}`)}</div>`;
     }
 
-    return `<div style="display:flex;justify-content:${align};margin-bottom:12px">
-      <div class="chat-bubble-inner" style="max-width:${maxWidth};background:${bubbleBg};border-radius:12px;padding:12px 16px;box-shadow:0 1px 2px rgba(0,0,0,0.06)">
+    return `<div class="${CHAT_BUBBLE_CLASS} ${bubbleRoleClass}">
+      <div class="${bubbleInnerClass}">
         <div style="font-size:11px;font-weight:600;color:${bubbleColor};margin-bottom:4px;text-transform:uppercase;letter-spacing:0.05em">${escapeHtml(m.role)}</div>
         ${bodyHtml}
         ${markerBadges}
@@ -4210,8 +4249,6 @@ export function renderChatThreadPage(
 
   function addBubble(role, body, isError, attachmentName) {
     var isUser = role === 'user';
-    var align = isUser ? 'flex-end' : 'flex-start';
-    var bg = isUser ? '#eef2ff' : '#f0fdf4';
     var color = isUser ? '#4f46e5' : '#166534';
     var bodyHtml = isUser
       ? '<div style="font-size:14px;white-space:pre-wrap;color:' + color + '">' + escHtml(body) + '</div>'
@@ -4223,8 +4260,8 @@ export function renderChatThreadPage(
       ? '<div style="display:inline-block;margin-top:8px;padding:3px 8px;background:#e5e7eb;color:#374151;border-radius:6px;font-size:12px">📎 ' + escHtml(attachmentName) + '</div>'
       : '';
     var bubble = document.createElement('div');
-    bubble.style.cssText = 'display:flex;justify-content:' + align + ';margin-bottom:12px';
-    bubble.innerHTML = '<div style="max-width:70%;background:' + bg + ';border-radius:12px;padding:12px 16px;box-shadow:0 1px 2px rgba(0,0,0,0.06)">'
+    bubble.className = '${CHAT_BUBBLE_CLASS} ${CHAT_BUBBLE_CLASS}--' + role;
+    bubble.innerHTML = '<div class="${CHAT_BUBBLE_INNER_CLASS}">'
       + '<div style="font-size:11px;font-weight:600;color:' + color + ';margin-bottom:4px;text-transform:uppercase;letter-spacing:0.05em">' + escHtml(role) + '</div>'
       + (isError ? errorHtml : bodyHtml)
       + attachmentHtml
@@ -4448,11 +4485,11 @@ export function renderChatThreadPage(
 
   return renderAdminPage({
     title: `${rawTitle} - Shipwright Admin`,
-    extraStyles: `${threadPaneStyles}${chatPageStyles}
+    extraStyles: `${threadPaneStyles}${chatPageStyles}${chatThreadStyles}
   `,
     body: `${renderAdminToolbar(userName, activePath)}
-  <div class="vos-page" style="display:flex;flex-direction:column;height:calc(100vh - 52px);max-width:900px;margin:0 auto;padding:0 24px">
-    <div class="page-header" style="padding-top:20px;padding-bottom:16px;flex-shrink:0">
+  <div class="vos-page chat-thread-page">
+    <div class="page-header chat-thread-header">
       <div>
         <a href="/admin/chat?agentId=${safeAgentId}" class="btn btn-secondary" style="margin-bottom:8px">&larr; Back to threads</a>
         <h1 class="page-title">${title}</h1>
@@ -4475,33 +4512,31 @@ export function renderChatThreadPage(
       ${sidebar}
       <div style="flex:1;min-width:0;display:flex;flex-direction:column">
         <!-- Messages area (scrollable) -->
-        <div id="messages-container" style="flex:1;overflow-y:auto;padding:8px 0;min-height:0">
+        <div id="messages-container" class="chat-messages-container">
           ${messageBubbles}
           ${emptyState}
         </div>
 
         <!-- Send form -->
-        <form id="send-form" enctype="multipart/form-data" style="flex-shrink:0;padding:16px 0;border-top:1px solid #e5e7eb;margin-top:8px">
-          <div style="display:flex;gap:8px;align-items:flex-end">
+        <form id="send-form" enctype="multipart/form-data" class="chat-composer-form">
+          <div class="chat-composer-row">
             <textarea
               id="message-input"
               name="body"
               rows="3"
               placeholder="Type a message..."
-              style="flex:1;resize:vertical;padding:10px 12px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;font-family:inherit;line-height:1.5;outline:none"
+              class="chat-message-input"
             ></textarea>
             <input type="file" id="file-input" name="file" style="display:none" accept="text/*,image/*,application/pdf,application/json">
             <button
               type="button"
               id="attach-btn"
-              class="btn btn-secondary"
-              style="flex-shrink:0;height:44px;padding:0 16px"
+              class="btn btn-secondary chat-composer-btn chat-composer-btn--attach"
             >Attach file</button>
             <button
               type="submit"
               id="send-btn"
-              class="btn btn-primary"
-              style="flex-shrink:0;height:44px;padding:0 20px"
+              class="btn btn-primary chat-composer-btn chat-composer-btn--send"
             >Send</button>
           </div>
           <div id="file-name" style="font-size:12px;color:#6b7280;margin-top:6px;min-height:16px"></div>

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -5995,6 +5995,175 @@ describe("renderChatThreadPage", () => {
   });
 });
 
+// ─── renderChatThreadPage — inline styles moved to classes (CFB-1.3) ────────
+// Migrated elements must carry the new classes and no longer carry a `style=`
+// attribute of their own (background/text styling on nested badges etc. is
+// out of scope and untouched).
+
+describe("renderChatThreadPage — CFB-1.3 class migration", () => {
+  const THREAD: ChatThread = {
+    id: "thread-abc",
+    agentId: "agent-xyz",
+    title: "My Test Thread",
+    memberId: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  };
+
+  const USER_MSG: ChatMessage = {
+    id: "msg-1",
+    threadId: "thread-abc",
+    role: "user",
+    body: "Hello, agent!",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    claimedBy: null,
+    repliedAt: null,
+    tokens: null,
+    costUsd: null,
+    errorKind: null,
+    attachmentFilename: null,
+    attachmentSize: null,
+  };
+
+  const SYSTEM_MSG: ChatMessage = {
+    id: "msg-sys",
+    threadId: "thread-abc",
+    role: "system",
+    body: "System notice",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    claimedBy: null,
+    repliedAt: null,
+    tokens: null,
+    costUsd: null,
+    errorKind: null,
+    attachmentFilename: null,
+    attachmentSize: null,
+  };
+
+  test("page wrapper (.vos-page) carries no inline style attribute", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const match = html.match(/<div class="vos-page[^"]*"[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+    expect(match?.[0]).toContain("chat-thread-page");
+  });
+
+  test("header (.page-header) carries no inline style attribute", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const match = html.match(/<div class="page-header[^"]*"[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+  });
+
+  test("messages container carries no inline style attribute", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const match = html.match(/<div id="messages-container"[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+  });
+
+  test("bubble wrapper carries chat-bubble + chat-bubble--user classes, no inline style", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const match = html.match(
+      /<div class="chat-bubble chat-bubble--user"[^>]*>/,
+    );
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+  });
+
+  test("bubble wrapper for assistant role carries chat-bubble--assistant class", () => {
+    const html = renderChatThreadPage(
+      "agent-xyz",
+      THREAD,
+      [{ ...USER_MSG, id: "msg-a", role: "assistant" }],
+      "alice",
+    );
+    const match = html.match(
+      /<div class="chat-bubble chat-bubble--assistant"[^>]*>/,
+    );
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+  });
+
+  test("bubble wrapper for system role carries chat-bubble--system class", () => {
+    const html = renderChatThreadPage(
+      "agent-xyz",
+      THREAD,
+      [SYSTEM_MSG],
+      "alice",
+    );
+    const match = html.match(
+      /<div class="chat-bubble chat-bubble--system"[^>]*>/,
+    );
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+  });
+
+  test("bubble inner carries chat-bubble-inner class and no inline max-width", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const match = html.match(/<div class="chat-bubble-inner[^"]*"[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("max-width");
+  });
+
+  test("no inline max-width appears in any server-rendered bubble wrapper/inner", () => {
+    const html = renderChatThreadPage(
+      "agent-xyz",
+      THREAD,
+      [USER_MSG, SYSTEM_MSG],
+      "alice",
+    );
+    const bubbleMatches = html.match(/<div class="chat-bubble[^>]*>/g) ?? [];
+    expect(bubbleMatches.length).toBeGreaterThan(0);
+    for (const bubbleTag of bubbleMatches) {
+      expect(bubbleTag).not.toContain("max-width");
+    }
+  });
+
+  test("composer form and row carry no inline style attribute", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const formMatch = html.match(/<form id="send-form"[^>]*>/);
+    expect(formMatch).not.toBeNull();
+    expect(formMatch?.[0]).not.toContain("style=");
+  });
+
+  test("message input carries no inline style attribute", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const match = html.match(/<textarea[^>]*id="message-input"[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match?.[0]).not.toContain("style=");
+  });
+
+  test("attach and send buttons carry no inline style attribute", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    const attachMatch = html.match(/<button[^>]*id="attach-btn"[^>]*>/);
+    const sendMatch = html.match(/<button[^>]*id="send-btn"[^>]*>/);
+    expect(attachMatch).not.toBeNull();
+    expect(sendMatch).not.toBeNull();
+    expect(attachMatch?.[0]).not.toContain("style=");
+    expect(sendMatch?.[0]).not.toContain("style=");
+  });
+
+  test("chatThreadStyles is included in extraStyles and defines chat-bubble rules", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    expect(html).toContain(".chat-bubble--user");
+    expect(html).toContain(".chat-bubble--assistant");
+    expect(html).toContain("justify-content:flex-end");
+    expect(html).toContain("justify-content:flex-start");
+  });
+
+  test("inline JS bubble builder (addBubble) uses the same chat-bubble class constants as the server renderer", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [USER_MSG], "alice");
+    // The class names baked into server-rendered HTML must also appear inside
+    // the inline <script> block, proving both come from the same source.
+    expect(html).toContain(
+      "bubble.className = 'chat-bubble chat-bubble--' + role;",
+    );
+    expect(html).toContain('class="chat-bubble-inner"');
+    expect(html).not.toContain("bubble.style.cssText");
+  });
+});
+
 // ─── classifyTaskState (HBV-1.2) ─────────────────────────────────────────────
 // Mirrors task-store/src/task-service.ts's list()/listReady()/listBlocked()
 // grouping: blockedBy is computed server-side for every status (not just


### PR DESCRIPTION
## Summary
- Migrated ~10 inline-styled elements on the chat thread page (`renderChatThreadPage()`) into a new `chatThreadStyles` CSS constant, beside `threadPaneStyles`/`chatPageStyles`, so the existing mobile media queries can actually take effect (inline styles were outranking them)
- Exported `CHAT_BUBBLE_CLASS`/`CHAT_BUBBLE_INNER_CLASS`/`CHAT_BUBBLE_INNER_WIDE_CLASS` constants and interpolated them into both the server-rendered bubble markup and the inline JS `addBubble()` client builder, so the two can no longer drift apart
- Dropped the now-unneeded `!important` on `.chat-bubble-inner` in the mobile media query, since no inline `max-width` remains for it to fight

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Strict 1:1 lift — byte-identical class bodies | MET | chatThreadStyles const bodies match removed inline style values exactly |
| 2 | Class-name constants shared by server + inline JS | MET | CHAT_BUBBLE_CLASS/CHAT_BUBBLE_INNER_CLASS exported and interpolated into both renderMessageBubble() and addBubble() |
| 3 | Unit test: 5 migrated elements emit no style= | MET | 13 new unit tests in admin-ui-pages.unit.test.ts cover page wrapper, header, messages container, bubble wrapper, bubble inner (+more) |
| 4 | Desktop e2e: .chat-bubble-inner computed width ratio 70% at 1280px | MET | New e2e spec chat-thread-page.e2e.ts asserts ratio in (0.65, 0.71] at 1280px viewport |

## Test Plan
- `admin/src/admin-ui-pages.unit.test.ts` — 635/635 pass (13 new tests for the class migration)
- `admin/e2e/chat-thread-page.e2e.ts` (new) — 3/3 pass, including the AC4 computed-width proof at 1280px
- Full `admin/` Playwright e2e suite — 28/28 pass (no regressions)
- `task lint`, `task typecheck` — clean
- Coverage on the changed file (`admin/src/admin-ui-pages.ts`): 98.52% lines / 98.05% branches
- `task ci`'s `test:coverage` step surfaces 31 pre-existing, unrelated failures (metrics/env var pollution, task-store openapi smoke fixtures, a check-test-readiness fixture) — verified these reproduce identically against a clean `origin/main` checkout and an unrelated worktree, so they predate this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
