### PR TITLE
feat: add shared CSS component classes for redesigned admin pages

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2045,13 +2045,13 @@ export function renderRepoOrgFilterFields(
       })
       .join("");
 
-  return `<div class="form-group" style="margin-bottom:0">
+  return `<div class="form-group scope-select-group" style="margin-bottom:0">
           <label class="form-label" style="font-size:11px">Org</label>
-          <select name="org" multiple class="form-input" style="font-size:12px;padding:4px 8px">${renderOptions(orgOptionValues, activeOrgs)}</select>
+          <select name="org" multiple class="form-input scope-select" style="font-size:12px;padding:4px 8px">${renderOptions(orgOptionValues, activeOrgs)}</select>
         </div>
-        <div class="form-group" style="margin-bottom:0">
+        <div class="form-group scope-select-group" style="margin-bottom:0">
           <label class="form-label" style="font-size:11px">Repo</label>
-          <select name="repo" multiple class="form-input" style="font-size:12px;padding:4px 8px">${renderOptions(repoOptionValues, activeRepos)}</select>
+          <select name="repo" multiple class="form-input scope-select" style="font-size:12px;padding:4px 8px">${renderOptions(repoOptionValues, activeRepos)}</select>
         </div>`;
 }
 

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -2607,6 +2607,42 @@ describe("renderTasksPage — org/repo multiselect filters", () => {
     expect(html).toContain('<option value="app-vitals/repo-b">');
   });
 
+  test("Org and Repo multiselects carry the new scope-select pill/tag styling class (AXR-1.1)", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals"], repos: ["app-vitals/repo-a"] },
+    );
+    expect(html).toContain(
+      '<select name="org" multiple class="form-input scope-select"',
+    );
+    expect(html).toContain(
+      '<select name="repo" multiple class="form-input scope-select"',
+    );
+  });
+
+  test("Org and Repo stay independent multiselect fields, not merged into one combined scope pill", () => {
+    const html = renderTasksPage(
+      [],
+      {},
+      false,
+      "user@test.com",
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals"], repos: ["app-vitals/repo-a"] },
+    );
+    const selectCount = (html.match(/<select /g) ?? []).length;
+    expect(selectCount).toBeGreaterThanOrEqual(2);
+    expect(html).toContain('<select name="org" multiple');
+    expect(html).toContain('<select name="repo" multiple');
+  });
+
   test("marks currently-active repo filter values as selected (array)", () => {
     const html = renderTasksPage(
       [],
@@ -4505,6 +4541,42 @@ describe("renderPrsPage — org/repo multiselect filters", () => {
     );
     expect(html).toContain('<option value="org/repo-a">');
     expect(html).toContain('<option value="org/repo-b">');
+  });
+
+  test("Org and Repo multiselects carry the new scope-select pill/tag styling class (AXR-1.1)", () => {
+    const html = renderPrsPage(
+      [],
+      {},
+      false,
+      USER_NAME,
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals"], repos: ["app-vitals/repo-a"] },
+    );
+    expect(html).toContain(
+      '<select name="org" multiple class="form-input scope-select"',
+    );
+    expect(html).toContain(
+      '<select name="repo" multiple class="form-input scope-select"',
+    );
+  });
+
+  test("Org and Repo stay independent multiselect fields, not merged into one combined scope pill", () => {
+    const html = renderPrsPage(
+      [],
+      {},
+      false,
+      USER_NAME,
+      {},
+      pagination,
+      undefined,
+      { orgs: ["app-vitals"], repos: ["app-vitals/repo-a"] },
+    );
+    const selectCount = (html.match(/<select /g) ?? []).length;
+    expect(selectCount).toBeGreaterThanOrEqual(2);
+    expect(html).toContain('<select name="org" multiple');
+    expect(html).toContain('<select name="repo" multiple');
   });
 
   test("marks currently-active repo filter values as selected (array)", () => {

--- a/admin/src/admin-ui-styles.ts
+++ b/admin/src/admin-ui-styles.ts
@@ -223,6 +223,170 @@ export function baseStyles(): string {
       color: #92400e;
     }
 
+    /* ─── Scope pills (filter chips) ────────────────────── */
+    .scope-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 11px;
+      font-weight: 500;
+      padding: 3px 10px;
+      border-radius: 9999px;
+      background: #f3f4f6;
+      color: #374151;
+      border: 1px solid #e5e7eb;
+    }
+    .scope-pill.active {
+      background: #eef2ff;
+      color: #4338ca;
+      border-color: #c7d2fe;
+    }
+    .scope-pill-remove {
+      cursor: pointer;
+      color: #9ca3af;
+      font-weight: 700;
+      line-height: 1;
+    }
+    .scope-pill-remove:hover { color: #374151; }
+
+    /* Org/Repo multiselect filters (renderRepoOrgFilterFields) restyled as
+       pill/tag-style fields (AXR-1.1). These stay two independent
+       <select multiple> controls -- not merged into one combined pill. */
+    .scope-select-group {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .scope-select {
+      border-radius: 10px;
+      background: #f9fafb;
+    }
+    .scope-select option:checked {
+      background: #eef2ff;
+      color: #4338ca;
+    }
+
+    /* ─── Board / column / card layout ──────────────────── */
+    .board {
+      display: flex;
+      gap: 16px;
+      align-items: flex-start;
+      overflow-x: auto;
+      padding-bottom: 8px;
+    }
+    .column {
+      flex: 0 0 280px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      background: #f9fafb;
+      border: 1px solid #e8e8ee;
+      border-radius: 10px;
+      padding: 12px;
+    }
+    .column-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 12px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 4px;
+    }
+    .column-count {
+      font-size: 11px;
+      font-weight: 600;
+      color: #9ca3af;
+      background: #fff;
+      border: 1px solid #e8e8ee;
+      border-radius: 9999px;
+      padding: 1px 8px;
+    }
+    /* Individual board items reuse .card for the panel look; this modifier
+       tightens padding/margins for the denser board context. */
+    .column .card {
+      margin-bottom: 0;
+      padding: 12px 14px;
+    }
+
+    /* ─── Additional badge variants (beyond badge-hitl/badge-dep) ───────── */
+    .badge-purple {
+      background: #ede9fe;
+      color: #5b21b6;
+    }
+    .badge-teal {
+      background: #ccfbf1;
+      color: #0f766e;
+    }
+
+    /* ─── Header tooltip (hover, data-tip attribute) ────── */
+    .header-tooltip {
+      position: relative;
+      cursor: help;
+      border-bottom: 1px dotted #9ca3af;
+    }
+    .header-tooltip[data-tip]:hover::after {
+      content: attr(data-tip);
+      position: absolute;
+      bottom: 125%;
+      left: 50%;
+      transform: translateX(-50%);
+      white-space: nowrap;
+      background: #1a1a2e;
+      color: #fff;
+      font-size: 11px;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 6px;
+      z-index: 10;
+      pointer-events: none;
+    }
+
+    /* ─── Heartbeat status dots (fresh/aging/stale) ─────── */
+    .heartbeat-dot {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 9999px;
+      background: #d1d5db;
+    }
+    .heartbeat-dot.fresh { background: #22c55e; }
+    .heartbeat-dot.aging { background: #f59e0b; }
+    .heartbeat-dot.stale { background: #ef4444; }
+
+    /* ─── More filters disclosure ───────────────────────── */
+    .more-filters {
+      margin-top: 8px;
+    }
+    .more-filters summary {
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 500;
+      color: #6b7280;
+      list-style: none;
+    }
+    .more-filters summary::-webkit-details-marker { display: none; }
+    .more-filters summary::before {
+      content: "▸";
+      display: inline-block;
+      margin-right: 4px;
+      transition: transform 0.15s ease;
+    }
+    .more-filters[open] summary::before {
+      transform: rotate(90deg);
+    }
+    .more-filters[open] summary {
+      color: #1a1a2e;
+    }
+    .more-filters-panel {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 8px;
+    }
+
     /* ─── Provision page ────────────────────────────────── */
     .provision-steps {
       display: flex;

--- a/admin/src/admin-ui-styles.unit.test.ts
+++ b/admin/src/admin-ui-styles.unit.test.ts
@@ -51,3 +51,53 @@ describe("baseStyles — CFB-3.1 responsive breakpoints", () => {
     expect(formInputBase?.[1]).toContain("font-size: 14px");
   });
 });
+
+describe("baseStyles — AXR-1.1 shared explore board component classes", () => {
+  test("defines a scope-pill filter chip class", () => {
+    const css = baseStyles();
+    expect(css).toContain(".scope-pill");
+  });
+
+  test("defines the restyled pill/tag select class used by the Org/Repo multiselect fields", () => {
+    const css = baseStyles();
+    expect(css).toContain(".scope-select");
+  });
+
+  test("defines board/column layout classes for the kanban-style board pages", () => {
+    const css = baseStyles();
+    expect(css).toContain(".board");
+    expect(css).toContain(".column");
+  });
+
+  test("defines new badge variants beyond the existing badge-hitl/badge-dep", () => {
+    const css = baseStyles();
+    expect(css).toContain(".badge-purple");
+    expect(css).toContain(".badge-teal");
+  });
+
+  test("defines a header-tooltip pattern driven by a data-tip attribute", () => {
+    const css = baseStyles();
+    expect(css).toContain(".header-tooltip");
+    expect(css).toContain("data-tip");
+  });
+
+  test("defines heartbeat-dot status indicator with fresh/aging/stale modifiers", () => {
+    const css = baseStyles();
+    expect(css).toContain(".heartbeat-dot");
+    expect(css).toMatch(/\.heartbeat-dot\.fresh/);
+    expect(css).toMatch(/\.heartbeat-dot\.aging/);
+    expect(css).toMatch(/\.heartbeat-dot\.stale/);
+  });
+
+  test("defines more-filters disclosure styling", () => {
+    const css = baseStyles();
+    expect(css).toContain(".more-filters");
+  });
+
+  test("does not rename or remove existing badge/pill classes", () => {
+    const css = baseStyles();
+    expect(css).toContain(".badge-green");
+    expect(css).toContain(".badge-gray");
+    expect(css).toContain(".badge-warning");
+  });
+});


### PR DESCRIPTION
## Summary
- Add new additive CSS component classes to `admin/src/admin-ui-styles.ts` matching the intel mockups' visual language: `scope-pill` filter chips, `board`/`column`/`card` layout, new badge variants (`badge-purple`, `badge-teal`), a `header-tooltip` (`data-tip` hover) pattern, `heartbeat-dot` status indicators (fresh/aging/stale), and `more-filters` disclosure styling.
- Restyle the existing `renderRepoOrgFilterFields` Org and Repo `<select multiple>` fields with new `scope-select-group`/`scope-select` classes — both fields remain independent, multi-selectable filters (not merged into a single combined pill).
- No existing CSS class renamed or removed; `lib/web/toolbar.ts`, page background, and font stack are untouched.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | New classes: scope-pill, board/column/card, badge variants, header-tooltip, heartbeat-dot, more-filters | MET |
| 2 | Org/Repo restyled as independent pill/tag multi-selects | MET |
| 3 | No existing CSS class renamed/removed | MET |
| 4 | toolbar.ts untouched | MET |
| 5 | Unit test asserting new classes present | MET |

## Test Plan
- `admin-ui-styles.unit.test.ts`: 7 new tests asserting each new class definition is present in the generated stylesheet string, plus a regression test confirming existing badge classes are untouched.
- `admin-ui-pages.unit.test.ts`: 4 new tests confirming the Org/Repo selects carry the new `scope-select` class and remain two independent `<select multiple>` controls.
- [x] `bun test admin/src/admin-ui-styles.unit.test.ts admin/src/admin-ui-pages.unit.test.ts` — 688 pass
- [x] `task typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
