### PR TITLE
feat: add 'Use existing GitHub App' as a detail-page connect-later action

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -816,10 +816,14 @@ export function renderNewLocalAgentPage(
 
 /**
  * A single "connect later" action on the agent detail page (Connect Slack /
- * Set up GitHub App / Add GitHub PAT) — a `<details>/<summary>` popover
- * mirroring the "Sync Manifest" pattern. `envKey` is the per-agent AgentEnv
- * key whose presence in `envVars` means this integration is already
- * configured, hiding the action.
+ * Set up GitHub App / Add GitHub PAT / Use existing GitHub App) — a
+ * `<details>/<summary>` popover mirroring the "Sync Manifest" pattern.
+ * `envKey` is the per-agent AgentEnv key whose presence in `envVars` means
+ * this integration is already configured, hiding the action.
+ *
+ * `inputs` is an array so an action can collect more than one field (e.g.
+ * the manual GitHub App connect needs App ID + Installation ID + a Private
+ * Key file upload) — every existing action still supplies exactly one entry.
  */
 interface ConnectActionConfig {
   envKey: string;
@@ -827,7 +831,12 @@ interface ConnectActionConfig {
   description: string;
   action: string;
   hiddenFields?: Record<string, string>;
-  input: { name: string; type: string; placeholder: string; mono?: boolean };
+  inputs: Array<{
+    name: string;
+    type: "text" | "password" | "file";
+    placeholder?: string;
+    mono?: boolean;
+  }>;
 }
 
 function renderConnectAction(
@@ -841,20 +850,26 @@ function renderConnectAction(
         `<input type="hidden" name="${escapeHtml(k)}" value="${escapeHtml(v)}" />`,
     )
     .join("\n              ");
+  const hasFileInput = cfg.inputs.some((input) => input.type === "file");
+  const visibleInputs = cfg.inputs
+    .map(
+      (input) => `<input
+                name="${escapeHtml(input.name)}"
+                type="${input.type}"
+                class="form-input${input.mono ? " mono" : ""}"
+                ${input.placeholder ? `placeholder="${escapeHtml(input.placeholder)}"` : ""}
+                required
+                style="font-size:12px"
+              />`,
+    )
+    .join("\n              ");
   return `<details style="position:relative">
           <summary class="btn btn-secondary" style="cursor:pointer;font-size:12px;list-style:none">${escapeHtml(cfg.label)}</summary>
           <div style="position:absolute;left:0;margin-top:6px;background:#fff;border:1px solid #e5e7eb;border-radius:6px;padding:12px;box-shadow:0 4px 12px rgba(0,0,0,0.08);z-index:10;min-width:320px">
             <p style="font-size:12px;color:#6b7280;margin:0 0 10px">${cfg.description}</p>
-            <form method="POST" action="${cfg.action}" style="display:flex;flex-direction:column;gap:8px">
+            <form method="POST" action="${cfg.action}"${hasFileInput ? ' enctype="multipart/form-data"' : ""} style="display:flex;flex-direction:column;gap:8px">
               ${hiddenInputs}
-              <input
-                name="${cfg.input.name}"
-                type="${cfg.input.type}"
-                class="form-input${cfg.input.mono ? " mono" : ""}"
-                placeholder="${escapeHtml(cfg.input.placeholder)}"
-                required
-                style="font-size:12px"
-              />
+              ${visibleInputs}
               <button type="submit" class="btn btn-primary" style="font-size:12px;align-self:flex-start">${escapeHtml(cfg.label)}</button>
             </form>
           </div>
@@ -932,12 +947,14 @@ export function renderAgentDetailPage(
       label: "Connect Slack",
       description: `Connects this agent to a Slack app. Requires a Slack app configuration token (<span class="mono">xoxe.xoxp-</span>).`,
       action: `/admin/agents/${escapeHtml(agent.id)}/connect-slack`,
-      input: {
-        name: "xoxpToken",
-        type: "password",
-        placeholder: "xoxe.xoxp-...",
-        mono: true,
-      },
+      inputs: [
+        {
+          name: "xoxpToken",
+          type: "password",
+          placeholder: "xoxe.xoxp-...",
+          mono: true,
+        },
+      ],
     },
     {
       envKey: "GH_APP_ID",
@@ -946,7 +963,24 @@ export function renderAgentDetailPage(
         "Creates a GitHub App for this agent from a manifest. You'll be redirected to GitHub to finish creating it under the chosen org.",
       action: `/admin/agents/${escapeHtml(agent.id)}/connect-github`,
       hiddenFields: { ghAuthMode: "app", ghAppMode: "auto" },
-      input: { name: "githubOrg", type: "text", placeholder: "my-org" },
+      inputs: [{ name: "githubOrg", type: "text", placeholder: "my-org" }],
+    },
+    {
+      envKey: "GH_APP_ID",
+      label: "Use existing GitHub App",
+      description:
+        "Connects an existing GitHub App you've already created — paste its App ID and Installation ID, and upload its private key (PEM file).",
+      action: `/admin/agents/${escapeHtml(agent.id)}/connect-github`,
+      hiddenFields: { ghAuthMode: "app", ghAppMode: "manual" },
+      inputs: [
+        { name: "ghAppId", type: "text", placeholder: "App ID" },
+        {
+          name: "ghAppInstallationId",
+          type: "text",
+          placeholder: "Installation ID",
+        },
+        { name: "ghAppPrivateKeyFile", type: "file" },
+      ],
     },
     {
       envKey: "GH_TOKEN",
@@ -955,12 +989,14 @@ export function renderAgentDetailPage(
         "Connects this agent to GitHub using a personal access token.",
       action: `/admin/agents/${escapeHtml(agent.id)}/connect-github`,
       hiddenFields: { ghAuthMode: "pat" },
-      input: {
-        name: "ghPat",
-        type: "password",
-        placeholder: "ghp_...",
-        mono: true,
-      },
+      inputs: [
+        {
+          name: "ghPat",
+          type: "password",
+          placeholder: "ghp_...",
+          mono: true,
+        },
+      ],
     },
   ];
   const connectActions = connectActionConfigs

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -922,6 +922,116 @@ describe("renderNewLocalAgentPage", () => {
   });
 });
 
+// ─── renderAgentDetailPage — connect-later actions (UAP-2.3 / UAP-5.4) ───────
+
+describe("renderAgentDetailPage — connect-later actions", () => {
+  function render(envVars: Record<string, string>): string {
+    return renderAgentDetailPage(
+      AGENT,
+      envVars,
+      [],
+      [],
+      [],
+      [],
+      [],
+      USER_NAME,
+      true,
+      { timezone: "UTC" },
+    );
+  }
+
+  test("Connect Slack action renders exactly one field (single-input backward compat)", () => {
+    const html = render({});
+    expect(html).toContain("Connect Slack");
+    const slackForm = html.match(
+      /action="\/admin\/agents\/agent-123\/connect-slack"[\s\S]*?<\/form>/,
+    )?.[0] as string;
+    expect(slackForm).toBeDefined();
+    const inputCount = (slackForm.match(/<input\b/g) ?? []).length;
+    expect(inputCount).toBe(1);
+    expect(slackForm).toMatch(/name="xoxpToken"[^>]*type="password"/);
+  });
+
+  test("Connect Slack action is hidden once SLACK_APP_TOKEN is set", () => {
+    const html = render({ SLACK_APP_TOKEN: "xoxe.xoxp-abc" });
+    expect(html).not.toContain("Connect Slack<");
+  });
+
+  test("Set up GitHub App (auto) action renders exactly one field (single-input backward compat)", () => {
+    const html = render({});
+    const forms = html.match(
+      /action="\/admin\/agents\/agent-123\/connect-github"[\s\S]*?<\/form>/g,
+    ) as string[];
+    const autoForm = forms.find((f) => f.includes('value="auto"')) as string;
+    expect(autoForm).toBeDefined();
+    const inputCount = (autoForm.match(/<input\b/g) ?? []).length;
+    // 2 hidden fields (ghAuthMode, ghAppMode) + 1 visible githubOrg field.
+    expect(inputCount).toBe(3);
+    expect(autoForm).toMatch(/name="githubOrg"[^>]*type="text"/);
+  });
+
+  test("Add GitHub PAT action renders exactly one field (single-input backward compat)", () => {
+    const html = render({});
+    const forms = html.match(
+      /action="\/admin\/agents\/agent-123\/connect-github"[\s\S]*?<\/form>/g,
+    ) as string[];
+    const patForm = forms.find((f) => f.includes('name="ghPat"')) as string;
+    expect(patForm).toBeDefined();
+    // 1 hidden field (ghAuthMode=pat) + 1 visible ghPat field.
+    const inputCount = (patForm.match(/<input\b/g) ?? []).length;
+    expect(inputCount).toBe(2);
+    expect(patForm).toMatch(/name="ghPat"[^>]*type="password"/);
+  });
+
+  test("Set up GitHub App and Add GitHub PAT are both hidden once GH_APP_ID/GH_TOKEN are set", () => {
+    const html = render({ GH_APP_ID: "12345", GH_TOKEN: "ghp_abc" });
+    expect(html).not.toContain("Set up GitHub App<");
+    expect(html).not.toContain("Add GitHub PAT<");
+  });
+
+  test("'Use existing GitHub App' action appears when GH_APP_ID is not set", () => {
+    const html = render({});
+    expect(html).toContain("Use existing GitHub App");
+  });
+
+  test("'Use existing GitHub App' action is hidden once GH_APP_ID is set (same gate as auto flow)", () => {
+    const html = render({ GH_APP_ID: "12345" });
+    expect(html).not.toContain("Use existing GitHub App");
+  });
+
+  test("'Use existing GitHub App' action posts to connect-github with hidden ghAuthMode=app/ghAppMode=manual", () => {
+    const html = render({});
+    const forms = html.match(
+      /action="\/admin\/agents\/agent-123\/connect-github"[\s\S]*?<\/form>/g,
+    ) as string[];
+    const manualForm = forms.find(
+      (f) => f.includes('value="manual"') && f.includes("ghAppId"),
+    ) as string;
+    expect(manualForm).toBeDefined();
+    expect(manualForm).toMatch(
+      /<input[^>]*type="hidden"[^>]*name="ghAuthMode"[^>]*value="app"[^>]*>/,
+    );
+    expect(manualForm).toMatch(
+      /<input[^>]*type="hidden"[^>]*name="ghAppMode"[^>]*value="manual"[^>]*>/,
+    );
+  });
+
+  test("'Use existing GitHub App' action renders three fields: App ID text, Installation ID text, Private Key file", () => {
+    const html = render({});
+    const forms = html.match(
+      /action="\/admin\/agents\/agent-123\/connect-github"[\s\S]*?<\/form>/g,
+    ) as string[];
+    const manualForm = forms.find(
+      (f) => f.includes('value="manual"') && f.includes("ghAppId"),
+    ) as string;
+    expect(manualForm).toMatch(/name="ghAppId"[^>]*type="text"/);
+    expect(manualForm).toMatch(/name="ghAppInstallationId"[^>]*type="text"/);
+    expect(manualForm).toMatch(/name="ghAppPrivateKeyFile"[^>]*type="file"/);
+    // The <form> itself must allow file uploads.
+    expect(manualForm).toContain('enctype="multipart/form-data"');
+  });
+});
+
 // ─── renderAgentDetailPage — env vars section ────────────────────────────────
 
 describe("renderAgentDetailPage — env vars", () => {

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -4178,6 +4178,54 @@ describe("admin UI — POST /admin/agents/:id/connect-github (mode=app, app-manu
     ).toBe(true);
   });
 
+  it("UAP-5.4: valid App ID/Installation ID/PEM uploaded as a file → 200 completion page, GH_APP_PRIVATE_KEY stored with the file's text content", async () => {
+    const patchCalls: Array<{ env: Record<string, string> }> = [];
+    const app = createAdminUIApp(
+      makeMockDeps({
+        agentEnvService: {
+          getByAgentId: async () => ({ env: {}, secretKeys: [] }),
+          upsert: async () => {},
+          patch: async (_agentId: string, env: Record<string, string>) => {
+            patchCalls.push({ env });
+          },
+          deleteKey: async () => {},
+          getConfigBundle: async () => null,
+        },
+      }),
+    );
+
+    const pemContents =
+      "-----BEGIN RSA PRIVATE KEY-----\nfaketestkeydata\n-----END RSA PRIVATE KEY-----";
+    const form = new FormData();
+    form.append("ghAuthMode", "app");
+    form.append("ghAppMode", "manual");
+    form.append("ghAppId", "12345");
+    form.append("ghAppInstallationId", "67890");
+    form.append(
+      "ghAppPrivateKeyFile",
+      new File([pemContents], "private-key.pem", {
+        type: "application/x-pem-file",
+      }),
+    );
+
+    const res = await app.request(`/admin/agents/${AGENT_ID}/connect-github`, {
+      method: "POST",
+      body: form,
+      headers: {
+        Cookie: `admin_session=${adminCookie}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(patchCalls.some((c) => c.env.GH_APP_ID === "12345")).toBe(true);
+    expect(
+      patchCalls.some((c) => c.env.GH_APP_INSTALLATION_ID === "67890"),
+    ).toBe(true);
+    expect(
+      patchCalls.some((c) => c.env.GH_APP_PRIVATE_KEY === pemContents),
+    ).toBe(true);
+  });
+
   it("non-numeric App ID → error, no env write", async () => {
     let patched = false;
     const app = createAdminUIApp(

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1374,9 +1374,9 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
     // either, so it's skipped when Slack is also requested) so GH_TOKEN is
     // already in place by the time the user lands back from Slack's OAuth
     // callback — then Slack's redirect is returned last.
-    let ghPatResult: Awaited<
-      ReturnType<typeof githubProvisioningService.startPatConnect>
-    > | undefined;
+    let ghPatResult:
+      | Awaited<ReturnType<typeof githubProvisioningService.startPatConnect>>
+      | undefined;
     if (ghAuthMode === "pat") {
       ghPatResult = await githubProvisioningService.startPatConnect(
         agent.id,
@@ -2411,7 +2411,16 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
       ghAppMode = formData.get("ghAppMode")?.toString() ?? "manual";
       ghAppId = formData.get("ghAppId")?.toString();
       ghAppInstallationId = formData.get("ghAppInstallationId")?.toString();
-      ghAppPrivateKey = formData.get("ghAppPrivateKey")?.toString();
+      // The detail page's "Use existing GitHub App" action (UAP-5.4) submits
+      // the private key as a file upload rather than pasted text — read its
+      // contents server-side. Falls back to a plain ghAppPrivateKey text
+      // field for back-compat with any other caller still posting it that
+      // way (e.g. API clients).
+      const ghAppPrivateKeyFile = formData.get("ghAppPrivateKeyFile");
+      ghAppPrivateKey =
+        ghAppPrivateKeyFile instanceof File
+          ? await ghAppPrivateKeyFile.text()
+          : formData.get("ghAppPrivateKey")?.toString();
       githubOrg = formData.get("githubOrg")?.toString()?.trim();
     } catch {
       return html(


### PR DESCRIPTION
## Summary
- Extends `ConnectActionConfig`/`renderConnectAction` (agent detail page) to support an array of input fields (text/password/file) instead of a single field, with existing "Connect Slack"/"Set up GitHub App"/"Add GitHub PAT" actions migrated to single-element arrays (no behavior change).
- Adds a new "Use existing GitHub App" connect-later action, gated on `GH_APP_ID` absence, with App ID + Installation ID text fields and a PEM private-key file upload.
- Updates the `POST /admin/agents/:id/connect-github` route to read the uploaded private-key file's content server-side (`ghAppPrivateKeyFile` via `file instanceof File` → `.text()`), falling back to the existing `ghAppPrivateKey` text field for back-compat.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | ConnectActionConfig/renderConnectAction supports an array of inputs (text/password/file) without changing existing actions' rendering/behavior | MET |
| 2 | New "Use existing GitHub App" action appears only when GH_APP_ID is unset, with 3 fields, and persists GH_APP_ID/GH_APP_INSTALLATION_ID/GH_APP_PRIVATE_KEY on submit | MET |
| 3 | Existing "Connect Slack"/"Set up GitHub App"/"Add GitHub PAT" actions unaffected | MET |
| 4 | Tests: unit (multi-field/file rendering, visibility gate) + smoke (file-upload manual-connect case) | MET |

## Test Plan
- `admin/src/admin-ui-pages.unit.test.ts`: new "connect-later actions" describe block — backward-compat single-field rendering for the 3 existing actions, visibility gates, and the new action's 3-field/file-input/`enctype="multipart/form-data"` rendering.
- `admin/src/admin-ui.smoke.test.ts`: new case posting real `multipart/form-data` with a `File` for the private key and asserting `GH_APP_ID`/`GH_APP_INSTALLATION_ID`/`GH_APP_PRIVATE_KEY` are persisted with the file's exact text content.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
