### PR TITLE
feat: single "+ New agent" CTA on the agents list page (UAP-2.2)

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -558,13 +558,10 @@ export function renderAgentsPage(
           )
           .join("\n");
 
-  // Primary path is /admin/agents/new — it creates in-cluster or self-hosted
-  // agents and needs no Slack, so it never dead-ends. /admin/provision is the
-  // Slack-app bootstrap wizard (requires an xoxp token), offered as a secondary
-  // action for setups that use Slack.
+  // Single CTA to create an agent — the /admin/agents/new page handles agent
+  // creation and provides inline options to connect Slack/GitHub if desired.
   const createAgentButtons = isAdmin
-    ? `<a href="/admin/agents/new" class="btn btn-primary">+ New agent</a>
-      <a href="/admin/provision" class="btn btn-secondary" style="margin-left:8px">Connect Slack app</a>`
+    ? `<a href="/admin/agents/new" class="btn btn-primary">+ New agent</a>`
     : "";
 
   return renderAdminPage({

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -253,10 +253,13 @@ describe("renderAgentsPage", () => {
     expect(html).toContain('href="/admin/agents/new"');
   });
 
-  test("admin: Slack wizard is offered only as a secondary action", () => {
+  test("admin: only one CTA (no secondary Slack button)", () => {
     const html = renderAgentsPage([AGENT_LIST_ITEM], USER_NAME, true, "UTC");
-    expect(html).toContain("Connect Slack app");
-    expect(html).toContain('href="/admin/provision"');
+    // Should NOT have the secondary Slack app button in the page header
+    expect(html).not.toContain("Connect Slack app");
+    // Should have exactly one btn-primary (the + New agent button)
+    const btnMatches = html.match(/class="btn btn-primary"/g);
+    expect(btnMatches).toHaveLength(1);
   });
 
   test("agent name appears as a link", () => {

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -395,7 +395,7 @@ service, so make one at `http://shipwright.local/admin/agents/new`:
 **No Slack credentials are required.** An agent with no Slack tokens boots in
 offline mode and is driven from the admin console's **Chat** tab
 (`http://shipwright.local/admin/chat`). Slack is optional and can be connected
-later from the `/admin/provision` wizard.
+later from the agent's detail page via the inline "Connect Slack" action.
 
 ### TLS and security
 

--- a/site/src/content/docs/admin-console.mdx
+++ b/site/src/content/docs/admin-console.mdx
@@ -51,10 +51,10 @@ set for admins, or only agents the user is a member of otherwise:
 | Created | Creation date |
 | (actions) | **Manage**, **Cron Logs**, **Work Queue** buttons |
 
-Admins see two buttons above the table: **+ Provision agent** (→ `/admin/provision`) and
-**+ New local agent** (→ `/admin/agents/new`). After a successful agent deletion the list also shows
-a dismissible "Agent deleted." banner and, if any cleanup steps require manual follow-up (e.g.
-revoking a hand-pasted `GH_TOKEN`), a warning panel listing each manual step.
+Admins see a single **+ New agent** button above the table (→ `/admin/agents/new`), which handles
+agent creation and offers inline options to connect Slack/GitHub afterward. After a successful agent
+deletion the list also shows a dismissible "Agent deleted." banner and, if any cleanup steps require
+manual follow-up (e.g. revoking a hand-pasted `GH_TOKEN`), a warning panel listing each manual step.
 
 ### New local agent — `GET /admin/agents/new`, `POST /admin/agents`
 


### PR DESCRIPTION
## Summary
- Removed the secondary "Connect Slack app" button from the agents list page — `+ New agent` is now the only create-agent CTA, pointing at the extended `/admin/agents/new` page (UAP-2.1) which offers inline Slack/GitHub connection.
- Refreshed `docs/deploy-kubernetes.md` to describe the new inline "Connect Slack" flow instead of the retired `/admin/provision` wizard reference.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Agents list page renders exactly one create-agent CTA | MET | `createAgentButtons` now emits only the `+ New agent` link. |
| 2 | Helper copy on the creation page no longer references /admin/provision | MET | Already satisfied by prerequisite UAP-2.1; verified via grep — no remaining reference. |
| 3 | Test decision: EXTEND unit test for single CTA, RETIRE two-button assertion | MET | `admin-ui-pages.unit.test.ts` test retired/replaced with an assertion of exactly one `btn-primary` and absence of "Connect Slack app". |

## Test Plan
- `NODE_ENV=test bun test admin/src/admin-ui-pages.unit.test.ts` — all 672 tests pass
- Typecheck passes
- Coverage on changed file: 95.77% lines / 96.99% functions (target 90%/89%)
- `task ci` fails only on pre-existing, unrelated failures (`metrics/src/lib/errors.unit.test.ts`, `metrics/src/lib/env.unit.test.ts`, `task-store/src/routes/prs.openapi.smoke.test.ts`) — reproduced identically on unmodified `main`, not touched by this diff
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
