### PR TITLE
feat: replace deploy/merge CI gate with full statusCheckRollup check

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -40,6 +40,12 @@ function extractStep3aSection(md: string): string {
   return match?.[0] ?? "";
 }
 
+function extractStep3bSection(md: string): string {
+  const match = md.match(/### 3b\. Verify[\s\S]*?(?=\n#{2,3} |\n---)/);
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
 describe("deploy.md — own-PRs-only check (AC1 & AC2)", () => {
   it("contains own GH login check (AGENT_LOGIN or 'own GH login')", () => {
     const hasAgentLogin = content.includes("AGENT_LOGIN");
@@ -963,5 +969,26 @@ describe("deploy.md — self-review approval fallback (RHA-1.1)", () => {
     expect(occurrences).toBe(1);
     const step4bSection = extractStep4bSection(content);
     expect(step4bSection).not.toContain("--admin");
+  });
+});
+
+describe("deploy.md — Step 3b: verify all checks are green (CGC-1.2)", () => {
+  it("verifies all checks are green on the PR head commit via statusCheckRollup", () => {
+    const section = extractStep3bSection(content);
+    expect(section).toContain("headRefOid");
+    expect(section).toContain("statusCheckRollup");
+    expect(section).toContain("CheckRun");
+    expect(section).toContain("StatusContext");
+  });
+
+  it("does not use the legacy actions/runs CI-name-filter check", () => {
+    const section = extractStep3bSection(content);
+    expect(section).not.toContain('ascii_downcase == "ci"');
+    expect(section).not.toContain("actions/runs");
+  });
+
+  it("fails with a clear message when not all checks are green", () => {
+    const section = extractStep3bSection(content);
+    expect(section).toContain("not all checks are green");
   });
 });

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -163,26 +163,40 @@ If no matching review is found (or `allow_self_review` is false), print and stop
     2. Run /shipwright:review on the PR — once an APPROVE review is posted, re-run /shipwright:deploy.
 ```
 
-### 3b. Verify CI is Green
+### 3b. Verify All Checks Are Green
 
-Fetch the most recent CI runs on the PR's head commit:
+Fetch the PR's head commit and its full check-status rollup in a single call:
 
 ```bash
-HEAD_SHA=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid')
-REPO="{org}/{repo}"
-gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
-  --jq '[.workflow_runs[] | select(.name | ascii_downcase == "ci") | {status, conclusion}]'
+PR_JSON=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid,statusCheckRollup)
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+ALL_GREEN=$(echo "$PR_JSON" | jq -r '
+  (.statusCheckRollup // []) as $r
+  | ($r | length > 0) and ($r | all(
+      if .__typename == "CheckRun" then
+        (.status == "COMPLETED") and ((.conclusion // "") as $c | ["SUCCESS","NEUTRAL","SKIPPED"] | index($c) != null)
+      elif .__typename == "StatusContext" then
+        .state == "SUCCESS"
+      else
+        false
+      end
+    ))
+')
 ```
 
-Matched case-insensitively — a repo's CI workflow `name:` field may be `CI` or `ci` (both are
-common conventions; e.g. `app-vitals/squadron`'s `.github/workflows/ci.yml` uses `name: ci`), and
-an exact-case match here would silently and permanently exclude that repo's PRs from ever
-passing this check.
+`statusCheckRollup` covers every check on the PR's head commit — GitHub Actions check runs
+(`__typename == "CheckRun"`) and legacy commit statuses (`__typename == "StatusContext"`) alike —
+not just a single named CI workflow. This catches required checks a single-workflow filter would
+miss entirely (e.g. `pr-title-lint`, or any other repo-specific required check).
 
-If no CI run has `conclusion == "success"` (or no CI run exists at all), print and stop:
+A `CheckRun` is green when `status == "COMPLETED"` and `conclusion` is one of `SUCCESS`,
+`NEUTRAL`, or `SKIPPED`. A `StatusContext` is green when `state == "SUCCESS"`. All checks must
+be green, and there must be at least one check — an empty rollup is not green.
+
+If `ALL_GREEN` is not `"true"` (or the rollup is empty), print and stop:
 ```
-✗ Pre-flight failed: CI is not green on PR #{pr} head ({HEAD_SHA[0..7]}).
-  Resolve CI failures before deploying.
+✗ Pre-flight failed: not all checks are green on PR #{pr} head ({HEAD_SHA[0..7]}).
+  Resolve check failures before deploying.
 ```
 
 ### 3c. Pre-flight Summary
@@ -191,7 +205,7 @@ If both checks pass:
 ```
 ✓ Pre-flight passed
   Approval:    {if approval_source == "github": "GitHub — approved by: {approvers}" | if approval_source == "self_review": "Self-review — APPROVE found in GitHub review body"}
-  CI:          green ({HEAD_SHA[0..7]})
+  Checks:      all green ({HEAD_SHA[0..7]})
 ```
 
 ---

--- a/plugins/shipwright/commands/merge.content.test.ts
+++ b/plugins/shipwright/commands/merge.content.test.ts
@@ -139,11 +139,12 @@ describe("merge.md — Step 2: Pre-flight Checks", () => {
     expect(section).toContain('sub("^\\\\*+";"")');
   });
 
-  it("verifies CI is green on the PR head commit", () => {
+  it("verifies all checks are green on the PR head commit via statusCheckRollup", () => {
     const section = extractStep2Section(content);
     expect(section).toContain("headRefOid");
-    expect(section).toContain('ascii_downcase == "ci"');
-    expect(section).toContain('conclusion == "success"');
+    expect(section).toContain("statusCheckRollup");
+    expect(section).toContain("CheckRun");
+    expect(section).toContain("StatusContext");
   });
 
   it("has a pre-flight summary subsection", () => {
@@ -157,9 +158,9 @@ describe("merge.md — Step 2: Pre-flight Checks", () => {
     expect(section).toContain("not approved");
   });
 
-  it("fails with a clear message when CI is not green", () => {
+  it("fails with a clear message when not all checks are green", () => {
     const section = extractStep2Section(content);
-    expect(section).toContain("CI is not green");
+    expect(section).toContain("not all checks are green");
   });
 });
 

--- a/plugins/shipwright/commands/merge.md
+++ b/plugins/shipwright/commands/merge.md
@@ -156,26 +156,40 @@ If no matching review is found (or `allow_self_review` is false), print and stop
     2. Run /shipwright:review on the PR — once an APPROVE review is posted, re-run /shipwright:merge.
 ```
 
-### 2b. Verify CI is Green
+### 2b. Verify All Checks Are Green
 
-Fetch the most recent CI runs on the PR's head commit:
+Fetch the PR's head commit and its full check-status rollup in a single call:
 
 ```bash
-HEAD_SHA=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid --jq '.headRefOid')
-REPO="{org}/{repo}"
-gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
-  --jq '[.workflow_runs[] | select(.name | ascii_downcase == "ci") | {status, conclusion}]'
+PR_JSON=$(gh pr view {pr} --repo {org}/{repo} --json headRefOid,statusCheckRollup)
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+ALL_GREEN=$(echo "$PR_JSON" | jq -r '
+  (.statusCheckRollup // []) as $r
+  | ($r | length > 0) and ($r | all(
+      if .__typename == "CheckRun" then
+        (.status == "COMPLETED") and ((.conclusion // "") as $c | ["SUCCESS","NEUTRAL","SKIPPED"] | index($c) != null)
+      elif .__typename == "StatusContext" then
+        .state == "SUCCESS"
+      else
+        false
+      end
+    ))
+')
 ```
 
-Matched case-insensitively — a repo's CI workflow `name:` field may be `CI` or `ci` (both are
-common conventions; e.g. `app-vitals/squadron`'s `.github/workflows/ci.yml` uses `name: ci`), and
-an exact-case match here would silently and permanently exclude that repo's PRs from ever
-passing this check.
+`statusCheckRollup` covers every check on the PR's head commit — GitHub Actions check runs
+(`__typename == "CheckRun"`) and legacy commit statuses (`__typename == "StatusContext"`) alike —
+not just a single named CI workflow. This catches required checks a single-workflow filter would
+miss entirely (e.g. `pr-title-lint`, or any other repo-specific required check).
 
-If no CI run has `conclusion == "success"` (or no CI run exists at all), print and stop:
+A `CheckRun` is green when `status == "COMPLETED"` and `conclusion` is one of `SUCCESS`,
+`NEUTRAL`, or `SKIPPED`. A `StatusContext` is green when `state == "SUCCESS"`. All checks must
+be green, and there must be at least one check — an empty rollup is not green.
+
+If `ALL_GREEN` is not `"true"` (or the rollup is empty), print and stop:
 ```
-✗ Pre-flight failed: CI is not green on PR #{pr} head ({HEAD_SHA[0..7]}).
-  Resolve CI failures before merging.
+✗ Pre-flight failed: not all checks are green on PR #{pr} head ({HEAD_SHA[0..7]}).
+  Resolve check failures before merging.
 ```
 
 ### 2c. Pre-flight Summary
@@ -184,7 +198,7 @@ If both checks pass:
 ```
 ✓ Pre-flight passed
   Approval:    {if approval_source == "github": "GitHub — approved by: {approvers}" | if approval_source == "self_review": "Self-review — APPROVE found in GitHub review body"}
-  CI:          green ({HEAD_SHA[0..7]})
+  Checks:      all green ({HEAD_SHA[0..7]})
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Replace `deploy.md` Step 3b and `merge.md` Step 2b's `gh api actions/runs?head_sha=...` CI-gate (filtered to a workflow literally named `ci`) with a single `gh pr view --json headRefOid,statusCheckRollup` call, folding HEAD_SHA and the green/not-green verdict into one request.
- The new jq check requires a non-empty rollup where every `CheckRun` entry has `status == "COMPLETED"` and `conclusion` in `{SUCCESS, NEUTRAL, SKIPPED}`, and every legacy `StatusContext` entry has `state == "SUCCESS"` — so required checks other than the named `CI` workflow (e.g. `pr-title-lint`) are no longer silently ignored.
- Updated pass/fail print messages to describe "all checks" rather than a single named CI workflow, keeping the existing print format/structure unchanged.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Both deploy.md and merge.md compute HEAD_SHA and the green/not-green verdict from a single `gh pr view --json headRefOid,statusCheckRollup` call — no separate `gh api actions/runs` call remains in either file for this purpose | MET |
| 2 | Pass/fail print messages updated for "all checks" instead of a named CI workflow (format otherwise unchanged) | MET |
| 3 | merge.content.test.ts's `ascii_downcase == "ci"` assertion updated to assert the new rollup-based check | MET |
| 4 | deploy.content.test.ts re-checked for the same assertion pattern and updated (none existed previously; new coverage added) | MET |
| 5 | Content-test layer only — no new runtime test | MET |

## Test Plan
- `bun test plugins/shipwright/commands/merge.content.test.ts plugins/shipwright/commands/deploy.content.test.ts` — 145 pass, 0 fail
- Standalone `jq` verification of the `ALL_GREEN` expression against green/empty/in-progress/failure/legacy-pending fixtures
- Confirmed unrelated post-merge CI-watch `gh api actions/runs` calls further down in `deploy.md` (Promote-to-Prod polling) were left untouched
- `task typecheck` passes
- `bunx biome lint` clean on changed files
- Pre-existing failures in `metrics/src/lib/errors.unit.test.ts` and `task-store/src/routes/prs.openapi.smoke.test.ts` reproduce identically on `main` (verified) — unrelated to this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
