### PR TITLE
fix: remove Renovate automerge from shipwright's renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "platformAutomerge": true,
-  "automergeType": "pr",
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
@@ -35,8 +33,7 @@
     {
       "description": "Group routine (non-security) minor/patch bumps to cut down PR noise",
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "routine dependency updates",
-      "automerge": true
+      "groupName": "routine dependency updates"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Removes `platformAutomerge` and `automergeType` top-level keys from `renovate.json`
- Removes `automerge: true` from the "routine dependency updates" package rule (the grouping itself is unchanged)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `platformAutomerge` and `automergeType` top-level keys removed | MET |
| 2 | 'routine dependency updates' package rule's `automerge: true` removed (grouping stays) | MET |
| 3 | No automated test applies to a bot config file; verified by confirming the next Renovate PR does not carry an autoMergeRequest | Verified post-merge (runtime observation) |

## Test Plan
- Config-only change to a bot config file — no automated test applies (per task's own test decision)
- Validated `renovate.json` is well-formed JSON
- Confirmed `task lint`, `task typecheck`, `task check-config-docs`, `task check-version-sync` all pass
- `task test:coverage` has pre-existing failures on `main` (unrelated env/sentry/prs-validation tests) — verified identical failures exist at current main HEAD before this change
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
