### PR TITLE
docs: sweep allowlist rename + dependency-risk-aware review references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,8 @@ these four phases; it merges candidates from `agent/src`'s per-phase qualificati
 functions and dispatches the winning item's command with its id/PR embedded directly in the
 prompt. `merge` is currently human-invoked only. A human can invoke any of the five directly with an explicit target.
 
+The `review` command performs dependency-risk-aware analysis on pull requests that modify dependency manifests (e.g., `package.json`, `Gemfile`), analyzing the nature and scope of version changes and producing a risk assessment that informs the review verdict — see `commands/review.md` for details.
+
 The plugin is pure TypeScript with **no server, no database, and no external HTTP in production code** — only `unit` and `integration` test layers apply.
 
 A repo or team can extend this loop with its own commands, skills, or scheduled automation — via a companion marketplace plugin and/or a custom cron — without forking `plugins/shipwright/`. See **[extending.md](./extending.md)**.

--- a/site/src/content/docs/security.mdx
+++ b/site/src/content/docs/security.mdx
@@ -264,7 +264,8 @@ Two independent, optional scoping controls narrow an agent's exposure further:
 | Control | Default | Effect |
 |---|---|---|
 | `restrictSlackToMembers` | `false` | When `true`, only Slack users registered as that agent's members can DM or mention it; when `false`, any user in the Slack workspace can |
-| `reviewAuthorAllowlist` | empty (anyone) | A list of GitHub logins whose pull requests the agent will act on. An empty allowlist means any authenticated GitHub user's PRs are eligible |
+| `reviewAuthorAllowlist` | empty (anyone) | A list of GitHub logins whose pull requests the agent will review. An empty allowlist means any authenticated GitHub user's PRs are eligible for review |
+| `patchAuthorAllowlist` | empty (self-authored only) | A list of GitHub logins naming additional authors whose PRs this agent will treat as patch candidates. Patch work normally only touches the agent's own PRs; this allowlist adds other authors to the candidate pool. An empty allowlist means only self-authored PRs are eligible for patching |
 
 ## Admins vs. agent members
 


### PR DESCRIPTION
## Summary
- Updated `site/src/content/docs/security.mdx`'s scoping-controls table: clarified `reviewAuthorAllowlist`'s description to specify it scopes review candidacy, and added the missing `patchAuthorAllowlist` row
- Added a short paragraph to `docs/architecture.md` describing the `review` command's dependency-risk-aware analysis of dependency-manifest changes, linking to `commands/review.md`
- Verified `docs/configuration.md` (already updated by DBR-1.4/DBR-2.4) and `docs/agent.md`/`docs/agent-api.md` (already cleaned by DBR-3.4) need no further changes — confirmed via grep

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | docs/configuration.md and security.mdx rows updated: authorAllowlist → reviewAuthorAllowlist (scope: review), patchAuthorAllowlist added | MET | configuration.md already had both rows; security.mdx now has both, with review-scope clarified |
| 2 | docs/agent.md, docs/agent-api.md no longer reference triage-dependency-bot-pr(s) or dependency-bot-triage cron | MET | grep confirms zero matches in both files |
| 3 | docs/architecture.md skills list drops retired skills + mentions review.md's dependency-risk detection | MET | skills list already clean; new paragraph added referencing commands/review.md |
| 4 | No stale references to removed field name or retired skills remain (grep-verifiable) | MET | grep sweep across docs/ finds zero stale hits |

## Test Plan
- Docs-only change; no code touched (confirmed via `git diff --stat`)
- `task lint` passes
- `task typecheck` passes
- Manual grep verification of all four acceptance criteria (see table above)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
