### PR TITLE
feat: add concurrency group to build-*.yml workflows to prevent tag races

### DIFF
--- a/.github/workflows/build-admin.yml
+++ b/.github/workflows/build-admin.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 # Least privilege at the workflow level; the build-and-push job widens to
 # packages:write. Neither job needs contents:write — the "Tag release" step
 # creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 # Least privilege at the workflow level; the build-and-push job widens to
 # packages:write. Neither job needs contents:write — the "Tag release" step
 # creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the

--- a/.github/workflows/build-chat.yml
+++ b/.github/workflows/build-chat.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 # Least privilege at the workflow level; the build-and-push job widens to
 # packages:write. Neither job needs contents:write — the "Tag release" step
 # creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the

--- a/.github/workflows/build-mcp-server.yml
+++ b/.github/workflows/build-mcp-server.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 # Least privilege at the workflow level; the build-and-push job widens to
 # packages:write. Neither job needs contents:write — the "Tag release" step
 # creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 # Least privilege at the workflow level; the build-and-push job widens to
 # packages:write. Neither job needs contents:write — the "Tag release" step
 # creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the

--- a/.github/workflows/build-task-store.yml
+++ b/.github/workflows/build-task-store.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 # Least privilege at the workflow level; the build-and-push job widens to
 # packages:write. Neither job needs contents:write — the "Tag release" step
 # creates a git tag via the GitHub API using secrets.DISPATCH_TOKEN, not the


### PR DESCRIPTION
## Summary
- Add a workflow-level `concurrency` block (`group: ${{ github.workflow }}`, `cancel-in-progress: false`) to all 6 `build-*.yml` workflows (agent, admin, chat, mcp-server, task-store, metrics)
- Prevents overlapping `workflow_run`-triggered runs of the same build workflow from racing on the same mutable GHCR tag — previously, two near-simultaneous merges could each independently compute the same "next tag" and push, with whichever docker push finished last silently winning regardless of commit correctness (confirmed in production on 2026-08-31: an older commit's build overwrote a correct fix's image 12 seconds after it had already pushed)
- Purely additive config — no changes to filter/build/push job logic

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Each of the 6 build-*.yml files has a top-level `concurrency:` block with `group: ${{ github.workflow }}` and `cancel-in-progress: false`, placed after `on:` and before `permissions:` | MET | All 6 files show identical 4-line insertion in correct position |
| 2 | YAML remains valid, workflows still trigger on workflow_run | MET | No other lines touched; YAML syntax validated locally |
| 3 | No behavior change to filter/build/push job logic — additive config only | MET | `git diff --stat` shows only insertions (24 insertions, 0 deletions) across exactly the 6 target files |
| 4 | No automated test added/changed | MET | No test files in diff; correct per task's explicit no-test decision (no workflow-lint tooling exists in this repo, and GitHub validates YAML syntax at push time) |

## Test Plan
- [x] YAML syntax validated locally (Python yaml parser) for all 6 edited files
- [x] `git diff main...HEAD` confirmed only the 6 target files changed, additive-only
- [x] `task ci` run — pre-existing failures unrelated to this change (30 failing tests present identically on `main`, confirmed via direct comparison; none touch workflow YAML)
- [ ] Post-merge manual verification: confirm in the Actions tab that a subsequent `build-agent.yml` run shows queued (not concurrent) behavior when two main-branch merges land close together

Generated with [Claude Code](https://claude.com/claude-code)
