### PR TITLE
feat: switch hitl dev loop to auto permission mode

### DIFF
--- a/scripts/hitl.ts
+++ b/scripts/hitl.ts
@@ -1200,7 +1200,7 @@ async function runLoop(): Promise<void> {
         "claude",
         command,
         "--permission-mode",
-        "acceptEdits",
+        "auto",
         "--allowedTools",
         ...HITL_ALLOWED_TOOLS,
       ],


### PR DESCRIPTION
<!-- Keep PRs free of secrets, tokens, client names, or proprietary code — this repository is public. -->

## Summary

Switches the `hitl` dev loop's interactively-spawned Claude Code session (`scripts/hitl.ts`'s `runLoop`, around line 1200) from `--permission-mode acceptEdits` to `--permission-mode auto`.

**Why:** `auto` is now Claude Code's default permission mode, and the `hitl` loop already has a human operator attached (`stdin: "inherit"`, run via `/shipwright:hitl`) who is available to unblock anything `auto` mode declines to auto-approve. This moves the loop from pinning to the old default onto tracking the current one, rather than introducing a new safety posture from scratch.

**What actually changes, mechanically** (per Claude Code's permission-mode docs): both modes route tool calls that match `--allowedTools` (`HITL_ALLOWED_TOOLS`, unchanged by this PR — see `scripts/hitl.ts:76-83`) straight through without a prompt. The difference is in what happens to calls that *don't* match the allowlist — which is where Bash and Agent land, since the comment above `HITL_ALLOWED_TOOLS` explains they're deliberately left off:
- Under `acceptEdits`, an out-of-allowlist Bash call always stops and prompts the human operator before running.
- Under `auto`, an out-of-allowlist Bash/Agent call is instead evaluated by Claude Code's background classifier. If the classifier judges it safe it runs with no human prompt at all; the human operator is only pulled back in when the classifier blocks the action (a notification + retry-with-manual-approval), or after repeated blocks (3 in a row / 20 total) trip a fallback to interactive prompting.

So `HITL_ALLOWED_TOOLS` itself is unchanged — Bash and Agent are still off the allowlist — but the nature of the gate behind that exclusion changes: from "every out-of-allowlist call prompts a human" to "every out-of-allowlist call is classifier-reviewed, with the human as a backstop for what the classifier flags or can't decide." That's consistent with this PR's stated rationale (human-in-the-loop as the unblock mechanism), but it is a real narrowing of per-action human visibility, not a no-op — worth calling out explicitly rather than asserting the old boundary is preserved unchanged.

This is a **local dev-tool change only**. No other file is touched by this diff, and the production agent path (`agent/src/claude.ts`, which spawns Claude non-interactively with its own `--permission-mode acceptEdits`) is untouched.

## Related issue

N/A

## Verification

No automated test covers this line — it's a single CLI argument to an interactively-spawned (`stdin: "inherit"`) `claude` process in a manual dev tool, not independently testable behavior. Verification is via the diff itself: a one-line permission-mode string change (`acceptEdits` → `auto`) with no other code paths affected. `bunx biome lint scripts/hitl.ts` passes clean with no changes required, and CI is green: https://github.com/app-vitals/shipwright/actions/runs/33811085029

## Closing Checklist

- [ ] Tests land in this PR, at the correct layer (unit / integration / smoke / e2e / content) — no "tests later" — N/A: single CLI-arg string change to a manually-run dev tool, not independently testable behavior; see Verification above
- [x] Verification-command output (or a CI run link) is pasted into the PR body above, before merge
- [x] Conventional Commit title (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`)
- [x] No secrets, tokens, client names, or proprietary content
- [x] CI is green (lint, typecheck, tests)
