### PR TITLE
feat: review.md detects dependency-manifest changes, invokes risk analysis (DBR-3.2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.223.0",
+      "version": "1.228.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -102,7 +102,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.223.0",
+      "version": "1.228.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -120,8 +120,12 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.223.0",
+      "version": "1.228.0",
+      "dependencies": {
+        "js-yaml": "^4.3.1",
+      },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "bun-types": "*",
         "typescript": "*",
       },
@@ -370,6 +374,8 @@
     "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.2", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 

--- a/plugins/shipwright/commands/review.content.test.ts
+++ b/plugins/shipwright/commands/review.content.test.ts
@@ -1954,3 +1954,186 @@ describe("review.md — testReadinessContext fallback checks principles.md overr
     expect(lower).toMatch(/check.*project|project.*override|override.*check/);
   });
 });
+
+// ─── DBR-3.2: dependency-manifest detection + risk analysis ─────────────────
+//
+// review.md's new Step 5.8 sits between Step 5 (Gather Context) and Step 6
+// (Classify Changes by Domain). It builds a per-repo watched-path set from
+// that repo's renovate.json/.github/dependabot.yml (falling back to a
+// universal manifest-file list when neither is present), compares it against
+// the PR's changed files (regardless of PR_AUTHOR), and — when triggered —
+// folds `references/dependency-risk-analysis.md`'s heuristics into the
+// review's findings, distinguishable from ordinary code-review findings.
+
+function extractStep58Section(md: string): string {
+  const step58Idx = md.indexOf("## Step 5.8: Dependency Manifest Detection");
+  const step6Idx = md.indexOf("## Step 6: Classify Changes by Domain");
+  expect(step58Idx).toBeGreaterThan(-1);
+  expect(step6Idx).toBeGreaterThan(step58Idx);
+  return md.slice(step58Idx, step6Idx);
+}
+
+describe("review.md — Step 5.8 exists between Step 5 and Step 6 (DBR-3.2)", () => {
+  it("has a '## Step 5.8: Dependency Manifest Detection' heading positioned after Step 5 and before Step 6", () => {
+    const step5Idx = content.indexOf("## Step 5: Gather Context");
+    const step58Idx = content.indexOf("## Step 5.8: Dependency Manifest Detection");
+    const step6Idx = content.indexOf("## Step 6: Classify Changes by Domain");
+
+    expect(step5Idx).toBeGreaterThan(-1);
+    expect(step58Idx).toBeGreaterThan(step5Idx);
+    expect(step6Idx).toBeGreaterThan(step58Idx);
+  });
+});
+
+describe("review.md — Step 5.8 reads renovate.json and dependabot.yml (DBR-3.2)", () => {
+  it("documents reading renovate.json from the target repo", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("renovate.json");
+  });
+
+  it("documents reading .github/dependabot.yml from the target repo", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain(".github/dependabot.yml");
+  });
+
+  it("invokes the resolve-dependency-watched-paths script", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("resolve-dependency-watched-paths.ts");
+  });
+
+  it("notes the watched-path set is built per-repo, not a hardcoded global list", () => {
+    const section = extractStep58Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toMatch(/per-repo|repo-specific/);
+  });
+});
+
+describe("review.md — Step 5.8 documents the universal fallback list (DBR-3.2)", () => {
+  it("documents falling back to the universal manifest-file list when neither config file is present", () => {
+    const section = extractStep58Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("fallback");
+    expect(lower).toMatch(/neither.*present|neither.*found|absent/);
+  });
+
+  it("lists package.json in the fallback list", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("package.json");
+  });
+
+  it("lists at least one common lockfile in the fallback list", () => {
+    const section = extractStep58Section(content);
+    expect(
+      ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"].some((f) =>
+        section.includes(f),
+      ),
+    ).toBe(true);
+  });
+
+  it("lists go.mod in the fallback list", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("go.mod");
+  });
+
+  it("lists Gemfile in the fallback list", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("Gemfile");
+  });
+
+  it("lists requirements.txt in the fallback list", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("requirements.txt");
+  });
+
+  it("lists Cargo.toml in the fallback list", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("Cargo.toml");
+  });
+});
+
+describe("review.md — Step 5.8 detection is not gated on PR author (DBR-3.2)", () => {
+  it("explicitly states detection triggers regardless of PR_AUTHOR / author.login", () => {
+    const section = extractStep58Section(content);
+    expect(section).toMatch(/PR_AUTHOR|author\.login/);
+    const lower = section.toLowerCase();
+    expect(lower).toMatch(/regardless of|not gated on|independent of/);
+  });
+
+  it("does not scope detection to a bot-authored PR (e.g. dependabot/renovate login check)", () => {
+    const section = extractStep58Section(content);
+    // The section may *mention* dependabot/renovate logins as context for the
+    // downstream risk-analysis reference, but must not condition triggering
+    // the detection itself on author login — assert the explicit disclaimer
+    // exists rather than the absence of the substrings (which legitimately
+    // appear when explaining the reference's own author-branching).
+    const lower = section.toLowerCase();
+    expect(lower).toMatch(/any pr|any author|human-authored/);
+  });
+});
+
+describe("review.md — Step 5.8 invokes the DBR-3.1 risk-analysis reference (DBR-3.2)", () => {
+  it("references dependency-risk-analysis.md by path", () => {
+    const section = extractStep58Section(content);
+    expect(section).toContain("references/dependency-risk-analysis.md");
+  });
+
+  it("documents applying the reference's heuristics against this PR's diff/body/author", () => {
+    const section = extractStep58Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("diff");
+    expect(lower).toContain("body");
+    expect(section).toMatch(/recommendation|flags|reasoning/);
+  });
+
+  it("documents matching changed files against the watched-path set, including basename matching for nested files", () => {
+    const section = extractStep58Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toContain("basename");
+  });
+
+  it("documents that this step is a no-op when detection does not trigger", () => {
+    const section = extractStep58Section(content);
+    const lower = section.toLowerCase();
+    expect(lower).toMatch(/no-op|not triggered|does not trigger/);
+  });
+});
+
+describe("review.md — Step 9's template includes a Dependency Risk Analysis section (DBR-3.2)", () => {
+  it("Step 9's markdown template contains a '## Dependency Risk Analysis' section, distinct from Critical/Important/Suggestions", () => {
+    const step9Idx = content.indexOf("## Step 9: Write Review File");
+    const step95Idx = content.indexOf(
+      "## Step 9.5: Unaddressed-Findings Hard Gate",
+    );
+    expect(step9Idx).toBeGreaterThan(-1);
+    expect(step95Idx).toBeGreaterThan(step9Idx);
+    const step9Section = content.slice(step9Idx, step95Idx);
+
+    expect(step9Section).toContain("## Dependency Risk Analysis");
+  });
+
+  it("Step 9 documents that the Dependency Risk Analysis section is omitted when Step 5.8 did not trigger", () => {
+    const step9Idx = content.indexOf("## Step 9: Write Review File");
+    const step95Idx = content.indexOf(
+      "## Step 9.5: Unaddressed-Findings Hard Gate",
+    );
+    const step9Section = content.slice(step9Idx, step95Idx);
+
+    const lower = step9Section.toLowerCase();
+    expect(lower).toMatch(/omit|only.*present|only.*included/);
+  });
+});
+
+describe("review.md — Step 10's JSON-building prose references the dependency-analysis output (DBR-3.2)", () => {
+  it("Step 10 mentions folding the dependency risk analysis into the review body when present", () => {
+    const step10Idx = content.indexOf("## Step 10: Build Review JSON");
+    const step105Idx = content.indexOf(
+      "### Step 10.5: Hard-Gate Validation",
+    );
+    expect(step10Idx).toBeGreaterThan(-1);
+    expect(step105Idx).toBeGreaterThan(step10Idx);
+    const step10Section = content.slice(step10Idx, step105Idx);
+
+    const lower = step10Section.toLowerCase();
+    expect(lower).toContain("dependency");
+  });
+});

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -509,7 +509,13 @@ gets the exact same dependency-risk analysis as a bot-authored one.
    list rather than narrowing it. It reads `.github/dependabot.yml`'s `updates[]` array —
    each entry's `package-ecosystem` (e.g. `npm`, `bundler`, `pip`, `gomod`, `cargo`) maps to
    that ecosystem's manifest filename(s), joined with the entry's `directory` prefix (e.g.
-   `directory: "/backend"` + `npm` -> `backend/package.json`). When both config files are
+   `directory: "/backend"` + `npm` -> `backend/package.json`). A dependabot.yml that yields
+   zero recognized ecosystems — an empty `updates: []`, or entries whose `package-ecosystem`
+   values this script doesn't map — resolves to an **empty** watched-path set, not the
+   universal list: an explicit dependabot.yml is authoritative about what the repo watches,
+   so this step simply no-ops for that repo rather than widening back out. (A dependabot.yml
+   that can't be parsed at all — invalid YAML, or a missing `updates` key — is a different
+   case and still degrades to the universal list.) When both config files are
    present, the two watched-path sets are unioned, not one picked over the other — a repo
    can run both tools at once. **When neither config file is present in the repo, this falls
    back to the universal manifest-file list**: `package.json` and common lockfiles

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -525,17 +525,24 @@ gets the exact same dependency-risk analysis as a bot-authored one.
 
 2. **Compare against the changed files.** Using Step 5.3's already-extracted changed-files
    list and the `paths` array from the script's output above, a changed file matches the
