### PR TITLE
fix: derive metrics dashboard feature-grouping from tasks, not pr.taskId (PTL-2.2)

### DIFF
--- a/metrics/src/lib/task-store-client.ts
+++ b/metrics/src/lib/task-store-client.ts
@@ -62,13 +62,20 @@ export type TaskRecord = Pick<
   | "simplifyNaming"
   | "simplifyComplexity"
   | "simplifyConsistency"
+  | "pr"
 > &
   Partial<TaskOptionalOverrides>;
 
 /** Fields required on the generated PullRequest schema that PrRecord treats as optional. */
 type PrOptionalOverrides = Pick<
   PullRequestSchema,
-  "id" | "repo" | "reviewState" | "createdAt" | "reviewCycles" | "patchCycles"
+  | "id"
+  | "repo"
+  | "reviewState"
+  | "createdAt"
+  | "reviewCycles"
+  | "patchCycles"
+  | "prNumber"
 >;
 
 /**

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -240,7 +240,13 @@ const CRON_STATS_WITH_PHASE: CronRunTokenStats = {
 const CHAT_STATS: ChatTokenStats = {
   totals: agg(400, 200, 80, 40, 0.6),
   byAgent: [{ key: "agent-a", ...agg(400, 200, 80, 40, 0.6) }],
-  byModel: [{ key1: "agent-a", key2: "claude-sonnet-4-5", ...agg(400, 200, 80, 40, 0.6) }],
+  byModel: [
+    {
+      key1: "agent-a",
+      key2: "claude-sonnet-4-5",
+      ...agg(400, 200, 80, 40, 0.6),
+    },
+  ],
   daily: [{ period: "2026-06-03", ...agg(400, 200, 80, 40, 0.6) }],
 };
 
@@ -1014,7 +1020,9 @@ describe("TaskStoreProvider (integration)", () => {
 
     // Correctness is unaffected by the cache — computed values still match
     // what a non-coalesced call would produce.
-    expect(summaryTable.results[0][colIndex(summaryTable, "tasks_completed")]).toBe(2);
+    expect(
+      summaryTable.results[0][colIndex(summaryTable, "tasks_completed")],
+    ).toBe(2);
     expect(cycleTimeTable.columns).toEqual(["avg_cycle_time_hours"]);
     expect(cycleTimeTable.results[0][0]).not.toBeNull();
   });

--- a/metrics/src/providers/task-store-provider.integration.test.ts
+++ b/metrics/src/providers/task-store-provider.integration.test.ts
@@ -65,6 +65,7 @@ const TASKS: TaskRecord[] = [
     session: "cron",
     hours: 5,
     complexity: 3,
+    pr: 1,
     startedAt: "2026-06-02T08:00:00.000Z",
     completedAt: "2026-06-02T12:00:00.000Z",
     mergedAt: "2026-06-02T12:00:00.000Z",
@@ -85,6 +86,7 @@ const TASKS: TaskRecord[] = [
     session: "cron",
     hours: 3,
     complexity: 2,
+    pr: 2,
     startedAt: "2026-06-03T09:00:00.000Z",
     completedAt: "2026-06-03T15:00:00.000Z",
     mergedAt: "2026-06-03T15:00:00.000Z",
@@ -123,10 +125,16 @@ const TASKS: TaskRecord[] = [
   },
 ];
 
+// `taskId` is deliberately left null on both — mirrors production, where the
+// field is populated only ~10% of the time. featuresReviews() groups from
+// `tasks` (via task.id-derived prefix + task.pr matched against `prNumber`),
+// not from `pr.taskId`; see the "featuresReviews groups by feature prefix"
+// test below.
 const PRS: PrRecord[] = [
   {
     id: "pr-1",
-    taskId: "QS-1.1",
+    taskId: null,
+    prNumber: 1,
     reviewState: "approved",
     createdAt: "2026-06-02T11:00:00.000Z",
     mergedAt: "2026-06-02T12:00:00.000Z",
@@ -135,7 +143,8 @@ const PRS: PrRecord[] = [
   },
   {
     id: "pr-2",
-    taskId: "QS-1.2",
+    taskId: null,
+    prNumber: 2,
     reviewState: "posted",
     createdAt: "2026-06-03T14:00:00.000Z",
     mergedAt: "2026-06-03T15:00:00.000Z",
@@ -481,6 +490,25 @@ describe("TaskStoreProvider (integration)", () => {
     expect(row[colIndex(t, "tasks_approved")]).toBe(1);
     // task-store PR records carry no findings count → always null
     expect(row[colIndex(t, "avg_review_findings")]).toBeNull();
+  });
+
+  test("featuresReviews groups PRs by feature prefix via task.pr, not pr.taskId", async () => {
+    // Both PRS fixtures have taskId: null (the common production case) but a
+    // matching TASKS[i].pr → prNumber. Grouping must originate from tasks.
+    const provider = buildProvider();
+    const t = await provider.query({ kind: "featuresReviews", range: RANGE });
+    expect(t.columns).toEqual([
+      "feature_prefix",
+      "reviews_total",
+      "reviews_ship_it",
+    ]);
+    const qsRow = t.results.find(
+      (r) => r[colIndex(t, "feature_prefix")] === "QS",
+    );
+    expect(qsRow).toBeDefined();
+    // pr-1 (approved, QS-1.1) + pr-2 (posted, QS-1.2) both group under "QS".
+    expect(qsRow?.[colIndex(t, "reviews_total")]).toBe(2);
+    expect(qsRow?.[colIndex(t, "reviews_ship_it")]).toBe(1);
   });
 
   test("trends includes coverage_reports and avg_coverage_delta columns computed per period", async () => {

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -531,7 +531,17 @@ export class TaskStoreProvider implements MetricsProvider {
       const prefix = featurePrefix(t.id);
       if (!prefix) continue;
       if (t.pr == null) continue;
-      const pr = prs.find((p) => p.repo === t.repo && p.prNumber === t.pr);
+      // `Task.repo` is nullable (a legal state for unscoped tasks; see
+      // docs/task-store.md), whereas `PullRequest.repo` is always a non-null
+      // string. A strict `p.repo === t.repo` therefore silently drops every
+      // null-repo task's PR — the same silent-drop class this method exists to
+      // fix. Treat a null/undefined `t.repo` as unscoped and match on prNumber
+      // alone; otherwise require the repo to match so two PRs sharing a number
+      // across repos can't be confused.
+      const pr = prs.find(
+        (p) =>
+          (t.repo == null || p.repo === t.repo) && p.prNumber === t.pr,
+      );
       if (!pr) continue;
       const arr = map.get(prefix) ?? [];
       arr.push(pr);

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -512,15 +512,30 @@ export class TaskStoreProvider implements MetricsProvider {
     return map;
   }
 
-  private groupPrsByPrefix(prs: PrRecord[]): Map<string, PrRecord[]> {
+  /**
+   * Groups PR records by feature prefix, originating from `tasks` rather than
+   * `pr.taskId` — that field is populated only ~10% of the time (0% in
+   * several repos), so grouping from it silently dropped the large majority
+   * of PRs. Each task supplies its own id-derived prefix and its `.pr`
+   * field is matched against the fetched PR list by (repo, prNumber) to find
+   * the PR record to attach. Because the loop is per-task, a PR shared by
+   * multiple tasks (the bundle case) is attached under each of those tasks'
+   * own feature buckets rather than only one.
+   */
+  private groupPrsByPrefix(
+    tasks: TaskRecord[],
+    prs: PrRecord[],
+  ): Map<string, PrRecord[]> {
     const map = new Map<string, PrRecord[]>();
-    for (const pr of prs) {
-      const id = pr.taskId ?? "";
-      const p = featurePrefix(id);
-      if (!p) continue;
-      const arr = map.get(p) ?? [];
+    for (const t of tasks) {
+      const prefix = featurePrefix(t.id);
+      if (!prefix) continue;
+      if (t.pr == null) continue;
+      const pr = prs.find((p) => p.repo === t.repo && p.prNumber === t.pr);
+      if (!pr) continue;
+      const arr = map.get(prefix) ?? [];
       arr.push(pr);
-      map.set(p, arr);
+      map.set(prefix, arr);
     }
     return map;
   }
@@ -570,8 +585,8 @@ export class TaskStoreProvider implements MetricsProvider {
     from: string;
     to: string;
   }): Promise<MetricTable> {
-    const prs = await this.prs(win);
-    const groups = this.groupPrsByPrefix(prs);
+    const [tasks, prs] = await Promise.all([this.tasks(win), this.prs(win)]);
+    const groups = this.groupPrsByPrefix(tasks, prs);
     const columns = ["feature_prefix", "reviews_total", "reviews_ship_it"];
     const rows = [...groups.entries()].map(([prefix, group]) => [
       prefix,

--- a/metrics/src/providers/task-store-provider.ts
+++ b/metrics/src/providers/task-store-provider.ts
@@ -778,7 +778,17 @@ export class TaskStoreProvider implements MetricsProvider {
       costUsd: number;
     };
     const merged = new Map<string, Cells>();
-    const add = (key1: string, key2: string, a: { input: number; output: number; cacheRead: number; cacheCreation: number; costUsd?: number }) => {
+    const add = (
+      key1: string,
+      key2: string,
+      a: {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheCreation: number;
+        costUsd?: number;
+      },
+    ) => {
       const k = `${key1}\0${key2}`;
       const existing = merged.get(k) ?? {
         input: 0,
@@ -920,7 +930,13 @@ export class TaskStoreProvider implements MetricsProvider {
     // Collapse multiple agents' byModel rows into a single per-model-family total.
     const fleetByModel = new Map<
       string,
-      { input: number; output: number; cacheRead: number; cacheCreation: number; costUsd: number }
+      {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheCreation: number;
+        costUsd: number;
+      }
     >();
 
     for (const entry of cronStats.byModel) {
@@ -972,7 +988,13 @@ export class TaskStoreProvider implements MetricsProvider {
         OPUS_MODEL,
       );
       const savingsUsd = opusUsd - routedUsd;
-      rows.push([`agent:${entry.key1}`, modelFamily, routedUsd, opusUsd, savingsUsd]);
+      rows.push([
+        `agent:${entry.key1}`,
+        modelFamily,
+        routedUsd,
+        opusUsd,
+        savingsUsd,
+      ]);
     }
 
     // ── Per-cron×model rows (byCronModel) ────────────────────────────────────
@@ -989,7 +1011,13 @@ export class TaskStoreProvider implements MetricsProvider {
         OPUS_MODEL,
       );
       const savingsUsd = opusUsd - routedUsd;
-      rows.push([`cron:${entry.key1}`, modelFamily, routedUsd, opusUsd, savingsUsd]);
+      rows.push([
+        `cron:${entry.key1}`,
+        modelFamily,
+        routedUsd,
+        opusUsd,
+        savingsUsd,
+      ]);
     }
 
     return table(columns, rows);

--- a/metrics/src/providers/task-store-provider.unit.test.ts
+++ b/metrics/src/providers/task-store-provider.unit.test.ts
@@ -1,0 +1,174 @@
+/**
+ * metrics/src/providers/task-store-provider.unit.test.ts
+ * Unit: pure feature-grouping logic in TaskStoreProvider — specifically the
+ * task-originated groupPrsByPrefix() replacement exercised via the
+ * featuresReviews() query kind.
+ *
+ * PTL-2.2: the grouping mechanism moved from reading `pr.taskId` (populated
+ * ~10% of the time, 0% in several repos — silently dropping most PRs from
+ * the dashboard's feature/session groupings) to originating from `task`
+ * records (task.id-derived prefix + task.pr), then attaching each task's PR
+ * by matching (repo, pr) against the fetched PR list. This also naturally
+ * handles the bundle case: multiple tasks pointing at the same PR each
+ * attach it to their own feature bucket.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { PrRecord, TaskRecord } from "../lib/task-store-client.ts";
+import { FixedClock } from "../lib/test-helpers.ts";
+import { TaskStoreProvider } from "./task-store-provider.ts";
+import {
+  RecordedAdminMetricsClient,
+  RecordedTaskStoreClient,
+} from "./task-store-recorded.ts";
+
+const CLOCK = FixedClock("2026-06-10T12:00:00.000Z");
+const RANGE = { from: "2026-06-01", to: "2026-06-07" } as const;
+
+const ZERO_AGG = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  total: 0,
+};
+const EMPTY_CRON_STATS = {
+  totals: ZERO_AGG,
+  byAgent: [],
+  byCron: [],
+  byModel: [],
+  daily: [],
+  byCronModel: [],
+  byPhase: [],
+};
+const EMPTY_CHAT_STATS = {
+  totals: ZERO_AGG,
+  byAgent: [],
+  byModel: [],
+  daily: [],
+};
+
+function colIndex(t: { columns: string[] }, name: string): number {
+  return t.columns.indexOf(name);
+}
+
+function buildProvider(tasks: TaskRecord[], prs: PrRecord[]) {
+  const taskStore = new RecordedTaskStoreClient(tasks, prs);
+  const admin = new RecordedAdminMetricsClient(
+    EMPTY_CRON_STATS,
+    EMPTY_CHAT_STATS,
+  );
+  return new TaskStoreProvider(taskStore, admin, CLOCK);
+}
+
+describe("TaskStoreProvider.featuresReviews (unit) — task-originated grouping", () => {
+  test("a PR with taskId null but a matching task.pr groups correctly", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "QS-1.1",
+        status: "merged",
+        repo: "org/repo",
+        pr: 42,
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        createdAt: "2026-06-01T08:00:00.000Z",
+      },
+    ];
+    const prs: PrRecord[] = [
+      {
+        taskId: null,
+        prNumber: 42,
+        repo: "org/repo",
+        reviewState: "approved",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+      },
+    ];
+
+    const provider = buildProvider(tasks, prs);
+    const t = await provider.query({ kind: "featuresReviews", range: RANGE });
+
+    const row = t.results.find((r) => r[colIndex(t, "feature_prefix")] === "QS");
+    expect(row).toBeDefined();
+    expect(row?.[colIndex(t, "reviews_total")]).toBe(1);
+    expect(row?.[colIndex(t, "reviews_ship_it")]).toBe(1);
+  });
+
+  test("a bundle PR shared by 2 tasks with different prefixes appears in both groupings", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "AA-1.1",
+        status: "merged",
+        repo: "org/repo",
+        pr: 99,
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        createdAt: "2026-06-01T08:00:00.000Z",
+      },
+      {
+        id: "BB-2.1",
+        status: "merged",
+        repo: "org/repo",
+        pr: 99,
+        startedAt: "2026-06-03T08:00:00.000Z",
+        completedAt: "2026-06-03T12:00:00.000Z",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        createdAt: "2026-06-02T08:00:00.000Z",
+      },
+    ];
+    const prs: PrRecord[] = [
+      {
+        taskId: null,
+        prNumber: 99,
+        repo: "org/repo",
+        reviewState: "approved",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+      },
+    ];
+
+    const provider = buildProvider(tasks, prs);
+    const t = await provider.query({ kind: "featuresReviews", range: RANGE });
+
+    const rowAA = t.results.find((r) => r[colIndex(t, "feature_prefix")] === "AA");
+    const rowBB = t.results.find((r) => r[colIndex(t, "feature_prefix")] === "BB");
+    expect(rowAA).toBeDefined();
+    expect(rowBB).toBeDefined();
+    expect(rowAA?.[colIndex(t, "reviews_total")]).toBe(1);
+    expect(rowBB?.[colIndex(t, "reviews_total")]).toBe(1);
+    expect(rowAA?.[colIndex(t, "reviews_ship_it")]).toBe(1);
+    expect(rowBB?.[colIndex(t, "reviews_ship_it")]).toBe(1);
+  });
+
+  test("a task with no matching PR (missing .pr or no matching record) contributes nothing, no crash", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "CC-1.1",
+        status: "merged",
+        repo: "org/repo",
+        // no .pr field at all
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        createdAt: "2026-06-01T08:00:00.000Z",
+      },
+      {
+        id: "DD-1.1",
+        status: "merged",
+        repo: "org/repo",
+        pr: 7, // points at a PR number that doesn't exist in the fetched PR list
+        startedAt: "2026-06-03T08:00:00.000Z",
+        completedAt: "2026-06-03T12:00:00.000Z",
+        mergedAt: "2026-06-03T12:00:00.000Z",
+        createdAt: "2026-06-02T08:00:00.000Z",
+      },
+    ];
+    const prs: PrRecord[] = [];
+
+    const provider = buildProvider(tasks, prs);
+    const t = await provider.query({ kind: "featuresReviews", range: RANGE });
+
+    expect(t.results.find((r) => r[colIndex(t, "feature_prefix")] === "CC")).toBeUndefined();
+    expect(t.results.find((r) => r[colIndex(t, "feature_prefix")] === "DD")).toBeUndefined();
+  });
+});

--- a/metrics/src/providers/task-store-provider.unit.test.ts
+++ b/metrics/src/providers/task-store-provider.unit.test.ts
@@ -146,6 +146,40 @@ describe("TaskStoreProvider.featuresReviews (unit) — task-originated grouping"
     expect(rowBB?.[colIndex(t, "reviews_ship_it")]).toBe(1);
   });
 
+  test("a task with repo null and a matching pr groups against a non-null-repo PR record", async () => {
+    const tasks: TaskRecord[] = [
+      {
+        id: "EE-1.1",
+        status: "merged",
+        repo: null,
+        pr: 55,
+        startedAt: "2026-06-02T08:00:00.000Z",
+        completedAt: "2026-06-02T12:00:00.000Z",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+        createdAt: "2026-06-01T08:00:00.000Z",
+      },
+    ];
+    const prs: PrRecord[] = [
+      {
+        taskId: null,
+        prNumber: 55,
+        repo: "org/repo",
+        reviewState: "approved",
+        mergedAt: "2026-06-02T12:00:00.000Z",
+      },
+    ];
+
+    const provider = buildProvider(tasks, prs);
+    const t = await provider.query({ kind: "featuresReviews", range: RANGE });
+
+    const row = t.results.find(
+      (r) => r[colIndex(t, "feature_prefix")] === "EE",
+    );
+    expect(row).toBeDefined();
+    expect(row?.[colIndex(t, "reviews_total")]).toBe(1);
+    expect(row?.[colIndex(t, "reviews_ship_it")]).toBe(1);
+  });
+
   test("a task with no matching PR (missing .pr or no matching record) contributes nothing, no crash", async () => {
     const tasks: TaskRecord[] = [
       {

--- a/metrics/src/providers/task-store-provider.unit.test.ts
+++ b/metrics/src/providers/task-store-provider.unit.test.ts
@@ -88,7 +88,9 @@ describe("TaskStoreProvider.featuresReviews (unit) — task-originated grouping"
     const provider = buildProvider(tasks, prs);
     const t = await provider.query({ kind: "featuresReviews", range: RANGE });
 
-    const row = t.results.find((r) => r[colIndex(t, "feature_prefix")] === "QS");
+    const row = t.results.find(
+      (r) => r[colIndex(t, "feature_prefix")] === "QS",
+    );
     expect(row).toBeDefined();
     expect(row?.[colIndex(t, "reviews_total")]).toBe(1);
     expect(row?.[colIndex(t, "reviews_ship_it")]).toBe(1);
@@ -130,8 +132,12 @@ describe("TaskStoreProvider.featuresReviews (unit) — task-originated grouping"
     const provider = buildProvider(tasks, prs);
     const t = await provider.query({ kind: "featuresReviews", range: RANGE });
 
-    const rowAA = t.results.find((r) => r[colIndex(t, "feature_prefix")] === "AA");
-    const rowBB = t.results.find((r) => r[colIndex(t, "feature_prefix")] === "BB");
+    const rowAA = t.results.find(
+      (r) => r[colIndex(t, "feature_prefix")] === "AA",
+    );
+    const rowBB = t.results.find(
+      (r) => r[colIndex(t, "feature_prefix")] === "BB",
+    );
     expect(rowAA).toBeDefined();
     expect(rowBB).toBeDefined();
     expect(rowAA?.[colIndex(t, "reviews_total")]).toBe(1);
@@ -168,7 +174,11 @@ describe("TaskStoreProvider.featuresReviews (unit) — task-originated grouping"
     const provider = buildProvider(tasks, prs);
     const t = await provider.query({ kind: "featuresReviews", range: RANGE });
 
-    expect(t.results.find((r) => r[colIndex(t, "feature_prefix")] === "CC")).toBeUndefined();
-    expect(t.results.find((r) => r[colIndex(t, "feature_prefix")] === "DD")).toBeUndefined();
+    expect(
+      t.results.find((r) => r[colIndex(t, "feature_prefix")] === "CC"),
+    ).toBeUndefined();
+    expect(
+      t.results.find((r) => r[colIndex(t, "feature_prefix")] === "DD"),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- `groupPrsByPrefix()` now originates from `tasks` (task.id-derived prefix + task.pr) instead of reading the unreliable `pr.taskId` field, which is populated only ~10% of the time (0% in several repos) — this dashboard grouping was silently incomplete for the large majority of PRs.
- Each task's own `.pr` is matched against the fetched PR list by `(repo, prNumber)`, so a PR shared by multiple tasks (bundle case) now correctly appears under each of those tasks' feature buckets instead of only one.
- `TaskRecord`/`PrRecord` gained the `pr`/`prNumber` fields needed to do that matching.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | groupPrsByPrefix derives groupings from task records, not pr.taskId | MET | `groupPrsByPrefix(tasks, prs)` loops over tasks, derives prefix from `t.id`, matches PR via `(t.repo, t.pr)` |
| 2 | PR with taskId null still groups via matching task.pr | MET | Integration + unit tests set `taskId: null` with matching `task.pr` and assert correct grouping |
| 3 | Bundle PR (shared by 2 tasks) appears under each task's bucket | MET | Unit test asserts a shared PR appears under both feature buckets |
| 4 | Unit tests added for both cases; stale pr.taskId-only fixtures retired | MET | New `task-store-provider.unit.test.ts`; integration fixtures changed from `taskId: "QS-1.1"` to `taskId: null` + `prNumber` |
| 5 | Safe to deploy standalone (no schema change) | MET | Only dashboard grouping logic + test fixtures changed |

## Test Plan
- `bun test src/providers/task-store-provider.unit.test.ts src/providers/task-store-provider.integration.test.ts` — 28 pass, 0 fail
- `tsc --noEmit` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
