### PR TITLE
feat: add doc size governance with split proposal (RDQ-1.3)

### DIFF
--- a/plugins/shipwright/commands/research-docs.md
+++ b/plugins/shipwright/commands/research-docs.md
@@ -119,6 +119,16 @@ Each task: `layer: "CLI"`, `session: "docs-freshness-cron"`.
 
 Track a running count of tasks filed this way for the current repo — this becomes the `Quality flags tasked` figure in Step A9's per-repo summary.
 
+After the quality-pass checks above, also check the doc's resulting **line count** against the hard threshold defined in Interactive Mode Step 6.6 (Size Governance) — 200 lines. Reuse that step's threshold and section-grouping logic rather than re-deriving it here.
+
+Over 200 lines: file **one** task-store task via the same `/tasks/bulk` mechanism used above (same endpoint, same auth header — no second endpoint). Auto mode never creates a split file — only a task:
+
+- `title: "Split {doc} — exceeds {N} lines"`
+- `description`: a best-effort section-grouping suggestion — which `##`/`###` sections would move to a new sub-topic doc, grouped by topic, following the same grouping approach as Step 6.6
+- `layer: "CLI"`, `session: "docs-freshness-cron"`
+
+Track a running count of split-proposal tasks filed this way for the current repo — this becomes the `Split proposals tasked` figure in Step A9's per-repo summary.
+
 ### Step A6: Update CLAUDE.md References
 
 Check if `CLAUDE.md` has a reference or docs section (patterns: `@docs/`, `docs/`, or a "Reference" heading).
@@ -175,6 +185,7 @@ Repos processed: {N}
   CLAUDE.md: {updated | unchanged}
   Tasks created: {N missing-doc tasks, or "none"}
   Quality flags tasked: {N}
+  Split proposals tasked: {N}
   Sync anchor: {HEAD SHA} → state/docs-last-synced.json
 
 {org/repo-2}: skipped (no docs/ directory)
@@ -520,6 +531,48 @@ Proceed? (Apply proposed fixes / Pick specific / Skip)
 ```
 
 Wait for user confirmation before applying any `Edit`. A skipped or declined flag is left as-is — do not silently apply it anyway.
+
+---
+
+## Step 6.6: Size Governance
+
+Run this pass against every doc **updated in Step 6** — not docs drafted fresh in Step 5, and not docs left untouched by this run. Run it after Step 6.5's proposed fixes have been applied or declined, so the line count reflects the doc's actual final state for this run, not an intermediate one.
+
+**Thresholds:** soft target **150 lines**, hard threshold **200 lines**, for a single generated doc. The goal is a doc that can be fully read when consulted, not a doc that keeps growing forever.
+
+Count the doc's current line count (`wc -l` or equivalent) after Step 6.5.
+
+**Under 200 lines: this step is a no-op.** The doc behaves exactly as before this step existed — no split proposal, no prompt, nothing further to do. This is the common case and requires no output beyond noting the doc is fine.
+
+**Over 200 lines: propose a split — never automatic.** Identify which `##`/`###` sections would move to one or more new sub-topic doc(s), grouped by topic (e.g. all sections about one sub-area move together). For each proposed new doc, propose a filename following the naming pattern detected in Step 4 (`{topic}.md`, `{service}-api.md`, etc. — whatever this project's existing convention is). Present the proposal and wait for confirmation before creating anything:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+SIZE GOVERNANCE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+docs/architecture.md is now 238 lines (hard threshold: 200)
+
+Proposed split:
+  Keep in docs/architecture.md:
+    ## Overview
+    ## System Diagram
+    ## Core Modules
+
+  Move to docs/architecture-deployment.md (new):
+    ## Deployment Topology
+    ## Scaling Notes
+    ## Infra Dependencies
+
+docs/architecture.md would keep a pointer to the new doc under its own
+"## Deployment" heading.
+
+Proceed? (Create split / Skip)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+- **If confirmed:** create the new sub-topic doc(s) via `Write` (moving the identified sections' content verbatim, or lightly re-headed to stand alone), then trim the original doc via `Edit` to keep only the remaining sections plus a short pointer to the new doc(s).
+- **If declined or skipped:** leave the doc as-is, oversized. It is not retried automatically on a later run — it will surface again next time this doc is updated and re-checked by this step.
 
 ---
 

--- a/plugins/shipwright/commands/research-docs.unit.test.ts
+++ b/plugins/shipwright/commands/research-docs.unit.test.ts
@@ -317,3 +317,104 @@ describe("research-docs.md — quality pass", () => {
     expect(stepA9Section).toContain("Quality flags tasked");
   });
 });