-   watched-path set when EITHER:
-   - it is an exact, case-sensitive match to a watched path (e.g. changed file
-     `package.json` matches watched path `package.json`), or
-   - its **basename** matches a watched path that is itself a bare filename with no
-     directory component (e.g. changed file `packages/foo/package.json` matches watched
-     path `package.json` by basename, even though the watched-path set didn't anticipate
-     that nested location) — this basename fallback only applies when the watched-path
-     entry has no `/` in it; a watched path with a directory prefix (e.g.
-     `backend/package.json`, from a dependabot.yml `directory` entry) requires the exact
-     full-path match, since that prefix was an explicit scoping choice, not something a
-     bare basename match should widen back out.
+   watched-path set when ANY of the following three rules apply:
+   - **exact match**: the changed file is an exact, case-sensitive match to a watched path
+     (e.g. changed file `package.json` matches watched path `package.json`), or
+   - **basename match**: the changed file's **basename** matches a watched path that is
+     itself a bare filename with no directory component (e.g. changed file
+     `packages/foo/package.json` matches watched path `package.json` by basename, even
+     though the watched-path set didn't anticipate that nested location) — this basename
+     fallback only applies when the watched-path entry has no `/` in it; a watched path
+     with a directory prefix (e.g. `backend/package.json`, from a dependabot.yml
+     `directory` entry) requires the exact full-path match, since that prefix was an
+     explicit scoping choice, not something a bare basename match should widen back out,
+     or
+   - **directory-prefix match**: the changed file's path starts with a watched path that
+     itself ends with `/` (e.g. watched path `.github/workflows/` — as emitted for the
+     `github-actions` ecosystem — matches changed file `.github/workflows/ci.yml`). This
+     is distinct from the basename case above: a trailing `/` marks the entry as a
+     directory-prefix convention rather than a bare filename, so no glob syntax is ever
+     needed in the watched-path set.
 
 3. **When triggered** (at least one changed file matches, by either rule above): apply
    `references/dependency-risk-analysis.md`'s heuristics — using this PR's `diff` (Step

--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -477,6 +477,78 @@ Respond `[silent]`, and stop.
 
 ---
 
+## Step 5.8: Dependency Manifest Detection (DBR-3.2)
+
+Regardless of `PR_AUTHOR` — this step runs the same for any PR, human-authored or
+bot-authored; it is not gated on `PR_AUTHOR`/`author.login` at all, unlike the
+Dependabot/Renovate-specific `triage-dependency-bot-pr` skill. A human-authored PR that
+happens to touch a dependency manifest (e.g. hand-editing `package.json` to pin a version)
+gets the exact same dependency-risk analysis as a bot-authored one.
+
+1. **Build the repo's watched-path set.** cwd is already the worktree root at this point in
+   the procedure (per Step 4's "All subsequent steps run from
+   `.../{repo}-{branch-slug}/`" transition), so read the two config files relative to cwd
+   if present:
+   ```bash
+   RENOVATE_JSON=$(cat renovate.json 2>/dev/null || echo "")
+   DEPENDABOT_YML=$(cat .github/dependabot.yml 2>/dev/null || echo "")
+   ```
+   Then resolve the watched-path set — repo-specific, not a hardcoded global list — via
+   `resolve-dependency-watched-paths.ts` (mirroring `compute-review-verdict.ts`'s CLI
+   pattern):
+   ```bash
+   WATCHED_PATHS_RESULT=$(bun run "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-dependency-watched-paths.ts" \
+     "$(jq -n --arg renovateJson "$RENOVATE_JSON" --arg dependabotYml "$DEPENDABOT_YML" \
+       '{renovateJson: (if $renovateJson == "" then null else $renovateJson end),
+         dependabotYml: (if $dependabotYml == "" then null else $dependabotYml end)}')")
+   # -> {"paths":["package.json","go.mod",...],"source":"renovate"|"dependabot"|"both"|"fallback"}
+   ```
+   The script reads `renovate.json`'s configured `managers` array (when present) to narrow
+   scope to only the ecosystems it names; when `managers` is absent, Renovate's own default
+   is "detect all supported manifests", so the script treats that as the full universal
+   list rather than narrowing it. It reads `.github/dependabot.yml`'s `updates[]` array —
+   each entry's `package-ecosystem` (e.g. `npm`, `bundler`, `pip`, `gomod`, `cargo`) maps to
+   that ecosystem's manifest filename(s), joined with the entry's `directory` prefix (e.g.
+   `directory: "/backend"` + `npm` -> `backend/package.json`). When both config files are
+   present, the two watched-path sets are unioned, not one picked over the other — a repo
+   can run both tools at once. **When neither config file is present in the repo, this falls
+   back to the universal manifest-file list**: `package.json` and common lockfiles
+   (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`), `go.mod`
+   (and `go.sum`), `Gemfile` (and `Gemfile.lock`), `requirements.txt` (and `Pipfile`,
+   `Pipfile.lock`, `pyproject.toml`), and `Cargo.toml` (and `Cargo.lock`).
+
+2. **Compare against the changed files.** Using Step 5.3's already-extracted changed-files
+   list and the `paths` array from the script's output above, a changed file matches the
+   watched-path set when EITHER:
+   - it is an exact, case-sensitive match to a watched path (e.g. changed file
+     `package.json` matches watched path `package.json`), or
+   - its **basename** matches a watched path that is itself a bare filename with no
+     directory component (e.g. changed file `packages/foo/package.json` matches watched
+     path `package.json` by basename, even though the watched-path set didn't anticipate
+     that nested location) — this basename fallback only applies when the watched-path
+     entry has no `/` in it; a watched path with a directory prefix (e.g.
+     `backend/package.json`, from a dependabot.yml `directory` entry) requires the exact
+     full-path match, since that prefix was an explicit scoping choice, not something a
+     bare basename match should widen back out.
+
+3. **When triggered** (at least one changed file matches, by either rule above): apply
+   `references/dependency-risk-analysis.md`'s heuristics — using this PR's `diff` (Step
+   5.2), `body` and `author.login` (Step 5.1's PR metadata), and `labels` if available — to
+   produce `recommendation` (`merge`/`review`/`hold`), `flags` (`breakingChange`,
+   `securityRelevant`, `productionImpact`), and `reasoning`. Follow that reference's
+   Dependabot path, Renovate path, or author-mismatch fallback exactly as documented there —
+   this step does not restate those heuristics, only invokes them. Carry the resulting
+   `{recommendation, flags, reasoning}` forward as `DEPENDENCY_RISK_ANALYSIS` for Step 9 (the
+   review file's dedicated "Dependency Risk Analysis" section) and Step 10 (folded into the
+   JSON body's reasoning) — kept distinguishable there from the ordinary code-review
+   Critical/Important/Suggestions findings, never merged into that list.
+
+4. **When not triggered** (no changed file matches): this step is a no-op — do not add a
+   "Dependency Risk Analysis" section anywhere downstream; `DEPENDENCY_RISK_ANALYSIS` stays
+   unset/absent for Steps 9 and 10.
+
+---
+
 ## Step 6: Classify Changes by Domain
 
 Before reading individual files, build a structural picture of what kind of work this PR does. Work from the PR body, commit messages, and file list:
@@ -656,6 +728,21 @@ Write `$WORKSPACE_ROOT/state/reviews/PR_REVIEW_{pr}.md`:
 ## CI Status
 
 {Current status of checks}
+
+## Dependency Risk Analysis
+
+{Only present when Step 5.8 triggered — omit this entire section (heading included) when
+Step 5.8 found no changed file matching the repo's watched-path set. When present, this
+section is populated from `DEPENDENCY_RISK_ANALYSIS` (Step 5.8's application of
+`references/dependency-risk-analysis.md`'s heuristics) and is kept visually and
+structurally distinguishable from the ordinary code-review findings below — it is never
+folded into Critical Issues/Important Issues/Suggestions, since it reflects a different
+analysis (dependency-bump risk, not general code review) even on a PR that also has
+ordinary findings.}
+
+**Recommendation**: {merge|review|hold}
+**Flags**: {breakingChange, securityRelevant, productionImpact — whichever apply, or "none"}
+**Reasoning**: {DEPENDENCY_RISK_ANALYSIS.reasoning}
 
 ## Critical Issues ({count})
 
@@ -977,6 +1064,16 @@ Write `$WORKSPACE_ROOT/state/reviews/pr_review_{pr}.json`:
 
 For a COMMENT verdict, the `body` follows the same convention, e.g.
 `"body": "Verdict: COMMENT — {one-line summary of the most important finding}"`.
+
+**Folding in the dependency risk analysis (DBR-3.2).** When Step 5.8 triggered and
+`DEPENDENCY_RISK_ANALYSIS` is set, append a short, clearly-labeled dependency-risk clause to
+the `body` after the `Verdict: ...` lead-in, e.g. `"Verdict: COMMENT — {code-review summary};
+dependency risk: {DEPENDENCY_RISK_ANALYSIS.recommendation} — {DEPENDENCY_RISK_ANALYSIS.reasoning}"`.
+This is additive to the verdict computed above, not a replacement for it — the
+`compute-review-verdict.ts` truth table still solely determines `event`/`verdictLabel`; the
+dependency-risk `recommendation` (`merge`/`review`/`hold`) does not feed into that
+computation. When Step 5.8 did not trigger, omit this clause entirely — the body reads
+exactly as it would without this feature.
 
 **Diff-line mapping**: for each finding with a `file:line` reference, check if the
 line is in the diff (`git diff origin/{base}...HEAD -- {file}`). Only lines within diff

--- a/plugins/shipwright/package.json
+++ b/plugins/shipwright/package.json
@@ -7,7 +7,11 @@
     "test": "NODE_ENV=test bun test",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "js-yaml": "^4.3.1"
+  },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "bun-types": "*",
     "typescript": "*"
   }

--- a/plugins/shipwright/scripts/resolve-dependency-watched-paths.ts
+++ b/plugins/shipwright/scripts/resolve-dependency-watched-paths.ts
@@ -187,7 +187,15 @@ function resolveFromRenovateJson(renovateJson: string): string[] {
 // into the fallback list) since an explicit dependabot.yml is itself
 // authoritative about which ecosystems this repo watches — unlike
 // renovate.json's un-narrowed case, a dependabot.yml with `updates: []` (or
-// entries this parser doesn't recognize) legitimately watches nothing.
+// entries this parser doesn't recognize) legitimately watches nothing, and
+// this function returns an empty path set for it rather than degrading to the
+// universal fallback list (which would spuriously trigger review.md's Step 5.8
+// dependency-risk analysis on manifests the repo demonstrably does not watch).
+//
+// The universal fallback is reserved for the cases where the config could not
+// be *understood* at all — unparseable YAML, a non-object document, or a
+// missing/non-array `updates` key. Those are "we don't know what this repo
+// watches", which is materially different from "this repo watches nothing".
 function resolveFromDependabotYml(dependabotYml: string): string[] {
   let parsed: unknown;
   try {
@@ -234,7 +242,10 @@ function resolveFromDependabotYml(dependabotYml: string): string[] {
     }
   }
 
-  return paths.size > 0 ? [...paths] : [...UNIVERSAL_FALLBACK_PATHS];
+  // No universal-fallback degradation here: an `updates: []` array, or one
+  // whose every entry names an ecosystem this parser doesn't recognize, is an
+  // authoritative "watches nothing" — see the comment above this function.
+  return [...paths];
 }
 
 function normalizeDirectoryPrefix(directory: string): string {

--- a/plugins/shipwright/scripts/resolve-dependency-watched-paths.ts
+++ b/plugins/shipwright/scripts/resolve-dependency-watched-paths.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env bun
+// Dependency-manifest watched-path resolution (DBR-3.2).
+//
+// Given the raw text contents of a target repo's renovate.json and/or
+// .github/dependabot.yml (or their absence), resolves the set of file paths
+// that repo's PR review should treat as "dependency-manifest changes" — see
+// plugins/shipwright/commands/review.md's Step 5.8, which invokes this
+// script's CLI to build the watched-path set before comparing it against a
+// PR's changed files (regardless of PR author).
+//
+// This is a best-effort scope narrowing, not a full Renovate/Dependabot
+// config interpreter — see the comments on `narrowByRenovateManagers` and
+// `dependabotUpdatesToPaths` below for exactly how much each config format
+// is understood.
+//
+// Pure logic only — no filesystem or network I/O in the exported function;
+// review.md's bash step reads the two files (if present) and passes their
+// contents (or omits them) to the CLI below, mirroring
+// compute-review-verdict.ts's / compute-unaddressed-findings.ts's
+// inject-don't-reach-for-fs pattern.
+//
+// CLI:
+//   bun run plugins/shipwright/scripts/resolve-dependency-watched-paths.ts \
+//     '{"renovateJson":"{...}","dependabotYml":"updates:\n  - ..."}'
+// or pipe the same JSON blob via stdin. Either field may be omitted/null
+// when the corresponding file does not exist in the repo.
+
+import * as yaml from "js-yaml";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type WatchedPathSource = "renovate" | "dependabot" | "both" | "fallback";
+
+export type ResolveDependencyWatchedPathsInput = {
+  /** Raw text contents of the target repo's renovate.json, or undefined if absent. */
+  renovateJson: string | undefined;
+  /** Raw text contents of the target repo's .github/dependabot.yml, or undefined if absent. */
+  dependabotYml: string | undefined;
+};
+
+export type ResolveDependencyWatchedPathsResult = {
+  /** De-duplicated list of watched file paths (repo-root-relative). */
+  paths: string[];
+  /** Which input(s) produced this set. */
+  source: WatchedPathSource;
+};
+
+// ─── Universal fallback list ──────────────────────────────────────────────────
+//
+// Used when neither renovate.json nor dependabot.yml is present in the repo,
+// and as the base set narrowed by ecosystem/manager mappings below.
+
+export const UNIVERSAL_FALLBACK_PATHS: readonly string[] = [
+  "package.json",
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "bun.lockb",
+  "go.mod",
+  "go.sum",
+  "Gemfile",
+  "Gemfile.lock",
+  "requirements.txt",
+  "Pipfile",
+  "Pipfile.lock",
+  "pyproject.toml",
+  "Cargo.toml",
+  "Cargo.lock",
+];
+
+// ─── Ecosystem <-> manifest-file mapping ───────────────────────────────────────
+//
+// Shared between the Renovate `managers` narrowing and the Dependabot
+// `package-ecosystem` mapping below — the two config formats name the same
+// underlying package-manager concept with different vocabularies (Renovate's
+// "manager" ids vs. Dependabot's "package-ecosystem" ids), so each entry here
+// lists both names where they differ, pointing at the same manifest files.
+
+type EcosystemEntry = {
+  renovateManagers: string[];
+  dependabotEcosystems: string[];
+  manifestFiles: string[];
+};
+
+const ECOSYSTEMS: EcosystemEntry[] = [
+  {
+    renovateManagers: ["npm"],
+    dependabotEcosystems: ["npm"],
+    manifestFiles: [
+      "package.json",
+      "package-lock.json",
+      "yarn.lock",
+      "pnpm-lock.yaml",
+      "bun.lock",
+      "bun.lockb",
+    ],
+  },
+  {
+    renovateManagers: ["bundler"],
+    dependabotEcosystems: ["bundler"],
+    manifestFiles: ["Gemfile", "Gemfile.lock"],
+  },
+  {
+    renovateManagers: ["pip_requirements", "pip_setup", "pipenv", "poetry"],
+    dependabotEcosystems: ["pip"],
+    manifestFiles: [
+      "requirements.txt",
+      "Pipfile",
+      "Pipfile.lock",
+      "pyproject.toml",
+    ],
+  },
+  {
+    renovateManagers: ["gomod"],
+    dependabotEcosystems: ["gomod"],
+    manifestFiles: ["go.mod", "go.sum"],
+  },
+  {
+    renovateManagers: ["cargo"],
+    dependabotEcosystems: ["cargo"],
+    manifestFiles: ["Cargo.toml", "Cargo.lock"],
+  },
+  {
+    renovateManagers: ["github-actions"],
+    dependabotEcosystems: ["github-actions"],
+    // Directory join below is skipped for this ecosystem's glob entries —
+    // see dependabotUpdatesToPaths.
+    manifestFiles: [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+  },
+];
+
+// ─── renovate.json parsing ──────────────────────────────────────────────────
+//
+// Best-effort scope narrowing, not a full Renovate config interpreter: only
+// the top-level `managers` array is consulted. If `managers` is absent,
+// Renovate's own default behavior is "detect all supported manifests" — so
+// an unrestricted renovate.json (or one that fails to parse) is treated as
+// watching the full universal fallback list, since its presence alone does
+// not narrow scope. `matchPackageNames`/`packageRules[].matchPackageNames`
+// scope individual *packages* within an already-detected manifest, not which
+// manifest *files* are watched, so they do not further narrow the path set
+// this function resolves (see the module comment in review.md's Step 5.8 for
+// why: this is a file-level watch list, not a package-level one).
+function resolveFromRenovateJson(renovateJson: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(renovateJson);
+  } catch {
+    return [...UNIVERSAL_FALLBACK_PATHS];
+  }
+
+  const managers =
+    parsed &&
+    typeof parsed === "object" &&
+    Array.isArray((parsed as { managers?: unknown }).managers)
+      ? ((parsed as { managers: unknown[] }).managers.filter(
+          (m): m is string => typeof m === "string",
+        ) as string[])
+      : undefined;
+
+  if (!managers || managers.length === 0) {
+    return [...UNIVERSAL_FALLBACK_PATHS];
+  }
+
+  const narrowed = new Set<string>();
+  for (const manager of managers) {
+    const entry = ECOSYSTEMS.find((e) => e.renovateManagers.includes(manager));
+    if (entry) {
+      for (const file of entry.manifestFiles) narrowed.add(file);
+    }
+  }
+
+  // An explicit `managers` array naming only unrecognized manager ids (not in
+  // the ECOSYSTEMS table above) would otherwise narrow to an empty set —
+  // degrade to the full fallback list rather than watching nothing.
+  return narrowed.size > 0 ? [...narrowed] : [...UNIVERSAL_FALLBACK_PATHS];
+}
+
+// ─── dependabot.yml parsing ──────────────────────────────────────────────────
+//
+// Parses the top-level `updates[]` array's `package-ecosystem` and
+// `directory` fields. Each ecosystem maps to its manifest filename(s) via
+// the shared ECOSYSTEMS table above; `directory` (when not "/" or empty) is
+// joined as a path prefix, e.g. `directory: "/backend"` + `npm` ->
+// `backend/package.json`. Unrecognized ecosystems are skipped (not folded
+// into the fallback list) since an explicit dependabot.yml is itself
+// authoritative about which ecosystems this repo watches — unlike
+// renovate.json's un-narrowed case, a dependabot.yml with `updates: []` (or
+// entries this parser doesn't recognize) legitimately watches nothing.
+function resolveFromDependabotYml(dependabotYml: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(dependabotYml);
+  } catch {
+    return [...UNIVERSAL_FALLBACK_PATHS];
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return [...UNIVERSAL_FALLBACK_PATHS];
+  }
+
+  const updates = (parsed as { updates?: unknown }).updates;
+  if (!Array.isArray(updates)) {
+    return [...UNIVERSAL_FALLBACK_PATHS];
+  }
+
+  const paths = new Set<string>();
+  for (const update of updates) {
+    if (!update || typeof update !== "object") continue;
+    const ecosystem = (update as { "package-ecosystem"?: unknown })[
+      "package-ecosystem"
+    ];
+    if (typeof ecosystem !== "string") continue;
+
+    const entry = ECOSYSTEMS.find((e) =>
+      e.dependabotEcosystems.includes(ecosystem),
+    );
+    if (!entry) continue;
+
+    const rawDirectory = (update as { directory?: unknown }).directory;
+    const directory = typeof rawDirectory === "string" ? rawDirectory : "/";
+    const prefix = normalizeDirectoryPrefix(directory);
+
+    for (const file of entry.manifestFiles) {
+      // github-actions' glob-style entries are already repo-root-anchored
+      // (.github/workflows/...) regardless of `directory` — Dependabot
+      // itself does not relocate the workflows directory per-entry.
+      if (file.startsWith(".github/")) {
+        paths.add(file);
+        continue;
+      }
+      paths.add(prefix ? `${prefix}/${file}` : file);
+    }
+  }
+
+  return paths.size > 0 ? [...paths] : [...UNIVERSAL_FALLBACK_PATHS];
+}
+
+function normalizeDirectoryPrefix(directory: string): string {
+  const trimmed = directory.replace(/^\/+/, "").replace(/\/+$/, "");
+  return trimmed;
+}
+
+// ─── resolveDependencyWatchedPaths ─────────────────────────────────────────────
+
+export function resolveDependencyWatchedPaths(
+  input: ResolveDependencyWatchedPathsInput,
+): ResolveDependencyWatchedPathsResult {
+  const hasRenovate =
+    typeof input.renovateJson === "string" && input.renovateJson.length > 0;
+  const hasDependabot =
+    typeof input.dependabotYml === "string" && input.dependabotYml.length > 0;
+
+  if (!hasRenovate && !hasDependabot) {
+    return { paths: [...UNIVERSAL_FALLBACK_PATHS], source: "fallback" };
+  }
+
+  if (hasRenovate && !hasDependabot) {
+    return {
+      paths: resolveFromRenovateJson(input.renovateJson as string),
+      source: "renovate",
+    };
+  }
+
+  if (!hasRenovate && hasDependabot) {
+    return {
+      paths: resolveFromDependabotYml(input.dependabotYml as string),
+      source: "dependabot",
+    };
+  }
+
+  const renovatePaths = resolveFromRenovateJson(input.renovateJson as string);
+  const dependabotPaths = resolveFromDependabotYml(
+    input.dependabotYml as string,
+  );
+  const union = new Set([...renovatePaths, ...dependabotPaths]);
+  return { paths: [...union], source: "both" };
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+type CliInput = {
+  renovateJson?: string | null;
+  dependabotYml?: string | null;
+};
+
+function parseCliInput(raw: string): ResolveDependencyWatchedPathsInput {
+  const parsed = JSON.parse(raw) as CliInput;
+  return {
+    renovateJson:
+      typeof parsed.renovateJson === "string" ? parsed.renovateJson : undefined,
+    dependabotYml:
+      typeof parsed.dependabotYml === "string"
+        ? parsed.dependabotYml
+        : undefined,
+  };
+}
+
+if (import.meta.main) {
+  const arg = process.argv[2];
+  const raw = arg && arg.length > 0 ? arg : await Bun.stdin.text();
+  const input = parseCliInput(raw);
+  const result = resolveDependencyWatchedPaths(input);
+  console.log(JSON.stringify(result));
+}

--- a/plugins/shipwright/scripts/resolve-dependency-watched-paths.ts
+++ b/plugins/shipwright/scripts/resolve-dependency-watched-paths.ts
@@ -124,9 +124,17 @@ const ECOSYSTEMS: EcosystemEntry[] = [
   {
     renovateManagers: ["github-actions"],
     dependabotEcosystems: ["github-actions"],
-    // Directory join below is skipped for this ecosystem's glob entries —
-    // see dependabotUpdatesToPaths.
-    manifestFiles: [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+    // A directory-prefix entry (trailing `/`, no glob characters), not a
+    // bare filename — review.md's Step 5.8 comparison rule matches this
+    // against any changed file whose path starts with the prefix (e.g.
+    // `.github/workflows/ci.yml`). Glob-style entries like
+    // `.github/workflows/*.yml` were tried here previously, but Step 5.8's
+    // matcher only understands exact-path and bare-basename matches — a
+    // path containing both `/` and `*` could never match either rule, so
+    // github-actions detection was silently dead. Directory join below is
+    // still skipped for this ecosystem's `.github/`-rooted entry — see
+    // resolveFromDependabotYml.
+    manifestFiles: [".github/workflows/"],
   },
 ];
 
@@ -231,8 +239,8 @@ function resolveFromDependabotYml(dependabotYml: string): string[] {
     const prefix = normalizeDirectoryPrefix(directory);
 
     for (const file of entry.manifestFiles) {
-      // github-actions' glob-style entries are already repo-root-anchored
-      // (.github/workflows/...) regardless of `directory` — Dependabot
+      // github-actions' directory-prefix entry is already repo-root-anchored
+      // (.github/workflows/) regardless of `directory` — Dependabot
       // itself does not relocate the workflows directory per-entry.
       if (file.startsWith(".github/")) {
         paths.add(file);

--- a/plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts
+++ b/plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts
@@ -82,6 +82,24 @@ describe("resolveDependencyWatchedPaths — renovate.json only", () => {
     expect(result.paths).not.toContain("Gemfile");
   });
 
+  it("with `managers: [\"github-actions\"]`, narrows to a directory-prefix watched path — not a glob", () => {
+    const renovateJson = JSON.stringify({
+      managers: ["github-actions"],
+    });
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml: undefined,
+    });
+    // The watched path must be a plain directory-prefix (trailing `/`, no
+    // `*`) — review.md's Step 5.8 matcher only understands exact,
+    // basename, and directory-prefix matches, none of which can ever match
+    // a glob like `.github/workflows/*.yml` (see DBR-3.2 follow-up finding
+    // on PR #3112: glob entries were silently unmatchable).
+    expect(result.paths).toContain(".github/workflows/");
+    expect(result.paths.some((p) => p.includes("*"))).toBe(false);
+    expect(result.paths).not.toContain("package.json");
+  });
+
   it("malformed renovate.json (invalid JSON) falls back to the full universal list rather than throwing", () => {
     const result = resolveDependencyWatchedPaths({
       renovateJson: "{ this is not valid json",
@@ -136,6 +154,21 @@ updates:
       dependabotYml,
     });
     expect(result.paths).toContain("backend/package.json");
+  });
+
+  it("parses a github-actions update entry and maps it to a directory-prefix watched path, ignoring `directory`", () => {
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml,
+    });
+    expect(result.paths).toContain(".github/workflows/");
+    expect(result.paths.some((p) => p.includes("*"))).toBe(false);
   });
 
   it("handles multiple updates entries across different ecosystems", () => {

--- a/plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts
+++ b/plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts
@@ -1,0 +1,204 @@
+// Unit tests for resolve-dependency-watched-paths.ts — pure logic, no I/O.
+//
+// Covers DBR-3.2's watched-path resolution: given the raw text contents of a
+// target repo's renovate.json and/or .github/dependabot.yml (or their
+// absence), resolve which dependency-manifest file paths that repo's PR
+// review should treat as "dependency-manifest changes" — falling back to
+// the universal manifest-file list when neither config is present, and
+// narrowing to a repo-specific set when renovate.json's `managers` array
+// explicitly restricts scope.
+
+import { describe, expect, it } from "bun:test";
+import {
+  resolveDependencyWatchedPaths,
+  UNIVERSAL_FALLBACK_PATHS,
+} from "./resolve-dependency-watched-paths";
+
+describe("resolveDependencyWatchedPaths — neither config present (fallback)", () => {
+  it("returns the universal fallback list when both renovateJson and dependabotYml are undefined", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml: undefined,
+    });
+    expect(result.source).toBe("fallback");
+    expect(result.paths.sort()).toEqual([...UNIVERSAL_FALLBACK_PATHS].sort());
+  });
+
+  it("the universal fallback list includes the task-mandated manifest files", () => {
+    expect(UNIVERSAL_FALLBACK_PATHS).toContain("package.json");
+    expect(UNIVERSAL_FALLBACK_PATHS).toContain("go.mod");
+    expect(UNIVERSAL_FALLBACK_PATHS).toContain("Gemfile");
+    expect(UNIVERSAL_FALLBACK_PATHS).toContain("requirements.txt");
+    expect(UNIVERSAL_FALLBACK_PATHS).toContain("Cargo.toml");
+    // at least one common lockfile
+    expect(
+      UNIVERSAL_FALLBACK_PATHS.some((p) =>
+        ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"].includes(p),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("resolveDependencyWatchedPaths — renovate.json only", () => {
+  it("with no `managers` field, treats Renovate as watching the full universal fallback list", () => {
+    const renovateJson = JSON.stringify({
+      extends: ["config:base"],
+    });
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml: undefined,
+    });
+    expect(result.source).toBe("renovate");
+    expect(result.paths.sort()).toEqual([...UNIVERSAL_FALLBACK_PATHS].sort());
+  });
+
+  it("with `managers: [\"npm\"]`, narrows the watched-path set to npm manifests only", () => {
+    const renovateJson = JSON.stringify({
+      managers: ["npm"],
+    });
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml: undefined,
+    });
+    expect(result.source).toBe("renovate");
+    expect(result.paths).toContain("package.json");
+    expect(result.paths).not.toContain("go.mod");
+    expect(result.paths).not.toContain("Gemfile");
+    expect(result.paths).not.toContain("Cargo.toml");
+    expect(result.paths).not.toContain("requirements.txt");
+  });
+
+  it("with `managers: [\"gomod\", \"cargo\"]`, narrows to go + cargo manifests only", () => {
+    const renovateJson = JSON.stringify({
+      managers: ["gomod", "cargo"],
+    });
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml: undefined,
+    });
+    expect(result.paths).toContain("go.mod");
+    expect(result.paths).toContain("Cargo.toml");
+    expect(result.paths).not.toContain("package.json");
+    expect(result.paths).not.toContain("Gemfile");
+  });
+
+  it("malformed renovate.json (invalid JSON) falls back to the full universal list rather than throwing", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: "{ this is not valid json",
+      dependabotYml: undefined,
+    });
+    expect(result.source).toBe("renovate");
+    expect(result.paths.sort()).toEqual([...UNIVERSAL_FALLBACK_PATHS].sort());
+  });
+});
+
+describe("resolveDependencyWatchedPaths — dependabot.yml only", () => {
+  it("parses a single npm update entry at the repo root", () => {
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml,
+    });
+    expect(result.source).toBe("dependabot");
+    expect(result.paths).toContain("package.json");
+  });
+
+  it("parses a bundler update entry and maps it to Gemfile paths", () => {
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml,
+    });
+    expect(result.paths).toContain("Gemfile");
+  });
+
+  it("joins a non-root directory prefix onto the mapped manifest filenames", () => {
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml,
+    });
+    expect(result.paths).toContain("backend/package.json");
+  });
+
+  it("handles multiple updates entries across different ecosystems", () => {
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+  - package-ecosystem: "pip"
+    directory: "/scripts"
+  - package-ecosystem: "gomod"
+    directory: "/"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml,
+    });
+    expect(result.paths).toContain("package.json");
+    expect(result.paths).toContain("scripts/requirements.txt");
+    expect(result.paths).toContain("go.mod");
+  });
+
+  it("malformed dependabot.yml (invalid YAML) falls back to the full universal list rather than throwing", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml: "updates: [this is not: valid: yaml: at: all",
+    });
+    expect(result.source).toBe("dependabot");
+    expect(result.paths.sort()).toEqual([...UNIVERSAL_FALLBACK_PATHS].sort());
+  });
+});
+
+describe("resolveDependencyWatchedPaths — both present (union)", () => {
+  it("unions the renovate-narrowed set with the dependabot-derived set", () => {
+    const renovateJson = JSON.stringify({ managers: ["npm"] });
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml,
+    });
+    expect(result.source).toBe("both");
+    expect(result.paths).toContain("package.json");
+    expect(result.paths).toContain("go.mod");
+  });
+
+  it("does not duplicate paths present in both sources", () => {
+    const renovateJson = JSON.stringify({ managers: ["npm"] });
+    const dependabotYml = `
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml,
+    });
+    const packageJsonCount = result.paths.filter((p) => p === "package.json").length;
+    expect(packageJsonCount).toBe(1);
+  });
+});

--- a/plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts
+++ b/plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts
@@ -166,6 +166,64 @@ updates:
     expect(result.source).toBe("dependabot");
     expect(result.paths.sort()).toEqual([...UNIVERSAL_FALLBACK_PATHS].sort());
   });
+
+  it("an empty `updates: []` array watches nothing — no universal-fallback widening", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml: `
+version: 2
+updates: []
+`,
+    });
+    expect(result.source).toBe("dependabot");
+    expect(result.paths).toEqual([]);
+  });
+
+  it("updates entries naming only unrecognized ecosystems watch nothing rather than the universal list", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml: `
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+  - package-ecosystem: "terraform"
+    directory: "/infra"
+`,
+    });
+    expect(result.source).toBe("dependabot");
+    expect(result.paths).toEqual([]);
+    // Specifically must NOT spuriously watch manifests for ecosystems this
+    // repo's dependabot.yml never names.
+    expect(result.paths).not.toContain("go.mod");
+    expect(result.paths).not.toContain("package.json");
+  });
+
+  it("keeps only the recognized ecosystems when entries are a mix of recognized and unrecognized", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml: `
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+  - package-ecosystem: "docker"
+    directory: "/"
+`,
+    });
+    expect(result.paths).toContain("package.json");
+    expect(result.paths).not.toContain("go.mod");
+    expect(result.paths).not.toContain("Cargo.toml");
+  });
+
+  it("a dependabot.yml with no `updates` key at all is unparseable-intent and still falls back to the universal list", () => {
+    const result = resolveDependencyWatchedPaths({
+      renovateJson: undefined,
+      dependabotYml: "version: 2\n",
+    });
+    expect(result.source).toBe("dependabot");
+    expect(result.paths.sort()).toEqual([...UNIVERSAL_FALLBACK_PATHS].sort());
+  });
 });
 
 describe("resolveDependencyWatchedPaths — both present (union)", () => {
@@ -200,5 +258,21 @@ updates:
     });
     const packageJsonCount = result.paths.filter((p) => p === "package.json").length;
     expect(packageJsonCount).toBe(1);
+  });
+
+  it("a watches-nothing dependabot.yml does not widen a narrowed renovate.json back to the universal list", () => {
+    const renovateJson = JSON.stringify({ managers: ["npm"] });
+    const dependabotYml = `
+version: 2
+updates: []
+`;
+    const result = resolveDependencyWatchedPaths({
+      renovateJson,
+      dependabotYml,
+    });
+    expect(result.source).toBe("both");
+    expect(result.paths).toContain("package.json");
+    expect(result.paths).not.toContain("go.mod");
+    expect(result.paths).not.toContain("Cargo.toml");
   });
 });


### PR DESCRIPTION
## Summary
- Add Step 5.8 to `plugins/shipwright/commands/review.md`: detects dependency-manifest changes on any PR (regardless of author) by comparing changed files against a per-repo watched-path set
- New `plugins/shipwright/scripts/resolve-dependency-watched-paths.ts` builds that watched-path set from a repo's `renovate.json` (`managers` array) and/or `.github/dependabot.yml` (`updates[].package-ecosystem`/`directory`), falling back to a universal manifest-file list when neither is present
- When a dependency-manifest change is detected, Step 5.8 invokes the DBR-3.1 `references/dependency-risk-analysis.md` reference and folds its recommendation/flags/reasoning into a distinct "Dependency Risk Analysis" section (Step 9's review file) and a labeled clause in the verdict body (Step 10) — kept separate from ordinary Critical/Important/Suggestions findings

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Reads renovate.json (managers/matchPackageNames scope) + dependabot.yml (package-ecosystem/directory) per-repo | MET | `resolve-dependency-watched-paths.ts` `resolveFromRenovateJson`/`resolveFromDependabotYml`; review.md Step 5.8 §1 |
| 2 | Falls back to universal manifest-file list when neither present | MET | `UNIVERSAL_FALLBACK_PATHS` constant + fallback branch |
| 3 | Detection triggers regardless of pr.author.login | MET | Step 5.8 intro explicitly states "not gated on PR_AUTHOR/author.login at all" |
| 4 | DBR-3.1 reference output folded in, distinguishable from ordinary findings | MET | Step 5.8 §3 invokes `references/dependency-risk-analysis.md`; Step 9 adds separate "## Dependency Risk Analysis" section; Step 10 appends distinct clause |
| 5 | Content tests for parsing + fallback fixture coverage, additive only | MET | `review.content.test.ts` new describe blocks (no deletions); `resolve-dependency-watched-paths.unit.test.ts` covers renovate-only/dependabot-only/both/fallback/malformed-input cases |

## Test Plan
- `bun test plugins/shipwright/scripts/resolve-dependency-watched-paths.unit.test.ts plugins/shipwright/commands/review.content.test.ts` — 192 pass, 0 fail
- `task typecheck` — all packages pass
- `task lint` — no issues
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
