### PR TITLE
docs(planning): add slack-thread-context plan

### DIFF
--- a/planning/slack-thread-context/PLAN.md
+++ b/planning/slack-thread-context/PLAN.md
@@ -15,130 +15,109 @@ finish — or until the 25-min idle / 60-min hard timeout kills them.
 
 ## Codebase findings
 
-- `agent/src/claude.ts` — `createRunClaude()` returns
-  `runClaude(message, sessionKey?, onProgress?, signal?)`. `_runClaude` builds args,
-  calls `_spawn(args, onProgress, signal)` (and once more on the retry path).
-  `_spawn` builds the child env as `const { SENTRY_DSN, ...spawnEnv } = process.env`
-  and passes `{ cwd: workspace, env: spawnEnv, stdout: "pipe", stderr: "pipe" }` to the
-  injected `spawner`. No per-run env exists today.
-- `agent/src/slack.ts` — three handlers (`app.message`, `app_mention`,
-  `reaction_added`) all know `channel` and the reply thread (`thread_ts ?? ts`) — the
-  same pair used for `sessionKey = getThreadKey(channel, replyTs)` — and call
-  `runner(prompt, sessionKey, progress.onProgress)`. `ClaudeRunner` is declared at
-  `slack.ts:148` as `(message, sessionKey?, onProgress?)`.
-- `agent/src/cron-handler.ts` — `ClaudeRunner` is `(message, onProgress?)`;
-  `index.ts:209/547` adapt it as `(message, onProgress) => runner(message, undefined, onProgress)`.
-  For `channel` crons the channel is known before the run. For `user` crons the DM
-  channel is opened *after* the run (`conversations.open` at `cron-handler.ts:528`),
-  inside the delivery block that tags Slack failures.
-- `agent/workspace/CLAUDE.md.template` — response-marker table (lines 24–45) is where
-  per-run Slack facts are documented; "Waiting and Polling" (142–183) contains the
-  stale "resume failure silently clears the session" paragraph; `_runClaude`
-  (`claude.ts:655–710`) actually retries the same session once and rethrows leaving the
-  mapping intact.
-- `plugins/shipwright/scripts/` — self-contained scripts with sibling
-  `*.unit.test.ts`, `clock.ts` for injectable time, deps injected via a `deps` object
-  (`check-error-patrol.ts`). `task check-config-docs` requires every `process.env.*`
-  read under `agent/src/` and `plugins/shipwright/scripts/` to be documented in
-  `docs/configuration.md`.
-- Versioning is owned by semantic-release (`.claude/skills/marketplace-dev/SKILL.md`):
-  a `feat:` commit bumps the minor on merge — **no manual `plugin.json` edits**.
-- Existing test precedent: `claude.unit.test.ts:318` asserts the spawned `opts.env`
-  via the injected `mockSpawn`; `slack.unit.test.ts` mocks `runner` and asserts its
-  call args; `cron-handler.unit.test.ts` uses `mockRunner`.
+**Status: STC-1.1, STC-1.2, STC-1.3, and STC-2.1 have already shipped on `main`** —
+re-verified against `repos/shipwright` main (HEAD `9e291d14`), which is newer than either
+of these findings' original snapshot:
 
