### PR TITLE
fix: preserve org/repo format in plan-session.md repo auto-detect

### DIFF
--- a/plugins/shipwright/commands/plan-session.content.test.ts
+++ b/plugins/shipwright/commands/plan-session.content.test.ts
@@ -109,6 +109,57 @@ describe("plan-session.md — Step 6b template omits requiresHumanApproval (RHA-
   });
 });
 
+describe("plan-session.md — repo auto-detect preserves org/repo format (PRF-1.1)", () => {
+  function extractArgsAndAutoDetectSection(md: string): string {
+    const match = md.match(/^---[\s\S]*?Wait for user confirmation before continuing to Step 1\./);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("the repo arg description example is org/repo format, not a bare repo name", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    const argDescMatch = section.match(/- name: repo\n\s*description: (.+)/);
+    expect(argDescMatch).not.toBeNull();
+    const argDesc = argDescMatch?.[1] ?? "";
+    expect(argDesc).toMatch(/e\.g\.,\s*[\w.-]+\/[\w.-]+/);
+    expect(argDesc).not.toMatch(/e\.g\.,\s*shipwright\)/);
+  });
+
+  it("does not instruct stripping to the bare repo name in auto-detect", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    expect(section.toLowerCase()).not.toContain("bare repo name");
+  });
+
+  it("documents preserving the full owner/repo value from git remote parsing", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    const lower = section.toLowerCase();
+    expect(lower).toMatch(/preserve|do not strip|full owner\/repo/);
+  });
+
+  it("derives a repo-slug value for local path use", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    expect(section).toContain("repo-slug");
+  });
+
+  it("uses {repo-slug} for local filesystem paths, not {repo}", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    expect(section).toContain("~/src/{repo-slug}");
+    expect(section).not.toContain("~/src/{repo}/");
+  });
+
+  it("Step 1's CLAUDE.md fallback read path uses {repo-slug}", () => {
+    expect(content).toContain("otherwise read from `~/src/{repo-slug}/`");
+  });
+
+  it("Step 6b task JSON template still writes the full org/repo value into repo", () => {
+    const section = extractStep6bSection(content);
+    const codeBlockMatch = section.match(/```json[\s\S]*?```/);
+    expect(codeBlockMatch).not.toBeNull();
+    const codeBlock = codeBlockMatch?.[0] ?? "";
+    expect(codeBlock).toContain('"repo": "{repo}"');
+  });
+});
+
 describe("plan-session.md — Step 5 principles override check + security domain (PCO-1.1)", () => {
   function extractStep5Section(md: string): string {
     const match = md.match(/## Step 5: Task Breakdown[\s\S]*?(?=\n### Complexity and Model Scoring)/);

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -2,7 +2,7 @@
 description: Engineer planning pass — reads the product spec, explores the codebase, flags complexity, and produces a task queue
 arguments:
   - name: repo
-    description: The repo to plan work for (e.g., shipwright)
+    description: The repo to plan work for, in org/repo format (e.g., app-vitals/shipwright)
     required: true
   - name: session
     description: A short slug for this planning session (e.g., may-billing-refactor). Used to group tasks and PRs.
@@ -18,14 +18,15 @@ Parse `$ARGUMENTS` to extract:
 - **session**: second argument
 
 **If only one argument is provided**, treat it as `session` and auto-detect `repo`:
-1. `git remote get-url origin` → parse owner/repo, strip trailing `.git`. Use the bare repo name.
-2. Fallback: `basename $(git rev-parse --show-toplevel)`
+1. `git remote get-url origin` → parse the `org/repo` value, stripping trailing `.git`. Preserve the full owner/repo value — do not strip it down to just the repo segment. This is the `repo` value used for the task-store `repo` field.
+2. Fallback (only when the remote parse fails): `basename $(git rev-parse --show-toplevel)`. In this fallback case there is no owner segment, so `repo` and `repo-slug` end up the same bare value.
+3. Derive `repo-slug` from `repo`: the last path segment, lowercased — e.g. `app-vitals/shipwright` → `shipwright`. Use `repo-slug` for all local filesystem path references.
 
 Then print:
 ```
 ⚠ Auto-detected repo: {repo}
 This will be written to every task in the task store and used by /dev-task to
-locate the source tree (~/src/{repo}). Confirm it is correct before proceeding.
+locate the source tree (~/src/{repo-slug}). Confirm it is correct before proceeding.
 ```
 Wait for user confirmation before continuing to Step 1.
 
@@ -38,7 +39,7 @@ This is the engineering planning pass. The product spec (what and why) is alread
 
 ## Step 1: Load Context
 
-1. Read `CLAUDE.md` in the repo worktree if available, otherwise read from `~/src/{repo}/`
+1. Read `CLAUDE.md` in the repo worktree if available, otherwise read from `~/src/{repo-slug}/`
 2. Glob the repo structure to understand the codebase layout
 3. Check for any existing tasks in this session to avoid duplicates:
    ```bash


### PR DESCRIPTION
## Summary
- Fix `plan-session.md`'s repo auto-detect to preserve the full `owner/repo` value instead of stripping it to a bare repo name, which was the confirmed root cause of a production 400 from task-store's `validateRepo()` when the bare value flowed into Step 6b's task JSON `repo` field.
- Introduce a separate `{repo-slug}` value (last path segment of `repo`, lowercased) for local filesystem path references, mirroring the pattern already used in `entropy-fix/SKILL.md`'s 6q.1.
- Add a content-test assertion guarding against regression to a bare-repo-name auto-detect instruction.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Arg description example (line 5) updated to org/repo format (e.g. "app-vitals/shipwright") | MET |
| 2 | Auto-detect logic preserves full owner/repo value, separately derives {repo-slug} | MET |
| 3 | Local filesystem path references (Step 1, confirmation banner) use {repo-slug} instead of {repo} | MET |
| 4 | Step 6b's task JSON template continues writing the full org/repo value into "repo" | MET |
| 5 | Content-test assertion added to plan-session.content.test.ts guarding against regression | MET |

## Test Plan
- `bun test plugins/shipwright/commands/plan-session.content.test.ts` — 21/21 pass (14 pre-existing + 7 new)
- `task typecheck` — all 7 workspaces pass
- `bunx biome lint` on changed files — clean
- `task ci` run in full; 31 pre-existing failures confirmed unrelated (reproduce identically on `main`: env-var config defaults, GH App credential checks, Sentry init — all environment-contamination issues, none touching plan-session.md or repo-format logic)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
