### PR TITLE
fix: migrate patch.md's task lookups off stored PR.taskId

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -830,12 +830,34 @@ describe("patch.md — skip CI-fix dispatch when an unresolved HITL escalation a
     expect(section).toContain("PR_BLOCKED");
   });
 
-  it("also checks the linked task's status field when taskId is present", () => {
+  it("queries GET /tasks?repo=&pr= directly instead of reading PR_RECORD.taskId", () => {
     const section = getStep6b6Section();
-    expect(section).toContain("taskId");
-    expect(section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$');
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}");
+    // No jq extraction of .taskId off the PR record anymore.
+    expect(section).not.toMatch(/jq -r '\.taskId/);
+    expect(section).not.toContain('echo "$PR_RECORD" | jq -r \'.taskId');
+  });
+
+  it("treats the PR as HITL-escalated if ANY matched task has hitl===true OR status==='blocked' (OR across all matches, mirrors PTL-1.1's check-helpers.ts semantics)", () => {
+    const section = getStep6b6Section();
     expect(section).toContain("TASK_BLOCKED");
-    expect(section).toContain('.status');
+    expect(section).toMatch(/hitl.{0,20}(===|==)\s*true/i);
+    expect(section).toMatch(/status.{0,20}(===|==)\s*['"]blocked['"]/i);
+    expect(section.toLowerCase()).toContain("any");
+    expect(section).toContain("PTL-1.1");
+    expect(section).toContain("check-helpers.ts");
+  });
+
+  it("zero-match fallback at Step 6b.6 is unchanged: only PR_BLOCKED (from the PR record) matters, no task-based escalation signal", () => {
+    const section = getStep6b6Section();
+    expect(section).toMatch(/no (matching )?tasks?.{0,60}(found|match)/i);
+    expect(section.toLowerCase()).toContain("no task-based escalation signal");
+  });
+
+  it("Step 6b.6 exposes a single PR_TASK_ID (first matched task, or empty if none) for Step 6d's downstream BLOCKED-escalation reuse", () => {
+    const section = getStep6b6Section();
+    expect(section).toContain("PR_TASK_ID");
+    expect(section.toLowerCase()).toMatch(/first match|first task/i);
   });
 
   it("true branch releases the claim, does not dispatch the fix subagent, and moves to the next PR in List D", () => {
@@ -964,11 +986,35 @@ describe("patch.md — shared patch model tier resolution (MTR-2.1)", () => {
     expect(step2_5Idx).toBeGreaterThan(step2_1Idx);
   });
 
-  it("Step 2.1 resolves PR_TASK_ID via GET /prs?repo=...&prNumber=... using the .prs[0].taskId jq path", () => {
+  it("Step 2.1 resolves matched tasks via GET /tasks?repo=&pr= directly, not PullRequest.taskId", () => {
+    const section = getStep2_1Section();
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}");
+    expect(section).not.toContain("$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}");
+    expect(section).not.toContain(".prs[0].taskId");
+  });
+
+  it("Step 2.1 escalates the HIGHEST model tier among ALL matched tasks (mirrors PTL-1.2's review.md rule)", () => {
+    const section = getStep2_1Section();
+    expect(section.toLowerCase()).toContain("highest tier");
+    expect(section).toMatch(/all match(ed|es)/i);
+    expect(section).toContain("PTL-1.2");
+  });
+
+  it("Step 2.1 still resolves a single PR_TASK_ID scalar for downstream single-task escalation-PATCH reuse, and documents why", () => {
     const section = getStep2_1Section();
     expect(section).toContain("PR_TASK_ID");
-    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}");
-    expect(section).toContain(".prs[0].taskId // empty");
+    // Must explain the single-scalar choice explicitly, since the model-tier calc now
+    // considers multiple matches but downstream consumers still PATCH one task.
+    expect(section.toLowerCase()).toMatch(/downstream|escalation-patch consumers/i);
+  });
+
+  it("Step 2.1's zero-match fallback is unchanged: PATCH_MODEL=sonnet, warning, not a hard stop", () => {
+    const section = getStep2_1Section();
+    expect(section).toMatch(/no (matching )?tasks?.{0,60}(found|match)/i);
+    expect(section).toMatch(/PATCH_MODEL\s*=\s*"?sonnet"?/);
+    expect(section.toLowerCase()).toContain("no escalation");
+    expect(section.toLowerCase()).toContain("not a hard stop");
+    expect(section).toContain("⚠");
   });
 
   it("Step 2.1 documents the full escalation ladder (haiku->sonnet, sonnet->opus, opus->opus) and the no-task/failed-fetch sonnet fallback with no hard stop", () => {
@@ -1262,7 +1308,7 @@ describe("patch.md — escalate first-time BLOCKED status to HITL before releasi
     const step6cIdx = content.indexOf("### Step 6c: Dispatch Fix Subagent");
     const step6b6Section = content.slice(step6b6Idx, step6cIdx);
     expect(step6b6Section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID"');
-    expect(step6b6Section).toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks/$');
+    expect(step6b6Section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}");
 
     const step6dSection = getStep6dSection();
     const blocked = getBlockedBranch(step6dSection);

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1000,6 +1000,19 @@ describe("patch.md — shared patch model tier resolution (MTR-2.1)", () => {
     expect(section).toContain("PTL-1.2");
   });
 
+  it("Step 2.1 has real jq/bash computing PATCH_MODEL and PR_TASK_ID from $MATCHED_TASKS, not just prose (mirrors Step 6b.6's jq mechanics)", () => {
+    const section = getStep2_1Section();
+    // Must reference the tasks array and each task's model field via jq, not just describe
+    // the computation in prose.
+    expect(section).toMatch(/\.tasks\[\]/);
+    expect(section).toMatch(/\.model/);
+    expect(section).toContain("jq -r");
+    expect(section).toContain("echo \"$MATCHED_TASKS\"");
+    // Must actually assign both output variables from that jq, not just declare them.
+    expect(section).toMatch(/PATCH_MODEL=\$\(/);
+    expect(section).toMatch(/PR_TASK_ID=\$\(/);
+  });
+
   it("Step 2.1 still resolves a single PR_TASK_ID scalar for downstream single-task escalation-PATCH reuse, and documents why", () => {
     const section = getStep2_1Section();
     expect(section).toContain("PR_TASK_ID");

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -95,39 +95,51 @@ resolves the target PR — this is independent of claim state (reading the linke
 model doesn't require holding a claim), and the computed value is reused as-is at Step 4b,
 Step 5b, Step 6c, and Step 5a.7. None of those four sites re-fetches it.
 
+`PullRequest.taskId` is populated only a fraction of the time (most PRs have no reliable
+task linkage via that field) — query the task store directly by PR number instead of
+trusting it:
+
 ```bash
-PR_TASK_ID=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-  "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" | jq -r '.prs[0].taskId // empty')
+MATCHED_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}")
 ```
 
-- **`PR_TASK_ID` non-empty** (the PR has a linked task): fetch that task's planned model
-  and escalate one tier:
-  ```bash
-  TASK_MODEL=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" | jq -r '.model // "sonnet"')
-  ```
-  Compute `PATCH_MODEL` by escalating `TASK_MODEL` one tier up the same ladder
-  `dev-task.md`'s Step 5c BLOCKED handling already climbs — a patch dispatch is always
-  reacting to a problem the way a BLOCKED implementation subagent is, so it starts where
-  that ladder's first escalation would land, instead of waiting to hit it:
-  `haiku`->`sonnet`, `sonnet`->`opus`, `opus`->`opus` (already at the top tier — stays put).
+- **One or more tasks match**: this PR can have more than one task linked to it (e.g. a
+  bundled multi-task branch), so compute `PATCH_MODEL` from the **highest tier among ALL
+  matched tasks' `.model` fields** (`model ?? 'sonnet'` for any task with the field unset),
+  escalated one tier up the same ladder `dev-task.md`'s Step 5c BLOCKED handling already
+  climbs — a patch dispatch is always reacting to a problem the way a BLOCKED
+  implementation subagent is, so it starts where that ladder's first escalation would land,
+  instead of waiting to hit it: `haiku`->`sonnet`, `sonnet`->`opus`, `opus`->`opus` (already
+  at the top tier — stays put). This mirrors the "highest tier among all matches" rule
+  PTL-1.2 applies to review.md's equivalent lookup — same idea, applied here.
 
-  | `TASK_MODEL` (or `model ?? 'sonnet'` if the field is unset) | `PATCH_MODEL` |
+  | Highest `TASK_MODEL` among matches (or `model ?? 'sonnet'` if the field is unset) | `PATCH_MODEL` |
   |---|---|
   | `haiku` | `sonnet` |
   | `sonnet` | `opus` |
   | `opus` | `opus` (already at the top tier — stays put) |
 
-- **`PR_TASK_ID` is unresolved (empty), or either `curl -sf` call above fails (non-200)**:
-  `PATCH_MODEL = "sonnet"` — plain `sonnet`, with **no escalation**. Print a one-line
-  warning and continue; this is **not a hard stop**:
+  Also set `PR_TASK_ID` to the id of the task that produced the highest tier (the first
+  match on a tie). Several sites further down this file — Step 4c's BLOCKED handling, Step
+  5a.7, Step 5c's BLOCKED handling, and `references/escalation-pattern.md`'s shared
+  PATCH/comment/release sequence — reuse `PR_TASK_ID` as a single scalar to PATCH one task
+  to `status: blocked` during HITL escalation. The model-tier calculation above now
+  considers every matched task, but that downstream escalation-PATCH mechanism still only
+  ever flags one task, so `PR_TASK_ID` stays a single value here rather than becoming a set.
+
+- **Zero tasks match, or the `curl -sf` call above fails (non-200)**: `PATCH_MODEL =
+  "sonnet"` — plain `sonnet`, with **no escalation**. `PR_TASK_ID` is empty. Print a
+  one-line warning and continue; this is **not a hard stop**:
   ```bash
   PATCH_MODEL="sonnet"
-  echo "⚠ no linked task found (or lookup failed) for PR #{pr} — PATCH_MODEL defaulting to sonnet, no escalation"
+  PR_TASK_ID=""
+  echo "⚠ no matching tasks found (or lookup failed) for PR #{pr} — PATCH_MODEL defaulting to sonnet, no escalation"
   ```
   There's no known baseline tier to escalate from on a PR Shipwright didn't create (or
-  whose task record isn't reachable), so defaulting straight to `opus` would be a surprise
-  cost spike with no signal backing it — `sonnet` is the safe, unescalated default.
+  whose linked task records aren't reachable), so defaulting straight to `opus` would be a
+  surprise cost spike with no signal backing it — `sonnet` is the safe, unescalated
+  default.
 
 ---
 
@@ -781,10 +793,10 @@ comment and the claim release:
 - **`{temp_file_slug}`**: `escalation` (temp file: `/tmp/shipwright-patch-escalation-{pr}.txt`
   — note this site's slug is `escalation`, not `blocked-5a7`, since it fires before
   dispatch rather than after a BLOCKED report)
-- **`PR_TASK_ID`**: reused from Step 2.1 (no fresh fetch — Step 2.1 fetched
-  `GET /prs?repo={org}/{repo}&prNumber={pr}` and captured `.prs[0].taskId` right after Step 2
-  resolved this same PR, independent of any claim, so it's already available by the time
-  this check runs)
+- **`PR_TASK_ID`**: reused from Step 2.1 (no fresh fetch — Step 2.1 queried
+  `GET /tasks?repo={org}/{repo}&pr={pr}` and resolved `PR_TASK_ID` to the highest-tier match
+  right after Step 2 resolved this same PR, independent of any claim, so it's already
+  available by the time this check runs)
 - **Claim released**: the pre-work claim from Step 5a.6
 
 **Extra step, unique to this site — resolve unresolved inline threads before releasing the
@@ -1320,17 +1332,25 @@ already has an unresolved HITL escalation.
    PR_RECORD=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
      "$SHIPWRIGHT_TASK_STORE_URL/prs/$PR_RECORD_ID")
    PR_BLOCKED=$(echo "$PR_RECORD" | jq -r '.blocked // false')
-   PR_TASK_ID=$(echo "$PR_RECORD" | jq -r '.taskId // empty')
    ```
-2. If `PR_TASK_ID` is non-empty, also fetch the linked task and check its `status` field:
+2. Query the task store directly by PR number instead of reading `PR_RECORD.taskId` — that
+   field is populated only a fraction of the time, so a direct query finds every task linked
+   to this PR rather than relying on it:
    ```bash
-   TASK_BLOCKED=false
-   if [ -n "$PR_TASK_ID" ]; then
-     TASK_STATUS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-       "$SHIPWRIGHT_TASK_STORE_URL/tasks/$PR_TASK_ID" | jq -r '.status // empty')
-     [ "$TASK_STATUS" = "blocked" ] && TASK_BLOCKED=true
-   fi
+   MATCHED_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}")
+   TASK_BLOCKED=$(echo "$MATCHED_TASKS" | jq -r \
+     '[.tasks[]? | select(.hitl == true or .status == "blocked")] | length > 0')
+   PR_TASK_ID=$(echo "$MATCHED_TASKS" | jq -r '.tasks[0].id // empty')
    ```
+   `TASK_BLOCKED` is an **OR across every matched task** — `true` if ANY matched task has
+   `hitl === true` OR `status === 'blocked'`, not just the first one. This mirrors the same
+   multi-match semantics task PTL-1.1 applies on the TypeScript side in
+   `agent/src/check-helpers.ts`'s `isTaskBlockedForDispatch`, kept consistent here in prose
+   form. `PR_TASK_ID` is set to the first matched task's id (or empty if zero tasks match) —
+   Step 6d's BLOCKED handling reuses this single scalar for its own PATCH-to-blocked
+   escalation, so one task id is still exposed here even though the blocked-check above
+   considers every match.
 
 **If `PR_BLOCKED` is `true` OR `TASK_BLOCKED` is `true`** (an unresolved HITL escalation already
 exists — most likely from Step 5a.7 on this same PR, this cycle or a prior one): skip —
@@ -1350,9 +1370,13 @@ decision already recorded on the PR.
    ```
 3. Move to the next PR in List D. If no candidates remain, continue to Step 7.
 
-**Otherwise** (neither the PR record has `blocked: true` nor its linked task has
-`status: 'blocked'`): no escalation
-is on record for this PR — proceed to Step 6b.7.
+**Otherwise** (neither the PR record has `blocked: true` nor any matched task has
+`hitl === true` or `status === 'blocked'`): no escalation is on record for this PR —
+proceed to Step 6b.7. If no matching tasks were found for this PR (zero results from the
+`GET /tasks?repo=&pr=` query), this branch is the only possible outcome for the task side
+of the check — there's no task-based escalation signal to read, so only `PR_BLOCKED` (from
+the PR record) can trigger the escalation branch above, same as today's no-linked-task
+default.
 
 ### Step 6b.7: Bundle Completeness Gate (PH-1.1)
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -120,6 +120,24 @@ MATCHED_TASKS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN"
   | `sonnet` | `opus` |
   | `opus` | `opus` (already at the top tier — stays put) |
 
+  ```bash
+  TIER_RANK='{"haiku":0,"sonnet":1,"opus":2}'
+  TIER_NEXT='{"haiku":"sonnet","sonnet":"opus","opus":"opus"}'
+
+  PATCH_MODEL=$(echo "$MATCHED_TASKS" | jq -r --argjson rank "$TIER_RANK" --argjson next "$TIER_NEXT" '
+    [.tasks[]? | (.model // "sonnet")] as $models
+    | ($models | map($rank[.]) | max) as $maxRank
+    | ($models | map($rank[.]) | index($maxRank)) as $idx
+    | $next[$models[$idx]]
+  ')
+  PR_TASK_ID=$(echo "$MATCHED_TASKS" | jq -r --argjson rank "$TIER_RANK" '
+    [.tasks[]? | (.model // "sonnet")] as $models
+    | ($models | map($rank[.]) | max) as $maxRank
+    | ($models | map($rank[.]) | index($maxRank)) as $idx
+    | .tasks[$idx].id // empty
+  ')
+  ```
+
   Also set `PR_TASK_ID` to the id of the task that produced the highest tier (the first
   match on a tie). Several sites further down this file — Step 4c's BLOCKED handling, Step
   5a.7, Step 5c's BLOCKED handling, and `references/escalation-pattern.md`'s shared

--- a/plugins/shipwright/commands/references/escalation-pattern.md
+++ b/plugins/shipwright/commands/references/escalation-pattern.md
@@ -12,9 +12,13 @@ comment — breaks that loop by giving a human the context to decide, and by giv
 Each call site in `patch.md` links here for the mechanics and states its own trigger
 condition and parameter values inline. `PR_TASK_ID` and `PR_RECORD_ID` are assumed already
 resolved by the caller before this sequence runs — most sites reuse `PR_TASK_ID` from Step
-2.1 (resolved once, right after Step 2 resolves the target PR); Step 6d's BLOCKED handling
-instead reuses the `PR_TASK_ID` resolved by Step 6b.6's escalation check. `PR_RECORD_ID`
-comes from that site's own pre-work claim (Step 4a.6 / 5a.6 / 6b.5).
+2.1 (resolved once, right after Step 2 resolves the target PR, by querying
+`GET /tasks?repo=&pr=` and picking the task among the matches that produced the highest
+model tier); Step 6d's BLOCKED handling instead reuses the `PR_TASK_ID` resolved by Step
+6b.6's escalation check (its own `GET /tasks?repo=&pr=` query, picking the first matched
+task). Either way this sequence only ever PATCHes a single task — the multi-match
+resolution behind `PR_TASK_ID` at each site does not change that. `PR_RECORD_ID` comes from
+that site's own pre-work claim (Step 4a.6 / 5a.6 / 6b.5).
 
 ## Parameters
 


### PR DESCRIPTION
## Summary
- patch.md's Step 2.1 (model-tier escalation) no longer reads `PullRequest.taskId` (populated ~10% of the time); it now queries `GET /tasks?repo={org}/{repo}&pr={pr}` directly and escalates to the highest model tier among all matched tasks.
- patch.md's Step 6b.6 (HITL-escalation pre-dispatch check) similarly drops the `.taskId` read and queries the same endpoint, treating the PR as already-escalated if ANY matched task has `hitl === true` or `status === 'blocked'` — mirroring PTL-1.1's multi-match semantics in `check-helpers.ts`.
- Zero-match fallback at both sites is unchanged (Step 2.1: plain `sonnet`, no escalation; Step 6b.6: only `PR_BLOCKED` can trigger escalation).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 2.1 queries `GET /tasks?repo=&pr=` directly, escalates to highest tier among all matches | MET |
| 2 | Step 6b.6 queries `GET /tasks?repo=&pr=` directly, ORs `hitl===true`/`status==='blocked'` across all matches | MET |
| 3 | Zero-match behavior at both sites unchanged | MET |
| 4 | patch.content.test.ts asserts both sites query `/tasks?repo=&pr=` and documents highest-tier/OR-blocked rules; no existing test retired | MET |
| 5 | Safe to deploy standalone (additive correctness fix, no removal) | MET |

## Test Plan
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 158/158 pass
- `task typecheck` — clean
- `task lint` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
