### PR TITLE
docs: migrate investigate-cron SKILL.md's task lookup off stored PR.taskId

### DIFF
--- a/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
@@ -295,12 +295,31 @@ describe("SKILL.md — Step 2: ground-truth snapshot (IC-1.2)", () => {
     expect(content).toContain("/tasks/");
   });
 
-  it("surfaces claimedBy, hitl, reviewState, patchCycles, and taskId from the task-store record", () => {
+  it("surfaces claimedBy, hitl, reviewState, patchCycles from the task-store PR record (not taskId)", () => {
     expect(content).toContain("claimedBy");
     expect(content).toContain("hitl");
     expect(content).toContain("reviewState");
     expect(content).toContain("patchCycles");
-    expect(content).toContain("taskId");
+    // taskId should NOT be in the diagnostic print — it's being removed from the schema
+    expect(content.match(/jq '.*taskId.*'/)).toBeNull();
+  });
+
+  it("queries task-store GET /tasks?repo=&pr= to resolve task ids for a PR (live lookup, not stored .taskId fallback)", () => {
+    const hasLiveTaskLookup =
+      content.includes("/tasks?repo=") &&
+      content.includes("&pr=") &&
+      !content.match(/\.taskId\s*\/\/\s*empty/); // Should NOT fall back to stored .taskId
+    expect(hasLiveTaskLookup).toBe(true);
+  });
+
+  it("handles the multi-task bundle case (PR mapped to zero, one, or many tasks) by looping over results", () => {
+    // Must mention looping/iteration over tasks, not assuming a single match
+    const hasLoopOrMany =
+      content.includes("loop") ||
+      content.includes("foreach") ||
+      content.includes("for ") ||
+      (content.includes("multiple") && content.includes("task"));
+    expect(hasLoopOrMany).toBe(true);
   });
 
   it("surfaces the readyFor*At fields from the task-store record", () => {

--- a/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts
@@ -322,6 +322,15 @@ describe("SKILL.md — Step 2: ground-truth snapshot (IC-1.2)", () => {
     expect(hasLoopOrMany).toBe(true);
   });
 
+  it("does not gate the PR-reference task lookup on PR_RECORD_JSON being non-empty", () => {
+    // PR_RECORD_JSON only reflects whether the task-store's PullRequest record
+    // exists (created on first review/patch/deploy claim), not whether ITEM_ARG
+    // is a PR reference. A freshly-opened, not-yet-claimed PR has no
+    // PullRequest record yet but real Task records already exist — gating on
+    // PR_RECORD_JSON would silently skip the live lookup for that case.
+    expect(content).not.toContain('elif [ -n "$PR_RECORD_JSON" ]');
+  });
+
   it("surfaces the readyFor*At fields from the task-store record", () => {
     const hasReadyForFields =
       content.includes("readyForReviewAt") ||

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -306,8 +306,12 @@ if [[ "$ITEM_ARG" =~ ^[A-Z]+-[0-9]+\.[0-9]+$ ]]; then
   else
     echo "$TASK_JSON" | jq '{id, status, hitl, dependencies}'
   fi
-elif [ -n "$PR_RECORD_JSON" ]; then
-  # ITEM_ARG is a PR reference — fetch associated tasks via live lookup
+else
+  # ITEM_ARG is a PR reference — fetch associated tasks via live lookup.
+  # Gated on ITEM_ARG's shape, not on PR_RECORD_JSON being non-empty: a
+  # freshly-opened PR not yet claimed by review/patch/deploy has no
+  # PullRequest record yet, but real Task records (Task.repo/Task.pr) can
+  # already exist — the live lookup below must still run for it.
   TASKS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
     "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}" 2>/dev/null)
   if [ -z "$TASKS_JSON" ]; then

--- a/plugins/shipwright/skills/investigate-cron/SKILL.md
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.md
@@ -293,18 +293,33 @@ PR_RECORD_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN
 if [ -z "$PR_RECORD_JSON" ]; then
   echo "No task-store PR record for {org}/{repo}#{pr} — not yet tracked, or never a PR. Skip this signal."
 else
-  echo "$PR_RECORD_JSON" | jq '{claimedBy, hitl, reviewState, readyForReviewAt, readyForPatchAt, readyForDeployAt, taskId, patchCycles, commitSha}'
+  echo "$PR_RECORD_JSON" | jq '{claimedBy, hitl, reviewState, readyForReviewAt, readyForPatchAt, readyForDeployAt, patchCycles, commitSha}'
 fi
 
-# Task record (when the item is a bare taskId, or the PR record above has a taskId):
-TASK_ID_TO_FETCH="${ITEM_ARG:-$(echo "$PR_RECORD_JSON" | jq -r '.taskId // empty')}"
-if [ -n "$TASK_ID_TO_FETCH" ]; then
+# Task record(s) — live lookup via GET /tasks?repo=&pr= for a PR, or /tasks/{id} for a bare task id:
+if [[ "$ITEM_ARG" =~ ^[A-Z]+-[0-9]+\.[0-9]+$ ]]; then
+  # ITEM_ARG is a bare task id (e.g., "IC-1.1")
   TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
-    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$TASK_ID_TO_FETCH" 2>/dev/null)
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/$ITEM_ARG" 2>/dev/null)
   if [ -z "$TASK_JSON" ]; then
-    echo "No task-store task record for $TASK_ID_TO_FETCH — skip this signal."
+    echo "No task-store task record for $ITEM_ARG — skip this signal."
   else
     echo "$TASK_JSON" | jq '{id, status, hitl, dependencies}'
+  fi
+elif [ -n "$PR_RECORD_JSON" ]; then
+  # ITEM_ARG is a PR reference — fetch associated tasks via live lookup
+  TASKS_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}" 2>/dev/null)
+  if [ -z "$TASKS_JSON" ]; then
+    echo "No tasks found for {org}/{repo}#{pr} — skip this signal."
+  else
+    # Loop over zero, one, or many tasks (the bundle case)
+    TASK_COUNT=$(echo "$TASKS_JSON" | jq '.tasks | length')
+    if [ "$TASK_COUNT" -eq 0 ]; then
+      echo "No tasks found for {org}/{repo}#{pr} — skip this signal."
+    else
+      echo "$TASKS_JSON" | jq '.tasks[] | {id, status, hitl, dependencies}'
+    fi
   fi
 fi
 ```
@@ -312,7 +327,9 @@ fi
 `hitl=true`, a `reviewState` that clearly blocks progress (e.g. stuck at
 `pending` with no recent activity), or an unmet `dependencies` entry on the
 task record are all direct, no-transcript-needed explanations for "why didn't
-this proceed."
+this proceed." Note: a PR can map to zero, one, or multiple tasks (the bundle
+case, where several tasks share the same PR) — the live lookup loops over all
+results to surface blocking conditions on any of them.
 
 ### 2c. Live GitHub state, diffed against the cached task-store view
 

--- a/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
@@ -287,12 +287,21 @@ describe("SKILL.md — Step 2: ground-truth snapshot (IC-1.2)", () => {
     expect(content).toContain("/tasks/");
   });
 
-  it("surfaces claimedBy, hitl, reviewState, patchCycles, and taskId from the task-store record", () => {
+  it("surfaces claimedBy, hitl, reviewState, patchCycles from the task-store PR record (not taskId)", () => {
     expect(content).toContain("claimedBy");
     expect(content).toContain("hitl");
     expect(content).toContain("reviewState");
     expect(content).toContain("patchCycles");
-    expect(content).toContain("taskId");
+    // taskId should NOT be in the diagnostic print — it's being removed from the schema
+    expect(content.match(/jq '.*taskId.*'/)).toBeNull();
+  });
+
+  it("queries task-store GET /tasks?repo=&pr= to resolve task ids for a PR (live lookup, not stored .taskId fallback)", () => {
+    const hasLiveTaskLookup =
+      content.includes("/tasks?repo=") &&
+      content.includes("&pr=") &&
+      !content.match(/\.taskId\s*\/\/\s*empty/); // Should NOT fall back to stored .taskId
+    expect(hasLiveTaskLookup).toBe(true);
   });
 
   it("queries live GitHub state via gh pr view with mergeStateStatus/headRefOid", () => {

--- a/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
+++ b/plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts
@@ -304,6 +304,15 @@ describe("SKILL.md — Step 2: ground-truth snapshot (IC-1.2)", () => {
     expect(hasLiveTaskLookup).toBe(true);
   });
 
+  it("does not gate the PR-reference task lookup on PR_RECORD_JSON being non-empty", () => {
+    // PR_RECORD_JSON only reflects whether the task-store's PullRequest record
+    // exists (created on first review/patch/deploy claim), not whether ITEM_ARG
+    // is a PR reference. A freshly-opened, not-yet-claimed PR has no
+    // PullRequest record yet but real Task records already exist — gating on
+    // PR_RECORD_JSON would silently skip the live lookup for that case.
+    expect(content).not.toContain('elif [ -n "$PR_RECORD_JSON" ]');
+  });
+
   it("queries live GitHub state via gh pr view with mergeStateStatus/headRefOid", () => {
     expect(content).toContain("gh pr view");
     expect(content).toContain("mergeStateStatus");


### PR DESCRIPTION
## Summary
- Replaces investigate-cron `SKILL.md`'s stored `.taskId` fallback with a live `GET /tasks?repo=&pr=` lookup, since the `PullRequest.taskId` column/API field is being removed by a follow-up task (PTL-3.1)
- Loops over the lookup results to correctly handle the multi-task bundle case (a PR mapping to zero, one, or many tasks) instead of assuming a single match
- Drops `taskId` from the diagnostic `jq` print of the PR record, and updates surrounding prose to describe the new live-lookup behavior
- Rewrites the matching assertions in `SKILL.content.test.ts` and `SKILL.unit.test.ts` to check for the live-lookup snippet instead of the old `taskId` string

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | SKILL.md section 2b no longer reads `.taskId` off `PR_RECORD_JSON` — uses live `GET /tasks?repo=&pr=` lookup, looping over results for the bundle case | MET |
| 2 | Diagnostic jq print of the PR record no longer includes `taskId` | MET |
| 3 | Surrounding prose in section 2b describes the live-lookup behavior | MET |
| 4 | `SKILL.content.test.ts` and `SKILL.unit.test.ts` rewritten to assert the new live-lookup snippet's content instead of `taskId` presence | MET |

## Test Plan
- `NODE_ENV=test bun test plugins/shipwright/skills/investigate-cron/SKILL.content.test.ts plugins/shipwright/skills/investigate-cron/SKILL.unit.test.ts` — 120 pass, 0 fail
- `bun run --filter='*' --sequential typecheck` — passes
- `task ci` — pre-existing failures unrelated to this change (task-store `prs.ts` validateRepo null-repos bug, metrics env test flakes, github-app-auth integration tests); none touch investigate-cron/SKILL.md
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
