### PR TITLE
fix: fail-closed isAdmin default in getSessionUser (admin-ui.ts)

### DIFF
--- a/admin/e2e/agents-page.e2e.ts
+++ b/admin/e2e/agents-page.e2e.ts
@@ -98,7 +98,7 @@ async function mintSession(
 ): Promise<string> {
   const nowSec = Math.floor(Date.now() / 1000);
   return sign(
-    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    { userId, email, isAdmin: true, iat: nowSec, exp: nowSec + 3600 },
     SESSION_SECRET,
     "HS256",
   );

--- a/admin/e2e/chat-degraded.e2e.ts
+++ b/admin/e2e/chat-degraded.e2e.ts
@@ -99,7 +99,7 @@ async function mintSession(
 ): Promise<string> {
   const nowSec = Math.floor(Date.now() / 1000);
   return sign(
-    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    { userId, email, isAdmin: true, iat: nowSec, exp: nowSec + 3600 },
     SESSION_SECRET,
     "HS256",
   );

--- a/admin/e2e/chat-page.e2e.ts
+++ b/admin/e2e/chat-page.e2e.ts
@@ -90,7 +90,7 @@ async function mintSession(
 ): Promise<string> {
   const nowSec = Math.floor(Date.now() / 1000);
   return sign(
-    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    { userId, email, isAdmin: true, iat: nowSec, exp: nowSec + 3600 },
     SESSION_SECRET,
     "HS256",
   );

--- a/admin/e2e/chat-progress.e2e.ts
+++ b/admin/e2e/chat-progress.e2e.ts
@@ -100,7 +100,7 @@ async function mintSession(
 ): Promise<string> {
   const nowSec = Math.floor(Date.now() / 1000);
   return sign(
-    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    { userId, email, isAdmin: true, iat: nowSec, exp: nowSec + 3600 },
     SESSION_SECRET,
     "HS256",
   );

--- a/admin/e2e/chat-thread-page.e2e.ts
+++ b/admin/e2e/chat-thread-page.e2e.ts
@@ -91,7 +91,7 @@ async function mintSession(
 ): Promise<string> {
   const nowSec = Math.floor(Date.now() / 1000);
   return sign(
-    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    { userId, email, isAdmin: true, iat: nowSec, exp: nowSec + 3600 },
     SESSION_SECRET,
     "HS256",
   );

--- a/admin/e2e/test-server.ts
+++ b/admin/e2e/test-server.ts
@@ -225,11 +225,12 @@ function buildMockDeps(chatClient: ChatClient | undefined): AdminUIDeps {
       },
       // Referenced by the agent detail page's admin-only member list and by
       // assertAgentAccess's non-admin membership check. Sessions minted for
-      // these e2e tests omit an `isAdmin` claim, and getSessionUser treats a
-      // missing claim as admin (isAdmin !== false) — so the render path always
-      // takes the admin branch (prisma.agentMember.findMany), never the
-      // non-admin findUnique branch. No members fixture exists, so both
-      // resolve to empty/not-found.
+      // these e2e tests (via mintAdminSession) explicitly set `isAdmin: true`,
+      // so the render path deliberately takes the admin branch
+      // (prisma.agentMember.findMany), never the non-admin findUnique branch.
+      // No members fixture exists, so both resolve to empty/not-found. A
+      // non-admin session case isn't exercised here — that's an intentional
+      // test-coverage gap, not a fixture bug.
       agentMember: {
         findMany: async () => [],
         findUnique: async () => null,
@@ -392,7 +393,7 @@ export async function mintAdminSession(
 ): Promise<string> {
   const nowSec = Math.floor(Date.now() / 1000);
   return sign(
-    { userId, email, iat: nowSec, exp: nowSec + 3600 },
+    { userId, email, isAdmin: true, iat: nowSec, exp: nowSec + 3600 },
     ADMIN_E2E_SESSION_SECRET,
     "HS256",
   );

--- a/admin/src/admin-ui.smoke.test.ts
+++ b/admin/src/admin-ui.smoke.test.ts
@@ -8317,6 +8317,46 @@ describe("admin UI — PRs page", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  // authz-missing-check (fail-open isAdmin default): getSessionUser must treat
+  // a session token that omits the isAdmin claim — or sets it to any non-true
+  // value — as non-admin, not as admin-by-default.
+  it("GET /admin/prs returns 403 when the session token omits the isAdmin claim entirely", async () => {
+    const omittedAdminClaimCookie = await sign(
+      {
+        userId: "google-sub-no-claim",
+        email: "no-claim@example.com",
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      SESSION_SECRET,
+      "HS256",
+    );
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/prs", {
+      headers: { Cookie: `admin_session=${omittedAdminClaimCookie}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /admin/prs returns 403 when the session token's isAdmin claim is a non-boolean truthy value", async () => {
+    const nonBooleanAdminClaimCookie = await sign(
+      {
+        userId: "google-sub-string-claim",
+        email: "string-claim@example.com",
+        isAdmin: "true",
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      SESSION_SECRET,
+      "HS256",
+    );
+    const app = createAdminUIApp(makeMockDeps());
+    const res = await app.request("/admin/prs", {
+      headers: { Cookie: `admin_session=${nonBooleanAdminClaimCookie}` },
+    });
+    expect(res.status).toBe(403);
+  });
 });
 
 // ─── Public task board ────────────────────────────────────────────────────────

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -498,7 +498,7 @@ async function getSessionUser(
       typeof payload.email === "string" &&
       payload.email.length > 0
     ) {
-      return { email: payload.email, isAdmin: payload.isAdmin !== false };
+      return { email: payload.email, isAdmin: payload.isAdmin === true };
     }
     return null;
   } catch {


### PR DESCRIPTION
## Summary
- `getSessionUser` in `admin/src/admin-ui.ts` now computes `isAdmin` as `payload.isAdmin === true` (fail-closed) instead of `payload.isAdmin !== false` (fail-open), matching the fail-closed pattern used by every other `c.var.isAdmin` check in this file.
- A session token missing the `isAdmin` claim, or with a non-boolean value for it, is now treated as non-admin rather than defaulting to admin.
- Not currently exploitable — the sole token-issuing path (`createSessionToken`) always sets `isAdmin` explicitly and tokens are HMAC-signed — but this closes a latent fail-open default that would silently grant admin if any future code path ever minted a session token without explicitly setting `isAdmin`.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Line 501's `isAdmin` computation changed from `payload.isAdmin !== false` to `payload.isAdmin === true` | MET | `admin/src/admin-ui.ts:501` |
| 2 | Test asserting a session token with `isAdmin` omitted or set to a non-true value is treated as non-admin | MET | Two new smoke tests in `admin/src/admin-ui.smoke.test.ts` asserting 403 for an omitted claim and for a non-boolean truthy claim |

## Test Plan
- New smoke tests: `GET /admin/prs returns 403 when the session token omits the isAdmin claim entirely` and `GET /admin/prs returns 403 when the session token's isAdmin claim is a non-boolean truthy value` — both confirmed RED against the original fail-open code, GREEN after the fix.
- Full `admin-ui.smoke.test.ts` suite: 299/299 pass, no regressions to existing admin/session tests (real admin sessions with `isAdmin: true` still work).
- `task typecheck`: clean.
- `task ci` fails with 31 pre-existing test failures in `metrics/src/lib/env.unit.test.ts`, `metrics/src/lib/errors.unit.test.ts`, and `task-store/src/routes/prs.openapi.smoke.test.ts` — verified identical failure count reproduces on a clean `origin/main` checkout, unrelated to this change.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
