### PR TITLE
fix: register ChatThreadWatch on the chat UI's actual send route (CFB-4.4)

### DIFF
--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -3230,6 +3230,7 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     async (c) => {
       if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
 
+      const agentId = c.req.param("agentId");
       const threadId = c.req.param("threadId");
 
       if (!chatClient) {
@@ -3274,6 +3275,16 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
           body ?? "",
           attachment,
         );
+        // Record that this user is watching the thread so the agent's reply
+        // can be targeted back to them via push (CFB-4.2). This is the route
+        // the live chat UI's send box actually posts to (see
+        // admin-ui-pages.ts's uploadUrl) — the form POST /messages and
+        // /messages.json routes above are alternate entry points with their
+        // own identical call; all three must stay in sync. Best-effort —
+        // never block the response.
+        if (pushEnabled) {
+          await watchThread(c.var.userEmail, agentId, threadId);
+        }
         return c.json({ message }, 201);
       } catch {
         return c.json({ error: "failed to create message" }, 500);

--- a/admin/src/chat.smoke.test.ts
+++ b/admin/src/chat.smoke.test.ts
@@ -25,6 +25,7 @@ import type {
   ChatThread,
   ThreadStats,
 } from "./http-chat-client.ts";
+import type { PushService } from "./push-service.ts";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -1152,6 +1153,163 @@ describe("POST /admin/chat/:agentId/threads/:threadId/messages.json", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { message: null };
     expect(body.message).toBeNull();
+  });
+});
+
+// ─── Upload API: POST messages/upload ─────────────────────────────────────────
+// This is the route the live chat UI's send box actually posts to
+// (admin-ui-pages.ts's uploadUrl) — distinct from the form POST /messages and
+// JSON POST /messages.json routes above. It was missing the watchThread()
+// call the other two have (CFB-4.4 follow-up bug: real push subscriptions
+// existed but ChatThreadWatch stayed empty, so notifyThreadReply always found
+// zero recipients).
+
+function makeFakePushService(
+  notifyThreadReply: (thread: {
+    threadId: string;
+    agentId: string;
+    title: string | null;
+    preview: string | null;
+  }) => Promise<{ delivered: number; pruned: number }> = async () => ({
+    delivered: 0,
+    pruned: 0,
+  }),
+): PushService {
+  return { notifyThreadReply } as unknown as PushService;
+}
+
+describe("POST /admin/chat/:agentId/threads/:threadId/messages/upload", () => {
+  let sessionCookie: string;
+
+  beforeAll(async () => {
+    sessionCookie = await makeSessionCookie();
+  });
+
+  it("returns 302 to login without session cookie", async () => {
+    const chatClient = makeMockChatClient();
+    const app = createAdminUIApp(makeBaseDeps({ chatClient }));
+    const res = await app.request(
+      `/admin/chat/${AGENT_ID}/threads/${THREAD_ID}/messages/upload`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "body=test+message",
+      },
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/admin/login");
+  });
+
+  it("returns 201 JSON with message when chatClient present", async () => {
+    const chatClient = makeMockChatClient();
+    const app = createAdminUIApp(makeBaseDeps({ chatClient }));
+    const res = await app.request(
+      `/admin/chat/${AGENT_ID}/threads/${THREAD_ID}/messages/upload`,
+      {
+        method: "POST",
+        headers: {
+          Cookie: `admin_session=${sessionCookie}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "body=Hello%2C+agent!",
+      },
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { message: ChatMessage };
+    expect(body.message.id).toBe(MOCK_MESSAGE.id);
+  });
+
+  it("returns 400 when neither body nor file is present", async () => {
+    const chatClient = makeMockChatClient();
+    const app = createAdminUIApp(makeBaseDeps({ chatClient }));
+    const res = await app.request(
+      `/admin/chat/${AGENT_ID}/threads/${THREAD_ID}/messages/upload`,
+      {
+        method: "POST",
+        headers: {
+          Cookie: `admin_session=${sessionCookie}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "",
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("registers a ChatThreadWatch row when push is enabled (CFB-4.4 regression)", async () => {
+    const chatClient = makeMockChatClient();
+    const base = makeBaseDeps();
+    const watchUpserts: Array<{
+      where: { userEmail_threadId: { userEmail: string; threadId: string } };
+      create: { userEmail: string; threadId: string; agentId: string };
+      update: { agentId: string };
+    }> = [];
+    const app = createAdminUIApp({
+      ...base,
+      chatClient,
+      pushService: makeFakePushService(),
+      vapidPublicKey: "test-vapid-public-key",
+      prisma: {
+        ...base.prisma,
+        chatThreadWatch: {
+          upsert: async (args) => {
+            watchUpserts.push(args);
+            return { id: "watch-1" };
+          },
+        },
+      },
+    });
+    const res = await app.request(
+      `/admin/chat/${AGENT_ID}/threads/${THREAD_ID}/messages/upload`,
+      {
+        method: "POST",
+        headers: {
+          Cookie: `admin_session=${sessionCookie}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "body=testing+notifications",
+      },
+    );
+    expect(res.status).toBe(201);
+    expect(watchUpserts).toHaveLength(1);
+    expect(watchUpserts[0]?.create).toEqual({
+      userEmail: "admin@example.com",
+      threadId: THREAD_ID,
+      agentId: AGENT_ID,
+    });
+  });
+
+  it("does not touch ChatThreadWatch when push is disabled", async () => {
+    const chatClient = makeMockChatClient();
+    const base = makeBaseDeps();
+    const watchUpserts: unknown[] = [];
+    const app = createAdminUIApp({
+      ...base,
+      chatClient,
+      // No pushService/vapidPublicKey — pushEnabled stays false.
+      prisma: {
+        ...base.prisma,
+        chatThreadWatch: {
+          upsert: async (args) => {
+            watchUpserts.push(args);
+            return { id: "watch-1" };
+          },
+        },
+      },
+    });
+    const res = await app.request(
+      `/admin/chat/${AGENT_ID}/threads/${THREAD_ID}/messages/upload`,
+      {
+        method: "POST",
+        headers: {
+          Cookie: `admin_session=${sessionCookie}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "body=push+disabled+case",
+      },
+    );
+    expect(res.status).toBe(201);
+    expect(watchUpserts).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Found while doing device verification for CFB-4.4: a real iOS push subscription existed, the agent replied several times, but no push notification ever arrived.
- Root cause: `POST /admin/chat/:agentId/threads/:threadId/messages/upload` — the route the live chat UI's send box actually posts to (`admin-ui-pages.ts`'s `uploadUrl`) — never called `watchThread()`. The two other message-creation routes (`/messages` form POST, `/messages.json`) both call it; this one was missing it entirely, so `ChatThreadWatch` stayed permanently empty and `PushService.notifyThreadReply` always found zero recipients for every thread, with no error anywhere (both failure paths are silent-unless-erroring by design).
- Fix: add the same `if (pushEnabled) { await watchThread(...) }` call this route was missing, mirroring the other two.

## Test plan
- [x] Added 5 new smoke tests in `chat.smoke.test.ts` covering `/messages/upload`: auth gate, happy path, 400 on empty body, and — the actual regression coverage — asserting `chatThreadWatch.upsert` is called with the right `{userEmail, threadId, agentId}` when push is enabled, and NOT called when it's disabled.
- [x] `bun test admin/src/chat.smoke.test.ts` — 45 pass
- [x] `bun run --filter='@shipwright/admin' typecheck` — clean
- [x] Verified live in prod after this fix's logic was manually confirmed against the DB (real `PushSubscription` rows existed, `ChatThreadWatch` was empty across 4+ real agent replies before the fix)

Generated with [Claude Code](https://claude.com/claude-code)