### PR TITLE
fix: preserve org/repo format in prd.md repo auto-detect

### DIFF
--- a/plugins/shipwright/commands/prd.md
+++ b/plugins/shipwright/commands/prd.md
@@ -26,12 +26,12 @@ Follow all phases in order. Proceed automatically between phases. The only pause
    - `Gemfile` → Ruby
    - `Makefile` → Generic Make
 
-2b. **Detect repo name** from git metadata (used in the handoff to `/plan-session` and written to every task in the task store):
-   - `git remote get-url origin` → parse the `owner/repo` segment, strip any trailing `.git`. Use the bare `{repo}` portion.
+2b. **Detect repo name** from git metadata (the full `org/repo` value is what gets handed off to `/plan-session` and written to every task in the task store):
+   - `git remote get-url origin` → parse the `owner/repo` segment, strip any trailing `.git`. Use the full `owner/repo` value as `{repo}` — do not strip to the bare repo name.
    - Fallback if no remote: `basename $(git rev-parse --show-toplevel)`
    - Last resort if not in a git repo: `basename $(pwd)` and print a warning.
 
-   Print `Detected repo: {repo}` in the Phase 0 summary so the user can catch a misdetection before investing time in the session.
+   Print `Detected repo: {repo}` (full `owner/repo` value) in the Phase 0 summary so the user can catch a misdetection before investing time in the session.
 
 3. **Read project documentation** (lightweight scan — highlights only, no deep code dive):
    - `CLAUDE.md` — conventions, architecture decisions, and constraints


### PR DESCRIPTION
## Summary
- Fixed `prd.md`'s Phase 0b repo auto-detect to preserve the full `owner/repo` value instead of stripping to the bare repo name, matching task-store's `validateRepo()` requirement (org/repo format).
- Updated the surrounding description text (line 29) and the detected-repo print statement (line 34) to make explicit that the full `org/repo` value is what gets handed off / written to the task store.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Line 30 updated to preserve the full owner/repo value instead of stripping to the bare portion | MET | Instruction now reads "Use the full `owner/repo` value as `{repo}` — do not strip to the bare repo name." |
| 2 | Detected-repo print statement (line 34) and surrounding description text (line 29) reflect the full org/repo value | MET | Both lines updated to explicitly reference the full `org/repo` value. |
| 3 | No test change needed | MET | prd.md has no existing `.content.test.ts` file; fix is a one-line instructional correction with no runtime logic to test. |

## Test Plan
- No runtime logic changed — this is a documentation/instruction fix inside a Claude Code command file, no test suite applies.
- [x] Pre-commit checks passing (lint clean, no docs refresh needed)

Generated with [Claude Code](https://claude.com/claude-code)
