### PR TITLE
feat: extract dependency risk-analysis heuristics into a reusable reference

### DIFF
--- a/plugins/shipwright/references/dependency-risk-analysis.content.test.ts
+++ b/plugins/shipwright/references/dependency-risk-analysis.content.test.ts
@@ -1,0 +1,137 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REFERENCE_PATH = join(import.meta.dir, "dependency-risk-analysis.md");
+
+let content: string;
+
+beforeAll(() => {
+  if (existsSync(REFERENCE_PATH)) {
+    content = readFileSync(REFERENCE_PATH, "utf-8");
+  } else {
+    content = "";
+  }
+});
+
+describe("dependency-risk-analysis.md — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(REFERENCE_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(content.length).toBeGreaterThan(200);
+  });
+});
+
+describe("dependency-risk-analysis.md — recommendation options", () => {
+  it("documents the merge recommendation", () => {
+    expect(content).toContain("merge");
+  });
+
+  it("documents the review recommendation", () => {
+    expect(content).toContain("review");
+  });
+
+  it("documents the hold recommendation", () => {
+    expect(content).toContain("hold");
+  });
+});
+
+describe("dependency-risk-analysis.md — flags to assess", () => {
+  it("documents breakingChange", () => {
+    expect(content).toContain("breakingChange");
+  });
+
+  it("documents securityRelevant", () => {
+    expect(content).toContain("securityRelevant");
+  });
+
+  it("documents productionImpact", () => {
+    expect(content).toContain("productionImpact");
+  });
+});
+
+describe("dependency-risk-analysis.md — Dependabot-path heuristics", () => {
+  it("references app/dependabot as the single-package path", () => {
+    expect(content).toContain("app/dependabot");
+  });
+
+  it("describes patch bump heuristic", () => {
+    expect(content.toLowerCase()).toContain("patch bump");
+  });
+
+  it("describes minor bump heuristic", () => {
+    expect(content.toLowerCase()).toContain("minor bump");
+  });
+
+  it("describes major bump heuristic", () => {
+    expect(content.toLowerCase()).toContain("major bump");
+  });
+
+  it("mentions CVE detection", () => {
+    expect(content).toContain("CVE");
+  });
+
+  it("mentions devDependencies handling", () => {
+    expect(content).toContain("devDependencies");
+  });
+
+  it("mentions dependencies (production) handling", () => {
+    expect(content).toContain("dependencies");
+  });
+});
+
+describe("dependency-risk-analysis.md — Renovate grouped-analysis section", () => {
+  it("references app/renovate as the grouped path", () => {
+    expect(content).toContain("app/renovate");
+  });
+
+  it("describes parsing the grouped markdown table out of the PR body", () => {
+    expect(content).toContain("Package");
+    expect(content).toContain("Type");
+    expect(content).toContain("Update");
+    expect(content).toContain("Change");
+  });
+
+  it("describes rolling multiple packages into a single PR-level recommendation", () => {
+    expect(content).toMatch(/single|one/i);
+    expect(content).toContain("recommendation");
+    expect(content.toLowerCase()).toContain("maximum-severity");
+  });
+
+  it("notes the needs-human label convention is repo-specific", () => {
+    expect(content).toContain("renovate:needs-human");
+    expect(content.toLowerCase()).toContain("repo-specific");
+  });
+
+  it("notes heuristics must degrade gracefully without the label", () => {
+    expect(content.toLowerCase()).toContain("degrade gracefully");
+  });
+
+  it("falls back to Dependabot heuristics for unrecognized authors", () => {
+    expect(content.toLowerCase()).toContain("author mismatch");
+  });
+});
+
+describe("dependency-risk-analysis.md — generic input/output framing", () => {
+  it("phrases inputs in terms of a PR's diff, body, and author", () => {
+    expect(content.toLowerCase()).toContain("diff");
+    expect(content.toLowerCase()).toContain("body");
+    expect(content).toContain("author.login");
+  });
+
+  it("does not couple to the fetch-PR gh CLI wrapper (Step 2/3 fetch logic)", () => {
+    expect(content).not.toContain("gh pr view $PR");
+    expect(content).not.toContain("gh pr diff $PR");
+  });
+
+  it("does not include comment-formatting/posting wrapper logic", () => {
+    expect(content).not.toContain("gh pr comment");
+    expect(content).not.toContain("--body-file");
+  });
+
+  it("does not include state-file management wrapper logic", () => {
+    expect(content).not.toContain("state/dependency-bot-reviews.json");
+  });
+});

