### PR TITLE
chore(chart): bump chart version to 1.19.56

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.19.56] - 2026-09-02
+
+### Changed
+
+- auto-bump to chart v1.19.56 triggered by release tag(s): `admin-v1.119.1`, `agent-v1.219.0`, `chat-v1.67.0`, `metrics-v1.69.0`, `task-store-v1.93.0`
+
 ## [1.19.55] - 2026-09-02
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.19.55
+version: 1.19.56
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,7 +30,15 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.19.55 triggered by release tag admin-v1.119.0"
+      description: "auto-bump to chart v1.19.56 triggered by release tag admin-v1.119.1"
+    - kind: changed
+      description: "auto-bump to chart v1.19.56 triggered by release tag agent-v1.219.0"
+    - kind: changed
+      description: "auto-bump to chart v1.19.56 triggered by release tag chat-v1.67.0"
+    - kind: changed
+      description: "auto-bump to chart v1.19.56 triggered by release tag metrics-v1.69.0"
+    - kind: changed
+      description: "auto-bump to chart v1.19.56 triggered by release tag task-store-v1.93.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -223,7 +223,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.119.0
+    tag: admin-v1.119.1
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -295,7 +295,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v1.67.1
+    tag: metrics-v1.69.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -411,7 +411,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.218.0
+    tag: agent-v1.219.0
     pullPolicy: ""
   service:
     port: 3000
@@ -434,7 +434,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.218.0
+      tag: agent-v1.219.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).
@@ -765,7 +765,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.91.1
+    tag: task-store-v1.93.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -918,7 +918,7 @@ chat:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-chat
-    tag: chat-v1.66.0
+    tag: chat-v1.67.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.19.55 → 1.19.56

**Triggering tags:**
- `admin-v1.119.1`
- `agent-v1.219.0`
- `chat-v1.67.0`
- `metrics-v1.69.0`
- `task-store-v1.93.0`

**New chart version:** `1.19.56`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.119.1`
- `agent.image.tag`: `agent-v1.219.0`
- `agent.provisioning.image.tag`: `agent-v1.219.0`
- `chat.image.tag`: `chat-v1.67.0`
- `metrics.image.tag`: `metrics-v1.69.0`
- `taskStore.image.tag`: `task-store-v1.93.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.19.56 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._