### PR TITLE
feat(demo): sully sizzle — generic Bold Move deck, ready to record

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,6 +82,11 @@ tasks:
     cmds:
       - bun scripts/hitl.ts
 
+  demo:serve:
+    desc: Serve demo/slides/*.html for local sizzle-reel recording → http://localhost:4321/slides/
+    cmds:
+      - bunx serve demo -l 4321
+
   stack:
     aliases: [stack:up]
     desc: Launch the full dev stack in a tmux session (6 panes — metrics :3460, admin :3001, task-store :3002, chat-svc :3003, agent, logs). Chat with the agent at http://localhost:3001/admin/chat. Requires tmux; falls back to `task dev`.

--- a/demo/scenes.yaml
+++ b/demo/scenes.yaml
@@ -110,7 +110,7 @@ scenes:
   - id: "pipeline"
     type: browser
     duration: 18
-    narration: "Every change, the same way. Spec — product intent captured as a reviewable spec. Plan — estimated, dependency-ordered tasks. Build — tests first, every criterion independently verified. Review — policy-controlled with confidence thresholds. Ship — merge, deploy, canary, automatic revert on failure."
+    narration: "Every change, the same way. Spec — product intent captured as a reviewable spec. Plan — estimated, dependency-ordered tasks. Build — tests first, every criterion independently verified. Review — policy-controlled with confidence thresholds. Ship — green CI and an approved review, merged and deployed via Helm."
     url: "http://localhost:4321/slides/pipeline.html"
     action: screenshot
     playwright: |
@@ -152,7 +152,7 @@ scenes:
   - id: "last-mile"
     type: browser
     duration: 18
-    narration: "Most AI tools stop when the code is written. Shipwright carries it the rest of the way. Review — findings fixed on a schedule. Merge — green CI, approved review. Deploy — into your own environment. Canary — watched after release. Auto-revert when something fails."
+    narration: "Most AI tools stop when the code is written. Shipwright carries it the rest of the way. Review — findings fixed on a schedule. Merge — green CI, approved review. Deploy — into your own environment. Canary — an opt-in staged rollout, when your pipeline supports it. Auto-revert, available when something fails."
     url: "http://localhost:4321/slides/last-mile.html"
     action: screenshot
     playwright: |

--- a/demo/scenes.yaml
+++ b/demo/scenes.yaml
@@ -1,165 +1,260 @@
-# demo/scenes.yaml — "Inside a task" walkthrough
+# demo/scenes.yaml — Shipwright Generic Sizzle + "Bold Move" Ad Campaign
 #
-# A factual, step-by-step explainer of the 14 steps /shipwright:dev-task runs
-# when it picks up a ticket. Mirrors the "Inside a task" tab on the homepage
-# (site/src/pages/index.astro → devTaskSteps), which is itself faithful to
-# plugins/shipwright/commands/dev-task.md.
+# FULL 15-SLIDE DECK — generic version for:
+#   - shipwrightharness.com  (hero video embed)
+#   - app-vitals.com         (homepage "See what we built" section)
 #
-# Style: one branded title-card per step. Narration explains, in human terms,
-# what the step does and why a developer finds it useful. Works fully offline —
-# no running stack required.
+# Ad campaign hook: "You're still paying your developers to write code?
+#                    Bold move. Good luck." — leads every placement.
+#
+# All HTML slides live in demo/slides/ and are served by `task demo:serve`
+# (see Taskfile.yml demo:serve target). Two title-card scenes (ad-hook, close)
+# use ffmpeg drawtext and need no local server.
 #
 # Workflow:
-#   1. /demo-recorder:demo-preview            — review the shot list
-#   2. /demo-recorder:demo-record             — draft video (say/Piper narration)
-#   3. approve narration, edit lines here
-#   4. /demo-recorder:demo-record --final     — swap in ElevenLabs narration
-#   5. commit demo/output/inside-a-task.mp4 + the .script.md artifact
+#   1. task demo:serve            (in a separate pane)
+#   2. /sizzle:preview            — review the shot list
+#   3. /sizzle:record --final     — record with ElevenLabs narration
+#   4. bash demo/brand-overlay.sh demo/output/shipwright-hero.mp4
+#   5. Commit demo/output/shipwright-hero.mp4 + .script.md artifact
+#
+# Source for HTML slide templates: demo/slides/*.html
+# Source for real metrics: https://proof.shipwrightharness.com/public/dashboard
+# Refresh the Proof slide metrics before every re-record.
 
 video:
-  title: "Inside a Task — The 14 Steps of /shipwright:dev-task"
-  output_name: "inside-a-task"
+  title: "Shipwright — Bold Move (Full Deck)"
+  output_name: "shipwright-hero"
   formats:
-    - "16:9"   # website embed on the homepage "Inside a task" tab
+    - "16:9"   # website embed, YouTube
+    - "9:16"   # Shorts, LinkedIn portrait
   font: "JetBrains Mono"
   theme: "dark"
+  transition: "fade"
 
 scenes:
   # ---------------------------------------------------------------------------
-  # Intro card — frame the walkthrough.
+  # 00 — Ad Campaign Hook (6s) — title-card, no server needed
+  # The new advertising initiative. Provocative open. Works as a standalone
+  # ad clip too — crop this scene alone for social.
+  # ---------------------------------------------------------------------------
+  - id: "ad-hook"
+    type: title-card
+    duration: 6
+    text: "You're still paying your developers\nto write code?"
+    subtext: "Bold move. Good luck."
+    background: "#080E1E"
+    narration: "You're still paying your developers to write code? Bold move. Good luck."
+
+  # ---------------------------------------------------------------------------
+  # 01 — Intro (15s)
+  # "Almost everyone has adopted AI. Almost no one has integrated it."
+  # Generic — no client name.
   # ---------------------------------------------------------------------------
   - id: "intro"
-    type: title-card
-    duration: 11
-    text: "Inside a task\nThe 14 steps of dev-task"
-    subtext: "shipwrightharness.com"
-    background: "#080E1E"
-    narration: "When Shipwright picks up a ticket, fourteen steps run end to end — from reading your toolchain to opening a green pull request. Here is each one, and why it matters."
-
-  # --- SETUP ----------------------------------------------------------------
-  - id: "step-01"
-    type: title-card
-    duration: 12
-    text: "01\nDetect the toolchain"
-    subtext: "Setup · Step 1 of 14"
-    background: "#080E1E"
-    narration: "First it reads your build config and learns your test, lint, and typecheck commands — so every later step runs your project's real commands, not guesses."
-
-  - id: "step-02"
-    type: title-card
-    duration: 11
-    text: "02\nPick the next task"
-    subtext: "Setup · Step 2 of 14"
-    background: "#080E1E"
-    narration: "It resumes anything left in progress, or pulls the next ready item off the queue and checks it has everything it needs — so work never starts on a half-defined ticket."
-
-  - id: "step-03"
-    type: title-card
-    duration: 10
-    text: "03\nMark in-progress"
-    subtext: "Setup · Step 3 of 14"
-    background: "#080E1E"
-    narration: "It clears out any leftover branch or PR from a crashed run, then flips the task to in-progress — so the board always reflects what is actually happening."
-
-  - id: "step-04"
-    type: title-card
-    duration: 11
-    text: "04\nBuild the brief"
-    subtext: "Setup · Step 4 of 14"
-    background: "#080E1E"
-    narration: "It turns the ticket's title, description, acceptance criteria, and layer into a single implementation brief — the same context a developer would gather before writing a line."
-
-  - id: "step-05"
-    type: title-card
-    duration: 10
-    text: "05\nSet up a worktree"
-    subtext: "Setup · Step 5 of 14"
-    background: "#080E1E"
-    narration: "It creates an isolated git worktree on the task's own branch — never on main — so the work is sandboxed and your main branch stays clean."
-
-  # --- BUILD ----------------------------------------------------------------
-  - id: "step-06"
-    type: title-card
-    duration: 10
-    text: "06\nTests first, then code"
-    subtext: "Build · Step 6 of 14"
-    background: "#080E1E"
-    narration: "It writes failing tests first, makes them pass, then refactors — so behavior is pinned by tests before any production code exists."
-
-  # --- VERIFY ---------------------------------------------------------------
-  - id: "step-07"
-    type: title-card
-    duration: 11
-    text: "07\nSimplify"
-    subtext: "Verify · Step 7 of 14"
-    background: "#080E1E"
-    narration: "It re-reads its own diff for duplication, dead code, and needless complexity, and fixes them — the cleanup pass reviewers usually have to ask for."
-
-  - id: "step-08"
-    type: title-card
-    duration: 10
-    text: "08\nVerify the spec"
-    subtext: "Verify · Step 8 of 14"
-    background: "#080E1E"
-    narration: "A second, independent agent checks every acceptance criterion against the diff and patches whatever is missing — a fresh set of eyes before anyone is notified."
-
-  - id: "step-09"
-    type: title-card
-    duration: 10
-    text: "09\nGrade requirements"
-    subtext: "Verify · Step 9 of 14"
-    background: "#080E1E"
-    narration: "It scores each criterion met, partial, or not-met, and blocks the task if anything is still unmet — so a pull request never claims to be done when it is not."
-
-  # --- PRE-SHIP -------------------------------------------------------------
-  - id: "step-10"
-    type: title-card
-    duration: 11
-    text: "10\nPre-ship checks"
-    subtext: "Pre-ship · Step 10 of 14"
-    background: "#080E1E"
-    narration: "It runs validate, lint, test, and typecheck, and reports how coverage moved against your threshold — the same gate your CI will enforce, caught early."
-
-  - id: "step-11"
-    type: title-card
-    duration: 10
-    text: "11\nRefresh the docs"
-    subtext: "Pre-ship · Step 11 of 14"
-    background: "#080E1E"
-    narration: "A docs agent updates anything the change made stale and commits it separately — so documentation lands with the feature instead of drifting behind it."
-
-  # --- SHIP -----------------------------------------------------------------
-  - id: "step-12"
-    type: title-card
-    duration: 10
-    text: "12\nPush & open the PR"
-    subtext: "Ship · Step 12 of 14"
-    background: "#080E1E"
-    narration: "It pushes the branch and opens a pull request — or adds commits to the existing one — with a summary and the acceptance-criteria table already filled in."
-
-  - id: "step-13"
-    type: title-card
-    duration: 10
-    text: "13\nWatch CI, fix failures"
-    subtext: "Ship · Step 13 of 14"
-    background: "#080E1E"
-    narration: "It polls CI, reads the failure logs, and retries fixes up to six times before giving up — turning red builds green without anyone having to step in."
-
-  - id: "step-14"
-    type: title-card
-    duration: 10
-    text: "14\nRecord metrics & hand off"
-    subtext: "Ship · Step 14 of 14"
-    background: "#080E1E"
-    narration: "Finally it moves the task to pr-open, records the metrics, and prints a handoff summary — so the next task, and the next measurement, are ready to go."
+    type: browser
+    duration: 15
+    narration: "Almost everyone has adopted AI. Almost no one has integrated it. This is why the agent that ships your backlog should run in your cloud, on your codebase."
+    url: "http://localhost:4321/slides/intro.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
 
   # ---------------------------------------------------------------------------
-  # Close card — the payoff.
+  # 02 — Problem: Stats (20s)
+  # Data-driven: code output up, review time up, bugs up, incidents up.
+  # ---------------------------------------------------------------------------
+  - id: "problem-stats"
+    type: browser
+    duration: 20
+    narration: "AI made code generation fast. Nothing after it got faster. Output is up ninety-eight percent. Review time up four hundred percent. Bugs per developer up fifty-four. Incidents per change, two forty-three. Speed without structure is just louder."
+    url: "http://localhost:4321/slides/problem-stats.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 03 — Problem: Babysitting (18s)
+  # "Your most expensive people are babysitting code generation."
+  # ---------------------------------------------------------------------------
+  - id: "problem-babysitting"
+    type: browser
+    duration: 18
+    narration: "Your most expensive engineers are inside the loop of every AI task. Prompting, watching, steering — one task at a time. Output is capped by one person's attention. With Shipwright, the coding leaves their day — in the cloud, around the clock, through quality gates the team controls."
+    url: "http://localhost:4321/slides/problem-babysitting.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 04 — What It Is (15s)
+  # "A delivery system, not another assistant."
+  # ---------------------------------------------------------------------------
+  - id: "what-it-is"
+    type: browser
+    duration: 15
+    narration: "Shipwright is a delivery system, not another assistant. A cloud agent you deploy into your own environment. It picks up queued work, ships on a schedule, and talks to the team where they already are. Deploy to your cloud. Talks in Slack. Ships on cron. One governed pipeline."
+    url: "http://localhost:4321/slides/what-it-is.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 05 — The Pipeline (18s)
+  # "Every Change, The Same Way" — Spec → Plan → Build → Review → Ship
+  # ---------------------------------------------------------------------------
+  - id: "pipeline"
+    type: browser
+    duration: 18
+    narration: "Every change, the same way. Spec — product intent captured as a reviewable spec. Plan — estimated, dependency-ordered tasks. Build — tests first, every criterion independently verified. Review — policy-controlled with confidence thresholds. Ship — merge, deploy, canary, automatic revert on failure."
+    url: "http://localhost:4321/slides/pipeline.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 06 — For The Architect (15s)
+  # "An enforced quality bar." — tests before code, independent verification.
+  # ---------------------------------------------------------------------------
+  - id: "quality-bar"
+    type: browser
+    duration: 15
+    narration: "An enforced quality bar. Tests are written before code and land in the same change. A second agent independently grades every acceptance criterion against the diff. A pull request is blocked if anything is unmet. Enforced by the system, not suggested by a prompt."
+    url: "http://localhost:4321/slides/quality-bar.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 07 — Governance (15s)
+  # "Humans keep the judgment calls."
+  # ---------------------------------------------------------------------------
+  - id: "governance"
+    type: browser
+    duration: 15
+    narration: "Humans keep the judgment calls. Sensitive work is routed to a person at planning time — before any code is written. The agent never touches credentials or production access on its own. Every autonomy level is a toggle your team controls."
+    url: "http://localhost:4321/slides/governance.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 08 — The Last Mile (18s)
+  # "Most AI tools stop when the code is written. Shipwright carries it further."
+  # ---------------------------------------------------------------------------
+  - id: "last-mile"
+    type: browser
+    duration: 18
+    narration: "Most AI tools stop when the code is written. Shipwright carries it the rest of the way. Review — findings fixed on a schedule. Merge — green CI, approved review. Deploy — into your own environment. Canary — watched after release. Auto-revert when something fails."
+    url: "http://localhost:4321/slides/last-mile.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 09 — Measured (15s)
+  # "AI ROI becomes a number, not a feeling."
+  # ---------------------------------------------------------------------------
+  - id: "measured"
+    type: browser
+    duration: 15
+    narration: "AI ROI becomes a number, not a feeling. First-time quality rate. Cycle time. Review verdicts. Estimation accuracy. Every task graded, on a dashboard you host."
+    url: "http://localhost:4321/slides/measured.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 10 — Standing Maintenance (15s)
+  # "The upkeep no one prioritizes, done continuously."
+  # ---------------------------------------------------------------------------
+  - id: "maintenance"
+    type: browser
+    duration: 15
+    narration: "The upkeep no one prioritizes, done continuously. Security patrol. Error patrol. Code-health patrol. Dependency patrol. Documentation patrol. Each on its own schedule. Findings become queued, reviewable work."
+    url: "http://localhost:4321/slides/maintenance.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 11 — Ownership (15s)
+  # "Free. Open source. Yours." — MIT, no seats, runs in your cloud.
+  # ---------------------------------------------------------------------------
+  - id: "ownership"
+    type: browser
+    duration: 15
+    narration: "Free. Open source. Yours. Closed, hosted agents charge per seat and run on someone else's infrastructure. Shipwright is MIT throughout. No tiers, no seats. Runs entirely in your cloud, on any stack — Node, Go, Rust, Python, Ruby."
+    url: "http://localhost:4321/slides/ownership.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 12 — Proof (18s)
+  # "Shipwright builds Shipwright." — LIVE METRICS from proof dashboard.
+  # ⚠️  UPDATE THESE NUMBERS before re-recording. Source:
+  #     https://proof.shipwrightharness.com/public/dashboard (90-day window)
+  # ---------------------------------------------------------------------------
+  - id: "proof"
+    type: browser
+    duration: 18
+    narration: "Shipwright builds Shipwright. Over eighteen hundred changes merged — mostly shipped by the agent itself. Two hundred thirty-two tasks completed in the last ninety days. Ninety-one percent passed all automated checks on the first try. Ninety-four percent approved on first review. Live and public at proof.shipwrightharness.com."
+    url: "http://localhost:4321/slides/proof.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 13 — Live Dashboard (15s)
+  # Actual screenshot of the public proof dashboard — browser capture.
+  # ⚠️  Requires proof.shipwrightharness.com to be live and accessible.
+  # ---------------------------------------------------------------------------
+  - id: "dashboard"
+    type: browser
+    duration: 15
+    narration: "The metrics dashboard runs in your cloud. Self-hosted. Yours forever. Every number is yours to keep."
+    url: "https://proof.shipwrightharness.com/public/dashboard"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.overview-section', { timeout: 20000 });
+      await page.waitForTimeout(1500);
+
+  # ---------------------------------------------------------------------------
+  # 14 — Adoption Ramp (15s)
+  # "Autonomy is a ramp, not a switch."
+  # ---------------------------------------------------------------------------
+  - id: "adoption"
+    type: browser
+    duration: 15
+    narration: "Autonomy is a ramp, not a switch. Build — start with the plugin, review everything. Review and patch — the agent handles feedback, CI stays green. Autonomous delivery — full pipeline, ships on a schedule. You control the rate of handoff."
+    url: "http://localhost:4321/slides/adoption.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(800);
+
+  # ---------------------------------------------------------------------------
+  # 15 — Close (10s) — title-card, no server needed
   # ---------------------------------------------------------------------------
   - id: "close"
-    type: title-card
+    type: browser
     duration: 10
-    text: "Fourteen steps. One command.\nTested, reviewed, documented, measured."
-    subtext: "shipwrightharness.com"
-    background: "#080E1E"
-    narration: "Fourteen steps, one command. Every task ships the same way — tested, reviewed, documented, and measured. That's Shipwright."
+    narration: "MIT. Self-hosted. Your code never leaves your infrastructure. Shipwright."
+    url: "http://localhost:4321/slides/close.html"
+    action: screenshot
+    playwright: |
+      await page.waitForSelector('.slide-ready', { timeout: 10000 });
+      await page.waitForTimeout(600);

--- a/demo/slides/adoption.html
+++ b/demo/slides/adoption.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Adoption</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; }
+  .headline { font-size: 60px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; }
+  .stage-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px; max-width: 1300px; }
+  .stage-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 16px; padding: 44px 36px; }
+  .stage-num { font-family: var(--font-mono); font-size: 13px; color: var(--text-faint); letter-spacing: 0.1em; margin-bottom: 16px; }
+  .stage-name { font-size: 30px; font-weight: 700; margin-bottom: 16px; }
+  .stage-body { font-size: 18px; line-height: 1.6; color: var(--text-muted); }
+  .stage-card:last-child { border-color: var(--brand-green); border-width: 2px; }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Adoption</p>
+    <h1 class="headline">Autonomy is a ramp, not a switch.</h1>
+    <div class="stage-grid">
+      <div class="stage-card">
+        <div class="stage-num">Stage 01</div>
+        <div class="stage-name">Build</div>
+        <div class="stage-body">Start with the plugin. Review everything. The agent writes — you approve every step.</div>
+      </div>
+      <div class="stage-card">
+        <div class="stage-num">Stage 02</div>
+        <div class="stage-name">Review &amp; patch</div>
+        <div class="stage-body">The agent handles review feedback and keeps CI green. You stay in the loop on merges.</div>
+      </div>
+      <div class="stage-card">
+        <div class="stage-num">Stage 03</div>
+        <div class="stage-name">Autonomous delivery</div>
+        <div class="stage-body">Full pipeline. Ships on a schedule. You control the rate of handoff.</div>
+      </div>
+    </div>
+  </div>
+  <div class="slide-footer"><span>Adoption</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/base-styles.css
+++ b/demo/slides/base-styles.css
@@ -1,0 +1,104 @@
+/* Base styles for all Shipwright sizzle slides */
+/* 1920x1080 target. Each slide is a full-viewport card. */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-base:        #080E1E;
+  --brand-green:    #34C77B;
+  --brand-teal:     #2DD4BF;
+  --text-primary:   #FFFFFF;
+  --text-muted:     rgba(255,255,255,0.5);
+  --text-faint:     rgba(255,255,255,0.25);
+  --card-border:    rgba(255,255,255,0.08);
+  --card-bg:        rgba(255,255,255,0.03);
+  --green-glow:     rgba(52, 199, 123, 0.12);
+  --stat-green:     #34C77B;
+  --stat-red:       #F87171;
+  --margin:         72px;
+  --font-mono:      'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+  --font-display:   'Inter', system-ui, sans-serif;
+}
+
+html, body {
+  width: 1920px;
+  height: 1080px;
+  overflow: hidden;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* === Top-left brand lockup === */
+.brand-lockup {
+  position: absolute;
+  top: var(--margin);
+  left: var(--margin);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  /* Shipwright green diamond mark placeholder — replace with actual SVG */
+  background: var(--brand-green);
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  flex-shrink: 0;
+}
+.brand-wordmark {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+.brand-rule {
+  position: absolute;
+  top: calc(var(--margin) + 50px);
+  left: var(--margin);
+  width: 360px;
+  height: 2px;
+  background: var(--brand-green);
+  opacity: 0.85;
+}
+
+/* === Footer === */
+.slide-footer {
+  position: absolute;
+  bottom: var(--margin);
+  left: var(--margin);
+  right: var(--margin);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-faint);
+  letter-spacing: 0.08em;
+}
+
+/* === Eyebrow label === */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--brand-teal);
+  margin-bottom: 28px;
+}
+
+/* === Background glow orbs === */
+.glow-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  pointer-events: none;
+}
+.glow-tr { top: -15%; right: -8%; width: 600px; height: 600px; background: var(--green-glow); }
+.glow-bl { bottom: -20%; left: -10%; width: 500px; height: 500px; background: rgba(45, 212, 191, 0.06); }
+
+/* Slide-ready sentinel — Playwright waits for this */
+.slide-ready { display: none; }

