### PR TITLE
feat: add dependency-patch remediation reference file

### DIFF
--- a/plugins/shipwright/references/dependency-patch.content.test.ts
+++ b/plugins/shipwright/references/dependency-patch.content.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REFERENCE_PATH = join(import.meta.dir, "dependency-patch.md");
+
+let content: string;
+
+beforeAll(() => {
+  if (existsSync(REFERENCE_PATH)) {
+    content = readFileSync(REFERENCE_PATH, "utf-8");
+  } else {
+    content = "";
+  }
+});
+
+describe("dependency-patch.md — file exists and has content", () => {
+  it("file exists", () => {
+    expect(existsSync(REFERENCE_PATH)).toBe(true);
+  });
+
+  it("is non-empty", () => {
+    expect(content.length).toBeGreaterThan(200);
+  });
+});
+
+describe("dependency-patch.md — cross-references dependency-risk-analysis.md", () => {
+  it("names dependency-risk-analysis.md directly as the producer of its inputs", () => {
+    expect(content).toContain("dependency-risk-analysis.md");
+  });
+
+  it("frames its inputs as the {recommendation, flags, reasoning} shape", () => {
+    expect(content).toContain("recommendation");
+    expect(content).toContain("flags");
+    expect(content).toContain("reasoning");
+  });
+});
+
+describe("dependency-patch.md — Inputs/Output sections", () => {
+  it("documents an Inputs section", () => {
+    expect(content).toContain("## Inputs");
+  });
+
+  it("documents an Output section", () => {
+    expect(content).toContain("## Output");
+  });
+
+  it("documents the PR's worktree and diff as inputs", () => {
+    expect(content.toLowerCase()).toContain("worktree");
+    expect(content.toLowerCase()).toContain("diff");
+  });
+});
+
+describe("dependency-patch.md — reproduce-before-fixing protocol", () => {
+  it("documents a reproduce-before-fixing protocol section", () => {
+    expect(content.toLowerCase()).toContain("reproduce-before-fixing protocol");
+  });
+
+  it("requires running the verification command before attempting any fix", () => {
+    expect(content.toLowerCase()).toContain("verification command");
+    expect(content.toLowerCase()).toContain("before");
+  });
+
+  it("requires re-running the verification command after the fix, before claiming it fixed", () => {
+    expect(content.toLowerCase()).toContain("re-run");
+    expect(content.toLowerCase()).toContain("after");
+    expect(content.toLowerCase()).toContain("claiming");
+  });
+});
+
+describe("dependency-patch.md — bounded remediation strategy catalog", () => {
+  it("documents the catalog is explicitly bounded", () => {
+    expect(content.toLowerCase()).toContain("bounded");
+  });
+
+  it("documents the transitive-dependency override/resolution pin strategy", () => {
+    expect(content.toLowerCase()).toContain("transitive");
+    expect(content.toLowerCase()).toContain("override");
+    expect(content.toLowerCase()).toContain("resolution pin");
+  });
+
+  it("documents the removed/renamed first-party API call-site update strategy", () => {
+    expect(content.toLowerCase()).toContain("renamed");
+    expect(content.toLowerCase()).toContain("removed");
+    expect(content.toLowerCase()).toContain("call site");
+  });
+});
+
+describe("dependency-patch.md — no-safe-strategy exit", () => {
+  it("documents the leave-as-hold exit language", () => {
+    expect(content.toLowerCase()).toContain("leave as hold");
+  });
+
+  it("documents that anything outside the catalog exits to hold", () => {
+    expect(content.toLowerCase()).toContain("outside");
+  });
+
+  it("documents that an unreproducible or unverifiable claim exits to hold", () => {
+    expect(content.toLowerCase()).toContain("unreproducible");
+    expect(content.toLowerCase()).toContain("unverifiable");
+  });
+
+  it("explicitly forbids fabricating a fix", () => {
+    expect(content.toLowerCase()).toContain("fabricate");
+  });
+});

