### PR TITLE
refactor: remove Slack navbar item and dead provisioning paste-form

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1946,50 +1946,6 @@ export function renderProvisionXappTokenPage(
   });
 }
 
-// Paste form shown after OAuth callback — user enters SLACK_APP_ID and SLACK_SIGNING_SECRET
-// from the Slack App Credentials page (signing secret is not returned by Slack's OAuth API).
-export function renderProvisionPasteForm(
-  userName: string,
-  opts?: { agentId?: string; error?: string },
-): string {
-  const errorHtml = opts?.error
-    ? `<div class="alert alert-error">${escapeHtml(opts.error)}</div>`
-    : "";
-
-  return renderAdminPage({
-    title: "Complete Provisioning — Shipwright Admin",
-    body: `${renderAdminToolbar(userName, "/admin/provision")}
-  <div class="vos-page">
-    <div class="page-header">
-      <h1 class="page-title">Provision Agent</h1>
-    </div>
-    <div class="provision-steps">
-      <span class="provision-step">1. Create Slack App</span>
-      <span class="provision-step">2. Authorize</span>
-      <span class="provision-step active">3. Paste Credentials</span>
-    </div>
-    <div class="card">
-      <p style="font-size:14px;margin-bottom:16px;color:#6b7280">
-        Open your Slack App's <strong>Basic Information</strong> page and paste the credentials below.
-      </p>
-      ${errorHtml}
-      <form method="POST" action="/admin/provision/complete">
-        <input type="hidden" name="agentId" value="${escapeHtml(opts?.agentId ?? "")}" />
-        <div class="form-group">
-          <label class="form-label" for="appId">App ID</label>
-          <input id="appId" name="appId" type="text" class="form-input" placeholder="AXXXXXXXXXX" required />
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="signingSecret">Signing Secret</label>
-          <input id="signingSecret" name="signingSecret" type="password" class="form-input" placeholder="Paste from App Credentials" required />
-        </div>
-        <button type="submit" class="btn btn-primary">Save Credentials →</button>
-      </form>
-    </div>
-  </div>`,
-  });
-}
-
 function statusBadgeClass(s: string): string {
   if (s === "in_progress" || s === "pr_open" || s === "approved")
     return "badge-blue";

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -39,7 +39,6 @@ import {
   renderNewLocalAgentPage,
   renderPrDetailPage,
   renderProvisionCompletePage,
-  renderProvisionPasteForm,
   renderProvisionXappTokenPage,
   renderPrsPage,
   renderQueueActivityPage,
@@ -1871,69 +1870,6 @@ describe("renderAgentDetailPage — plugins", () => {
   });
 });
 
