### PR TITLE
docs: sync freshness anchor (audit found no stale docs)

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"b385f7b4f3b7e0606fd86e54cf2cf4e869c49a3b","timestamp":"2026-09-05T07:11:40Z"}
+{"sha":"47d0a848f240d3157e4c2a49cb4c3faf0ad3feb1","timestamp":"2026-09-06T07:10:13Z"}


### PR DESCRIPTION
## Summary

Automated daily docs-freshness audit (`/shipwright:research-docs --auto`) for `app-vitals/shipwright`.

- Anchor advanced from `b385f7b4f3b7e0606fd86e54cf2cf4e869c49a3b` (2026-09-05) to `47d0a848f240d3157e4c2a49cb4c3faf0ad3feb1` (2026-09-06).
- Candidates checked (A3, grepped against the 39 changed source files in this window): `docs/agent-key-files.md`, `docs/agent-ops.md`, `docs/agent-types.md`, `docs/agent.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/helm-repo.md`, `docs/migration.md`.
- Staleness check (A4): all 8 came back **current** — every checked reference (file paths, symbols, endpoints, values.yaml/Chart.yaml literals) still resolves against the current codebase. No `Edit`s applied.
- Quality pass (A5.5): skipped — no doc was rewritten this run.
- CLAUDE.md reference section (A6): unchanged — no docs created or removed.
- Missing-docs / cross-cutting concerns (A7): filed **1** task — `Document error-handling conventions` (task-store's `ApiError`/`HTTPException` error-class hierarchy and central error-handler middleware in `task-store/src/app.ts` + `task-store/src/errors.ts` + `task-store/src/routes/tasks.ts` is materially present and touched this window but undocumented anywhere in `docs/`).
- Sync anchor (A8): bumped to `47d0a848f240d3157e4c2a49cb4c3faf0ad3feb1`.

Only the anchor file changed — shipping per this repo's standing precedent that a "no stale docs found" run still lands a small PR since `state/docs-last-synced.json` is tracked in git.

## Test plan

- [x] N/A — anchor-only change, no code/doc edits to verify