### PR TITLE
feat: add slide-over drawer to task board cards

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -1994,6 +1994,25 @@ const TASKS_PAGE_EXTRA_STYLES = `
     .badge-hitl { background:#fff7ed;color:#c2410c;border:1px solid #fed7aa; }
     .badge-dep { background:#fefce8;color:#a16207;border:1px solid #fde047; }
     .alert-warning { background:#fefce8;color:#854d0e;border:1px solid #fde047;border-radius:6px;padding:10px 14px;margin-bottom:16px;font-size:13px; }
+    /* ─── Task board card slide-over drawer (AXR-1.4) ────────────────────── */
+    .task-drawer-toggle { position:absolute;opacity:0;width:1px;height:1px;pointer-events:none }
+    .task-drawer-scrim {
+      display:none;position:fixed;inset:0;z-index:55;
+      background:rgba(0,0,0,0.4);cursor:pointer;
+    }
+    .task-drawer-toggle:checked ~ .task-drawer-scrim { display:block }
+    .task-drawer {
+      position:fixed;top:0;right:0;bottom:0;z-index:60;
+      width:100%;max-width:400px;min-width:300px;
+      background:#fff;border-left:1px solid #e8e8ee;
+      overflow-y:auto;
+      transform:translateX(100%);
+      transition:transform 0.2s ease;
+    }
+    .task-drawer-toggle:checked ~ .task-drawer { transform:translateX(0) }
+    @media (prefers-reduced-motion: reduce) {
+      .task-drawer { transition:none }
+    }
   `;
 
 export function renderTasksPage(
@@ -2522,7 +2541,7 @@ function renderTasksBoard(args: {
         <button type="submit" class="btn btn-secondary" style="font-size:11px;padding:3px 8px">Release</button>
       </form>`;
 
-    return `<div class="card"${readOnly ? "" : ` data-href="${detailHref}" style="cursor:pointer"`}${prJoinAttrs}>
+    const cardMarkup = `<div class="card"${readOnly ? "" : ` data-drawer-toggle="task-drawer-toggle-${escapeHtml(t.id)}" style="cursor:pointer"`}${prJoinAttrs}>
         <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:8px">
           <div style="font-size:13px;font-weight:600">${readOnly ? escapeHtml(t.title) : `<a href="${detailHref}" style="color:inherit;text-decoration:none">${escapeHtml(t.title)}</a>`}</div>
           <span class="badge ${statusBadgeClass(t.status)}" style="font-size:10px;white-space:nowrap">${escapeHtml(t.status)}</span>
@@ -2537,6 +2556,47 @@ function renderTasksBoard(args: {
         ${blockerBadges}${prBadge}
         ${releaseForm}
       </div>`;
+
+    // For readOnly, render the card without drawer wrapper
+    if (readOnly) {
+      return cardMarkup;
+    }
+
+    // For non-readOnly, wrap card with drawer markup
+    const drawerContent = `
+      <div style="padding:20px 24px">
+        <div style="display:flex;justify-content:space-between;align-items:start;gap:12px;margin-bottom:16px">
+          <div>
+            <h2 style="font-size:16px;font-weight:600;margin-bottom:4px">${escapeHtml(t.title)}</h2>
+            <div class="mono" style="font-size:12px;color:#9ca3af">${escapeHtml(t.id)}</div>
+          </div>
+          <label for="task-drawer-toggle-${escapeHtml(t.id)}" style="cursor:pointer;color:#6b7280;font-size:20px;line-height:1">×</label>
+        </div>
+        <div style="display:flex;gap:8px;margin-bottom:16px">
+          <span class="badge ${statusBadgeClass(t.status)}">${escapeHtml(t.status)}</span>
+        </div>
+        ${t.repo ? `<div style="font-size:12px;color:#6b7280;margin-bottom:8px"><strong>Repo:</strong> ${escapeHtml(t.repo)}</div>` : ""}
+        ${t.session ? `<div style="font-size:12px;color:#6b7280;margin-bottom:8px"><strong>Session:</strong> ${escapeHtml(t.session)}</div>` : ""}
+        ${agentId ? `<div style="font-size:12px;color:#6b7280;margin-bottom:16px"><strong>Agent:</strong> ${escapeHtml(agentNames[agentId] ?? agentId)}</div>` : ""}
+        ${t.description ? `<div style="font-size:13px;color:#374151;line-height:1.6;margin-bottom:16px">${renderMarkdown(t.description)}</div>` : ""}
+        ${joinedPr ? `
+          <div style="border-top:1px solid #e8e8ee;padding-top:16px">
+            <h3 style="font-size:13px;font-weight:600;margin-bottom:8px">Pull Request</h3>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:4px"><strong>Number:</strong> <a href="https://github.com/${escapeHtml(joinedPr.repo)}/pull/${joinedPr.prNumber}" style="color:#6366f1;text-decoration:none">#${joinedPr.prNumber}</a></div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:4px"><strong>State:</strong> ${escapeHtml(joinedPr.state)}</div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:4px"><strong>Review State:</strong> ${escapeHtml(joinedPr.reviewState)}</div>
+            ${joinedPr.blocked ? `<div style="font-size:12px;color:#dc2626"><strong>Blocked:</strong> ${escapeHtml(joinedPr.blockedReason ?? "Yes")}</div>` : ""}
+          </div>
+        ` : ""}
+      </div>
+    `;
+
+    return `<div class="task-card-wrap">
+      <input type="checkbox" id="task-drawer-toggle-${escapeHtml(t.id)}" class="task-drawer-toggle" aria-hidden="true">
+      ${cardMarkup}
+      <label for="task-drawer-toggle-${escapeHtml(t.id)}" class="task-drawer-scrim" aria-label="Close task detail"></label>
+      <div class="task-drawer">${drawerContent}</div>
+    </div>`;
   };
 
   const columnsHtml = TASK_BOARD_COLUMNS.map(({ key, label }) => {
@@ -2613,15 +2673,28 @@ function renderTasksBoard(args: {
     bodyEnd: readOnly
       ? ""
       : `<script>
-    document.querySelectorAll(".column .card[data-href]").forEach(function(card) {
+    document.querySelectorAll(".column .card[data-drawer-toggle]").forEach(function(card) {
       card.addEventListener("click", function(e) {
         var target = e.target;
         while (target && target !== card) {
           if (target.tagName === "A" || target.tagName === "BUTTON" || target.tagName === "FORM" || target.tagName === "INPUT") return;
           target = target.parentElement;
         }
-        window.location.href = card.getAttribute("data-href");
+        var toggleId = card.getAttribute("data-drawer-toggle");
+        var checkbox = document.getElementById(toggleId);
+        if (checkbox) {
+          checkbox.checked = true;
+          checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+        }
       });
+    });
+    document.addEventListener("keydown", function(e) {
+      if ((e.key === "Escape" || e.key === "Esc") && document.querySelector(".task-drawer-toggle:checked")) {
+        document.querySelectorAll(".task-drawer-toggle:checked").forEach(function(toggle) {
+          toggle.checked = false;
+          toggle.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+      }
     });
   </script>`,
   });

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2592,7 +2592,7 @@ function renderTasksBoard(args: {
     `;
 
     return `<div class="task-card-wrap">
-      <input type="checkbox" id="task-drawer-toggle-${escapeHtml(t.id)}" class="task-drawer-toggle" aria-hidden="true">
+      <input type="checkbox" id="task-drawer-toggle-${escapeHtml(t.id)}" class="task-drawer-toggle" aria-hidden="true" tabindex="-1">
       ${cardMarkup}
       <label for="task-drawer-toggle-${escapeHtml(t.id)}" class="task-drawer-scrim" aria-label="Close task detail"></label>
       <div class="task-drawer">${drawerContent}</div>

--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2681,6 +2681,9 @@ function renderTasksBoard(args: {
           target = target.parentElement;
         }
         var toggleId = card.getAttribute("data-drawer-toggle");
+        document.querySelectorAll(".task-drawer-toggle:checked").forEach(function(openToggle) {
+          if (openToggle.id !== toggleId) openToggle.checked = false;
+        });
         var checkbox = document.getElementById(toggleId);
         if (checkbox) {
           checkbox.checked = true;

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -3745,6 +3745,24 @@ describe("renderTasksPage — board view (AXR-1.3)", () => {
     expect(html).toContain('aria-hidden="true"');
   });
 
+  // aria-hidden only removes the checkbox from the accessibility tree, not the
+  // tab order — without tabindex="-1" a keyboard user can Tab to the hidden
+  // per-card checkbox and Space-check it directly, bypassing the card's click
+  // handler (the only place that closes any other already-open drawer) and
+  // ending up with two stacked .task-drawer panels.
+  test("hidden drawer checkbox is removed from tab order via tabindex=-1", () => {
+    const task: TaskItem = {
+      id: "TABINDEX-TEST",
+      title: "Tabindex test task",
+      status: "pending",
+      claimedBy: null,
+      assignee: null,
+    };
+    const html = renderBoard([task]);
+    expect(html).toContain('id="task-drawer-toggle-TABINDEX-TEST"');
+    expect(html).toContain('tabindex="-1"');
+  });
+
   test("drawer checkbox appears before the drawer panel in DOM order", () => {
     const task: TaskItem = {
       id: "DOM-ORDER-TEST",

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -3870,6 +3870,19 @@ describe("renderTasksPage — board view (AXR-1.3)", () => {
     expect(html).not.toContain('class="task-drawer"');
     expect(html).not.toContain('data-drawer-toggle=');
   });
+
+  // Opening a card's drawer must close any other drawer already open — two
+  // .task-drawer panels are both position:fixed at the same spot, so leaving
+  // a prior toggle checked would stack an invisible-but-still-checked drawer
+  // behind the new one instead of a clean single-drawer UX.
+  test("click handler closes any other open drawer before opening the clicked card's", () => {
+    const html = renderBoard([
+      { id: "T-A", title: "A", status: "pending", claimedBy: null, assignee: null },
+      { id: "T-B", title: "B", status: "pending", claimedBy: null, assignee: null },
+    ]);
+    expect(html).toContain('.task-drawer-toggle:checked").forEach(function(openToggle)');
+    expect(html).toContain("if (openToggle.id !== toggleId) openToggle.checked = false;");
+  });
 });
 
 // ─── renderTasksPage — ?view=table toggle (AXR-1.3) ──────────────────────────

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -3726,6 +3726,150 @@ describe("renderTasksPage — board view (AXR-1.3)", () => {
     const html = renderBoard([]);
     expect(html).toContain("view=table");
   });
+
+  // ─── Task board card slide-over drawer (AXR-1.4) ───────────────────────────────
+  // Each card opens a drawer showing full task + joined PR detail via a checkbox-driven
+  // off-canvas pattern, reusing the existing chat-drawer mechanics.
+
+  test("each board card renders a hidden checkbox with id=task-drawer-toggle-{taskId}", () => {
+    const task: TaskItem = {
+      id: "DRAWER-TEST",
+      title: "Drawer test task",
+      status: "pending",
+      claimedBy: null,
+      assignee: null,
+    };
+    const html = renderBoard([task]);
+    expect(html).toContain('id="task-drawer-toggle-DRAWER-TEST"');
+    expect(html).toContain('class="task-drawer-toggle"');
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  test("drawer checkbox appears before the drawer panel in DOM order", () => {
+    const task: TaskItem = {
+      id: "DOM-ORDER-TEST",
+      title: "DOM order test",
+      status: "pending",
+      claimedBy: null,
+      assignee: null,
+    };
+    const html = renderBoard([task]);
+    const checkboxIndex = html.indexOf('id="task-drawer-toggle-DOM-ORDER-TEST"');
+    const drawerPanelIndex = html.indexOf('class="task-drawer"');
+    expect(checkboxIndex).toBeGreaterThanOrEqual(0);
+    expect(drawerPanelIndex).toBeGreaterThanOrEqual(0);
+    expect(checkboxIndex).toBeLessThan(drawerPanelIndex);
+  });
+
+  test("drawer renders a scrim label bound to the drawer toggle", () => {
+    const task: TaskItem = {
+      id: "SCRIM-TEST",
+      title: "Scrim test task",
+      status: "pending",
+      claimedBy: null,
+      assignee: null,
+    };
+    const html = renderBoard([task]);
+    expect(html).toContain('class="task-drawer-scrim"');
+    expect(html).toContain('for="task-drawer-toggle-SCRIM-TEST"');
+  });
+
+  test("drawer panel renders the task title and id", () => {
+    const task: TaskItem = {
+      id: "TITLE-ID-TEST",
+      title: "My task title",
+      status: "pending",
+      claimedBy: null,
+      assignee: null,
+    };
+    const html = renderBoard([task]);
+    const drawerPanel = html.match(
+      /class="task-drawer"[^>]*>([\s\S]*?)<\/div>\s*<\/div>\s*<\/div>/,
+    );
+    expect(drawerPanel).not.toBeNull();
+    if (drawerPanel) {
+      expect(drawerPanel[1]).toContain("My task title");
+      expect(drawerPanel[1]).toContain("TITLE-ID-TEST");
+    }
+  });
+
+  test("drawer panel includes PR state and reviewState when a joined PR exists", () => {
+    const task: TaskItem = {
+      id: "PR-STATE-TEST",
+      title: "PR state test",
+      status: "in_progress",
+      claimedBy: "agent-1",
+      assignee: null,
+      repo: "org/repo",
+      pr: 42,
+    };
+    const pr: PrListItem = {
+      id: "pr-1",
+      repo: "org/repo",
+      prNumber: 42,
+      staged: false,
+      state: "open",
+      reviewState: "approved",
+      patchCycles: 1,
+      reviewCycles: 2,
+      blocked: false,
+    };
+    const html = renderBoard([task], {}, undefined, { [task.id]: pr });
+    const drawerPanel = html.match(
+      /class="task-drawer"[^>]*>([\s\S]*?)<\/div>\s*<\/div>\s*<\/div>/,
+    );
+    expect(drawerPanel).not.toBeNull();
+    if (drawerPanel) {
+      // The drawer should show the PR state and review state
+      expect(drawerPanel[1]).toContain("open");
+      expect(drawerPanel[1]).toContain("approved");
+    }
+  });
+
+  test("multiple cards each get unique drawer checkbox ids", () => {
+    const tasks: TaskItem[] = [
+      { id: "TASK-1", title: "Task 1", status: "pending", claimedBy: null, assignee: null },
+      { id: "TASK-2", title: "Task 2", status: "pending", claimedBy: null, assignee: null },
+      { id: "TASK-3", title: "Task 3", status: "pending", claimedBy: null, assignee: null },
+    ];
+    const html = renderBoard(tasks);
+    expect(html).toContain('id="task-drawer-toggle-TASK-1"');
+    expect(html).toContain('id="task-drawer-toggle-TASK-2"');
+    expect(html).toContain('id="task-drawer-toggle-TASK-3"');
+    // Verify no duplicate ids
+    const idMatches = html.match(/id="task-drawer-toggle-[^"]+"/g) ?? [];
+    expect(idMatches.length).toBe(3);
+    expect(new Set(idMatches).size).toBe(3);
+  });
+
+  test("readOnly board rendering does not render drawer toggles or scrims", () => {
+    const task: TaskItem = {
+      id: "READONLY-TEST",
+      title: "Readonly task",
+      status: "pending",
+      claimedBy: null,
+      assignee: null,
+    };
+    const html = renderTasksPage(
+      [task],
+      {},
+      false,
+      USER_NAME,
+      {},
+      BOARD_PAGINATION,
+      undefined,
+      undefined,
+      true, // readOnly = true
+      "America/Los_Angeles",
+      {},
+      "board",
+    );
+    // Check that the HTML elements are not rendered (the class definitions in CSS are OK)
+    expect(html).not.toContain('id="task-drawer-toggle-');
+    expect(html).not.toContain('class="task-drawer-scrim"');
+    expect(html).not.toContain('class="task-drawer"');
+    expect(html).not.toContain('data-drawer-toggle=');
+  });
 });
 
 // ─── renderTasksPage — ?view=table toggle (AXR-1.3) ──────────────────────────


### PR DESCRIPTION
## Summary
- Adds a slide-over detail drawer to Tasks board cards, reusing the existing `.chat-drawer-toggle` checkbox-driven off-canvas pattern (CFB-3.2) instead of a new JS library/framework
- Clicking a card now opens its own drawer (title, id, status, repo, session, agent, description, joined PR state/reviewState/blocked) in place, rather than navigating away; title/id links still deep-link to the full detail page
- Closes via scrim click, an in-drawer close control, or Escape — all through the same checkbox toggle. Opening a new card's drawer also closes any other drawer left open, since multiple `.task-drawer` panels share the same fixed position

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Clicking a board card opens a slide-over drawer showing full task + joined PR detail, using the checkbox-driven pattern (no new JS framework/library) | MET |
| 2 | The drawer closes via the same checkbox-toggle mechanism used by the existing chat-drawer pattern | MET |
| 3 | Unit test asserting the drawer markup (checkbox id, labelled toggle, drawer content section) renders per card | MET |

## Test Plan
- 9 new unit tests in `admin/src/admin-ui-pages.unit.test.ts` covering checkbox id/DOM order, scrim label binding, drawer content (title/id/PR state), per-card unique ids, readOnly omission, and the close-other-open-drawers fix
- `NODE_ENV=test bun test admin/src/admin-ui-pages.unit.test.ts` — 719 pass, 0 fail
- `bunx biome lint` — clean
- `bun run --filter='*' --sequential typecheck` — clean across all workspaces
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
