### PR TITLE
fix: catch synchronous throw when Slack client lacks agents namespace

### DIFF
--- a/agent/src/slack-progress.ts
+++ b/agent/src/slack-progress.ts
@@ -18,12 +18,14 @@
  * stay open for follow-up messages — "closed" is for ending a conversation
  * entirely.
  *
- * Every Slack API call is wrapped in .catch(() => {}) — a progress failure
- * must never throw or break the real reply.
+ * Every Slack API call is wrapped in try/catch — a progress failure must
+ * never throw or break the real reply. This covers a client that lacks the
+ * `agents` namespace entirely (property access throws synchronously), not
+ * just a setStatus() call that rejects.
  */
 
-import type { ModelUsage } from "./claude.ts";
 import type { ProgressPhase } from "@shipwright/lib/progress-phases";
+import type { ModelUsage } from "./claude.ts";
 
 // biome-ignore lint/suspicious/noExplicitAny: Bolt client type is complex
 type SlackClient = any;
@@ -60,13 +62,25 @@ export class SlackProgress {
   private async setStatus(
     status: "active" | "processing" | "suspended" | "closed",
   ): Promise<void> {
-    await this.client.agents.sessions
-      .setStatus({
+    // The whole call — including the `agents.sessions` property access, not
+    // just the setStatus() promise — is wrapped in try/catch: a Bolt client
+    // built from a `@slack/web-api` version that predates the Agent Sessions
+    // API (as of 2026-08-20) has no `agents` namespace at all, so accessing
+    // it throws synchronously before setStatus() is ever called and a
+    // trailing `.catch()` never attaches. A progress failure must never
+    // throw or break the real reply.
+    try {
+      await this.client.agents.sessions.setStatus({
         channel_id: this.channel,
         thread_ts: this.threadTs,
         status,
-      })
-      .catch(() => {});
+      });
+    } catch (err) {
+      console.warn(
+        `[slack-progress] setStatus(${status}) failed:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   }
 
   /**

--- a/agent/src/slack-progress.unit.test.ts
+++ b/agent/src/slack-progress.unit.test.ts
@@ -5,14 +5,17 @@
  * thread replies. Covers start()/finish() calling `agents.sessions.setStatus`
  * with the fixed lifecycle values ("processing" / "active"), that onProgress()
  * no longer drives any Slack API call (the new API has no per-phase text
- * slot), and that every Slack API failure is swallowed rather than thrown.
+ * slot), and that every Slack API failure is swallowed rather than thrown
+ * (and logged via console.warn instead — swapped in per-test via a local
+ * save/restore, same pattern as check-helpers.unit.test.ts's
+ * mapReposTolerant suite, since Bun shares the test process globally).
  *
  * The mock Slack client is a plain object of mock fns — no mock.module(), no
  * global overrides. No Clock injection is needed: SlackProgress does no
  * time-based scheduling.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { SlackProgress } from "./slack-progress.ts";
 
 // ─── Mock Slack client ────────────────────────────────────────────────────────
@@ -95,21 +98,76 @@ describe("SlackProgress — finish()", () => {
 // ─── errors-swallowed ────────────────────────────────────────────────────────────
 
 describe("SlackProgress — errors swallowed", () => {
-  test("start() does not throw when setStatus rejects", async () => {
+  let savedWarn: typeof console.warn;
+  let warnCalls: unknown[][];
+
+  beforeEach(() => {
+    savedWarn = console.warn;
+    warnCalls = [];
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+  });
+
+  afterEach(() => {
+    console.warn = savedWarn;
+  });
+
+  test("start() does not throw when setStatus rejects, and warns", async () => {
     const client = makeMockClient();
     client.agents.sessions.setStatus.mockRejectedValueOnce(
       new Error("api down"),
     );
     const { progress } = makeProgress({ client });
     await expect(progress.start()).resolves.toBeUndefined();
+    expect(warnCalls).toEqual([
+      ["[slack-progress] setStatus(processing) failed:", "api down"],
+    ]);
   });
 
-  test("finish() does not throw when setStatus rejects", async () => {
+  test("finish() does not throw when setStatus rejects, and warns", async () => {
     const client = makeMockClient();
     client.agents.sessions.setStatus.mockRejectedValueOnce(
       new Error("api down"),
     );
     const { progress } = makeProgress({ client });
     await expect(progress.finish()).resolves.toBeUndefined();
+    expect(warnCalls).toEqual([
+      ["[slack-progress] setStatus(active) failed:", "api down"],
+    ]);
+  });
+
+  // Regression: a Bolt-supplied client built from a @slack/web-api version
+  // that predates the Agent Sessions API has no `agents` namespace at all —
+  // accessing `.agents.sessions` throws synchronously, before setStatus()
+  // is ever called, so a trailing `.catch()` never attaches.
+  test("start() does not throw when the client has no agents namespace, and warns", async () => {
+    const progress = new SlackProgress({
+      client: {},
+      channel: CHANNEL,
+      threadTs: THREAD_TS,
+    });
+    await expect(progress.start()).resolves.toBeUndefined();
+    expect(warnCalls).toEqual([
+      [
+        "[slack-progress] setStatus(processing) failed:",
+        "undefined is not an object (evaluating 'this.client.agents.sessions')",
+      ],
+    ]);
+  });
+
+  test("finish() does not throw when the client has no agents namespace, and warns", async () => {
+    const progress = new SlackProgress({
+      client: {},
+      channel: CHANNEL,
+      threadTs: THREAD_TS,
+    });
+    await expect(progress.finish()).resolves.toBeUndefined();
+    expect(warnCalls).toEqual([
+      [
+        "[slack-progress] setStatus(active) failed:",
+        "undefined is not an object (evaluating 'this.client.agents.sessions')",
+      ],
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

Three Slack-enabled Shipwright agents in production (vitals-os namespace) were repeatedly logging:

```
TypeError: undefined is not an object (evaluating 'this.client.agents.sessions')
  at setStatus (agent/src/slack-progress.ts:63)
An unhandled error occurred while Bolt processed (type: event_callback, ...)
```

`SlackProgress.setStatus()` (#2997) calls `this.client.agents.sessions.setStatus(...)`, Slack's new Agent Sessions API. The `client` passed into Bolt event handlers is built from Bolt's own bundled `@slack/web-api` dependency (`^7.16.0`, resolved to `7.19.0`), which predates that API — it has no `agents` namespace at all.

The bug: only the `setStatus()` *promise* was wrapped in `.catch(() => {})`. Accessing `this.client.agents.sessions` throws **synchronously**, before `.setStatus()` is even called and before `.catch()` ever attaches to anything. That throw becomes an unhandled rejection in the surrounding `async` function, propagating up through `start()`/`finish()` into Bolt's event pipeline — visibly breaking Slack thread status updates and spamming error logs on every Slack-triggered agent run.

## Fix

- Wrap the whole call — property access included — in `try/catch`, matching the class's stated invariant that a progress failure must never throw or break the real reply.
- Log the swallowed error via `console.warn` (previously it vanished silently, even on the pre-existing rejection path) — matches the swallowed-error convention already used by `mapReposTolerant` in `check-helpers.ts`. A genuine `setStatus` failure (rate limit, bad token, etc.) now stays visible instead of disappearing without a trace.

## Testing

- Added regression tests: a client with no `agents` namespace at all (reproduces the exact production failure) and a rejecting `setStatus` call, both asserting the warning is logged with the expected message.
- `bun test agent/src/slack-progress.unit.test.ts` — 9 pass.
- `bunx biome check` — clean on both touched files.
- `tsc --noEmit` in `agent/` shows pre-existing, unrelated errors (stale generated Prisma client / missing `playwright`/`yaml` deps) present identically on `main` before this change — confirmed via `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pNRtq4qTN2Zz916zJwfQN