### PR TITLE
feat: add pure work-queue merge-dedupe and eligible-agent helpers

### DIFF
--- a/admin/src/agent-work-queue-merge.ts
+++ b/admin/src/agent-work-queue-merge.ts
@@ -1,0 +1,159 @@
+/**
+ * admin/src/agent-work-queue-merge.ts
+ *
+ * Pure, no-I/O helpers supporting the merged all-agent work-queue view:
+ *
+ *   1. mergeWorkQueueSnapshots() — takes each agent's latest
+ *      AgentWorkQueueSnapshot-shaped `{ agentId, items }` pair and dedupes
+ *      items across agents by `(type, id)`, annotating each surviving row
+ *      with `queuedByAgentIds` — every agent whose snapshot currently
+ *      contains that item.
+ *
+ *   2. buildEligibilityIndex() / lookupEligibleAgents() / annotateEligibility()
+ *      — build a `repo -> agentId[]` index once from the fleet's Agent list
+ *      (O(agents)), then apply it per merged item (O(items)) to produce
+ *      `eligibleAgentIds`. This two-step index-then-lookup shape is
+ *      deliberate: a nested loop over merged items (each snapshot capped at
+ *      50 items) times agent count is cheap today (<10 agents) but stops
+ *      being cheap as the fleet grows toward ~250 agents.
+ *
+ * Deliberately generic over the caller's item shape rather than importing
+ * RankedWorkItem (agent/src/work-selector.ts) or AgentWorkQueueSnapshot
+ * (admin/src/agent-work-queue.ts) directly — those types are owned
+ * elsewhere and are not modified by this module (see AAV-1.3's AC3).
+ * RankedWorkItem in particular has no `repo` field today, so the
+ * eligibility step is expressed as its own generic constrained to
+ * `{ repo: string }` rather than baked into the merge step's generic.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * One agent's work-queue snapshot, as seen by the merge step. Mirrors the
+ * shape of AgentWorkQueueSnapshot (admin/src/agent-work-queue.ts) closely
+ * enough to build from it, but is declared independently here so this
+ * module never needs to import the Prisma-generated type (whose `items`
+ * field is untyped JSON at the DB layer).
+ */
+export interface AgentSnapshotForMerge<T extends { type: string; id: string }> {
+  agentId: string;
+  items: T[];
+}
+
+/**
+ * A merged, deduped work item — the original item fields plus the list of
+ * every agent whose snapshot currently contains it. Order of
+ * queuedByAgentIds follows the order snapshots were passed in (and, within
+ * one agent's snapshot, the order items appeared) — no re-sorting.
+ */
+export type MergedWorkItem<T extends { type: string; id: string }> = T & {
+  queuedByAgentIds: string[];
+};
+
+/**
+ * Minimal fleet-agent shape the eligibility index needs — a subset of the
+ * full Agent type in admin/src/agents-api.ts.
+ */
+export interface AgentForEligibility {
+  id: string;
+  repos: string[];
+}
+
+/** repo -> agentId[], built once from the fleet's agent list. */
+export type EligibilityIndex = Map<string, string[]>;
+
+// ─── Merge / dedupe ─────────────────────────────────────────────────────────
+
+/**
+ * Merge N agents' work-queue snapshots into one deduped list, keyed by
+ * `(type, id)`. An item present in multiple agents' snapshots collapses to
+ * a single row carrying every agent's id in `queuedByAgentIds`, in the
+ * order those snapshots were encountered.
+ *
+ * If the same agent's own snapshot somehow lists the same (type, id) item
+ * twice, that agent's id is appended to queuedByAgentIds once per
+ * occurrence — this reflects what was actually queued rather than silently
+ * de-duplicating within a single agent's list, and is intentionally
+ * lenient about upstream data quality (this function does no I/O and
+ * trusts its input).
+ *
+ * Non-key fields (title, phase, age, repo, ...) are taken from the first
+ * occurrence of a given (type, id) encountered across all snapshots; later
+ * occurrences only contribute their agentId to queuedByAgentIds.
+ */
+export function mergeWorkQueueSnapshots<T extends { type: string; id: string }>(
+  snapshots: AgentSnapshotForMerge<T>[],
+): MergedWorkItem<T>[] {
+  const merged = new Map<string, MergedWorkItem<T>>();
+
+  for (const snapshot of snapshots) {
+    for (const item of snapshot.items) {
+      const key = `${item.type}:${item.id}`;
+      const existing = merged.get(key);
+      if (existing) {
+        existing.queuedByAgentIds.push(snapshot.agentId);
+      } else {
+        merged.set(key, { ...item, queuedByAgentIds: [snapshot.agentId] });
+      }
+    }
+  }
+
+  return [...merged.values()];
+}
+
+// ─── Eligibility index + lookup ─────────────────────────────────────────────
+
+/**
+ * Build a `repo -> agentId[]` index from the fleet's agent list — O(agents).
+ * An agent with an empty `repos[]` contributes no entries. Call this once
+ * per merged-view render, then reuse the returned index for every item via
+ * lookupEligibleAgents()/annotateEligibility() (O(items)) — never rebuild it
+ * per item, which would degrade this to an O(items x agents) nested loop.
+ */
+export function buildEligibilityIndex(
+  agents: AgentForEligibility[],
+): EligibilityIndex {
+  const index: EligibilityIndex = new Map();
+
+  for (const agent of agents) {
+    for (const repo of agent.repos) {
+      const agentIds = index.get(repo);
+      if (agentIds) {
+        agentIds.push(agent.id);
+      } else {
+        index.set(repo, [agent.id]);
+      }
+    }
+  }
+
+  return index;
+}
+
+/**
+ * Look up the agentIds eligible for a given repo via a prebuilt
+ * EligibilityIndex — O(1). Returns [] (never throws) when no agent lists
+ * that repo.
+ */
+export function lookupEligibleAgents(
+  index: EligibilityIndex,
+  repo: string,
+): string[] {
+  return index.get(repo) ?? [];
+}
+
+/**
+ * Annotate a list of items (each carrying a `repo` field) with
+ * `eligibleAgentIds`, via a prebuilt EligibilityIndex — O(items) given an
+ * already-built index. Intended to run on mergeWorkQueueSnapshots()'s
+ * output, but independently pure/testable on any `{ repo: string }`-shaped
+ * item list.
+ */
+export function annotateEligibility<T extends { repo: string }>(
+  items: T[],
+  index: EligibilityIndex,
+): (T & { eligibleAgentIds: string[] })[] {
+  return items.map((item) => ({
+    ...item,
+    eligibleAgentIds: lookupEligibleAgents(index, item.repo),
+  }));
+}