--- a/demo/slides/close.html
+++ b/demo/slides/close.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Close</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 0 var(--margin);
+  }
+  .headline { font-size: 64px; font-weight: 700; line-height: 1.15; letter-spacing: -0.03em; margin-bottom: 36px; }
+  .install-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 32px;
+    background: rgba(52,199,123,0.08);
+    border: 1px solid rgba(52,199,123,0.3);
+    border-radius: 100px;
+    font-family: var(--font-mono);
+    font-size: 20px;
+    color: var(--brand-green);
+    margin-bottom: 48px;
+  }
+  .links { display: flex; gap: 40px; justify-content: center; }
+  .link { font-size: 18px; color: var(--text-faint); text-decoration: none; }
+  .link.primary { color: var(--text-primary); font-weight: 600; }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Shipwright Harness</p>
+    <h1 class="headline">The open-source autonomous<br>delivery agent for Claude Code.</h1>
+    <div class="install-pill">/plugin install shipwright@app-vitals/shipwright</div>
+    <div class="links">
+      <span class="link primary">shipwrightharness.com</span>
+      <span class="link">github.com/app-vitals/shipwright</span>
+      <span class="link">proof.shipwrightharness.com</span>
+    </div>
+  </div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/governance.html
+++ b/demo/slides/governance.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Governance</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; max-width: 1100px; }
+  .headline { font-size: 64px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; }
+  .bullet-list { display: flex; flex-direction: column; gap: 28px; }
+  .bullet { display: flex; align-items: flex-start; gap: 24px; }
+  .bullet-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--brand-green); flex-shrink: 0; margin-top: 10px; }
+  .bullet-text { font-size: 22px; line-height: 1.5; color: var(--text-muted); }
+  .bullet-text strong { color: var(--text-primary); font-weight: 600; }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Governance</p>
+    <h1 class="headline">Humans keep the judgment calls.</h1>
+    <div class="bullet-list">
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text"><strong>Sensitive work is routed to a person</strong> at planning time — before any code is written.</div></div>
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text">The agent <strong>never touches credentials or production access</strong> on its own.</div></div>
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text"><strong>Every autonomy level is a toggle</strong> your team controls.</div></div>
+    </div>
+  </div>
+  <div class="slide-footer"><span>Why adopt it · 2 / 6</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/intro.html
+++ b/demo/slides/intro.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Intro</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0 var(--margin);
+    padding-top: 140px; /* below brand lockup */
+    max-width: 1300px;
+  }
+
+  .headline {
+    font-size: 72px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    margin-bottom: 36px;
+  }
+  .headline em { color: var(--brand-teal); font-style: normal; }
+
+  .subtext {
+    font-size: 28px;
+    line-height: 1.5;
+    color: var(--text-muted);
+    max-width: 900px;
+  }
+  .subtext strong { color: var(--text-primary); font-weight: 600; }
+</style>
+</head>
+<body>
+  <!-- Background orbs -->
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+
+  <!-- Brand lockup -->
+  <div class="brand-lockup">
+    <div class="brand-mark"></div>
+    <span class="brand-wordmark">Shipwright Harness</span>
+  </div>
+  <div class="brand-rule"></div>
+
+  <!-- Eyebrow -->
+  <div class="content">
+    <p class="eyebrow">Shipwright Harness · Open Source · Built on Claude Code</p>
+
+    <h1 class="headline">
+      Almost everyone has <em>adopted</em> AI.<br>
+      Almost no one has <em>integrated</em> it.
+    </h1>
+
+    <p class="subtext">
+      Why the agent that ships your backlog should run in <strong>your</strong> cloud,
+      on <strong>your</strong> codebase.
+    </p>
+  </div>
+
+  <!-- Footer -->
+  <div class="slide-footer">
+    <span>The open-source autonomous delivery agent for Claude Code</span>
+    <span>shipwrightharness.com</span>
+  </div>
+
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/last-mile.html
+++ b/demo/slides/last-mile.html
@@ -29,8 +29,8 @@
       <div class="step-card"><div class="step-name">Review</div><div class="step-body">Findings fixed on a schedule</div></div>
       <div class="step-card"><div class="step-name">Merge</div><div class="step-body">Green CI, approved review</div></div>
       <div class="step-card"><div class="step-name">Deploy</div><div class="step-body">Into your own environment</div></div>
