### PR TITLE
feat: persist last-write-wins progress on chat Message row

### DIFF
--- a/chat/openapi.json
+++ b/chat/openapi.json
@@ -882,7 +882,7 @@
         "tags": [
           "messages"
         ],
-        "summary": "Bump a claimed message's heartbeatAt (proof of life for a long-running reply)",
+        "summary": "Bump a claimed message's heartbeatAt (proof of life for a long-running reply), optionally recording the current progress phase",
         "parameters": [
           {
             "schema": {
@@ -894,6 +894,16 @@
             "in": "path"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HeartbeatBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Updated message",
@@ -901,6 +911,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }
@@ -1296,6 +1316,26 @@
             "format": "date-time",
             "example": null
           },
+          "progressPhase": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "reading"
+          },
+          "progressSeq": {
+            "type": "integer",
+            "default": 0,
+            "example": 3
+          },
+          "cancelRequestedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": null
+          },
           "repliedAt": {
             "type": [
               "string",
@@ -1426,6 +1466,15 @@
               "null"
             ],
             "example": null
+          }
+        }
+      },
+      "HeartbeatBody": {
+        "type": "object",
+        "properties": {
+          "phase": {
+            "type": "string",
+            "example": "reading"
           }
         }
       },

--- a/chat/prisma/migrations/20260829183057_add_progress_tracking/migration.sql
+++ b/chat/prisma/migrations/20260829183057_add_progress_tracking/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "cancelRequestedAt" TIMESTAMP(3),
+ADD COLUMN     "progressPhase" TEXT,
+ADD COLUMN     "progressSeq" INTEGER NOT NULL DEFAULT 0;

--- a/chat/prisma/schema.prisma
+++ b/chat/prisma/schema.prisma
@@ -65,6 +65,15 @@ model Message {
   // pollers can tell "still working" apart from "wedged" (see heartbeat()
   // in message-service.ts). Only ever set on claimed user messages.
   heartbeatAt        DateTime?
+  // Last-write-wins progress tracking (see heartbeat() in message-service.ts).
+  // Latest milestone + elapsed only, not a transcript — deliberately NOT an
+  // append-only events table. Deliberately NOT indexed: unindexed updates to
+  // these narrow columns stay HOT (heap-only tuple), so heartbeat churn (up
+  // to ~1200 writes/message over a 1h ceiling at a 3s cadence) produces no
+  // index bloat.
+  progressPhase      String?
+  progressSeq        Int       @default(0)
+  cancelRequestedAt  DateTime?
   repliedAt          DateTime?
   errorKind          String?
   createdAt          DateTime  @default(now())

--- a/chat/src/message-service.integration.test.ts
+++ b/chat/src/message-service.integration.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { PrismaClient } from "../prisma/client/index.js";
 import { FixedClock } from "./clock.ts";
+import { BadRequestError } from "./errors.ts";
 import { MessageService } from "./message-service.ts";
 
 const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_CHAT;
@@ -452,6 +453,104 @@ describeOrSkip("MessageService (integration)", () => {
         where: { id: replied.id },
       });
       expect(reloaded?.heartbeatAt).toBeNull();
+    });
+
+    it("bumps heartbeatAt and increments progressSeq when phase is omitted", async () => {
+      const threadId = await createThread(prisma);
+      const clock = FixedClock(new Date("2026-05-01T10:00:00Z"));
+      const svc = new MessageService(prisma, clock);
+
+      const claimed = await prisma.message.create({
+        data: {
+          threadId,
+          role: "user",
+          body: "long question",
+          claimed: true,
+          claimedAt: new Date("2026-05-01T09:59:00Z"),
+          claimedBy: "worker-1",
+        },
+      });
+      expect(claimed.progressSeq).toBe(0);
+      expect(claimed.progressPhase).toBeNull();
+
+      const updated = await svc.heartbeat(claimed.id, "worker-1");
+
+      expect(updated?.heartbeatAt).toEqual(new Date("2026-05-01T10:00:00Z"));
+      expect(updated?.progressSeq).toBe(1);
+      expect(updated?.progressPhase).toBeNull();
+    });
+
+    it("persists progressPhase and increments progressSeq in one update when a valid phase is given", async () => {
+      const threadId = await createThread(prisma);
+      const clock = FixedClock(new Date("2026-05-01T10:00:00Z"));
+      const svc = new MessageService(prisma, clock);
+
+      const claimed = await prisma.message.create({
+        data: {
+          threadId,
+          role: "user",
+          body: "long question",
+          claimed: true,
+          claimedAt: new Date("2026-05-01T09:59:00Z"),
+          claimedBy: "worker-1",
+        },
+      });
+
+      const updated = await svc.heartbeat(claimed.id, "worker-1", "reading");
+
+      expect(updated?.heartbeatAt).toEqual(new Date("2026-05-01T10:00:00Z"));
+      expect(updated?.progressPhase).toBe("reading");
+      expect(updated?.progressSeq).toBe(1);
+    });
+
+    it("rejects an invalid phase with BadRequestError and does not touch the row", async () => {
+      const threadId = await createThread(prisma);
+      const svc = new MessageService(prisma);
+
+      const claimed = await prisma.message.create({
+        data: {
+          threadId,
+          role: "user",
+          body: "long question",
+          claimed: true,
+          claimedAt: new Date("2026-05-01T09:59:00Z"),
+          claimedBy: "worker-1",
+        },
+      });
+
+      await expect(
+        svc.heartbeat(claimed.id, "worker-1", "not-a-real-phase"),
+      ).rejects.toThrow(BadRequestError);
+
+      const reloaded = await prisma.message.findUnique({
+        where: { id: claimed.id },
+      });
+      expect(reloaded?.progressSeq).toBe(0);
+      expect(reloaded?.progressPhase).toBeNull();
+      expect(reloaded?.heartbeatAt).toBeNull();
+    });
+
+    it("increments progressSeq monotonically across repeated heartbeats", async () => {
+      const threadId = await createThread(prisma);
+      const svc = new MessageService(prisma);
+
+      const claimed = await prisma.message.create({
+        data: {
+          threadId,
+          role: "user",
+          body: "long question",
+          claimed: true,
+          claimedAt: new Date("2026-05-01T09:59:00Z"),
+          claimedBy: "worker-1",
+        },
+      });
+
+      const first = await svc.heartbeat(claimed.id, "worker-1", "thinking");
+      expect(first?.progressSeq).toBe(1);
+
+      const second = await svc.heartbeat(claimed.id, "worker-1", "editing");
+      expect(second?.progressSeq).toBe(2);
+      expect(second?.progressPhase).toBe("editing");
     });
   });
 