--- a/admin/src/agent-work-queue-merge.unit.test.ts
+++ b/admin/src/agent-work-queue-merge.unit.test.ts
@@ -1,0 +1,288 @@
+/**
+ * admin/src/agent-work-queue-merge.unit.test.ts
+ *
+ * Unit tests for the pure merge/dedupe and eligibility-index helpers in
+ * agent-work-queue-merge.ts. No I/O — pure logic only.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  type AgentForEligibility,
+  type AgentSnapshotForMerge,
+  annotateEligibility,
+  buildEligibilityIndex,
+  lookupEligibleAgents,
+  mergeWorkQueueSnapshots,
+} from "./agent-work-queue-merge.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface TestItem {
+  type: "task" | "pr";
+  id: string;
+  repo?: string;
+  title?: string;
+}
+
+function makeItem(overrides: Partial<TestItem> = {}): TestItem {
+  return {
+    type: "task",
+    id: "item-1",
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<AgentSnapshotForMerge<TestItem>> = {},
+): AgentSnapshotForMerge<TestItem> {
+  return {
+    agentId: "agent-1",
+    items: [],
+    ...overrides,
+  };
+}
+
+function makeAgent(
+  overrides: Partial<AgentForEligibility> = {},
+): AgentForEligibility {
+  return {
+    id: "agent-1",
+    repos: [],
+    ...overrides,
+  };
+}
+
+// ─── mergeWorkQueueSnapshots ────────────────────────────────────────────────
+
+describe("mergeWorkQueueSnapshots", () => {
+  it("returns [] for an empty snapshot list", () => {
+    expect(mergeWorkQueueSnapshots([])).toEqual([]);
+  });
+
+  it("dedupes identical (type,id) items across N agents' snapshots into one row with a correct queuedByAgentIds list", () => {
+    const shared = makeItem({ type: "task", id: "t1", title: "Shared task" });
+    const snapshots = [
+      makeSnapshot({ agentId: "agent-a", items: [shared] }),
+      makeSnapshot({ agentId: "agent-b", items: [shared] }),
+      makeSnapshot({ agentId: "agent-c", items: [shared] }),
+    ];
+
+    const merged = mergeWorkQueueSnapshots(snapshots);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      type: "task",
+      id: "t1",
+      title: "Shared task",
+    });
+    expect(merged[0]?.queuedByAgentIds).toEqual([
+      "agent-a",
+      "agent-b",
+      "agent-c",
+    ]);
+  });
+
+  it("keeps an item that appears in only one agent's snapshot with a single-element queuedByAgentIds", () => {
+    const solo = makeItem({ type: "pr", id: "pr1" });
+    const snapshots = [
+      makeSnapshot({ agentId: "agent-a", items: [solo] }),
+      makeSnapshot({ agentId: "agent-b", items: [] }),
+    ];
+
+    const merged = mergeWorkQueueSnapshots(snapshots);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.queuedByAgentIds).toEqual(["agent-a"]);
+  });
+
+  it("keeps distinct (type,id) items as separate rows, and disambiguates by type even when id collides", () => {
+    const taskItem = makeItem({ type: "task", id: "shared-id" });
+    const prItem = makeItem({ type: "pr", id: "shared-id" });
+    const snapshots = [
+      makeSnapshot({ agentId: "agent-a", items: [taskItem, prItem] }),
+    ];
+
+    const merged = mergeWorkQueueSnapshots(snapshots);
+
+    expect(merged).toHaveLength(2);
+    expect(merged.find((m) => m.type === "task")?.queuedByAgentIds).toEqual([
+      "agent-a",
+    ]);
+    expect(merged.find((m) => m.type === "pr")?.queuedByAgentIds).toEqual([
+      "agent-a",
+    ]);
+  });
+
+  it("appends an agent to queuedByAgentIds even if the same agent's snapshot lists the same item twice (reflects reality of what was queued)", () => {
+    const dup = makeItem({ type: "task", id: "t1" });
+    const snapshots = [makeSnapshot({ agentId: "agent-a", items: [dup, dup] })];
+
+    const merged = mergeWorkQueueSnapshots(snapshots);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.queuedByAgentIds).toEqual(["agent-a", "agent-a"]);
+  });
+
+  it("handles an agent snapshot with an empty items array without error", () => {
+    const merged = mergeWorkQueueSnapshots([
+      makeSnapshot({ agentId: "agent-a", items: [] }),
+    ]);
+    expect(merged).toEqual([]);
+  });
+});
+
+// ─── buildEligibilityIndex ──────────────────────────────────────────────────
+
+describe("buildEligibilityIndex", () => {
+  it("builds a repo -> agentId[] map directly from the agent list, independent of any items/lookup call", () => {
+    const agents = [
+      makeAgent({ id: "agent-a", repos: ["org/repo-1", "org/repo-2"] }),
+      makeAgent({ id: "agent-b", repos: ["org/repo-1"] }),
+    ];
+
+    const index = buildEligibilityIndex(agents);
+
+    // Assert the index's shape directly — this is what verifies the
+    // index-building step runs independent of item count (AC2).
+    expect(index).toBeInstanceOf(Map);
+    expect(index.get("org/repo-1")).toEqual(["agent-a", "agent-b"]);
+    expect(index.get("org/repo-2")).toEqual(["agent-a"]);
+    expect(index.size).toBe(2);
+  });
+
+  it("returns an empty index for an empty agent list", () => {
+    const index = buildEligibilityIndex([]);
+    expect(index.size).toBe(0);
+  });
+
+  it("an agent with an empty repos[] contributes no eligibility matches for any repo", () => {
+    const agents = [
+      makeAgent({ id: "agent-a", repos: [] }),
+      makeAgent({ id: "agent-b", repos: ["org/repo-1"] }),
+    ];
+
+    const index = buildEligibilityIndex(agents);
+
+    expect(index.size).toBe(1);
+    expect(index.get("org/repo-1")).toEqual(["agent-b"]);
+    // agent-a appears nowhere in the index at all.
+    for (const agentIds of index.values()) {
+      expect(agentIds).not.toContain("agent-a");
+    }
+  });
+});
+
+// ─── lookupEligibleAgents ───────────────────────────────────────────────────
+
+describe("lookupEligibleAgents", () => {
+  it("returns the agentIds registered for a repo present in the index", () => {
+    const index = buildEligibilityIndex([
+      makeAgent({ id: "agent-a", repos: ["org/repo-1"] }),
+    ]);
+    expect(lookupEligibleAgents(index, "org/repo-1")).toEqual(["agent-a"]);
+  });
+
+  it("returns an empty array (not an error) for a repo matching zero agents", () => {
+    const index = buildEligibilityIndex([
+      makeAgent({ id: "agent-a", repos: ["org/repo-1"] }),
+    ]);
+    expect(lookupEligibleAgents(index, "org/unknown-repo")).toEqual([]);
+  });
+
+  it("returns an empty array for an empty index", () => {
+    const index = buildEligibilityIndex([]);
+    expect(lookupEligibleAgents(index, "org/repo-1")).toEqual([]);
+  });
+});
+
+// ─── annotateEligibility ────────────────────────────────────────────────────
+
+describe("annotateEligibility", () => {
+  it("adds eligibleAgentIds to each item based on its repo field, via the prebuilt index", () => {
+    const index = buildEligibilityIndex([
+      makeAgent({ id: "agent-a", repos: ["org/repo-1"] }),
+      makeAgent({ id: "agent-b", repos: ["org/repo-1", "org/repo-2"] }),
+    ]);
+    const items = [
+      { type: "task" as const, id: "t1", repo: "org/repo-1" },
+      { type: "task" as const, id: "t2", repo: "org/repo-2" },
+    ];
+
+    const annotated = annotateEligibility(items, index);
+
+    expect(annotated).toEqual([
+      {
+        type: "task",
+        id: "t1",
+        repo: "org/repo-1",
+        eligibleAgentIds: ["agent-a", "agent-b"],
+      },
+      {
+        type: "task",
+        id: "t2",
+        repo: "org/repo-2",
+        eligibleAgentIds: ["agent-b"],
+      },
+    ]);
+  });
+
+  it("gives an item whose repo matches zero agents an empty eligibleAgentIds array, not an error", () => {
+    const index = buildEligibilityIndex([
+      makeAgent({ id: "agent-a", repos: ["org/repo-1"] }),
+    ]);
+    const items = [{ type: "task" as const, id: "t1", repo: "org/no-match" }];
+
+    const annotated = annotateEligibility(items, index);
+
+    expect(annotated).toEqual([
+      { type: "task", id: "t1", repo: "org/no-match", eligibleAgentIds: [] },
+    ]);
+  });
+
+  it("returns [] for an empty items list", () => {
+    const index = buildEligibilityIndex([
+      makeAgent({ id: "agent-a", repos: ["org/repo-1"] }),
+    ]);
+    expect(annotateEligibility([], index)).toEqual([]);
+  });
+});
+
+// ─── End-to-end composition ─────────────────────────────────────────────────
+
+interface TestItemWithRepo {
+  type: "task" | "pr";
+  id: string;
+  repo: string;
+}
+
+describe("mergeWorkQueueSnapshots + buildEligibilityIndex + annotateEligibility composed", () => {
+  it("produces merged rows carrying both queuedByAgentIds and eligibleAgentIds", () => {
+    const item: TestItemWithRepo = {
+      type: "task",
+      id: "t1",
+      repo: "org/repo-1",
+    };
+    const snapshots: AgentSnapshotForMerge<TestItemWithRepo>[] = [
+      { agentId: "agent-a", items: [item] },
+      { agentId: "agent-b", items: [item] },
+    ];
+    const agents = [
+      makeAgent({ id: "agent-a", repos: ["org/repo-1"] }),
+      makeAgent({ id: "agent-c", repos: ["org/repo-1"] }),
+    ];
+
+    const merged = mergeWorkQueueSnapshots(snapshots);
+    const index = buildEligibilityIndex(agents);
+    const annotated = annotateEligibility(merged, index);
+
+    expect(annotated).toEqual([
+      {
+        type: "task",
+        id: "t1",
+        repo: "org/repo-1",
+        queuedByAgentIds: ["agent-a", "agent-b"],
+        eligibleAgentIds: ["agent-a", "agent-c"],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a new pure, no-I/O module `admin/src/agent-work-queue-merge.ts` with `mergeWorkQueueSnapshots()` — dedupes work items across multiple agents' work-queue snapshots by `(type, id)`, annotating each row with `queuedByAgentIds`
- Add `buildEligibilityIndex()` / `lookupEligibleAgents()` / `annotateEligibility()` — build a `repo -> agentId[]` index once from the fleet's agent list (O(agents)), then look up per merged item (O(items)) to produce `eligibleAgentIds`, avoiding an O(items x agents) nested-loop scan as the fleet grows toward ~250 agents
- No changes to the existing `RankedWorkItem` or `AgentWorkQueueSnapshot` types — the new module is generic over caller-supplied item shapes

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Unit tests cover dedup across N agents, single-agent item, empty snapshot list, agent with empty repos[], repo matching zero agents | MET |
| 2 | Eligibility computed as build-index-once + per-item-lookup, verified by a test asserting index shape independent of items | MET |
| 3 | No existing RankedWorkItem/AgentWorkQueueSnapshot type changes | MET |

## Test Plan
- `admin/src/agent-work-queue-merge.unit.test.ts` — 16 unit tests, 100% line/function coverage of the new module
- [x] Pre-commit checks passing
- [x] `task typecheck` passing
- [x] `bunx biome lint .` clean

Generated with [Claude Code](https://claude.com/claude-code)
