### PR TITLE
fix: scope deploy.md and merge.md task lookups by repo

### DIFF
--- a/plugins/shipwright/commands/deploy.content.test.ts
+++ b/plugins/shipwright/commands/deploy.content.test.ts
@@ -46,6 +46,20 @@ function extractStep3bSection(md: string): string {
   return match?.[0] ?? "";
 }
 
+describe("deploy.md — Step 2: task lookup is repo-scoped (DTL-1.1)", () => {
+  it("looks up the task via a repo-scoped /tasks?repo=...&pr={pr} query", () => {
+    // Unscoped by repo, this cross-matches a same-numbered PR in a different
+    // repo sharing the task store (PR numbers are per-repo) — confirmed live
+    // on squadron PR #119, which resolved to a marketing-site task instead of
+    // the correct squadron one, silently corrupting the deploy pipeline's
+    // task-status tracking.
+    expect(content).toContain(
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}",
+    );
+    expect(content).not.toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks?pr={pr}"');
+  });
+});
+
 describe("deploy.md — own-PRs-only check (AC1 & AC2)", () => {
   it("contains own GH login check (AGENT_LOGIN or 'own GH login')", () => {
     const hasAgentLogin = content.includes("AGENT_LOGIN");

--- a/plugins/shipwright/commands/deploy.md
+++ b/plugins/shipwright/commands/deploy.md
@@ -47,7 +47,7 @@ today.
 Look up the task via the task store:
 
 ```bash
-TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?pr={pr}" | jq .)
+TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}" | jq .)
 TASK_ID=$(echo "$TASK_JSON" | jq -r '.tasks[0].id // empty')
 TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.tasks[0].title // empty')
 TASK_STATUS=$(echo "$TASK_JSON" | jq -r '.tasks[0].status // empty')

--- a/plugins/shipwright/commands/merge.content.test.ts
+++ b/plugins/shipwright/commands/merge.content.test.ts
@@ -80,8 +80,15 @@ describe("merge.md — Arguments section (AC1)", () => {
 });
 
 describe("merge.md — Step 1: Resolve Target PR (own-PRs-only + bundle gate)", () => {
-  it("looks up the task via /tasks?pr={pr}", () => {
-    expect(content).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks?pr=");
+  it("looks up the task via a repo-scoped /tasks?repo=...&pr={pr} query", () => {
+    // Unscoped by repo, this cross-matches a same-numbered PR in a different
+    // repo sharing the task store (PR numbers are per-repo) — confirmed live
+    // on squadron PR #119, which resolved to a marketing-site task instead of
+    // the correct squadron one.
+    expect(content).toContain(
+      "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}",
+    );
+    expect(content).not.toContain('"$SHIPWRIGHT_TASK_STORE_URL/tasks?pr={pr}"');
   });
 
   it("falls back to merge-only mode language when no task is found", () => {

--- a/plugins/shipwright/commands/merge.md
+++ b/plugins/shipwright/commands/merge.md
@@ -41,7 +41,7 @@ and `pr`.
 Look up the task via the task store:
 
 ```bash
-TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?pr={pr}" | jq .)
+TASK_JSON=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" "$SHIPWRIGHT_TASK_STORE_URL/tasks?repo={org}/{repo}&pr={pr}" | jq .)
 TASK_ID=$(echo "$TASK_JSON" | jq -r '.tasks[0].id // empty')
 TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.tasks[0].title // empty')
 TASK_STATUS=$(echo "$TASK_JSON" | jq -r '.tasks[0].status // empty')


### PR DESCRIPTION
## Summary
- Scope `deploy.md`'s and `merge.md`'s task-store task lookups by repo: `GET /tasks?pr={pr}` → `GET /tasks?repo={org}/{repo}&pr={pr}`.
- Add missing content-test coverage in `deploy.content.test.ts` for this query, and update `merge.content.test.ts`'s existing assertion (which pinned the unscoped, buggy form) to assert the scoped version instead.

## Why
PR numbers are per-repo — every repo restarts numbering at #1 — so an unscoped `/tasks?pr={pr}` query taking `.tasks[0]` silently cross-matches a task in a *different* repo whenever two repos sharing the same task store happen to have a PR with the same number.

Confirmed live: `app-vitals/squadron` PR #119 resolved via this exact query to `CTD-1.1`, a task in `app-vitals/marketing-site`, instead of the correct `DPM-1.1` in squadron. `deploy.md`'s subsequent `PATCH /tasks/$TASK_ID` therefore targeted the wrong repo's task — which a squadron-scoped deploying agent can't write to, so it silently failed — leaving the real task's `deployingAt`/`deployedAt` stamps permanently unset even though its PR merged cleanly. Reproduced the same collision pattern on two more historically-stuck squadron tasks (PR #70: `AV-1.4` marketing-site vs `KPI-1.11` squadron; PR #95: `ORC-1.1` marketing-site vs `ACC-1.6` squadron).

The fix mirrors an already-correct, already-tested pattern elsewhere in this codebase: `agent/src/check-helpers.ts`'s `createTaskStatusQuery` (used by `check-review.ts`/`check-patch.ts`/`check-deploy.ts`'s candidate-selection layer) already builds `/tasks?repo={repo}&pr={prNumber}`. `deploy.md` and `merge.md` just hand-rolled their own separate, unscoped lookup once acting on a specific PR. Confirmed via `task-store/src/openapi-schemas.ts` that `repo` and `pr` filters compose as an AND.

Planned via `planning/deploy-task-lookup-scope/PLAN.md`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `deploy.md:50` and `merge.md:44` both query `/tasks?repo={org}/{repo}&pr={pr}` (repo-scoped), not the bare `/tasks?pr={pr}` | MET |
| 2 | `merge.content.test.ts`'s existing assertion updated to assert the scoped query, fails against the old unscoped form | MET |
| 3 | `deploy.content.test.ts` gains a new test asserting the same scoped-query pattern (genuinely new coverage) | MET |
| 4 | Test decision: content layer only, no unit/integration change needed | MET |

## Test Plan
- `bun test plugins/shipwright/commands/deploy.content.test.ts plugins/shipwright/commands/merge.content.test.ts` — 150/150 pass
- `bunx biome lint` on changed files — clean
- `task check-strings` / `task check-config-docs` — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
