### PR TITLE
fix: retry once on Claude connection-lost-mid-response in _spawn

### DIFF
--- a/agent/src/claude.ts
+++ b/agent/src/claude.ts
@@ -179,6 +179,23 @@ export class ClaudeRunError extends Error {
 }
 
 /**
+ * Substring match against the Claude CLI's own error text for a transient
+ * network drop between the CLI process and the Anthropic API mid-stream
+ * (Sentry issue 7616867192 / VITALS-OS-47, e.g. "API Error: Connection lost
+ * mid-response. The response above may be incomplete.") — distinct from
+ * other `is_error` failures (auth, rate limits, etc.), which are not
+ * eligible for `_spawn`'s single connection-lost retry.
+ */
+const CONNECTION_LOST_MID_RESPONSE = "Connection lost mid-response";
+
+function _isConnectionLostMidResponse(err: unknown): err is ClaudeRunError {
+  return (
+    err instanceof ClaudeRunError &&
+    err.resultMessage.includes(CONNECTION_LOST_MID_RESPONSE)
+  );
+}
+
+/**
  * Thrown when a run is cancelled via its AbortSignal (e.g. a chat cancel
  * request surfaced through the heartbeat tick). Mirrors ClaudeTimeoutError /
  * ClaudeRunError's shape — it carries whatever session id the killed run
@@ -471,7 +488,7 @@ export function createRunClaude(
     return { result, modelUsage: accumulated, raw, sessionId: earlySessionId };
   }
 
-  async function _spawn(
+  async function _spawnOnce(
     args: string[],
     perCallOnProgress?: ProgressCallback,
     signal?: AbortSignal,
@@ -620,6 +637,36 @@ export function createRunClaude(
       totalCostUsd: result.total_cost_usd,
       modelUsage: result.modelUsage,
     };
+  }
+
+  /**
+   * Thin wrapper around `_spawnOnce` that retries exactly once on a
+   * connection-lost-mid-response failure — a transient network drop between
+   * the Claude Code CLI process and the Anthropic API, external to this
+   * codebase (Sentry issue 7616867192 / VITALS-OS-47). Human decision (Dave,
+   * 2026-09-08): retry ONCE, discarding the partial response and re-running
+   * the whole spawn from scratch (never resuming it) — no further retries.
+   * Accepts the small duplicate-side-effect risk; logs the retry via Sentry
+   * so it stays visible. Any other failure (including a second
+   * connection-lost error on the retry itself) propagates unchanged.
+   */
+  async function _spawn(
+    args: string[],
+    perCallOnProgress?: ProgressCallback,
+    signal?: AbortSignal,
+    extraEnv?: Record<string, string>,
+  ): Promise<ClaudeRunResult> {
+    try {
+      return await _spawnOnce(args, perCallOnProgress, signal, extraEnv);
+    } catch (err) {
+      if (!_isConnectionLostMidResponse(err)) throw err;
+      sentryClient?.captureMessage?.(
+        `Claude spawn: Connection lost mid-response — retrying once (session ${
+          err.sessionId ?? "unknown"
+        })`,
+      );
+      return _spawnOnce(args, perCallOnProgress, signal, extraEnv);
+    }
   }
 
   async function _saveSession(

--- a/agent/src/claude.unit.test.ts
+++ b/agent/src/claude.unit.test.ts
@@ -1138,6 +1138,122 @@ describe("resume retry", () => {
   });
 });
 
