### PR TITLE
fix(agent): patch @slack/socket-mode's undici ping for Bun compat

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -32,6 +32,7 @@ COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
 COPY mcp-server/package.json ./mcp-server/
+COPY patches/ ./patches/
 
 RUN bun install --frozen-lockfile
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -149,6 +149,7 @@ COPY chat/prisma ./chat/prisma/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
 COPY mcp-server/package.json ./mcp-server/
+COPY patches/ ./patches/
 
 # Install all dependencies (including devDependencies for typecheck)
 RUN bun install --frozen-lockfile

--- a/agent/package.json
+++ b/agent/package.json
@@ -20,7 +20,9 @@
     "playwright": "1.61.1"
   },
   "devDependencies": {
+    "@types/ws": "^8.18.1",
     "bun-types": "^1.3.14",
-    "typescript": "*"
+    "typescript": "*",
+    "ws": "^8.21.3"
   }
 }

--- a/agent/src/slack-socket-mode-ping.integration.test.ts
+++ b/agent/src/slack-socket-mode-ping.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * agent/src/slack-socket-mode-ping.integration.test.ts
+ *
+ * Regression coverage for the fleet-wide Slack reconnect-loop incident that
+ * followed the @slack/bolt 4.7.3 -> 5.0.0 bump (SSB-1.1, #3006): Bolt 5's
+ * bundled @slack/socket-mode@3.x builds its whole ping/pong heartbeat
+ * (SlackWebSocket's monitorPingToSlack / monitorPingFromSlack) on the real
+ * `undici` package's module-level `ping()` helper and its
+ * `undici:websocket:ping` / `undici:websocket:pong` diagnostics_channel
+ * events. Bun always intercepts the bare "undici" specifier with its own
+ * built-in polyfill — even though the real package is installed right
+ * alongside it — and that polyfill implements neither API
+ * (oven-sh/bun#37110, root-caused and reproduced by Bun's own team; fix in
+ * progress at PR #37111, unmerged as of this writing). Under Bun, every
+ * client-side ping tick threw `undici_1.ping is not a function` and
+ * immediately disconnected — a continuous ~5-7s reconnect loop across the
+ * whole agent fleet, not an intermittent Slack-side issue.
+ *
+ * patches/@slack%2Fsocket-mode@3.0.1.patch (see package.json
+ * `patchedDependencies`) fixes this by requiring `undici/index.js` (a
+ * subpath, which Bun's specifier interception does not match) instead of
+ * bare `"undici"` — resolving the real, complete undici package that
+ * already satisfies this file's own `peerDependencies: { undici: "^7.0.0"
+ * }` and sits right there as a sibling in its own resolved node_modules.
+ *
+ * No existing suite would catch a regression here:
+ *   - slack.integration.test.ts / slack-bolt-client.integration.test.ts
+ *     construct a real @slack/bolt App but never open a live socket-mode
+ *     connection, so they never reach SlackWebSocket's ping/pong cycle.
+ *   - A unit test mocking the websocket/undici surface would pass
+ *     regardless of which `undici` Bun actually resolves at runtime — the
+ *     whole failure mode is specific to Bun's real, unmocked module
+ *     resolution.
+ *
+ * This test opens a REAL local WebSocket server and drives @slack/bolt's
+ * actual bundled @slack/socket-mode's SlackWebSocket against it — resolved
+ * via require.resolve anchored at @slack/bolt's own location, so it
+ * exercises the exact same file and dependency resolution Bolt uses in
+ * production — asserting both ping directions succeed and the connection
+ * survives multiple ping/pong cycles without disconnecting.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { WebSocketServer } from "ws";
+
+type SlackWebSocketCtor = new (options: {
+  url: string;
+  client: EventEmitter;
+  logger: {
+    getLevel: () => string;
+    debug: (...args: unknown[]) => void;
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+  pingInterval?: number;
+  clientPingTimeoutMS?: number;
+  serverPingTimeoutMS?: number;
+}) => {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+};
+
+function resolveSlackWebSocket(): SlackWebSocketCtor {
+  const boltEntry = require.resolve("@slack/bolt");
+  const swPath = require.resolve(
+    "@slack/socket-mode/dist/src/SlackWebSocket.js",
+    {
+      paths: [boltEntry],
+    },
+  );
+  // biome-ignore lint/suspicious/noExplicitAny: dynamic require of an internal dist file
+  return (require(swPath) as any).SlackWebSocket;
+}
+
+describe("@slack/socket-mode SlackWebSocket — ping/pong heartbeat under Bun", () => {
+  test("client ping, server ping, and pong detection all work without disconnecting", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const port = (server.address() as { port: number }).port;
+
+    let serverGotClientPing = false;
+    let serverSentPing = false;
+    server.on("connection", (ws) => {
+      ws.on("ping", () => {
+        serverGotClientPing = true;
+      });
+      // Simulate Slack's own server-initiated pings.
+      const interval = setInterval(() => {
+        serverSentPing = true;
+        ws.ping(Buffer.from("srv"));
+      }, 300);
+      ws.on("close", () => clearInterval(interval));
+    });
+
+    const SlackWebSocket = resolveSlackWebSocket();
+    const client = new EventEmitter();
+    let disconnected = false;
+    client.on("close", () => {
+      disconnected = true;
+    });
+
+    const errors: string[] = [];
+    const sw = new SlackWebSocket({
+      url: `ws://localhost:${port}`,
+      client,
+      logger: {
+        getLevel: () => "info",
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: (m: unknown) => {
+          errors.push(String(m));
+        },
+      },
+      pingInterval: 300,
+      clientPingTimeoutMS: 900,
+      serverPingTimeoutMS: 1500,
+    });
+
+    try {
+      await sw.connect();
+      // Long enough to cross several ping intervals in both directions —
+      // the original bug disconnected on the very first tick.
+      await new Promise((r) => setTimeout(r, 2000));
+
+      expect(errors).toEqual([]);
+      expect(serverGotClientPing).toBe(true);
+      expect(serverSentPing).toBe(true);
+      expect(disconnected).toBe(false);
+    } finally {
+      sw.disconnect();
+      server.close();
+    }
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.214.0",
+      "version": "1.215.1",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -60,8 +60,10 @@
         "playwright": "1.61.1",
       },
       "devDependencies": {
+        "@types/ws": "^8.18.1",
         "bun-types": "^1.3.14",
         "typescript": "*",
+        "ws": "^8.21.3",
       },
     },
     "chat": {
@@ -100,12 +102,12 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.214.0",
+      "version": "1.215.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
         "@sentry/hono": "^10.63.0",
-        "@shipwright/lib": "*",
+        "@shipwright/lib": "workspace:*",
         "hono": "^4.13.1",
         "openapi-fetch": "^0.13",
         "zod": "^3",
@@ -118,7 +120,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.214.0",
+      "version": "1.215.1",
       "devDependencies": {
         "bun-types": "*",
         "typescript": "*",
@@ -142,6 +144,9 @@
         "typescript": "*",
       },
     },
