### PR TITLE
fix: split dev-task.md's {repo} into org/repo and {repo-slug} for local paths

### DIFF
--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -347,7 +347,7 @@ describe("dev-task.md 0b — docs-first toolchain discovery + per-repo cache (TD
     expect(stepIdx).toBeGreaterThan(-1);
     const section = content.slice(stepIdx, stepIdx + 2000);
     expect(section).toMatch(/\*\*Check the cache\.\*\*/i);
-    expect(section).toContain("state/toolchain-cache/{repo}.json");
+    expect(section).toContain("state/toolchain-cache/{repo-slug}.json");
   });
 
   it("reads CLAUDE.md and docs/ai-docs before falling back to config-file scanning", () => {
@@ -513,7 +513,7 @@ describe("Step 4 — unconditional branch/PR reality check (DOH-1.1)", () => {
   it("incomplete/stale path closes the PR (if any) and deletes the branch (remote + local) before falling through to fresh worktree creation", () => {
     const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
     expect(realityCheckIdx).toBeGreaterThan(-1);
-    const section = content.slice(realityCheckIdx, realityCheckIdx + 5500);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 6000);
     expect(section).toMatch(/incomplete|stale/i);
     expect(section).toContain("gh pr close");
     expect(section).toContain("git push origin --delete {branch}");
@@ -525,7 +525,7 @@ describe("Step 4 — unconditional branch/PR reality check (DOH-1.1)", () => {
     // can leave `{branch}` checked out in a worktree, so the worktree must be removed first.
     const realityCheckIdx = content.indexOf("### Branch/PR Reality Check");
     expect(realityCheckIdx).toBeGreaterThan(-1);
-    const section = content.slice(realityCheckIdx, realityCheckIdx + 5500);
+    const section = content.slice(realityCheckIdx, realityCheckIdx + 6000);
     const staleSectionIdx = section.search(/\*\*Incomplete, stale/i);
     expect(staleSectionIdx).toBeGreaterThan(-1);
     const staleSection = section.slice(staleSectionIdx);
@@ -645,5 +645,42 @@ describe("dev-task.md — ScheduleWakeup/backgrounding prohibition guardrail (SW
     const section = getStep9b2Section();
     expect(section).toContain("30 seconds");
     expect(section).toContain("10 minutes");
+  });
+});
+
+describe("dev-task.md Step 1 — repo-slug derivation for local paths (PRF-1.4)", () => {
+  it("derives {repo-slug} in Step 1, immediately after the task fetch and before the Same-Branch Sibling Check", () => {
+    const fetchIdx = content.indexOf('"$SHIPWRIGHT_TASK_STORE_URL/tasks/{task-id}"');
+    expect(fetchIdx).toBeGreaterThan(-1);
+    const siblingCheckIdx = content.indexOf("### Same-Branch Sibling Check");
+    expect(siblingCheckIdx).toBeGreaterThan(fetchIdx);
+
+    const section = content.slice(fetchIdx, siblingCheckIdx);
+    expect(section).toContain("{repo-slug}");
+    expect(section).toMatch(/last path segment/i);
+  });
+
+  it("no longer uses raw {repo} for ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} style local paths", () => {
+    // This exact substring would NOT match {repo-slug} (which has extra chars before the
+    // closing brace), so it robustly distinguishes "still raw {repo}" from "now {repo-slug}".
+    expect(content.match(/\$\{SHIPWRIGHT_REPO_DIR:-\$HOME\/src\}\/\{repo\}/)).toBeNull();
+  });
+
+  it("keeps the Same-Branch Sibling Check's task-store API call scoped by the full {repo} (org/repo) value, unchanged", () => {
+    expect(content).toContain(
+      '"$SHIPWRIGHT_TASK_STORE_URL/tasks?branch={branch}&status=in_progress&repo={repo}"',
+    );
+  });
+
+  it("derives GH_REPO from the local checkout using {repo-slug}, not {repo}", () => {
+    expect(content).toContain(
+      "git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} remote get-url origin",
+    );
+  });
+
+  it("constructs worktree paths using {repo-slug}-{branch-slug}", () => {
+    expect(content).toContain(
+      "${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug}",
+    );
   });
 });

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -42,6 +42,14 @@ curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks/{task-id}" | jq '.'
 ```
 
+Once the task is fetched, derive `{repo-slug}` from its `repo` field: the last path segment,
+lowercased — e.g. `app-vitals/shipwright` → `shipwright`. `{repo-slug}` is used for all local
+filesystem paths for the rest of this command (Step 0b's toolchain cache/repo dir, Step 4's
+worktree paths, Step 8.5's docs-refresher prompt), since `SHIPWRIGHT_REPO_DIR` clones live
+flat as `repos/<bare-name>` (e.g. `repos/shipwright`), not `repos/<org>/<repo>`. The full
+`{repo}` value (the fetched `org/repo` string, unchanged) continues to be used for task-store
+API calls — e.g. the Same-Branch Sibling Check's `?repo=` filter below.
+
 - **404**: the task doesn't exist. Print `⚠ Task {task-id} not found.` and stop.
 - **Found, `status == "in_progress"`**: a prior session left this task in progress (or a
   human is manually re-running dev-task against it) — the task is already claimed, so skip
@@ -168,13 +176,13 @@ Deps:    {dependencies or "none"}
 
 Record `task_started_at` (current ISO timestamp) for metrics, if not already recorded above.
 
-Now detect the project toolchain for `{repo}` (used throughout):
+Now detect the project toolchain for `{repo-slug}` (used throughout):
 
 ### 0b. Detect Project Toolchain
 
 Auto-detect the project toolchain (run once, reuse throughout), checking the cross-run cache before any fresh detection:
 
-1. **Check the cache.** Compute the fingerprint against `${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo}` and read `state/toolchain-cache/{repo}.json` — see `references/toolchain-patterns.md`'s "Caching Across Runs" section for the exact fingerprint command and cache format. If the file exists and its fingerprint matches, reuse the cached commands and skip to Step 4.
+1. **Check the cache.** Compute the fingerprint against `${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug}` and read `state/toolchain-cache/{repo-slug}.json` — see `references/toolchain-patterns.md`'s "Caching Across Runs" section for the exact fingerprint command and cache format. If the file exists and its fingerprint matches, reuse the cached commands and skip to Step 4.
 
 2. **Docs-first discovery** (cache miss only). Read `CLAUDE.md` and any `docs/*.md` / `ai-docs/*.md` for explicit build/test/lint/typecheck commands — many projects wrap the raw tool invocations (custom scripts, task runners, mise-managed runtimes) that config-file scanning alone won't catch. See `references/toolchain-patterns.md`'s "Docs-First Discovery" section. Treat anything found here as authoritative.
 
@@ -198,7 +206,7 @@ Auto-detect the project toolchain (run once, reuse throughout), checking the cro
    - **typecheck**: Type check command if applicable (e.g., `pnpm -r check`, `tsc --noEmit`)
    - **build**: Build command (e.g., `pnpm build`, `cargo build`, `go build ./...`)
 
-   On a cache miss (step 2/3 ran), overwrite `state/toolchain-cache/{repo}.json` with the new fingerprint + commands.
+   On a cache miss (step 2/3 ran), overwrite `state/toolchain-cache/{repo-slug}.json` with the new fingerprint + commands.
 
 Refer to `references/toolchain-patterns.md` for the full detection lookup table and the caching protocol.
 
@@ -279,15 +287,15 @@ Reuse the exact `--repo` derivation already used later in this step for the stal
 branch check, since CWD is the workspace, not the target repo:
 
 ```bash
-GH_REPO=$(git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
+GH_REPO=$(git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
 ```
 
 Check all three signals:
 
 ```bash
 # Local branch (pull first so remote-tracking state is current)
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} pull
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch --list {branch}
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} pull
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} branch --list {branch}
 
 # Remote branch
 git ls-remote --heads origin {branch}
@@ -303,9 +311,9 @@ recover — proceed to the standard branch-existence check below.
 **If any of the three exist**, assess whether the existing work is complete and correct
 against the task's acceptance criteria before deciding how to proceed:
 
-1. Inspect the existing work: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} log {branch} --oneline -20`
-   and `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} diff main...{branch}` (fetch first if
-   the branch is remote-only: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} fetch origin {branch}`).
+1. Inspect the existing work: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} log {branch} --oneline -20`
+   and `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} diff main...{branch}` (fetch first if
+   the branch is remote-only: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} fetch origin {branch}`).
 2. Compare the diff/log against the task's `acceptanceCriteria` (same MET/PARTIAL/NOT MET
    evaluation used in Step 7) — every criterion should show clear evidence in the diff.
 3. **If a PR exists**, additionally check its CI status before treating it as complete —
@@ -349,9 +357,9 @@ from a crashed session — clean up before starting fresh.
    refuses to force-delete a branch checked out in any worktree, so this must happen before
    step 4's `branch -D`.
    ```bash
-   git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} --force
+   git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug} --force
    ```
-4. If a local branch exists, delete it: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} branch -D {branch}`
+4. If a local branch exists, delete it: `git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} branch -D {branch}`
 5. Print:
    ```
    ⚠ {branch} had incomplete/stale prior work — cleaned up (PR closed, branch deleted). Starting fresh.
@@ -370,7 +378,7 @@ never existed, it was routed through the "complete and correct" local-only short
 was deleted during the incomplete/stale cleanup — so a local branch is guaranteed absent
 here. Standard flow:
 ```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/main -b {branch}
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug} origin/main -b {branch}
 ```
 
 **If the branch DOES exist on remote** (bundled task — joining an existing branch/PR):
@@ -378,7 +386,7 @@ git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTR
 First, check whether the remote branch belongs to a merged PR. The check runs before the worktree exists, so derive the repo from the git remote explicitly:
 
 ```bash
-GH_REPO=$(git -C ${SHIPWRIGHT_REPO_DIR:-repos}/{repo} remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
+GH_REPO=$(git -C ${SHIPWRIGHT_REPO_DIR:-repos}/{repo-slug} remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
 gh pr list --head {branch} --state merged --limit 1 --json number,title --repo "$GH_REPO"
 ```
 
@@ -396,22 +404,22 @@ git push origin --delete {branch}
 
 Fall through to the standard fresh-start flow (same as branch-absent path):
 ```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-repos}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-worktrees}/{repo}-{branch-slug} origin/main -b {branch}
+git -C ${SHIPWRIGHT_REPO_DIR:-repos}/{repo-slug} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-worktrees}/{repo-slug}-{branch-slug} origin/main -b {branch}
 ```
 
 **If no merged PR** (open PR or no PR — genuine bundled task, joining an existing branch/PR):
 ```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} fetch origin
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} origin/{branch} --track -b {branch}
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} fetch origin
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} worktree add ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug} origin/{branch} --track -b {branch}
 ```
 
 If the worktree already exists (interrupted prior run), remove it first regardless of branch status:
 ```bash
-git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug} --force
+git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} worktree remove ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug} --force
 # then run the appropriate add command above
 ```
 
-All subsequent file operations and commands run from `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}/`.
+All subsequent file operations and commands run from `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug}/`.
 
 Print:
 ```
@@ -752,7 +760,7 @@ You are refreshing docs for the current branch.
 
 Branch:    {branch}
 Base ref:  main
-Worktree:  ~/worktrees/{repo}-{branch-slug}
+Worktree:  ~/worktrees/{repo-slug}-{branch-slug}
 
 Follow your agent instructions exactly. Pre-filter docs by diff overlap, run the
 staleness recipe on candidates, edit only stale sections, commit as

--- a/plugins/shipwright/commands/spc-2.1.unit.test.ts
+++ b/plugins/shipwright/commands/spc-2.1.unit.test.ts
@@ -32,16 +32,19 @@ function bashBlocks(content: string): string {
 }
 
 describe("dev-task.md — SHIPWRIGHT_REPO_DIR", () => {
-  it("replaces ~/src/{repo} with ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo} in bash blocks", () => {
+  it("replaces ~/src/{repo} with ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} in bash blocks", () => {
+    // Local filesystem paths use {repo-slug} (PRF-1.4) — SHIPWRIGHT_REPO_DIR clones live
+    // flat as repos/<bare-name>, not repos/<org>/<repo>. {repo} (org/repo) remains reserved
+    // for task-store API calls.
     const blocks = bashBlocks(devTask);
     expect(blocks).not.toContain("~/src/{repo}");
-    expect(blocks).toContain("${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo}");
+    expect(blocks).toContain("${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug}");
   });
 
-  it("replaces ~/worktrees/{repo} with ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo} in bash blocks", () => {
+  it("replaces ~/worktrees/{repo} with ${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug} in bash blocks", () => {
     const blocks = bashBlocks(devTask);
     expect(blocks).toContain(
-      "${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}",
+      "${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}",
     );
   });
 
@@ -99,7 +102,7 @@ describe("dev-task.md — subagent prompt templates", () => {
 
   it("uses env var form for prose line (line ~176)", () => {
     expect(devTask).toContain(
-      "${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}/",
+      "${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo-slug}-{branch-slug}/",
     );
   });
 });


### PR DESCRIPTION
## Summary
- `plugins/shipwright/commands/dev-task.md` now explicitly derives `{repo-slug}` (the last path segment of the fetched task's `repo` field, lowercased) immediately after the Step 1 task fetch, mirroring the pattern already established in `entropy-fix/SKILL.md`'s Step 6q.1.
- Every local filesystem path reference in the doc (`${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo}`, `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}`, `state/toolchain-cache/{repo}.json`, the GH_REPO derivations, and the docs-refresher agent prompt) now uses `{repo-slug}` instead of `{repo}`. Task-store API calls (e.g. the Same-Branch Sibling Check's `?repo=` filter) and the informational `TASK:` banner continue to use the full `{repo}` (org/repo) value, unchanged.
- Added a content-test assertion block guarding the new derivation and path construction; updated one pre-existing stale assertion in `dev-task.content.test.ts` and three in `spc-2.1.unit.test.ts` that asserted the old `{repo}`-based paths.

No behavior change intended beyond disambiguation — this documents/enforces a distinction executing agents were already expected to self-correct via workspace `CLAUDE.md`'s `repos/<repo>` convention.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 1 documents deriving {repo-slug} immediately after the fetch | MET | New paragraph after the fetch curl block (dev-task.md): "Once the task is fetched, derive `{repo-slug}` from its `repo` field: the last path segment, lowercased" |
| 2 | Every local filesystem path reference updated to {repo-slug} | MET | All occurrences of `${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo}`, `${SHIPWRIGHT_WORKTREE_DIR:-$HOME/worktrees}/{repo}-{branch-slug}`, and `state/toolchain-cache/{repo}.json` replaced; only 3 exempted `{repo}` occurrences remain (task-store API call, banner display, `gh pr view --repo {org}/{repo}`) |
| 3 | Task-store API calls keep full org/repo {repo}, unchanged | MET | Same-Branch Sibling Check's `?repo={repo}` query param and explanatory prose unchanged |
| 4 | GH_REPO derivation reads from {repo-slug}-based local path | MET | Both `GH_REPO=$(git -C ${SHIPWRIGHT_REPO_DIR:-$HOME/src}/{repo-slug} remote get-url origin ...)` occurrences updated |
| 5 | Content-test assertion guards the new behavior | MET | New describe block "dev-task.md Step 1 — repo-slug derivation for local paths (PRF-1.4)" with 5 assertions added |

## Test Plan
- `bun test plugins/shipwright/commands/dev-task.content.test.ts` — 74/74 pass (5 new + updated assertions, RED confirmed before doc edit, GREEN after)
- `bun test plugins/shipwright/commands/spc-2.1.unit.test.ts` — collateral assertions updated to match, passing
- `bunx biome lint` on touched files — clean
- Manual `grep -n '{repo}' dev-task.md` — confirmed only the 3 intentionally-exempted occurrences remain
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
