### PR TITLE
feat: port patch-author allowlist into patch.md scope check and author-reply detection

### DIFF
--- a/plugins/shipwright/CLAUDE.md
+++ b/plugins/shipwright/CLAUDE.md
@@ -62,7 +62,9 @@ always names a specific PR (`org/repo#number`); there is no self-scan/queue-buil
 Any PR is serviceable when named this way, regardless of author — it is not limited to PRs
 authored by the authenticated user. `patch` and `deploy` are scoped to the authenticated
 user's own open PRs (matching by PR author), because they take write actions (pushing fixes,
-merging) that should only be performed on PRs the agent owns.
+merging) that should only be performed on PRs the agent owns. `patch`'s scope is additionally
+config-driven: a PR authored by an entry in the agent's configured `patchAuthorAllowlist` is
+also in scope, on top of (not instead of) the agent's own PRs.
 
 Applies to: **review**, **patch**, **deploy**
 

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -54,6 +54,56 @@ describe("patch.md — explicit-target-only argument contract (WLS-3.3)", () => 
   });
 });
 
+describe("patch.md — patch-author allowlist (PAS-1.1)", () => {
+  it("Step 1 fetches the agent's patchAuthorAllowlist via /agents/{id}/config, mirroring review.md's config-fetch pattern", () => {
+    const step1Idx = content.indexOf("## Step 1: Get Own GH Login");
+    expect(step1Idx).toBeGreaterThan(-1);
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    expect(step2Idx).toBeGreaterThan(-1);
+    const step1Section = content.slice(step1Idx, step2Idx);
+    expect(step1Section).toContain("CURRENT_USER=$(gh api /user -q '.login')");
+    expect(step1Section).toContain("/agents/$SHIPWRIGHT_AGENT_ID/config");
+    expect(step1Section).toContain("patchAuthorAllowlist");
+    expect(step1Section).toContain("PATCH_AUTHOR_ALLOWLIST");
+  });
+
+  it("documents fail-closed behavior: a failed config fetch or empty/absent allowlist falls back to CURRENT_USER-only", () => {
+    const step1Idx = content.indexOf("## Step 1: Get Own GH Login");
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    const step1Section = content.slice(step1Idx, step2Idx);
+    expect(step1Section).toMatch(/fail[- ]closed/i);
+    expect(step1Section).toContain("today's `CURRENT_USER`-only behavior");
+  });
+
+  it("Step 2's scope check widens to author.login == CURRENT_USER OR author.login in PATCH_AUTHOR_ALLOWLIST, preserving the pre-existing CURRENT_USER-only substring", () => {
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    const step2_5Idx = content.indexOf("## Step 2.5:");
+    const step2Section = content.slice(step2Idx, step2_5Idx);
+    // Pre-existing substring must survive (WLS-3.3's original test pins this exact string).
+    expect(step2Section).toContain("author.login != CURRENT_USER");
+    // New: the gate must also reference the allowlist as an alternative match.
+    expect(step2Section).toContain("PATCH_AUTHOR_ALLOWLIST");
+  });
+
+  it("Step 2 captures PR_AUTHOR from the gh pr view result for reuse at Step 5a.7", () => {
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    const step2_5Idx = content.indexOf("## Step 2.5:");
+    const step2Section = content.slice(step2Idx, step2_5Idx);
+    expect(step2Section).toContain("PR_AUTHOR");
+  });
+
+  it("Step 5a.7's author-reply detection threads PR_AUTHOR instead of a hardcoded CURRENT_USER-only comparison", () => {
+    const step5a7Idx = content.indexOf("### Step 5a.7: Second-Round Escalation Check (RPF-1.3)");
+    expect(step5a7Idx).toBeGreaterThan(-1);
+    const nextSectionIdx = content.indexOf("### Step 5a.8", step5a7Idx);
+    const step5a7End = nextSectionIdx > -1 ? nextSectionIdx : content.indexOf("### Step 5b", step5a7Idx);
+    expect(step5a7End).toBeGreaterThan(-1);
+    const step5a7Section = content.slice(step5a7Idx, step5a7End);
+    expect(step5a7Section).toContain("author.login == PR_AUTHOR");
+    expect(step5a7Section).not.toContain("author.login == CURRENT_USER");
+  });
+});
+
 describe("patch.md — pre-work PR claim lock (CLM-2.1)", () => {
   it("Step 4 (merge conflicts): claims the PR (phase: patch) before dispatching the conflict-resolution subagent", () => {
     const step4bIdx = content.indexOf("### Step 4b: Dispatch Conflict Resolution Subagent");

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -85,6 +85,30 @@ describe("patch.md — patch-author allowlist (PAS-1.1)", () => {
     expect(step2Section).toContain("PATCH_AUTHOR_ALLOWLIST");
   });
 
+  it("Step 1 keeps the allowlist as a JSON array (jq -c), not a comma-joined string, so Step 2 can test exact membership", () => {
+    const step1Idx = content.indexOf("## Step 1: Get Own GH Login");
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    const step1Section = content.slice(step1Idx, step2Idx);
+    expect(step1Section).toContain("jq -c '.patchAuthorAllowlist // []'");
+    // A comma-joined string is exactly what invites a substring match downstream.
+    expect(step1Section).not.toContain('join(",")');
+  });
+
+  it("Step 2 shows a concrete exact-membership jq snippet and explicitly warns off the substring form", () => {
+    const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
+    const step2_5Idx = content.indexOf("## Step 2.5:");
+    const step2Section = content.slice(step2Idx, step2_5Idx);
+    // The mechanical check must be shown, not just described in prose.
+    expect(step2Section).toContain(
+      `jq -e --arg a "$PR_AUTHOR" 'any(.[]; . == $a)'`,
+    );
+    // And the unsafe substring alternative must be called out as forbidden.
+    expect(step2Section).toContain(
+      `[[ "$PATCH_AUTHOR_ALLOWLIST" == *"$PR_AUTHOR"* ]]`,
+    );
+    expect(step2Section).toMatch(/never a substring|not a substring|Do \*\*not\*\*/);
+  });
+
   it("Step 2 captures PR_AUTHOR from the gh pr view result for reuse at Step 5a.7", () => {
     const step2Idx = content.indexOf("## Step 2: Resolve Target PR");
     const step2_5Idx = content.indexOf("## Step 2.5:");

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -23,8 +23,9 @@ addressing, or when no target PR is given.
 
 Parse `$ARGUMENTS`:
 - `org/repo#number` (e.g. `app-vitals/shipwright#123`): **required** — target a specific
-  PR. Fetch just this PR (still scoped to `CURRENT_USER` as author, per the Independence
-  Principles' "own PRs only" rule for patch) and classify it into Lists A/C/D as usual from
+  PR. Fetch just this PR (still scoped to `CURRENT_USER` as author, or an entry in the
+  agent's configured `patchAuthorAllowlist`, per the Independence Principles' "own PRs only"
+  rule for patch — see Step 1/Step 2, PAS-1.1) and classify it into Lists A/C/D as usual from
   Step 3 onward.
 - _(no arguments)_: not supported — respond `[silent]` and stop, with no GitHub scan across
   all open PRs (see Step 0).
@@ -59,6 +60,24 @@ into all subsequent commands that need it:
 CURRENT_USER=$(gh api /user -q '.login')
 ```
 
+Also resolve the agent's configured patch-author allowlist (PAS-1.1) — an additive list of
+GitHub logins, beyond `CURRENT_USER`, whose own open PRs this agent may patch. This mirrors
+`check-patch.ts`'s `patchAuthorAllowlistRef` (RAS-1.1/DBR-1.4), the same allowlist the
+server-side candidate provider already applies when building patch candidates, and follows
+`review.md`'s Step 14 config-fetch pattern (`GET /agents/{id}/config`):
+
+```bash
+PATCH_AUTHOR_ALLOWLIST=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.patchAuthorAllowlist // [] | join(",")')
+```
+
+**Fail-closed, not fail-open.** On any curl failure, or when `.patchAuthorAllowlist` is
+absent or an empty array, `PATCH_AUTHOR_ALLOWLIST` ends up empty — Step 2's scope check then
+falls back to exactly today's `CURRENT_USER`-only behavior. An unreachable config endpoint or
+an unsynced allowlist must never be read as "allow everyone"; it must be read as "no
+additional authors beyond `CURRENT_USER`," identical to `patchAuthorAllowlistRef`'s own
+fail-closed default on the server side.
+
 ---
 
 ## Step 2: Resolve Target PR
@@ -76,8 +95,16 @@ gh pr view {number} --repo {org}/{repo} \
   --json number,title,headRefName,headRefOid,additions,deletions,mergeStateStatus,state,author
 ```
 
-- **Not found, or `state != "OPEN"`, or `author.login != CURRENT_USER`**: this PR is not
-  workable by patch (per the Independence Principles' "own PRs only" scope). Print
+Capture `PR_AUTHOR` from this result's `author.login` field (e.g. via `jq -r '.author.login'`
+on the same JSON) — reused unchanged at Step 5a.7's author-reply detection below, mirroring
+`check-patch.ts`'s `prAuthor = data.prAuthor ?? currentUser` threading (RAS-1.1/DBR-1.4). For
+a self-authored PR, `PR_AUTHOR` naturally equals `CURRENT_USER`; for an allowlisted PR it's
+that PR's own real author.
+
+- **Not found, or `state != "OPEN"`, or (`author.login != CURRENT_USER` AND `author.login` is
+  not in `PATCH_AUTHOR_ALLOWLIST`)**: this PR is not workable by patch (per the Independence
+  Principles' "own PRs only" scope, widened by PAS-1.1 to include any agent-configured
+  `patchAuthorAllowlist` entry from Step 1). Print
   `⚠ PR {org}/{repo}#{number} not found among own open PRs.` and stop.
 - **Match found**: use it as the sole entry in the unified PR list and proceed directly to
   Step 2.5.
@@ -742,7 +769,9 @@ same disagreement.
 pre-filter, not the final gate — see Step 2 below for the decisive judgment. For each
 qualifying review from Step 3a (`state == "COMMENTED"` or `"CHANGES_REQUESTED"`, contributing
 to this PR's List A membership), check the PR-level comments already fetched in Step 3a
-(`comments.nodes`) for an author reply: a comment whose `author.login == CURRENT_USER` with
+(`comments.nodes`) for an author reply: a comment whose `author.login == PR_AUTHOR` (captured
+in Step 2 from the PR's own `author.login`, per PAS-1.1 — not a hardcoded `CURRENT_USER`
+comparison, so a genuine reply from an allowlisted PR's real author is recognized too) with
 `createdAt` **before** that review's `submittedAt`. This mirrors `check-patch.ts`'s
 `isAddressedByAuthorReply` (an author reply *after* a review marks that review addressed) as
 a shared timestamp-comparison mechanism, but checks the opposite direction — a reply dated

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -68,15 +68,23 @@ server-side candidate provider already applies when building patch candidates, a
 
 ```bash
 PATCH_AUTHOR_ALLOWLIST=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_AGENT_API_KEY" \
-  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -r '.patchAuthorAllowlist // [] | join(",")')
+  "$SHIPWRIGHT_API_URL/agents/$SHIPWRIGHT_AGENT_ID/config" | jq -c '.patchAuthorAllowlist // []')
+PATCH_AUTHOR_ALLOWLIST=${PATCH_AUTHOR_ALLOWLIST:-[]}
 ```
 
+Keep `PATCH_AUTHOR_ALLOWLIST` as a **JSON array**, not a comma-joined string. Step 2's scope
+check gates a write-action command, so it must test exact membership; a flattened string
+invites a substring test (`[[ "$PATCH_AUTHOR_ALLOWLIST" == *"$PR_AUTHOR"* ]]`), which would
+match `bot` against an allowlist entry of `dependabot`, or `renovate` against an author of
+`not-renovate-bot`. The array form keeps `jq`'s element-wise equality available — see Step 2.
+
 **Fail-closed, not fail-open.** On any curl failure, or when `.patchAuthorAllowlist` is
-absent or an empty array, `PATCH_AUTHOR_ALLOWLIST` ends up empty — Step 2's scope check then
-falls back to exactly today's `CURRENT_USER`-only behavior. An unreachable config endpoint or
-an unsynced allowlist must never be read as "allow everyone"; it must be read as "no
-additional authors beyond `CURRENT_USER`," identical to `patchAuthorAllowlistRef`'s own
-fail-closed default on the server side.
+absent or an empty array, `PATCH_AUTHOR_ALLOWLIST` ends up as the empty JSON array `[]` (the
+`${...:-[]}` default covers the curl-failure case, where the pipeline emits nothing) — Step
+2's scope check then falls back to exactly today's `CURRENT_USER`-only behavior. An
+unreachable config endpoint or an unsynced allowlist must never be read as "allow everyone";
+it must be read as "no additional authors beyond `CURRENT_USER`," identical to
+`patchAuthorAllowlistRef`'s own fail-closed default on the server side.
 
 ---
 
@@ -101,10 +109,33 @@ on the same JSON) — reused unchanged at Step 5a.7's author-reply detection bel
 a self-authored PR, `PR_AUTHOR` naturally equals `CURRENT_USER`; for an allowlisted PR it's
 that PR's own real author.
 
-- **Not found, or `state != "OPEN"`, or (`author.login != CURRENT_USER` AND `author.login` is
-  not in `PATCH_AUTHOR_ALLOWLIST`)**: this PR is not workable by patch (per the Independence
-  Principles' "own PRs only" scope, widened by PAS-1.1 to include any agent-configured
-  `patchAuthorAllowlist` entry from Step 1). Print
+Then evaluate the in-scope test with an **exact** membership check — never a substring one:
+
+```bash
+# In scope iff PR_AUTHOR is CURRENT_USER, or equals an allowlist entry exactly.
+# `jq -e` exits 0 only when some element is character-for-character equal to
+# $PR_AUTHOR, and exits non-zero on `false` OR on malformed/empty input — so a
+# failed config fetch in Step 1 fails closed here rather than widening scope.
+if [ "$PR_AUTHOR" = "$CURRENT_USER" ] || \
+   printf '%s' "$PATCH_AUTHOR_ALLOWLIST" \
+     | jq -e --arg a "$PR_AUTHOR" 'any(.[]; . == $a)' >/dev/null 2>&1; then
+  IN_SCOPE=true
+else
+  IN_SCOPE=false
+fi
+```
+
+Do **not** substitute a substring form such as `[[ "$PATCH_AUTHOR_ALLOWLIST" == *"$PR_AUTHOR"* ]]`.
+Patch takes write actions (pushing commits, merging), so a false positive — `bot` matching an
+allowlisted `dependabot`, or `renovate` matching an author `not-renovate-bot` — would let
+patch act on an out-of-scope PR. This mirrors `check-patch.ts`'s server-side
+`listAllowlistedOpenPrs`, which queries `gh pr list --author {login}` once per allowlist
+entry and is therefore exact by construction.
+
+- **Not found, or `state != "OPEN"`, or `IN_SCOPE` is false (i.e. `author.login != CURRENT_USER`
+  AND `author.login` is not exactly equal to any entry in `PATCH_AUTHOR_ALLOWLIST`)**: this PR
+  is not workable by patch (per the Independence Principles' "own PRs only" scope, widened by
+  PAS-1.1 to include any agent-configured `patchAuthorAllowlist` entry from Step 1). Print
   `⚠ PR {org}/{repo}#{number} not found among own open PRs.` and stop.
 - **Match found**: use it as the sole entry in the unified PR list and proceed directly to
   Step 2.5.


### PR DESCRIPTION
## Summary
- Widens `/shipwright:patch` Step 2's authorization gate to accept PRs authored by either `CURRENT_USER` or an entry in the agent's configured `patchAuthorAllowlist` (fetched from `GET /agents/{id}/config`), instead of hardcoding `CURRENT_USER`-only — fail-closed on a fetch failure or empty/absent allowlist.
- Threads a real `PR_AUTHOR` variable (captured in Step 2's `gh pr view` result) into the Step 5a.7 author-reply-detection logic in place of the hardcoded `CURRENT_USER`, mirroring `check-patch.ts`'s own RAS-1.1/DBR-1.4 fix for the identical bug shape.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Step 2's scope check accepts `author.login == CURRENT_USER` OR `author.login` in `patchAuthorAllowlist`; fail-closed on fetch failure/empty allowlist | MET | Step 1 fetches `PATCH_AUTHOR_ALLOWLIST` via `/agents/{id}/config`; Step 2's gate widened while preserving fail-closed default |
| 2 | `PR_AUTHOR` captured in Step 2, threaded into Step 5a.7's author-reply detection | MET | Step 2 captures `PR_AUTHOR` from `gh pr view`'s `author.login`; Step 5a.7 now compares `author.login == PR_AUTHOR` |
| 3 | Content-layer tests only (`patch.content.test.ts`), net-new, no existing test retired | MET | 5 new tests added; pre-existing WLS-3.3 substring assertion preserved; all 163 tests pass |
| 4 | Manual verification note (not automated) | Documented | Re-running `/shipwright:patch` against a live app/renovate-authored PR should proceed past Step 2 instead of printing "not found among own open PRs" |

## Test Plan
- `bun test plugins/shipwright/commands/patch.content.test.ts` — 163 pass, 0 fail
- `task lint`, `task typecheck`, `task check-strings` — all pass
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
