### PR TITLE
feat: rework homepage differentiators and compare pillars into ladder narrative

### DIFF
--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -175,16 +175,28 @@ const landscape = [
 
 // The three things that actually distinguish Shipwright — framed as *how* it
 // works, not as an empty-category claim.
+//
+// MESSAGING.md D10: every competitor fact stated in a pillar body carries a
+// primary-source citation on that same pillar. Pillar-source mapping
+// re-verified 2026-09-06 against each vendor's own docs — in particular,
+// Factory's Missions overview states missions run user-facing QA testing as
+// they work and self-correct, so the pillar-1 body describes Factory's QA as
+// running-but-not-merge-blocking rather than as opt-in test generation.
 const pillars = [
   {
     title: "Tests are enforced, not offered",
-    body: "Everyone in this table can generate tests. Nobody else gates on them. OpenHands is explicit that running the suite is CI's job, not the agent's; Factory, Augment and Cursor all offer test generation you opt into. Shipwright writes the failing test before the implementation and will not merge without green CI. It is the pipeline's rule, not the agent's discretion.",
+    body: "Everyone in this table can generate tests. Nobody else makes passing them the default gate. OpenHands is explicit that running the suite is CI's job, not the agent's. Factory's Missions do run QA against your app as they work and self-correct, but nothing holds the merge on a red suite. Augment generates tests when you ask for them, and Cursor's missing-test PR checks are rules you opt into. Shipwright writes the failing test before the implementation and will not merge without green CI. It is the pipeline's rule, not the agent's discretion.",
+    citations: [
+      { label: "OpenHands: QA is CI's job", url: "https://docs.openhands.dev/openhands/usage/use-cases/qa-changes" },
+      { label: "Factory Missions", url: "https://docs.factory.ai/features/missions/overview" },
+      { label: "Augment: Agent use cases", url: "https://docs.augmentcode.com/using-augment/agent" },
+      { label: "Cursor: test generation", url: "https://cursor.com/for/test-generation" },
+    ],
   },
   {
     title: "An opinionated loop you can take apart",
     body: "OpenHands gives you primitives and no opinion: you assemble the pipeline yourself. Factory gives you an opinion you cannot open. Shipwright ships the loop already opinionated, then lets you disable phases, override the review principles per repo, and bolt on your own commands and scheduled jobs. Start on rails, then change the rails.",
     citations: [
-      { label: "OpenHands: QA is CI's job", url: "https://docs.openhands.dev/openhands/usage/use-cases/qa-changes" },
       { label: "Factory Missions", url: "https://docs.factory.ai/features/missions/overview" },
     ],
   },

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -182,6 +182,10 @@ const landscape = [
 // Factory's Missions overview states missions run user-facing QA testing as
 // they work and self-correct, so the pillar-1 body describes Factory's QA as
 // running-but-not-merge-blocking rather than as opt-in test generation.
+// Pillar 2's "primitives and no opinion" claim is sourced to OpenHands' own SDK
+// product page, which states verbatim: "OpenHands gives you primitives, not
+// prescriptions, so you can adapt agents to your codebase, tooling, and
+// governance needs."
 const pillars = [
   {
     title: "Tests are enforced, not offered",
@@ -197,6 +201,7 @@ const pillars = [
     title: "An opinionated loop you can take apart",
     body: "OpenHands gives you primitives and no opinion: you assemble the pipeline yourself. Factory gives you an opinion you cannot open. Shipwright ships the loop already opinionated, then lets you disable phases, override the review principles per repo, and bolt on your own commands and scheduled jobs. Start on rails, then change the rails.",
     citations: [
+      { label: "OpenHands: primitives, not prescriptions", url: "https://www.openhands.dev/product/sdk" },
       { label: "Factory Missions", url: "https://docs.factory.ai/features/missions/overview" },
     ],
   },

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -177,16 +177,23 @@ const landscape = [
 // works, not as an empty-category claim.
 const pillars = [
   {
-    title: "Plan-approval by default, not by tier",
-    body: "Specs become a reviewable task queue before a line of code is written, and a human approves the plan on every task. Some competitors are adding plan approval as an optional add-on; in Shipwright it is the default path for all work, not something you have to unlock.",
+    title: "Tests are enforced, not offered",
+    body: "Everyone in this table can generate tests. Nobody else gates on them. OpenHands is explicit that running the suite is CI's job, not the agent's; Factory, Augment and Cursor all offer test generation you opt into. Shipwright writes the failing test before the implementation and will not merge without green CI. It is the pipeline's rule, not the agent's discretion.",
   },
   {
-    title: "Tests land with the code",
-    body: 'Every task ships its tests in the same PR, written before the implementation (red-green-refactor is enforced). CI must be green before merge. No “add tests later.”',
+    title: "An opinionated loop you can take apart",
+    body: "OpenHands gives you primitives and no opinion: you assemble the pipeline yourself. Factory gives you an opinion you cannot open. Shipwright ships the loop already opinionated, then lets you disable phases, override the review principles per repo, and bolt on your own commands and scheduled jobs. Start on rails, then change the rails.",
+    citations: [
+      { label: "OpenHands: QA is CI's job", url: "https://docs.openhands.dev/openhands/usage/use-cases/qa-changes" },
+      { label: "Factory Missions", url: "https://docs.factory.ai/features/missions/overview" },
+    ],
   },
   {
-    title: "Claude-native by design",
-    body: "The planning prompts, review loops, and context system are tuned for one runtime instead of averaged across many. Claude-optimized, not lowest-common-denominator.",
+    title: "Open throughout, not open core",
+    body: "MIT is table stakes in open source now, so the question is what the license actually covers. In OpenHands, authentication, role-based access control, multi-user organisations and isolated sandboxes sit in the commercial product. In Shipwright, SSO and scoped per-agent access are in the repo you fork. Their open source converts to a paid product exactly when a team needs it. Ours does not.",
+    citations: [
+      { label: "OpenHands: Enterprise vs OSS", url: "https://docs.openhands.dev/enterprise/enterprise-vs-oss" },
+    ],
   },
 ];
 
@@ -358,11 +365,24 @@ const landscapeRows = landscape.map((row) => {
   <!-- What actually makes Shipwright different -->
   <section class="relative z-10 py-20" style="border-top: 1px solid var(--sw-color-border-subtle);">
     <h2>What actually makes Shipwright different</h2>
+    <p class="mt-3 max-w-2xl">
+      Three things hold up under a direct comparison. We have retired the ones that did not.
+    </p>
     <div class="mt-8 grid gap-6 sm:grid-cols-3">
       {pillars.map((p) => (
         <div class="sw-card">
           <h3>{p.title}</h3>
           <p class="mt-2" style="color:var(--sw-color-text-body);">{p.body}</p>
+          {p.citations && (
+            <p class="mt-3 text-sm" style="color: var(--sw-color-text-muted);">
+              {p.citations.map((c, i) => (
+                <>
+                  {i > 0 && " "}
+                  <a href={c.url} class="text-sm">[{c.label}]</a>
+                </>
+              ))}
+            </p>
+          )}
         </div>
       ))}
     </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -299,24 +299,24 @@ const stages = [
 // Differentiators: generic, no competitor names. Claude Code is the platform.
 const differentiators = [
   {
-    label: "Own it",
-    title: "Free & open-source (MIT)",
-    body: "No tiers, no seats, no data leaving your control. Clone it, run it in your own cloud, fork it if you want to.",
+    label: "Start here",
+    title: "Run our loop on day one",
+    body: "Install it and the whole pipeline is already opinionated: spec, plan, build, tests, review, deploy. You do not assemble anything. You point it at a repo and it ships.",
   },
   {
-    label: "Test-readiness",
-    title: "Tests land with the code",
-    body: "Every task ships its tests at the correct layer — unit, integration, smoke, or e2e — in the same PR. No 'tests later'.",
+    label: "Then change it",
+    title: "Swap out any phase",
+    body: "Turn off the phases you do not want. Override the review principles per repo. Add your own commands and scheduled jobs as a companion plugin. The loop is opinionated, not sealed.",
   },
   {
-    label: "Metric-first",
-    title: "Measured, not vibes",
-    body: "First-time-quality, estimation accuracy, and review verdicts are tracked per task so the pipeline gets honestly better.",
+    label: "Then outgrow it",
+    title: "Leave and keep everything",
+    body: "What it writes into your repo is vanilla Claude Code: your CLAUDE.md, docs, skills and commands. Stop using Shipwright and all of it still works. The exit is cheap on purpose.",
   },
   {
-    label: "Repo-agnostic",
-    title: "Runs on your stack",
-    body: "Node, Rust, Go, Python, Ruby, Make — the plugin drives any repository it's pointed at, not a blessed template.",
+    label: "Throughout",
+    title: "Tests are not optional",
+    body: "Every task writes its failing test before the implementation, at the correct layer, in the same PR. CI must be green to merge. This is enforced by the pipeline, not left to the agent's judgment.",
   },
 ];
 
@@ -997,6 +997,9 @@ const differentiators = [
     <p class="mt-5 max-w-2xl text-lg">
       It runs on Claude Code — the platform it's built for — and stays entirely
       in your hands: open-source, self-hosted, and measured.
+    </p>
+    <p class="mt-3 max-w-2xl text-lg">
+      Three rungs, and you decide how far up you go.
     </p>
 
     <div class="mt-10 grid gap-4 sm:grid-cols-2">

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -407,7 +407,10 @@ test("each pillar cites the competitors its own body names", async ({
     await expect(testsPillar.locator(`a[href="${url}"]`)).toHaveCount(1);
   }
 
-  // Pillar 2 is about architecture/extensibility, not testing — the
+  // Pillar 2 names both OpenHands ("primitives and no opinion") and Factory —
+  // both need a primary source on this card. The OpenHands source is the SDK
+  // product page ("primitives, not prescriptions"), not the QA-changes doc:
+  // this pillar is about architecture/extensibility, not testing, so the
   // QA-is-CI's-job link belongs on pillar 1 and must not appear here.
   const loopPillar = card("An opinionated loop you can take apart");
   await expect(
@@ -415,11 +418,12 @@ test("each pillar cites the competitors its own body names", async ({
       'a[href="https://docs.openhands.dev/openhands/usage/use-cases/qa-changes"]',
     ),
   ).toHaveCount(0);
-  await expect(
-    loopPillar.locator(
-      'a[href="https://docs.factory.ai/features/missions/overview"]',
-    ),
-  ).toHaveCount(1);
+  for (const url of [
+    "https://www.openhands.dev/product/sdk",
+    "https://docs.factory.ai/features/missions/overview",
+  ]) {
+    await expect(loopPillar.locator(`a[href="${url}"]`)).toHaveCount(1);
+  }
 
   await expect(
     card("Open throughout, not open core").locator(

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -357,6 +357,56 @@ test("header nav links to /compare on every page", async ({ page }) => {
   }
 });
 
+// MKT-LADDER-NARRATIVE-1: the pillars section is retired from the old
+// "Plan-approval / Tests land / Claude-native" framing to a direct-comparison
+// narrative, with citations on the two pillars that reference OpenHands/Factory.
+test("pillars section presents the retired-narrative titles and intro", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).toContain(
+    "Three things hold up under a direct comparison. We have retired the ones that did not.",
+  );
+  for (const title of [
+    "Tests are enforced, not offered",
+    "An opinionated loop you can take apart",
+    "Open throughout, not open core",
+  ]) {
+    expect(text).toContain(title);
+  }
+});
+
+test("pillars section links its OpenHands and Factory citations", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const heading = page.getByRole("heading", {
+    name: /What actually makes Shipwright different/i,
+  });
+  const section = page.locator("section").filter({ has: heading });
+  await expect(
+    section.locator(
+      'a[href="https://docs.openhands.dev/openhands/usage/use-cases/qa-changes"]',
+    ),
+  ).toHaveCount(1);
+  await expect(
+    section.locator('a[href="https://docs.factory.ai/features/missions/overview"]'),
+  ).toHaveCount(1);
+  await expect(
+    section.locator('a[href="https://docs.openhands.dev/enterprise/enterprise-vs-oss"]'),
+  ).toHaveCount(1);
+});
+
+test("retired pillar copy no longer appears anywhere on /compare", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).not.toContain("Plan-approval by default");
+  expect(text).not.toContain("Claude-native by design");
+});
+
 test("homepage differentiators bridge into /compare (competitor-free)", async ({
   page,
 }) => {

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -377,7 +377,12 @@ test("pillars section presents the retired-narrative titles and intro", async ({
   }
 });
 
-test("pillars section links its OpenHands and Factory citations", async ({
+// MESSAGING.md D10: every competitor fact must be cited, and the citation
+// must sit on the pillar that actually states the fact. Assert per-card, not
+// per-section — a section-wide link count passes even when a citation is
+// attached to the wrong pillar (which is exactly how the QA-is-CI's-job link
+// ended up on the architecture pillar).
+test("each pillar cites the competitors its own body names", async ({
   page,
 }) => {
   await page.goto("/compare");
@@ -385,17 +390,53 @@ test("pillars section links its OpenHands and Factory citations", async ({
     name: /What actually makes Shipwright different/i,
   });
   const section = page.locator("section").filter({ has: heading });
+  const card = (title: string) =>
+    section.locator(".sw-card").filter({
+      has: page.getByRole("heading", { name: title }),
+    });
+
+  // Pillar 1 names OpenHands, Factory, Augment and Cursor — all four need a
+  // primary source on this card.
+  const testsPillar = card("Tests are enforced, not offered");
+  for (const url of [
+    "https://docs.openhands.dev/openhands/usage/use-cases/qa-changes",
+    "https://docs.factory.ai/features/missions/overview",
+    "https://docs.augmentcode.com/using-augment/agent",
+    "https://cursor.com/for/test-generation",
+  ]) {
+    await expect(testsPillar.locator(`a[href="${url}"]`)).toHaveCount(1);
+  }
+
+  // Pillar 2 is about architecture/extensibility, not testing — the
+  // QA-is-CI's-job link belongs on pillar 1 and must not appear here.
+  const loopPillar = card("An opinionated loop you can take apart");
   await expect(
-    section.locator(
+    loopPillar.locator(
       'a[href="https://docs.openhands.dev/openhands/usage/use-cases/qa-changes"]',
     ),
-  ).toHaveCount(1);
+  ).toHaveCount(0);
   await expect(
-    section.locator('a[href="https://docs.factory.ai/features/missions/overview"]'),
+    loopPillar.locator(
+      'a[href="https://docs.factory.ai/features/missions/overview"]',
+    ),
   ).toHaveCount(1);
+
   await expect(
-    section.locator('a[href="https://docs.openhands.dev/enterprise/enterprise-vs-oss"]'),
+    card("Open throughout, not open core").locator(
+      'a[href="https://docs.openhands.dev/enterprise/enterprise-vs-oss"]',
+    ),
   ).toHaveCount(1);
+});
+
+// Factory's Missions overview documents QA testing running automatically as a
+// mission works — so the pillar must not frame Factory's testing as opt-in.
+test("pillar 1 does not claim Factory's test generation is opt-in", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).not.toContain("Factory, Augment and Cursor all offer test");
+  expect(text).toMatch(/Factory's Missions do run QA/);
 });
 
 test("retired pillar copy no longer appears anywhere on /compare", async ({

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -381,6 +381,53 @@ test("differentiators names no competitors except a single linked Devin mention"
   }
 });
 
+// MKT-LADDER-NARRATIVE-1: the differentiators grid tells a three-rung ladder
+// story (start here / then change it / then outgrow it), plus a fourth
+// always-on card. Competitor names stay banned in this section.
+test("differentiators present the three-rung ladder narrative", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const section = page.locator("#differentiators");
+  await expect(section).toBeVisible();
+  await expect(
+    section.getByText("Three rungs, and you decide how far up you go."),
+  ).toBeVisible();
+  for (const title of [
+    "Run our loop on day one",
+    "Swap out any phase",
+    "Leave and keep everything",
+    "Tests are not optional",
+  ]) {
+    await expect(section.getByText(title, { exact: true })).toBeVisible();
+  }
+  const text = (await section.textContent())?.toLowerCase() ?? "";
+  for (const competitor of [
+    "openhands",
+    "factory",
+    "devin",
+    "cursor",
+    "augment",
+    "copilot",
+  ]) {
+    expect(text).not.toContain(competitor);
+  }
+});
+
+// Honesty guardrail: the "Then outgrow it" card must read as "leave and keep
+// everything works", never a productized guided "build your own" / DIY path
+// (Shipwright does not ship a DIY-kit product).
+test("differentiators do not claim a guided build-your-own / DIY path", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const section = page.locator("#differentiators");
+  const text = (await section.textContent())?.toLowerCase() ?? "";
+  expect(text).not.toContain("build your own");
+  expect(text).not.toContain("diy");
+  expect(text).not.toContain("assemble your own pipeline");
+});
+
 test("'Run the full stack' tab shows the task stack:up walkthrough video", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Replace the homepage `#differentiators` cards and /compare `pillars` with a three-rung "ladder" narrative (start with our loop → swap out phases → outgrow it and keep everything), retiring two decayed /compare pillars ("Plan-approval by default" and "Claude-native by design") that no longer hold up against the current competitive field.
- Add primary-source citations (OpenHands, Factory) to the two /compare pillars that make competitor claims, per brand/MESSAGING.md D10.
- Keep the homepage `#differentiators` section fully competitor-free; "Metric-first" and "Repo-agnostic" concepts already live elsewhere on the page and were left untouched.

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | index.astro differentiators array replaced with the four specified cards, verbatim | MET |
| 2 | Section intro line added above the differentiators grid | MET |
| 3 | index.astro contains NO competitor names in the differentiators section (D10) | MET |
| 4 | Metric-first and repo-agnostic points are relocated, not silently deleted | MET (already present elsewhere on the page) |
| 5 | compare.astro pillars array replaced with the three specified pillars, verbatim | MET |
| 6 | compare.astro pillars intro updated as specified | MET |
| 7 | Pillar 2 and 3 competitor claims carry primary-source citations | MET |
| 8 | No guided build-your-own / DIY-kit claim anywhere | MET |
| 9 | No prices, tier names, SWE-bench figures, or multi-backend claims introduced | MET |
| 10 | MKT-COMPARE-ACCURACY-1 cell corrections, citations and verifiedDate preserved | MET |
| 11 | site build passes (cd site && npm run build) | MET |
| 12 | site tests updated to cover the new differentiators and pillars copy | MET |

## Test Plan
- Added 5 new Playwright tests across `site/tests/home.spec.ts` and `site/tests/compare.spec.ts` covering the new copy, citation links, and honesty guardrails (no DIY-kit claim, no competitor names on the homepage).
- `cd site && npm test` — 69/69 passing (home.spec.ts + compare.spec.ts).
- `cd site && npm run build` / `build:check` — passing, no brand-lint violations.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