-Complexity flags: none material. All changes are additive (optional params, new env
-vars, new script). No renames or removals → every task is safe to deploy standalone.
+- `agent/src/claude.ts` — `createRunClaude()`'s returned function already has the 5th
+  `extraEnv?: Record<string, string>` param; `_runClaude` forwards it to `_spawn` on
+  both the first attempt and the retry; `_spawn` spreads it over `spawnEnv`
+  (`{ ...spawnEnv, ...extraEnv }`) after the `SENTRY_DSN` strip. Shipped via PR #3143
+  ("feat: add per-run extraEnv to the claude runner").
+- `agent/src/slack.ts` — all three handlers (`app.message`, `app_mention`,
+  `reaction_added`) already pass `{ SLACK_CHANNEL_ID, SLACK_THREAD_TS }` to the runner,
+  using the same `replyTs` value as the session key. Shipped via PR #3143 (tagged
+  `STC-1.2`).
+- `agent/src/cron-handler.ts` — already resolves `SLACK_CHANNEL_ID` before the run
+  (comments tagged `STC-1.3`): `channel` crons pass the cron's channel directly; `user`
+  crons resolve the DM channel via `conversations.open` *before* the run and reuse it
+  for post-run delivery; resolution failures log and run without the var. Shipped via
+  PR #3143 (tagged `STC-1.3`).
+- `plugins/shipwright/scripts/slack-say.ts` already exists alongside
+  `slack-say.unit.test.ts`, and `docs/configuration.md` already documents both
+  `SLACK_CHANNEL_ID` and `SLACK_THREAD_TS` (injection behavior, cron vs. Slack-triggered
+  differences, and `slack-say.ts` consumption). `plugins/shipwright/skills/slack-say/SKILL.md`
+  also already exists, and `plugins/shipwright/README.md`'s file tree already lists it.
+  All shipped via PR #3146 ("feat: add slack-say plugin script with unit tests and
+  config docs"). `slack.unit.test.ts` and `cron-handler.unit.test.ts` already carry
+  `STC-1.2`/`STC-1.3`-tagged test blocks; `cron-handler.smoke.test.ts` references the
+  STC-1.3 pre-run resolution too.
+
+**What's still genuinely outstanding**, confirmed against the same HEAD:
+
+- `plugins/shipwright/TESTING.md` has zero mentions of `slack-say` — no manual test
+  scenario exists for it (the README file-tree line is not a test scenario).
+- `agent/workspace/CLAUDE.md.template` has no "Run context" subsection and no mention
+  of `slack-say`, `SLACK_CHANNEL_ID`, or `SLACK_THREAD_TS` anywhere. Its "Waiting and
+  Polling" section (lines 142–184) still contains the stale paragraph claiming a failed
+  resume "silently clears the session" and restarts context-free — verified against
+  `_runClaude` in `claude.ts` (~line 661 on), which retries the same resumed session
+  once and, on double failure, rethrows the *original* error while leaving the session
+  mapping intact. The paragraph is still wrong and still needs the rewrite, plus the
+  submit-and-stop / `preCheck`-cron pattern this plan originally called for.
+
+Versioning is owned by semantic-release (`.claude/skills/marketplace-dev/SKILL.md`): a
+`feat:` commit bumps the minor on merge — no manual `plugin.json`/`marketplace.json`
+edits, ever (that skill explicitly forbids it; `marketplace.json` doesn't exist yet).
+
+Complexity flags: none material. Remaining changes are additive, docs-only edits.
 
 ## Design
 
-**Business logic / Background**
+**Docs (the only work remaining — STC-1.1–1.3 and STC-2.1's runtime/CLI work above is
+already live on `main`)**
 
-1. `createRunClaude()`'s returned function gains an optional fifth parameter
-   `extraEnv?: Record<string, string>`. `_runClaude` forwards it to `_spawn` on both
-   the first attempt and the retry; `_spawn` spreads it over `spawnEnv`
-   (`{ ...spawnEnv, ...extraEnv }`) *after* the `SENTRY_DSN` strip so the strip is
-   unchanged. `ClaudeRunner` in `slack.ts` and `cron-handler.ts` gain the same optional
-   param; `index.ts` adapters forward it.
-2. `slack.ts` handlers pass
-   `{ SLACK_CHANNEL_ID: channel, SLACK_THREAD_TS: replyTs }` where `replyTs` is the
-   same value used for the session key (`thread_ts ?? ts`; for `reaction_added`,
-   `item.ts`).
-3. `cron-handler.ts` passes `{ SLACK_CHANNEL_ID: channel }` for `channel` crons.
-   For `user` crons it resolves the DM channel with `conversations.open` **before**
-   the run (best-effort: on failure log and run without it) and reuses that id for the
-   post-run delivery, leaving the existing failure-tagging block intact. `silent`
-   crons with neither field pass nothing. `SLACK_THREAD_TS` is never set on cron runs.
+1. `plugins/shipwright/TESTING.md` — add a manual test scenario for `slack-say`:
+   invoking it with no env/flags (stdout fallback), with `--channel`/`--thread` flags,
+   and with only `SLACK_CHANNEL_ID`/`SLACK_THREAD_TS` env set, confirming the resulting
+   `chat.postMessage` body shape. Mirrors the existing scenario style already in the
+   file.
+2. `agent/workspace/CLAUDE.md.template`:
+   - Add a "Run context" subsection next to the response-marker table documenting
+     `SLACK_CHANNEL_ID` / `SLACK_THREAD_TS` and pointing at `slack-say`.
+   - Rewrite the stale resume paragraph in "Waiting and Polling" (lines 142–184) to
+     match `_runClaude`'s actual behavior (retries the same session once; on double
+     failure rethrows the *original* error and leaves the session mapping intact —
+     never silently restarts context-free).
+   - Add the submit-and-stop pattern (persist a job id in a state file, end the turn,
+     let a `preCheck` cron poll and continue) as the recommendation for waits beyond
+     the Bash ceiling.
 
