### PR TITLE
feat: retry Slack startup from config-sync when credentials arrive after boot

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -70,6 +70,11 @@ import { createFileSessionStore, threadKey } from "./sessions.ts";
 import { ensureAgentHome, installPlugins, runMiseStartup } from "./setup.ts";
 import { HttpShipwrightRuntimeClient } from "./shipwright-runtime-client.ts";
 import { createSlackApp, hasSlackCredentials } from "./slack.ts";
+import {
+  slackClientRef,
+  startSlackIfPossible,
+  type StartableSlackApp,
+} from "./slack-startup.ts";
 import { sendBackOnlineDm } from "./startup-dm.ts";
 import { resolveDisplayName, resolveUserEmail } from "./users.ts";
 import { synthesizeSpeech } from "./voice.ts";
@@ -126,18 +131,23 @@ console.log(`[agent] agent home initialized: ${config.paths.home}`);
 const slackClock = SystemClock();
 const sessions = createFileSessionStore(config.paths.sessions);
 
-// Slack is optional (see Step 7). Building a WebClient around an empty token
-// would make every downstream call fail with `invalid_auth` instead of being
-// skipped, so a chat-only agent gets no client at all and callers branch on
-// `undefined`.
-const slackAppConfig = {
-  botToken: config.slack.botToken ?? "",
-  appToken: config.slack.appToken ?? "",
-  signingSecret: config.slack.signingSecret ?? "",
-};
-const slack = hasSlackCredentials(slackAppConfig)
-  ? new WebClient(slackAppConfig.botToken)
-  : undefined;
+// Slack is optional (see Step 7 + startSlackIfPossible in slack-startup.ts).
+// Building a WebClient around an empty token would make every downstream
+// call fail with `invalid_auth` instead of being skipped, so a chat-only
+// agent gets no client at all and callers branch on `undefined`.
+//
+// buildSlackAppConfig() reads live process.env rather than the static
+// `config` snapshot taken above at module-load time — SLK-1.1: credentials
+// saved to the admin DB after boot only reach this process via syncConfig()'s
+// `Object.assign(process.env, bundle.env)`, so re-reading `config.slack.*`
+// here would keep seeing the boot-time (absent) values forever.
+function buildSlackAppConfig() {
+  return {
+    botToken: process.env.SLACK_BOT_TOKEN ?? "",
+    appToken: process.env.SLACK_APP_TOKEN ?? "",
+    signingSecret: process.env.SLACK_SIGNING_SECRET ?? "",
+  };
+}
 const runner = createRunClaude(
   Bun.spawn,
   sessions,
@@ -185,7 +195,13 @@ const workQueueReporter =
     : new NoopWorkQueueReporter();
 
 const cronDeps: CronHandlerDeps = {
-  slack,
+  // SLK-1.1: a getter, not a plain field — Slack may start after boot (see
+  // slack-startup.ts's startSlackIfPossible()), so cron dispatch must read
+  // the live slackClientRef on every fire rather than closing over a
+  // boot-time `undefined` forever.
+  get slack() {
+    return slackClientRef.get();
+  },
   runner: (message, onProgress) => runner(message, undefined, onProgress),
   formatter: markdownToSlack,
   onSession: async (channel: string, ts: string, sessionId: string) => {
@@ -197,6 +213,51 @@ const cronDeps: CronHandlerDeps = {
   alertsChannel: config.alerts.channel,
   cronRunReporter,
   agentId: config.shipwright.agentId,
+};
+
+// SLK-1.1: shared Slack-start deps, built once so both the Step 4
+// (config-sync) and Step 7 (boot) call sites of startSlackIfPossible()
+// operate on the same module-scope `app`/client-ref state — a start from
+// either call site is visible to the other via isAppStarted()/slackClientRef.
+let app: ReturnType<typeof createSlackApp> | undefined;
+
+function buildSlackApp() {
+  return createSlackApp(
+    runner,
+    markdownToSlack,
+    threadKey,
+    undefined, // appFactory — default Bolt App
+    buildSlackAppConfig(),
+    process.env.SENTRY_DSN ? Sentry : undefined,
+    undefined, // fileDownloaderFn — default
+    config.voice,
+    undefined, // transcribeAudioFn — default
+    synthesizeSpeech,
+    (userId, client) => resolveDisplayName(userId, client),
+    undefined, // botUserId — resolved by Bolt
+    undefined, // conversationsRepliesFn — default
+    (key) => sessions.get(key),
+    undefined, // blocksConverter — default
+    chatTokenReporter,
+    (userId, client) => resolveUserEmail(userId, client),
+    agentSlackMembershipRef,
+    config.slack.thinkingStepsEnabled,
+  );
+}
+
+const slackStartDeps = {
+  buildSlackConfig: buildSlackAppConfig,
+  hasSlackCredentials,
+  isAppStarted: () => app !== undefined,
+  createSlackApp: buildSlackApp,
+  setApp: (started: StartableSlackApp) => {
+    app = started as ReturnType<typeof createSlackApp>;
+  },
+  createSlackClient: () => new WebClient(buildSlackAppConfig().botToken),
+  setSlackClient: slackClientRef.set,
+  markSlackConnected,
+  sendBackOnlineDm: (client: WebClient) =>
+    sendBackOnlineDm(client, config.owner.user),
 };
 
 const healthPort = Number(
@@ -279,11 +340,16 @@ if (runtimeClient && agentId) {
       agentReposRef.set(bundle.repos);
 
       // Sync the agent's author-allowlist live ref
-      agentAuthorAllowlistRef.set(resolveAuthorAllowlist(bundle.authorAllowlist));
+      agentAuthorAllowlistRef.set(
+        resolveAuthorAllowlist(bundle.authorAllowlist),
+      );
 
       // Sync the agent's Slack-membership-restriction live ref
       agentSlackMembershipRef.set(
-        resolveSlackMembership(bundle.restrictSlackToMembers, bundle.memberEmails),
+        resolveSlackMembership(
+          bundle.restrictSlackToMembers,
+          bundle.memberEmails,
+        ),
       );
     } catch (err) {
       if (
@@ -296,6 +362,26 @@ if (runtimeClient && agentId) {
       }
       console.error(
         "[config-sync] failed to fetch config bundle:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return;
+    }
+
+    // SLK-1.1: retry Slack startup on every successful tick — a no-op unless
+    // credentials are newly complete against live process.env AND Bolt
+    // hasn't already started (see startSlackIfPossible's own guards). Kept
+    // in its own try/catch, separate from the fetch/env-sync try above, so a
+    // Bolt start failure (e.g. a bad token that fails Socket Mode auth) is
+    // logged distinctly rather than being misreported as a config-bundle
+    // fetch failure — and so it can never mask an already-successful env
+    // sync that happened earlier in this same tick.
+    try {
+      if (await startSlackIfPossible(slackStartDeps)) {
+        console.log("[config-sync] Slack app started — running");
+      }
+    } catch (err) {
+      console.error(
+        "[config-sync] Slack startup failed:",
         err instanceof Error ? err.message : String(err),
       );
     }
@@ -362,7 +448,9 @@ if (runtimeClient && agentId) {
   let reviewStateReconcilerDeps:
     | ReturnType<typeof buildReviewStateReconcilerDeps>
     | undefined;
-  let worktreeReaperDeps: ReturnType<typeof buildWorktreeReaperDeps> | undefined;
+  let worktreeReaperDeps:
+    | ReturnType<typeof buildWorktreeReaperDeps>
+    | undefined;
   let claimInvariantReconcilerDeps:
     | ReturnType<typeof buildClaimInvariantReconcilerDeps>
     | undefined;
@@ -574,40 +662,24 @@ if (config.chat.serviceUrl && config.chat.serviceToken) {
 // Bolt's Socket Mode throws "Must provide an App-Level Token" if constructed
 // without an appToken, so the agent runs Slack ONLY when both tokens are present.
 // Absent creds → offline mode: skip Slack, keep health green, interact via the chat UI.
+//
+// SLK-1.1: startSlackIfPossible() (slack-startup.ts) is the single shared
+// start path — attempted here AND again from inside syncConfig()'s success
+// branch (Step 4, above — slackStartDeps is built earlier in this file so
+// both call sites can share it). In the common case where credentials are
+// already present at boot, Step 4's `await syncConfig()` (which runs before
+// this point) already starts Slack, making this call a no-op; this call site
+// exists so a config-bundle fetch that 404s or errors on the very first tick
+// doesn't prevent Slack from starting when creds are already in the process
+// env at boot. Every later syncConfig() tick is what retries the start for
+// credentials that arrive after boot (the SLK-1.1 fix). Its own
+// start-in-flight guard makes overlapping call sites racing safe; its own
+// isAppStarted() check makes an already-successful start here a permanent
+// no-op for every later attempt.
 
-let app: ReturnType<typeof createSlackApp> | undefined;
-
-if (hasSlackCredentials(slackAppConfig)) {
-  app = createSlackApp(
-    runner,
-    markdownToSlack,
-    threadKey,
-    undefined, // appFactory — default Bolt App
-    slackAppConfig,
-    process.env.SENTRY_DSN ? Sentry : undefined,
-    undefined, // fileDownloaderFn — default
-    config.voice,
-    undefined, // transcribeAudioFn — default
-    synthesizeSpeech,
-    (userId, client) => resolveDisplayName(userId, client),
-    undefined, // botUserId — resolved by Bolt
-    undefined, // conversationsRepliesFn — default
-    (key) => sessions.get(key),
-    undefined, // blocksConverter — default
-    chatTokenReporter,
-    (userId, client) => resolveUserEmail(userId, client),
-    agentSlackMembershipRef,
-    config.slack.thinkingStepsEnabled,
-  );
-
-  await app.start();
-  markSlackConnected();
+if (await startSlackIfPossible(slackStartDeps)) {
   console.log("[agent] Slack app started — running");
-
-  // `slack` is non-undefined whenever hasSlackCredentials() held, but TypeScript
-  // cannot narrow it across this distance.
-  if (slack) await sendBackOnlineDm(slack, config.owner.user);
-} else {
+} else if (!hasSlackCredentials(buildSlackAppConfig())) {
   console.warn(
     "[agent] Slack credentials absent (need SLACK_BOT_TOKEN + SLACK_APP_TOKEN) — " +
       "skipping Slack startup. Offline mode: use the admin chat UI (/admin/chat) to interact.",

--- a/agent/src/slack-startup.ts
+++ b/agent/src/slack-startup.ts
@@ -1,0 +1,170 @@
+/**
+ * agent/src/slack-startup.ts
+ *
+ * Decision logic + live-client box for (re)starting the Slack Bolt Socket
+ * Mode app once credentials are available — whether that happens at boot
+ * (Step 7 in index.ts) or later, when syncConfig() picks up a
+ * SLACK_BOT_TOKEN/SLACK_APP_TOKEN pair that was saved to the admin DB after
+ * the pod already started.
+ *
+ * Why this exists: before this module, both the Bolt `app` and the `slack`
+ * WebClient were built once at boot from a static config snapshot taken
+ * before syncConfig() ever ran. If credentials arrived even a few seconds
+ * late (a plausible race during provisioning), the boot-time
+ * hasSlackCredentials() check failed once and the agent stayed in permanent
+ * offline mode — syncConfig() re-applies process.env every tick but had no
+ * hook to retry Slack startup. This module gives syncConfig() (and the boot
+ * path) a single, shared, testable decision: "are credentials live now, and
+ * has Bolt not already started? If so, start it — exactly once."
+ *
+ * Kept dependency-injected and I/O-free itself (matches the project's
+ * no-`mock.module()` isolation rule) — real Slack/Bolt/DM calls are injected
+ * by the caller (index.ts), so this module's own tests use fakes/spies
+ * instead of hitting real Slack. Mirrors agent-repos-ref.ts /
+ * agent-slack-membership-ref.ts's get/set-ref style for the live client box,
+ * and the same style is reused here for the start-in-flight guard so no
+ * module-scope mutable state leaks across test cases (each test constructs
+ * its own guard via createSlackStartGuard()).
+ */
+
+import type { WebClient } from "@slack/web-api";
+
+/** Minimal shape `startSlackIfPossible` needs from a started Bolt App. */
+export interface StartableSlackApp {
+  start(): Promise<unknown>;
+}
+
+export interface SlackClientRef {
+  /** Returns the current live Slack WebClient, or undefined if Slack hasn't started yet. */
+  get(): WebClient | undefined;
+  /** Replaces the current live Slack WebClient. */
+  set(client: WebClient | undefined): void;
+}
+
+/** Creates a new, independent Slack client ref defaulting to undefined (no client yet). */
+export function createSlackClientRef(): SlackClientRef {
+  let client: WebClient | undefined;
+
+  return {
+    get(): WebClient | undefined {
+      return client;
+    },
+    set(next: WebClient | undefined): void {
+      client = next;
+    },
+  };
+}
+
+/**
+ * The process-wide Slack client ref. index.ts's cronDeps.slack and the
+ * back-online DM call site read through `.get()` rather than closing over a
+ * boot-time `const slack`, so a late (re)start via startSlackIfPossible()
+ * makes both see a live client without an agent restart.
+ */
+export const slackClientRef: SlackClientRef = createSlackClientRef();
+
+/**
+ * Guards startSlackIfPossible() against overlapping callers — e.g. two
+ * syncConfig() ticks racing because syncConfig() is dispatched via an
+ * unawaited setInterval, or a boot call racing a config-sync call. Kept as
+ * its own tiny ref (rather than a module-scope `let`) so tests can construct
+ * an independent, disposable guard instead of mutating shared state that
+ * would otherwise leak between test cases.
+ */
+export interface SlackStartGuard {
+  isInFlight(): boolean;
+  set(inFlight: boolean): void;
+}
+
+export function createSlackStartGuard(): SlackStartGuard {
+  let inFlight = false;
+  return {
+    isInFlight: () => inFlight,
+    set: (next: boolean) => {
+      inFlight = next;
+    },
+  };
+}
+
+/**
+ * The process-wide start-in-flight guard used by index.ts's two real call
+ * sites (boot + syncConfig()). A single shared instance is required in
+ * production so a boot-time start and a config-sync-tick start can't race
+ * each other; tests should construct their own via createSlackStartGuard()
+ * instead of reusing this singleton.
+ */
+export const slackStartGuard: SlackStartGuard = createSlackStartGuard();
+
+export interface StartSlackDeps {
+  /** Reads live env-derived Slack config (botToken/appToken/signingSecret) at call time — not a static snapshot. */
+  buildSlackConfig: () => {
+    botToken: string;
+    appToken: string;
+    signingSecret: string;
+  };
+  /** Same credential-completeness check used at boot — see slack.ts. */
+  hasSlackCredentials: (cfg: { botToken: string; appToken: string }) => boolean;
+  /** True once Bolt has already been started (by any prior call, boot or config-sync). */
+  isAppStarted: () => boolean;
+  /** Builds (but does not start) the Bolt app from live config. */
+  createSlackApp: () => StartableSlackApp;
+  /** Records the started Bolt app so isAppStarted() reflects it on the next call. */
+  setApp: (app: StartableSlackApp) => void;
+  /** Builds the WebClient to publish via the slack client ref once credentials are confirmed live. */
+  createSlackClient: () => WebClient;
+  setSlackClient: (client: WebClient | undefined) => void;
+  markSlackConnected: () => void;
+  sendBackOnlineDm: (client: WebClient) => Promise<void>;
+  /** Start-in-flight guard — defaults to the process-wide singleton; tests inject their own. */
+  guard?: SlackStartGuard;
+}
+
+/**
+ * Attempts to start the Slack Bolt app if — and only if — credentials are
+ * complete right now AND Bolt hasn't already been started. Safe to call on
+ * every boot attempt and every syncConfig() tick: a no-op when credentials
+ * are still incomplete, and a no-op once a prior call already started Bolt.
+ *
+ * Returns true iff this call actually started Bolt; false for every no-op
+ * path (incomplete credentials, already started, or a racing call that lost
+ * the in-flight guard).
+ *
+ * Errors from `createSlackApp()`/`app.start()` propagate to the caller (not
+ * swallowed here) so index.ts's two call sites can each decide how to
+ * handle a start failure consistently with their surrounding context — see
+ * the call sites in index.ts for the boot-vs-config-sync tradeoff.
+ */
+export async function startSlackIfPossible(
+  deps: StartSlackDeps,
+): Promise<boolean> {
+  const guard = deps.guard ?? slackStartGuard;
+
+  if (guard.isInFlight()) return false;
+  if (deps.isAppStarted()) return false;
+
+  const slackConfig = deps.buildSlackConfig();
+  if (!deps.hasSlackCredentials(slackConfig)) return false;
+
+  guard.set(true);
+  try {
+    // Re-check after acquiring the guard in case another call already
+    // started Bolt between the check above and here — defense in depth on
+    // top of the guard itself (JS has no preemption between the isInFlight
+    // check and the set(true) above, so this branch is unreachable today,
+    // but keeps the invariant obvious even if that ordering ever changes).
+    if (deps.isAppStarted()) return false;
+
+    const app = deps.createSlackApp();
+    await app.start();
+    deps.setApp(app);
+    deps.markSlackConnected();
+
+    const client = deps.createSlackClient();
+    deps.setSlackClient(client);
+
+    await deps.sendBackOnlineDm(client);
+    return true;
+  } finally {
+    guard.set(false);
+  }
+}

--- a/agent/src/slack-startup.unit.test.ts
+++ b/agent/src/slack-startup.unit.test.ts
@@ -1,0 +1,303 @@
+/**
+ * agent/src/slack-startup.unit.test.ts
+ *
+ * Unit tests for startSlackIfPossible() and the Slack client ref — pure
+ * logic, no I/O. All Slack/Bolt/DM calls are fakes/spies injected via
+ * StartSlackDeps; no real network or `mock.module()` usage.
+ */
+
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it } from "bun:test";
+import {
+  createSlackClientRef,
+  createSlackStartGuard,
+  slackClientRef,
+  startSlackIfPossible,
+  type StartableSlackApp,
+  type StartSlackDeps,
+} from "./slack-startup.ts";
+
+/** Builds a minimal fake WebClient stand-in for identity/shape assertions. */
+function fakeClient(tag: string): WebClient {
+  return { fake: tag } as unknown as WebClient;
+}
+
+/**
+ * Builds a fresh, fully-independent set of fakes for one test case —
+ * mirrors production semantics (isAppStarted flips true only after setApp)
+ * but with no real Slack I/O, and returns spy call counters for assertions.
+ */
+function buildFakeDeps(overrides?: {
+  botToken?: string;
+  appToken?: string;
+}) {
+  let appStarted: StartableSlackApp | undefined;
+  const calls = {
+    createSlackApp: 0,
+    appStart: 0,
+    setApp: 0,
+    markSlackConnected: 0,
+    createSlackClient: 0,
+    setSlackClient: 0,
+    sendBackOnlineDm: 0,
+  };
+
+  const clientRef = createSlackClientRef();
+  const guard = createSlackStartGuard();
+
+  const deps: StartSlackDeps = {
+    buildSlackConfig: () => ({
+      botToken: overrides?.botToken ?? "xoxb-live",
+      appToken: overrides?.appToken ?? "xapp-live",
+      signingSecret: "shh",
+    }),
+    hasSlackCredentials: (cfg) =>
+      cfg.botToken.trim() !== "" && cfg.appToken.trim() !== "",
+    isAppStarted: () => appStarted !== undefined,
+    createSlackApp: () => {
+      calls.createSlackApp++;
+      return {
+        start: async () => {
+          calls.appStart++;
+        },
+      };
+    },
+    setApp: (app) => {
+      calls.setApp++;
+      appStarted = app;
+    },
+    createSlackClient: () => {
+      calls.createSlackClient++;
+      // A minimal stand-in — startSlackIfPossible only threads this through
+      // to setSlackClient/sendBackOnlineDm, never calls real WebClient methods.
+      return fakeClient("started");
+    },
+    setSlackClient: (client) => {
+      calls.setSlackClient++;
+      clientRef.set(client);
+    },
+    markSlackConnected: () => {
+      calls.markSlackConnected++;
+    },
+    sendBackOnlineDm: async () => {
+      calls.sendBackOnlineDm++;
+    },
+    guard,
+  };
+
+  return {
+    deps,
+    calls,
+    clientRef,
+    guard,
+    isStarted: () => appStarted !== undefined,
+  };
+}
+
+describe("startSlackIfPossible", () => {
+  it("credentials complete on a later tick (not boot) triggers exactly one Slack start", async () => {
+    const { deps, calls, clientRef } = buildFakeDeps();
+
+    const started = await startSlackIfPossible(deps);
+
+    expect(started).toBe(true);
+    expect(calls.createSlackApp).toBe(1);
+    expect(calls.appStart).toBe(1);
+    expect(calls.setApp).toBe(1);
+    expect(calls.markSlackConnected).toBe(1);
+    expect(calls.createSlackClient).toBe(1);
+    expect(calls.sendBackOnlineDm).toBe(1);
+    expect(clientRef.get()).toBeDefined();
+    expect((clientRef.get() as unknown as { fake: string }).fake).toBe(
+      "started",
+    );
+  });
+
+  it("a later tick with the app already started does not re-trigger a start", async () => {
+    const { deps, calls } = buildFakeDeps();
+
+    const first = await startSlackIfPossible(deps);
+    const second = await startSlackIfPossible(deps);
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(calls.createSlackApp).toBe(1);
+    expect(calls.appStart).toBe(1);
+    expect(calls.setApp).toBe(1);
+    expect(calls.markSlackConnected).toBe(1);
+    expect(calls.sendBackOnlineDm).toBe(1);
+  });
+
+  it("a tick with still-incomplete credentials (missing app token) does not attempt a start", async () => {
+    const { deps, calls } = buildFakeDeps({
+      botToken: "xoxb-live",
+      appToken: "",
+    });
+
+    const started = await startSlackIfPossible(deps);
+
+    expect(started).toBe(false);
+    expect(calls.createSlackApp).toBe(0);
+    expect(calls.appStart).toBe(0);
+    expect(calls.setApp).toBe(0);
+    expect(calls.markSlackConnected).toBe(0);
+    expect(calls.createSlackClient).toBe(0);
+    expect(calls.sendBackOnlineDm).toBe(0);
+  });
+
+  it("a tick with still-incomplete credentials (missing bot token) does not attempt a start", async () => {
+    const { deps, calls } = buildFakeDeps({
+      botToken: "",
+      appToken: "xapp-live",
+    });
+
+    const started = await startSlackIfPossible(deps);
+
+    expect(started).toBe(false);
+    expect(calls.createSlackApp).toBe(0);
+    expect(calls.appStart).toBe(0);
+  });
+
+  it("a tick with both credentials missing does not attempt a start", async () => {
+    const { deps, calls } = buildFakeDeps({ botToken: "", appToken: "" });
+
+    const started = await startSlackIfPossible(deps);
+
+    expect(started).toBe(false);
+    expect(calls.createSlackApp).toBe(0);
+  });
+
+  it("overlapping/concurrent calls (two ticks racing before the first app.start() resolves) do not double-start", async () => {
+    const { deps, calls } = buildFakeDeps();
+
+    // Make app.start() hang until we let both calls race against it, so the
+    // second call's isAppStarted() check still sees "not started" while the
+    // first is mid-flight — the in-flight guard, not timing luck, must be
+    // what prevents a double start.
+    let releaseStart: () => void = () => {};
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    deps.createSlackApp = () => {
+      calls.createSlackApp++;
+      return {
+        start: async () => {
+          await startGate;
+          calls.appStart++;
+        },
+      };
+    };
+
+    const firstCall = startSlackIfPossible(deps);
+    const secondCall = startSlackIfPossible(deps);
+
+    releaseStart();
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+
+    expect([first, second].filter(Boolean)).toHaveLength(1);
+    expect(calls.createSlackApp).toBe(1);
+    expect(calls.appStart).toBe(1);
+    expect(calls.setApp).toBe(1);
+    expect(calls.markSlackConnected).toBe(1);
+    expect(calls.sendBackOnlineDm).toBe(1);
+  });
+
+  it("app already started before syncConfig's first tick (boot succeeded) is a no-op", async () => {
+    const { deps, calls } = buildFakeDeps();
+
+    // Simulate boot having already started Bolt.
+    await startSlackIfPossible(deps);
+    calls.createSlackApp = 0;
+    calls.appStart = 0;
+    calls.setApp = 0;
+    calls.markSlackConnected = 0;
+    calls.sendBackOnlineDm = 0;
+
+    const started = await startSlackIfPossible(deps);
+
+    expect(started).toBe(false);
+    expect(calls.createSlackApp).toBe(0);
+    expect(calls.appStart).toBe(0);
+    expect(calls.setApp).toBe(0);
+    expect(calls.markSlackConnected).toBe(0);
+    expect(calls.sendBackOnlineDm).toBe(0);
+  });
+
+  it("errors from app.start() propagate to the caller rather than being swallowed", async () => {
+    const { deps } = buildFakeDeps();
+    deps.createSlackApp = () => ({
+      start: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await expect(startSlackIfPossible(deps)).rejects.toThrow("boom");
+  });
+
+  it("errors from app.start() release the in-flight guard so a subsequent retry can proceed", async () => {
+    const { deps, calls, guard } = buildFakeDeps();
+    deps.createSlackApp = () => ({
+      start: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await expect(startSlackIfPossible(deps)).rejects.toThrow("boom");
+    expect(guard.isInFlight()).toBe(false);
+
+    // Retry with working deps — should succeed since the app never actually started.
+    deps.createSlackApp = () => {
+      calls.createSlackApp++;
+      return {
+        start: async () => {
+          calls.appStart++;
+        },
+      };
+    };
+    const started = await startSlackIfPossible(deps);
+    expect(started).toBe(true);
+  });
+});
+
+describe("SlackClientRef", () => {
+  it("createSlackClientRef() defaults to undefined (no client yet)", () => {
+    const ref = createSlackClientRef();
+    expect(ref.get()).toBeUndefined();
+  });
+
+  it("set() replaces the current client, reflected by the next get()", () => {
+    const ref = createSlackClientRef();
+    const client = fakeClient("a");
+
+    ref.set(client);
+    expect(ref.get()).toBe(client);
+  });
+
+  it("multiple independent ref instances don't share state", () => {
+    const refA = createSlackClientRef();
+    const refB = createSlackClientRef();
+    const client = fakeClient("a");
+
+    refA.set(client);
+
+    expect(refA.get()).toBe(client);
+    expect(refB.get()).toBeUndefined();
+  });
+});
+
+describe("slackClientRef (process-wide singleton)", () => {
+  it("is a working ref that reflects set() through get(), independent of createSlackClientRef() instances", () => {
+    const independent = createSlackClientRef();
+    const leakClient = fakeClient("should-not-leak");
+    independent.set(leakClient);
+
+    const realClient = fakeClient("real");
+    slackClientRef.set(realClient);
+
+    expect(slackClientRef.get()).toBe(realClient);
+    expect(independent.get()).toBe(leakClient);
+
+    // Reset the process-wide singleton so this test doesn't leak state into siblings.
+    slackClientRef.set(undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts the inline Slack Bolt-start block in `agent/src/index.ts` into a shared, dependency-injected `startSlackIfPossible()` (new `agent/src/slack-startup.ts`), called from both the existing boot path (Step 7) and from inside `syncConfig()`'s success branch — so credentials saved to the admin DB shortly after pod boot now retry Slack startup on the next 60s config-sync tick instead of leaving the agent permanently offline.
- Replaces the frozen `const slack` WebClient with a mutable `slackClientRef` (mirrors the existing `agentReposRef` / `agentAuthorAllowlistRef` / `agentSlackMembershipRef` live-ref convention), so `cronDeps.slack` and the back-online DM pick up a live client once credentials arrive late instead of staying permanently `undefined`.
- Adds a start-in-flight guard so overlapping `syncConfig()` ticks (or a boot call racing a config-sync call) can't double-start Bolt; a tick with still-incomplete credentials is a no-op.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Slack startup attempted both at boot and from syncConfig()'s success branch | MET | `index.ts` calls `startSlackIfPossible(slackStartDeps)` at Step 7 boot and inside `syncConfig()`'s success branch, sharing `slackStartDeps` |
| 2 | `slack` WebClient becomes a mutable `slackClientRef` | MET | `slack-startup.ts`'s `slackClientRef` replaces `const slack`; `cronDeps.slack` is a getter reading `slackClientRef.get()` |
| 3 | Overlapping ticks guarded; incomplete creds don't attempt start | MET | `slackStartGuard` in-flight flag + `hasSlackCredentials()` gate in `startSlackIfPossible()`, covered by a racing-calls unit test |
| 4 | Unit test for config-sync-driven Slack startup; no existing test removed | MET | `slack-startup.unit.test.ts` (13 tests) covers tick-N start, no re-trigger, incomplete creds, races, boot-already-started no-op, error propagation; `slack.unit.test.ts` untouched (42/42 passing) |

## Test Plan
- `bun test agent/src/slack-startup.unit.test.ts agent/src/slack.unit.test.ts` — 42/42 pass (13 new + 29 existing, no regressions)
- `task typecheck` — passes across all workspaces
- New module has 100% line/function coverage
- `task ci`'s full-suite run surfaces 31 pre-existing failures unrelated to this change (confirmed identical failures reproduce on `main` in isolation — a Bun `process.env.X = undefined` semantics quirk affecting several `config.unit.test.ts`/`env.unit.test.ts` cases, plus unrelated GitHub-app-auth/Sentry/migration test issues); none touch `agent/src/index.ts` or `slack-startup.ts`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