--- a/chat/src/message-service.ts
+++ b/chat/src/message-service.ts
@@ -3,8 +3,10 @@
  * MessageService — CRUD for messages + queue operations (claim/reply).
  */
 
+import { PROGRESS_PHASES } from "@shipwright/lib/progress-phases";
 import { Prisma } from "../prisma/client/index.js";
 import { type Clock, SystemClock } from "./clock.ts";
+import { BadRequestError } from "./errors.ts";
 import type { Message, PrismaClient } from "./index.ts";
 
 export type { Message };
@@ -68,8 +70,18 @@ export interface MessageServiceLike {
    * Bump a claimed message's heartbeatAt to now — proof of life for a
    * long-running reply. Scoped to the claim's owner: returns null unless the
    * message is an unreplied user message currently claimed by `claimedBy`.
+   *
+   * When `phase` is provided it must be one of PROGRESS_PHASES — otherwise
+   * this throws BadRequestError and no write happens. progressSeq is always
+   * incremented by exactly 1 in the same update as heartbeatAt (and
+   * progressPhase, when phase is given) — last-write-wins, not an
+   * append-only log.
    */
-  heartbeat(id: string, claimedBy: string): Promise<Message | null>;
+  heartbeat(
+    id: string,
+    claimedBy: string,
+    phase?: string,
+  ): Promise<Message | null>;
 
   /**
    * Post an agent reply to a claimed message.
@@ -215,7 +227,26 @@ export class MessageService implements MessageServiceLike {
     }
   }
 
-  async heartbeat(id: string, claimedBy: string): Promise<Message | null> {
+  async heartbeat(
+    id: string,
+    claimedBy: string,
+    phase?: string,
+  ): Promise<Message | null> {
+    if (phase !== undefined && !PROGRESS_PHASES.includes(phase as never)) {
+      throw new BadRequestError(
+        `invalid phase: ${phase} (must be one of ${PROGRESS_PHASES.join(", ")})`,
+      );
+    }
+
+    const data: Prisma.MessageUpdateInput = {
+      heartbeatAt: this.clock.now(),
+      // progressSeq is a deterministic, clock-skew-free change-detector: under
+      // FixedClock, heartbeatAt is byte-identical across two beats, so an
+      // incrementing integer is what makes "did this heartbeat land" testable.
+      progressSeq: { increment: 1 },
+    };
+    if (phase !== undefined) data.progressPhase = phase;
+
     try {
       // Scoped to the current owner of an in-flight claim: only the agent that
       // actually claimed this message, and only while the reply is still
@@ -223,7 +254,7 @@ export class MessageService implements MessageServiceLike {
       // the thread keep an arbitrary message looking alive.
       return await this.prisma.message.update({
         where: { id, role: "user", claimed: true, repliedAt: null, claimedBy },
-        data: { heartbeatAt: this.clock.now() },
+        data,
       });
     } catch (err: unknown) {
       // Not found, unclaimed, already replied, or owned by another worker —

--- a/chat/src/messages.smoke.test.ts
+++ b/chat/src/messages.smoke.test.ts
@@ -419,6 +419,53 @@ describe("POST /threads/:id/messages/:msgId/heartbeat", () => {
     );
     expect(res.status).toBe(404);
   });
+
+  it("persists progressPhase and bumps progressSeq when a valid phase is posted", async () => {
+    const ts = fakeThreadService();
+    const ms = fakeMessageService();
+    const thread = await ts.create({ agentId: "a1" });
+    const userMsg = await ms.create(thread.id, {
+      role: "user",
+      body: "Long-running question",
+    });
+    await ms.claim(thread.id, "admin");
+    const app = buildApp(ts, ms);
+
+    const res = await app.request(
+      `/threads/${thread.id}/messages/${userMsg.id}/heartbeat`,
+      {
+        method: "POST",
+        headers: H.post,
+        body: JSON.stringify({ phase: "reading" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Message;
+    expect(body.progressPhase).toBe("reading");
+    expect(body.progressSeq).toBe(1);
+  });
+
+  it("returns 400 for an invalid phase", async () => {
+    const ts = fakeThreadService();
+    const ms = fakeMessageService();
+    const thread = await ts.create({ agentId: "a1" });
+    const userMsg = await ms.create(thread.id, {
+      role: "user",
+      body: "Long-running question",
+    });
+    await ms.claim(thread.id, "admin");
+    const app = buildApp(ts, ms);
+
+    const res = await app.request(
+      `/threads/${thread.id}/messages/${userMsg.id}/heartbeat`,
+      {
+        method: "POST",
+        headers: H.post,
+        body: JSON.stringify({ phase: "not-a-real-phase" }),
+      },
+    );
+    expect(res.status).toBe(400);
+  });
 });
 
 // ─── Queue API: reply ─────────────────────────────────────────────────────────

--- a/chat/src/openapi-schemas.ts
+++ b/chat/src/openapi-schemas.ts
@@ -126,6 +126,18 @@ export const MessageSchema = z
       .nullable()
       .optional()
       .openapi({ example: null }),
+    progressPhase: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "reading" }),
+    progressSeq: z.number().int().default(0).openapi({ example: 3 }),
+    cancelRequestedAt: z
+      .string()
+      .datetime()
+      .nullable()
+      .optional()
+      .openapi({ example: null }),
     repliedAt: z
       .string()
       .datetime()

--- a/chat/src/routes/messages.ts
+++ b/chat/src/routes/messages.ts
@@ -105,6 +105,17 @@ const UpdateMessageBodySchema = z
   })
   .openapi("UpdateMessageBody");
 
+/** Request body for POST /:id/heartbeat.
+ * `phase`, when given, must be one of PROGRESS_PHASES — validated by
+ * MessageService.heartbeat() (custom BadRequestError message), not by Zod,
+ * per the permissive-schema/manual-validation convention.
+ */
+const HeartbeatBodySchema = z
+  .object({
+    phase: z.string().optional().openapi({ example: "reading" }),
+  })
+  .openapi("HeartbeatBody");
+
 /** Request body for POST /:id/reply.
  * `body` is required at runtime by the handler (custom error message), but
  * kept optional here per the permissive-schema/manual-validation convention.
@@ -293,14 +304,23 @@ const heartbeatRoute = createRoute({
   path: "/:id/heartbeat",
   tags: ["messages"],
   summary:
-    "Bump a claimed message's heartbeatAt (proof of life for a long-running reply)",
+    "Bump a claimed message's heartbeatAt (proof of life for a long-running reply), " +
+    "optionally recording the current progress phase",
   request: {
     params: MessageIdParamSchema,
+    body: {
+      content: { "application/json": { schema: HeartbeatBodySchema } },
+      required: false,
+    },
   },
   responses: {
     200: {
       description: "Updated message",
       content: { "application/json": { schema: MessageSchema } },
+    },
+    400: {
+      description: "Bad request",
+      content: { "application/json": { schema: ErrorSchema } },
     },
     404: {
       description: "Thread or message not found",
@@ -549,9 +569,13 @@ export function createMessagesRoutes(
     const callerAgentId = c.get("agentId");
     const claimedBy = callerAgentId ?? "admin";
 
+    const body = await readJson(c);
+    const phase = typeof body.phase === "string" ? body.phase : undefined;
+
     const updated = await messageService.heartbeat(
       c.req.param("id"),
       claimedBy,
+      phase,
     );
     if (!updated) throw new NotFoundError("message not found");
     return c.json(updated, 200);

--- a/chat/src/test-fakes.ts
+++ b/chat/src/test-fakes.ts
@@ -4,7 +4,9 @@
  * Do not import from production code paths.
  */
 
+import { PROGRESS_PHASES } from "@shipwright/lib/progress-phases";
 import type { Prisma } from "../prisma/client/index.js";
+import { BadRequestError } from "./errors.ts";
 import type { Message, MessageServiceLike } from "./message-service.ts";
 import type {
   Thread,
@@ -185,6 +187,9 @@ export function fakeMessageService(
         claimedAt: null,
         claimedBy: null,
         heartbeatAt: null,
+        progressPhase: null,
+        progressSeq: 0,
+        cancelRequestedAt: null,
         repliedAt: null,
         errorKind: null,
         createdAt: new Date(),
@@ -245,7 +250,12 @@ export function fakeMessageService(
       msg.claimedBy = claimedBy;
       return msg;
     },
-    async heartbeat(id, claimedBy) {
+    async heartbeat(id, claimedBy, phase) {
+      if (phase !== undefined && !PROGRESS_PHASES.includes(phase as never)) {
+        throw new BadRequestError(
+          `invalid phase: ${phase} (must be one of ${PROGRESS_PHASES.join(", ")})`,
+        );
+      }
       const msg = store.find((m) => m.id === id);
       if (
         !msg ||
@@ -256,6 +266,8 @@ export function fakeMessageService(
       )
         return null;
       msg.heartbeatAt = new Date();
+      msg.progressSeq += 1;
+      if (phase !== undefined) msg.progressPhase = phase;
       return msg;
     },
     async reply(messageId, data) {
@@ -276,6 +288,9 @@ export function fakeMessageService(
         claimedAt: null,
         claimedBy: null,
         heartbeatAt: null,
+        progressPhase: null,
+        progressSeq: 0,
+        cancelRequestedAt: null,
         repliedAt: null,
         errorKind: null,
         createdAt: new Date(),

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -210,7 +210,11 @@ Returns `404` if not found, otherwise the deleted message with `200`.
 POST /threads/:threadId/messages/:id/heartbeat
 ```
 
-Bumps `heartbeatAt` to now on the target message — proof of life while the claiming agent works a long-running reply. The agent's chat poll loop calls this on a fixed interval (`heartbeatIntervalMs`, default 3s) that runs for the whole duration of the reply — interval-driven rather than tied to Claude's turn cadence, since a single long-running tool call can go quiet for minutes between stream events. The admin chat UI uses `heartbeatAt` (alongside `claimedAt`) to extend its own timeout instead of tripping a flat cutoff. Scoped to the claim's owner: the caller's identity (`agentId`, or `"admin"` for the admin UI) must match the message's `claimedBy`, or the update no-ops. Returns `404` if the message doesn't exist, doesn't belong to `:threadId`, isn't currently claimed by the caller, or has already been replied to; otherwise the updated message with `200`.
+Bumps `heartbeatAt` to now on the target message — proof of life while the claiming agent works a long-running reply. The agent's chat poll loop calls this on a fixed interval (`heartbeatIntervalMs`, default 3s) that runs for the whole duration of the reply — interval-driven rather than tied to Claude's turn cadence, since a single long-running tool call can go quiet for minutes between stream events. The admin chat UI uses `heartbeatAt` (alongside `claimedAt`) to extend its own timeout instead of tripping a flat cutoff. Scoped to the claim's owner: the caller's identity (`agentId`, or `"admin"` for the admin UI) must match the message's `claimedBy`, or the update no-ops.
+
+Optional request body: `{ phase?: string }`. When `phase` is provided, it must be one of the valid `PROGRESS_PHASES` — otherwise returns `400`. On success, `progressPhase` is updated and `progressSeq` is incremented atomically alongside `heartbeatAt`.
+
+Returns `400` if `phase` is provided but invalid, `404` if the message doesn't exist, doesn't belong to `:threadId`, isn't currently claimed by the caller, or has already been replied to; otherwise the updated message with `200`.
 
 #### Reply (queue API)
 
@@ -276,6 +280,9 @@ Indexes: `[agentId, updatedAt desc]` (list-by-agent ordering), `[memberId]`.
 | `claimedAt` | `DateTime?` | |
 | `claimedBy` | `String?` | Caller `agentId`, or `"admin"` |
 | `heartbeatAt` | `DateTime?` | Bumped by the heartbeat queue endpoint while a claimed message is being worked |
+| `progressPhase` | `String?` | Latest milestone + elapsed during claim processing; last-write-wins, not append-only; updated by heartbeat endpoint when `phase` is provided |
+| `progressSeq` | `Int` | Default `0`; incremented with each heartbeat to track change events across same-timestamp updates |
+| `cancelRequestedAt` | `DateTime?` | Cancellation request timestamp, if set |
 | `repliedAt` | `DateTime?` | Set by the reply queue endpoint; guards against double-reply |
 | `errorKind` | `String?` | |
 | `createdAt` | `DateTime` | |


### PR DESCRIPTION
## Summary
- Add `progressPhase` (`String?`), `progressSeq` (`Int @default(0)`), and `cancelRequestedAt` (`DateTime?`) to the chat `Message` model — last-write-wins progress columns, deliberately unindexed so heartbeat churn (~1200 writes/message over the 1h ceiling) stays HOT and produces no index bloat.
- `MessageService.heartbeat()` now accepts an optional `phase`, validated against `PROGRESS_PHASES` (from `lib/progress-phases.ts`) before any write; a valid phase and the `progressSeq` increment land in the same atomic `UPDATE` as `heartbeatAt`. An invalid phase throws `BadRequestError` (400) with zero DB mutation.
- `POST /:threadId/messages/:id/heartbeat` gained an optional `{ phase?: string }` request body and a documented `400` response; `chat/openapi.json` and `MessageSchema` regenerated to carry the three new fields.
- `docs/chat.md` refreshed to document the new fields and the heartbeat endpoint's phase/400 behavior.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Migration adds the three columns; none of them indexed | MET |
| 2 | `heartbeat()` accepts an optional phase, validated against `PROGRESS_PHASES`, and increments `progressSeq` in the same UPDATE | MET |
| 3 | Invalid phase returns 400 | MET |
| 4 | `chat/openapi.json` regenerated; `MessageSchema` carries the new fields | MET |
| 5 | Data verifiable end to end by curl with no UI change in this PR | MET |

## Test Plan
- New integration tests in `chat/src/message-service.integration.test.ts`: phase omitted still bumps `heartbeatAt` + increments `progressSeq`; valid phase persists `progressPhase` + increments `progressSeq` in one update; invalid phase throws `BadRequestError` with zero row mutation; repeated heartbeats increment `progressSeq` monotonically.
- New smoke tests in `chat/src/messages.smoke.test.ts`: `POST .../heartbeat` with `{"phase":"reading"}` returns 200 with `progressPhase`/`progressSeq` populated (curl-equivalent proof); invalid phase returns 400.
- `chat/` test suite: 174 pass, 0 fail. New/changed source (`message-service.ts`, `openapi-schemas.ts`) at 100% line coverage.
- `task typecheck` — all 7 workspaces pass. `bunx biome lint .` — clean. `check-strings`, `check-config-docs`, `check-version-sync` — all pass.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
