### PR TITLE
fix: derive org/repo for error-fix task JSON instead of bare repo dir name

### DIFF
--- a/plugins/shipwright/skills/error-fix/SKILL.content.test.ts
+++ b/plugins/shipwright/skills/error-fix/SKILL.content.test.ts
@@ -33,6 +33,27 @@ describe("error-fix — SKILL.md exists", () => {
   });
 });
 
+describe("error-fix — Step 8 task JSON derives org/repo, not the bare dir name", () => {
+  it("documents deriving org/repo via git remote get-url origin", () => {
+    const skill = readSkill();
+    expect(skill).toContain("remote get-url origin");
+    expect(skill.toLowerCase()).toContain("org/repo");
+  });
+
+  it("references entropy-fix's derivation pattern for consistency", () => {
+    expect(readSkill()).toContain("entropy-fix");
+  });
+
+  it("the task JSON template's repo field is not documented as the bare dir name", () => {
+    const skill = readSkill();
+    const repoFieldLine = skill
+      .split("\n")
+      .find((line) => line.includes('"repo":') && line.includes("<"));
+    expect(repoFieldLine).toBeDefined();
+    expect(repoFieldLine).not.toContain("repo dir name from error-report.md");
+  });
+});
+
 describe("error-fix — Step 5 dedup query is pagination-safe", () => {
   it("raises the dedup query limit well above the API's default page size", () => {
     expect(readSkill()).toContain("limit=1000");

--- a/plugins/shipwright/skills/error-fix/SKILL.md
+++ b/plugins/shipwright/skills/error-fix/SKILL.md
@@ -280,7 +280,7 @@ For each issue with a primary fix task to queue:
   "id": "error-{sentry-issue-id}-{slug}",
   "title": "Error fix: {issue title}",
   "source": "error-fix",
-  "repo": "<repo dir name from error-report.md's Service → Repo Mapping table, or re-derived from state/error-patrol-ledger.json's serviceRepoMap if the report is stale>",
+  "repo": "<org/repo derived from the matched repo dir name — see Repo Derivation below>",
   "branch": "fix/error-{sentry-issue-id}-{slug}",
   "layer": "Background",
   "status": "pending",
@@ -306,12 +306,25 @@ For each companion observability-fix task to queue:
 }
 ```
 
-Repo derivation: read the repo dir name from `error-report.md`'s `## Service → Repo Mapping`
-table (matched by the issue's service tag) — this is the primary source since it reflects
-this run's data. Only fall back to re-deriving from `state/error-patrol-ledger.json`'s
-`serviceRepoMap` if the report's mapping for that service is missing/stale (e.g. the report
-predates the ledger's most recent scan). Never queue a task for a service that's `unmapped`
-in either source — that issue should already have been filtered out in Step 2.
+Repo derivation: first, read the repo **dir name** from `error-report.md`'s `## Service →
+Repo Mapping` table (matched by the issue's service tag) — this is the primary source since
+it reflects this run's data. Only fall back to re-deriving from
+`state/error-patrol-ledger.json`'s `serviceRepoMap` if the report's mapping for that service
+is missing/stale (e.g. the report predates the ledger's most recent scan). Never queue a task
+for a service that's `unmapped` in either source — that issue should already have been
+filtered out in Step 2.
+
+That dir name (e.g. `shipwright`) is a bare local directory name — `error-scan/SKILL.md`
+Step 3 derives it purely for local grep-based service-to-repo matching, with no org prefix.
+task-store's `validateRepo()` rejects a bare dir name posted as a task's `repo` field, so
+before building the task JSON, derive the `org/repo` value the same way
+`entropy-fix/SKILL.md`'s Step 6q.1 (and test-fix/consolidation-fix/security-fix) do: run
+`git -C "$SHIPWRIGHT_REPO_DIR/<dir-name>" remote get-url origin` and strip the
+`https://github.com/` (or `git@github.com:`, stripping the `.git` suffix) prefix to get
+`org/repo` — e.g. `app-vitals/shipwright`. Use that `org/repo` value for the task JSON's
+`repo` field on both the primary and companion task. Continue to use the bare dir name
+everywhere else (e.g. the `description` template's `Repo: {repo}` line below, matching
+`error-report.md`'s own format) — only the task JSON's `repo` field is affected.
 
 `slug`: lowercase, hyphens, max 5 words, derived from the issue title.
 


### PR DESCRIPTION
## Summary
- `error-fix/SKILL.md` Step 8's task JSON template posted the bare repo dir name (e.g. `"shipwright"`) as the task's `repo` field, which task-store's `validateRepo()` rejects since it requires `org/repo` format.
- Documented deriving `org/repo` via `git -C "$SHIPWRIGHT_REPO_DIR/<dir-name>" remote get-url origin` on the matched repo dir, matching the pattern already used in entropy-fix/test-fix/consolidation-fix/security-fix (entropy-fix/SKILL.md's Step 6q.1).
- Left the bare dir name usage unchanged everywhere else (e.g. the description template's `Repo: {repo}` line) — only the task JSON's `repo` field is affected.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step 8.1's task JSON templates (primary + companion) use a freshly-derived org/repo value for the repo field, not the bare dir name | MET |
| 2 | The derivation step (git remote get-url origin → strip to org/repo) is documented explicitly near Step 8, referencing entropy-fix/SKILL.md's 6q.1 | MET |
| 3 | Remaining bare-dir-name usage (e.g. description template's `Repo: {repo}` line) is left unchanged — only the task JSON's repo field is affected | MET |
| 4 | Test decision: content-test assertion added to SKILL.content.test.ts asserting Step 8's task JSON template documents deriving org/repo, not the bare dir name | MET |

## Test Plan
- Added 3 new content-test assertions in `plugins/shipwright/skills/error-fix/SKILL.content.test.ts` — confirmed RED before the fix, GREEN after.
- [x] `bun test plugins/shipwright/skills/error-fix/SKILL.content.test.ts` passing (8/8)
- [x] `bunx biome lint` passing on changed files
- Full `task ci` run has 31 pre-existing unrelated test failures (env/config leakage, `task-store/prs.ts` smoke test) — verified identical on `origin/main`, not introduced by this change.

Generated with [Claude Code](https://claude.com/claude-code)
