### PR TITLE
fix(review): gh api --jq doesn't support --arg, breaks Step 14 precheck

### DIFF
--- a/plugins/shipwright/commands/review.md
+++ b/plugins/shipwright/commands/review.md
@@ -1396,10 +1396,15 @@ precheck=$(gh api graphql -f query='
       }
     }
   }
-}' --arg currentUser "$CURRENT_USER" --jq '.data.repository.pullRequest as $pr | ([$pr.reviews.nodes[] | select(.commit.oid == $pr.headRefOid and ((.body | test("verdict\\**\\s*:\\s*\\**(approve|comment)\\b"; "i")) or .state == "APPROVED")) | .submittedAt] | max) as $maxTerminalSubmittedAt | {headRefOid: $pr.headRefOid, terminal: (if $maxTerminalSubmittedAt != null then ([$pr.comments.nodes[] | select(.author.login != $currentUser and (.createdAt > $maxTerminalSubmittedAt)) | .createdAt] | length == 0) else false end)}')
+}' | jq --arg currentUser "$CURRENT_USER" '.data.repository.pullRequest as $pr | ([$pr.reviews.nodes[] | select(.commit.oid == $pr.headRefOid and ((.body | test("verdict\\**\\s*:\\s*\\**(approve|comment)\\b"; "i")) or .state == "APPROVED")) | .submittedAt] | max) as $maxTerminalSubmittedAt | {headRefOid: $pr.headRefOid, terminal: (if $maxTerminalSubmittedAt != null then ([$pr.comments.nodes[] | select(.author.login != $currentUser and (.createdAt > $maxTerminalSubmittedAt)) | .createdAt] | length == 0) else false end)}')
 headRefOid=$(echo "$precheck" | jq -r '.headRefOid')
 terminal=$(echo "$precheck" | jq -r '.terminal')
 ```
+
+`gh api`'s own `--jq`/`-q` flag does not support `--arg` — that's a `jq`-binary-only
+flag for injecting external variables into a filter. Passing `--arg` to `gh api` fails
+with `unknown flag: --arg`. Pipe the raw GraphQL response into the real `jq` binary
+instead, where `--arg` is supported.
 
 This filters reviews down to only those submitted at the current `headRefOid`, then tests
 whether ANY of them is terminal — either its body matches a terminal verdict label, or its


### PR DESCRIPTION
## Summary
- `/shipwright:review`'s Step 14 precheck built a `gh api graphql` call as `-f query='...' --arg currentUser "$CURRENT_USER" --jq '...'`. `gh api` has no `--arg` flag — that's a `jq`-binary-only concept for injecting external variables into a filter — so the call fails immediately with `unknown flag: --arg`.
- Confirmed via `gh api --help` (2.100.0): valid flags are `-f/--raw-field`, `-F/--field`, `-q/--jq`; no `--arg`.
- Found via a learn-dream mining pass across the 2026-09-03 20:00 UTC → 2026-09-04 UTC transcript window: the identical failure recurred in 10+ independent `/shipwright:review` sessions (each self-corrected mid-session by switching to a jq pipe, wasting a round-trip every time since each cron-triggered session starts fresh with no memory of the prior fix).
- Fix: drop `--arg`/`--jq` from the `gh api` call and pipe its raw JSON response into the real `jq` binary, which does support `--arg`. Verified the filter logic is unchanged and produces the same `{headRefOid, terminal}` shape against a representative fixture.

## Test plan
- [x] Verified `gh api --help` confirms no `--arg` flag exists
- [x] Ran the corrected `jq --arg currentUser ... '...'` filter against a representative GraphQL response fixture locally — produces the expected `{headRefOid, terminal}` output
- [ ] Next live `/shipwright:review` invocation should complete Step 14's precheck without the `unknown flag: --arg` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)