### PR TITLE
feat: expose GET /tasks/:id/events

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -155,6 +155,29 @@ GET /tasks/:id
 
 Returns `404` if the task doesn't exist or is outside the agent's scope.
 
+#### Get task events
+
+```
+GET /tasks/:id/events
+```
+
+Fetch a task's `TaskEvent` audit trail — a complete history of field-level state transitions recorded in append-only order.
+
+Query params:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `limit` | number | Page size. Defaults to `50` when omitted. |
+| `offset` | number | Page offset. Defaults to `0` when omitted. |
+
+Returns `{ events: TaskEvent[], total: number, limit: number, offset: number }` where:
+- `events` — the task's `TaskEvent` objects, ordered by `at` ascending (oldest first)
+- `total` — count of all events for this task (independent of `limit`/`offset`)
+- `limit` — the limit applied (defaults to 50)
+- `offset` — the offset applied (defaults to 0)
+
+Returns `404` if the task doesn't exist or is outside the agent's scope.
+
 #### Update task
 
 ```

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -1014,6 +1014,87 @@
         }
       }
     },
+    "/tasks/{id}/events": {
+      "get": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "Fetch a task's TaskEvent audit trail, ordered by `at` ascending (oldest first)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "clx1234567890"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Max records to return",
+              "example": "50"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Pagination offset",
+              "example": "0"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task's event history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskEventsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tokens": {
       "get": {
         "tags": [
@@ -2615,6 +2696,98 @@
             "example": "build failed"
           }
         }
+      },
+      "TaskEvent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "clxevent123456"
+          },
+          "taskId": {
+            "type": "string",
+            "example": "clx0987654321"
+          },
+          "field": {
+            "type": "string",
+            "example": "status"
+          },
+          "oldValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "pending"
+          },
+          "newValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "in_progress"
+          },
+          "actor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "agent-abc123"
+          },
+          "method": {
+            "type": "string",
+            "example": "claim"
+          },
+          "at": {
+            "type": "string",
+            "example": "2026-08-17T12:00:00.000Z"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-08-17T12:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "taskId",
+          "field",
+          "oldValue",
+          "newValue",
+          "actor",
+          "method",
+          "at",
+          "createdAt"
+        ]
+      },
+      "TaskEventsResponse": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskEvent"
+            },
+            "description": "This task's TaskEvent audit trail, ordered by `at` ascending (oldest first)."
+          },
+          "total": {
+            "type": "integer",
+            "example": 1
+          },
+          "limit": {
+            "type": "integer",
+            "example": 50
+          },
+          "offset": {
+            "type": "integer",
+            "example": 0
+          }
+        },
+        "required": [
+          "events",
+          "total",
+          "limit",
+          "offset"
+        ]
       },
       "TaskToken": {
         "type": "object",

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -214,6 +214,9 @@ function fakeTaskService(
     async distinct(_agentId?) {
       return { sessions: [], repos: [], orgs: [] };
     },
+    async getEvents(_id, _opts) {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/app.readiness.smoke.test.ts
+++ b/task-store/src/app.readiness.smoke.test.ts
@@ -66,6 +66,9 @@ function fakeTaskService(): TaskServiceLike {
     async distinct() {
       return { sessions: [], repos: [], orgs: [] };
     },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -177,6 +177,9 @@ function fakeTaskService(
     async distinct(_agentId?) {
       return { sessions: [], repos: [], orgs: [] };
     },
+    async getEvents(_id, _opts) {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/generate-spec.ts
+++ b/task-store/src/generate-spec.ts
@@ -69,6 +69,9 @@ const stubTaskService: TaskServiceLike = {
   async resetSkip() {
     return {} as never;
   },
+  async getEvents() {
+    return { events: [], total: 0 };
+  },
 };
 
 const stubTokenService: TokenServiceLike = {

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -299,6 +299,25 @@ export const PullRequestEventSchema = z
 
 export type PullRequestEvent = z.infer<typeof PullRequestEventSchema>;
 
+export const TaskEventSchema = z
+  .object({
+    id: z.string().openapi({ example: "clxevent123456" }),
+    taskId: z.string().openapi({ example: "clx0987654321" }),
+    field: z.string().openapi({ example: "status" }),
+    oldValue: z.string().nullable().openapi({ example: "pending" }),
+    newValue: z.string().nullable().openapi({ example: "in_progress" }),
+    actor: z.string().nullable().openapi({ example: "agent-abc123" }),
+    method: z.string().openapi({ example: "claim" }),
+    at: z.string().openapi({ example: "2026-08-17T12:00:00.000Z" }),
+    createdAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-08-17T12:00:00.000Z" }),
+  })
+  .openapi("TaskEvent");
+
+export type TaskEvent = z.infer<typeof TaskEventSchema>;
+
 // ─── Pull Request ─────────────────────────────────────────────────────────────
 
 export const PullRequestSchema = z
@@ -723,6 +742,33 @@ export const PrEventsResponseSchema = z
     offset: z.number().int().openapi({ example: 0 }),
   })
   .openapi("PrEventsResponse");
+
+/** Query params for GET /tasks/:id/events */
+export const TaskEventsQuerySchema = z
+  .object({
+    limit: z
+      .string()
+      .optional()
+      .openapi({ example: "50", description: "Max records to return" }),
+    offset: z
+      .string()
+      .optional()
+      .openapi({ example: "0", description: "Pagination offset" }),
+  })
+  .openapi("TaskEventsQuery");
+
+/** Response for GET /tasks/:id/events */
+export const TaskEventsResponseSchema = z
+  .object({
+    events: z.array(TaskEventSchema).openapi({
+      description:
+        "This task's TaskEvent audit trail, ordered by `at` ascending (oldest first).",
+    }),
+    total: z.number().int().openapi({ example: 1 }),
+    limit: z.number().int().openapi({ example: 50 }),
+    offset: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("TaskEventsResponse");
 
 export const ClaimPrBodySchema = z
   .object({

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -519,6 +519,9 @@ function fakeTaskService(): TaskServiceLike {
     async distinct() {
       return { sessions: [], repos: [], orgs: [] };
     },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/routes/tasks.openapi.smoke.test.ts
+++ b/task-store/src/routes/tasks.openapi.smoke.test.ts
@@ -10,8 +10,8 @@
 import { describe, expect, it } from "bun:test";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import type { TaskStoreAuthEnv } from "../auth.ts";
-import { ApiError, BadRequestError } from "../errors.ts";
-import type { Task } from "../index.ts";
+import { ApiError, BadRequestError, NotFoundError } from "../errors.ts";
+import type { Task, TaskEvent } from "../index.ts";
 import type { TaskServiceLike } from "../task-service.ts";
 import { createTasksRoutes } from "./tasks.ts";
 
@@ -78,6 +78,21 @@ function withBlockedBy(task: Task) {
   return { ...task, blockedBy: [] };
 }
 
+function makeEvent(overrides: Partial<TaskEvent> = {}): TaskEvent {
+  return {
+    id: "event-1",
+    taskId: "task-1",
+    field: "status",
+    oldValue: "pending",
+    newValue: "in_progress",
+    actor: "agent-abc123",
+    method: "claim",
+    at: "2026-08-17T00:00:00.000Z",
+    createdAt: new Date(),
+    ...overrides,
+  } as TaskEvent;
+}
+
 function fakeTaskService(
   opts: {
     tasks?: Task[];
@@ -85,6 +100,11 @@ function fakeTaskService(
     onBulk?: (tasks: unknown) => void;
     onUpdate?: (id: string, data: unknown) => void;
     onCreate?: (data: unknown) => void;
+    eventsResult?: { events: TaskEvent[]; total: number } | Error;
+    getEventsCalls?: Array<{
+      id: string;
+      opts?: { limit?: number; offset?: number };
+    }>;
   } = {},
 ): TaskServiceLike {
   const tasks = opts.tasks ?? [];
@@ -146,6 +166,16 @@ function fakeTaskService(
     },
     async distinct() {
       return { sessions: [], repos: [], orgs: [] };
+    },
+    async getEvents(id, eventsOpts) {
+      opts.getEventsCalls?.push({ id, opts: eventsOpts });
+      if (opts.eventsResult !== undefined) {
+        if (opts.eventsResult instanceof Error) throw opts.eventsResult;
+        return opts.eventsResult;
+      }
+      const exists = tasks.some((t) => t.id === id);
+      if (!exists) throw new NotFoundError("task not found");
+      return { events: [], total: 0 };
     },
   };
 }
@@ -878,5 +908,144 @@ describe("POST / and POST /bulk — strip removed 'hitlNotifiedAt' field (HSR-1.
     const tasks = received as Record<string, unknown>[];
     expect(tasks).toHaveLength(1);
     expect("hitlNotifiedAt" in (tasks[0] ?? {})).toBe(false);
+  });
+});
+
+describe("GET /:id/events (TCS-1.2)", () => {
+  it("returns 200 with an events array in ascending `at` order, plus total/limit/offset", async () => {
+    const task = makeTask({ id: "t-1" });
+    const events = [
+      makeEvent({
+        id: "event-1",
+        taskId: "t-1",
+        field: "status",
+        oldValue: "pending",
+        newValue: "in_progress",
+        method: "claim",
+        at: "2026-08-17T00:00:00.000Z",
+      }),
+      makeEvent({
+        id: "event-2",
+        taskId: "t-1",
+        field: "status",
+        oldValue: "in_progress",
+        newValue: "pending",
+        method: "release",
+        at: "2026-08-17T01:00:00.000Z",
+      }),
+    ];
+    const app = createTasksRoutes(
+      fakeTaskService({ tasks: [task], eventsResult: { events, total: 2 } }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/t-1/events");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      events: TaskEvent[];
+      total: number;
+      limit: number;
+      offset: number;
+    };
+    expect(body.events).toHaveLength(2);
+    expect(body.events[0]?.id).toBe("event-1");
+    expect(body.events[0]?.at).toBe("2026-08-17T00:00:00.000Z");
+    expect(body.events[1]?.id).toBe("event-2");
+    expect(body.events[1]?.at).toBe("2026-08-17T01:00:00.000Z");
+    expect(body.total).toBe(2);
+    expect(typeof body.limit).toBe("number");
+    expect(typeof body.offset).toBe("number");
+  });
+
+  it("returns 404 when the task does not exist", async () => {
+    const app = createTasksRoutes(fakeTaskService({ tasks: [] }));
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/missing/events");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with an empty array when the task has zero events (not 404)", async () => {
+    const task = makeTask({ id: "t-1" });
+    const app = createTasksRoutes(
+      fakeTaskService({ tasks: [task], eventsResult: { events: [], total: 0 } }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/t-1/events");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: TaskEvent[]; total: number };
+    expect(body.events).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it("?limit=&offset= parses limit/offset and forwards them to the service", async () => {
+    const task = makeTask({ id: "t-1" });
+    const getEventsCalls: Array<{
+      id: string;
+      opts?: { limit?: number; offset?: number };
+    }> = [];
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        eventsResult: { events: [], total: 0 },
+        getEventsCalls,
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/t-1/events?limit=10&offset=5");
+    expect(res.status).toBe(200);
+    expect(getEventsCalls).toHaveLength(1);
+    expect(getEventsCalls[0]?.id).toBe("t-1");
+    expect(getEventsCalls[0]?.opts?.limit).toBe(10);
+    expect(getEventsCalls[0]?.opts?.offset).toBe(5);
+  });
+
+  it("without limit/offset leaves them undefined (service applies defaults)", async () => {
+    const task = makeTask({ id: "t-1" });
+    const getEventsCalls: Array<{
+      id: string;
+      opts?: { limit?: number; offset?: number };
+    }> = [];
+    const app = createTasksRoutes(
+      fakeTaskService({
+        tasks: [task],
+        eventsResult: { events: [], total: 0 },
+        getEventsCalls,
+      }),
+    );
+    const parent = makeAdminParent(app);
+
+    const res = await parent.request("/t-1/events");
+    expect(res.status).toBe(200);
+    expect(getEventsCalls).toHaveLength(1);
+    expect(getEventsCalls[0]?.opts?.limit).toBeUndefined();
+    expect(getEventsCalls[0]?.opts?.offset).toBeUndefined();
+  });
+
+  it("agent token with no ownership (not assignee/claimant, repo outside scope) -> 403", async () => {
+    const task = makeTask({
+      id: "t-1",
+      assignee: "agent-other",
+      claimedBy: "agent-other",
+      repo: "acme-inc/backend-api",
+    });
+    const app = createTasksRoutes(fakeTaskService({ tasks: [task] }));
+    const parent = makeAgentParent(app, "agent-1", ["some-other/repo"]);
+
+    const res = await parent.request("/t-1/events");
+    expect(res.status).toBe(403);
+  });
+
+  it("agent token that is the assignee -> 200 (ownership enforced, not blanket-denied)", async () => {
+    const task = makeTask({ id: "t-1", assignee: "agent-1" });
+    const app = createTasksRoutes(
+      fakeTaskService({ tasks: [task], eventsResult: { events: [], total: 0 } }),
+    );
+    const parent = makeAgentParent(app, "agent-1", []);
+
+    const res = await parent.request("/t-1/events");
+    expect(res.status).toBe(200);
   });
 });

--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -32,6 +32,7 @@
  *   POST   /tasks/:id/release   unclaim → pending
  *   POST   /tasks/:id/skip      increment skipCount, auto-block at threshold
  *   POST   /tasks/:id/skip/reset  reset skipCount back to 0
+ *   GET    /tasks/:id/events    fetch a TaskEvent audit trail (?limit, ?offset)
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
@@ -47,6 +48,8 @@ import {
   DistinctResponseSchema,
   ErrorSchema,
   FailBodySchema,
+  TaskEventsQuerySchema,
+  TaskEventsResponseSchema,
   TaskIdParamSchema,
   TaskListQuerySchema,
   TaskListResponseSchema,
@@ -540,6 +543,36 @@ const skipResetRoute = createRoute({
   },
 });
 
+const eventsRoute = createRoute({
+  method: "get",
+  path: "/:id/events",
+  tags: ["tasks"],
+  summary:
+    "Fetch a task's TaskEvent audit trail, ordered by `at` ascending (oldest first)",
+  request: {
+    params: TaskIdParamSchema,
+    query: TaskEventsQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Task's event history",
+      content: { "application/json": { schema: TaskEventsResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
 // ─── Factory ──────────────────────────────────────────────────────────────────
 
 export function createTasksRoutes(
@@ -872,6 +905,40 @@ export function createTasksRoutes(
     await requireOwnership(taskService, c.req.param("id"), agentId, repos);
     const task = await taskService.resetSkip(c.req.param("id"));
     return c.json(task, 200);
+  });
+
+  // ─── Events ────────────────────────────────────────────────────────────────
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(eventsRoute, async (c): Promise<any> => {
+    const agentId = c.get("agentId");
+    const repos = c.get("repos") ?? [];
+    await requireOwnership(taskService, c.req.param("id"), agentId, repos);
+
+    const limitRaw = c.req.query("limit");
+    const offsetRaw = c.req.query("offset");
+    const limit =
+      limitRaw !== undefined
+        ? Number.parseInt(limitRaw, 10) || undefined
+        : undefined;
+    const offset =
+      offsetRaw !== undefined
+        ? Number.parseInt(offsetRaw, 10) || undefined
+        : undefined;
+
+    const result = await taskService.getEvents(c.req.param("id"), {
+      limit,
+      offset,
+    });
+
+    return c.json(
+      {
+        events: result.events,
+        total: result.total,
+        limit: limit ?? 50,
+        offset: offset ?? 0,
+      },
+      200,
+    );
   });
 
   return app;

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -181,6 +181,9 @@ function fakeTaskService(opts: {
     async distinct() {
       return { sessions: [], repos: [], orgs: [] };
     },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/task-claim-status-invariant.integration.test.ts
+++ b/task-store/src/task-claim-status-invariant.integration.test.ts
@@ -40,9 +40,11 @@ describeOrSkip("Task pending/claimedBy DB invariant (integration)", () => {
     prisma = makePrisma();
     // PullRequestEvent's FK is ON DELETE RESTRICT (PSA-1.2) — clear event
     // rows before their parent PullRequest rows, in case another test file
-    // sharing TEST_DB left rows behind.
+    // sharing TEST_DB left rows behind. TaskEvent's FK is ON DELETE RESTRICT
+    // too (TCS-1.1) — same reasoning applies to Task rows (TCS-1.2).
     await prisma.pullRequestEvent.deleteMany();
     await prisma.pullRequest.deleteMany();
+    await prisma.taskEvent.deleteMany();
     await prisma.task.deleteMany();
   });
 

--- a/task-store/src/task-service.integration.test.ts
+++ b/task-store/src/task-service.integration.test.ts
@@ -204,5 +204,51 @@ describeOrSkip(
       });
       expect(eventsAfter).toBe(0);
     });
+
+    it("getEvents() returns rows from both a claim() and a subsequent release(), ordered oldest-first (TCS-1.2)", async () => {
+      const task = await prisma.task.create({
+        data: { title: "claim-then-release-events", status: "pending" },
+      });
+
+      await service.claim(task.id, "agent-x");
+      await service.release(task.id);
+
+      const result = await service.getEvents(task.id);
+
+      // claim() writes 4 rows (status/claimedBy/claimedAt/startedAt) and
+      // release() writes 3 rows (status/claimedBy/claimedAt) — both
+      // transitions' rows must be present in the audit trail.
+      expect(result.total).toBe(7);
+      expect(result.events).toHaveLength(7);
+
+      const claimEvents = result.events.filter((e) => e.method === "claim");
+      const releaseEvents = result.events.filter(
+        (e) => e.method === "release",
+      );
+      expect(claimEvents).toHaveLength(4);
+      expect(releaseEvents).toHaveLength(3);
+
+      // Ordered oldest-first by `at` — every claim() row must precede every
+      // release() row given the sequential await above.
+      const claimAts = claimEvents.map((e) => e.at);
+      const releaseAts = releaseEvents.map((e) => e.at);
+      const maxClaimAt = claimAts.sort().at(-1) as string;
+      const minReleaseAt = releaseAts.sort()[0] as string;
+      expect(maxClaimAt <= minReleaseAt).toBe(true);
+
+      // The returned array itself is sorted ascending by `at`.
+      const ats = result.events.map((e) => e.at);
+      const sortedAts = [...ats].sort();
+      expect(ats).toEqual(sortedAts);
+
+      // Spot-check the status transition rows from each phase.
+      const statusClaim = claimEvents.find((e) => e.field === "status");
+      expect(statusClaim?.oldValue).toBe("pending");
+      expect(statusClaim?.newValue).toBe("in_progress");
+
+      const statusRelease = releaseEvents.find((e) => e.field === "status");
+      expect(statusRelease?.oldValue).toBe("in_progress");
+      expect(statusRelease?.newValue).toBe("pending");
+    });
   },
 );

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -15,7 +15,7 @@
 import { type BlockedByEntry, computeBlockedBy } from "./blocked-by.ts";
 import { type Clock, SystemClock } from "./clock.ts";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
-import type { Prisma, PrismaClient, Task } from "./index.ts";
+import type { Prisma, PrismaClient, Task, TaskEvent } from "./index.ts";
 import { buildRepoOrgWhere } from "./lib/repo-org-filter.ts";
 import { resolveReadyTasks } from "./ready.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
@@ -241,6 +241,12 @@ export interface TaskListResult {
   offset: number;
 }
 
+/** Result from TaskService.getEvents. */
+export interface GetTaskEventsResult {
+  events: TaskEvent[];
+  total: number;
+}
+
 /** The subset of TaskService the routes depend on. */
 export interface TaskServiceLike {
   list(filters?: TaskListFilters): Promise<TaskListResult>;
@@ -273,6 +279,10 @@ export interface TaskServiceLike {
   release(id: string): Promise<Task>;
   recordSkip(id: string): Promise<Task>;
   resetSkip(id: string): Promise<Task>;
+  getEvents(
+    id: string,
+    opts?: { limit?: number; offset?: number },
+  ): Promise<GetTaskEventsResult>;
 }
 
 export class TaskService implements TaskServiceLike {
@@ -863,6 +873,41 @@ export class TaskService implements TaskServiceLike {
     } catch (err: unknown) {
       throw this.translateNotFound(err, "task not found");
     }
+  }
+
+  /**
+   * Fetch a task's TaskEvent audit trail (TCS-1.2), ordered by `at` ascending
+   * (oldest first) — uses the (taskId, at) index (TCS-1.1). Existence-checks
+   * the task first (mirrors PullRequestService.getEvents()) so a missing task
+   * surfaces as a clean NotFoundError rather than an empty result being
+   * indistinguishable from "task exists but has zero events".
+   */
+  async getEvents(
+    id: string,
+    opts: { limit?: number; offset?: number } = {},
+  ): Promise<GetTaskEventsResult> {
+    const existing = await this.prisma.task.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!existing) {
+      throw new NotFoundError("task not found");
+    }
+
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+
+    const [events, total] = await this.prisma.$transaction([
+      this.prisma.taskEvent.findMany({
+        where: { taskId: id },
+        orderBy: { at: "asc" },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.taskEvent.count({ where: { taskId: id } }),
+    ]);
+
+    return { events, total };
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/task-store/src/tasks.execution-fields.smoke.test.ts
+++ b/task-store/src/tasks.execution-fields.smoke.test.ts
@@ -211,6 +211,9 @@ function fakeTaskService(
     }> {
       return Promise.resolve({ sessions: [], repos: [], orgs: [] });
     },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/tokens.smoke.test.ts
+++ b/task-store/src/tokens.smoke.test.ts
@@ -187,6 +187,9 @@ function fakeTaskService(): TaskServiceLike {
     async resetSkip() {
       return null as never;
     },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 

--- a/task-store/src/validate.smoke.test.ts
+++ b/task-store/src/validate.smoke.test.ts
@@ -187,6 +187,9 @@ function fakeTaskService(
     ): Promise<{ sessions: string[]; repos: string[]; orgs: string[] }> {
       return Promise.resolve({ sessions: [], repos: [], orgs: [] });
     },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds `GET /tasks/:id/events`, mirroring the existing `GET /prs/:id/events` route pattern
- Paginated (`?limit`/`?offset`, defaults 50/0), 404 on missing task, ownership-enforced via the existing `requireOwnership` helper used by every other `/tasks/:id/*` route
- Regenerated `task-store/openapi.json`; documented the new endpoint in `docs/task-store.md`

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New route GET /tasks/:id/events, paginated (limit/offset), 404 on missing task, ownership-enforced like other /tasks/:id/* routes | MET | `eventsRoute` + handler in `tasks.ts` wired through `requireOwnership()`; `TaskService.getEvents()` throws `NotFoundError`; limit/offset parsed and forwarded, defaults 50/0 |
| 2 | OpenAPI schema entry added; docs/task-store.md updated | MET | `TaskEventSchema`/`TaskEventsQuerySchema`/`TaskEventsResponseSchema` added; `openapi.json` regenerated; "Get task events" doc section added |
| 3 | Smoke test: claim() -> release() cycle, GET .../events returns rows oldest-first covering both transitions | MET | Integration test asserts 7 events (4 claim + 3 release), oldest-first ordering, both transitions represented; HTTP contract covered separately by smoke tests |
| 4 | No existing tests removed — net-new endpoint | MET | Diff is additions-only; 8 fake `TaskServiceLike` implementations updated with a `getEvents` stub, no deletions |

## Test Plan
- `task-store/src/routes/tasks.openapi.smoke.test.ts` — new `describe("GET /:id/events (TCS-1.2)")` block: 200 shape, 404 missing task, empty-events-not-404, limit/offset pass-through, ownership 403/200
- `task-store/src/task-service.integration.test.ts` — real-DB claim() -> release() -> getEvents() cycle, asserts both transitions' rows present and ordered oldest-first (gated on `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST`)
- [x] Pre-commit checks passing (lint, typecheck, full test suite — 30 pre-existing unrelated `agent/` env-var-leakage failures confirmed on `main`)

Generated with [Claude Code](https://claude.com/claude-code)
