### PR TITLE
feat: add slack-say plugin script with unit tests and config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,8 @@ Slack vars are env-var-only (secrets); the agent does not function as a Slack bo
 | `SLACK_ADMIN_TOKEN` | `string` | — | Optional admin-level token for privileged Slack operations. |
 | `SLACK_ALERT_CHANNEL` | `string` | — | Slack channel ID to post system alerts (e.g. startup errors). |
 | `SLACK_OWNER_USER` | `string` | — | Slack user ID of the agent owner, used for DM fallback. |
+| `SLACK_CHANNEL_ID` | `string` | — | Slack channel to post into for the current run. Not user-configured — injected per run by the agent runtime alongside `SLACK_BOT_TOKEN` above, not persisted config. Slack-triggered runs get this var set; cron runs also get it set (to the configured alert/report channel) but do not get `SLACK_THREAD_TS`. Read by `plugins/shipwright/scripts/slack-say.ts` (`bun run ${CLAUDE_PLUGIN_ROOT}/scripts/slack-say.ts [--channel C] [--thread T] "text"`) to let any skill post a one-line progress message; a `--channel` flag overrides this var. When neither is set, `slack-say.ts` falls back to printing the text to stdout instead of calling the Slack API. |
+| `SLACK_THREAD_TS` | `string` | — | Slack thread timestamp to reply into for the current run. Not user-configured — injected per run by the agent runtime, same as `SLACK_CHANNEL_ID` above, but **only for Slack-triggered runs** (DMs/@mentions); cron runs never get this var since they have no originating thread. Read by `slack-say.ts`; a `--thread` flag overrides it, and when neither resolves, the posted message omits `thread_ts` (posts to the channel directly rather than a thread). |
 
 ### GitHub
 

--- a/plugins/shipwright/README.md
+++ b/plugins/shipwright/README.md
@@ -302,6 +302,8 @@ shipwright/
 │   │   └── SKILL.md             # Query PR records — filter by repo, state, reviewState, staged
 │   ├── review-staged/
 │   │   └── SKILL.md             # Conversational walkthrough of staged reviews
+│   ├── slack-say/
+│   │   └── SKILL.md             # Post a one-line progress ping to Slack at stage boundaries
 │   └── task-store/
 │       └── SKILL.md             # Query and update the task store — lifecycle invocations, env var config
 ├── references/

