### PR TITLE
fix: resolve and persist agent.slackId after Slack OAuth completes

### DIFF
--- a/admin/src/admin-dev-login.smoke.test.ts
+++ b/admin/src/admin-dev-login.smoke.test.ts
@@ -197,6 +197,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
         clientSecret: "test-client-secret",
         signingSecret: "test-signing-secret",
       }),
+      authTest: async () => ({ userId: "U0AALR8M69X" }),
       updateAppManifest: async () => {},
       exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
     },

--- a/admin/src/admin-local-agent.smoke.test.ts
+++ b/admin/src/admin-local-agent.smoke.test.ts
@@ -83,6 +83,7 @@ function makeMockDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
     }),
     updateAppManifest: async () => {},
     exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
+    authTest: async () => ({ userId: "U0AALR8M69X" }),
   };
 
   const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {

--- a/admin/src/admin-tokens.smoke.test.ts
+++ b/admin/src/admin-tokens.smoke.test.ts
@@ -54,6 +54,7 @@ const BASE_SLACK_CLIENT: AdminUISlackClient = {
   }),
   updateAppManifest: async () => {},
   exchangeOAuthCode: async () => ({ botToken: "xoxb-mock" }),
+  authTest: async () => ({ userId: "U0AALR8M69X" }),
 };
 
 const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -4723,6 +4723,119 @@ describe("admin UI — GET /admin/agents/:id/connect-slack/callback", () => {
     expect(patchCalls.some((c) => "SLACK_BOT_TOKEN" in c.env)).toBe(true);
   });
 
+  it("valid state cookie + code param → persists the resolved slackId through the full HTTP route, and the agent detail page then renders the Sync Manifest button (UAP-1.3 acceptance criterion 2)", async () => {
+    // Step 1: exercise the real connect-slack/callback HTTP route (not just
+    // the service layer) with an agent that has no slackId yet, and prove
+    // agentService.updateFields is invoked with the Slack-resolved user id.
+    const updateFieldsCalls: Array<{
+      agentId: string;
+      fields: { slackId?: string | null };
+    }> = [];
+    const initialAgent = {
+      id: AGENT_ID,
+      name: "Test Agent",
+      slackId: null,
+      selfHosted: false,
+      typeName: "coding",
+      createdAt: new Date("2024-01-01"),
+      updatedAt: new Date("2024-01-01"),
+      repos: [],
+      authorAllowlist: [],
+      restrictSlackToMembers: false,
+      missingRequiredEnv: [],
+    };
+
+    const callbackApp = createAdminUIApp(
+      makeMockDeps({
+        agentService: {
+          listAll: async () => [],
+          listByIds: async () => [],
+          searchByName: async () => [],
+          listOptions: async () => [],
+          create: async () => {
+            throw new Error("not implemented");
+          },
+          delete: async () => {},
+          getDetail: async () => initialAgent,
+          updateFields: async (
+            agentId: string,
+            fields: { slackId?: string | null },
+          ) => {
+            updateFieldsCalls.push({ agentId, fields });
+            return { ...initialAgent, ...fields };
+          },
+        },
+        agentEnvService: {
+          getByAgentId: async () => ({ env: {}, secretKeys: [] }),
+          upsert: async () => {},
+          patch: async () => {},
+          deleteKey: async () => {},
+          getConfigBundle: async () => null,
+        },
+      }),
+    );
+
+    // Sanity check: before the flow, the agent page does NOT show the
+    // Sync Manifest button (slackId is null).
+    const beforeRes = await callbackApp.request(`/admin/agents/${AGENT_ID}`, {
+      headers: { Cookie: `admin_session=${adminCookie}` },
+    });
+    expect(beforeRes.status).toBe(200);
+    const beforeHtml = await beforeRes.text();
+    expect(beforeHtml).not.toContain("Sync Manifest");
+
+    const provisionState = await makeProvisionStateCookie();
+    const callbackRes = await callbackApp.request(
+      `/admin/agents/${AGENT_ID}/connect-slack/callback?code=valid-oauth-code`,
+      {
+        headers: {
+          Cookie: `admin_session=${adminCookie}; ${PROVISION_STATE_COOKIE}=${provisionState}`,
+        },
+      },
+    );
+    expect(callbackRes.status).toBe(200);
+
+    // The key assertion: updateFields was called through the real HTTP
+    // route with a non-null, non-empty slackId for the correct agent.
+    expect(updateFieldsCalls).toHaveLength(1);
+    expect(updateFieldsCalls[0]?.agentId).toBe(AGENT_ID);
+    expect(updateFieldsCalls[0]?.fields.slackId).toBeTruthy();
+
+    // Step 2: prove admin-ui-pages.ts's Sync Manifest gate renders once
+    // slackId is populated, by hitting the agent detail route again with
+    // a mock reflecting the post-flow (slackId-populated) state — mirroring
+    // what completeConnect() just persisted above.
+    const resolvedSlackId = updateFieldsCalls[0]?.fields.slackId as string;
+    const detailApp = createAdminUIApp(
+      makeMockDeps({
+        agentService: {
+          listAll: async () => [],
+          listByIds: async () => [],
+          searchByName: async () => [],
+          listOptions: async () => [],
+          create: async () => {
+            throw new Error("not implemented");
+          },
+          delete: async () => {},
+          getDetail: async () => ({
+            ...initialAgent,
+            slackId: resolvedSlackId,
+          }),
+          updateFields: async () => {
+            throw new Error("not implemented");
+          },
+        },
+      }),
+    );
+
+    const afterRes = await detailApp.request(`/admin/agents/${AGENT_ID}`, {
+      headers: { Cookie: `admin_session=${adminCookie}` },
+    });
+    expect(afterRes.status).toBe(200);
+    const afterHtml = await afterRes.text();
+    expect(afterHtml).toContain("Sync Manifest");
+  });
+
   it("missing state cookie → renders an error page", async () => {
     const app = createAdminUIApp(makeMockDeps());
 

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -183,6 +183,7 @@ const BASE_SLACK_CLIENT: AdminUISlackClient = {
   }),
   updateAppManifest: async () => {},
   exchangeOAuthCode: async () => ({ botToken: "xoxb-mock-bot-token" }),
+  authTest: async () => ({ userId: "U0AALR8M69X" }),
 };
 
 const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -150,6 +150,7 @@ export interface AdminUISlackClient {
     clientSecret: string,
     redirectUri: string,
   ): Promise<{ botToken: string }>;
