### PR TITLE
fix: split home and /vs/devin title tags to stop Devin-query cannibalization

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -15,8 +15,10 @@ const heroSubhead =
 // Prior canonical tagline — demoted, not deleted (brand/MESSAGING.md §1).
 const priorTagline =
   "The open-source autonomous delivery agent for Claude Code.";
-const pageTitle = "Shipwright -- The open source alternative to Devin";
-const pageDescription = `${heroH1} ${heroSubhead}`;
+const pageTitle = "Shipwright — Open Source Autonomous Delivery Agent";
+const pageDescription =
+  "Shipwright is the MIT-licensed, spec-to-deploy autonomous delivery agent that " +
+  "runs entirely in your own cloud. An open source alternative to Devin.";
 const install = "/plugin install shipwright@app-vitals/shipwright";
 const githubUrl = "https://github.com/app-vitals/shipwright";
 const proofUrl = "https://proof.shipwrightharness.com/public/dashboard";

--- a/site/src/pages/vs/devin.astro
+++ b/site/src/pages/vs/devin.astro
@@ -92,8 +92,8 @@ const dimensionRows = comparisonRows.map((row) => ({
 ---
 
 <BaseLayout
-  title="The open source alternative to Devin — Shipwright vs Devin"
-  description="Shipwright vs Devin — the open source alternative to Devin: a license-file comparison, deployment contrast, and honest breakdown of when to choose each."
+  title="Shipwright vs Devin — Open Source Devin Alternative Compared"
+  description="A sourced, head-to-head Shipwright vs Devin comparison: MIT licence vs proprietary, self-hosted vs vendor-hosted, spec-to-deploy vs spec-to-PR, and an honest breakdown of when to choose each."
   pagefindIgnore={true}
 >
   <!-- Page header -->

--- a/site/tests/home.spec.ts
+++ b/site/tests/home.spec.ts
@@ -568,12 +568,12 @@ test("the og:image asset is actually served (1280x640 PNG)", async ({
   expect(res.headers()["content-type"]).toContain("image/png");
 });
 
-test("default page title is the SEO-targeted open-source-alternative-to-Devin string", async ({
+test("default page title is the brand + category SEO string", async ({
   page,
 }) => {
   await page.goto("/");
   expect(await page.title()).toBe(
-    "Shipwright -- The open source alternative to Devin",
+    "Shipwright — Open Source Autonomous Delivery Agent",
   );
 });
 
@@ -583,7 +583,7 @@ test("og:title meta content matches the default title", async ({ page }) => {
     page.locator('head meta[property="og:title"]'),
   ).toHaveAttribute(
     "content",
-    "Shipwright -- The open source alternative to Devin",
+    "Shipwright — Open Source Autonomous Delivery Agent",
   );
 });
 

--- a/site/tests/vs-devin.spec.ts
+++ b/site/tests/vs-devin.spec.ts
@@ -26,11 +26,13 @@ test("vs/devin route responds 200", async ({ page }) => {
   expect(response?.status()).toBe(200);
 });
 
-test("page title targets the open-source-alternative-to-Devin query", async ({
+test("page title targets the Shipwright vs Devin comparison query", async ({
   page,
 }) => {
   await page.goto("/vs/devin");
-  expect(await page.title()).toContain("open source alternative to Devin");
+  expect(await page.title()).toBe(
+    "Shipwright vs Devin — Open Source Devin Alternative Compared",
+  );
 });
 
 test("page ships no runtime JS beyond the analytics tag", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Homepage `<title>` no longer leads with "open source alternative to Devin" — changed to "Shipwright — Open Source Autonomous Delivery Agent" (the phrase is retained in the meta description for topical relevance, just removed from the title).
- `/vs/devin` `<title>`/description changed to "Shipwright vs Devin — Open Source Devin Alternative Compared" so it targets its own, distinct query instead of competing with the homepage.
- 90 days of GSC data showed the homepage wins every "devin harness" impression while `/vs/devin` (the page built to convert Devin-evaluation searchers) never ranks — this was pure title-tag keyword cannibalization since both pages led with the identical head phrase and the root URL carries more internal-link authority.
- Updated the two hard-coded title assertions in `site/tests/home.spec.ts`, plus one in `site/tests/vs-devin.spec.ts` (not called out in the original spec, but it hard-coded the old `/vs/devin` title and would otherwise break — upgraded from a loose `toContain` check to an exact match on the new title).

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `bun install && bun run build` succeeds | MET | build completed, 27 pages built |
| 2 | `dist/index.html` title exactly "Shipwright — Open Source Autonomous Delivery Agent" | MET | verified on built output |
| 3 | `dist/vs/devin/index.html` title exactly "Shipwright vs Devin — Open Source Devin Alternative Compared" | MET | verified on built output |
| 4 | Neither title contains the other's head phrase | MET | confirmed no cross-contamination |
| 5 | `<link rel="canonical">` unchanged on both pages | MET | `BaseLayout.astro` untouched |
| 6 | `site/tests/home.spec.ts` suite passes | MET | full site e2e suite: 54/54 in touched files, no regressions elsewhere |

`heroH1`/`heroSubhead`/`priorTagline` (human-owned D1 canonical positioning) and the H1-assertion tests are untouched. No changes to `/vs/factory`, `/vs/openhands`, `/compare`, or sitemap/redirects.

## Test Plan
- `cd site && npm run build` — succeeds, titles verified byte-for-byte in built HTML.
- `cd site && npx playwright test` — full suite passes (pre-existing, unrelated `docs-search.spec.ts` failures reproduce identically on `main`, confirmed via `git stash`).
- [x] Pre-commit checks passing (`bunx biome check` clean on all 4 changed files)

Generated with [Claude Code](https://claude.com/claude-code)