--- a/plugins/shipwright/scripts/slack-say.ts
+++ b/plugins/shipwright/scripts/slack-say.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env bun
+/**
+ * plugins/shipwright/scripts/slack-say.ts
+ *
+ * One-line way for any skill to post a progress message into the Slack
+ * thread its run was started from.
+ *
+ * Resolution order for channel/thread: CLI flag, then env
+ * (SLACK_CHANNEL_ID, SLACK_THREAD_TS). Auth token is env-only
+ * (SLACK_BOT_TOKEN) — there is no flag for it, on purpose.
+ *
+ * Behaviour:
+ *   - No token or no channel resolved → write the text to stdout, exit 0.
+ *   - Slack non-2xx or `ok:false` → write one stderr line naming Slack's
+ *     `error` string, exit 0.
+ *   - Success → exit 0 silently.
+ * Never throws to the caller — this is a best-effort progress ping, not a
+ * step whose failure should ever fail the calling skill.
+ *
+ * Usage:
+ *   bun run ${CLAUDE_PLUGIN_ROOT}/scripts/slack-say.ts [--channel C] [--thread T] "text"
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * The minimal shape this script needs from `fetch` — narrower than the full
+ * Fetch API `Response` so tests can stub it with a plain object literal
+ * instead of constructing a real `Response`.
+ */
+export type FetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+export interface Deps {
+  fetch: FetchLike;
+  env: (name: string) => string | undefined;
+  stdout: (chunk: string) => void;
+  stderr: (chunk: string) => void;
+}
+
+export interface SlackSayResult {
+  exit: 0;
+}
+
+interface ParsedArgs {
+  channel?: string;
+  thread?: string;
+  text: string;
+}
+
+interface SlackApiResponse {
+  ok?: boolean;
+  error?: string;
+}
+
+// ─── Argument parsing ───────────────────────────────────────────────────────
+
+/**
+ * Parses `[--channel C] [--thread T] "text"` — flags may appear in either
+ * order/position; every non-flag token is joined with a space to form the
+ * message text (so an unquoted multi-word message still works).
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  let channel: string | undefined;
+  let thread: string | undefined;
+  const textParts: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--channel") {
+      channel = argv[++i];
+    } else if (arg === "--thread") {
+      thread = argv[++i];
+    } else {
+      textParts.push(arg);
+    }
+  }
+
+  return { channel, thread, text: textParts.join(" ") };
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+function describeSlackError(
+  status: number,
+  response: SlackApiResponse,
+): string {
+  if (response.error) return response.error;
+  return `http_${status}`;
+}
+
+export async function postSlackSay(
+  deps: Deps,
+  argv: string[],
+): Promise<SlackSayResult> {
+  const { channel: flagChannel, thread: flagThread, text } = parseArgs(argv);
+
+  const token = deps.env("SLACK_BOT_TOKEN");
+  const channel = flagChannel ?? deps.env("SLACK_CHANNEL_ID");
+  const thread = flagThread ?? deps.env("SLACK_THREAD_TS");
+
+  if (!token || !channel) {
+    deps.stdout(`${text}\n`);
+    return { exit: 0 };
+  }
+
+  const body: Record<string, unknown> = {
+    channel,
+    text,
+    mrkdwn: true,
+    unfurl_links: false,
+  };
+  if (thread) body.thread_ts = thread;
+
+  try {
+    const res = await deps.fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    let parsed: SlackApiResponse = {};
+    try {
+      parsed = (await res.json()) as SlackApiResponse;
+    } catch {
+      parsed = {};
+    }
+
+    if (!res.ok || !parsed.ok) {
+      deps.stderr(
+        `slack-say: chat.postMessage failed: ${describeSlackError(res.status, parsed)}\n`,
+      );
+      return { exit: 0 };
+    }
+
+    return { exit: 0 };
+  } catch (err) {
+    deps.stderr(`slack-say: chat.postMessage failed: ${String(err)}\n`);
+    return { exit: 0 };
+  }
+}
+
+// ─── Production deps ──────────────────────────────────────────────────────────
+
+function buildProductionDeps(): Deps {
+  return {
+    fetch: (url, init) => fetch(url, init),
+    env: (name: string) => process.env[name],
+    stdout: (chunk: string) => {
+      process.stdout.write(chunk);
+    },
+    stderr: (chunk: string) => {
+      process.stderr.write(chunk);
+    },
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const deps = buildProductionDeps();
+  const result = await postSlackSay(deps, process.argv.slice(2));
+  process.exit(result.exit);
+}
+
+if (import.meta.main) {
+  main().catch((e: unknown) => {
+    process.stderr.write(`error: ${String(e)}\n`);
+    process.exit(0);
+  });
+}

--- a/plugins/shipwright/scripts/slack-say.unit.test.ts
+++ b/plugins/shipwright/scripts/slack-say.unit.test.ts
@@ -1,0 +1,331 @@
+/**
+ * plugins/shipwright/scripts/slack-say.unit.test.ts
+ *
+ * Unit tests for slack-say.ts
+ *
+ * Design: the script exports a `postSlackSay(deps, argv)` function that
+ * accepts injected dependencies (fetch, env lookup, stdout/stderr writers).
+ * Tests inject stub implementations — no real network calls, no
+ * `global.fetch`/`global.*` overrides, no `mock.module()`, per the repo's
+ * test isolation rule.
+ *
+ * Fixtures use placeholder Slack ids only (no real channel/token/thread ids).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { type Deps, postSlackSay } from "./slack-say.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const FAKE_TOKEN = "xoxb-fake-token";
+const FAKE_CHANNEL = "C123456";
+const FAKE_THREAD = "1234567890.123456";
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("slack-say", () => {
+  test("stdout fallback: no SLACK_BOT_TOKEN → writes text to stdout, exits 0, never calls fetch", async () => {
+    const stdoutChunks: string[] = [];
+    const fetchCalls: unknown[] = [];
+    const deps: Deps = {
+      fetch: async (url, init) => {
+        fetchCalls.push({ url, init });
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      },
+      env: (name) => (name === "SLACK_CHANNEL_ID" ? FAKE_CHANNEL : undefined),
+      stdout: (chunk) => stdoutChunks.push(chunk),
+      stderr: () => {
+        throw new Error("stderr should not be called");
+      },
+    };
+
+    const result = await postSlackSay(deps, ["hello world"]);
+
+    expect(result.exit).toBe(0);
+    expect(fetchCalls.length).toBe(0);
+    expect(stdoutChunks.join("")).toContain("hello world");
+  });
+
+  test("stdout fallback: no channel resolved (flag or env) → writes text to stdout, exits 0, never calls fetch", async () => {
+    const stdoutChunks: string[] = [];
+    const fetchCalls: unknown[] = [];
+    const deps: Deps = {
+      fetch: async (url, init) => {
+        fetchCalls.push({ url, init });
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      },
+      env: (name) => (name === "SLACK_BOT_TOKEN" ? FAKE_TOKEN : undefined),
+      stdout: (chunk) => stdoutChunks.push(chunk),
+      stderr: () => {
+        throw new Error("stderr should not be called");
+      },
+    };
+
+    const result = await postSlackSay(deps, ["progress update"]);
+
+    expect(result.exit).toBe(0);
+    expect(fetchCalls.length).toBe(0);
+    expect(stdoutChunks.join("")).toContain("progress update");
+  });
+
+  test("stdout fallback: neither token nor channel resolved → writes text to stdout, exits 0", async () => {
+    const stdoutChunks: string[] = [];
+    const deps: Deps = {
+      fetch: async () => {
+        throw new Error("fetch should not be called");
+      },
+      env: () => undefined,
+      stdout: (chunk) => stdoutChunks.push(chunk),
+      stderr: () => {
+        throw new Error("stderr should not be called");
+      },
+    };
+
+    const result = await postSlackSay(deps, ["no config at all"]);
+
+    expect(result.exit).toBe(0);
+    expect(stdoutChunks.join("")).toContain("no config at all");
+  });
+
+  test("env precedence: channel/thread resolved from env when no flags given; thread_ts included in body", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    const deps: Deps = {
+      fetch: async (url, init) => {
+        fetchCalls.push({ url, init: init as RequestInit });
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      },
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        if (name === "SLACK_THREAD_TS") return FAKE_THREAD;
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called on success");
+      },
+      stderr: () => {
+        throw new Error("stderr should not be called on success");
+      },
+    };
+
+    const result = await postSlackSay(deps, ["build finished"]);
+
+    expect(result.exit).toBe(0);
+    expect(fetchCalls.length).toBe(1);
+    const call = fetchCalls[0];
+    expect(call.url).toBe("https://slack.com/api/chat.postMessage");
+    expect(call.init.method).toBe("POST");
+    expect((call.init.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${FAKE_TOKEN}`,
+    );
+    expect(JSON.parse(call.init.body as string)).toEqual({
+      channel: FAKE_CHANNEL,
+      text: "build finished",
+      mrkdwn: true,
+      unfurl_links: false,
+      thread_ts: FAKE_THREAD,
+    });
+  });
+
+  test("flag precedence: --channel and --thread flags override env values", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    const deps: Deps = {
+      fetch: async (url, init) => {
+        fetchCalls.push({ url, init: init as RequestInit });
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      },
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return "C999999";
+        if (name === "SLACK_THREAD_TS") return "9999999999.999999";
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called on success");
+      },
+      stderr: () => {
+        throw new Error("stderr should not be called on success");
+      },
+    };
+
+    const result = await postSlackSay(deps, [
+      "--channel",
+      FAKE_CHANNEL,
+      "--thread",
+      FAKE_THREAD,
+      "flagged message",
+    ]);
+
+    expect(result.exit).toBe(0);
+    expect(fetchCalls.length).toBe(1);
+    const body = JSON.parse(fetchCalls[0].init.body as string);
+    expect(body.channel).toBe(FAKE_CHANNEL);
+    expect(body.thread_ts).toBe(FAKE_THREAD);
+    expect(body.text).toBe("flagged message");
+  });
+
+  test("thread omission: thread_ts key absent from body when unresolved from flag or env", async () => {
+    const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
+    const deps: Deps = {
+      fetch: async (url, init) => {
+        fetchCalls.push({ url, init: init as RequestInit });
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      },
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called on success");
+      },
+      stderr: () => {
+        throw new Error("stderr should not be called on success");
+      },
+    };
+
+    const result = await postSlackSay(deps, ["no thread here"]);
+
+    expect(result.exit).toBe(0);
+    const body = JSON.parse(fetchCalls[0].init.body as string);
+    expect(body).toEqual({
+      channel: FAKE_CHANNEL,
+      text: "no thread here",
+      mrkdwn: true,
+      unfurl_links: false,
+    });
+    expect("thread_ts" in body).toBe(false);
+  });
+
+  test("Slack ok:false → single stderr line containing Slack's error string, exit 0", async () => {
+    const stderrChunks: string[] = [];
+    const deps: Deps = {
+      fetch: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: false, error: "channel_not_found" }),
+      }),
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called");
+      },
+      stderr: (chunk) => stderrChunks.push(chunk),
+    };
+
+    const result = await postSlackSay(deps, ["oops"]);
+
+    expect(result.exit).toBe(0);
+    expect(stderrChunks.length).toBe(1);
+    expect(stderrChunks[0]).toContain("channel_not_found");
+    expect(stderrChunks[0].match(/\n/g)?.length).toBe(1);
+  });
+
+  test("Slack non-2xx response → single stderr line containing the Slack error string, exit 0", async () => {
+    const stderrChunks: string[] = [];
+    const deps: Deps = {
+      fetch: async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({ ok: false, error: "internal_error" }),
+      }),
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called");
+      },
+      stderr: (chunk) => stderrChunks.push(chunk),
+    };
+
+    const result = await postSlackSay(deps, ["oops again"]);
+
+    expect(result.exit).toBe(0);
+    expect(stderrChunks.length).toBe(1);
+    expect(stderrChunks[0]).toContain("internal_error");
+  });
+
+  test("Slack non-2xx response with unparsable body → single stderr line, exit 0, never throws", async () => {
+    const stderrChunks: string[] = [];
+    const deps: Deps = {
+      fetch: async () => ({
+        ok: false,
+        status: 503,
+        json: async () => {
+          throw new Error("not json");
+        },
+      }),
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called");
+      },
+      stderr: (chunk) => stderrChunks.push(chunk),
+    };
+
+    const result = await postSlackSay(deps, ["service unavailable"]);
+
+    expect(result.exit).toBe(0);
+    expect(stderrChunks.length).toBe(1);
+  });
+
+  test("success: exits 0 silently — nothing written to stdout or stderr", async () => {
+    let stdoutCalled = false;
+    let stderrCalled = false;
+    const deps: Deps = {
+      fetch: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      }),
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        return undefined;
+      },
+      stdout: () => {
+        stdoutCalled = true;
+      },
+      stderr: () => {
+        stderrCalled = true;
+      },
+    };
+
+    const result = await postSlackSay(deps, ["all good"]);
+
+    expect(result.exit).toBe(0);
+    expect(stdoutCalled).toBe(false);
+    expect(stderrCalled).toBe(false);
+  });
+
+  test("fetch throwing (network error) is caught defensively — single stderr line, exit 0, never throws to caller", async () => {
+    const stderrChunks: string[] = [];
+    const deps: Deps = {
+      fetch: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+      env: (name) => {
+        if (name === "SLACK_BOT_TOKEN") return FAKE_TOKEN;
+        if (name === "SLACK_CHANNEL_ID") return FAKE_CHANNEL;
+        return undefined;
+      },
+      stdout: () => {
+        throw new Error("stdout should not be called");
+      },
+      stderr: (chunk) => stderrChunks.push(chunk),
+    };
+
+    const result = await postSlackSay(deps, ["network down"]);
+
+    expect(result.exit).toBe(0);
+    expect(stderrChunks.length).toBe(1);
+  });
+});

--- a/plugins/shipwright/skills/slack-say/SKILL.md
+++ b/plugins/shipwright/skills/slack-say/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: slack-say
+description: >
+  Post a one-line progress update into the Slack thread or channel a run started
+  from. Use exactly at stage boundaries of long-running work — e.g. finishing
+  discovery, starting implementation, opening a PR, entering a fix loop — so a
+  human watching Slack can see the run is alive and where it is. Do NOT use for
+  chatter, for every small step, or as a substitute for the agent's final
+  response — it is a best-effort ping, not the answer. Triggers on: multi-step
+  commands/skills that run long enough a human might wonder if they stalled
+  (dev-task, patch, review, plan-session, deploy), or when the user mentions
+  "post progress to Slack", "slack-say", or "progress ping". Invokes
+  `scripts/slack-say.ts` via `bun run` — never throws, never fails the caller.
+---
+
+# slack-say — Skill
+
+Post a single-line progress message into the Slack thread (or channel) a run started
+from. It exists so a human watching a long-running command can see it is still moving
+without waiting for the final response.
+
+---
+
+## When to use this
+
+- **One line at each stage boundary** of long-running work — e.g. "starting
+  implementation", "opening PR #123", "CI failed, retrying fix (2/6)". A stage boundary is
+  a transition between the major phases of a command/skill (discovery → build → review →
+  ship), not every individual tool call.
+- **Never for chatter.** Do not narrate routine tool calls, intermediate reasoning, or
+  anything that isn't a meaningful phase transition.
+- **Never as a replacement for the final response.** The calling command/skill still owes
+  the user its normal end-of-run summary — `slack-say` only pings interim progress.
+
+---
+
+## Invocation
+
+```bash
+bun run "${CLAUDE_PLUGIN_ROOT}/scripts/slack-say.ts" [--channel C] [--thread T] "text"
+```
+
+- `text` — every non-flag argument is joined with a space, so an unquoted multi-word
+  message still works.
+- `--channel` — overrides the resolved channel (see resolution order below).
+- `--thread` — overrides the resolved thread timestamp.
+- There is no `--token` flag, on purpose — the Slack bot token is env-only.
+
+---
+
+## Resolution order
+
+| Value | Source (highest priority first) |
+|---|---|
+| Channel | `--channel` flag → `SLACK_CHANNEL_ID` env var |
+| Thread | `--thread` flag → `SLACK_THREAD_TS` env var |
+| Token | `SLACK_BOT_TOKEN` env var only (no flag) |
+
+`SLACK_CHANNEL_ID` and `SLACK_THREAD_TS` are injected per run by the agent runtime, not
+user-configured:
+
+- **Slack-triggered runs** (a DM or @mention) get both `SLACK_CHANNEL_ID` and
+  `SLACK_THREAD_TS` set, so the message replies into the originating thread.
+- **Cron runs** get `SLACK_CHANNEL_ID` set (to the configured alert/report channel) but
+  never `SLACK_THREAD_TS` — there is no originating thread, so the message posts directly
+  to the channel instead of a reply.
+
+See `docs/configuration.md` for the full env var reference.
+
+---
+
+## Fallback behavior
+
+`slack-say.ts` never throws and never fails the calling step — it is a best-effort ping,
+not a step whose failure should block anything:
+
+- **No `SLACK_BOT_TOKEN` or no channel resolved** (neither flag nor env var) → the text is
+  written to stdout instead, exit 0. This is the expected path for local/non-Slack runs.
+- **Slack API returns non-2xx or `ok: false`** → one line naming Slack's `error` string is
+  written to stderr, exit 0.
+- **No thread resolved** (neither `--thread` nor `SLACK_THREAD_TS`) → the message posts to
+  the channel directly rather than as a threaded reply.
+
+---
+
+## Reference
+
+- Script: `plugins/shipwright/scripts/slack-say.ts`
+- Unit tests: `plugins/shipwright/scripts/slack-say.unit.test.ts`
+- Env var reference: `docs/configuration.md`


### PR DESCRIPTION
## Summary
- Add `plugins/shipwright/scripts/slack-say.ts` — a one-line way for any skill to post a progress message into the Slack thread its run was started from, runnable as `bun run ${CLAUDE_PLUGIN_ROOT}/scripts/slack-say.ts [--channel C] [--thread T] "text"`
- Resolves channel/thread from CLI flags then `SLACK_CHANNEL_ID`/`SLACK_THREAD_TS` env vars, falls back to printing the text to stdout when no token/channel resolves, and never throws to the caller (Slack failures write a single stderr line and still exit 0)
- Documents `SLACK_CHANNEL_ID` and `SLACK_THREAD_TS` in `docs/configuration.md`, cross-referencing the existing `SLACK_BOT_TOKEN` row, so `task check-config-docs` passes

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Flags override env; `thread_ts` included only when resolved; body/auth match spec exactly | MET |
| 2 | Missing token/channel → stdout, exit 0; Slack error → single stderr line, exit 0; never throws | MET |
| 3 | `task check-config-docs`, `task check-strings`, `task lint`, `task typecheck` green; fixtures use placeholder ids only | MET |
| 4 | Unit tests cover flag/env precedence, thread omission, stdout fallback, ok:false, exact request body — via injected `fetch`, no `global.fetch`/`mock.module()`; no existing tests retired | MET |
| 5 | Safe to deploy standalone | MET |

## Test Plan
- `bun test plugins/shipwright/scripts/slack-say.unit.test.ts` — 11/11 pass, covering flag/env precedence, thread omission, stdout fallback, Slack `ok:false`, non-2xx, unparsable JSON body, fetch throwing, and the exact success-path request body/headers
- `task check-config-docs`, `task check-strings`, `bunx biome lint .`, `task typecheck` — all green
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
