### PR TITLE
fix: raise drawer/scrim z-index above sticky toolbar (DNZ-1.1)

### DIFF
--- a/admin/src/admin-ui-pages.ts
+++ b/admin/src/admin-ui-pages.ts
@@ -2006,12 +2006,12 @@ const TASKS_PAGE_EXTRA_STYLES = `
     /* ─── Task board card slide-over drawer (AXR-1.4) ────────────────────── */
     .task-drawer-toggle { position:absolute;opacity:0;width:1px;height:1px;pointer-events:none }
     .task-drawer-scrim {
-      display:none;position:fixed;inset:0;z-index:55;
+      display:none;position:fixed;inset:0;z-index:101;
       background:rgba(0,0,0,0.4);cursor:pointer;
     }
     .task-drawer-toggle:checked ~ .task-drawer-scrim { display:block }
     .task-drawer {
-      position:fixed;top:0;right:0;bottom:0;z-index:60;
+      position:fixed;top:0;right:0;bottom:0;z-index:102;
       width:100%;max-width:400px;min-width:300px;
       background:#fff;border-left:1px solid #e8e8ee;
       overflow-y:auto;
@@ -4503,7 +4503,7 @@ const chatPageStyles = `
          edge by default and slid in when the checkbox is :checked. A scrim
          dims/blocks the background and closes the drawer on tap. */
       .chat-thread-sidebar {
-        position:fixed;top:0;left:0;bottom:0;z-index:60;
+        position:fixed;top:0;left:0;bottom:0;z-index:102;
         width:80%;max-width:300px;min-width:0;
         margin:0;border-radius:0;overflow-y:auto;
         transform:translateX(-100%);
@@ -4514,7 +4514,7 @@ const chatPageStyles = `
          the a11y/visibility tree when closed — Playwright's toBeVisible() (and
          assistive tech) treat an opacity:0 element as still visible. */
       .chat-drawer-scrim {
-        display:none;position:fixed;inset:0;z-index:55;
+        display:none;position:fixed;inset:0;z-index:101;
         background:rgba(0,0,0,0.4);cursor:pointer;
       }
       .chat-drawer-toggle:checked ~ .chat-drawer-scrim { display:block }

--- a/admin/src/admin-ui-pages.unit.test.ts
+++ b/admin/src/admin-ui-pages.unit.test.ts
@@ -8903,6 +8903,86 @@ describe("renderQueueActivityPage — Upcoming/Past sectioning", () => {
   });
 });
 
+// ─── Drawer/scrim z-index vs sticky toolbar (DNZ-1.1) ─────────────────────────
+//
+// Drawers and their scrims must render above the sticky toolbar (z-index: 100)
+// so they're never obscured by the sticky top nav. Each drawer's scrim should
+// render below the drawer itself (z-index: scrim < drawer), but both must be
+// above the toolbar (z-index > 100). Toolbar z-index is 100 per lib/web/toolbar.ts.
+
+describe("drawer z-index above sticky toolbar (DNZ-1.1)", () => {
+  const TOOLBAR_ZINDEX = 100;
+
+  const THREAD: ChatThread = {
+    id: "thread-dnz-1",
+    agentId: "agent-xyz",
+    title: "DNZ-1 Thread",
+    memberId: null,
+    createdAt: "2026-06-01T09:00:00Z",
+    updatedAt: "2026-06-01T09:00:00Z",
+  };
+
+  const MSG: ChatMessage = {
+    id: "msg-dnz-1",
+    threadId: "thread-dnz-1",
+    role: "user",
+    body: "test",
+    createdAt: "2026-06-01T09:00:00Z",
+    claimedBy: null,
+    repliedAt: null,
+    tokens: null,
+    costUsd: null,
+    errorKind: null,
+    attachmentFilename: null,
+    attachmentSize: null,
+  };
+
+  test("task drawer and scrim z-indexes are above toolbar (> 100) with scrim < drawer", () => {
+    const html = renderTasksPage(
+      [TASK_ITEM],
+      {},
+      false,
+      USER_NAME,
+      {},
+      { total: 1, limit: 50, page: 1 },
+    );
+
+    const scrimMatch = html.match(/\.task-drawer-scrim\s*\{[^}]*z-index:(\d+)/);
+    const drawerMatch = html.match(/\.task-drawer\s*\{[^}]*z-index:(\d+)/);
+
+    expect(scrimMatch).not.toBeNull();
+    expect(drawerMatch).not.toBeNull();
+
+    const scrimZIndex = scrimMatch ? Number.parseInt(scrimMatch[1], 10) : 0;
+    const drawerZIndex = drawerMatch ? Number.parseInt(drawerMatch[1], 10) : 0;
+
+    expect(scrimZIndex).toBeGreaterThan(TOOLBAR_ZINDEX);
+    expect(drawerZIndex).toBeGreaterThan(TOOLBAR_ZINDEX);
+    expect(scrimZIndex).toBeLessThan(drawerZIndex);
+  });
+
+  test("chat thread sidebar and scrim z-indexes are above toolbar (> 100) with scrim < sidebar", () => {
+    const html = renderChatThreadPage("agent-xyz", THREAD, [MSG], USER_NAME);
+
+    const sidebarMatch = html.match(
+      /\.chat-thread-sidebar\s*\{[^}]*z-index:(\d+)/,
+    );
+    const scrimMatch = html.match(/\.chat-drawer-scrim\s*\{[^}]*z-index:(\d+)/);
+
+    expect(sidebarMatch).not.toBeNull();
+    expect(scrimMatch).not.toBeNull();
+
+    const sidebarZIndex = sidebarMatch
+      ? Number.parseInt(sidebarMatch[1], 10)
+      : 0;
+    const scrimZIndex = scrimMatch ? Number.parseInt(scrimMatch[1], 10) : 0;
+
+    expect(sidebarZIndex).toBeGreaterThan(TOOLBAR_ZINDEX);
+    expect(scrimZIndex).toBeGreaterThan(TOOLBAR_ZINDEX);
+    expect(scrimZIndex).toBeLessThan(sidebarZIndex);
+  });
+});
+
 // ─── All page renderers — shared head via renderAdminPage (CFB-1.2) ─────────
 //
 // Every render*Page-style function in this file builds its <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- Raise `.task-drawer-scrim`/`.task-drawer` and `.chat-drawer-scrim`/`.chat-thread-sidebar` z-index values (55/60 → 101/102) above `lib/web/toolbar.ts`'s sticky `.vos-toolbar` (z-index:100), so the sticky top nav never paints over an open drawer's title/content.
- Preserves the existing relative order between each drawer and its own scrim (drawer above scrim).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Opening a task board card's drawer shows its title fully, not obscured by the sticky top nav, at any scroll position. | MET |
| 2 | Opening the chat thread mobile sidebar drawer shows its content fully, not obscured by the sticky top nav. | MET |
| 3 | Each drawer's scrim still renders below its own drawer and above the page content underneath. | MET |
| 4 | Unit assertions pin the numeric z-index of `.task-drawer`/`.chat-thread-sidebar` (and their scrims) above the toolbar's z-index:100. | MET |

## Test Plan
- Added `describe("drawer z-index above sticky toolbar (DNZ-1.1)")` in `admin/src/admin-ui-pages.unit.test.ts`, asserting both drawer pairs render z-index > 100 and scrim < drawer/sidebar.
- `NODE_ENV=test bun test admin/src/admin-ui-pages.unit.test.ts` — 748 pass, 0 fail.
- `bunx biome lint .` — clean.
- `bun run --filter='*' --sequential typecheck` — all packages pass.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
