### PR TITLE
docs: sync freshness anchor (audit found no stale docs)

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"1acd66c5d9a8e4b0e411cc933c9b1158c36728e0","timestamp":"2026-09-07T07:04:36Z"}
+{"sha":"3e0bd4738a7d67a23f206a15e5d4f53ed132370e","timestamp":"2026-09-08T07:05:35Z"}


### PR DESCRIPTION
## Summary
- Automated daily docs-freshness audit (`shipwright:research-docs --auto`).
- Anchor advanced from `1acd66c5` to `3e0bd473` (2026-09-07 → 2026-09-08).
- Changed files in this window: `admin/e2e/{agents-page,chat-degraded,chat-page,chat-progress,chat-thread-page}.e2e.ts`, `admin/e2e/test-server.ts`, `admin/src/admin-ui.{ts,smoke.test.ts}`, `charts/shipwright/{CHANGELOG.md,Chart.yaml,values.yaml}`, `site/bun.lock`.
- 9 candidate docs checked (`agent-key-files.md`, `agent-types.md`, `agent.md`, `configuration.md`, `deploy-kubernetes.md`, `helm-repo.md`, `metrics.md`, `migration.md`, `testing.md`) — all remained current. The admin-ui.ts change is a one-line fail-closed `isAdmin` authz fix with no doc-visible symbol/endpoint/path change; the chart changes are a routine auto-bump with no version-pinned doc references.
- No docs updated, no CLAUDE.md changes, no tasks filed.

## Test plan
- [x] `state/docs-last-synced.json` anchor SHA matches this branch's HEAD parent commit