### PR TITLE
fix: check Step 10a PATCH status in dev-task.md

### DIFF
--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -132,6 +132,57 @@ describe("dev-task.md Step 2 — atomic claim", () => {
   });
 });
 
+describe("dev-task.md Step 10a — PATCH status check", () => {
+  const getStep10aSection = () => {
+    const step10aIdx = content.indexOf("### 10a. Update Queue");
+    expect(step10aIdx).toBeGreaterThan(-1);
+    const step10dIdx = content.indexOf("### 10d. Print Handoff");
+    expect(step10dIdx).toBeGreaterThan(step10aIdx);
+    return content.slice(step10aIdx, step10dIdx);
+  };
+
+  it("captures the HTTP status code of the PATCH call (mirrors Step 2's claim pattern)", () => {
+    const section = getStep10aSection();
+    expect(section).toContain("%{http_code}");
+    expect(section).toMatch(/PATCH_CODE=\$\(curl/);
+  });
+
+  it("writes the PATCH response body to a temp file instead of piping straight to jq", () => {
+    const section = getStep10aSection();
+    expect(section).toMatch(/-o \/tmp\/task_patch_10a\.json/);
+  });
+
+  it("still PATCHes the same status/pr/simplify/coverage/model fields unchanged", () => {
+    const section = getStep10aSection();
+    expect(section).toContain('\\"status\\": \\"pr_open\\"');
+    expect(section).toContain('\\"pr\\": {pr_number}');
+    expect(section).toContain('\\"prCreatedAt\\": \\"$PR_CREATED_AT\\"');
+    expect(section).toContain('\\"ciFixAttempts\\": {ci_attempt}');
+    expect(section).toContain('\\"simplifyTotal\\": {simplify_total}');
+    expect(section).toContain('\\"simplifyDry\\": {simplify_dry}');
+    expect(section).toContain('\\"simplifyDeadCode\\": {simplify_dead_code}');
+    expect(section).toContain('\\"simplifyNaming\\": {simplify_naming}');
+    expect(section).toContain('\\"simplifyComplexity\\": {simplify_complexity}');
+    expect(section).toContain('\\"simplifyConsistency\\": {simplify_consistency}');
+    expect(section).toContain('\\"coverageDelta\\": {coverage_delta}');
+    expect(section).toContain('\\"model\\": \\"{EFFECTIVE_MODEL}\\"');
+  });
+
+  it("branches on a non-2xx status with a clear failure message and halts before the DONE handoff", () => {
+    const section = getStep10aSection();
+    expect(section).toMatch(/non-2xx/i);
+    expect(section).toMatch(/Step 10a PATCH failed/i);
+    expect(section).toMatch(/task-store not updated/i);
+    expect(section).toMatch(/handoff aborted/i);
+    expect(section).toMatch(/do not proceed to Step 10d/i);
+  });
+
+  it("prints the successful response on a 2xx status", () => {
+    const section = getStep10aSection();
+    expect(section).toMatch(/jq \. \/tmp\/task_patch_10a\.json/);
+  });
+});
+
 describe("Step 4 — stale bundle branch detection", () => {
   it("checks --state merged before entering the bundled-task path", () => {
     // The merged-PR check must appear BEFORE the bundled worktree add command

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -1064,13 +1064,26 @@ curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
 
 ### 10a. Update Queue
 
+Capture the HTTP status of the PATCH explicitly — same shape as Step 2's `CLAIM_CODE` —
+instead of piping straight to `jq` and assuming success:
+
 ```bash
 PR_CREATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+PATCH_CODE=$(curl -s -o /tmp/task_patch_10a.json -w '%{http_code}' -X PATCH \
+  -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   -H "Content-Type: application/json" \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
-  -d "{\"status\": \"pr_open\", \"pr\": {pr_number}, \"prCreatedAt\": \"$PR_CREATED_AT\", \"ciFixAttempts\": {ci_attempt}, \"simplifyTotal\": {simplify_total}, \"simplifyDry\": {simplify_dry}, \"simplifyDeadCode\": {simplify_dead_code}, \"simplifyNaming\": {simplify_naming}, \"simplifyComplexity\": {simplify_complexity}, \"simplifyConsistency\": {simplify_consistency}, \"coverageDelta\": {coverage_delta}, \"model\": \"{EFFECTIVE_MODEL}\"}" | jq .
+  -d "{\"status\": \"pr_open\", \"pr\": {pr_number}, \"prCreatedAt\": \"$PR_CREATED_AT\", \"ciFixAttempts\": {ci_attempt}, \"simplifyTotal\": {simplify_total}, \"simplifyDry\": {simplify_dry}, \"simplifyDeadCode\": {simplify_dead_code}, \"simplifyNaming\": {simplify_naming}, \"simplifyComplexity\": {simplify_complexity}, \"simplifyConsistency\": {simplify_consistency}, \"coverageDelta\": {coverage_delta}, \"model\": \"{EFFECTIVE_MODEL}\"}")
 ```
+
+- **2xx**: updated successfully. Print the updated task: `jq . /tmp/task_patch_10a.json`.
+  Continue to Step 10d.
+- **non-2xx**: the handoff did not succeed — the task store still thinks this task is
+  unclaimed/`in_progress` even though the PR is open. Print:
+  ```
+  ⚠ Step 10a PATCH failed with status $PATCH_CODE — task-store not updated, handoff aborted.
+  ```
+  Do not proceed to Step 10d's DONE handoff — stop here instead of reporting success.
 
 ### 10d. Print Handoff
 


### PR DESCRIPTION
## Summary
- Step 10a's PR-open PATCH now captures the HTTP status explicitly via `PATCH_CODE=$(curl -s -o /tmp/task_patch_10a.json -w '%{http_code}' ...)`, mirroring Step 2's `CLAIM_CODE` capture-and-branch pattern instead of piping straight to `jq` and assuming success.
- Added explicit branching: 2xx prints the updated task and continues to Step 10d; non-2xx prints a clear failure (`⚠ Step 10a PATCH failed with status $PATCH_CODE — task-store not updated, handoff aborted.`) and halts before the DONE handoff instead of silently reporting success.
- All existing PATCH body fields (status, pr, prCreatedAt, ciFixAttempts, simplify*, coverageDelta, model) are preserved unchanged.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 10a captures HTTP status explicitly (same shape as Step 2's CLAIM_CODE) | MET | `PATCH_CODE=$(curl -s -o /tmp/task_patch_10a.json -w '%{http_code}' ...)` mirrors Step 2's `CLAIM_CODE` pattern exactly |
| 2 | Non-2xx response halts with a clear error instead of silently continuing to the DONE handoff | MET | New branching prints a clear warning and instructs to not proceed to Step 10d's DONE handoff |
| 3 | Content test asserts Step 10a captures and branches on the HTTP status code | MET | New `describe("dev-task.md Step 10a — PATCH status check")` block with 5 tests |
| 4 | No code/unit tests apply — markdown-only change, verified via content test per repo convention | MET | Diff touches only `dev-task.md` and `dev-task.content.test.ts` |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/commands/dev-task.content.test.ts` — 69/69 pass
- `task lint` — clean
- `task typecheck` — clean across all workspaces
- `task ci`'s `test:coverage` step has 30 pre-existing unrelated failures (metrics env tests, task-store `validateRepo` smoke test) confirmed present on `main` as well — not introduced by this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
