### PR TITLE
docs: refresh stale references

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"e048075b624fcceb34025bcd4f8c52e18a6b37fa","timestamp":"2026-09-02T07:04:09Z"}
+{"sha":"48f020d12b5a582a8a25dfa21c887cd5950a5d1c","timestamp":"2026-09-03T00:00:00Z"}


### PR DESCRIPTION
## Summary
- Scoped docs-freshness audit against the file set changed since the last anchor (`e048075b`..`48f020d1`): admin-ui, check-patch, slack.ts/slack-progress/slack-startup/slack-thread-status-tracker, progress-phases, hitl.ts, clone-plan, agent-workspace-pull.ts, chart/values.yaml, marketplace/plugin manifests, etc.
- Candidate docs (referenced changed files/symbols): `agent.md`, `architecture.md`, `configuration.md`, `agent-types.md`, `helm-repo.md`, `migration.md`, `testing.md`. All verified **current** — every checked file path/symbol/env var/route still resolves against the codebase at `48f020d1`. No stale sections found, no edits needed.
- Bumped `state/docs-last-synced.json` to the audited HEAD SHA (anchor-only bump, per the established pattern e.g. #2559).
- Filed a task-store task (`docs-freshness-cron` session) to document `agent/src/slack-startup.ts` — a genuinely new module (single commit, #3071) not yet covered in `docs/agent.md`'s per-file reference table.

## Test plan
- [x] Grepped each `docs/*.md` for references to the changed filenames/symbols to scope candidates
- [x] Verified each candidate doc's extracted file paths, symbols, env vars, and routes against current source (Glob/Grep)
- [x] Confirmed `docs/test-readiness/*.md` excluded (read-only, owned by different plugin)
- [x] No CLAUDE.md reference-list changes needed (no docs created/deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)