### PR TITLE
docs: add "See it in the wild" conversion link cluster to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ See [`docs/quickstart.md`](./docs/quickstart.md) for the full onboarding prompt 
 
 Shipwright Harness is a [Claude Code](https://www.anthropic.com/claude-code) plugin through and through — built on it, for it, and used with it daily. If you already run Claude Code, Shipwright is a `/plugin install` away.
 
+## See it in the wild
+
+- **Compare it** — how Shipwright's plan → queue → loop differs from [Devin](https://app-vitals.com/blog/shipwright-vs-devin/) and from [Claude Code orchestrators](https://app-vitals.com/blog/shipwright-vs-claude-code-orchestrators/).
+- **Have us run it on your pipeline** — the [design-partner program](https://app-vitals.com/shipwright/design-partners/): the people who built Shipwright, hands-on on your codebase.
+- **Read the full story** — [shipwrightharness.com](https://shipwrightharness.com).
+
 ## Test system
 
 Shipwright enforces a four-layer test architecture (unit / integration / smoke / e2e) across all three components. Layer boundaries, per-component run commands, speed budgets, and the test-isolation contract are defined in [`docs/test-readiness/test-system.md`](./docs/test-readiness/test-system.md).


### PR DESCRIPTION
## Summary
- Adds a "See it in the wild" link cluster to the README, immediately after "## Built on Claude Code" and before "## Test system"
- Routes readers to the marketing/conversion layer (comparison posts, design-partner program, shipwrightharness.com) instead of dead-ending at the repo
- Additive only — no existing section modified

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | New "## See it in the wild" section added to README.md between "## Built on Claude Code" and "## Test system", copy verbatim from the task body | MET | Section inserted at line 175, verbatim |
| 2 | All four links use the exact URLs in the task body | MET | app-vitals.com for the two comparison posts and the design-partner page; shipwrightharness.com only for the bare site-root link |
| 3 | No existing README section modified | MET | Diff is additive only (6 insertions, 0 deletions) |
| 4 | `bun test readme.content.test.ts` passes | MET | 2 pass, 0 fail |
| 5 | PR opened, not merged (merge gated on Dave/Dan) | MET | This PR |

## Test Plan
- [x] `bun test readme.content.test.ts` passes (verified before and after the edit)
- [x] `bunx biome lint .` passes clean
- [x] `task typecheck` passes clean across all workspaces
- [x] Diff reviewed to confirm only the new section was added

Task: RSW-1.2. Approved by Dan McAulay 2026-09-03 (Slack #growth, "queue both").

Generated with [Claude Code](https://claude.com/claude-code)
