### PR TITLE
fix: attach truncated response body to task-store query() 500 errors

### DIFF
--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -535,8 +535,21 @@ export function createTaskStoreClient(opts?: { fetchFn?: FetchFn }): {
   return {
     async query(params: URLSearchParams): Promise<Task[]> {
       const res = await doFetch(`${baseUrl}/tasks?${params}`, { headers });
-      if (!res.ok)
-        throw new Error(`task-store GET /tasks?${params} → ${res.status}`);
+      if (!res.ok) {
+        // Attach a truncated response body snippet so a 500 (e.g. task-store
+        // DB unreachable) is diagnosable from the thrown error alone, without
+        // cross-referencing task-store's own logs/Sentry events by timestamp.
+        let bodySnippet = "";
+        try {
+          bodySnippet = (await res.text()).slice(0, 500);
+        } catch {
+          // Body unreadable (already consumed, network cut mid-read, etc.) —
+          // fall back to the status-only message below.
+        }
+        throw new Error(
+          `task-store GET /tasks?${params} → ${res.status}${bodySnippet ? ` — ${bodySnippet}` : ""}`,
+        );
+      }
       const data = (await res.json()) as unknown;
       // Temporary: accept legacy bare Task[] from older task-store instances
       if (Array.isArray(data)) return data as Task[];

--- a/agent/src/check-helpers.ts
+++ b/agent/src/check-helpers.ts
@@ -473,6 +473,75 @@ type FetchFn = (
 ) => Promise<Response>;
 
 /**
+ * Max chars of a non-ok response body scanned when redacting. Deliberately
+ * larger than the emitted snippet so a secret straddling the emit cut is still
+ * matched and masked in full, rather than half of it slipping through.
+ */
+const BODY_SCAN_LIMIT = 2000;
+
+/** Max chars of the redacted body snippet folded into a thrown error message. */
+const BODY_SNIPPET_LIMIT = 500;
+
+/**
+ * Secret-shaped patterns masked out of another service's error body before any
+ * of it is attached to a thrown Error.
+ *
+ * `docs/observability.md` documents that request/response bodies are never
+ * attached to a Sentry event, and `lib/sentry.ts`'s scrub hook only redacts
+ * *this* process's own live `SECRET_ENV_VARS` values by exact string match —
+ * neither does anything for credential material embedded in a *different*
+ * service's response body (e.g. a Prisma `P1013` error echoing task-store's
+ * own `DATABASE_URL`). Task-store's `onError` returns `{ error: err.message }`
+ * verbatim for any unhandled 500, so that body reaches the agent, and the
+ * agent's own failure path (`loop-orchestrator.ts` / `cron-failure-reporter.ts`)
+ * hands the resulting Error to `captureException`. These patterns close that
+ * gap at the point of capture: the snippet keeps its diagnostic value (status
+ * text, error class, Prisma error code, host/table names) without carrying
+ * credentials.
+ */
+const BODY_SECRET_PATTERNS: readonly {
+  readonly re: RegExp;
+  readonly replacement: string;
+}[] = [
+  // URI userinfo credentials — postgresql://user:pw@host, redis://…, https://…
+  {
+    re: /([a-z][a-z0-9+.-]*:\/\/)[^\s/@]*:[^\s/@]*@/gi,
+    replacement: "$1[Filtered]@",
+  },
+  // Well-known token prefixes (GitHub, Anthropic, Slack).
+  {
+    re: /\b(?:gh[pousr]_|github_pat_|sk-|xox[abprs]-)[A-Za-z0-9_-]{8,}/g,
+    replacement: "[Filtered]",
+  },
+  // Authorization scheme values — "Bearer abc123", "Basic dXNlcjpwdw==".
+  {
+    re: /\b(bearer|basic|token)\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+    replacement: "$1 [Filtered]",
+  },
+  // Secret-shaped key/value pairs in JSON bodies, query strings, and env dumps.
+  {
+    re: /(["']?[A-Za-z0-9_.-]*(?:password|passwd|secret|token|api[_-]?key|apikey|credential|private[_-]?key|authorization)[A-Za-z0-9_.-]*["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;&)}\]]+)/gi,
+    replacement: '$1"[Filtered]"',
+  },
+];
+
+/**
+ * Scrubs secret-shaped material out of a foreign service's response body and
+ * truncates it to a bounded snippet safe to fold into a thrown Error message
+ * (and therefore into a Sentry Issue). Redaction runs over a wider window than
+ * the emitted snippet so truncation can't expose the leading half of a secret.
+ *
+ * Exported for direct unit testing; callers should prefer `query()`.
+ */
+export function redactBodySnippet(body: string): string {
+  let redacted = body.slice(0, BODY_SCAN_LIMIT);
+  for (const { re, replacement } of BODY_SECRET_PATTERNS) {
+    redacted = redacted.replace(re, replacement);
+  }
+  return redacted.slice(0, BODY_SNIPPET_LIMIT);
+}
+
+/**
  * Reads SHIPWRIGHT_TASK_STORE_URL and SHIPWRIGHT_TASK_STORE_TOKEN from the
  * environment, validates they are present, and returns a minimal fetch client
  * for the task-store HTTP API.
@@ -536,12 +605,15 @@ export function createTaskStoreClient(opts?: { fetchFn?: FetchFn }): {
     async query(params: URLSearchParams): Promise<Task[]> {
       const res = await doFetch(`${baseUrl}/tasks?${params}`, { headers });
       if (!res.ok) {
-        // Attach a truncated response body snippet so a 500 (e.g. task-store
-        // DB unreachable) is diagnosable from the thrown error alone, without
-        // cross-referencing task-store's own logs/Sentry events by timestamp.
+        // Attach a redacted, truncated response body snippet so a 500 (e.g.
+        // task-store DB unreachable) is diagnosable from the thrown error
+        // alone, without cross-referencing task-store's own logs/Sentry events
+        // by timestamp. The snippet passes through redactBodySnippet first —
+        // this Error's message reaches Sentry via captureException, and
+        // lib/sentry.ts's scrub hook cannot redact another service's secrets.
         let bodySnippet = "";
         try {
-          bodySnippet = (await res.text()).slice(0, 500);
+          bodySnippet = redactBodySnippet(await res.text());
         } catch {
           // Body unreadable (already consumed, network cut mid-read, etc.) —
           // fall back to the status-only message below.

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -828,6 +828,58 @@ describe("createTaskStoreClient query()", () => {
       ({
         ok: false,
         status: 500,
+        text: async () => "",
+        json: async () => ({}),
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    await expect(
+      client.query(new URLSearchParams({ ready: "true" })),
+    ).rejects.toThrow("task-store GET /tasks");
+  });
+
+  test("attaches a truncated response body snippet to the thrown error", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        text: async () => '{"error":"database unreachable"}',
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    await expect(
+      client.query(new URLSearchParams({ ready: "true" })),
+    ).rejects.toThrow(/database unreachable/);
+  });
+
+  test("truncates a long response body attached to the thrown error", async () => {
+    const longBody = "x".repeat(2000);
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        text: async () => longBody,
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    let caught: Error | undefined;
+    try {
+      await client.query(new URLSearchParams({ ready: "true" }));
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message.length).toBeLessThan(longBody.length);
+  });
+
+  test("still throws the status-only error when reading the response body fails", async () => {
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        text: async (): Promise<string> => {
+          throw new Error("body already consumed");
+        },
         json: async () => ({}),
       }) as Response) as unknown as typeof fetch;
 

--- a/agent/src/check-helpers.unit.test.ts
+++ b/agent/src/check-helpers.unit.test.ts
@@ -33,6 +33,7 @@ import {
   isTaskBlockedForDispatch,
   isTerminalReviewLabel,
   parseCandidateId,
+  redactBodySnippet,
   resolveAllRepos,
   resolveRepos,
   reviewsAtHeadCommit,
@@ -870,6 +871,36 @@ describe("createTaskStoreClient query()", () => {
     }
     expect(caught).toBeDefined();
     expect(caught?.message.length).toBeLessThan(longBody.length);
+  });
+
+  test("redacts credentials out of the response body snippet", async () => {
+    // Shape of a Prisma P1013 error echoed verbatim by task-store's onError.
+    const leakyBody = JSON.stringify({
+      error:
+        "P1013: the provided database string is invalid: postgresql://swuser:hunter2@db.internal:5432/task_store",
+    });
+    const fakeFetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        text: async () => leakyBody,
+      }) as Response) as unknown as typeof fetch;
+
+    const client = createTaskStoreClient({ fetchFn: fakeFetch });
+    let caught: Error | undefined;
+    try {
+      await client.query(new URLSearchParams({ ready: "true" }));
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    // The credentials are gone…
+    expect(caught?.message).not.toContain("hunter2");
+    expect(caught?.message).not.toContain("swuser");
+    // …but the diagnostic remainder that motivated the snippet survives.
+    expect(caught?.message).toContain("P1013");
+    expect(caught?.message).toContain("db.internal:5432");
+    expect(caught?.message).toContain("[Filtered]");
   });
 
   test("still throws the status-only error when reading the response body fails", async () => {
@@ -2287,5 +2318,64 @@ describe("isPrRecordBlockedForDispatch", () => {
 
   test("returns false for an undefined record", () => {
     expect(isPrRecordBlockedForDispatch(undefined)).toBe(false);
+  });
+});
+
+describe("redactBodySnippet", () => {
+  test("masks userinfo credentials in a connection string", () => {
+    expect(
+      redactBodySnippet(
+        "postgresql://swuser:hunter2@db.internal:5432/task_store",
+      ),
+    ).toBe("postgresql://[Filtered]@db.internal:5432/task_store");
+  });
+
+  test("masks well-known token prefixes", () => {
+    const out = redactBodySnippet(
+      "auth failed for ghp_abcdefghijklmnop and xoxb-123456789012-abcdef",
+    );
+    expect(out).not.toContain("ghp_abcdefghijklmnop");
+    expect(out).not.toContain("xoxb-123456789012-abcdef");
+    expect(out).toContain("[Filtered]");
+  });
+
+  test("masks Authorization scheme values", () => {
+    expect(redactBodySnippet("upstream sent Bearer abcdef1234567890")).toBe(
+      "upstream sent Bearer [Filtered]",
+    );
+  });
+
+  test("masks secret-shaped key/value pairs in a JSON body", () => {
+    const out = redactBodySnippet(
+      '{"error":"env dump","DB_PASSWORD":"s3cr3t","api_key":"abc123","host":"db.internal"}',
+    );
+    expect(out).not.toContain("s3cr3t");
+    expect(out).not.toContain("abc123");
+    // Non-secret fields are untouched, so the snippet stays diagnostic.
+    expect(out).toContain('"host":"db.internal"');
+  });
+
+  test("leaves an ordinary error body untouched", () => {
+    const body = '{"error":"P2021: table `Task` does not exist"}';
+    expect(redactBodySnippet(body)).toBe(body);
+  });
+
+  test("truncates to 500 chars", () => {
+    expect(redactBodySnippet("x".repeat(5000))).toHaveLength(500);
+  });
+
+  test("redacts past the emit cut so a straddling secret is not half-emitted", () => {
+    // The password starts just before the 500-char emit boundary — without the
+    // wider scan window its leading characters would survive truncation.
+    const padding = "x".repeat(470);
+    const out = redactBodySnippet(
+      `${padding}postgresql://u:supersecretpassword@db.internal/task_store`,
+    );
+    expect(out).not.toContain("supersecret");
+    expect(out).toContain("[Filtered]");
+  });
+
+  test("returns an empty string for an empty body", () => {
+    expect(redactBodySnippet("")).toBe("");
   });
 });

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -22,10 +22,25 @@ When `SENTRY_DSN` is set, a service reports to Sentry. Below is a summary of wha
 | Caller identity — which admin or agent token triggered an error | Yes |
 | Tags (structured key-value metadata: `service`, `agent_id`, `item_type`, `item_id`) | Yes |
 | `Authorization` and `Cookie` header values | Redacted — replaced with `[Filtered]` regardless of configuration |
-| Request or response bodies | No — never attached to an event |
+| Request or response bodies | No — never attached to an event, with one narrow exception: see [Foreign response-body snippets](#foreign-response-body-snippets) |
 | The live value of any secret-shaped env var | Redacted — scrubbed wherever it appears, including nested inside longer strings |
 
 **Tags** are structured key-value metadata attached to every event: `service` (the reporting service name, always present), and `agent_id` (when initializing Sentry for an agent runner with an `agentId`). These process-wide tags are set once at init time via `buildSentryInitOptions()`'s static `initialScope`. The agent additionally tags `item_type`/`item_id` (`"task"` or `"pr"`, plus that item's id) on any Sentry event captured during `loop-orchestrator.ts`'s `dispatch()` — its per-item execution runs inside a forked Sentry scope (`sentryClient.withScope(...)`, not a bare `Sentry.setTag()` global mutation) so the tags are scoped to that single dispatch and never leak across concurrent or sequential dispatches. This lets a Sentry Issue or Log be attributed to the specific task/PR that was in flight, not just "which service/agent" — see `lib/sentry.ts`'s `ErrorCapturingClient.withScope` and `loop-orchestrator.ts`'s `dispatch()`.
+
+### Foreign response-body snippets
+
+The one exception to "response bodies are never attached" is the agent's task-store client (`createTaskStoreClient().query()` in `agent/src/check-helpers.ts`). When a `GET /tasks` call returns a non-ok status, the response body is attached to the thrown `Error`'s message so a task-store 500 (e.g. its database being unreachable) is diagnosable from the Sentry Issue alone, instead of requiring a timestamp-correlated cross-reference against task-store's own events.
+
+Because the body comes from a *different* service, neither scrub hook above protects it: `stripSensitiveHeaders` only touches `event.request.headers`, and `redactSecrets` only masks *this* process's own live `SECRET_ENV_VARS` values by exact string match. Task-store's `onError` returns `{ error: err.message }` verbatim for any unhandled 500, so a dependency error that echoes its own credentials (a Prisma `P1013` connection-string validation error, for example) would otherwise reach Sentry unredacted.
+
+`redactBodySnippet()` closes that gap at the point of capture, before the message is ever constructed:
+
+- URI userinfo credentials (`postgresql://user:pw@host` → `postgresql://[Filtered]@host`)
+- Well-known token prefixes (`ghp_`/`github_pat_`/`sk-`/`xox*-`)
+- `Authorization`-style scheme values (`Bearer …`, `Basic …`, `token …`)
+- Secret-shaped key/value pairs (`password`, `secret`, `token`, `api_key`, `credential`, `private_key`, `authorization`) in JSON, query strings, and env dumps
+
+Redaction runs over a 2000-char window and the result is then truncated to 500 chars, so a secret straddling the truncation boundary is masked in full rather than half-emitted. What survives is the diagnostic remainder: status text, error class, Prisma error code, host and table names.
 
 ## Disabling Sentry
 


### PR DESCRIPTION
## Summary
- `query()` in `agent/src/check-helpers.ts`'s `createTaskStoreClient()` now attaches a truncated (500-char) response body snippet to the `Error` it throws on a non-2xx task-store response, instead of a status-code-only message.
- This is an observability-only change — no polling behavior, cadence, or dispatch logic was touched.

## Background
Sentry issue [VITALS-OS-4P](https://app-vitals-llc.sentry.io/issues/7621911681/) shows the agent's dev-task candidate poll (`GET /tasks?ready=true`) intermittently 500ing, but the thrown error carried no detail beyond the status code, making the task-store-side root cause undiagnosable from the event alone.

The task's leading root-cause hypothesis is that this is a downstream symptom of the task-store DB-connectivity issue tracked in `error-7603012949-db-unreachable` ("Can't reach database server at 127.0.0.1:5432" — 45.9k+ events, still open/pending, HITL). That correlation could **not** be confirmed here: this session has no Sentry API credentials to pull exact event timestamps for either issue and cross-reference them. Going forward, the next occurrence of this 500 will carry the task-store's own response body in the error message, so a human (or a future agent with Sentry access) can confirm or rule out that correlation directly from the error text — no cross-service timestamp comparison needed.

## Acceptance Criteria
No formal `acceptanceCriteria` were set on this task; verified instead against the human-approved scope note on the task record:

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `query()` in `agent/src/check-helpers.ts` attaches a truncated response body to the thrown Error | MET | try/catch around `res.text()`, sliced to 500 chars, appended to the error message on non-ok response |
| 2 | Do not change polling behavior | MET | No changes to `check-dev-task.ts`, `loop-orchestrator.ts`, or any polling cadence/dispatch logic |
| 3 | Correlate with `error-7603012949` timestamps in the PR description | UNVERIFIABLE | No Sentry API access in this session — see Background above |

## Test Plan
- Added unit tests covering: body snippet attached on failure, long bodies truncated, and body-read failures falling back to the status-only message.
- `NODE_ENV=test bun test agent/src/check-helpers.unit.test.ts` — 161/161 pass.
- `bun run --filter='*' --sequential typecheck` — all packages pass.
- `bunx biome lint` on changed files — clean.
- `task check-strings`, `task check-config-docs`, `task check-version-sync`, `task secret-scan` — all pass.
- `task test:coverage` (full suite) has 30 pre-existing failures identical on `main` (test-order pollution in `metrics/src/lib/{errors,env}.unit.test.ts` and a known `task-store/src/routes/prs.ts` `validateRepo` null-repos bug) — confirmed unrelated to this change by running the same suite on `main`.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