--- a/plugins/shipwright/references/dependency-patch.md
+++ b/plugins/shipwright/references/dependency-patch.md
@@ -1,0 +1,108 @@
+# Dependency Patch Remediation
+
+Bounded remediation for a dependency-bump PR that a risk analysis has already flagged as
+needing attention. This reference consumes the `{recommendation, flags, reasoning}` shape
+produced by [`dependency-risk-analysis.md`](./dependency-risk-analysis.md) — that reference
+decides *whether* a dependency bump is risky; this one decides *what, if anything, to do
+about it* inside the PR's own worktree. It has no opinion on how the caller obtained the
+risk analysis result, how it fetched the PR into a worktree, how it reports the outcome, or
+how/whether it escalates to a human — those are the calling skill's concerns, not this
+reference's.
+
+## Inputs
+
+- **`recommendation`** — the `merge` / `review` / `hold` verdict produced by
+  `dependency-risk-analysis.md`. Remediation is typically only invoked for a `review` or
+  `hold` recommendation — a `merge` recommendation has, by definition, nothing to remediate.
+- **`flags`** — `breakingChange`, `securityRelevant`, `productionImpact` (booleans), from the
+  same analysis result. `breakingChange` is the flag most directly relevant here: it signals
+  that the failure this reference is being asked to fix is likely a genuine breaking
+  API/behavior change in the bumped package, not a transient flake.
+- **`reasoning`** — the free-text explanation from the risk analysis. Critically, this is
+  expected to name (or make directly derivable) a **verification command** — the test,
+  build, or lint invocation that demonstrates the breaking change in practice (e.g. "`bun
+  test` fails with `TypeError: x.oldMethod is not a function`", or "`cargo build` fails: `no
+  method named 'foo' found for struct 'Bar'`"). The reproduce-before-fixing protocol below
+  depends on this command being nameable — see the no-safe-strategy exit for what happens
+  when it isn't.
+- **the PR's worktree** — a local checkout of the dependency-bump PR's branch, with the
+  lockfile/manifest bump already applied.
+- **the PR's diff** — the actual dependency version bump(s) in the PR, for identifying
+  exactly which package(s) moved and by how much.
+
+## Output
+
+- **`outcome`** — one of `fixed` / `held` (exactly one per remediation attempt).
+- **`actions`** — free text describing what was actually changed (which catalog strategy was
+  applied, and to which file(s)) when `outcome` is `fixed`; empty/absent when `held`.
+- **`verificationCommand`** — the command identified from `reasoning`, run to reproduce the
+  failure and re-run to confirm the fix — recorded verbatim so the caller can show its exact
+  output rather than a paraphrase.
+- **`reasoning`** — free text explaining why the outcome was reached: either what the fix did
+  and how it was confirmed, or exactly why no in-catalog strategy applied, or why the failure
+  could not be reproduced or verified.
+
+## Reproduce-before-fixing protocol
+
+**Never attempt a fix before reproducing the failure.** Before touching any code:
+
+1. Extract the verification command named (or directly derivable) from `reasoning`.
+2. Run it, unmodified, in the PR's worktree — exactly as `dependency-risk-analysis.md`'s
+   `reasoning` described it, not a substitute or "equivalent" command.
+3. Confirm it fails the same way `reasoning` describes. If it does not fail — it passes
+   cleanly, or fails with a different, unrelated error — the finding is not reproducible
+   here and now. Do not guess at a fix for a failure you cannot see; exit via the
+   no-safe-strategy exit below.
+
+Only once the failure is reproduced locally, exactly as described, does the remediation
+strategy catalog below apply.
+
+**After applying a fix, re-run the same verification command before claiming anything
+fixed.** The exact command run in step 2 above — not a different or "equivalent" one — must
+be re-run after the fix, and it must pass. If it still fails, the fix did not work: do not
+report `outcome: fixed`. Treat a fix that doesn't clear re-verification exactly like an
+unreproducible failure, and exit via the no-safe-strategy exit below rather than reporting a
+fix the verification command itself contradicts.
+
+## Remediation strategy catalog
+
+This catalog is **bounded** — exactly two strategies are in scope. Nothing outside this list
+is attempted by this reference, no matter how plausible it looks:
+
+1. **Transitive-dependency override / resolution pin.** When the reproduced failure comes
+   from a *transitive* dependency (not the package the PR directly bumps) landing at a bad
+   version, pin it to a known-good version via the ecosystem's override mechanism — e.g.
+   npm/Yarn's `overrides` or `resolutions` field in `package.json`, a Cargo `[patch]`
+   section, or the equivalent resolution-pin mechanism for the project's toolchain. This
+   strategy never touches application code — only the dependency-resolution manifest and its
+   lockfile.
+2. **Removed/renamed first-party API call-site update.** When the reproduced failure is a
+   removed or renamed API in the *directly* bumped package, update the codebase's own call
+   site(s) to match the new API shape — e.g. renaming a method call, adjusting an import
+   path, or updating an argument list at each affected call site. This is a small, mechanical,
+   targeted call-site update scoped exactly to what the verification command's failure
+   names — not a broader refactor of surrounding code.
+
+## No-safe-strategy exit
+
+Anything outside the two catalog strategies above — and any claim that is unreproducible or
+unverifiable — exits to **leave as hold** rather than attempting a speculative fix. Do not
+fabricate a fix when the failure can't be reproduced, and do not report a fix that the
+re-run verification command doesn't actually confirm.
+
+Concretely, leave as hold when any of the following is true:
+
+- The verification command from `reasoning` does not reproduce the described failure (an
+  **unreproducible** claim — see the reproduce-before-fixing protocol above).
+- The reproduced failure requires a change outside the bounded catalog above — e.g. a
+  genuine breaking-behavior migration in application logic, a config schema change, a data
+  migration, or anything requiring judgment calls the catalog's two mechanical strategies
+  don't cover.
+- A fix was attempted from the catalog, but the re-run verification command still fails
+  afterward — an **unverifiable** fix, meaning the attempted fix did not actually resolve
+  the failure.
+
+In every one of these cases, report `outcome: held` with `reasoning` explaining exactly
+which condition applied, and stop — do not retry with a different guess, and do not report
+`outcome: fixed` on anything less than a passing re-run of the exact verification command
+identified at the start.


### PR DESCRIPTION
## Summary
- Adds `plugins/shipwright/references/dependency-patch.md`, a bounded reference for remediating a dependency-bump PR that `dependency-risk-analysis.md` has already flagged as `review`/`hold` — it defines the reproduce-before-fixing protocol, a two-strategy bounded remediation catalog (transitive-dependency override/resolution pin; removed/renamed first-party API call-site update), the re-verify step, and an explicit no-safe-strategy exit to "leave as hold".
- Pure reference content — no caller wiring in this task.
- Adds `plugins/shipwright/references/dependency-patch.content.test.ts` (content layer), mirroring `dependency-risk-analysis.content.test.ts`'s assertion style.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `dependency-patch.md` exists, documents Inputs/Output/protocol sections matching `dependency-risk-analysis.md`'s structure and cross-references it directly | MET |
| 2 | Reproduce-before-fixing protocol requires running the reasoning's named verification command before any fix, and re-running it after, before claiming fixed | MET |
| 3 | Remediation catalog is explicitly bounded (exactly two in-scope strategies); anything outside, or unreproducible/unverifiable, exits to "leave as hold" | MET |
| 4 | `dependency-patch.content.test.ts` added (content layer) asserting the required sections/language, mirroring the existing content test's style | MET |

## Test Plan
- `bun test plugins/shipwright/references/dependency-patch.content.test.ts` — 17/17 pass
- `bunx biome lint` on both new files — clean
- `task ci` — lint, check-strings, typecheck, check-config-docs, check-version-sync all pass. `test:coverage` fails at the repo-aggregate level due to 31 pre-existing failures in `metrics/src/lib/env.unit.test.ts`, `metrics/src/lib/errors.unit.test.ts`, and `task-store/src/routes/prs.openapi.smoke.test.ts` — confirmed these reproduce identically on an untouched worktree of `main` at the same commit (no diff applied), and GitHub's own CI is green on the latest merged main commit. Unrelated to this change (this PR only touches `plugins/shipwright/references/`).
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