+  },
+  "patchedDependencies": {
+    "@slack/socket-mode@3.0.1": "patches/@slack%2Fsocket-mode@3.0.1.patch",
   },
   "overrides": {
     "@hono/node-server": "^2.0.12",
@@ -383,6 +388,8 @@
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
     "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -1101,6 +1108,8 @@
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -27,6 +27,7 @@ COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
 COPY mcp-server/package.json ./mcp-server/
+COPY patches/ ./patches/
 
 RUN bun install --frozen-lockfile
 

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -29,6 +29,7 @@ COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
 COPY mcp-server/package.json ./mcp-server/
+COPY patches/ ./patches/
 
 RUN bun install --frozen-lockfile
 

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -37,6 +37,7 @@ COPY agent/package.json ./agent/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
 COPY mcp-server/package.json ./mcp-server/
+COPY patches/ ./patches/
 
 RUN bun install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "js-yaml": "^4.3.1",
     "tar": "^7.5.21",
     "deepmerge-ts": "^8.0.2"
+  },
+  "patchedDependencies": {
+    "@slack/socket-mode@3.0.1": "patches/@slack%2Fsocket-mode@3.0.1.patch"
   }
 }

--- a/patches/@slack%2Fsocket-mode@3.0.1.patch
+++ b/patches/@slack%2Fsocket-mode@3.0.1.patch
@@ -1,0 +1,141 @@
+diff --git a/node_modules/@slack/socket-mode/.bun-tag-120797cf624f9ab3 b/.bun-tag-120797cf624f9ab3
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@slack/socket-mode/.bun-tag-32110a218c551f17 b/.bun-tag-32110a218c551f17
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/src/SlackWebSocket.js b/dist/src/SlackWebSocket.js
+index 1e38e34650c34b8cd78e9fc7e76ae3b611a16c91..4363be025fe3b78ee0aef138af499820dc0a85c2 100644
+--- a/dist/src/SlackWebSocket.js
++++ b/dist/src/SlackWebSocket.js
+@@ -35,7 +35,29 @@ var __importStar = (this && this.__importStar) || (function () {
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.SlackWebSocket = exports.WS_READY_STATES = void 0;
+ const node_diagnostics_channel_1 = require("node:diagnostics_channel");
+-const undici_1 = require("undici");
++// PATCH (Bun/undici compat, oven-sh/bun#37110): Bun always intercepts the
++// bare "undici" specifier with its own built-in polyfill — even when the
++// real npm `undici` package is installed right alongside it — and that
++// polyfill implements neither the module-level `ping()` helper nor the
++// `undici:websocket:ping`/`undici:websocket:pong` diagnostics_channel events
++// this file's whole ping/pong heartbeat (monitorPingToSlack,
++// monitorPingFromSlack) is built on. Under Bun, every tick of the client's
++// own keepalive ping throws (undici_1.ping is not a function) and
++// immediately disconnects; separately, since Bun's WebSocket never
++// publishes to those diagnostics channels, incoming server pings and pong
++// replies would go undetected even if the ping call itself were patched to
++// succeed some other way — confirmed against oven-sh/bun#37110 (root-caused
++// and reproduced by Bun's own team; fix in progress at PR #37111, unmerged).
++// Bun's bare-specifier interception matches only the exact string "undici" —
++// a subpath require falls through to normal filesystem resolution and finds
++// the real, complete `undici` package satisfying this file's own
++// `peerDependencies: { undici: "^7.0.0" }` (present as a sibling in this
++// package's own resolved node_modules; no separate alias dependency
++// needed). Using it for every undici API this file touches (not just ping)
++// keeps WebSocket, ping, and the diagnostics channels it relies on all
++// coming from one consistent, real implementation — not something a Bun
++// version bump is expected to fix.
++const undici_1 = require("undici/index.js");
+ const errors_1 = require("./errors");
+ const logger_1 = __importStar(require("./logger"));
+ exports.WS_READY_STATES = ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'];
+diff --git a/dist/src/SocketModeClient.js b/dist/src/SocketModeClient.js
+index 1809f52fba621ab556098d4b03c04fee898736e5..bca8ffbed8d54590104bf3748a29605e167d8f1a 100644
+--- a/dist/src/SocketModeClient.js
++++ b/dist/src/SocketModeClient.js
+@@ -39,7 +39,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.SocketModeClient = void 0;
+ const web_api_1 = require("@slack/web-api");
+ const eventemitter3_1 = require("eventemitter3");
+-const undici_1 = require("undici");
++// PATCH (Bun/undici compat, oven-sh/bun#37110): see the matching patch note
++// in SlackWebSocket.js — kept consistent here so the `dispatcher` this file
++// builds (when one is configured) is a real-undici dispatcher, matching the
++// real-undici WebSocket that SlackWebSocket.js now constructs, rather than
++// mixing a Bun-shim dispatcher into a real-undici WebSocket.
++const undici_1 = require("undici/index.js");
+ const package_json_1 = __importDefault(require("../package.json"));
+ const errors_1 = require("./errors");
+ const logger_1 = __importStar(require("./logger"));
+diff --git a/node_modules/@slack/socket-mode/package.json.bak b/package.json.bak
+new file mode 100644
+index 0000000000000000000000000000000000000000..19e13326640d9d106f8a6f97acb310a9d121eefc
+--- /dev/null
++++ b/package.json.bak
+@@ -0,0 +1,76 @@
++{
++  "name": "@slack/socket-mode",
++  "version": "3.0.1",
++  "description": "Official library for using the Slack Platform's Socket Mode API",
++  "author": "Slack Technologies, LLC",
++  "license": "MIT",
++  "keywords": [
++    "slack",
++    "socket",
++    "websocket",
++    "firewall",
++    "bot",
++    "client",
++    "http",
++    "websocket",
++    "api",
++    "proxy",
++    "state",
++    "connection"
++  ],
++  "main": "dist/src/index.js",
++  "types": "./dist/src/index.d.ts",
++  "files": [
++    "dist/**/*"
++  ],
++  "engines": {
++    "node": ">=20",
++    "npm": ">=9.6.4"
++  },
++  "repository": {
++    "type": "git",
++    "url": "git+https://github.com/slackapi/node-slack-sdk.git"
++  },
++  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/socket-mode/",
++  "publishConfig": {
++    "access": "public"
++  },
++  "bugs": {
++    "url": "https://github.com/slackapi/node-slack-sdk/issues"
++  },
++  "scripts": {
++    "build": "npm run build:clean && tsc",
++    "build:clean": "shx rm -rf ./dist",
++    "docs": "npx typedoc --plugin typedoc-plugin-markdown",
++    "prepack": "npm run build",
++    "test": "npm run test:unit && npm run test:integration",
++    "test:coverage": "npm run build && bash -c 'node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts test/integrations/*.test.js'",
++    "test:integration": "npm run build && bash -c 'node --import tsx --test test/integrations/*.test.js'",
++    "test:types": "tsd",
++    "test:unit": "npm run build && bash -c 'node --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts'",
++    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm test"
++  },
++  "dependencies": {
++    "@slack/logger": "^5.0.0",
++    "@slack/web-api": "^8.0.0",
++    "@types/node": ">=20",
++    "eventemitter3": "^5",
++    "undici-real": "npm:undici@^7.29.0"
++  },
++  "peerDependencies": {
++    "undici": "^7.0.0"
++  },
++  "devDependencies": {
++    "@types/proxyquire": "^1.3.31",
++    "@types/sinon": "^22.0.0",
++    "nodemon": "^3.1.0",
++    "proxyquire": "^2.1.3",
++    "sinon": "^22.1.0",
++    "tsd": "^0.33.0",
++    "undici": "^7.25.0",
++    "ws": "^8.21.3"
++  },
++  "tsd": {
++    "directory": "test/types"
++  }
++}

--- a/patches/@slack%2Fsocket-mode@3.0.1.patch
+++ b/patches/@slack%2Fsocket-mode@3.0.1.patch
@@ -4,6 +4,9 @@ index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2
 diff --git a/node_modules/@slack/socket-mode/.bun-tag-32110a218c551f17 b/.bun-tag-32110a218c551f17
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@slack/socket-mode/.bun-tag-e28ad44d755772b7 b/.bun-tag-e28ad44d755772b7
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/src/SlackWebSocket.js b/dist/src/SlackWebSocket.js
 index 1e38e34650c34b8cd78e9fc7e76ae3b611a16c91..4363be025fe3b78ee0aef138af499820dc0a85c2 100644
 --- a/dist/src/SlackWebSocket.js
@@ -57,85 +60,3 @@ index 1809f52fba621ab556098d4b03c04fee898736e5..bca8ffbed8d54590104bf3748a29605e
  const package_json_1 = __importDefault(require("../package.json"));
  const errors_1 = require("./errors");
  const logger_1 = __importStar(require("./logger"));
-diff --git a/node_modules/@slack/socket-mode/package.json.bak b/package.json.bak
-new file mode 100644
-index 0000000000000000000000000000000000000000..19e13326640d9d106f8a6f97acb310a9d121eefc
---- /dev/null
-+++ b/package.json.bak
-@@ -0,0 +1,76 @@
-+{
-+  "name": "@slack/socket-mode",
-+  "version": "3.0.1",
-+  "description": "Official library for using the Slack Platform's Socket Mode API",
-+  "author": "Slack Technologies, LLC",
-+  "license": "MIT",
-+  "keywords": [
-+    "slack",
-+    "socket",
-+    "websocket",
-+    "firewall",
-+    "bot",
-+    "client",
-+    "http",
-+    "websocket",
-+    "api",
-+    "proxy",
-+    "state",
-+    "connection"
-+  ],
-+  "main": "dist/src/index.js",
-+  "types": "./dist/src/index.d.ts",
-+  "files": [
-+    "dist/**/*"
-+  ],
-+  "engines": {
-+    "node": ">=20",
-+    "npm": ">=9.6.4"
-+  },
-+  "repository": {
-+    "type": "git",
-+    "url": "git+https://github.com/slackapi/node-slack-sdk.git"
-+  },
-+  "homepage": "https://docs.slack.dev/tools/node-slack-sdk/socket-mode/",
-+  "publishConfig": {
-+    "access": "public"
-+  },
-+  "bugs": {
-+    "url": "https://github.com/slackapi/node-slack-sdk/issues"
-+  },
-+  "scripts": {
-+    "build": "npm run build:clean && tsc",
-+    "build:clean": "shx rm -rf ./dist",
-+    "docs": "npx typedoc --plugin typedoc-plugin-markdown",
-+    "prepack": "npm run build",
-+    "test": "npm run test:unit && npm run test:integration",
-+    "test:coverage": "npm run build && bash -c 'node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts test/integrations/*.test.js'",
-+    "test:integration": "npm run build && bash -c 'node --import tsx --test test/integrations/*.test.js'",
-+    "test:types": "tsd",
-+    "test:unit": "npm run build && bash -c 'node --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml --import tsx --test src/*.test.ts'",
-+    "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm test"
-+  },
-+  "dependencies": {
-+    "@slack/logger": "^5.0.0",
-+    "@slack/web-api": "^8.0.0",
-+    "@types/node": ">=20",
-+    "eventemitter3": "^5",
-+    "undici-real": "npm:undici@^7.29.0"
-+  },
-+  "peerDependencies": {
-+    "undici": "^7.0.0"
-+  },
-+  "devDependencies": {
-+    "@types/proxyquire": "^1.3.31",
-+    "@types/sinon": "^22.0.0",
-+    "nodemon": "^3.1.0",
-+    "proxyquire": "^2.1.3",
-+    "sinon": "^22.1.0",
-+    "tsd": "^0.33.0",
-+    "undici": "^7.25.0",
-+    "ws": "^8.21.3"
-+  },
-+  "tsd": {
-+    "directory": "test/types"
-+  }
-+}

--- a/task-store/Dockerfile
+++ b/task-store/Dockerfile
@@ -27,6 +27,7 @@ COPY metrics/package.json ./metrics/
 COPY plugins/shipwright/package.json ./plugins/shipwright/
 COPY lib/package.json ./lib/
 COPY mcp-server/package.json ./mcp-server/
+COPY patches/ ./patches/
 
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Fixes a live, fleet-wide incident: since `@slack/bolt` was bumped to `5.0.0` (#3006), every Shipwright agent's Slack socket-mode connection has been stuck in a continuous ~5-7s reconnect loop in production, not an intermittent Slack-side issue.

## Root cause

Bolt `5.0.0` bundles `@slack/socket-mode@3.x`, whose ping/pong heartbeat (`SlackWebSocket`'s `monitorPingToSlack` / `monitorPingFromSlack`) depends on:
- the real `undici` package's module-level `ping()` helper, and
- its `undici:websocket:ping` / `undici:websocket:pong` `node:diagnostics_channel` events.

Bun always intercepts the bare `"undici"` specifier with its own built-in polyfill — even when the real package is installed right alongside it — and that polyfill implements neither API. Every client-side ping tick threw `undici_1.ping is not a function` and immediately called `disconnect()`.

This is a confirmed, currently-open Bun bug: [oven-sh/bun#37110](https://github.com/oven-sh/bun/issues/37110), root-caused and reproduced by Bun's own team, with a fix in progress at [PR #37111](https://github.com/oven-sh/bun/pull/37111) (unmerged). It is **not** a bug in `@slack/socket-mode` — its code is correct under real Node.js + real `undici`. It's also not something a Bun version bump fixes today (long-standing, unscheduled gap — see oven-sh/bun#17799, #19748).

## Fix

Patches `@slack/socket-mode@3.0.1` (via `bun patch`, tracked in `patchedDependencies`) so both of its `require("undici")` call sites (`SlackWebSocket.js`, `SocketModeClient.js`) use a subpath require — `require("undici/index.js")` — instead of the bare specifier. Bun's interception matches only the exact string `"undici"`; the subpath falls through to normal filesystem resolution and finds the real, complete `undici` package that already satisfies this file's own `peerDependencies: { undici: "^7.0.0" }`, sitting right there as a sibling in its own resolved `node_modules`. No new dependency needed — an earlier alias-based approach (`"undici-real": "npm:undici@..."`) was considered but turned out to be unnecessary and didn't resolve cleanly under this repo's Bun install layout anyway.

## Verification

- Reproduced the exact production failure locally against a real WebSocket server, both **before** (unpatched: throws `undici_1.ping is not a function`, client disconnects) and **after** (patched: clean, both ping directions delivered, connection survives multiple ping/pong cycles).
- Verified through a full clean-room `bun install --frozen-lockfile` — the exact command `agent/Dockerfile` runs — confirming the patch travels via the committed `patches/*.patch` + `patchedDependencies` and isn't local-only state.
- Added `agent/src/slack-socket-mode-ping.integration.test.ts`, which drives `@slack/bolt`'s actual bundled `SlackWebSocket` (resolved the same way Bolt resolves it in production) against a real local WebSocket server. Confirmed this test fails against the unpatched package and passes against the patched one.
- Full `agent/` suite (1632 tests), lint, and typecheck all green.

## Follow-up

Once oven-sh/bun#37111 merges and lands in a Bun release we take, drop `patches/@slack%2Fsocket-mode@3.0.1.patch` and the `patchedDependencies` entry in one small cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)