### PR TITLE
chore: bump docs sync anchor

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"1e8f9fb8be94e696ff643b1a9a7f54c068cc4db4","timestamp":"2026-09-01T07:06:14Z"}
+{"sha":"e048075b624fcceb34025bcd4f8c52e18a6b37fa","timestamp":"2026-09-02T07:04:09Z"}


### PR DESCRIPTION
## Summary
- research-docs cron run for 2026-09-02: checked all `docs/*.md` candidates matching source files changed since anchor `1e8f9fb8b`
- Every candidate (docs/agent.md, docs/agent-types.md, docs/architecture.md, docs/chat.md, docs/helm-repo.md) was verified against current source — all references resolve, nothing stale
- Bumps `state/docs-last-synced.json` to HEAD (`e048075b`) so the next cron run diffs from here

## Test plan
- [x] N/A — anchor-only change, no doc content edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)