-// ─── renderProvisionPasteForm ─────────────────────────────────────────────────
-
-describe("renderProvisionPasteForm", () => {
-  test("returns a valid HTML document", () => {
-    const html = renderProvisionPasteForm(USER_NAME);
-    expect(html).toContain("<!DOCTYPE html>");
-    expect(html).toContain("<html");
-    expect(html).toContain("</html>");
-  });
-
-  test("form action is /admin/provision/complete", () => {
-    const html = renderProvisionPasteForm(USER_NAME);
-    expect(html).toContain('action="/admin/provision/complete"');
-  });
-
-  test("agentId in hidden input when provided", () => {
-    const html = renderProvisionPasteForm(USER_NAME, { agentId: "agent-abc" });
-    expect(html).toContain('name="agentId"');
-    expect(html).toContain('value="agent-abc"');
-  });
-
-  test("hidden agentId input empty when not provided", () => {
-    const html = renderProvisionPasteForm(USER_NAME);
-    expect(html).toContain('name="agentId"');
-    expect(html).toContain('value=""');
-  });
-
-  test("XSS: agentId in hidden input is escaped", () => {
-    const html = renderProvisionPasteForm(USER_NAME, {
-      agentId: '"><script>xss()</script>',
-    });
-    expect(html).not.toContain('"><script>xss()</script>');
-    expect(html).toContain("&lt;script&gt;");
-  });
-
-  test("no error div when no error", () => {
-    const html = renderProvisionPasteForm(USER_NAME);
-    expect(html).not.toContain('class="alert alert-error"');
-  });
-
-  test("error shown when opts.error set", () => {
-    const html = renderProvisionPasteForm(USER_NAME, {
-      error: "Missing credentials",
-    });
-    expect(html).toContain('class="alert alert-error"');
-    expect(html).toContain("Missing credentials");
-  });
-
-  test("XSS: error is escaped", () => {
-    const html = renderProvisionPasteForm(USER_NAME, {
-      error: "<script>bad()</script>",
-    });
-    expect(html).not.toContain("<script>bad()</script>");
-    expect(html).toContain("&lt;script&gt;");
-  });
-
-  test("includes App ID and Signing Secret fields", () => {
-    const html = renderProvisionPasteForm(USER_NAME);
-    expect(html).toContain('name="appId"');
-    expect(html).toContain('name="signingSecret"');
-  });
-});
-
 // ─── renderProvisionCompletePage ─────────────────────────────────────────────
 
 describe("renderProvisionCompletePage", () => {
@@ -3530,39 +3466,20 @@ describe("renderTasksPage — 4-state toggle", () => {
 // ─── renderAdminToolbar — active nav highlight ────────────────────────────────
 
 describe("renderAdminToolbar — active nav highlight", () => {
-  test("activePath /admin/agents: Agents link is active, Provision is not", () => {
+  test("activePath /admin/agents: Agents link is active", () => {
     const html = renderAdminToolbar(USER_NAME, "/admin/agents");
     expect(html).toContain('href="/admin/agents" class="vos-nav-link active"');
-    expect(html).toContain('href="/admin/provision" class="vos-nav-link"');
-    expect(html).not.toContain(
-      'href="/admin/provision" class="vos-nav-link active"',
-    );
   });
 
   test("activePath sub-path /admin/agents/agent-id: Agents link is still active (startsWith)", () => {
     const html = renderAdminToolbar(USER_NAME, "/admin/agents/agent-id");
     expect(html).toContain('href="/admin/agents" class="vos-nav-link active"');
-    expect(html).not.toContain(
-      'href="/admin/provision" class="vos-nav-link active"',
-    );
-  });
-
-  test("activePath /admin/provision: Provision link is active, Agents is not", () => {
-    const html = renderAdminToolbar(USER_NAME, "/admin/provision");
-    expect(html).toContain(
-      'href="/admin/provision" class="vos-nav-link active"',
-    );
-    expect(html).toContain('href="/admin/agents" class="vos-nav-link"');
-    expect(html).not.toContain(
-      'href="/admin/agents" class="vos-nav-link active"',
-    );
   });
 
   test("activePath '' (default): neither link is active", () => {
     const html = renderAdminToolbar(USER_NAME);
     expect(html).not.toContain('class="vos-nav-link active"');
     expect(html).toContain('href="/admin/agents" class="vos-nav-link"');
-    expect(html).toContain('href="/admin/provision" class="vos-nav-link"');
   });
 });
 
@@ -7959,7 +7876,6 @@ describe("all page renderers — single DOCTYPE and viewport meta (CFB-1.2)", ()
       "renderProvisionXappTokenPage",
       () => renderProvisionXappTokenPage(USER_NAME, { agentId: "agent-123" }),
     ],
-    ["renderProvisionPasteForm", () => renderProvisionPasteForm(USER_NAME)],
     [
       "renderTasksPage",
       () =>
@@ -8029,8 +7945,8 @@ describe("all page renderers — single DOCTYPE and viewport meta (CFB-1.2)", ()
     ],
   ];
 
-  test("all 20 render sites are covered by this loop", () => {
-    expect(renderers.length).toBe(20);
+  test("all 19 render sites are covered by this loop", () => {
+    expect(renderers.length).toBe(19);
   });
 
   for (const [name, render] of renderers) {

--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -215,7 +215,6 @@ export function renderShipwrightToolbar(
     <a href="${adminBase}/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="${adminBase}/admin/agents" class="vos-nav-link${active("/admin/agents")}">Agents</a>
-      <a href="${adminBase}/admin/provision" class="vos-nav-link${active("/admin/provision")}">Slack</a>
       <a href="${adminBase}/admin/tasks?state=ready" class="vos-nav-link${active("/admin/tasks")}">Tasks</a>
       <a href="${adminBase}/admin/prs" class="vos-nav-link${active("/admin/prs")}">PRs</a>
       <a href="${adminBase}/admin/chat" class="vos-nav-link${active("/admin/chat")}">Chat</a>

--- a/lib/web/toolbar.unit.test.ts
+++ b/lib/web/toolbar.unit.test.ts
@@ -30,10 +30,8 @@ describe("renderShipwrightToolbar", () => {
       expect(html).toContain("Metrics");
     });
 
-    test("Slack wizard link is labeled 'Slack' (not the generic 'Provision')", () => {
-      expect(html).toContain('href="/admin/provision"');
-      expect(html).toContain(">Slack</a>");
-      expect(html).not.toContain(">Provision</a>");
+    test("does not render an /admin/provision link (removed dead nav shortcut)", () => {
+      expect(html).not.toContain('href="/admin/provision"');
     });
 
     test("active link has active class", () => {

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -163,7 +163,6 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
@@ -656,7 +655,6 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
@@ -1149,7 +1147,6 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
@@ -1642,7 +1639,6 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
     <a href="/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
       <a href="/admin/agents" class="vos-nav-link">Agents</a>
-      <a href="/admin/provision" class="vos-nav-link">Slack</a>
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>


### PR DESCRIPTION
## Summary
- Removed the "Slack" nav link (`/admin/provision`) from `renderShipwrightToolbar()`'s authenticated-mode nav — the `/admin/provision` GET redirect route itself is untouched, only the shortcut to it is gone
- Deleted the dead `renderProvisionPasteForm` render function from `admin/src/admin-ui-pages.ts` (zero import sites; superseded by the inline Slack connect flow on the New Agent form and the per-agent connect-later flow)

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `renderShipwrightToolbar()` drops the Slack/`/admin/provision` link in authenticated mode; read-only mode unchanged; `/admin/provision` GET redirect untouched | MET |
| 2 | `renderProvisionPasteForm` removed from `admin/src/admin-ui-pages.ts` | MET |
| 3 | Test updates: toolbar test replaced, admin-ui-pages describe block/import/table-entry deleted, nav-highlight assertions removed, dashboard snapshot regenerated | MET |
| 4 | `task lint`, `task typecheck`, `task test` pass for lib/admin/metrics | MET |
| 5 | Safe to deploy standalone (no route removed) | MET |

## Test Plan
- [x] `lib/web/toolbar.unit.test.ts` — new assertion that no `/admin/provision` link renders in authenticated mode
- [x] `admin/src/admin-ui-pages.unit.test.ts` — dead-form tests removed, nav-highlight assertions updated
- [x] `metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap` regenerated
- [x] `bunx biome lint .` clean
- [x] `bun run --filter='*' --sequential typecheck` clean
- [x] `NODE_ENV=test bun test lib admin metrics` — 2522 pass; 6 pre-existing failures confirmed present identically on unmodified `main` via `git stash` comparison (unrelated env-var test-isolation flakiness)
- [x] Full `task ci` test run — 30 pre-existing failures confirmed identical on `main` via stash comparison, none touching changed files

Generated with [Claude Code](https://claude.com/claude-code)
