### PR TITLE
fix: remove competitor tier names from vs/factory.astro and self-hosted.astro (MESSAGING.md D5)

### DIFF
--- a/site/src/pages/self-hosted.astro
+++ b/site/src/pages/self-hosted.astro
@@ -76,7 +76,7 @@ const architectureRows = [
     license: "Proprietary",
     architecture: "Cloud-orchestrated by default — full airgap is Enterprise-only.",
     detail:
-      "Cloud-Managed and Hybrid both keep orchestration in Factory's cloud (Hybrid limits it to metadata). The Fully Airgapped tier genuinely removes Factory's servers from the loop at runtime, including orchestration — but it ships only through the Enterprise plan's sales-gated flow, with no self-serve path at any price point.",
+      "Cloud-Managed and Hybrid both keep orchestration in Factory's cloud (Hybrid limits it to metadata). The Fully Airgapped tier genuinely removes Factory's servers from the loop at runtime, including orchestration — but it ships only through their sales-gated commercial flow, with no self-serve path.",
     citation: [src.factoryDeployment, src.factoryPricing],
     self: false,
   },

--- a/site/src/pages/self-hosted.astro
+++ b/site/src/pages/self-hosted.astro
@@ -47,7 +47,7 @@ const architectureRows = [
   {
     tool: "OpenHands",
     license: "MIT root, time-limited PolyForm carve-out on enterprise/",
-    architecture: "Productized VPC self-host is Enterprise-gated.",
+    architecture: "Productized VPC self-host is sales-gated.",
     detail:
       "The MIT license applies to the local tier; VPC self-hosting for the delivery-pipeline features is sold, not shipped free — the vendor's own site states \"Talk to sales\" for it.",
     citation: src.openhandsPricing,
@@ -74,9 +74,9 @@ const architectureRows = [
   {
     tool: "Factory",
     license: "Proprietary",
-    architecture: "Cloud-orchestrated by default — full airgap is Enterprise-only.",
+    architecture: "Cloud-orchestrated by default — full airgap is sales-gated.",
     detail:
-      "Cloud-Managed and Hybrid both keep orchestration in Factory's cloud (Hybrid limits it to metadata). The Fully Airgapped tier genuinely removes Factory's servers from the loop at runtime, including orchestration — but it ships only through their sales-gated commercial flow, with no self-serve path.",
+      "Cloud-Managed and Hybrid both keep orchestration in Factory's cloud (Hybrid limits it to metadata). Their fully-airgapped deployment mode genuinely removes Factory's servers from the loop at runtime, including orchestration — but it ships only through their sales-gated commercial flow, with no self-serve path.",
     citation: [src.factoryDeployment, src.factoryPricing],
     self: false,
   },
@@ -163,8 +163,8 @@ const architectureTableRows = architectureRows.map((row) => {
       Shipwright's control plane, agent runtime, and your code all run on
       infrastructure you own, at every tier — no managed-service layer in
       between. The rest of the field is either hybrid (part of the system
-      stays in the vendor's cloud) or gates full self-hosting behind an
-      Enterprise sales conversation.
+      stays in the vendor's cloud) or gates full self-hosting behind a
+      sales conversation.
     </p>
     <ComparisonTable columns={architectureColumns} rows={architectureTableRows} />
     <p class="mt-6 max-w-2xl sw-editorial">

--- a/site/src/pages/vs/factory.astro
+++ b/site/src/pages/vs/factory.astro
@@ -227,7 +227,7 @@ const dimensionRows = comparisonRows.map((row) => {
       are not optional or a droid you opt into: every task ships its tests,
       written before the implementation, and CI must be green before merge.
       Second, plan approval is the default path for all work, not a
-      Missions-tier mode you unlock at Enterprise or Max. And underneath both,
+      Missions mode you unlock through their commercial offering. And underneath both,
       Shipwright is MIT: you can fork it, read every line, and run it with
       nothing between your repository and the agent. Factory's plan approval
       and orchestration live inside a managed product you do not control.

--- a/site/src/pages/vs/factory.astro
+++ b/site/src/pages/vs/factory.astro
@@ -52,7 +52,7 @@ const comparisonRows = [
   {
     dimension: "Plan approval",
     shipwright: "Default, on every task.",
-    factory: "Missions flow (Enterprise / Max tier).",
+    factory: "Missions flow, in their commercial offering.",
     citation: src.missions,
   },
   {
@@ -261,7 +261,7 @@ const dimensionRows = comparisonRows.map((row) => {
           items: [
             { text: "You have committed to Claude Code and want a pipeline tuned for it, not averaged across providers." },
             { text: "You want tests written first and landed with every change, gated by CI, enforced by the pipeline rather than left to an agent's judgment." },
-            { text: "You want plan approval on every task by default, not as a premium tier." },
+            { text: "You want plan approval on every task by default, not as a paid add-on." },
             { text: "You want MIT and self-hosted, forkable and auditable, with nothing managed between your repo and the agent." },
           ],
         },
@@ -273,8 +273,8 @@ const dimensionRows = comparisonRows.map((row) => {
   <section class="relative z-10 pb-16" style="border-top: 1px solid var(--sw-color-border-subtle); padding-top: 3rem;">
     <h2>Economics</h2>
     <p class="mt-3 max-w-2xl">
-      Factory's Missions run at the Enterprise and Max tiers, priced per the
-      managed platform with custom enterprise contracts. Shipwright is MIT: no
+      Factory's Missions are part of their commercial managed platform, sold
+      on custom contracts. Shipwright is MIT: no
       seat fees and no platform charge for the harness itself. You bring your
       own Claude Code credentials and run it on your own Docker or Kubernetes,
       so your cost is your compute plus your model usage, nothing routed

--- a/site/tests/self-hosted.spec.ts
+++ b/site/tests/self-hosted.spec.ts
@@ -83,6 +83,22 @@ test("page markets no pricing anywhere", async ({ page }) => {
   await expectNoDollarFigures(page);
 });
 
+// MESSAGING.md D5: no tier name may appear on /self-hosted, for Shipwright or
+// any named competitor. Gating is described qualitatively ("sales-gated")
+// instead of by naming a vendor's plan tier.
+test("page names no competitor pricing tier", async ({ page }) => {
+  await page.goto("/self-hosted");
+  await expectBannedPhrasesAbsent(page, [
+    "enterprise tier",
+    "enterprise plan",
+    "enterprise-only",
+    "enterprise-gated",
+    "enterprise sales",
+    "max tier",
+    "fully airgapped tier",
+  ]);
+});
+
 test("facts carry a verified-as-of date", async ({ page }) => {
   await page.goto("/self-hosted");
   await expect(page.getByText(/facts verified as of/i)).toBeVisible();

--- a/site/tests/vs-factory.spec.ts
+++ b/site/tests/vs-factory.spec.ts
@@ -145,6 +145,22 @@ test("page markets no pricing anywhere", async ({ page }) => {
   await expectNoDollarFigures(page);
 });
 
+// MESSAGING.md D5: no tier name may appear on /vs/*, for Shipwright or any
+// named competitor. Economics are framed qualitatively ("their commercial
+// offering") rather than by naming Factory's plan tiers.
+test("page names no competitor pricing tier", async ({ page }) => {
+  await page.goto("/vs/factory");
+  await expectBannedPhrasesAbsent(page, [
+    "enterprise tier",
+    "enterprise plan",
+    "enterprise-only",
+    "enterprise or max",
+    "max tier",
+    "missions-tier",
+    "premium tier",
+  ]);
+});
+
 test("CTA repeats the install command and links GitHub + discovery call", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Removes tier names and price-point framing from `vs/factory.astro` (P4) and `self-hosted.astro` (P5), per `brand/MESSAGING.md` D5's price-free framing rule for `/vs/*`, `/self-hosted`, `/compare`.
- `vs/factory.astro`: "Missions flow (Enterprise / Max tier)" → "Missions flow, in their commercial offering"; "premium tier" → "paid add-on"; Economics prose rewritten to drop "Enterprise and Max tiers" while preserving the substantive claim (custom managed-platform contracts).
- `self-hosted.astro`: "the Enterprise plan's sales-gated flow, with no self-serve path at any price point" → "their sales-gated commercial flow, with no self-serve path" — same underlying claim, no tier name or price reference.
- Scope discipline: only the flagged P4/P5 tier/price framing changed. Citations, verifiedDate values, and all other factual claims on both pages are untouched. `compare.astro` is not touched (handled separately by MKT-COMPARE-ACCURACY-1).

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | vs/factory.astro contains no tier names | MET |
| 2 | self-hosted.astro contains no tier names / price point phrasing | MET |
| 3 | Substantive verified claims preserved | MET |
| 4 | Citations and verifiedDate unchanged | MET |
| 5 | compare.astro is not modified | MET |
| 6 | site build passes | MET |
| 7 | self-hosted.spec.ts / vs-factory.spec.ts still pass | MET |
| 8 | PR opened, NOT merged | This PR — do not merge |

## Test Plan
- `cd site && npm run build` — passes
- `npm run brand-lint` — both changed pages report on-brand
- `npx playwright test self-hosted.spec.ts vs-factory.spec.ts` — 21/21 passed, no assertion changes needed
- [x] Pre-commit checks passing

**DO NOT MERGE** — per task instructions, this PR should be opened and left open.

Generated with [Claude Code](https://claude.com/claude-code)
