### PR TITLE
fix: suppress confirmed false-positive gitleaks finding (security-gitleaks-secret-shipwright-2026-W37)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -12,3 +12,7 @@ d36760ea08f97070d42d1c071c4a33f6064e4fb1:docs/test-readiness/test-system.md:gene
 6740dc2794c2c7351ad859b1c979f78a3126e461:agent/src/fixtures/slack-provision-cassette.json:generic-api-key:8
 # Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W32 on 2026-08-20 — confirmed false positive
 6740dc2794c2c7351ad859b1c979f78a3126e461:agent/src/admin-ui.smoke.test.ts:generic-api-key:95
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W37 on 2026-09-08 — confirmed false positive (fake test PEM fixture)
+6af111662ccfff375d2a2d8418aa992d14ee0545:admin/src/admin-local-agent.smoke.test.ts:private-key:1161
+# Suppressed via HITL task security-gitleaks-secret-shipwright-2026-W37 on 2026-09-08 — confirmed false positive (fake test PEM fixture)
+2e0c9eb31d29a29d0a5759f6008594103f56cffc:admin/src/admin-local-agent.smoke.test.ts:private-key:1161


### PR DESCRIPTION
Confirmed false positive during HITL review of security-gitleaks-secret-shipwright-2026-W37: the private-key match is the synthetic `faketestkeydata` PEM fixture in the GitHub App manual-PEM-upload smoke test, not real key material. Adds .gitleaksignore fingerprints for both historical commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqEXXTwdtmKXhnxs6GY9gp