### PR TITLE
docs: rewrite introduction.mdx to lead with the two-systems framing

### DIFF
--- a/site/src/content/docs/introduction.mdx
+++ b/site/src/content/docs/introduction.mdx
@@ -37,6 +37,15 @@ Install the plugin into your Claude Code workspace once:
 It ships as four artifacts — built and activated in sequence — so you can adopt as much or as little
 as you need.
 
+## Two systems: delivery and operations
+
+As you read on, you'll run into two categorically different systems. The **delivery lifecycle** is the
+five-beat story any engineer already recognizes — spec → plan → task → PR → review/patch → deploy —
+covered in the [Plugin](/docs/the-plugin) section of these docs. The **fleet-operations layer** is the
+machinery that runs that lifecycle unattended across many autonomous agents — crons, agent config and
+provisioning, and the task/PR queues — covered in the [Agent](/docs/the-agent) and [Operations](/docs/day-to-day-operations)
+sections. The four artifacts below span both, so know which kind of concept you're clicking into.
+
 ## How it works — A → B → C → D
 
 Each artifact is independently useful and adds capability when combined with the next:


### PR DESCRIPTION
## Summary
- Adds a "Two systems: delivery and operations" section to `site/src/content/docs/introduction.mdx`, placed before the "How it works — A → B → C → D" table
- Names the delivery lifecycle (spec → plan → task → PR → review/patch → deploy) and the fleet-operations layer (crons, agent config/provisioning, task/PR queues) as two distinct systems, mapping them to the existing Plugin / Agent+Operations sidebar sections
- No changes to the A→B→C→D table, "Design principles", "Next steps" sections, or the sidebar/content schema (explicitly out of scope for this task)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New section before A→B→C→D table naming both systems, mapped to Plugin/Agent+Operations sections | MET |
| 2 | A→B→C→D table, Design principles, Next steps unchanged | MET |
| 3 | `cd site && npm run build` succeeds | MET |
| 4 | No new test needed (prose-only addition, existing docs specs don't hardcode structure) | MET |

## Test Plan
- `cd site && npm run build` — 26 pages built successfully, no errors
- Verified linked pages (`/docs/the-plugin`, `/docs/the-agent`, `/docs/day-to-day-operations`) exist
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