-      <div class="step-card"><div class="step-name">Canary</div><div class="step-body">Watched after release</div></div>
-      <div class="step-card featured"><div class="step-name">Auto-revert</div><div class="step-body">When something fails</div></div>
+      <div class="step-card"><div class="step-name">Canary</div><div class="step-body">Opt-in staged rollout, when your pipeline supports it</div></div>
+      <div class="step-card featured"><div class="step-name">Auto-revert</div><div class="step-body">Available when something fails</div></div>
     </div>
   </div>
   <div class="slide-footer"><span>Why adopt it · 3 / 6</span><span>shipwrightharness.com</span></div>

--- a/demo/slides/last-mile.html
+++ b/demo/slides/last-mile.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Last Mile</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; }
+  .headline { font-size: 60px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 16px; }
+  .subhead { font-size: 28px; color: var(--text-muted); margin-bottom: 52px; }
+  .pipeline-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 20px; max-width: 1600px; }
+  .step-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 16px; padding: 32px 28px; }
+  .step-card.featured { border-color: var(--brand-green); border-width: 2px; background: rgba(52,199,123,0.04); }
+  .step-name { font-size: 26px; font-weight: 700; margin-bottom: 14px; }
+  .step-body { font-size: 16px; line-height: 1.6; color: var(--text-muted); }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">The Last Mile</p>
+    <h1 class="headline">Most AI tools stop when the code is written.</h1>
+    <p class="subhead">Shipwright carries it the rest of the way.</p>
+    <div class="pipeline-grid">
+      <div class="step-card"><div class="step-name">Review</div><div class="step-body">Findings fixed on a schedule</div></div>
+      <div class="step-card"><div class="step-name">Merge</div><div class="step-body">Green CI, approved review</div></div>
+      <div class="step-card"><div class="step-name">Deploy</div><div class="step-body">Into your own environment</div></div>
+      <div class="step-card"><div class="step-name">Canary</div><div class="step-body">Watched after release</div></div>
+      <div class="step-card featured"><div class="step-name">Auto-revert</div><div class="step-body">When something fails</div></div>
+    </div>
+  </div>
+  <div class="slide-footer"><span>Why adopt it · 3 / 6</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/maintenance.html
+++ b/demo/slides/maintenance.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Standing Maintenance</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; max-width: 1200px; }
+  .headline { font-size: 60px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; }
+  .pills { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 36px; }
+  .pill { display: inline-flex; align-items: center; gap: 10px; padding: 16px 28px; border-radius: 100px; border: 1px solid var(--card-border); background: var(--card-bg); font-size: 19px; font-weight: 500; color: var(--text-muted); }
+  .pill.green { border-color: rgba(52,199,123,0.4); background: rgba(52,199,123,0.06); color: var(--brand-green); }
+  .pill-dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; }
+  .subline { font-size: 20px; color: var(--text-muted); }
+  .subline strong { color: var(--text-primary); }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Standing Maintenance</p>
+    <h1 class="headline">The upkeep no one prioritizes,<br>done continuously.</h1>
+    <div class="pills">
+      <div class="pill green"><span class="pill-dot"></span> Security patrol</div>
+      <div class="pill green"><span class="pill-dot"></span> Error patrol</div>
+      <div class="pill green"><span class="pill-dot"></span> Code-health patrol</div>
+      <div class="pill green"><span class="pill-dot"></span> Dependency patrol</div>
+      <div class="pill green"><span class="pill-dot"></span> Documentation patrol</div>
+    </div>
+    <p class="subline">Each on its own schedule. Findings become <strong>queued, reviewable work</strong>.</p>
+  </div>
+  <div class="slide-footer"><span>Why adopt it · 5 / 6</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/measured.html
+++ b/demo/slides/measured.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Measured</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; }
+  .headline { font-size: 60px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; max-width: 900px; }
+  .metrics-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; max-width: 1400px; margin-bottom: 36px; }
+  .metric-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 16px; padding: 36px 28px; }
+  .metric-icon { font-size: 28px; margin-bottom: 16px; }
+  .metric-name { font-size: 20px; font-weight: 600; color: var(--text-primary); }
+  .subline { font-size: 20px; color: var(--text-muted); }
+  .subline strong { color: var(--text-primary); }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Measured</p>
+    <h1 class="headline">AI ROI becomes a number,<br>not a feeling.</h1>
+    <div class="metrics-grid">
+      <div class="metric-card"><div class="metric-name">First-time quality rate</div></div>
+      <div class="metric-card"><div class="metric-name">Cycle time</div></div>
+      <div class="metric-card"><div class="metric-name">Review verdicts</div></div>
+      <div class="metric-card"><div class="metric-name">Estimation accuracy</div></div>
+    </div>
+    <p class="subline">Every task graded, on a dashboard <strong>you host</strong>.</p>
+  </div>
+  <div class="slide-footer"><span>Why adopt it · 4 / 6</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/ownership.html
+++ b/demo/slides/ownership.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Ownership</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; }
+  .headline { font-size: 64px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; }
+  .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; max-width: 1400px; }
+  .compare-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 16px; padding: 44px 40px; }
+  .compare-card.featured { border-color: var(--brand-green); border-width: 2px; }
+  .card-label { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-faint); margin-bottom: 16px; }
+  .card-label.green { color: var(--brand-green); }
+  .card-title { font-size: 28px; font-weight: 700; margin-bottom: 20px; }
+  .card-body { font-size: 19px; line-height: 1.6; color: var(--text-muted); }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Ownership</p>
+    <h1 class="headline">Free. Open source. Yours.</h1>
+    <div class="compare-grid">
+      <div class="compare-card">
+        <div class="card-label">Closed, Hosted Agents — Rented</div>
+        <div class="card-title">Per-seat pricing</div>
+        <div class="card-body">Runs on someone else's infrastructure. Your code leaves your control.</div>
+      </div>
+      <div class="compare-card featured">
+        <div class="card-label green">Shipwright Harness — Owned</div>
+        <div class="card-title">MIT throughout. No tiers, no seats.</div>
+        <div class="card-body">Runs entirely in your cloud, on any stack — Node, Go, Rust, Python, Ruby.</div>
+      </div>
+    </div>
+  </div>
+  <div class="slide-footer"><span>Why adopt it · 6 / 6</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/pipeline.html
+++ b/demo/slides/pipeline.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — The Pipeline</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 140px; left: var(--margin); right: var(--margin); bottom: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .headline {
+    font-size: 60px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    margin-bottom: 56px;
+  }
+  .headline em { color: var(--brand-green); font-style: normal; }
+
+  .pipeline-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 20px;
+    max-width: 1600px;
+  }
+
+  .step-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 32px 28px;
+  }
+  .step-card.featured {
+    border-color: var(--brand-green);
+    border-width: 2px;
+    background: rgba(52, 199, 123, 0.04);
+  }
+
+  .step-num {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--text-faint);
+    letter-spacing: 0.1em;
+    margin-bottom: 16px;
+  }
+  .step-num.green { color: var(--brand-green); }
+
+  .step-name {
+    font-size: 28px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    letter-spacing: -0.01em;
+  }
+
+  .step-body {
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--text-muted);
+  }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+
+  <div class="brand-lockup">
+    <div class="brand-mark"></div>
+    <span class="brand-wordmark">Shipwright Harness</span>
+  </div>
+  <div class="brand-rule"></div>
+
+  <div class="content">
+    <p class="eyebrow">Every Change, The Same Way</p>
+    <h1 class="headline">Spec → Plan → Build → Review → <em>Ship</em></h1>
+
+    <div class="pipeline-grid">
+      <div class="step-card">
+        <div class="step-num">01</div>
+        <div class="step-name">Spec</div>
+        <div class="step-body">Product intent captured as a reviewable spec</div>
+      </div>
+      <div class="step-card">
+        <div class="step-num">02</div>
+        <div class="step-name">Plan</div>
+        <div class="step-body">Estimated, dependency-ordered tasks</div>
+      </div>
+      <div class="step-card">
+        <div class="step-num">03</div>
+        <div class="step-name">Build</div>
+        <div class="step-body">Tests first; every acceptance criterion independently verified</div>
+      </div>
+      <div class="step-card">
+        <div class="step-num">04</div>
+        <div class="step-name">Review</div>
+        <div class="step-body">Policy-controlled, with confidence thresholds</div>
+      </div>
+      <div class="step-card featured">
+        <div class="step-num green">05</div>
+        <div class="step-name">Ship</div>
+        <div class="step-body">Merge, deploy, canary — automatic revert on failure</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="slide-footer">
+    <span>The pipeline</span>
+    <span>shipwrightharness.com</span>
+  </div>
+
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/pipeline.html
+++ b/demo/slides/pipeline.html
@@ -103,7 +103,7 @@
       <div class="step-card featured">
         <div class="step-num green">05</div>
         <div class="step-name">Ship</div>
