### PR TITLE
chore(chart): bump chart version to 1.19.112

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.19.112] - 2026-09-05
+
+### Changed
+
+- auto-bump to chart v1.19.112 triggered by release tag(s): `agent-v1.253.0`
+
 ## [1.19.111] - 2026-09-05
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.19.111
+version: 1.19.112
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,7 +30,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.19.111 triggered by release tag admin-v1.144.0"
+      description: "auto-bump to chart v1.19.112 triggered by release tag agent-v1.253.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -404,7 +404,7 @@ agent:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-agent
-    tag: agent-v1.252.0
+    tag: agent-v1.253.0
     pullPolicy: ""
   service:
     port: 3000
@@ -427,7 +427,7 @@ agent:
     # -- Image the admin provisioner stamps onto agent Deployments.
     image:
       repository: ghcr.io/app-vitals/shipwright-agent
-      tag: agent-v1.252.0
+      tag: agent-v1.253.0
     # -- Replica count for provisioned agent Deployments.
     replicas: 1
     # -- ServiceAccount provisioned agent pods run as (SEPARATE from the admin SA).


### PR DESCRIPTION
## Chart version bump: 1.19.111 → 1.19.112

**Triggering tags:**
- `agent-v1.253.0`

**New chart version:** `1.19.112`

**Pinned in values.yaml:**
- `agent.image.tag`: `agent-v1.253.0`
- `agent.provisioning.image.tag`: `agent-v1.253.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.19.112 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._