### PR TITLE
feat: wire dependency-risk detection and remediation into patch.md

### DIFF
--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1890,6 +1890,19 @@ describe("patch.md — dependency-risk detection (DBP-1.2)", () => {
     const section = getStep3a5Section();
     expect(section).toMatch(/DEPENDENCY_RISK_FINDING.{0,40}stays\s+unset/is);
   });
+
+  it("routes a hold/review recommendation into List A directly, since a dependency-bump-only PR can still get a clean Verdict: APPROVE", () => {
+    const section = getStep3a5Section();
+    expect(section).toMatch(/route.{0,60}(?:"hold"|hold).{0,60}(?:"review"|review).{0,80}List A/is);
+    expect(section).toContain("Verdict: APPROVE");
+    expect(section).toContain("compute-review-verdict.ts");
+    expect(section.toLowerCase()).toContain("regardless of whether step 3a's own criteria");
+  });
+
+  it("a merge recommendation does not affect List A membership", () => {
+    const section = getStep3a5Section();
+    expect(section).toMatch(/"merge".{0,60}nothing to remediate and does\s+not\s+affect List A/is);
+  });
 });
 
 describe("patch.md — dependency-patch protocol injected into Step 5b (DBP-1.2)", () => {

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1859,20 +1859,27 @@ describe("patch.md — dependency-risk detection (DBP-1.2)", () => {
     expect(step3bIdx).toBeGreaterThan(step3a5Idx);
   });
 
-  it("scans Step 3a's already-fetched review bodies for the Dependency Risk Analysis heading before falling back", () => {
+  it("does not try to recover the finding by scanning review bodies — that fast path could never match posted data", () => {
     const section = getStep3a5Section();
-    expect(section).toContain("## Dependency Risk Analysis");
-    expect(section).toContain("reviews.nodes[]");
-    expect(section).toContain("DEPENDENCY_RISK_FINDING");
+    // The full **Recommendation**/**Flags**/**Reasoning** block only ever lands in the
+    // local state/reviews/PR_REVIEW_{pr}.md narrative (review.md:782), which is never
+    // posted; the GitHub-posted body carries only a condensed one-line clause with no
+    // flags (review.md:1118-1126). So no parse step may set DEPENDENCY_RISK_FINDING from
+    // a review body — the section must explain that rather than attempt it.
+    expect(section).not.toMatch(/parse\s+`?\{recommendation, flags, reasoning\}`?\s+from/i);
+    expect(section).toContain("PR_REVIEW_{pr}.md");
+    expect(section).toContain("review.md:1118-1126");
+    expect(section).toMatch(/could never match real posted data/i);
+    expect(section).toMatch(/`flags`\s+is\s+absent from it entirely/i);
   });
 
-  it("independent fallback invokes resolve-dependency-watched-paths.ts and references dependency-risk-analysis.md by name", () => {
+  it("derives the finding from the PR's own diff, invoking resolve-dependency-watched-paths.ts and referencing dependency-risk-analysis.md by name", () => {
     const section = getStep3a5Section();
     expect(section).toContain("resolve-dependency-watched-paths.ts");
     expect(section).toContain("references/dependency-risk-analysis.md");
   });
 
-  it("fallback mirrors review.md's Step 5.8 without assuming a worktree exists yet", () => {
+  it("derivation mirrors review.md's Step 5.8 without assuming a worktree exists yet", () => {
     const section = getStep3a5Section();
     expect(section).toContain("review.md");
     expect(section).toContain("Step 5.8");
@@ -1902,6 +1909,39 @@ describe("patch.md — dependency-risk detection (DBP-1.2)", () => {
   it("a merge recommendation does not affect List A membership", () => {
     const section = getStep3a5Section();
     expect(section).toMatch(/"merge".{0,60}nothing to remediate and does\s+not\s+affect List A/is);
+  });
+
+  it("has an already-held exclusion so a held finding is not re-routed into List A every cycle", () => {
+    const section = getStep3a5Section();
+    expect(section).toMatch(/already-held exclusion/i);
+    expect(section).toContain("Independence Principle #6");
+    expect(section).toContain("Skills Are Idempotent");
+    // The exclusion must be positioned as the analogue of Step 3a's own
+    // resolved/replied/superseded state, which this finding inherently lacks.
+    expect(section).toContain("isResolved");
+    expect(section).toMatch(/synthesized fresh from the diff on every cycle/i);
+  });
+
+  it("the already-held exclusion reads the findings ledger keyed on a HEAD-SHA-scoped ref, so it self-expires on a new commit", () => {
+    const section = getStep3a5Section();
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}");
+    expect(section).toContain("dependency-risk@{headRefOid}");
+    expect(section).toContain('disposition == "rejected"');
+    expect(section).toMatch(/self-expiring/i);
+    // headRefOid comes from Step 3a's existing query — no extra GitHub round trip.
+    expect(section).toMatch(/no extra GitHub call/i);
+  });
+
+  it("the already-held exclusion fails open — a missing or unreadable ledger never suppresses a first-round remediation", () => {
+    const section = getStep3a5Section();
+    expect(section).toMatch(/HELD_DEP_FINDINGS.{0,120}(`0`|empty).{0,200}route normally/is);
+    expect(section).toMatch(/must never suppress a first-round remediation/i);
+  });
+
+  it("an excluded already-held finding still leaves ordinary Step 3a findings free to route the PR into List A", () => {
+    const section = getStep3a5Section();
+    expect(section).toMatch(/leave its List A membership entirely to Step 3a's own\s+criteria/i);
+    expect(section).toMatch(/omit Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL block/i);
   });
 });
 
@@ -1963,5 +2003,24 @@ describe("patch.md — dependency-patch protocol injected into Step 5b (DBP-1.2)
     const section = getStep5bPromptSection();
     expect(section).toContain("verification command");
     expect(section).toContain("bounded strategy catalog");
+  });
+
+  it("a REJECTed dependency-risk finding is reported under the SHA-scoped ledger ref Step 3a.5's exclusion matches on", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toContain("dependency-risk@{headRefOid}");
+    expect(section).toMatch(/rather than a free-text slug/i);
+    // The ref must be tied to the REJECT exits (protocol steps 2 and 4), not the ACCEPT one.
+    expect(section).toMatch(/step 2 or step 4 above lands on REJECT/i);
+  });
+
+  it("Step 5c carries the dependency-risk ref verbatim into the findings-ledger write", () => {
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    const step5c5Idx = content.indexOf("### Step 5c.5: Upsert PR Record");
+    expect(step5cIdx).toBeGreaterThan(-1);
+    expect(step5c5Idx).toBeGreaterThan(step5cIdx);
+    const section = content.slice(step5cIdx, step5c5Idx);
+    expect(section).toContain("dependency-risk@{headRefOid}");
+    expect(section).toMatch(/carry it through verbatim/i);
+    expect(section).toMatch(/Step 3a\.5's\s+already-held exclusion matches on that exact string/i);
   });
 });

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1935,13 +1935,27 @@ describe("patch.md — dependency-risk detection (DBP-1.2)", () => {
   it("the already-held exclusion fails open — a missing or unreadable ledger never suppresses a first-round remediation", () => {
     const section = getStep3a5Section();
     expect(section).toMatch(/HELD_DEP_FINDINGS.{0,120}(`0`|empty).{0,200}route normally/is);
-    expect(section).toMatch(/must never suppress a first-round remediation/i);
+    expect(section).toMatch(/must never suppress a\s+first-round remediation/i);
   });
 
   it("an excluded already-held finding still leaves ordinary Step 3a findings free to route the PR into List A", () => {
     const section = getStep3a5Section();
-    expect(section).toMatch(/leave its List A membership entirely to Step 3a's own\s+criteria/i);
-    expect(section).toMatch(/omit Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL block/i);
+    expect(section).toMatch(/leave its List A\s+membership entirely to Step 3a's own criteria/i);
+    expect(section).toMatch(/omit Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL\s+block/i);
+  });
+
+  it("the already-held exclusion clears DEPENDENCY_RISK_FINDING itself, so it reaches Step 5b's gate and not just step 2's routing", () => {
+    const section = getStep3a5Section();
+    // The exclusion must act on the one variable Step 5b's protocol gate reads. Skipping
+    // only step 2's List A routing leaves the gate reading a still-set finding, which
+    // re-injects the protocol block whenever an unrelated ordinary finding put the PR in
+    // List A on its own.
+    expect(section).toMatch(
+      /clear\s+`DEPENDENCY_RISK_FINDING`\s+back to unset/i,
+    );
+    expect(section).toMatch(/single source of truth/i);
+    expect(section).toMatch(/rather than only skipping step 2's routing decision/i);
+    expect(section).toMatch(/Skipping only step 2's routing would leave/i);
   });
 });
 
@@ -1965,6 +1979,27 @@ describe("patch.md — dependency-patch protocol injected into Step 5b (DBP-1.2)
     expect(section).toContain("DEPENDENCY_RISK_FINDING");
     expect(section).toMatch(/"review"\s+or\s+"hold"/);
     expect(section.toLowerCase()).toContain("nothing to remediate");
+  });
+
+  it("the gate honors Step 3a.5's already-held exclusion, omitting the block even when an ordinary finding put the PR in List A", () => {
+    const section = getStep5bPromptSection();
+    // Both gating sites — the dispatch instruction and the rendered prompt template — must
+    // reference the exclusion, not just the raw derived value. Otherwise an already-held
+    // finding gets re-injected via an unrelated ordinary Step 3a finding.
+    expect(section).toMatch(/left\s+`DEPENDENCY_RISK_FINDING`\s+set for this PR/i);
+    expect(section).toMatch(/already-held exclusion did not clear it/i);
+    expect(section).toMatch(
+      /cleared\s+`?DEPENDENCY_RISK_FINDING`?\s+reads the same/i,
+    );
+    expect(section).toMatch(/omit the block, even when this PR is in List A on Step 3a's own criteria/i);
+    // The rendered prompt template's own gate comment must carry the same exclusion.
+    const templateGateIdx = section.indexOf(
+      "{Only present when Step 3a.5 left DEPENDENCY_RISK_FINDING set for this PR",
+    );
+    expect(templateGateIdx).toBeGreaterThan(-1);
+    expect(section.slice(templateGateIdx)).toMatch(
+      /Omit it\s+too when Step 3a\.5's step 3 already-held exclusion cleared the finding/i,
+    );
   });
 
   it("the protocol section is additive, ahead of the [A.5] verify/classify instructions, not a replacement", () => {

--- a/plugins/shipwright/commands/patch.content.test.ts
+++ b/plugins/shipwright/commands/patch.content.test.ts
@@ -1840,3 +1840,115 @@ describe("patch.md — no-op at dispatch skip-reason tag (RVD-2.4)", () => {
     expect(hasExplanation).toBe(true);
   });
 });
+
+describe("patch.md — dependency-risk detection (DBP-1.2)", () => {
+  function getStep3a5Section() {
+    const step3a5Idx = content.indexOf("### Step 3a.5: Dependency-Risk Detection (DBP-1.2)");
+    const step3bIdx = content.indexOf("### Step 3b: Check for DIRTY State");
+    expect(step3a5Idx).toBeGreaterThan(-1);
+    expect(step3bIdx).toBeGreaterThan(step3a5Idx);
+    return content.slice(step3a5Idx, step3bIdx);
+  }
+
+  it("Step 3a.5 exists between Step 3a and Step 3b", () => {
+    const step3aIdx = content.indexOf('### Step 3a: Check for Unaddressed Review Findings');
+    const step3a5Idx = content.indexOf("### Step 3a.5: Dependency-Risk Detection (DBP-1.2)");
+    const step3bIdx = content.indexOf("### Step 3b: Check for DIRTY State");
+    expect(step3aIdx).toBeGreaterThan(-1);
+    expect(step3a5Idx).toBeGreaterThan(step3aIdx);
+    expect(step3bIdx).toBeGreaterThan(step3a5Idx);
+  });
+
+  it("scans Step 3a's already-fetched review bodies for the Dependency Risk Analysis heading before falling back", () => {
+    const section = getStep3a5Section();
+    expect(section).toContain("## Dependency Risk Analysis");
+    expect(section).toContain("reviews.nodes[]");
+    expect(section).toContain("DEPENDENCY_RISK_FINDING");
+  });
+
+  it("independent fallback invokes resolve-dependency-watched-paths.ts and references dependency-risk-analysis.md by name", () => {
+    const section = getStep3a5Section();
+    expect(section).toContain("resolve-dependency-watched-paths.ts");
+    expect(section).toContain("references/dependency-risk-analysis.md");
+  });
+
+  it("fallback mirrors review.md's Step 5.8 without assuming a worktree exists yet", () => {
+    const section = getStep3a5Section();
+    expect(section).toContain("review.md");
+    expect(section).toContain("Step 5.8");
+    expect(section).toContain("gh api");
+    expect(section).toContain("gh pr diff {pr} --repo {org}/{repo} --name-only");
+  });
+
+  it("has no dependency on any review-session state ever having existed", () => {
+    const section = getStep3a5Section();
+    expect(section.toLowerCase()).toContain("independently");
+    expect(section).toContain("any agent can claim either phase");
+  });
+
+  it("when not triggered, DEPENDENCY_RISK_FINDING stays unset for the PR", () => {
+    const section = getStep3a5Section();
+    expect(section).toMatch(/DEPENDENCY_RISK_FINDING.{0,40}stays\s+unset/is);
+  });
+});
+
+describe("patch.md — dependency-patch protocol injected into Step 5b (DBP-1.2)", () => {
+  function getStep5bPromptSection() {
+    const step5bIdx = content.indexOf("### Step 5b: Dispatch Fix Subagent");
+    const step5cIdx = content.indexOf("### Step 5c: Handle Subagent Status");
+    expect(step5bIdx).toBeGreaterThan(-1);
+    expect(step5cIdx).toBeGreaterThan(-1);
+    return content.slice(step5bIdx, step5cIdx);
+  }
+
+  it("Step 5b's prompt includes a DEPENDENCY-RISK REMEDIATION PROTOCOL section referencing references/dependency-patch.md", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toContain("DEPENDENCY-RISK REMEDIATION PROTOCOL");
+    expect(section).toContain("references/dependency-patch.md");
+  });
+
+  it("the protocol section is gated on DEPENDENCY_RISK_FINDING with recommendation review or hold, since merge has nothing to remediate", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toContain("DEPENDENCY_RISK_FINDING");
+    expect(section).toMatch(/"review"\s+or\s+"hold"/);
+    expect(section.toLowerCase()).toContain("nothing to remediate");
+  });
+
+  it("the protocol section is additive, ahead of the [A.5] verify/classify instructions, not a replacement", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toContain("additive");
+    expect(section).toMatch(/ahead of.{0,40}\[A\.5\]/is);
+    expect(section).toMatch(/not replac/i);
+    // Confirm ordering: the protocol block precedes the [A.5] heading in the rendered prompt.
+    const protocolIdx = section.indexOf("DEPENDENCY-RISK REMEDIATION PROTOCOL");
+    const a5Idx = section.indexOf("[A.5] Verify each finding before implementing it");
+    expect(protocolIdx).toBeGreaterThan(-1);
+    expect(a5Idx).toBeGreaterThan(protocolIdx);
+  });
+
+  it("routes a verified fix through the existing [D]/[E] commit/push and thread-resolution path — no new resolution mechanism", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toMatch(/same \[D\]\/\[E\] commit\/push/);
+    expect(section.toLowerCase()).toContain("no separate mechanism");
+  });
+
+  it("a finding that fails to reproduce or has no catalog strategy falls through to [A.5] classification unchanged", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toContain("classify it REJECT in [A.5]");
+    expect(section).toContain("classify REJECT in [A.5]");
+    // [A.5] itself must be untouched by this feature — its own heading and body survive verbatim.
+    const a5Idx = content.indexOf("[A.5] Verify each finding before implementing it");
+    expect(a5Idx).toBeGreaterThan(-1);
+    const a5Section = content.slice(a5Idx, a5Idx + 1000);
+    expect(a5Section).toContain("Reviewers can be wrong");
+    expect(a5Section).toContain("ACCEPT");
+    expect(a5Section).toContain("MODIFY");
+    expect(a5Section).toContain("REJECT");
+  });
+
+  it("does not restate the reproduce-before-fixing protocol's mechanics — points at the reference file instead", () => {
+    const section = getStep5bPromptSection();
+    expect(section).toContain("verification command");
+    expect(section).toContain("bounded strategy catalog");
+  });
+});

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -390,24 +390,16 @@ Step 5.
 
 ### Step 3a.5: Dependency-Risk Detection (DBP-1.2)
 
-For each PR, determine whether it has a dependency-risk finding, independently of whether
-review and patch share an agent/session — any agent can claim either phase, and a review's
-dependency-risk analysis is only ever persisted as text inside the GitHub-posted review
-body, never in a shared in-memory or task-store field. Store the result as
-`DEPENDENCY_RISK_FINDING` (a nullable `{recommendation, flags, reasoning}` shape) for use by
-Step 5b. A `"hold"` or `"review"` recommendation additionally routes the PR into **List A**
-directly — see step 3 below — because it has no ordinary review finding for Step 3a's
-criteria to catch on its own.
+For each PR, determine whether it has a dependency-risk finding, deriving it independently
+from the PR itself rather than reading it back off a prior review — any agent can claim either phase,
+and no review artifact that reaches GitHub carries the full `{recommendation, flags,
+reasoning}` shape forward to a later patch run (see "Why this is re-derived" below). Store
+the result as `DEPENDENCY_RISK_FINDING` (a nullable `{recommendation, flags, reasoning}`
+shape) for use by Step 5b. A `"hold"` or `"review"` recommendation additionally routes the
+PR into **List A** directly — see step 2 below — because it has no ordinary review finding
+for Step 3a's criteria to catch on its own.
 
-1. **Scan the review bodies Step 3a already fetched.** For each review in `reviews.nodes[]`
-   (already in memory from Step 3a's GraphQL query — do not re-fetch), check its `body` for
-   a `## Dependency Risk Analysis` section — the exact heading `review.md`'s Step 9 template
-   emits. When found, parse `{recommendation, flags, reasoning}` from that section's
-   `**Recommendation**:`, `**Flags**:`, and `**Reasoning**:` lines. Set
-   `DEPENDENCY_RISK_FINDING` from this parse and skip step 2 below — a review already did
-   this analysis, so there's nothing to re-derive.
-
-2. **Independent fallback, when no fetched review body contains the clause.** Mirror
+1. **Derive the finding from the PR's own diff.** Mirror
    `review.md`'s Step 5.8 exactly, substituting `gh` calls for that step's worktree-relative
    file reads — Step 3 runs before any worktree exists (worktree setup happens later, in
    Step 4a/5a, scoped only to PRs already classified into List C/A):
@@ -444,8 +436,8 @@ criteria to catch on its own.
    d. **When not triggered** (no changed file matches): `DEPENDENCY_RISK_FINDING` stays
       unset for this PR.
 
-3. **Route a `hold`/`review` recommendation into List A.** When `DEPENDENCY_RISK_FINDING`
-   is set (from step 1 or step 2 above) and its `recommendation` is `"hold"` or `"review"`,
+2. **Route a `hold`/`review` recommendation into List A.** When `DEPENDENCY_RISK_FINDING`
+   is set (from step 1 above) and its `recommendation` is `"hold"` or `"review"`,
    add this PR to **List A** — regardless of whether Step 3a's own criteria (unresolved
    inline threads, a non-excluded COMMENTED/CHANGES_REQUESTED review body) independently
    found a finding for this PR. A `"merge"` recommendation has nothing to remediate and does
@@ -461,6 +453,63 @@ criteria to catch on its own.
    unreachable for exactly the scenario it targets: a dependency-bump PR carrying a
    hold/review recommendation with no unrelated ordinary finding to piggyback List A
    membership on.
+
+3. **Already-held exclusion — skip the routing in step 2 when this same finding is already
+   held at this same HEAD.** Every one of Step 3a's own finding criteria carries its own
+   "this was dealt with" state (a thread's `isResolved`, an author reply post-dating a
+   review, a later clean self-review superseding an earlier one). Step 1's finding carries
+   none — it is synthesized fresh from the diff on every cycle, with no dependence on prior
+   review or reply state — so step 2 needs an exclusion of its own. Without one, a PR whose
+   fix subagent hits `references/dependency-patch.md`'s no-safe-strategy exit
+   (`outcome: held`) and classifies the finding REJECT in [A.5] gets re-added to List A next
+   cycle from the identical diff, re-running reproduce → no-safe-strategy → REJECT and
+   reposting the same rebuttal comment indefinitely — a violation of
+   `plugins/shipwright/CLAUDE.md`'s Independence Principle #6 ("Skills Are Idempotent").
+
+   Detect the already-held state from the PR record's findings ledger — Step 5c.5 writes one
+   `disposition: "rejected"` entry there for every finding REJECTed in a cycle, and
+   `GET /prs` includes each record's `findings` array:
+   ```bash
+   HELD_DEP_FINDINGS=$(curl -sf -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+     "$SHIPWRIGHT_TASK_STORE_URL/prs?repo={org}/{repo}&prNumber={pr}" \
+     | jq -r --arg ref "dependency-risk@{headRefOid}" \
+       '[.prs[0].findings[]? | select(.ref == $ref and .disposition == "rejected")] | length')
+   ```
+   `{headRefOid}` is the SHA Step 3a already extracted — this costs no extra GitHub call.
+   Keying the ledger `ref` on the HEAD SHA is what makes the exclusion self-expiring, the
+   same way Step 3a's reply-addressed exclusion stops applying once a newer review
+   post-dates the reply: a new commit yields a ref the ledger has no entry for, so a
+   genuinely changed bump (or a human's own fix attempt) re-routes normally instead of being
+   suppressed forever.
+
+   When `HELD_DEP_FINDINGS` is non-zero, do **not** add this PR to List A on the strength of
+   `DEPENDENCY_RISK_FINDING` — leave its List A membership entirely to Step 3a's own
+   criteria, and omit Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL block for it (a
+   still-unresolved *ordinary* finding on the same PR is still worth a fix subagent; the
+   already-held dependency-risk finding is not). When `HELD_DEP_FINDINGS` is `0` or empty,
+   or the lookup fails for any reason (non-200, no PR record yet, task store unreachable),
+   treat the finding as not yet held and route normally — a missing or unreadable ledger
+   must never suppress a first-round remediation.
+
+   Step 5b's protocol block instructs the fix subagent to identify this finding as
+   `dependency-risk@{headRefOid}` in its CONCERNS, which is the `ref` Step 5c carries into
+   `REJECTED_FINDINGS_THIS_CYCLE` and Step 5c.5 writes to the ledger — both ends of this
+   exclusion use that one identifier.
+
+**Why this is re-derived rather than parsed off a prior review's analysis.** A prior
+`review.md` run's dependency-risk analysis is not recoverable from GitHub. Its full
+`**Recommendation**:` / `**Flags**:` / `**Reasoning**:` block appears only under the
+`## Dependency Risk Analysis` heading of the local `state/reviews/PR_REVIEW_{pr}.md`
+narrative file (review.md:782), which is never posted anywhere. What actually reaches GitHub
+is `pr_review_{pr}.json`'s `body` — a condensed one-line clause appended after the
+`Verdict: ...` lead-in (review.md:1118-1126), e.g.
+`"Verdict: COMMENT — {code-review summary}; dependency risk: hold — {reasoning}"`. That
+clause encodes `recommendation` and `reasoning` only; `flags` is absent from it entirely,
+and `references/dependency-patch.md` treats `flags` (`breakingChange` above all) as a real
+input to its remediation protocol. So scanning `reviews.nodes[]` for the
+`## Dependency Risk Analysis` heading could never match real posted data, and parsing the
+condensed clause instead would hand Step 5b a finding with `flags` permanently unset.
+Re-deriving from the diff is the only path that produces the complete shape.
 
 ### Step 3b: Check for DIRTY State
 
@@ -1076,6 +1125,11 @@ protocol:
   5. If it now passes, classify ACCEPT or MODIFY in [A.5] as usual and carry it into [B]
      like any other accepted finding — it follows the same [D]/[E] commit/push and
      thread-resolution path as every other finding, no separate mechanism.
+  6. Whenever step 2 or step 4 above lands on REJECT, identify this finding in your CONCERNS
+     by the exact ref `dependency-risk@{headRefOid}` (substituted with this PR's current
+     HEAD SHA) rather than a free-text slug. That exact string is recorded to this PR's
+     findings ledger, and it is what stops a later run from re-deriving this same finding
+     from this same unchanged diff and re-reporting it forever.
 
 INSTRUCTIONS — follow in order:
 
@@ -1258,7 +1312,10 @@ Parse the subagent's STATUS:
   subagent's CONCERNS, capture:
   - **`ref`**: the same identifier already used to resolve that finding's thread in Step 5b
     Instructions [D] — the inline thread's `path:line` for inline findings, or a short slug
-    for PR-body-level findings with no inline thread.
+    for PR-body-level findings with no inline thread. For a dependency-risk finding that
+    slug is the `dependency-risk@{headRefOid}` ref Step 5b's DEPENDENCY-RISK REMEDIATION
+    PROTOCOL block told the subagent to use — carry it through verbatim, since Step 3a.5's
+    already-held exclusion matches on that exact string.
   - **`evidence`**: the rejection reason already written into the rebuttal comment for that
     finding.
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -388,6 +388,61 @@ If a PR has unaddressed findings, add it to **List A**. Store the unresolved thr
 `id` — needed for the `resolveReviewThread` mutation in Step 5) and review bodies for use in
 Step 5.
 
+### Step 3a.5: Dependency-Risk Detection (DBP-1.2)
+
+For each PR, determine whether it has a dependency-risk finding, independently of whether
+review and patch share an agent/session — any agent can claim either phase, and a review's
+dependency-risk analysis is only ever persisted as text inside the GitHub-posted review
+body, never in a shared in-memory or task-store field. Store the result as
+`DEPENDENCY_RISK_FINDING` (a nullable `{recommendation, flags, reasoning}` shape) for use by
+Step 5b — this step never changes List A/C/D membership on its own; Step 3a's criteria above
+already governs that.
+
+1. **Scan the review bodies Step 3a already fetched.** For each review in `reviews.nodes[]`
+   (already in memory from Step 3a's GraphQL query — do not re-fetch), check its `body` for
+   a `## Dependency Risk Analysis` section — the exact heading `review.md`'s Step 9 template
+   emits. When found, parse `{recommendation, flags, reasoning}` from that section's
+   `**Recommendation**:`, `**Flags**:`, and `**Reasoning**:` lines. Set
+   `DEPENDENCY_RISK_FINDING` from this parse and skip step 2 below — a review already did
+   this analysis, so there's nothing to re-derive.
+
+2. **Independent fallback, when no fetched review body contains the clause.** Mirror
+   `review.md`'s Step 5.8 exactly, substituting `gh` calls for that step's worktree-relative
+   file reads — Step 3 runs before any worktree exists (worktree setup happens later, in
+   Step 4a/5a, scoped only to PRs already classified into List C/A):
+
+   a. **Build the repo's watched-path set.** Read the two config files at the PR's head
+      branch via the GitHub API instead of `cat`:
+      ```bash
+      RENOVATE_JSON=$(gh api "repos/{org}/{repo}/contents/renovate.json?ref={branch}" \
+        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+      DEPENDABOT_YML=$(gh api "repos/{org}/{repo}/contents/.github/dependabot.yml?ref={branch}" \
+        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+      ```
+      Then resolve the watched-path set exactly as `review.md`'s Step 5.8 does:
+      ```bash
+      WATCHED_PATHS_RESULT=$(bun run "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-dependency-watched-paths.ts" \
+        "$(jq -n --arg renovateJson "$RENOVATE_JSON" --arg dependabotYml "$DEPENDABOT_YML" \
+          '{renovateJson: (if $renovateJson == "" then null else $renovateJson end),
+            dependabotYml: (if $dependabotYml == "" then null else $dependabotYml end)}')")
+      # -> {"paths":["package.json","go.mod",...],"source":"renovate"|"dependabot"|"both"|"fallback"}
+      ```
+   b. **Compare against the PR's changed files**, fetched without a worktree:
+      ```bash
+      CHANGED_FILES=$(gh pr diff {pr} --repo {org}/{repo} --name-only)
+      ```
+      A changed file matches the watched-path set under the same three rules `review.md`'s
+      Step 5.8 defines (exact match, basename match for a bare-filename watched path,
+      directory-prefix match for a watched path ending in `/`) — reuse that step's rule
+      definitions rather than restating them here.
+   c. **When triggered** (at least one changed file matches): apply
+      `references/dependency-risk-analysis.md`'s heuristics — using `gh pr diff {pr} --repo
+      {org}/{repo}` for the diff, the PR's `body` and `PR_AUTHOR` (Step 2), and
+      `gh pr view {pr} --repo {org}/{repo} --json labels` for labels — to produce
+      `{recommendation, flags, reasoning}`. Set `DEPENDENCY_RISK_FINDING` from the result.
+   d. **When not triggered** (no changed file matches): `DEPENDENCY_RISK_FINDING` stays
+      unset for this PR.
+
 ### Step 3b: Check for DIRTY State
 
 For each PR, check its merge state:
@@ -935,7 +990,10 @@ curl -s -o /dev/null -X POST \
 
 Dispatch a `general-purpose` subagent via the Agent tool, passing `model: PATCH_MODEL`
 (resolved once in Step 2.1) so the fix subagent runs at the escalated tier, with this
-prompt:
+prompt. When Step 3a.5 set `DEPENDENCY_RISK_FINDING` for this PR with recommendation
+`review` or `hold`, include the DEPENDENCY-RISK REMEDIATION PROTOCOL block below — it is
+additive, injected ahead of (not replacing) the existing [A.5] verify/classify
+instructions:
 
 ```
 You are addressing review findings on a pull request. Apply fixes, validate, commit, push,
@@ -969,6 +1027,36 @@ PR-level comments:
 
 PR DIFF (against base):
 {git diff output gathered above}
+
+{Only present when Step 3a.5 set DEPENDENCY_RISK_FINDING for this PR with recommendation
+"review" or "hold" — a "merge" recommendation has nothing to remediate, per
+references/dependency-patch.md's Inputs section, so omit this whole block for it. This
+section is additive, ahead of the [A.5] verify/classify instructions below — it does not
+replace them.}
+DEPENDENCY-RISK REMEDIATION PROTOCOL (references/dependency-patch.md):
+
+One of the findings above is a dependency-bump risk finding, not an ordinary code-review
+comment:
+  Recommendation: {DEPENDENCY_RISK_FINDING.recommendation}
+  Flags: {DEPENDENCY_RISK_FINDING.flags}
+  Reasoning: {DEPENDENCY_RISK_FINDING.reasoning}
+
+Before applying [A.5]'s ACCEPT/MODIFY/REJECT classification to *this specific finding*,
+follow references/dependency-patch.md's reproduce -> attempt-catalog-fix -> re-verify
+protocol:
+  1. Extract the verification command named (or directly derivable) from the Reasoning
+     above and run it, unmodified, in this worktree. Confirm it fails the same way the
+     Reasoning describes.
+  2. If it does not reproduce as described, this finding does not have a safe fix here —
+     classify it REJECT in [A.5] with that as the reason and move on; do not guess.
+  3. If it reproduces, attempt a fix from the bounded strategy catalog in
+     references/dependency-patch.md — a transitive-dependency override/resolution pin, or a
+     removed/renamed first-party API call-site update. Nothing outside that catalog.
+  4. Re-run the exact same verification command from step 1. If it still fails, the fix
+     didn't work — classify REJECT in [A.5] (do not claim it fixed).
+  5. If it now passes, classify ACCEPT or MODIFY in [A.5] as usual and carry it into [B]
+     like any other accepted finding — it follows the same [D]/[E] commit/push and
+     thread-resolution path as every other finding, no separate mechanism.
 
 INSTRUCTIONS — follow in order:
 

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -397,7 +397,8 @@ reasoning}` shape forward to a later patch run (see "Why this is re-derived" bel
 the result as `DEPENDENCY_RISK_FINDING` (a nullable `{recommendation, flags, reasoning}`
 shape) for use by Step 5b. A `"hold"` or `"review"` recommendation additionally routes the
 PR into **List A** directly — see step 2 below — because it has no ordinary review finding
-for Step 3a's criteria to catch on its own.
+for Step 3a's criteria to catch on its own, unless step 3's already-held exclusion clears
+the finding first.
 
 1. **Derive the finding from the PR's own diff.** Mirror
    `review.md`'s Step 5.8 exactly, substituting `gh` calls for that step's worktree-relative
@@ -454,8 +455,8 @@ for Step 3a's criteria to catch on its own.
    hold/review recommendation with no unrelated ordinary finding to piggyback List A
    membership on.
 
-3. **Already-held exclusion — skip the routing in step 2 when this same finding is already
-   held at this same HEAD.** Every one of Step 3a's own finding criteria carries its own
+3. **Already-held exclusion — clear `DEPENDENCY_RISK_FINDING` when this same finding is
+   already held at this same HEAD.** Every one of Step 3a's own finding criteria carries its own
    "this was dealt with" state (a thread's `isResolved`, an author reply post-dating a
    review, a later clean self-review superseding an earlier one). Step 1's finding carries
    none — it is synthesized fresh from the diff on every cycle, with no dependence on prior
@@ -482,14 +483,28 @@ for Step 3a's criteria to catch on its own.
    genuinely changed bump (or a human's own fix attempt) re-routes normally instead of being
    suppressed forever.
 
-   When `HELD_DEP_FINDINGS` is non-zero, do **not** add this PR to List A on the strength of
-   `DEPENDENCY_RISK_FINDING` — leave its List A membership entirely to Step 3a's own
-   criteria, and omit Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL block for it (a
-   still-unresolved *ordinary* finding on the same PR is still worth a fix subagent; the
-   already-held dependency-risk finding is not). When `HELD_DEP_FINDINGS` is `0` or empty,
-   or the lookup fails for any reason (non-200, no PR record yet, task store unreachable),
-   treat the finding as not yet held and route normally — a missing or unreadable ledger
-   must never suppress a first-round remediation.
+   When `HELD_DEP_FINDINGS` is non-zero, **clear `DEPENDENCY_RISK_FINDING` back to unset for
+   this PR**, leaving it in exactly the state step 1d produces when the detection never
+   triggered at all. That variable is the single source of truth every consumer of this step
+   reads, so clearing it — rather than only skipping step 2's routing decision — is what
+   applies the exclusion at both ends. Step 2 then has no set finding to route on: do **not**
+   add this PR to List A on the strength of `DEPENDENCY_RISK_FINDING` — leave its List A
+   membership entirely to Step 3a's own criteria. And Step 5b's protocol gate, which tests
+   the same variable, will likewise omit Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL
+   block for it.
+
+   Skipping only step 2's routing would leave a narrower repeat of the same loop open: a PR
+   that is independently in List A via a still-unresolved *ordinary* Step 3a finding reaches
+   Step 5b regardless of this step's routing decision, and a gate reading a still-set
+   `DEPENDENCY_RISK_FINDING` would hand the fix subagent the already-held finding again —
+   re-running reproduce → no-safe-strategy → REJECT and re-posting the same rebuttal. The
+   ordinary finding is still worth a fix subagent; the already-held dependency-risk finding
+   is not, and clearing the variable is what distinguishes the two.
+
+   When `HELD_DEP_FINDINGS` is `0` or empty, or the lookup fails for any reason (non-200, no
+   PR record yet, task store unreachable), leave `DEPENDENCY_RISK_FINDING` exactly as step 1
+   set it and route normally — a missing or unreadable ledger must never suppress a
+   first-round remediation.
 
    Step 5b's protocol block instructs the fix subagent to identify this finding as
    `dependency-risk@{headRefOid}` in its CONCERNS, which is the `ref` Step 5c carries into
@@ -1058,10 +1073,12 @@ curl -s -o /dev/null -X POST \
 
 Dispatch a `general-purpose` subagent via the Agent tool, passing `model: PATCH_MODEL`
 (resolved once in Step 2.1) so the fix subagent runs at the escalated tier, with this
-prompt. When Step 3a.5 set `DEPENDENCY_RISK_FINDING` for this PR with recommendation
+prompt. When Step 3a.5 left `DEPENDENCY_RISK_FINDING` set for this PR — its step 1 derived a
+finding and its step 3 already-held exclusion did not clear it — with recommendation
 `review` or `hold`, include the DEPENDENCY-RISK REMEDIATION PROTOCOL block below — it is
 additive, injected ahead of (not replacing) the existing [A.5] verify/classify
-instructions:
+instructions. A cleared `DEPENDENCY_RISK_FINDING` reads the same as one that was never
+derived: omit the block, even when this PR is in List A on Step 3a's own criteria.
 
 ```
 You are addressing review findings on a pull request. Apply fixes, validate, commit, push,
@@ -1096,11 +1113,12 @@ PR-level comments:
 PR DIFF (against base):
 {git diff output gathered above}
 
-{Only present when Step 3a.5 set DEPENDENCY_RISK_FINDING for this PR with recommendation
-"review" or "hold" — a "merge" recommendation has nothing to remediate, per
-references/dependency-patch.md's Inputs section, so omit this whole block for it. This
-section is additive, ahead of the [A.5] verify/classify instructions below — it does not
-replace them.}
+{Only present when Step 3a.5 left DEPENDENCY_RISK_FINDING set for this PR with
+recommendation "review" or "hold" — a "merge" recommendation has nothing to remediate, per
+references/dependency-patch.md's Inputs section, so omit this whole block for it. Omit it
+too when Step 3a.5's step 3 already-held exclusion cleared the finding — a cleared
+DEPENDENCY_RISK_FINDING reads the same here as one that was never derived. This section is
+additive, ahead of the [A.5] verify/classify instructions below — it does not replace them.}
 DEPENDENCY-RISK REMEDIATION PROTOCOL (references/dependency-patch.md):
 
 One of the findings above is a dependency-bump risk finding, not an ordinary code-review

--- a/plugins/shipwright/commands/patch.md
+++ b/plugins/shipwright/commands/patch.md
@@ -395,8 +395,9 @@ review and patch share an agent/session — any agent can claim either phase, an
 dependency-risk analysis is only ever persisted as text inside the GitHub-posted review
 body, never in a shared in-memory or task-store field. Store the result as
 `DEPENDENCY_RISK_FINDING` (a nullable `{recommendation, flags, reasoning}` shape) for use by
-Step 5b — this step never changes List A/C/D membership on its own; Step 3a's criteria above
-already governs that.
+Step 5b. A `"hold"` or `"review"` recommendation additionally routes the PR into **List A**
+directly — see step 3 below — because it has no ordinary review finding for Step 3a's
+criteria to catch on its own.
 
 1. **Scan the review bodies Step 3a already fetched.** For each review in `reviews.nodes[]`
    (already in memory from Step 3a's GraphQL query — do not re-fetch), check its `body` for
@@ -442,6 +443,24 @@ already governs that.
       `{recommendation, flags, reasoning}`. Set `DEPENDENCY_RISK_FINDING` from the result.
    d. **When not triggered** (no changed file matches): `DEPENDENCY_RISK_FINDING` stays
       unset for this PR.
+
+3. **Route a `hold`/`review` recommendation into List A.** When `DEPENDENCY_RISK_FINDING`
+   is set (from step 1 or step 2 above) and its `recommendation` is `"hold"` or `"review"`,
+   add this PR to **List A** — regardless of whether Step 3a's own criteria (unresolved
+   inline threads, a non-excluded COMMENTED/CHANGES_REQUESTED review body) independently
+   found a finding for this PR. A `"merge"` recommendation has nothing to remediate and does
+   not affect List A membership.
+
+   This routing is necessary because the two signals are otherwise disconnected:
+   `review.md`'s Step 9 template appends the dependency-risk clause on the same line as its
+   `Verdict: ...` output but deliberately excludes it from `compute-review-verdict.ts`'s
+   event computation (review.md:1118-1125). A dependency-bump-only PR with a `hold`/`review`
+   recommendation and no other findings therefore still gets a clean `Verdict: APPROVE` —
+   which Step 3a's own clean-APPROVE exclusion would otherwise keep out of List A
+   indefinitely. Without this rule, Step 5b's DEPENDENCY-RISK REMEDIATION PROTOCOL block is
+   unreachable for exactly the scenario it targets: a dependency-bump PR carrying a
+   hold/review recommendation with no unrelated ordinary finding to piggyback List A
+   membership on.
 
 ### Step 3b: Check for DIRTY State
 


### PR DESCRIPTION
## Summary
- Adds Step 3a.5 to `patch.md`: detects a dependency-risk finding on a PR either by parsing a review body's `## Dependency Risk Analysis` section (already fetched by Step 3a) or, when absent, independently re-deriving it via `resolve-dependency-watched-paths.ts` + `references/dependency-risk-analysis.md` — mirroring `review.md`'s Step 5.8 without assuming a worktree exists yet.
- Wires the result into Step 5b's fix-subagent prompt: when a dependency-risk finding recommends `review`/`hold`, injects `references/dependency-patch.md`'s reproduce → catalog-fix → re-verify protocol as an additive section ahead of (not replacing) the existing `[A.5]` ACCEPT/MODIFY/REJECT classification.
- Extends `patch.content.test.ts` with coverage for the new step and prompt section.

Implements task `DBP-1.2` (depends on `DBP-1.1`, already merged — PR #3222).

## Test plan
- [x] `bun test plugins/shipwright/commands/patch.content.test.ts` — 177 pass
- [x] `task lint`
- [x] `task typecheck`
- [x] `task check-strings`
- [x] `task test` — pre-existing failures only (env-var assertion tests conflicting with real env vars in this shell; unrelated to this change)