-        <div class="step-body">Merge, deploy, canary — automatic revert on failure</div>
+        <div class="step-body">Green CI, approved review — merged and deployed via Helm</div>
       </div>
     </div>
   </div>

--- a/demo/slides/problem-babysitting.html
+++ b/demo/slides/problem-babysitting.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — The Problem 2</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 140px; left: var(--margin); right: var(--margin); bottom: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .headline {
+    font-size: 60px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    margin-bottom: 52px;
+  }
+
+  .compare-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    max-width: 1400px;
+  }
+
+  .compare-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 40px 40px;
+  }
+  .compare-card.featured {
+    border-color: var(--brand-green);
+    border-width: 2px;
+  }
+
+  .card-label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin-bottom: 16px;
+  }
+  .card-label.green { color: var(--brand-green); }
+
+  .card-title {
+    font-size: 26px;
+    font-weight: 700;
+    margin-bottom: 20px;
+    line-height: 1.2;
+  }
+
+  .card-body {
+    font-size: 19px;
+    line-height: 1.6;
+    color: var(--text-muted);
+  }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+
+  <div class="brand-lockup">
+    <div class="brand-mark"></div>
+    <span class="brand-wordmark">Shipwright Harness</span>
+  </div>
+  <div class="brand-rule"></div>
+
+  <div class="content">
+    <p class="eyebrow">The Problem</p>
+    <h1 class="headline">Your most expensive people are babysitting<br>code generation.</h1>
+
+    <div class="compare-grid">
+      <div class="compare-card">
+        <div class="card-label">Today · AI-Assisted</div>
+        <div class="card-title">An engineer inside the loop of every task</div>
+        <div class="card-body">Prompting, watching, steering — one task at a time. Output is capped by one person's attention.</div>
+      </div>
+      <div class="compare-card featured">
+        <div class="card-label green">With Shipwright · Autonomous</div>
+        <div class="card-title">Engineers define, queue, and judge</div>
+        <div class="card-body">The coding leaves their day. It happens in the cloud, around the clock, through quality gates the team controls.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="slide-footer">
+    <span>The problem · 2 / 3</span>
+    <span>shipwrightharness.com</span>
+  </div>
+
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/problem-stats.html
+++ b/demo/slides/problem-stats.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — The Problem</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 140px; left: var(--margin); right: var(--margin); bottom: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .headline {
+    font-size: 60px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    margin-bottom: 56px;
+    max-width: 900px;
+  }
+
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
+    max-width: 1600px;
+  }
+
+  .stat-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 32px 28px;
+  }
+  .stat-value {
+    font-family: var(--font-mono);
+    font-size: 52px;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: 12px;
+  }
+  .stat-value.green { color: var(--stat-green); }
+  .stat-value.red   { color: var(--stat-red); }
+  .stat-label {
+    font-size: 17px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+
+  .source-line {
+    margin-top: 28px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-faint);
+    letter-spacing: 0.04em;
+  }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+
+  <div class="brand-lockup">
+    <div class="brand-mark"></div>
+    <span class="brand-wordmark">Shipwright Harness</span>
+  </div>
+  <div class="brand-rule"></div>
+
+  <div class="content">
+    <p class="eyebrow">The Problem</p>
+    <h1 class="headline">AI made code generation fast.<br>Nothing after it got faster.</h1>
+
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-value green">+98%</div>
+        <div class="stat-label">code output in heavy-AI teams</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value green">+91–441%</div>
+        <div class="stat-label">time spent reviewing it</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value red">+54%</div>
+        <div class="stat-label">bugs per developer</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value red">+243%</div>
+        <div class="stat-label">incidents per change</div>
+      </div>
+    </div>
+
+    <p class="source-line">
+      Sources: Faros AI (10,000+ developers, 400+ orgs) · JetBrains adoption surveys · MIT / McKinsey pilot studies
+    </p>
+  </div>
+
+  <div class="slide-footer">
+    <span>The problem · 1 / 3</span>
+    <span>shipwrightharness.com</span>
+  </div>
+
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/proof.html
+++ b/demo/slides/proof.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Proof</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content { position: absolute; top: 140px; left: var(--margin); right: var(--margin); bottom: 120px; display: flex; flex-direction: column; justify-content: center; }
+  .headline { font-size: 60px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; }
+  .stats-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; max-width: 1500px; margin-bottom: 32px; }
+  .stat-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 16px; padding: 36px 28px; }
+  .stat-value { font-family: var(--font-mono); font-size: 52px; font-weight: 700; color: var(--brand-green); line-height: 1; margin-bottom: 12px; }
+  .stat-label { font-size: 17px; color: var(--text-muted); line-height: 1.4; }
+  .fine-print { font-family: var(--font-mono); font-size: 12px; color: var(--text-faint); }
+  .fine-print a { color: var(--brand-teal); }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">Proof</p>
+    <h1 class="headline">Shipwright builds Shipwright.</h1>
+    <div class="stats-grid">
+      <!-- UPDATE THESE NUMBERS before re-recording. Source: proof.shipwrightharness.com/public/dashboard (90-day window) -->
+      <div class="stat-card"><div class="stat-value">1,820+</div><div class="stat-label">changes merged — mostly shipped by the agent itself</div></div>
+      <div class="stat-card"><div class="stat-value">232</div><div class="stat-label">tasks completed in the last 90 days</div></div>
+      <div class="stat-card"><div class="stat-value">91%</div><div class="stat-label">passed all automated checks on the first try</div></div>
+      <div class="stat-card"><div class="stat-value">94%</div><div class="stat-label">approved on first review</div></div>
+    </div>
+    <p class="fine-print">Built in ~10 weeks, part-time, by a two-person team · Live &amp; public: proof.shipwrightharness.com · 90-day window</p>
+  </div>
+  <div class="slide-footer"><span>Proof · measured in the open</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/quality-bar.html
+++ b/demo/slides/quality-bar.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — Quality Bar</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 140px; left: var(--margin); right: var(--margin); bottom: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 1100px;
+  }
+  .headline { font-size: 64px; font-weight: 700; line-height: 1.1; letter-spacing: -0.03em; margin-bottom: 52px; }
+  .bullet-list { display: flex; flex-direction: column; gap: 28px; }
+  .bullet { display: flex; align-items: flex-start; gap: 24px; }
+  .bullet-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--brand-green); flex-shrink: 0; margin-top: 10px; }
+  .bullet-text { font-size: 22px; line-height: 1.5; color: var(--text-muted); }
+  .bullet-text strong { color: var(--text-primary); font-weight: 600; }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+  <div class="brand-lockup"><div class="brand-mark"></div><span class="brand-wordmark">Shipwright Harness</span></div>
+  <div class="brand-rule"></div>
+  <div class="content">
+    <p class="eyebrow">For The Architect</p>
+    <h1 class="headline">An enforced quality bar.</h1>
+    <div class="bullet-list">
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text"><strong>Tests before code</strong> — written first, landing in the same change.</div></div>
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text"><strong>Independent verification</strong> — a second agent grades every acceptance criterion against the diff.</div></div>
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text"><strong>Blocked if unmet</strong> — a pull request never claims to be done when it isn't.</div></div>
+      <div class="bullet"><div class="bullet-dot"></div><div class="bullet-text"><strong>Enforced by the system</strong>, not suggested by a prompt.</div></div>
+    </div>
+  </div>
+  <div class="slide-footer"><span>Why adopt it · 1 / 6</span><span>shipwrightharness.com</span></div>
+  <div class="slide-ready"></div>
+</body>
+</html>