-**CLI (plugin script)**
+**Testing**
 
-4. `plugins/shipwright/scripts/slack-say.ts` — `bun run …/slack-say.ts [--channel C]
-   [--thread T] "text"`. Pure `postSlackSay(deps, argv)` function with injected
-   `fetch`, `env`, `stdout`, `stderr`; `main()` wires real ones. Resolution: flags →
-   env (`SLACK_CHANNEL_ID`, `SLACK_THREAD_TS`, `SLACK_BOT_TOKEN`). No token or no
-   channel → print text to stdout, exit 0. Slack non-2xx or `ok:false` → stderr line
-   with the Slack `error` string, exit 0. Body: `channel`, `text`, `mrkdwn: true`,
-   `unfurl_links: false`, `thread_ts` only when resolved.
-5. `plugins/shipwright/skills/slack-say/SKILL.md` — when to use (stage boundaries of
-   long work; one line; never chatter), invocation, env resolution, terminal fallback.
-
-**Docs**
-
-6. `docs/configuration.md` Plugin Config table: `SLACK_CHANNEL_ID`, `SLACK_THREAD_TS`
-   (injected by the agent per run; read by `slack-say`). `SLACK_BOT_TOKEN` is already
-   documented under Agent Config → Slack; the slack-say row cross-references it.
-7. `agent/workspace/CLAUDE.md.template`: a "Run context" subsection next to the
-   marker table documenting the two env vars and pointing at `slack-say`; rewrite the
-   stale resume paragraph in "Waiting and Polling" to match `_runClaude`, and add the
-   submit-and-stop pattern (persist job id in a state file, end the turn, let a
-   `preCheck` cron poll and continue) as the recommendation for waits beyond the Bash
-   ceiling.
-
-**Testing (adopted from the spec's strategy — layer assignments confirmed against the
-codebase)**
-
-- unit: `claude.unit.test.ts` (extraEnv present on first and retry spawn; absent →
-  env unchanged; `SENTRY_DSN` still stripped), `slack.unit.test.ts` (runner called
-  with the env pair for each of the three handlers; thread value equals the session
-  key's ts), `cron-handler.unit.test.ts` (channel cron → `SLACK_CHANNEL_ID`, no
-  `SLACK_THREAD_TS`; user cron → DM channel from `conversations.open`; open failure →
-  no env, run still happens), `slack-say.unit.test.ts` (flag > env precedence,
-  `thread_ts` only when present, stdout fallback, `ok:false` → exit 0 + stderr).
-- smoke: none — no HTTP route surface.
-- docs: `task check-config-docs` and `task check-strings` green.
+- docs: `task check-config-docs` and `task check-strings` stay green (already true on
+  `main` post-#3146; re-verify after the template edit).
+- No unit/smoke coverage needed — both remaining tasks are markdown-only edits.
 
 ## Tasks
 
+STC-1.1, STC-1.2, STC-1.3 (PR #3143) and STC-2.1, plus the `slack-say` SKILL.md and
+README entry (both PR #3146), have already shipped on `main` — not re-listed below.
+
 | ID | Title | Branch | Deps | Layer | Cx | Model | HITL |
 |---|---|---|---|---|---|---|---|
-| STC-1.1 | Add per-run `extraEnv` to the claude runner | `feat/stc-thread-env` | — | Background | 3 | sonnet | |
-| STC-1.2 | Pass Slack channel and thread env from Slack handlers | `feat/stc-thread-env` | STC-1.1 | Background | 2→sonnet (bundle) | sonnet | |
-| STC-1.3 | Pass Slack channel env from cron dispatch | `feat/stc-thread-env` | STC-1.1 | Background | 3 | sonnet | |
-| STC-2.1 | Add `slack-say` plugin script with unit tests and config docs | `feat/stc-slack-say` | — | CLI | 3 | sonnet | |
-| STC-2.2 | Add `slack-say` skill doc and plugin README/TESTING entries | `feat/stc-slack-say` | STC-2.1 | CLI | 1→sonnet (bundle) | sonnet | |
-| STC-3.1 | Document run-context env vars and fix the resume/polling guidance in the agent template | `feat/stc-3-1-agent-template-docs` | STC-1.3, STC-2.1 | Shared | 1 | haiku | |
+| STC-2.2 | Add a `slack-say` manual test scenario to plugin TESTING.md | `feat/stc-2-2-testing-docs` | — | Docs | 1 | haiku | |
+| STC-3.1 | Document run-context env vars and fix the resume/polling guidance in the agent template | `feat/stc-3-1-agent-template-docs` | — | Docs | 1 | haiku | |
 
 Dependency map:
 
 ```
 [START]
-  ├─ STC-1.1: runner extraEnv (no deps)
-  │     ├─ STC-1.2: slack handlers pass env      (bundle: feat/stc-thread-env)
-  │     └─ STC-1.3: cron passes channel env      (bundle: feat/stc-thread-env)
-  └─ STC-2.1: slack-say script (no deps)
-        └─ STC-2.2: slack-say skill + README     (bundle: feat/stc-slack-say)
-                     └─ STC-3.1: template docs (needs 1.3, 2.1)
+  ├─ STC-2.2: slack-say TESTING.md entry (no deps)
+  └─ STC-3.1: agent template docs        (no deps)
 ```
 
 HITL scan: no tasks require human steps.
-Breaking-change scan: none; every task is safe to deploy standalone.
+Breaking-change scan: none; both remaining tasks are docs-only.
 
 ## Verification (post-merge)
 
-1. `task ci` green on `main`.
-2. Dev agent DM: a prompt that runs `slack-say "hello from mid-run"` then sleeps 20 s —
-   the line appears before the final reply.
-3. Channel thread: the line lands inside the thread.
-4. `channel` cron calling `slack-say` with no flags posts to that channel;
-   `env | grep SLACK_` in the prompt shows no `SLACK_THREAD_TS`.
-5. `bun run plugins/shipwright/scripts/slack-say.ts "x"` with no env prints `x`, exit 0.
+1. `task ci` green on `main` (already true — the STC-1.x/STC-2.1 runtime and CLI work
+   is live).
+2. `plugins/shipwright/TESTING.md` has a `slack-say` scenario covering the stdout
+   fallback, flag override, and env-only paths.
+3. `agent/workspace/CLAUDE.md.template` has a "Run context" subsection documenting
+   `SLACK_CHANNEL_ID`/`SLACK_THREAD_TS` and `slack-say`, and "Waiting and Polling" no
+   longer claims a failed resume silently restarts context-free.
+4. `task check-config-docs` and `task check-strings` stay green after the template
+   edit.

--- a/planning/slack-thread-context/PLAN.md
+++ b/planning/slack-thread-context/PLAN.md
@@ -1,0 +1,144 @@
+# Plan: Slack thread context for spawned runs + `slack-say`
+
+**Session:** `slack-thread-context`
+**Repo:** `app-vitals/shipwright`
+**Spec:** `planning/slack-thread-context/PRODUCT-SPEC.md`
+
+## Problem
+
+A `claude -p` run started from Slack can only reach Slack through its final response.
+The spawned process is never told which channel or thread it serves, so a skill that
+wants to post a progress line mid-run (a 30-minute media pipeline, a long deploy) has
+no address to post to, and a cron tick that continues that work can only post
+top-level to the cron's channel. Long-running skills therefore go quiet until they
+finish — or until the 25-min idle / 60-min hard timeout kills them.
+
+## Codebase findings
+
+- `agent/src/claude.ts` — `createRunClaude()` returns
+  `runClaude(message, sessionKey?, onProgress?, signal?)`. `_runClaude` builds args,
+  calls `_spawn(args, onProgress, signal)` (and once more on the retry path).
+  `_spawn` builds the child env as `const { SENTRY_DSN, ...spawnEnv } = process.env`
+  and passes `{ cwd: workspace, env: spawnEnv, stdout: "pipe", stderr: "pipe" }` to the
+  injected `spawner`. No per-run env exists today.
+- `agent/src/slack.ts` — three handlers (`app.message`, `app_mention`,
+  `reaction_added`) all know `channel` and the reply thread (`thread_ts ?? ts`) — the
+  same pair used for `sessionKey = getThreadKey(channel, replyTs)` — and call
+  `runner(prompt, sessionKey, progress.onProgress)`. `ClaudeRunner` is declared at
+  `slack.ts:148` as `(message, sessionKey?, onProgress?)`.
+- `agent/src/cron-handler.ts` — `ClaudeRunner` is `(message, onProgress?)`;
+  `index.ts:209/547` adapt it as `(message, onProgress) => runner(message, undefined, onProgress)`.
+  For `channel` crons the channel is known before the run. For `user` crons the DM
+  channel is opened *after* the run (`conversations.open` at `cron-handler.ts:528`),
+  inside the delivery block that tags Slack failures.
+- `agent/workspace/CLAUDE.md.template` — response-marker table (lines 24–45) is where
+  per-run Slack facts are documented; "Waiting and Polling" (142–183) contains the
+  stale "resume failure silently clears the session" paragraph; `_runClaude`
+  (`claude.ts:655–710`) actually retries the same session once and rethrows leaving the
+  mapping intact.
+- `plugins/shipwright/scripts/` — self-contained scripts with sibling
+  `*.unit.test.ts`, `clock.ts` for injectable time, deps injected via a `deps` object
+  (`check-error-patrol.ts`). `task check-config-docs` requires every `process.env.*`
+  read under `agent/src/` and `plugins/shipwright/scripts/` to be documented in
+  `docs/configuration.md`.
+- Versioning is owned by semantic-release (`.claude/skills/marketplace-dev/SKILL.md`):
+  a `feat:` commit bumps the minor on merge — **no manual `plugin.json` edits**.
+- Existing test precedent: `claude.unit.test.ts:318` asserts the spawned `opts.env`
+  via the injected `mockSpawn`; `slack.unit.test.ts` mocks `runner` and asserts its
+  call args; `cron-handler.unit.test.ts` uses `mockRunner`.
+
+Complexity flags: none material. All changes are additive (optional params, new env
+vars, new script). No renames or removals → every task is safe to deploy standalone.
+
+## Design
+
+**Business logic / Background**
+
+1. `createRunClaude()`'s returned function gains an optional fifth parameter
+   `extraEnv?: Record<string, string>`. `_runClaude` forwards it to `_spawn` on both
+   the first attempt and the retry; `_spawn` spreads it over `spawnEnv`
+   (`{ ...spawnEnv, ...extraEnv }`) *after* the `SENTRY_DSN` strip so the strip is
+   unchanged. `ClaudeRunner` in `slack.ts` and `cron-handler.ts` gain the same optional
+   param; `index.ts` adapters forward it.
+2. `slack.ts` handlers pass
+   `{ SLACK_CHANNEL_ID: channel, SLACK_THREAD_TS: replyTs }` where `replyTs` is the
+   same value used for the session key (`thread_ts ?? ts`; for `reaction_added`,
+   `item.ts`).
+3. `cron-handler.ts` passes `{ SLACK_CHANNEL_ID: channel }` for `channel` crons.
+   For `user` crons it resolves the DM channel with `conversations.open` **before**
+   the run (best-effort: on failure log and run without it) and reuses that id for the
+   post-run delivery, leaving the existing failure-tagging block intact. `silent`
+   crons with neither field pass nothing. `SLACK_THREAD_TS` is never set on cron runs.
+
+**CLI (plugin script)**
+
+4. `plugins/shipwright/scripts/slack-say.ts` — `bun run …/slack-say.ts [--channel C]
+   [--thread T] "text"`. Pure `postSlackSay(deps, argv)` function with injected
+   `fetch`, `env`, `stdout`, `stderr`; `main()` wires real ones. Resolution: flags →
+   env (`SLACK_CHANNEL_ID`, `SLACK_THREAD_TS`, `SLACK_BOT_TOKEN`). No token or no
+   channel → print text to stdout, exit 0. Slack non-2xx or `ok:false` → stderr line
+   with the Slack `error` string, exit 0. Body: `channel`, `text`, `mrkdwn: true`,
+   `unfurl_links: false`, `thread_ts` only when resolved.
+5. `plugins/shipwright/skills/slack-say/SKILL.md` — when to use (stage boundaries of
+   long work; one line; never chatter), invocation, env resolution, terminal fallback.
+
+**Docs**
+
+6. `docs/configuration.md` Plugin Config table: `SLACK_CHANNEL_ID`, `SLACK_THREAD_TS`
+   (injected by the agent per run; read by `slack-say`). `SLACK_BOT_TOKEN` is already
+   documented under Agent Config → Slack; the slack-say row cross-references it.
+7. `agent/workspace/CLAUDE.md.template`: a "Run context" subsection next to the
+   marker table documenting the two env vars and pointing at `slack-say`; rewrite the
+   stale resume paragraph in "Waiting and Polling" to match `_runClaude`, and add the
+   submit-and-stop pattern (persist job id in a state file, end the turn, let a
+   `preCheck` cron poll and continue) as the recommendation for waits beyond the Bash
+   ceiling.
+
+**Testing (adopted from the spec's strategy — layer assignments confirmed against the
+codebase)**
+
+- unit: `claude.unit.test.ts` (extraEnv present on first and retry spawn; absent →
+  env unchanged; `SENTRY_DSN` still stripped), `slack.unit.test.ts` (runner called
+  with the env pair for each of the three handlers; thread value equals the session
+  key's ts), `cron-handler.unit.test.ts` (channel cron → `SLACK_CHANNEL_ID`, no
+  `SLACK_THREAD_TS`; user cron → DM channel from `conversations.open`; open failure →
+  no env, run still happens), `slack-say.unit.test.ts` (flag > env precedence,
+  `thread_ts` only when present, stdout fallback, `ok:false` → exit 0 + stderr).
+- smoke: none — no HTTP route surface.
+- docs: `task check-config-docs` and `task check-strings` green.
+
+## Tasks
+
+| ID | Title | Branch | Deps | Layer | Cx | Model | HITL |
+|---|---|---|---|---|---|---|---|
+| STC-1.1 | Add per-run `extraEnv` to the claude runner | `feat/stc-thread-env` | — | Background | 3 | sonnet | |
+| STC-1.2 | Pass Slack channel and thread env from Slack handlers | `feat/stc-thread-env` | STC-1.1 | Background | 2→sonnet (bundle) | sonnet | |
+| STC-1.3 | Pass Slack channel env from cron dispatch | `feat/stc-thread-env` | STC-1.1 | Background | 3 | sonnet | |
+| STC-2.1 | Add `slack-say` plugin script with unit tests and config docs | `feat/stc-slack-say` | — | CLI | 3 | sonnet | |
+| STC-2.2 | Add `slack-say` skill doc and plugin README/TESTING entries | `feat/stc-slack-say` | STC-2.1 | CLI | 1→sonnet (bundle) | sonnet | |
+| STC-3.1 | Document run-context env vars and fix the resume/polling guidance in the agent template | `feat/stc-3-1-agent-template-docs` | STC-1.3, STC-2.1 | Shared | 1 | haiku | |
+
+Dependency map:
+
+```
+[START]
+  ├─ STC-1.1: runner extraEnv (no deps)
+  │     ├─ STC-1.2: slack handlers pass env      (bundle: feat/stc-thread-env)
+  │     └─ STC-1.3: cron passes channel env      (bundle: feat/stc-thread-env)
+  └─ STC-2.1: slack-say script (no deps)
+        └─ STC-2.2: slack-say skill + README     (bundle: feat/stc-slack-say)
+                     └─ STC-3.1: template docs (needs 1.3, 2.1)
+```
+
+HITL scan: no tasks require human steps.
+Breaking-change scan: none; every task is safe to deploy standalone.
+
+## Verification (post-merge)
+
+1. `task ci` green on `main`.
+2. Dev agent DM: a prompt that runs `slack-say "hello from mid-run"` then sleeps 20 s —
+   the line appears before the final reply.
+3. Channel thread: the line lands inside the thread.
+4. `channel` cron calling `slack-say` with no flags posts to that channel;
+   `env | grep SLACK_` in the prompt shows no `SLACK_THREAD_TS`.
+5. `bun run plugins/shipwright/scripts/slack-say.ts "x"` with no env prints `x`, exit 0.

--- a/planning/slack-thread-context/PRODUCT-SPEC.md
+++ b/planning/slack-thread-context/PRODUCT-SPEC.md
@@ -1,6 +1,6 @@
 # slack-thread-context — shipwright
 
-<!-- Generated: 2026-09-03 | Source design: app-vitals/goals docs/superpowers/specs/2026-09-03-saul-podcast-workflow-design.md (private repo; shipwright section) -->
+<!-- Generated: 2026-09-03 | Source design: an internal design doc from a private sibling repo (shipwright-relevant section) -->
 
 ## Why
 
@@ -26,7 +26,7 @@ The concrete driver is a multi-stage podcast pipeline run by a marketing agent f
 - Test isolation rules in `CLAUDE.md`: inject `fetch` into `slack-say` (no `global.fetch` override), inject time via `Clock` if any is needed, no `mock.module()`.
 - Env injection must not leak into cron-originated runs' `SLACK_THREAD_TS`, and must not change `spawnEnv` behaviour for `SENTRY_DSN` stripping.
 - Public repo: no client names, no channel ids or tokens in fixtures; use `C0EXAMPLE` / `1700000000.000100` style placeholders. Run `task check-strings` and `task pre-public` before committing.
-- Plugin version bump per the `marketplace-dev` skill checklist (new script + skill file → `plugin.json` / `marketplace.json` / README in sync).
+- Versioning is owned by semantic-release (`marketplace-dev` skill) — no manual `plugin.json`/`marketplace.json` edits; a `feat:` commit is sufficient to bump the minor on merge.
 - Follow `docs/agent.md` for the env-var reference table if one exists there.
 
 ## Testing strategy

--- a/planning/slack-thread-context/PRODUCT-SPEC.md
+++ b/planning/slack-thread-context/PRODUCT-SPEC.md
@@ -1,0 +1,52 @@
+# slack-thread-context — shipwright
+
+<!-- Generated: 2026-09-03 | Source design: app-vitals/goals docs/superpowers/specs/2026-09-03-saul-podcast-workflow-design.md (private repo; shipwright section) -->
+
+## Why
+
+A deployed agent's `claude -p` run can only reach Slack through its final response. The spawned process is not told which channel or thread it is serving, so a skill that wants to post a progress line mid-run (a 30-minute media pipeline, a long deploy, a multi-stage migration) has no way to address the thread it was started from. Background cron ticks that continue that work post to the cron's channel as top-level messages, not into the originating thread.
+
+The concrete driver is a multi-stage podcast pipeline run by a marketing agent from a channel thread, where the operator needs one status line per stage in that thread and the work is continued by a resumer cron between operator replies. The capability is general: any long-running skill on any agent benefits.
+
+## Scope
+
+1. **Thread context in the spawned env.** Slack-originated runs (`app.message`, `app_mention`, `reaction_added` in `agent/src/slack.ts`) pass the resolved `channel` and `thread_ts` (the same values used to build the session key) through the runner into `agent/src/claude.ts` `_spawn`, exported as `SLACK_CHANNEL_ID` and `SLACK_THREAD_TS` on the child env. Cron runs (`agent/src/cron-handler.ts`) set `SLACK_CHANNEL_ID` to the cron's `channel` (or the resolved DM channel for `user` crons) and leave `SLACK_THREAD_TS` unset. Both variables are documented in `agent/workspace/CLAUDE.md.template` alongside the response-marker table.
+
+2. **`slack-say` helper** at `plugins/shipwright/scripts/slack-say.ts`, invoked as `bun run ${CLAUDE_PLUGIN_ROOT}/scripts/slack-say.ts [--channel C] [--thread T] "text"`:
+   - `--channel` / `--thread` default from `SLACK_CHANNEL_ID` / `SLACK_THREAD_TS`.
+   - Posts via `chat.postMessage` with `SLACK_BOT_TOKEN`, `thread_ts` when present, `mrkdwn: true`, `unfurl_links: false`.
+   - If no token or no channel can be resolved, prints the text to stdout and exits 0 — it must never fail a run (terminal use, tests, misconfigured agent).
+   - Non-2xx / `ok: false` from Slack is logged to stderr with the Slack error string and exits 0 for the same reason.
+   - A skill entry (`plugins/shipwright/skills/slack-say/SKILL.md` or a section in an existing skill) documents when to use it: stage boundaries of long work, never for chatter.
+
+3. **Doc fix** in `agent/workspace/CLAUDE.md.template` "Waiting and Polling": the paragraph stating that a failed resume silently clears the session id and restarts context-free is stale — `_runClaude` retries the same resumed session once and, on double failure, rethrows leaving the mapping intact. Rewrite to match the code, and add the recommended pattern for waits longer than the Bash ceiling: submit the job, persist its id in a state file, end the turn, let a cron tick (with `preCheck`) poll and continue.
+
+## Constraints
+
+- Test isolation rules in `CLAUDE.md`: inject `fetch` into `slack-say` (no `global.fetch` override), inject time via `Clock` if any is needed, no `mock.module()`.
+- Env injection must not leak into cron-originated runs' `SLACK_THREAD_TS`, and must not change `spawnEnv` behaviour for `SENTRY_DSN` stripping.
+- Public repo: no client names, no channel ids or tokens in fixtures; use `C0EXAMPLE` / `1700000000.000100` style placeholders. Run `task check-strings` and `task pre-public` before committing.
+- Plugin version bump per the `marketplace-dev` skill checklist (new script + skill file → `plugin.json` / `marketplace.json` / README in sync).
+- Follow `docs/agent.md` for the env-var reference table if one exists there.
+
+## Testing strategy
+
+| Layer | What |
+|---|---|
+| unit | `slack.ts` handler → runner receives `{channel, thread_ts}`; `claude.ts` `_spawn` env contains `SLACK_CHANNEL_ID`/`SLACK_THREAD_TS` when provided and omits `SLACK_THREAD_TS` for cron; `slack-say` builds the correct `chat.postMessage` body, uses `thread_ts` only when present, falls back to stdout without token/channel, and exits 0 on a Slack `ok:false` |
+| smoke | none needed (no HTTP route surface) |
+| docs | `task check-config-docs` passes after the template change |
+
+## Out of scope
+
+- A one-shot / delayed scheduling primitive (the podcast pipeline uses a recurring `preCheck` cron instead).
+- Any change to the Thinking Steps stream or `SlackProgress`.
+- Reply-to-thread for cron posts themselves (the helper is what posts into threads; cron final text keeps its current behaviour).
+
+## Verification
+
+1. Unit tests above green; `task ci` green.
+2. On a dev agent: DM the agent with a prompt that runs `slack-say "hello from mid-run"` then waits 20 s before answering — the "hello" line appears in the DM before the final response.
+3. Same from a channel thread: the line lands inside the thread, not at channel top level.
+4. A cron with `channel` set runs a prompt calling `slack-say` with no flags: the line lands in that channel; `SLACK_THREAD_TS` is unset in the run (verify with `env | grep SLACK_` in the prompt).
+5. `bun run plugins/shipwright/scripts/slack-say.ts "x"` with no env prints `x` and exits 0.


### PR DESCRIPTION
Planning session for injecting Slack channel/thread context into spawned `claude -p` runs and adding a `slack-say` helper so long-running skills can post progress mid-run.

- `planning/slack-thread-context/PRODUCT-SPEC.md` — why, scope, constraints, testing strategy
- `planning/slack-thread-context/PLAN.md` — codebase findings, design, 6 tasks (STC-1.1…3.1) queued in the task store
- No code changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rxa4ThjFVuj5XJULS7NeY6