+  authTest(botToken: string): Promise<{ userId: string }>;
 }
 
 /**

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -271,11 +271,12 @@ function makeMockDeps(): AdminDeps {
           selfHosted?: boolean;
           repos?: string[];
           restrictSlackToMembers?: boolean;
+          slackId?: string | null;
         },
       ) => ({
         id,
         name: "Existing Agent",
-        slackId: null,
+        slackId: input.slackId ?? null,
         selfHosted: input.selfHosted ?? false,
         repos: input.repos ?? [],
         authorAllowlist: [],
@@ -2351,6 +2352,21 @@ describe("admin API — selfHosted field", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.selfHosted).toBe(true);
+  });
+
+  it("PATCH /agents/:id with {slackId} backfills the field and returns 200 with slackId in response (UAP-1.3)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ slackId: "U0AALR8M69X" }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slackId).toBe("U0AALR8M69X");
   });
 
   it("PATCH /agents/:id unknown id → 404", async () => {

--- a/admin/src/agents-api.smoke.test.ts
+++ b/admin/src/agents-api.smoke.test.ts
@@ -2369,6 +2369,21 @@ describe("admin API — selfHosted field", () => {
     expect(body.slackId).toBe("U0AALR8M69X");
   });
 
+  it("PATCH /agents/:id with {slackId: null} clears the field and returns 200 with slackId: null (UAP-1.3)", async () => {
+    const app = createAdminApp(makeMockDeps());
+    const res = await app.request(`/agents/${AGENT_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ slackId: null }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `admin_session=${cookie}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slackId).toBe(null);
+  });
+
   it("PATCH /agents/:id unknown id → 404", async () => {
     const app = createAdminApp(makeMockDeps());
     const res = await app.request("/agents/does-not-exist", {

--- a/admin/src/agents-api.ts
+++ b/admin/src/agents-api.ts
@@ -1119,6 +1119,7 @@ export function createAdminApp(deps: AdminDeps): OpenAPIHono<AdminAuthEnv> {
       ...(body.restrictSlackToMembers !== undefined
         ? { restrictSlackToMembers: body.restrictSlackToMembers }
         : {}),
+      ...(body.slackId !== undefined ? { slackId: body.slackId } : {}),
     });
     const warning = await computeRestrictSlackToMembersWarning(
       agentMemberService,

--- a/admin/src/agents.ts
+++ b/admin/src/agents.ts
@@ -78,6 +78,11 @@ export interface UpdateSelfHostedInput {
   repos?: string[];
   authorAllowlist?: string[];
   restrictSlackToMembers?: boolean;
+  /**
+   * Backfills agent.slackId (UAP-1.3) — nullable so it can also be
+   * explicitly cleared via PATCH /agents/:id.
+   */
+  slackId?: string | null;
 }
 
 interface AgentIdAndRepos {
@@ -270,6 +275,7 @@ export class AgentService {
         ...(input.restrictSlackToMembers !== undefined
           ? { restrictSlackToMembers: input.restrictSlackToMembers }
           : {}),
+        ...(input.slackId !== undefined ? { slackId: input.slackId } : {}),
       },
       select: DETAIL_SELECT,
     });

