### PR TITLE
fix: correct stale competitor cells on /compare, add citations and verified-date marker

### DIFF
--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -56,7 +56,7 @@ const landscape = [
     policyControls: "Security profiles, network policy, audit logs",
     humanReviewGate: "Optional",
     cronScheduling: "Yes",
-    slackWorkflow: "Yes - Slack Code",
+    slackWorkflow: "Yes — Slack Code",
     testsFirst: "No",
     self: false,
     citations: [{ label: "source", url: "https://docs.devin.ai/release-notes/2026" }],
@@ -69,12 +69,13 @@ const landscape = [
     teamVisibility: "Team dashboard",
     policyControls: "Model/MCP/repo allowlists",
     humanReviewGate: "PR review, no plan gate",
-    cronScheduling: "No",
-    slackWorkflow: "Yes - @cursor launches cloud agents",
+    cronScheduling: "Yes — cron and event automations",
+    slackWorkflow: "Yes — @cursor launches cloud agents",
     testsFirst: "No",
     self: false,
     citations: [
       { label: "Slack", url: "https://cursor.com/docs/integrations/slack" },
+      { label: "automations", url: "https://cursor.com/docs/cloud-agent/automations" },
       {
         label: "policy controls",
         url: "https://cursor.com/docs/enterprise/model-and-integration-management",
@@ -89,8 +90,8 @@ const landscape = [
     teamVisibility: "PR-level",
     policyControls: "Repo policies",
     humanReviewGate: "PR review",
-    cronScheduling: "Yes - scheduled and event automations",
-    slackWorkflow: "Yes - Slack and Teams",
+    cronScheduling: "Yes — scheduled and event automations",
+    slackWorkflow: "Yes — Slack and Teams",
     testsFirst: "No",
     self: false,
     citations: [
@@ -135,8 +136,8 @@ const landscape = [
     teamVisibility: "Slack + PR",
     policyControls: "SOC 2 Type II, ISO 42001",
     humanReviewGate: "PR review",
-    cronScheduling: "Yes - cron, webhook, event triggers",
-    slackWorkflow: "Yes - Slack as tool and trigger",
+    cronScheduling: "Yes — cron, webhook, event triggers",
+    slackWorkflow: "Yes — Slack as tool and trigger",
     testsFirst: "No",
     self: false,
     citations: [{ label: "source", url: "https://docs.augmentcode.com/cosmos/config-slack" }],
@@ -428,10 +429,22 @@ helm install shipwright shipwright/shipwright</code></pre>
     <h2 class="mt-4">Shipwright vs OpenHands</h2>
     <p class="mt-3 max-w-2xl">
       OpenHands is the category leader in open-source autonomous agents — MIT,
-      model-agnostic, deployable on your infra, ~78K stars, and it already runs
-      a delivery pipeline (scheduled tasks, triggers, PR review, opening reviewable
-      PRs). If you want maximum model flexibility and a mature ecosystem today,
-      it is an excellent choice. Here is where the two genuinely differ:
+      model-agnostic, deployable on your infra,{" "}
+      <a href="https://github.com/OpenHands/OpenHands">~86.3k GitHub stars</a>,
+      and it already runs a delivery pipeline (scheduled tasks, triggers, PR
+      review, opening reviewable PRs). It is the closest project to Shipwright
+      on this page: both are MIT, both open real PRs against your repository,
+      and both occupy the same architectural layer — the team delivery
+      pipeline, not the editor. Its{" "}
+      <a href="https://www.openhands.dev/blog/introducing-agent-canvas">Agent
+      Canvas</a> gives that pipeline a dashboard for creating and managing
+      automations, and its{" "}
+      <a href="https://docs.openhands.dev/openhands/usage/agent-canvas/acp-agents">ACP
+      support</a> can launch and drive Claude Code, Codex, or Gemini CLI
+      directly as a subprocess agent — so OpenHands can run the very runtime
+      Shipwright is built on. If you want maximum model flexibility and a
+      mature ecosystem today, it is an excellent choice. Here is where the two
+      genuinely differ:
     </p>
     <ChooseWhenGrid
       cards={[
@@ -450,7 +463,8 @@ helm install shipwright shipwright/shipwright</code></pre>
           items: [
             { text: "You need BYOK / model-agnostic across many providers, including local models." },
             { text: "You want the largest community and the most mature ecosystem available right now." },
-            { text: "You are not committed to a single runtime and want to keep that optionality." },
+            { text: "You are not committed to a single runtime and want to keep that optionality — OpenHands' ACP support can even drive Claude Code, Codex, or Gemini CLI as a subprocess agent." },
+            { text: "You want this same delivery-pipeline layer — OpenHands occupies it too, with Agent Canvas as its dashboard — and prefer its breadth to Shipwright's Claude Code focus." },
           ],
         },
       ]}

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -12,6 +12,11 @@ import ComparisonTable from "../components/ComparisonTable.astro";
 import TryItCta from "../components/TryItCta.astro";
 import { escapeHtml } from "../lib/html-escape";
 
+// Every competitor cell below is re-verified against vendor primary sources
+// (see each row's `citations`) as of this date — MESSAGING.md D10 requires a
+// visible verified-date marker on any page naming competitors.
+const verifiedDate = "September 5, 2026";
+
 // Market structure: 3-pole framing of the AI coding agent space.
 // Shipwright occupies the middle pole — team AI workflow, not copilot UX
 // and not fully autonomous fire-and-forget.
@@ -48,38 +53,56 @@ const landscape = [
     models: "Proprietary",
     taskQueue: "Yes",
     teamVisibility: "Dashboard",
-    policyControls: "Basic",
+    policyControls: "Security profiles, network policy, audit logs",
     humanReviewGate: "Optional",
     cronScheduling: "Yes",
-    slackWorkflow: "Partial",
+    slackWorkflow: "Yes - Slack Code",
     testsFirst: "No",
     self: false,
+    citations: [{ label: "source", url: "https://docs.devin.ai/release-notes/2026" }],
   },
   {
     tool: "Cursor",
     license: "Commercial",
     models: "Agnostic (multi)",
-    taskQueue: "No",
-    teamVisibility: "None",
-    policyControls: "None",
-    humanReviewGate: "No",
+    taskQueue: "No shared backlog",
+    teamVisibility: "Team dashboard",
+    policyControls: "Model/MCP/repo allowlists",
+    humanReviewGate: "PR review, no plan gate",
     cronScheduling: "No",
-    slackWorkflow: "No",
+    slackWorkflow: "Yes - @cursor launches cloud agents",
     testsFirst: "No",
     self: false,
+    citations: [
+      { label: "Slack", url: "https://cursor.com/docs/integrations/slack" },
+      {
+        label: "policy controls",
+        url: "https://cursor.com/docs/enterprise/model-and-integration-management",
+      },
+    ],
   },
   {
     tool: "GitHub Copilot Agent",
     license: "Commercial",
-    models: "GPT-4o / Claude",
+    models: "Agnostic (Claude / GPT / Gemini / Grok)",
     taskQueue: "Issues-based",
     teamVisibility: "PR-level",
     policyControls: "Repo policies",
     humanReviewGate: "PR review",
-    cronScheduling: "Via Actions",
-    slackWorkflow: "No",
+    cronScheduling: "Yes - scheduled and event automations",
+    slackWorkflow: "Yes - Slack and Teams",
     testsFirst: "No",
     self: false,
+    citations: [
+      {
+        label: "coding agent",
+        url: "https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent",
+      },
+      {
+        label: "model selection",
+        url: "https://github.blog/changelog/2026-04-14-model-selection-for-claude-and-codex-agents-on-github-com/",
+      },
+    ],
   },
   {
     tool: "OpenHands",
@@ -93,6 +116,16 @@ const landscape = [
     slackWorkflow: "Yes",
     testsFirst: "No",
     self: false,
+    citations: [
+      {
+        label: "enterprise vs OSS",
+        url: "https://docs.openhands.dev/enterprise/enterprise-vs-oss",
+      },
+      {
+        label: "automations",
+        url: "https://docs.openhands.dev/openhands/usage/automations/overview",
+      },
+    ],
   },
   {
     tool: "Augment Code",
@@ -100,12 +133,13 @@ const landscape = [
     models: "Agnostic (Claude/GPT/Gemini)",
     taskQueue: "Yes — Remote Agent queue",
     teamVisibility: "Slack + PR",
-    policyControls: "Enterprise (SOC 2 / ISO 42001)",
+    policyControls: "SOC 2 Type II, ISO 42001",
     humanReviewGate: "PR review",
-    cronScheduling: "No",
-    slackWorkflow: "Yes — codebase Q&A",
+    cronScheduling: "Yes - cron, webhook, event triggers",
+    slackWorkflow: "Yes - Slack as tool and trigger",
     testsFirst: "No",
     self: false,
+    citations: [{ label: "source", url: "https://docs.augmentcode.com/cosmos/config-slack" }],
   },
   {
     tool: "Factory",
@@ -113,12 +147,15 @@ const landscape = [
     models: "Agnostic (Claude/GPT/Gemini, BYOK)",
     taskQueue: "Yes — Missions",
     teamVisibility: "Mission Control",
-    policyControls: "Enterprise (SOC 2 / ISO 27001 / ISO 42001)",
+    policyControls: "SOC 2, ISO 27001, ISO 42001",
     humanReviewGate: "Missions (plan-approval)",
     cronScheduling: "Yes",
     slackWorkflow: "Yes — @-mention task delegation",
     testsFirst: "No",
     self: false,
+    citations: [
+      { label: "source", url: "https://docs.factory.ai/features/missions/overview" },
+    ],
   },
   {
     tool: "Shipwright Harness",
@@ -140,7 +177,7 @@ const landscape = [
 const pillars = [
   {
     title: "Plan-approval by default, not by tier",
-    body: "Specs become a reviewable task queue before a line of code is written, and a human approves the plan on every task. The commercial tier is adding plan approval as a premium mode; in Shipwright it is the default path for all work, not an enterprise upsell.",
+    body: "Specs become a reviewable task queue before a line of code is written, and a human approves the plan on every task. Some competitors are adding plan approval as an optional add-on; in Shipwright it is the default path for all work, not something you have to unlock.",
   },
   {
     title: "Tests land with the code",
@@ -173,53 +210,65 @@ const landscapeColumns = tableColumns.map((col, i) => ({
   style: `text-align:left; padding:0.6rem 1rem 0.6rem ${i === 0 ? "0" : ""}; font-family:var(--sw-font-mono); font-size:0.8125rem; text-transform:uppercase; letter-spacing:0.06em; color:var(--sw-color-text-muted); white-space:nowrap;`,
 }));
 
-const landscapeRows = landscape.map((row) => ({
-  highlight: row.self,
-  cells: [
-    {
-      style: "padding:0.7rem 1rem 0.7rem 0; vertical-align:top;",
-      html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${escapeHtml(row.tool)} </span>`,
-    },
-    {
-      style:
-        "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body); white-space:nowrap;",
-      html: escapeHtml(row.license),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.models),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.taskQueue),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.teamVisibility),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.policyControls),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.humanReviewGate),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.cronScheduling),
-    },
-    {
-      style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.slackWorkflow),
-    },
-    {
-      style:
-        "padding:0.7rem 0 0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
-      html: escapeHtml(row.testsFirst),
-    },
-  ],
-}));
+const landscapeRows = landscape.map((row) => {
+  // Competitor rows carry a `citations` array (per-row link cluster,
+  // MESSAGING.md D10); the Shipwright Harness self-row has none since it is
+  // not a competitor claim. Mirrors vs/factory.astro's inline
+  // citationsHtml map+join pattern.
+  const citationsHtml = row.citations
+    ? row.citations
+        .map((c) => `<a href="${c.url}" class="text-sm">\n[${escapeHtml(c.label)}]\n</a>`)
+        .join(" ")
+    : "";
+
+  return {
+    highlight: row.self,
+    cells: [
+      {
+        style: "padding:0.7rem 1rem 0.7rem 0; vertical-align:top;",
+        html: `<span style="font-family:var(--sw-font-display); font-weight:600; color:${row.self ? "var(--sw-color-brand-default)" : "var(--sw-color-text-heading)"};"> ${escapeHtml(row.tool)} </span>${citationsHtml ? ` ${citationsHtml}` : ""}`,
+      },
+      {
+        style:
+          "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body); white-space:nowrap;",
+        html: escapeHtml(row.license),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.models),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.taskQueue),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.teamVisibility),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.policyControls),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.humanReviewGate),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.cronScheduling),
+      },
+      {
+        style: "padding:0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.slackWorkflow),
+      },
+      {
+        style:
+          "padding:0.7rem 0 0.7rem 1rem; vertical-align:top; color:var(--sw-color-text-body);",
+        html: escapeHtml(row.testsFirst),
+      },
+    ],
+  };
+});
 ---
 
 <BaseLayout
@@ -288,14 +337,19 @@ const landscapeRows = landscape.map((row) => ({
       Agents pull from a background task queue and land review-ready PRs, and the
       commercial tier is moving fast.
     </p>
+    <p class="mt-4 text-sm" style="color: var(--sw-color-text-muted);">
+      Facts verified as of {verifiedDate}, from each vendor's own primary
+      sources (linked in the table above). Re-checked immediately before this
+      page ships — vendor terms change.
+    </p>
     <ComparisonTable columns={landscapeColumns} rows={landscapeRows} />
     <p class="mt-6 max-w-2xl sw-editorial">
       The field is converging on the middle. Factory's Missions now approves a
       plan before its droids execute, and Augment's Remote Agents land
       review-ready PRs. So the honest question is no longer who has a review
       gate, it is whose gate is the default and what it enforces. Shipwright
-      approves a plan on every task, not just in a premium mode, and it is the
-      only tool here that writes tests first and blocks merge until they pass.
+      approves a plan on every task, not just as an optional add-on, and it is
+      the only tool here that writes tests first and blocks merge until they pass.
       That combination, not the gate alone, is the whole point.
     </p>
   </section>

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -339,7 +339,7 @@ const landscapeRows = landscape.map((row) => {
     </p>
     <p class="mt-4 text-sm" style="color: var(--sw-color-text-muted);">
       Facts verified as of {verifiedDate}, from each vendor's own primary
-      sources (linked in the table above). Re-checked immediately before this
+      sources (linked in the table below). Re-checked immediately before this
       page ships — vendor terms change.
     </p>
     <ComparisonTable columns={landscapeColumns} rows={landscapeRows} />

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -216,6 +216,70 @@ test("CTA repeats the install command and links GitHub + discovery call", async 
   ).toHaveAttribute("href", BOOKING_URL);
 });
 
+// Re-verified 2026-09-05: 12 stale/wrong competitor cells corrected across
+// Cursor, GitHub Copilot Agent, Augment Code, and Devin (see MESSAGING.md
+// D10 verification pass). This test asserts one corrected cell per the
+// same row-locator pattern as the OpenHands correction test above.
+test("landscape table reflects corrected Cursor values (re-verified 2026-09-05)", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const row = page.locator("table tr").filter({
+    has: page.locator("td").first().getByText("Cursor", { exact: true }),
+  });
+  const rowText = (await row.textContent()) ?? "";
+  expect(rowText).toContain("Team dashboard");
+  expect(rowText).toContain("Model/MCP/repo allowlists");
+  expect(rowText).toContain("No shared backlog");
+  expect(rowText).toContain("PR review, no plan gate");
+  // Slack workflow cell (9th column, 0-indexed 8) must now read the
+  // corrected value, not "No".
+  const cells = row.locator("td");
+  await expect(cells.nth(8)).toContainText("Yes - @cursor launches cloud agents");
+});
+
+// The page must carry a visible "facts verified as of" marker (MESSAGING.md
+// D10) — mirrors the wording pattern on vs/devin.astro and vs/factory.astro.
+test("compare page shows a verified-date marker", async ({ page }) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).toContain("September 5, 2026");
+  expect(text.toLowerCase()).toContain("facts verified as of");
+});
+
+// Every competitor row must link at least one primary source (MESSAGING.md
+// D10); the Shipwright Harness self-row is not a competitor and carries no
+// citation.
+test("every competitor row in the landscape table links a primary source", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  for (const tool of [
+    "Devin",
+    "Cursor",
+    "GitHub Copilot Agent",
+    "OpenHands",
+    "Augment Code",
+    "Factory",
+  ]) {
+    const row = page.locator("table tr").filter({
+      has: page.locator("td").first().getByText(tool, { exact: true }),
+    });
+    const links = row.locator("td").first().locator("a");
+    expect(await links.count()).toBeGreaterThan(0);
+  }
+});
+
+// MESSAGING.md D5 bans tier-name framing (e.g. "Enterprise (...)" as a
+// stand-in for a feature list, "premium mode", "enterprise upsell").
+test("compare page contains no tier-name framing", async ({ page }) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).not.toContain("Enterprise (");
+  expect(text).not.toContain("premium mode");
+  expect(text).not.toContain("enterprise upsell");
+});
+
 test("compare page markets no pricing", async ({ page }) => {
   await page.goto("/compare");
   await expectBannedPhrasesAbsent(page, [

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -235,7 +235,52 @@ test("landscape table reflects corrected Cursor values (re-verified 2026-09-05)"
   // Slack workflow cell (9th column, 0-indexed 8) must now read the
   // corrected value, not "No".
   const cells = row.locator("td");
-  await expect(cells.nth(8)).toContainText("Yes - @cursor launches cloud agents");
+  await expect(cells.nth(8)).toContainText("Yes — @cursor launches cloud agents");
+  // Cron scheduling cell (8th column, 0-indexed 7): Cursor shipped cron and
+  // event automations for cloud agents (Aug 19 2026 changelog), so this cell
+  // must no longer read "No".
+  await expect(cells.nth(7)).toContainText("Yes — cron and event automations");
+  await expect(
+    row.locator("td").first().locator('a[href*="cloud-agent/automations"]'),
+  ).toHaveCount(1);
+});
+
+// Typographic consistency: every value cell in the landscape table that
+// qualifies a Yes/No uses an em dash, matching the pre-existing rows. An
+// ASCII hyphen in a cell value means a new/edited cell drifted from the
+// house style.
+test("landscape table cell values use em dashes, never ASCII hyphens", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const cells = await page.locator("table tbody tr td").allTextContents();
+  // Guard against a vacuous pass if the locator ever stops matching.
+  expect(cells.length).toBeGreaterThan(50);
+  for (const cell of cells) {
+    expect(cell).not.toMatch(/\b(Yes|No|Partial) - /);
+  }
+});
+
+// AC #8: the head-to-head prose must stay consistent with the corrected,
+// cited table row — no uncited fast-moving figures (MESSAGING.md D10), and
+// it must reflect the Agent Canvas / ACP capabilities the row now cites.
+test("OpenHands head-to-head prose is current and cited", async ({ page }) => {
+  await page.goto("/compare");
+  const section = page
+    .locator("section")
+    .filter({ has: page.getByRole("heading", { name: /Shipwright vs OpenHands/i }) });
+  const text = (await section.textContent()) ?? "";
+  // Stale, uncited star count is gone; the re-verified figure is cited.
+  expect(text).not.toContain("78K");
+  expect(text).toContain("~86.3k");
+  await expect(
+    section.getByRole("link", { name: /86\.3k GitHub stars/i }),
+  ).toHaveAttribute("href", "https://github.com/OpenHands/OpenHands");
+  // Decision-relevant context the corrected row already substantiates.
+  expect(text).toContain("Agent Canvas");
+  expect(text).toContain("ACP");
+  // Both projects occupy the same architectural layer — say so plainly.
+  expect(text).toMatch(/same architectural layer/i);
 });
 
 // The page must carry a visible "facts verified as of" marker (MESSAGING.md


### PR DESCRIPTION
## Summary
- Correct 12 wrong/stale competitor cells in `/compare`'s `landscape` array (Cursor, GitHub Copilot Agent, Augment Code, Devin) — all pre-verified against vendor primary sources 2026-09-05.
- Add a `citations` array to every competitor row (Devin, Cursor, GitHub Copilot Agent, OpenHands, Augment Code, Factory) linking at least one primary source, plus a visible `verifiedDate` ("September 5, 2026") marker near the landscape table — MESSAGING.md D10.
- Remove tier-name framing ("Enterprise (...)", "premium mode", "enterprise upsell") from `policyControls` cells and prose per MESSAGING.md D5.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | All 12 listed cell corrections applied exactly as specified | ✅ MET |
| 2 | testsFirst remains 'No' for all six competitors | ✅ MET |
| 3 | Shipwright Harness row unchanged | ✅ MET |
| 4 | Every competitor row links at least one primary source | ✅ MET |
| 5 | verifiedDate constant set + rendered visibly | ✅ MET |
| 6 | Zero tier names ('Enterprise (', 'Max tier', 'premium tier') | ✅ MET |
| 7 | Zero prices anywhere in compare.astro | ✅ MET |
| 8 | Prose sections re-read, consistent with corrected cells | ✅ MET |
| 9 | site build passes (`cd site && npm run build`) | ✅ MET |
| 10 | compare.spec.ts updated for verified-date + corrected cell | ✅ MET |

## Test Plan
- `cd site && npm run build` — passes, zero errors
- `cd site && npx playwright test compare.spec.ts` — 23/23 passed
- `bun run --filter='*' --sequential typecheck` — passes
- `bunx biome lint` on changed files — clean
- Added 4 new Playwright tests: corrected Cursor cells, verified-date marker visibility, per-row citation links, absence of tier-name framing
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