--- a/demo/slides/what-it-is.html
+++ b/demo/slides/what-it-is.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1920">
+<title>Shipwright — What It Is</title>
+<link rel="stylesheet" href="base-styles.css">
+<style>
+  .content {
+    position: absolute;
+    top: 140px; left: var(--margin); right: var(--margin); bottom: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 1300px;
+  }
+
+  .headline {
+    font-size: 68px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    margin-bottom: 32px;
+  }
+
+  .subtext {
+    font-size: 26px;
+    line-height: 1.6;
+    color: var(--text-muted);
+    max-width: 920px;
+    margin-bottom: 52px;
+  }
+  .subtext strong { color: var(--text-primary); }
+
+  .pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 24px;
+    border-radius: 100px;
+    border: 1px solid var(--card-border);
+    background: var(--card-bg);
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--text-muted);
+    letter-spacing: 0.01em;
+  }
+  .pill.green {
+    border-color: rgba(52, 199, 123, 0.4);
+    background: rgba(52, 199, 123, 0.06);
+    color: var(--brand-green);
+  }
+  .pill.teal {
+    border-color: rgba(45, 212, 191, 0.3);
+    background: rgba(45, 212, 191, 0.05);
+    color: var(--brand-teal);
+  }
+
+  .pill-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+</style>
+</head>
+<body>
+  <div class="glow-orb glow-tr"></div>
+  <div class="glow-orb glow-bl"></div>
+
+  <div class="brand-lockup">
+    <div class="brand-mark"></div>
+    <span class="brand-wordmark">Shipwright Harness</span>
+  </div>
+  <div class="brand-rule"></div>
+
+  <div class="content">
+    <p class="eyebrow">What It Is</p>
+    <h1 class="headline">A delivery system,<br>not another assistant.</h1>
+
+    <p class="subtext">
+      A cloud agent you deploy into <strong>your own environment</strong>. It picks up
+      queued work, ships on a schedule, and talks to the team where they already are.
+    </p>
+
+    <div class="pills">
+      <div class="pill green"><span class="pill-dot"></span> Deploy to your cloud</div>
+      <div class="pill teal"><span class="pill-dot"></span> Talks in Slack</div>
+      <div class="pill teal"><span class="pill-dot"></span> Ships on cron</div>
+      <div class="pill green"><span class="pill-dot"></span> One governed pipeline</div>
+    </div>
+  </div>
+
+  <div class="slide-footer">
+    <span>What it is</span>
+    <span>shipwrightharness.com</span>
+  </div>
+
+  <div class="slide-ready"></div>
+</body>
+</html>


### PR DESCRIPTION
## What

Full re-record package for the Shipwright sizzle reel — generic (no Ridgeline), with the new **"Bold Move"** ad campaign hook as the opener.

## Changes

- `demo/scenes.yaml` — 15-slide deck, "Bold Move" hook leads, all Ridgeline refs removed
- `demo/slides/` — all 15 HTML slide templates (matching the existing visual style)

## To record locally

```bash
# 1. Start slide server (in a separate pane)
task demo:serve

# 2. Record via Claude Code
/sizzle:record --final

# 3. Apply brand overlay
bash demo/brand-overlay.sh demo/output/shipwright-hero.mp4
```

Then commit `demo/output/shipwright-hero.mp4` + the `.script.md` artifact.

## ⚠️ Before recording

Update the stat numbers in `demo/slides/proof.html` from the live dashboard:
https://proof.shipwrightharness.com/public/dashboard (90-day window)

## Ad campaign note

The 6-second opener ("You're still paying your developers to write code? Bold move. Good luck.") is also a standalone social cut. The `9:16` format in `scenes.yaml` produces the Shorts/LinkedIn portrait version automatically.