### PR TITLE
docs: describe unified inline Slack/GitHub connect flow (UAP-4.1)

### DIFF
--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -392,10 +392,14 @@ service, so make one at `http://shipwright.local/admin/agents/new`:
   does not provision deployment-wide Claude credentials. You can also set
   `ANTHROPIC_API_KEY` from the agent's detail page afterwards.
 
-**No Slack credentials are required.** An agent with no Slack tokens boots in
-offline mode and is driven from the admin console's **Chat** tab
-(`http://shipwright.local/admin/chat`). Slack is optional and can be connected
-later from the agent's detail page via the inline "Connect Slack" action.
+**Slack and GitHub Authentication are optional and inline.** Both appear as optional
+fieldsets on the New Agent form: **Slack (optional)** reveals an inline Slack App
+Configuration Token field when checked, and **GitHub Authentication (optional)** offers
+three radio options (Skip, Personal Access Token, or Create GitHub App). You can
+connect either one at creation time, skip both and connect them later from the agent's
+detail page, or mix and match — it is your choice. An agent with no Slack or GitHub
+tokens boots in offline mode and is driven from the admin console's **Chat** tab
+(`http://shipwright.local/admin/chat`).
 
 ### TLS and security
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -137,7 +137,7 @@ In the admin console, go to **Agents → New** (<http://localhost:3001/admin/age
 
 Leave the runtime on **Self-hosted** — `task stack` runs the agent's container for you in the agent pane. (The **Provisioned in-cluster** option is disabled here anyway: it needs `SHIPWRIGHT_K8S_PROVISIONING`, which only the Helm chart sets. See [deploy-kubernetes.md](./deploy-kubernetes.md) for that path.)
 
-No Slack credentials are needed — you'll talk to the agent from the Chat tab in Step 4.
+No Slack or GitHub credentials are needed — you'll talk to the agent from the Chat tab in Step 4. Both are optional inline fields on the New Agent form; you can connect either one later from the agent's detail page if you prefer.
 
 The agent pane's wait-loop polls the database and detects the new agent automatically — no stack restart needed. Once detected, it seeds the agent's chat token and starts the Docker container with that agent's id.
 


### PR DESCRIPTION
## Summary
- Updated `docs/deploy-kubernetes.md`'s "Creating your first agent" section to describe Slack and GitHub Authentication as optional, inline fieldsets on the same New Agent form, instead of implying Slack can only be connected later from the agent detail page.
- Updated `docs/quickstart.md`'s Step 3 to mention both Slack and GitHub are optional inline fields on the New Agent form.
- Both docs already had no remaining references to `/admin/provision` or the old provisioning wizard (retired by UAP-3.1); this change closes the remaining doc-accuracy gap around the inline optional Slack/GitHub connect flow.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Both docs describe the unified flow and no longer reference /admin/provision as a distinct entry point | MET | `docs/deploy-kubernetes.md:392-402`, `docs/quickstart.md:140`; `grep -rn "admin/provision\|wizard"` on both files returns no matches |
| 2 | Test decision: none — docs-only change, no code under test | MET | Diff touches only the two markdown files |

## Test Plan
- Docs-only change — no test suite applies (per acceptance criteria).
- Verified admin UI source (`admin/src/admin-ui-pages.ts`, `renderNewLocalAgentPage`) to ground the doc wording in the actual current New Agent form fields.
- `grep -rn "admin/provision\|wizard" docs/quickstart.md docs/deploy-kubernetes.md` — no matches.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
