### PR TITLE
docs: rewrite docs/README.md to lead with the two-systems framing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ Shipwright Harness is the open-source autonomous delivery system in your own env
 
 > 🚧 **Early development.** These docs grow as the toolchain becomes runnable. Start with the [README](../README.md) for the overview and install command.
 
+As you read on, you'll run into two categorically different systems. The **delivery lifecycle** is the five-beat story any engineer already recognizes — plan → task → PR → review/patch → deploy — covered in [Quickstart](./quickstart.md) and the Plugin section of [Architecture](./architecture.md). The **fleet-operations layer** is the machinery that runs that lifecycle unattended across many autonomous agents — crons, the `shipwright-loop`, agent config/provisioning, and the task/PR queues — covered in [Shipwright agent](./agent.md) and [Agent API](./agent-api.md). The docs list below spans both, so know which kind of concept you're clicking into.
+
 ## Contents
 
 - **[Quickstart](./quickstart.md)** — prerequisites, step-by-step setup (clone → quickstart.sh → plugin install → task dev), and the copy-paste session prompt.


### PR DESCRIPTION
## Summary
- Added a short framing paragraph to `docs/README.md`, placed after the opening description and before `## Contents`
- Names the two categorically different systems a contributor is about to learn: the delivery lifecycle (plan/task/PR/review-patch/deploy, documented in `docs/quickstart.md` and `docs/architecture.md`'s Plugin section) and the fleet-operations layer (crons, `shipwright-loop`, agent provisioning, task/PR queues, documented in `docs/agent.md` and `docs/agent-api.md`)
- Existing Contents list and Command reference section are unchanged in content

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Framing paragraph naming both systems, placed after opening description and before `## Contents` | MET |
| 2 | Contents list and Command reference section unchanged in content | MET |
| 3 | No test change needed — build/lint pass is sufficient verification | MET |

## Test Plan
- [x] `task lint` — clean, no fixes needed
- [x] `task typecheck` — all workspaces pass
- [x] `task check-strings` — no banned strings found
- [x] Manual read-through of `docs/README.md` diff

Generated with [Claude Code](https://claude.com/claude-code)