--- a/admin/src/chat.smoke.test.ts
+++ b/admin/src/chat.smoke.test.ts
@@ -220,6 +220,7 @@ const BASE_SLACK_CLIENT: AdminUISlackClient = {
   }),
   updateAppManifest: async () => {},
   exchangeOAuthCode: async () => ({ botToken: "xoxb-mock" }),
+  authTest: async () => ({ userId: "U0AALR8M69X" }),
 };
 
 const BASE_GITHUB_APP_CLIENT: AdminUIGithubAppClient = {

--- a/admin/src/fixtures/slack-provision-cassette.json
+++ b/admin/src/fixtures/slack-provision-cassette.json
@@ -5,5 +5,8 @@
     "clientId": "1234567890.9876543210",
     "clientSecret": "test-client-secret-value",
     "signingSecret": "test-signing-secret-value"
+  },
+  "authTest": {
+    "userId": "U0AALR8M69X"
   }
 }

--- a/admin/src/fixtures/slack-provisioning-http-cassette.json
+++ b/admin/src/fixtures/slack-provisioning-http-cassette.json
@@ -78,5 +78,21 @@
   "deleteApp_slack_error": {
     "status": 200,
     "body": { "ok": false, "error": "app_not_found" }
+  },
+  "authTest_success": {
+    "status": 200,
+    "body": { "ok": true, "user_id": "U0AALR8M69X", "team_id": "T0123456789" }
+  },
+  "authTest_http_error": {
+    "status": 500,
+    "body": { "ok": false, "error": "internal_error" }
+  },
+  "authTest_slack_error": {
+    "status": 200,
+    "body": { "ok": false, "error": "invalid_auth" }
+  },
+  "authTest_missing_user_id": {
+    "status": 200,
+    "body": { "ok": true, "team_id": "T0123456789" }
   }
 }