+
+describe("research-docs.md — size governance", () => {
+  it("Step 6.6 exists between Step 6.5 and Step 7", () => {
+    const step6_5Idx = content.indexOf("## Step 6.5: Quality Pass");
+    const step6_6Idx = content.indexOf("## Step 6.6: Size Governance");
+    const step7Idx = content.indexOf("## Step 7: Update CLAUDE.md Reference");
+    expect(step6_5Idx).toBeGreaterThan(-1);
+    expect(step6_6Idx).toBeGreaterThan(-1);
+    expect(step7Idx).toBeGreaterThan(-1);
+    expect(step6_6Idx).toBeGreaterThan(step6_5Idx);
+    expect(step6_6Idx).toBeLessThan(step7Idx);
+  });
+
+  it("Step 6.6 runs against docs updated in Step 6, after Step 6.5's edits are applied", () => {
+    const step6_6Idx = content.indexOf("## Step 6.6: Size Governance");
+    const step7Idx = content.indexOf("## Step 7: Update CLAUDE.md Reference");
+    const section = content.slice(step6_6Idx, step7Idx);
+    expect(section).toContain("Step 6");
+    expect(section).toContain("Step 6.5");
+  });
+
+  it("Step 6.6 defines concrete soft (150) and hard (200) line thresholds", () => {
+    const step6_6Idx = content.indexOf("## Step 6.6: Size Governance");
+    const step7Idx = content.indexOf("## Step 7: Update CLAUDE.md Reference");
+    const section = content.slice(step6_6Idx, step7Idx);
+    expect(section).toContain("150");
+    expect(section).toContain("200");
+  });
+
+  it("Step 6.6 documents the under-threshold case as a no-op — behaves as today", () => {
+    const step6_6Idx = content.indexOf("## Step 6.6: Size Governance");
+    const step7Idx = content.indexOf("## Step 7: Update CLAUDE.md Reference");
+    const section = content.slice(step6_6Idx, step7Idx);
+    const hasNoOpLanguage =
+      section.toLowerCase().includes("no-op") ||
+      section.toLowerCase().includes("no action") ||
+      section.toLowerCase().includes("behaves as before") ||
+      section.toLowerCase().includes("behaves exactly as before");
+    expect(hasNoOpLanguage).toBe(true);
+  });
+
+  it("Step 6.6 documents the over-threshold split proposal — never automatic, gated on confirmation", () => {
+    const step6_6Idx = content.indexOf("## Step 6.6: Size Governance");
+    const step7Idx = content.indexOf("## Step 7: Update CLAUDE.md Reference");
+    const section = content.slice(step6_6Idx, step7Idx);
+    expect(section.toLowerCase()).toContain("split");
+    expect(section.toLowerCase()).toContain("sub-topic");
+    expect(section.toLowerCase()).toContain("never automatic");
+    expect(section).toContain("Proceed?");
+    expect(section.toLowerCase()).toContain("wait for confirmation");
+  });
+
+  it("Step 6.6 reuses Step 4's detected naming pattern for the new sub-topic doc filename", () => {
+    const step6_6Idx = content.indexOf("## Step 6.6: Size Governance");
+    const step7Idx = content.indexOf("## Step 7: Update CLAUDE.md Reference");
+    const section = content.slice(step6_6Idx, step7Idx);
+    expect(section).toContain("Step 4");
+  });
+
+  it("Step A5.5 also checks resulting line count against Step 6.6's hard threshold", () => {
+    const stepA5_5Idx = content.indexOf("### Step A5.5: Auto Mode Quality Pass");
+    const stepA6Idx = content.indexOf("### Step A6: Update CLAUDE.md References");
+    const section = content.slice(stepA5_5Idx, stepA6Idx);
+
+    expect(section.toLowerCase()).toContain("line count");
+    const referencesStep6_6 =
+      section.includes("Step 6.6") || section.includes("Size Governance");
+    expect(referencesStep6_6).toBe(true);
+  });
+
+  it("Step A5.5 files a Split proposal task via /tasks/bulk, never creates a file", () => {
+    const stepA5_5Idx = content.indexOf("### Step A5.5: Auto Mode Quality Pass");
+    const stepA6Idx = content.indexOf("### Step A6: Update CLAUDE.md References");
+    const section = content.slice(stepA5_5Idx, stepA6Idx);
+
+    expect(section).toContain("Split {doc} — exceeds");
+    expect(section).toContain("/tasks/bulk");
+    expect(section).toContain('layer: "CLI"');
+    expect(section).toContain('session: "docs-freshness-cron"');
+
+    // Still exactly one distinct bulk-like endpoint in the whole file
+    const bulkEndpointMatches = content.match(/\/tasks\/[a-zA-Z-]+/g) ?? [];
+    const uniqueBulkEndpoints = new Set(
+      bulkEndpointMatches.filter((m) => m.includes("bulk")),
+    );
+    expect(uniqueBulkEndpoints.size).toBe(1);
+    expect(uniqueBulkEndpoints.has("/tasks/bulk")).toBe(true);
+  });
+
+  it("Step A9's summary template includes a Split proposals tasked line, after Quality flags tasked", () => {
+    const stepA9Idx = content.indexOf("### Step A9");
+    expect(stepA9Idx).toBeGreaterThan(-1);
+    const stepA9Section = content.slice(stepA9Idx, stepA9Idx + 2000);
+    expect(stepA9Section).toContain("Split proposals tasked");
+
+    const qualityIdx = stepA9Section.indexOf("Quality flags tasked");
+    const splitIdx = stepA9Section.indexOf("Split proposals tasked");
+    expect(qualityIdx).toBeGreaterThan(-1);
+    expect(splitIdx).toBeGreaterThan(qualityIdx);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Interactive Mode `Step 6.6: Size Governance` — checks a doc's line count after Step 6/6.5, no-op under the 200-line hard threshold, proposes a section-grouped split into sub-topic doc(s) over threshold, gated on user confirmation (never automatic).
- Extend Auto Mode `Step A5.5` to also check line count after Step A5's rewrite and file a `"Split {doc} — exceeds {N} lines"` task-store task (never a file) via the existing `/tasks/bulk` mechanism; Step A9's summary gains a `Split proposals tasked: {N}` line.
- Add a new `describe("research-docs.md — size governance", ...)` block to `research-docs.unit.test.ts` covering both interactive cases and the auto-mode line-count/task-filing behavior; no existing tests changed.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Interactive mode: under-threshold update behaves as today (no split proposal) | MET |
| 2 | Interactive mode: over-threshold update triggers a split proposal identifying moved sections, waits for confirmation | MET |
| 3 | Auto mode: Step A5.5 checks line count, files split-proposal task without creating a file; Step A9 reports "Split proposals tasked: N" | MET |
| 4 | Test decision: new describe block covers both interactive cases + A5.5 behavior; no existing tests changed | MET |

## Test Plan
- `bun test plugins/shipwright/commands/research-docs.unit.test.ts` — 41/41 pass (9 new)
- `bunx biome lint` on changed files — clean
- `task typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
