### PR TITLE
feat: add default-agent route and navbar Queue & Activity tab

### DIFF
--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -2823,6 +2823,176 @@ describe("admin UI — member access control", () => {
   });
 });
 
+// ─── Default-agent queue-activity redirect (AXR-3.3) ─────────────────────────
+
+describe("admin UI — GET /admin/queue-activity (default-agent redirect)", () => {
+  it("unauthenticated GET /admin/queue-activity redirects to /admin/login", async () => {
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/queue-activity");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin/login");
+  });
+
+  it("admin is redirected to the first agent's queue-activity page (full fleet)", async () => {
+    const adminCookie = await makeSessionCookie(
+      SESSION_SECRET,
+      "google-sub-admin",
+      "admin@example.com",
+      true,
+    );
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/queue-activity", {
+      headers: { Cookie: `admin_session=${adminCookie}` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      `/admin/agents/${AGENT_ID}/queue-activity`,
+    );
+  });
+
+  it("non-admin AgentMember is redirected to their first accessible agent's queue-activity page", async () => {
+    const MEMBER_EMAIL = "member@example.com";
+    const OTHER_AGENT_ID = "agent-other-456";
+    const memberCookie = await makeSessionCookie(
+      SESSION_SECRET,
+      "google-sub-member",
+      MEMBER_EMAIL,
+      false,
+    );
+    const deps = makeMockDeps({
+      agentMemberService: {
+        listByEmail: async (email: string) =>
+          email === MEMBER_EMAIL
+            ? [
+                {
+                  id: "m1",
+                  agentId: AGENT_ID,
+                  email: MEMBER_EMAIL,
+                  createdAt: new Date(),
+                },
+              ]
+            : [],
+        exists: async () => false,
+        add: async () => ({
+          id: "m1",
+          agentId: AGENT_ID,
+          email: MEMBER_EMAIL,
+          createdAt: new Date(),
+        }),
+        remove: async () => {},
+        listByAgentId: async () => [],
+      },
+      agentService: {
+        listAll: async () => [
+          {
+            id: AGENT_ID,
+            name: "My Agent",
+            slackId: "U1",
+            selfHosted: false,
+            typeName: "coding",
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          },
+          {
+            id: OTHER_AGENT_ID,
+            name: "Other Agent",
+            slackId: "U2",
+            selfHosted: false,
+            typeName: "coding",
+            createdAt: new Date("2024-01-01"),
+            updatedAt: new Date("2024-01-01"),
+          },
+        ],
+        listByIds: async (ids: string[]) =>
+          [
+            {
+              id: AGENT_ID,
+              name: "My Agent",
+              slackId: "U1",
+              selfHosted: false,
+              typeName: "coding",
+              createdAt: new Date("2024-01-01"),
+              updatedAt: new Date("2024-01-01"),
+            },
+            {
+              id: OTHER_AGENT_ID,
+              name: "Other Agent",
+              slackId: "U2",
+              selfHosted: false,
+              typeName: "coding",
+              createdAt: new Date("2024-01-01"),
+              updatedAt: new Date("2024-01-01"),
+            },
+          ].filter((a) => ids.includes(a.id)),
+        searchByName: async () => [],
+        listOptions: async () => [
+          { id: AGENT_ID, name: "My Agent" },
+          { id: OTHER_AGENT_ID, name: "Other Agent" },
+        ],
+        create: async () => {
+          throw new Error("not implemented");
+        },
+        delete: async () => {},
+        getDetail: async () => null,
+        updateFields: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const res = await app.request("/admin/queue-activity", {
+      headers: { Cookie: `admin_session=${memberCookie}` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      `/admin/agents/${AGENT_ID}/queue-activity`,
+    );
+  });
+
+  it("non-admin with zero accessible agents is redirected to /admin/agents instead of a queue-activity page", async () => {
+    const outsiderCookie = await makeSessionCookie(
+      SESSION_SECRET,
+      "google-sub-outsider",
+      "outsider@example.com",
+      false,
+    );
+    const deps = makeMockDeps({
+      agentMemberService: {
+        listByEmail: async () => [],
+        exists: async () => false,
+        add: async () => ({
+          id: "m1",
+          agentId: AGENT_ID,
+          email: "member@example.com",
+          createdAt: new Date(),
+        }),
+        remove: async () => {},
+        listByAgentId: async () => [],
+      },
+      agentService: {
+        listAll: async () => [],
+        listByIds: async () => [],
+        searchByName: async () => [],
+        listOptions: async () => [],
+        create: async () => {
+          throw new Error("not implemented");
+        },
+        delete: async () => {},
+        getDetail: async () => null,
+        updateFields: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+    const app = createAdminUIApp(deps);
+    const res = await app.request("/admin/queue-activity", {
+      headers: { Cookie: `admin_session=${outsiderCookie}` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin/agents");
+  });
+});
+
 // ─── Agent delete route ───────────────────────────────────────────────────────
 
 describe("admin UI — agent delete route", () => {

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -1108,17 +1108,29 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
 
   // ─── Agents list ──────────────────────────────────────────────────────────
 
-  app.get("/admin/agents", requireAuth, async (c) => {
-    let agents: Awaited<ReturnType<typeof agentService.listAll>>;
-    if (c.var.isAdmin) {
-      agents = await agentService.listAll();
-    } else {
-      const memberships = await agentMemberService.listByEmail(
-        c.var.userEmail.toLowerCase(),
-      );
-      const agentIds = memberships.map((m) => m.agentId);
-      agents = await agentService.listByIds(agentIds);
+  // Access-scoping shared by the agents list and the /admin/queue-activity
+  // default-agent redirect: admins see the full fleet, non-admins see only
+  // the agents they have an AgentMember row for. No ordering/ranking beyond
+  // whatever agentService.listAll()/listByIds() already returns.
+  async function resolveAccessibleAgents(
+    userEmail: string,
+    isAdmin: boolean,
+  ): Promise<Awaited<ReturnType<typeof agentService.listAll>>> {
+    if (isAdmin) {
+      return agentService.listAll();
     }
+    const memberships = await agentMemberService.listByEmail(
+      userEmail.toLowerCase(),
+    );
+    const agentIds = memberships.map((m) => m.agentId);
+    return agentService.listByIds(agentIds);
+  }
+
+  app.get("/admin/agents", requireAuth, async (c) => {
+    const agents = await resolveAccessibleAgents(
+      c.var.userEmail,
+      c.var.isAdmin,
+    );
     const successMsg =
       c.req.query("success") === "deleted" ? "Agent deleted." : undefined;
     // Surfaced by POST /admin/agents/:id/delete after a successful
@@ -1140,6 +1152,24 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         manualSteps,
       }),
     );
+  });
+
+  // ─── Default-agent queue-activity redirect (AXR-3.3) ─────────────────────
+  // Top-level entry point into GET /admin/agents/:id/queue-activity: resolve
+  // the caller's accessible agents with the same scoping as /admin/agents
+  // above, then jump straight to the first one's queue-activity page. Zero
+  // accessible agents falls back to the agents list rather than erroring.
+
+  app.get("/admin/queue-activity", requireAuth, async (c) => {
+    const agents = await resolveAccessibleAgents(
+      c.var.userEmail,
+      c.var.isAdmin,
+    );
+    const firstAgent = agents[0];
+    if (!firstAgent) {
+      return c.redirect("/admin/agents", 302);
+    }
+    return c.redirect(`/admin/agents/${firstAgent.id}/queue-activity`, 302);
   });
 
   // ─── Agent detail ─────────────────────────────────────────────────────────

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     },
     "agent": {
       "name": "@shipwright/agent",
-      "version": "1.246.0",
+      "version": "1.249.0",
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@sentry/bun": "^10.63.0",
@@ -102,7 +102,7 @@
     },
     "metrics": {
       "name": "@shipwright/metrics",
-      "version": "1.246.0",
+      "version": "1.249.0",
       "dependencies": {
         "@hono/zod-openapi": "^0.18.3",
         "@sentry/bun": "^10.63.0",
@@ -120,7 +120,7 @@
     },
     "plugins/shipwright": {
       "name": "@shipwright/plugin",
-      "version": "1.246.0",
+      "version": "1.249.0",
       "dependencies": {
         "js-yaml": "^4.3.1",
       },

--- a/lib/web/toolbar.ts
+++ b/lib/web/toolbar.ts
@@ -192,6 +192,11 @@ export function renderShipwrightToolbar(
   const adminBase = opts.adminBaseUrl ?? "";
   const active = (prefix: string) =>
     activePath.startsWith(prefix) ? " active" : "";
+  // /admin/agents/:id/queue-activity starts with /admin/agents, so without
+  // this special case both "Agents" and "Queue & Activity" would highlight
+  // simultaneously on that page. Any path containing "/queue-activity"
+  // belongs to the new tab instead.
+  const isQueueActivity = activePath.includes("/queue-activity");
 
   // Public proof surface: only the read-only Metrics + Tasks views are routed and
   // reachable, so omit every /admin/* link and the sign-out form (they 404 on the
@@ -214,10 +219,11 @@ export function renderShipwrightToolbar(
   <nav class="vos-toolbar" aria-label="Site navigation">
     <a href="${adminBase}/admin/agents" class="vos-wordmark">Shipwright</a>
     <div id="vos-nav-content" class="vos-nav">
-      <a href="${adminBase}/admin/agents" class="vos-nav-link${active("/admin/agents")}">Agents</a>
+      <a href="${adminBase}/admin/agents" class="vos-nav-link${isQueueActivity ? "" : active("/admin/agents")}">Agents</a>
       <a href="${adminBase}/admin/tasks?state=ready" class="vos-nav-link${active("/admin/tasks")}">Tasks</a>
       <a href="${adminBase}/admin/prs" class="vos-nav-link${active("/admin/prs")}">PRs</a>
       <a href="${adminBase}/admin/chat" class="vos-nav-link${active("/admin/chat")}">Chat</a>
+      <a href="${adminBase}/admin/queue-activity" class="vos-nav-link${isQueueActivity ? " active" : ""}">Queue &amp; Activity</a>
       <a href="${metricsUrl}" class="vos-nav-link${active(metricsUrl)}">Metrics</a>
     </div>
     <div class="vos-user">

--- a/lib/web/toolbar.unit.test.ts
+++ b/lib/web/toolbar.unit.test.ts
@@ -59,6 +59,56 @@ describe("renderShipwrightToolbar", () => {
       expect(html).toContain("<script>");
       expect(html).toContain("change");
     });
+
+    test("contains a Queue & Activity link pointing at /admin/queue-activity", () => {
+      expect(html).toContain('href="/admin/queue-activity"');
+      expect(html).toContain("Queue &amp; Activity");
+    });
+  });
+
+  describe("active-tab highlighting: Agents vs Queue & Activity (AXR-3.3)", () => {
+    function activeHref(html: string): string | undefined {
+      const match = html.match(
+        /<a href="([^"]+)" class="vos-nav-link active">/,
+      );
+      return match?.[1];
+    }
+
+    test("/admin/agents highlights the Agents tab, not Queue & Activity", () => {
+      const html = renderShipwrightToolbar({
+        userName: "Alice",
+        activePath: "/admin/agents",
+        logoutAction: "/auth/logout",
+      });
+      expect(activeHref(html)).toBe("/admin/agents");
+      expect(html).toContain(
+        '<a href="/admin/queue-activity" class="vos-nav-link">',
+      );
+    });
+
+    test("/admin/agents/:id highlights the Agents tab, not Queue & Activity", () => {
+      const html = renderShipwrightToolbar({
+        userName: "Alice",
+        activePath: "/admin/agents/agent-123",
+        logoutAction: "/auth/logout",
+      });
+      expect(activeHref(html)).toBe("/admin/agents");
+      expect(html).toContain(
+        '<a href="/admin/queue-activity" class="vos-nav-link">',
+      );
+    });
+
+    test("/admin/agents/:id/queue-activity highlights Queue & Activity, not Agents", () => {
+      const html = renderShipwrightToolbar({
+        userName: "Alice",
+        activePath: "/admin/agents/agent-123/queue-activity",
+        logoutAction: "/auth/logout",
+      });
+      expect(activeHref(html)).toBe("/admin/queue-activity");
+      expect(html).toContain(
+        '<a href="/admin/agents" class="vos-nav-link">',
+      );
+    });
   });
 
   describe("read-only mode (readOnly=true)", () => {

--- a/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
+++ b/metrics/src/dashboard/__snapshots__/dashboard-page.unit.test.ts.snap
@@ -166,6 +166,7 @@ exports[`renderDashboardPage — snapshot renders full page for a regular user 1
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
+      <a href="/admin/queue-activity" class="vos-nav-link">Queue &amp; Activity</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">
@@ -657,6 +658,7 @@ exports[`renderDashboardPage — snapshot renders full page for an owner 1`] = `
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
+      <a href="/admin/queue-activity" class="vos-nav-link">Queue &amp; Activity</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">
@@ -1148,6 +1150,7 @@ exports[`renderDashboardPage — MG-1.2 clickable metric graphs snapshot matches
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
+      <a href="/admin/queue-activity" class="vos-nav-link">Queue &amp; Activity</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">
@@ -1639,6 +1642,7 @@ exports[`renderDashboardPage — TK-1.2 token trends chart snapshot matches afte
       <a href="/admin/tasks?state=ready" class="vos-nav-link">Tasks</a>
       <a href="/admin/prs" class="vos-nav-link">PRs</a>
       <a href="/admin/chat" class="vos-nav-link">Chat</a>
+      <a href="/admin/queue-activity" class="vos-nav-link">Queue &amp; Activity</a>
       <a href="/dashboard" class="vos-nav-link active">Metrics</a>
     </div>
     <div class="vos-user">


### PR DESCRIPTION
## Summary
- Extract the admin/AgentMember access-scoping logic from `GET /admin/agents` into a reusable `resolveAccessibleAgents()` helper, with identical behavior
- Add `GET /admin/queue-activity` (requireAuth), which resolves the caller's accessible agents and 302-redirects to the first agent's `/admin/agents/{id}/queue-activity` page, or `/admin/agents` if the caller has zero accessible agents
- Add a "Queue & Activity" link to the authenticated branch of the shared navbar (`lib/web/toolbar.ts`), and fix the active-tab highlight logic so any path containing `/queue-activity` highlights the new tab instead of "Agents"

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | GET /admin/queue-activity redirects to the first accessible agent's queue-activity page, matching /admin/agents scoping exactly | MET |
| 2 | Zero accessible agents redirects to /admin/agents instead of erroring | MET |
| 3 | Navbar shows a "Queue & Activity" link in the authenticated branch; read-only/public branch unchanged | MET |
| 4 | Any /admin/agents/:id/queue-activity URL highlights "Queue & Activity", not "Agents" | MET |
| 5 | Smoke test (admin/non-admin/zero-agents fixtures) + unit test (active-tab highlighting) added; no existing test removed | MET |

## Test Plan
- Smoke tests in `admin-ui.smoke.test.ts`: unauthenticated redirect, admin full-fleet redirect, non-admin/AgentMember-scoped redirect, zero-accessible-agents redirect
- Unit tests in `toolbar.unit.test.ts`: Queue & Activity link presence, active-tab highlighting for `/admin/agents`, `/admin/agents/:id`, and `/admin/agents/:id/queue-activity`
- Independent spec-compliance review: all 5 acceptance criteria MET
- `task typecheck`, `task lint` pass; touched-file test suite (`admin-ui.smoke.test.ts`, `toolbar.unit.test.ts`, `dashboard-page.unit.test.ts`) — 393/393 pass
- Full-suite `task ci` has 31 pre-existing failures unrelated to this diff (env-var/config tests, task-store PR validation) — verified reproducing identically on a clean `origin/main` checkout at the same commit this branch forked from
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
