### PR TITLE
feat: migrate shipwright:unblock's discovery/dedup off stored PR.taskId

### DIFF
--- a/plugins/shipwright/commands/unblock.content.test.ts
+++ b/plugins/shipwright/commands/unblock.content.test.ts
@@ -59,6 +59,25 @@ describe("unblock.md — discovery (AC1)", () => {
     const lower = content.toLowerCase();
     expect(lower).toContain("dependency");
   });
+
+  it("dedupes blocked PRs via a live GET /tasks?repo=&pr= lookup, not PullRequest.taskId", () => {
+    expect(content).toMatch(/\/tasks\?repo=.*&pr=/);
+    const lower = content.toLowerCase();
+    expect(lower).toContain("do not dedupe on `pullrequest.taskid`");
+  });
+
+  it("documents that a PR can have multiple linked tasks and each is triaged once per match", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("more than one");
+    expect(lower).toContain("bundle");
+    expect(lower).toContain("not one collapsed item");
+  });
+
+  it("still treats a PR with zero linked tasks as a PR-only record", () => {
+    const lower = content.toLowerCase();
+    expect(lower).toContain("zero");
+    expect(lower).toContain("pr-only record with no linked task");
+  });
 });
 
 describe("unblock.md — phase inference (AC2)", () => {

--- a/plugins/shipwright/commands/unblock.md
+++ b/plugins/shipwright/commands/unblock.md
@@ -89,14 +89,14 @@ one branch) only ever dedupes against whichever single task happened to be stamp
 `taskId`. Instead, for every blocked PR, query the task store live for its linked task(s):
 
 ```bash
-for pr in $BLOCKED_PRS; do
+while IFS= read -r pr; do
   PR_REPO=$(echo "$pr" | jq -r '.repo')
   PR_NUMBER=$(echo "$pr" | jq -r '.prNumber')
   LINKED_TASKS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
     "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo=${PR_REPO}&pr=${PR_NUMBER}")
   LINKED_TASKS=$(echo "$LINKED_TASKS_JSON" | jq -c '.tasks[]')
   # ... match each task in $LINKED_TASKS against $BLOCKED_TASKS by id, below
-done
+done <<< "$BLOCKED_PRS"
 ```
 
 `GET /tasks?repo=&pr=` can return **more than one** task for a single PR — a bundle branch

--- a/plugins/shipwright/commands/unblock.md
+++ b/plugins/shipwright/commands/unblock.md
@@ -80,9 +80,32 @@ BLOCKED_PRS=$(echo "$BLOCKED_PRS_JSON" | jq -c '.prs[]')
 `GET /prs?blocked=true` returns PRs where `pr.blocked === true` **OR** the PR has a linked
 task whose `task.status === 'blocked'`. That means a PR with a linked blocked task can
 appear in **both** this list and the blocked-tasks list from Step 2 — dedupe on the
-task/PR pairing: when a blocked PR's `taskId` is non-null and that task also came back from
-Step 2, triage it once as a task-with-PR item (Step 5's task.pr-having path), not twice.
-Only PRs with **no linked task** (`taskId` is null) are genuinely PR-only records.
+task/PR pairing.
+
+**Do not dedupe on `PullRequest.taskId`.** It is populated only ~10% of the time — most
+task↔PR links exist solely in the `Task.pr` direction — so a taskId-based dedup treats most
+blocked PRs with a real linked task as PR-only records, and a bundle PR (multiple tasks on
+one branch) only ever dedupes against whichever single task happened to be stamped into
+`taskId`. Instead, for every blocked PR, query the task store live for its linked task(s):
+
+```bash
+for pr in $BLOCKED_PRS; do
+  PR_REPO=$(echo "$pr" | jq -r '.repo')
+  PR_NUMBER=$(echo "$pr" | jq -r '.prNumber')
+  LINKED_TASKS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo=${PR_REPO}&pr=${PR_NUMBER}")
+  LINKED_TASKS=$(echo "$LINKED_TASKS_JSON" | jq -c '.tasks[]')
+  # ... match each task in $LINKED_TASKS against $BLOCKED_TASKS by id, below
+done
+```
+
+`GET /tasks?repo=&pr=` can return **more than one** task for a single PR — a bundle branch
+carries several tasks against the same `pr` number. Dedupe against **every** matched task,
+not just one: for each task returned by the lookup, if that task's `id` also appears in the
+Step 2 `BLOCKED_TASKS` list, triage it once as a task-with-PR item (Step 5's task.pr-having
+path) per match — a two-task bundle where both tasks are blocked produces two triage items,
+not one collapsed item. Only when the `/tasks?repo=&pr=` lookup returns **zero** tasks is
+the PR a genuinely PR-only record with no linked task to dedupe against.
 
 If both `BLOCKED_TASKS` and `BLOCKED_PRS` are empty after dedup, print and stop:
 


### PR DESCRIPTION
## Summary
- Replaced `unblock.md` Step 3's `PullRequest.taskId`-based dedup with a live `GET /tasks?repo=&pr=` lookup per blocked PR, since `taskId` is only populated ~10% of the time
- A blocked PR now dedupes against every linked task returned by the lookup (not just one), so bundle PRs with multiple blocked tasks are triaged once per task instead of collapsing to a single item
- Added content tests asserting the new lookup pattern and the multi-task dedup rule

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 3 dedup no longer relies on PullRequest.taskId; queries GET /tasks?repo=&pr= per blocked PR | MET |
| 2 | Blocked PR with linked task(s) also in Step 2 list triaged once per task, not duplicated | MET |
| 3 | Blocked PR with zero linked tasks still triaged as PR-only, unchanged | MET |
| 4 | Content test asserts dedup queries /tasks?repo=&pr= and documents multi-task rule; no test retired | MET |
| 5 | Safe to deploy standalone: additive correctness fix, no removal | MET |

## Test Plan
- `bun test plugins/shipwright/commands/unblock.content.test.ts` — 32/32 pass (29 pre-existing + 3 new)
- [x] Pre-commit checks passing
- Note: `task ci` shows 30 pre-existing failures unrelated to this change (`metrics/src/lib/env.unit.test.ts` flakiness and a known `task-store/src/routes/prs.ts` `validateRepo` null-repos bug), confirmed present on `main` before this branch's changes

Generated with [Claude Code](https://claude.com/claude-code)