+// ─── Connection-lost-mid-response retry (error-7616867192) ────────────────────
+//
+// A transient network drop between the Claude Code CLI and the Anthropic API
+// mid-response throws a ClaudeRunError whose result text contains "Connection
+// lost mid-response" (Sentry issue 7616867192 / VITALS-OS-47). Per human
+// decision (Dave, 2026-09-08), `_spawn` retries this specific failure exactly
+// once — discarding the partial response and re-running the whole spawn from
+// scratch — regardless of whether a session exists to resume. This is
+// independent of (and orthogonal to) the session-resume retry above.
+
+function connectionLostJson(sessionId = "sess-cl"): string {
+  return JSON.stringify({
+    type: "result",
+    subtype: "error",
+    result:
+      "API Error: Connection lost mid-response. The response above may be incomplete.",
+    session_id: sessionId,
+    is_error: true,
+  });
+}
+
+describe("connection-lost-mid-response retry", () => {
+  test("retries once even with no existing session to resume, then succeeds", async () => {
+    let callCount = 0;
+    const mockSpawn = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return fakeProc(connectionLostJson(), "", 1) as ReturnType<
+          typeof Bun.spawn
+        >;
+      }
+      return fakeProc(jsonOutput("recovered", "sess-cl")) as ReturnType<
+        typeof Bun.spawn
+      >;
+    });
+
+    mockGetSession.mockClear();
+    mockGetSession.mockReturnValue(undefined);
+    capturedMessages = [];
+    capturedExceptions = [];
+
+    const runClaude = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+    );
+
+    const result = await runClaude("hello");
+
+    expect(result.result).toBe("recovered");
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(capturedMessages).toHaveLength(1);
+    expect(capturedMessages[0]).toContain("Connection lost mid-response");
+    expect(capturedExceptions).toHaveLength(0);
+  });
+
+  test("does not retry a second time when the retry also hits connection-lost-mid-response", async () => {
+    const mockSpawn = mock(
+      () =>
+        fakeProc(connectionLostJson(), "", 1) as ReturnType<typeof Bun.spawn>,
+    );
+
+    mockGetSession.mockClear();
+    mockGetSession.mockReturnValue(undefined);
+    capturedMessages = [];
+    capturedExceptions = [];
+
+    const { ClaudeRunError } = await import("./claude.ts");
+    const runClaude = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+    );
+
+    await expect(runClaude("hello")).rejects.toBeInstanceOf(ClaudeRunError);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    // Logged once, for the one retry attempt — not on the second failure.
+    expect(capturedMessages).toHaveLength(1);
+  });
+
+  test("does not retry an unrelated is_error failure (only connection-lost-mid-response is eligible)", async () => {
+    const mockSpawn = mock(
+      () =>
+        fakeProc(
+          jsonOutput(
+            "You've hit your org's monthly usage limit",
+            "sess-x",
+            true,
+          ),
+          "",
+          1,
+        ) as ReturnType<typeof Bun.spawn>,
+    );
+
+    mockGetSession.mockClear();
+    mockGetSession.mockReturnValue(undefined);
+    capturedMessages = [];
+
+    const runClaude = createRunClaude(
+      mockSpawn as typeof Bun.spawn,
+      testSessions,
+      MODEL,
+      WORKSPACE,
+      fakeSentryClient,
+    );
+
+    await expect(runClaude("hello")).rejects.toThrow("monthly usage limit");
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(capturedMessages).toHaveLength(0);
+  });
+});
+
 // ─── Session persistence on failure (CSI-1.2) ─────────────────────────────────
 //
 // _saveSession only ran after a successful spawn, so a first-message timeout


### PR DESCRIPTION
## Summary
- Adds a targeted, single retry in `agent/src/claude.ts`'s `_spawn` for the "connection lost mid-response" failure mode reported in Sentry issue 7616867192 (VITALS-OS-47)
- Detection is a substring match on the CLI's own error text ("Connection lost mid-response"), scoped via a new `_isConnectionLostMidResponse` type guard so unrelated `is_error` failures (auth, rate limits, etc.) are untouched
- The existing `_spawn` body is renamed to `_spawnOnce`; `_spawn` is now a thin wrapper that catches this one failure mode, logs it via `sentryClient.captureMessage` for visibility, and re-runs the whole spawn exactly once (discarding the partial response) — a second failure of the same kind propagates normally, with no further retries
- This is independent of `_runClaude`'s existing session-resume retry, which only kicks in when there's an existing session id to resume — the new retry applies even to a brand-new (first-message) session

## Human decision (source of this change)
> Human decision 2026-09-08 (Dave): retry ONCE on the connection-lost-mid-response failure in `_spawn` (`agent/src/claude.ts` ~570), discarding the partial response and re-running the whole spawn. No further retries. Accept the small duplicate-side-effect risk; log the retry so it is visible.

## Acceptance Criteria
Task had no formal `acceptanceCriteria` entries — the task `note` field (quoted above) is the de facto spec.

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Retry exactly once on connection-lost-mid-response | MET | `_spawn` wrapper calls `_spawnOnce` a second time only inside the `catch`, and the second call bypasses the wrapper entirely |
| 2 | Discard the partial response, re-run the whole spawn | MET | Second `_spawnOnce` call uses the same `args` from scratch — no resume, no reuse of partial state |
| 3 | No further retries | MET | Test: "does not retry a second time when the retry also hits connection-lost-mid-response" — exactly 2 spawn calls |
| 4 | Log the retry so it's visible | MET | `sentryClient?.captureMessage?.(...)` fired before the retry; test asserts it's captured exactly once |
| 5 | Change point is `_spawn`, other failure modes unaffected | MET | Test: "does not retry an unrelated is_error failure" — exactly 1 spawn call, no log |

## Test Plan
- `bun test agent/src/claude.unit.test.ts` — 3 new tests added under `describe("connection-lost-mid-response retry")`, all passing; only a pre-existing, unrelated `extraAllowedTools` test fails (confirmed failing identically on `main`, caused by ambient `AGENT_ALLOWED_TOOLS` env in this sandbox)
- `task typecheck` — passes across all workspaces
- `bunx biome lint` / `biome format` — clean
- [x] Pre-commit checks passing (scoped to this change; unrelated pre-existing repo-wide test/env failures confirmed present on `main` baseline too)

Generated with [Claude Code](https://claude.com/claude-code)
