### PR TITLE
docs: sync freshness anchor (audit found no stale docs)

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"47d0a848f240d3157e4c2a49cb4c3faf0ad3feb1","timestamp":"2026-09-06T07:10:13Z"}
+{"sha":"1acd66c5d9a8e4b0e411cc933c9b1158c36728e0","timestamp":"2026-09-07T07:04:36Z"}


### PR DESCRIPTION
## Summary

Automated `/shipwright:research-docs --auto` run, scoped by precheck to these changed source files (marketing-copy tweaks to the homepage and Devin comparison page's title/meta-description, and their matching Playwright specs):

- `site/src/pages/index.astro`
- `site/src/pages/vs/devin.astro`
- `site/tests/home.spec.ts`
- `site/tests/vs-devin.spec.ts`

**Candidates checked:** Filtering `docs/*.md` for references to the changed files/basenames turned up one non-`test-readiness/` candidate — `docs/testing.md` (references `site/tests/home.spec.ts` and the `site/tests/*.spec.ts` E2E pattern). All other matches were under `docs/test-readiness/`, which is read-only/excluded per the auto-mode contract.

**Staleness check:** `docs/testing.md`'s file-path references (`site/tests/home.spec.ts`, `docs-platform.spec.ts`, `docs-redirect.spec.ts`, `docs-search.spec.ts`) all still resolve — the changes were copy-only (page `<title>`/meta description text), not structural. No doc quotes the old page-title string either. Marked **current** — no edits made.

**CLAUDE.md:** unchanged (no docs created/removed).

**Missing-doc / concern tasks:** none filed — the changed files are copy edits to already-documented marketing pages (covered by `docs/testing.md`'s E2E layer and CLAUDE.md's `site/` supporting-surface note), no new module or cross-cutting concern introduced.

**Quality-pass / split-proposal tasks:** none — no doc was rewritten this run, so Step A5.5/6.6 had nothing to check.

Per this repo's convention, the sync anchor is committed even when no docs needed updating.

**Anchor:** `1acd66c5d9a8e4b0e411cc933c9b1158c36728e0` (was `47d0a848f240d3157e4c2a49cb4c3faf0ad3feb1`)

## Test plan

- [x] N/A — anchor-only change, no code/doc content modified