--- a/plugins/shipwright/references/dependency-risk-analysis.md
+++ b/plugins/shipwright/references/dependency-risk-analysis.md
@@ -1,0 +1,94 @@
+# Dependency Risk Analysis
+
+Heuristics for classifying the risk of a dependency-bump PR (Dependabot or Renovate) and
+producing a recommendation. This is pure analysis — given a PR's **diff**, **body**, and
+**author** (`author.login`), it produces flags and a recommendation. It has no opinion on
+how the caller fetched that PR, how it formats a comment from the result, or how/whether it
+persists any state — those are the calling skill's concerns, not this reference's.
+
+## Inputs
+
+- **`diff`** — the PR's diff (e.g. `gh pr diff`). Used to see the actual version bump(s) and
+  how many semver levels each spans.
+- **`body`** — the bot's PR description. For Dependabot, a single-package changelog snippet.
+  For Renovate, typically a grouped markdown table (one row per bumped package).
+- **`author.login`** — the actual PR author (not a heuristic guess). Drives which analysis
+  path below applies.
+- **`labels`** (optional) — the PR's labels, if available. Used only by the Renovate path's
+  needs-human signal; safe to omit entirely (see below).
+
+## Output
+
+- **`recommendation`** — one of `merge` / `review` / `hold` (exactly one per PR, see the
+  Renovate rollup below for the grouped case).
+- **`flags`** — `breakingChange`, `securityRelevant`, `productionImpact` (booleans).
+- **`reasoning`** — free text explaining why the recommendation was reached.
+
+## Recommendation options
+
+Shared across both the Dependabot and Renovate paths:
+
+- `merge` — safe patch/minor update, no breaking changes, low risk
+- `review` — significant bump, possible breaking changes, or security-relevant
+- `hold` — known breaking change, deprecated package, or requires code changes first
+
+## Flags to assess
+
+Shared across both paths:
+
+- `breakingChange` — major version bump (X.0.0 → Y.0.0), or the body explicitly mentions
+  breaking changes
+- `securityRelevant` — a CVE is mentioned in the body, or the package is security-focused
+  (e.g. `helmet`, `bcrypt`, `jsonwebtoken`)
+- `productionImpact` — the package is in `dependencies` (not `devDependencies`)
+
+## Dependabot path (single package)
+
+Applies when `author.login == "app/dependabot"`.
+
+**Heuristics:**
+
+- Patch bump (x.y.Z → x.y.Z+1) → almost always `merge` unless security-flagged
+- Minor bump (x.Y.z → x.Y+1.z) → usually `merge`, check for deprecation warnings in the body
+- Major bump (X.y.z → X+1.y.z) → usually `review` or `hold`; read the body carefully
+- CVE in body → `review` minimum; flag `securityRelevant`
+- `devDependencies` only → lower production risk; usually `merge` or `review`
+- Package in `dependencies` (production) → flag `productionImpact`
+
+## Renovate path (grouped)
+
+Applies when `author.login == "app/renovate"`.
+
+Renovate bundles multiple package bumps into a single PR. Its body typically contains a
+markdown table with columns like `Package | Type | Update | Change` (one row per bumped
+package). Parse that table out of `body`.
+
+Unlike the Dependabot path, **do not re-derive the update type from the version strings** —
+each row already carries Renovate's own classification (`patch` / `minor` / `major`) in its
+`Update` column; use it as-is.
+
+This analysis always produces exactly **one** recommendation per PR, never one per package.
+Apply the same flags (`breakingChange`, `securityRelevant`, `productionImpact`) and the same
+recommendation options (`merge`/`review`/`hold`) to *each row*, then roll the group up by
+taking the **maximum-severity row** across the group — e.g. if 4 rows are patch bumps and 1
+is a major bump, the PR-level recommendation is driven by that one major row (`review` or
+`hold`), not diluted by the others.
+
+**Needs-human label signal:** check the PR's `labels` (when available) for a needs-human-style
+label — e.g. `renovate:needs-human`. When present, treat it as a first-class signal that
+forces the recommendation to at least `review` (or `hold` if the group also has a breaking
+row), regardless of what the table analysis alone would have produced.
+
+This label convention is **repo-specific** — it comes from that repo's own `renovate.json`
+config, not from Renovate itself. Some repos define a label like `renovate:needs-human` for
+this purpose; others may not have any such label configured, or may name it differently. The
+table-based heuristics above must **degrade gracefully** when no matching label is present or
+configured — i.e. they must still produce a correct recommendation from the table alone, with
+the label check only ever adding a stricter floor, never something the analysis depends on.
+
+## Author mismatch fallback
+
+When `author.login` is neither `app/dependabot` nor `app/renovate`, fall back to the
+Dependabot path's heuristics as a best-effort default, and explicitly note the author
+mismatch in the reasoning text — e.g. "author `{login}` did not match a known
+dependency-bot login; treated as a single-package update using Dependabot heuristics".


### PR DESCRIPTION
## Summary
- Extracts `triage-dependency-bot-pr/SKILL.md`'s Step 4 ("Analyze risk") into a standalone, repo-agnostic reference at `plugins/shipwright/references/dependency-risk-analysis.md`
- Covers the merge/review/hold recommendation options, the breakingChange/securityRelevant/productionImpact flags, Dependabot single-package bump heuristics, and the Renovate grouped-table parsing with maximum-severity rollup (including the repo-specific needs-human label signal and graceful degradation)
- `triage-dependency-bot-pr/SKILL.md` is left completely unmodified — this only adds the new reference; the wrapper logic (fetch/comment/state-management) stays behind for deletion in DBR-3.4

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New reference file contains classification heuristics, flags, and Renovate rollup logic, adapted to take a PR's diff/body/author as input and return flags + a recommendation | MET | `plugins/shipwright/references/dependency-risk-analysis.md` |
| 2 | Extracted content is a superset of Step 4 — no heuristic dropped | MET | Verified against `SKILL.md` Step 4; `SKILL.md` diff is empty |
| 3 | Content test mirroring `SKILL.content.test.ts`'s structure | MET | `plugins/shipwright/references/dependency-risk-analysis.content.test.ts` — 25 passing assertions |

## Test Plan
- [x] New content test passes: `bun test plugins/shipwright/references/dependency-risk-analysis.content.test.ts` (25/25)
- [x] `task typecheck` passes across all 7 packages
- [x] `task lint` passes (691 files, no issues)
- [x] `task ci`'s 31 pre-existing failures (env-var isolation issues in unrelated packages — agent config, admin migrations, GitHub token manager) verified present on `main` too; unrelated to this change

Generated with [Claude Code](https://claude.com/claude-code)