--- a/admin/src/openapi-schemas.ts
+++ b/admin/src/openapi-schemas.ts
@@ -127,6 +127,17 @@ export const CreateAgentBodySchema = z
 
 export const PatchAgentBodySchema = z
   .object({
+    /**
+     * Backfills agent.slackId for agents that completed Slack OAuth before
+     * UAP-1.3 shipped (it is otherwise resolved automatically via auth.test
+     * right after OAuth completes). Nullable so it can also be explicitly
+     * cleared.
+     */
+    slackId: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "U0AALR8M69X" }),
     selfHosted: z.boolean().optional().openapi({ example: false }),
     repos: z
       .array(

--- a/admin/src/provision-callback.smoke.test.ts
+++ b/admin/src/provision-callback.smoke.test.ts
@@ -89,6 +89,7 @@ function makeMockSlackClient(opts?: {
     clientSecret: string,
     redirectUri: string,
   ) => Promise<{ botToken: string }>;
+  authTest?: (botToken: string) => Promise<{ userId: string }>;
 }): AdminUISlackClient {
   return {
     createAppManifest: async () => ({
@@ -102,6 +103,8 @@ function makeMockSlackClient(opts?: {
     exchangeOAuthCode:
       opts?.exchangeOAuthCode ??
       (async () => ({ botToken: "xoxb-mock-bot-token" })),
+    authTest:
+      opts?.authTest ?? (async () => ({ userId: "U0AALR8M69X" })),
   };
 }
 
@@ -282,9 +285,19 @@ function makeMockDeps(
       },
       delete: async () => {},
       getDetail: async () => null,
-      updateFields: async () => {
-        throw new Error("not implemented");
-      },
+      updateFields: async (id: string) => ({
+        id,
+        name: "Test Agent",
+        slackId: "U0AALR8M69X",
+        selfHosted: false,
+        repos: [],
+        authorAllowlist: [],
+        restrictSlackToMembers: false,
+        typeName: "coding",
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+        missingRequiredEnv: [],
+      }),
     },
     sessionSecret: SESSION_SECRET,
     googleClientId: "test-google-client-id",

--- a/admin/src/pwa-https-gating.smoke.test.ts
+++ b/admin/src/pwa-https-gating.smoke.test.ts
@@ -180,6 +180,7 @@ function makeMinimalDeps(overrides: Partial<AdminUIDeps>): AdminUIDeps {
       },
       updateAppManifest: async () => {},
       exchangeOAuthCode: async () => ({ botToken: "xoxb" }),
+      authTest: async () => ({ userId: "U0AALR8M69X" }),
     },
     githubAppClient: {
       exchangeManifestCode: async () => {

--- a/admin/src/pwa-routes.smoke.test.ts
+++ b/admin/src/pwa-routes.smoke.test.ts
@@ -181,6 +181,7 @@ function makeMinimalDeps(overrides?: Partial<AdminUIDeps>): AdminUIDeps {
       },
       updateAppManifest: async () => {},
       exchangeOAuthCode: async () => ({ botToken: "xoxb" }),
+      authTest: async () => ({ userId: "U0AALR8M69X" }),
     },
     githubAppClient: {
       exchangeManifestCode: async () => {

--- a/admin/src/server.smoke.test.ts
+++ b/admin/src/server.smoke.test.ts
@@ -218,6 +218,7 @@ function buildComposedApp() {
       createAppManifest: notImplemented,
       updateAppManifest: notImplemented,
       exchangeOAuthCode: notImplemented,
+      authTest: notImplemented,
     },
     githubAppClient: {
       exchangeManifestCode: notImplemented,

--- a/admin/src/slack-provisioning-client.integration.test.ts
+++ b/admin/src/slack-provisioning-client.integration.test.ts
@@ -258,6 +258,43 @@ describe("HttpSlackProvisioningClient — createAppManifest", () => {
   });
 });
 
+// ─── authTest ────────────────────────────────────────────────────────────────
+
+describe("HttpSlackProvisioningClient — authTest", () => {
+  it("POSTs Bearer-auth to auth.test and returns the bot's own user id", async () => {
+    const { client, lastRequest } = makeClient("authTest_success");
+    const result = await client.authTest("xoxb-bot-token");
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("https://slack.com/api/auth.test");
+    expect(req.headers.get("authorization")).toBe("Bearer xoxb-bot-token");
+
+    expect(result).toEqual({ userId: "U0AALR8M69X" });
+  });
+
+  it("throws on an HTTP error response", async () => {
+    const { client } = makeClient("authTest_http_error");
+    await expect(client.authTest("xoxb-bot-token")).rejects.toThrow(
+      /Slack auth\.test HTTP error: 500/,
+    );
+  });
+
+  it("throws when Slack returns ok: false", async () => {
+    const { client } = makeClient("authTest_slack_error");
+    await expect(client.authTest("xoxb-bot-token")).rejects.toThrow(
+      /Slack auth\.test failed: invalid_auth/,
+    );
+  });
+
+  it("throws when user_id is missing from an ok response", async () => {
+    const { client } = makeClient("authTest_missing_user_id");
+    await expect(client.authTest("xoxb-bot-token")).rejects.toThrow(
+      /response missing user_id/,
+    );
+  });
+});
+
 // ─── Default construction (no opts) ─────────────────────────────────────────
 
 describe("HttpSlackProvisioningClient — default construction", () => {

--- a/admin/src/slack-provisioning-client.ts
+++ b/admin/src/slack-provisioning-client.ts
@@ -104,6 +104,12 @@ export interface SlackProvisioningClient {
     clientSecret: string,
     redirectUri: string,
   ): Promise<{ botToken: string }>;
+
+  /**
+   * Call auth.test with a bot token to resolve the bot's own Slack user id.
+   * Used right after exchangeOAuthCode() to persist `agent.slackId`.
+   */
+  authTest(botToken: string): Promise<{ userId: string }>;
 }
 
 // ─── Agent manifest ───────────────────────────────────────────────────────────
@@ -246,6 +252,38 @@ export class HttpSlackProvisioningClient implements SlackProvisioningClient {
     }
 
     return { botToken: data.access_token };
+  }
+
+  async authTest(botToken: string): Promise<{ userId: string }> {
+    const url = `${this.apiBase}/auth.test`;
+    const resp = await this.fetchFn(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+      },
+    });
+
+    if (!resp.ok) {
+      throw new Error(
+        `Slack auth.test HTTP error: ${resp.status} ${resp.statusText}`,
+      );
+    }
+
+    const data = (await resp.json()) as {
+      ok: boolean;
+      error?: string;
+      user_id?: string;
+    };
+
+    if (!data.ok) {
+      throw new Error(`Slack auth.test failed: ${data.error}`);
+    }
+
+    if (!data.user_id) {
+      throw new Error("Slack auth.test response missing user_id");
+    }
+
+    return { userId: data.user_id };
   }
 
   async updateAppManifest(

--- a/admin/src/slack-provisioning-service.integration.test.ts
+++ b/admin/src/slack-provisioning-service.integration.test.ts
@@ -37,6 +37,9 @@ interface ProvisionCassette {
     clientSecret: string;
     signingSecret: string;
   };
+  authTest: {
+    userId: string;
+  };
 }
 
 class RecordedSlackClient implements AdminUISlackClient {
@@ -45,6 +48,8 @@ class RecordedSlackClient implements AdminUISlackClient {
   readonly createdManifests: AppManifest[] = [];
   /** redirect_uri values passed to exchangeOAuthCode(), in call order. */
   readonly exchangeRedirectUris: string[] = [];
+  /** botToken values passed to authTest(), in call order. */
+  readonly authTestBotTokens: string[] = [];
 
   constructor(cassettePath: string) {
     this.cassette = JSON.parse(readFileSync(cassettePath, "utf-8"));
@@ -79,6 +84,11 @@ class RecordedSlackClient implements AdminUISlackClient {
     this.exchangeRedirectUris.push(redirectUri);
     return { botToken: "xoxb-test-cassette-bot-token" };
   }
+
+  async authTest(botToken: string): Promise<{ userId: string }> {
+    this.authTestBotTokens.push(botToken);
+    return this.cassette.authTest;
+  }
 }
 
 const CASSETTE_PATH = new URL(
@@ -94,10 +104,16 @@ interface PatchCall {
   secretKeys: string[];
 }
 
+interface UpdateFieldsCall {
+  id: string;
+  input: unknown;
+}
+
 function makeService(opts?: {
   slackClient?: AdminUISlackClient;
   patchCalls?: PatchCall[];
   reconcileCalls?: string[];
+  updateFieldsCalls?: UpdateFieldsCall[];
   getConfigBundle?: () => Promise<{
     env: Record<string, string>;
     agentId: string;
@@ -107,6 +123,7 @@ function makeService(opts?: {
 }): SlackProvisioningService {
   const patchCalls = opts?.patchCalls ?? [];
   const reconcileCalls = opts?.reconcileCalls ?? [];
+  const updateFieldsCalls = opts?.updateFieldsCalls ?? [];
   return new SlackProvisioningService({
     slackClient: opts?.slackClient ?? new RecordedSlackClient(CASSETTE_PATH),
     agentService: {
@@ -125,6 +142,22 @@ function makeService(opts?: {
           typeName: "coding",
           missingRequiredEnv: [],
         })),
+      updateFields: async (id: string, input: unknown) => {
+        updateFieldsCalls.push({ id, input });
+        return {
+          id,
+          name: "Test Agent",
+          slackId: "U123456",
+          selfHosted: false,
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          repos: [],
+          authorAllowlist: [],
+          restrictSlackToMembers: false,
+          typeName: "coding",
+          missingRequiredEnv: [],
+        };
+      },
     },
     agentEnvService: {
       getConfigBundle: opts?.getConfigBundle ?? (async () => null),
@@ -276,7 +309,8 @@ describe("SlackProvisioningService.startConnect", () => {
 describe("SlackProvisioningService.completeConnect", () => {
   it("valid state token + code → exchanges OAuth code (cassette) and stores SLACK_BOT_TOKEN, returns needs_app_token", async () => {
     const patchCalls: PatchCall[] = [];
-    const service = makeService({ patchCalls });
+    const updateFieldsCalls: UpdateFieldsCall[] = [];
+    const service = makeService({ patchCalls, updateFieldsCalls });
     const token = await makeProvisionStateToken();
 
     const result = await service.completeConnect(
@@ -296,10 +330,37 @@ describe("SlackProvisioningService.completeConnect", () => {
     expect(patchCalls[0].secretKeys).toContain("SLACK_BOT_TOKEN");
   });
 
-  it("reinstall (SLACK_APP_TOKEN already set) → returns reinstalled outcome", async () => {
+  it("valid state token + code → resolves the bot's own user id via auth.test (cassette) and persists it via agentService.updateFields", async () => {
+    const slackClient = new RecordedSlackClient(CASSETTE_PATH);
+    const updateFieldsCalls: UpdateFieldsCall[] = [];
+    const service = makeService({ slackClient, updateFieldsCalls });
+    const token = await makeProvisionStateToken();
+
+    const result = await service.completeConnect(
+      token,
+      "valid-oauth-code",
+      CONNECT_SLACK_CALLBACK,
+    );
+
+    expect(result.outcome).toBe("needs_app_token");
+
+    // auth.test is called with the freshly-exchanged bot token.
+    expect(slackClient.authTestBotTokens).toEqual([
+      "xoxb-test-cassette-bot-token",
+    ]);
+
+    // The resolved user id (from the cassette) is persisted to agent.slackId.
+    expect(updateFieldsCalls.length).toBe(1);
+    expect(updateFieldsCalls[0].id).toBe(AGENT_ID);
+    expect(updateFieldsCalls[0].input).toEqual({ slackId: "U0AALR8M69X" });
+  });
+
+  it("reinstall (SLACK_APP_TOKEN already set) → returns reinstalled outcome, still resolves and persists slackId via auth.test", async () => {
     const patchCalls: PatchCall[] = [];
+    const updateFieldsCalls: UpdateFieldsCall[] = [];
     const service = makeService({
       patchCalls,
+      updateFieldsCalls,
       getConfigBundle: async () => ({
         env: {
           SLACK_BOT_TOKEN: "xoxb-old",
@@ -320,6 +381,10 @@ describe("SlackProvisioningService.completeConnect", () => {
     expect(result.outcome).toBe("reinstalled");
     if (result.outcome !== "reinstalled") throw new Error("wrong outcome");
     expect(result.agentId).toBe(AGENT_ID);
+
+    expect(updateFieldsCalls.length).toBe(1);
+    expect(updateFieldsCalls[0].id).toBe(AGENT_ID);
+    expect(updateFieldsCalls[0].input).toEqual({ slackId: "U0AALR8M69X" });
   });
 
   it("missing state cookie → invalid_state outcome, no Slack call, no env write", async () => {
@@ -412,6 +477,9 @@ describe("SlackProvisioningService.completeConnect", () => {
       exchangeOAuthCode: async () => {
         throw new Error("invalid_code");
       },
+      authTest: async () => {
+        throw new Error("unused in this test");
+      },
     };
     const service = makeService({
       slackClient: failingSlackClient,
@@ -429,6 +497,41 @@ describe("SlackProvisioningService.completeConnect", () => {
     if (result.outcome !== "exchange_failed") throw new Error("wrong outcome");
     expect(result.error).toContain("invalid_code");
     expect(patchCalls.length).toBe(0);
+  });
+
+  it("auth.test failure after a successful exchange → exchange_failed outcome, SLACK_BOT_TOKEN not persisted", async () => {
+    const patchCalls: PatchCall[] = [];
+    const updateFieldsCalls: UpdateFieldsCall[] = [];
+    const failingAuthTestClient: AdminUISlackClient = {
+      createAppManifest: async () => {
+        throw new Error("unused in this test");
+      },
+      updateAppManifest: async () => {},
+      exchangeOAuthCode: async () => ({
+        botToken: "xoxb-test-cassette-bot-token",
+      }),
+      authTest: async () => {
+        throw new Error("token_revoked");
+      },
+    };
+    const service = makeService({
+      slackClient: failingAuthTestClient,
+      patchCalls,
+      updateFieldsCalls,
+    });
+    const token = await makeProvisionStateToken();
+
+    const result = await service.completeConnect(
+      token,
+      "valid-oauth-code",
+      CONNECT_SLACK_CALLBACK,
+    );
+
+    expect(result.outcome).toBe("exchange_failed");
+    if (result.outcome !== "exchange_failed") throw new Error("wrong outcome");
+    expect(result.error).toContain("token_revoked");
+    expect(patchCalls.length).toBe(0);
+    expect(updateFieldsCalls.length).toBe(0);
   });
 });
 

--- a/admin/src/slack-provisioning-service.ts
+++ b/admin/src/slack-provisioning-service.ts
@@ -99,7 +99,7 @@ export interface SlackAppManifestResult {
 
 export interface SlackProvisioningServiceDeps {
   slackClient: AdminUISlackClient;
-  agentService: Pick<AgentService, "getDetail">;
+  agentService: Pick<AgentService, "getDetail" | "updateFields">;
   agentEnvService: Pick<AgentEnvService, "patch" | "getConfigBundle">;
   agentCronJobService: Pick<AgentCronJobService, "reconcileSystemCrons">;
   sessionSecret: string;
@@ -311,6 +311,7 @@ export class SlackProvisioningService {
     }
 
     let botToken: string;
+    let slackUserId: string;
     try {
       const result = await this.deps.slackClient.exchangeOAuthCode(
         code,
@@ -319,6 +320,15 @@ export class SlackProvisioningService {
         provisionState.redirectUri ?? fallbackRedirectUri,
       );
       botToken = result.botToken;
+
+      // Resolve the bot's own Slack user id so it can be persisted to
+      // agent.slackId (UAP-1.3) — required for the Sync Manifest button to
+      // appear. Folded into the same try/catch as the exchange: an auth.test
+      // failure right after a successful exchange is treated the same as an
+      // exchange failure so the flow doesn't half-complete with a bot token
+      // stored but no resolved slackId.
+      const authTestResult = await this.deps.slackClient.authTest(botToken);
+      slackUserId = authTestResult.userId;
     } catch (err) {
       const msg =
         err instanceof Error
@@ -338,6 +348,13 @@ export class SlackProvisioningService {
       { SLACK_BOT_TOKEN: botToken },
       this.deps.secretEnvVars,
     );
+
+    // Persist unconditionally on every successful completion (both
+    // "reinstalled" and "needs_app_token" outcomes) — a bot reinstall can
+    // also resolve a fresh/different user id.
+    await this.deps.agentService.updateFields(provisionState.agentId, {
+      slackId: slackUserId,
+    });
 
     if (existingBundle?.env.SLACK_APP_TOKEN) {
       return { outcome: "reinstalled", agentId: provisionState.agentId };

--- a/admin/src/slack-provisioning.integration.test.ts
+++ b/admin/src/slack-provisioning.integration.test.ts
@@ -64,6 +64,10 @@ class RecordedSlackClient implements AdminUISlackClient {
   ): Promise<{ botToken: string }> {
     return { botToken: "xoxb-test-cassette-bot-token" };
   }
+
+  async authTest(_botToken: string): Promise<{ userId: string }> {
+    return { userId: "U0AALR8M69X" };
+  }
 }
 
 // ─── JWT helper ───────────────────────────────────────────────────────────────
@@ -243,9 +247,19 @@ function makeMockDeps(
         typeName: "coding",
         missingRequiredEnv: [],
       }),
-      updateFields: async () => {
-        throw new Error("not implemented");
-      },
+      updateFields: async (id: string) => ({
+        id,
+        name: "Test Agent",
+        slackId: "U0AALR8M69X",
+        selfHosted: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+        repos: [],
+        authorAllowlist: [],
+        restrictSlackToMembers: false,
+        typeName: "coding",
+        missingRequiredEnv: [],
+      }),
     },
     sessionSecret: SESSION_SECRET,
     googleClientId: "test-google-client-id",

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -81,7 +81,7 @@ Admin-only. Returns the full agent record including `selfHosted`, `repos`, `auth
 PATCH /agents/:id
 ```
 
-Admin-only. Updatable fields: `selfHosted` (boolean), `repos` (array of `org/repo` strings — each entry is validated for format), `authorAllowlist` (array of GitHub login strings — usernames of authors permitted to file pull requests scoped to this agent), `restrictSlackToMembers` (boolean — when `true`, restricts Slack access to configured members only). `typeName` is not updatable via this route. Returns the updated agent.
+Admin-only. Updatable fields: `selfHosted` (boolean), `repos` (array of `org/repo` strings — each entry is validated for format), `authorAllowlist` (array of GitHub login strings — usernames of authors permitted to file pull requests scoped to this agent), `restrictSlackToMembers` (boolean — when `true`, restricts Slack access to configured members only), `slackId` (nullable string — Slack user ID for the agent's bot account; normally resolved and persisted automatically via `auth.test` right after Slack OAuth completes, this field exists to backfill it for agents that connected Slack before that fix shipped). `typeName` is not updatable via this route. Returns the updated agent.
 
 ### Delete agent
 


### PR DESCRIPTION
## Summary
- After a successful Slack OAuth code exchange, resolve the bot's own Slack user id via `auth.test` and persist it to `agent.slackId` — this was previously never populated, silently breaking the Sync Manifest button for every agent provisioned through the wizard.
- Add `authTest()` to `SlackProvisioningClient`/`HttpSlackProvisioningClient` and the narrower `AdminUISlackClient` DI interface, folded into `SlackProvisioningService.completeConnect()`'s existing try/catch so a failed `auth.test` is treated the same as a failed OAuth exchange.
- Add `slackId` to `PatchAgentBodySchema` (nullable, optional) so `PATCH /agents/:id` can backfill it for agents that connected Slack before this fix shipped, threaded through `AgentService.updateSelfHosted()`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | After a successful OAuth code exchange, the bot's own Slack user id is resolved via auth.test and persisted to agent.slackId | MET |
| 2 | The Sync Manifest button appears after completing Slack connect through the current flow, verified by test | MET |
| 3 | PatchAgentBodySchema accepts an optional slackId field so PATCH /agents/:id can backfill it | MET |
| 4 | Test decision — extend connect-slack integration test + add PATCH smoke test | MET |

## Test Plan
- Extended `slack-provisioning-service.integration.test.ts` (recorded-fixture double) with auth.test success/reinstall/failure cases.
- Extended `slack-provisioning-client.integration.test.ts` with a full `authTest` describe block against the HTTP cassette.
- New smoke test in `admin-ui.smoke.test.ts` drives the real `GET /admin/agents/:id/connect-slack/callback` HTTP route end-to-end and asserts the agent detail page renders the "Sync Manifest" button once `slackId` is persisted.
- New smoke tests in `agents-api.smoke.test.ts` for `PATCH /agents/:id` with `slackId` set and cleared (null).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
