### PR TITLE
chore(chart): bump chart version to 1.19.121

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.19.121] - 2026-09-05
+
+### Changed
+
+- auto-bump to chart v1.19.121 triggered by release tag(s): `task-store-v1.110.1`
+
 ## [1.19.120] - 2026-09-05
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.19.120
+version: 1.19.121
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,11 +30,7 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.19.120 triggered by release tag admin-v1.149.1"
-    - kind: changed
-      description: "auto-bump to chart v1.19.120 triggered by release tag metrics-v1.86.0"
-    - kind: changed
-      description: "auto-bump to chart v1.19.120 triggered by release tag task-store-v1.110.0"
+      description: "auto-bump to chart v1.19.121 triggered by release tag task-store-v1.110.1"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -758,7 +758,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.110.0
+    tag: task-store-v1.110.1
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.19.120 → 1.19.121

**Triggering tags:**
- `task-store-v1.110.1`

**New chart version:** `1.19.121`

**Pinned in values.yaml:**
- `taskStore.image.tag`: `task-store-v1.110.1`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.19.121 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._