### PR TITLE
fix: seed renderedIds from upload response to prevent duplicate chat bubble

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -4894,6 +4894,13 @@ export function renderChatThreadPage(
           container.appendChild(errBubble);
           enableSend();
         });
+      } else {
+        // Success: parse response and seed renderedIds to prevent duplicate rendering
+        return r.json().then(function(data) {
+          if (data && data.message && data.message.id) {
+            renderedIds[data.message.id] = true;
+          }
+        });
       }
     }).catch(function() {
       // POST failed — Layer 1 ticker keeps going; poll loop still starts.

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -6588,6 +6588,13 @@ describe("renderChatThreadPage — CFB-2.3 live progress inline JS + status bubb
     expect(html).toContain("data-message-id");
   });
 
+  test("inline JS seeds renderedIds from the upload response", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [REPLIED_MSG], "u");
+    // The success branch of the fetch handler should parse JSON and seed renderedIds
+    // from data.message.id to prevent duplicate rendering.
+    expect(html).toContain("renderedIds[data.message.id]");
+  });
+
   test("inline JS renders every new server message, not just the last", () => {
     const html = renderChatThreadPage("agent-xyz", THREAD, [REPLIED_MSG], "u");
     // renderServerBubble is called in a loop over all msgs (the old code took


### PR DESCRIPTION
## Summary
- Seeds `renderedIds` from the upload response's `data.message.id` in `sendText()`'s fetch success branch, so the poll loop's subsequent `renderServerBubble()` call skips re-rendering the just-uploaded message.
- Fixes a duplicate chat bubble: the optimistic bubble drawn immediately by `addUserBubble()` and the server-echoed bubble from the poll loop both stayed in the DOM because `renderedIds` never learned the id from the upload response.
- No changes to the upload endpoint's response shape — `admin-ui.ts` already returns `{ message }` with `id`.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `sendText()`'s upload fetch success branch parses the JSON response and sets `renderedIds[data.message.id] = true` when present, before the poll loop can render a duplicate | MET | `admin/src/admin-ui-pages.ts:4897-4904` |
| 2 | Unit test added mirroring the existing "inline JS uses an id-based renderedIds dedupe set" test style; no existing tests retired | MET | `admin/src/admin-ui-pages.unit.test.ts:6591-6598` |
| 3 | No changes to the upload endpoint's response shape | MET | `admin-ui.ts` diff is empty |

## Test Plan
- Added unit test asserting the generated inline JS contains `renderedIds[data.message.id]`
- `bun test admin/src/admin-ui-pages.unit.test.ts` — 660/660 pass
- `bunx biome lint .` — clean
- `task typecheck` — clean
- `check-strings`, `check-config-docs`, `check-version-sync` — pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
