### PR TITLE
fix: validate GET /tasks status query param, return 400 instead of 500

### DIFF
--- a/task-store/src/routes/tasks.ts
+++ b/task-store/src/routes/tasks.ts
@@ -40,6 +40,7 @@ import { readJson } from "@shipwright/lib/http";
 import type { TaskStoreAuthEnv } from "../auth.ts";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.ts";
 import type { Prisma } from "../index.ts";
+import { CLOSED_STATUSES, OPEN_STATUSES } from "../statuses.ts";
 import {
   BulkInsertBodySchema,
   BulkInsertResponseSchema,
@@ -70,6 +71,15 @@ import { isOrgRepo } from "../validate.ts";
 // could still directly clear claimedBy/status, defeating that protection
 // outside the atomic claim path).
 const LIFECYCLE_GUARD_KEYS = ["claimedBy", "claimedAt", "heartbeatAt"] as const;
+
+// The full set of valid `TaskStatus` enum values (task-store/prisma/schema.prisma),
+// derived from the two existing single-source-of-truth exports rather than a
+// hand-written literal list, to avoid drift when new statuses are added.
+// GET /tasks?status= must validate against this before reaching
+// taskService.list() — an unrecognized value passed straight through to
+// Prisma's `where: { status: ... }` throws a PrismaClientValidationError,
+// which is not an ApiError and surfaces as a raw 500 (Sentry 7603167547).
+const VALID_STATUSES = new Set<string>([...OPEN_STATUSES, ...CLOSED_STATUSES]);
 
 // admin tokens (agentId === null) are unrestricted, mirroring the existing
 // admin-bypass convention already used by requireOwnership.
@@ -658,8 +668,13 @@ export function createTasksRoutes(
     const useAgentScope =
       agentId !== null && repos !== null && repos.length > 0;
 
+    const statusRaw = c.req.query("status");
+    if (statusRaw !== undefined && !VALID_STATUSES.has(statusRaw)) {
+      throw new BadRequestError(`invalid status: '${statusRaw}'`);
+    }
+
     const result = await taskService.list({
-      status: c.req.query("status"),
+      status: statusRaw,
       state,
       source: c.req.query("source"),
       session: c.req.query("session"),

--- a/task-store/src/tasks.status-validation.smoke.test.ts
+++ b/task-store/src/tasks.status-validation.smoke.test.ts
@@ -1,0 +1,259 @@
+/**
+ * task-store/src/tasks.status-validation.smoke.test.ts
+ *
+ * Smoke coverage for GET /tasks?status= input validation (Sentry issue
+ * 7603167547). Before this fix, an unvalidated ?status= value (e.g.
+ * "claimed" — not a member of the Prisma TaskStatus enum) reached
+ * taskService.list() unchecked; against the real Prisma-backed service this
+ * throws PrismaClientValidationError, which is not an ApiError and falls
+ * into the generic onError 500 branch. The fix validates ?status= against
+ * the union of OPEN_STATUSES/CLOSED_STATUSES (task-store/src/statuses.ts)
+ * before calling taskService.list(), returning 400 via BadRequestError for
+ * anything outside that set — matching the "status is required" validation
+ * precedent on POST /tasks.
+ *
+ * The fake TaskServiceLike below never throws on an invalid status (it has
+ * no knowledge of Prisma's enum), so this test suite is only meaningful
+ * against the route's own validation, not against fake behavior.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createTaskStoreApp } from "./app.ts";
+import type { Task } from "./index.ts";
+import type { TaskListFilters, TaskServiceLike } from "./task-service.ts";
+import type { TokenServiceLike } from "./token-service.ts";
+
+const VALID_TOKEN = "valid-token";
+
+function fakeTokenService(): TokenServiceLike {
+  return {
+    async create(label?: string) {
+      return {
+        token: {
+          id: "tok-1",
+          token: "hash",
+          label: label ?? null,
+          agentId: null,
+          createdAt: new Date(),
+          revokedAt: null,
+        },
+        rawToken: "raw",
+      };
+    },
+    async validate(raw: string) {
+      if (raw === VALID_TOKEN) return { id: "tok-1", agentId: null };
+      return null;
+    },
+    async revoke() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+    async update() {
+      return null;
+    },
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "A task",
+    status: "pending",
+    source: null,
+    session: null,
+    repo: null,
+    description: null,
+    acceptanceCriteria: [],
+    layer: null,
+    branch: null,
+    dependencies: [],
+    pr: null,
+    hours: null,
+    startedAt: null,
+    prCreatedAt: null,
+    mergedAt: null,
+    blockedAt: null,
+    blockedReason: null,
+    note: null,
+    type: null,
+    priority: null,
+    cancelledAt: null,
+    completedAt: null,
+    deployingAt: null,
+    ciFixAttempts: null,
+    mergeCommit: null,
+    prUrl: null,
+    assignee: null,
+    issue: null,
+    model: null,
+    complexity: null,
+    hitl: null,
+    hitlNotifiedAt: null,
+    claimedBy: null,
+    agentHint: null,
+    claimedAt: null,
+    heartbeatAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Task;
+}
+
+function fakeTaskService(opts: {
+  listResult?: Task[];
+  capturedListFilters?: TaskListFilters[];
+} = {}): TaskServiceLike {
+  return {
+    async list(filters?: TaskListFilters) {
+      if (opts.capturedListFilters && filters) {
+        opts.capturedListFilters.push({ ...filters });
+      }
+      const tasks = (opts.listResult ?? []).map((t) => ({
+        ...t,
+        blockedBy: [],
+      }));
+      return {
+        tasks,
+        total: tasks.length,
+        limit: filters?.limit ?? 50,
+        offset: filters?.offset ?? 0,
+      };
+    },
+    async listReady() {
+      return [];
+    },
+    async listBlocked() {
+      return [];
+    },
+    async get(id: string) {
+      return { ...makeTask({ id }), blockedBy: [] };
+    },
+    async create(data) {
+      return makeTask({ ...(data as Partial<Task>), id: "created-1" });
+    },
+    async update(id, data) {
+      return makeTask({ ...(data as Partial<Task>), id });
+    },
+    async remove() {
+      return;
+    },
+    async claim(id: string, claimedBy: string) {
+      return makeTask({ id, status: "in_progress", claimedBy });
+    },
+    async heartbeat(id: string) {
+      return makeTask({ id, status: "in_progress" });
+    },
+    async complete(id: string) {
+      return makeTask({ id, status: "done" });
+    },
+    async fail(id: string) {
+      return makeTask({ id, status: "blocked" });
+    },
+    async release(id: string) {
+      return makeTask({ id, status: "pending" });
+    },
+    async recordSkip(id: string) {
+      return makeTask({ id, skipCount: 1 });
+    },
+    async resetSkip(id: string) {
+      return makeTask({ id, skipCount: 0 });
+    },
+    async bulk(_tasks) {
+      return { inserted: 0, updated: 0, skipped: [] };
+    },
+    async distinct() {
+      return { sessions: [], repos: [], orgs: [] };
+    },
+    async getEvents() {
+      return { events: [], total: 0 };
+    },
+  };
+}
+
+function makeApp(taskService: TaskServiceLike) {
+  return createTaskStoreApp({
+    taskService,
+    tokenService: fakeTokenService(),
+  });
+}
+
+function auth(): Record<string, string> {
+  return { Authorization: `Bearer ${VALID_TOKEN}` };
+}
+
+describe("GET /tasks status validation (smoke)", () => {
+  it("returns 400 (not 500) for a status value that is not in the TaskStatus enum ('claimed')", async () => {
+    const app = makeApp(fakeTaskService());
+    const res = await app.request("/tasks?status=claimed", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("invalid status");
+    expect(body.error).toContain("claimed");
+  });
+
+  it("returns 400 for another arbitrary non-enum status value", async () => {
+    const app = makeApp(fakeTaskService());
+    const res = await app.request("/tasks?status=bogus-status", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an empty ?status= value", async () => {
+    const app = makeApp(fakeTaskService());
+    const res = await app.request("/tasks?status=", { headers: auth() });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a valid status value with unexpected casing ('Pending')", async () => {
+    const app = makeApp(fakeTaskService());
+    const res = await app.request("/tasks?status=Pending", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("still returns 200 for a valid TaskStatus enum value ('pending')", async () => {
+    const capturedListFilters: TaskListFilters[] = [];
+    const app = makeApp(fakeTaskService({ capturedListFilters }));
+    const res = await app.request("/tasks?status=pending", {
+      headers: auth(),
+    });
+    expect(res.status).toBe(200);
+    expect(capturedListFilters[0]?.status).toBe("pending");
+  });
+
+  it("still returns 200 for each valid TaskStatus enum value", async () => {
+    const validStatuses = [
+      "pending",
+      "in_progress",
+      "pr_open",
+      "approved",
+      "merged",
+      "done",
+      "deploying",
+      "deployed",
+      "blocked",
+      "cancelled",
+    ];
+    for (const status of validStatuses) {
+      const app = makeApp(fakeTaskService());
+      const res = await app.request(`/tasks?status=${status}`, {
+        headers: auth(),
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("still returns 200 when ?status= is omitted entirely (no filter applied)", async () => {
+    const capturedListFilters: TaskListFilters[] = [];
+    const app = makeApp(fakeTaskService({ capturedListFilters }));
+    const res = await app.request("/tasks", { headers: auth() });
+    expect(res.status).toBe(200);
+    expect(capturedListFilters[0]?.status).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /tasks?status=<value>` previously passed the raw query string straight into `taskService.list()` → `prisma.task.findMany({ where: { status } })`. An invalid/non-enum value (e.g. `claimed`, from Sentry issue [7603167547](https://app-vitals-llc.sentry.io/issues/7603167547/)) threw an unhandled `PrismaClientValidationError`, which fell into the generic `onError` 500 branch and got reported to Sentry.
- Added a validation guard in `task-store/src/routes/tasks.ts`'s `GET /tasks` handler: any `?status=` value not in the `TaskStatus` enum (derived from the existing `OPEN_STATUSES`/`CLOSED_STATUSES` exports in `statuses.ts`, avoiding a third hand-written literal list) now throws `BadRequestError`, returning a clean 400 — matching the existing `status is required` precedent already used on `POST /tasks`.
- Omitted `?status=` continues to apply no filter; every valid enum value continues to filter exactly as before.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Invalid/non-enum `status` returns 400, not 500 | MET | Guard throws `BadRequestError` before reaching `taskService.list()`; covered by smoke tests for `claimed`, `bogus-status`, empty string, and casing mismatch |
| 2 | Valid TaskStatus enum values keep working (200, filtered) | MET | All 10 enum values tested individually, plus a filter-capture assertion confirming the value passes through unchanged |
| 3 | Omitted `status` param keeps working (200, no filter) | MET | Guard only fires when `statusRaw !== undefined`; test asserts no filter is applied when omitted |
| 4 | 400 behavior covered by an automated test | MET | New `task-store/src/tasks.status-validation.smoke.test.ts` (7 tests, correct `*.smoke.test.ts` layer for an HTTP route contract) |

## Test Plan
- `bun test task-store/src/tasks.status-validation.smoke.test.ts` — 7/7 pass
- `bun test task-store/src` — 641 pass, 0 fail (full task-store suite, no regressions)
- `task typecheck` — passes across all workspaces
- `task lint`, `task check-strings` — pass
- Coverage on the changed file: `task-store/src/routes/tasks.ts` at 96.51% lines (target 90%)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
