### PR TITLE
docs: refresh stale docs (automated docs-freshness audit)

### DIFF
--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -963,7 +963,7 @@ agent:
     enabled: true
     provider: whisper            # "whisper" (self-hosted pod) | "groq" (cloud STT)
     whisper:
-      image: onerahmet/openai-whisper-asr-webservice:v1.3.0  # default; do not float to :latest — the plain-text /asr contract is tightly coupled to this tag
+      image: onerahmet/openai-whisper-asr-webservice:v1.10.0  # default; do not float to :latest — the plain-text /asr contract is tightly coupled to this tag
       service:
         port: 9000               # in-cluster Service port → WHISPER_SERVICE_URL
       model: ""                  # ASR model name → ASR_MODEL (e.g. tiny, base, small, medium, large-v3, tiny.en); empty = image default

--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"3e0bd4738a7d67a23f206a15e5d4f53ed132370e","timestamp":"2026-09-08T07:05:35Z"}
+{"sha":"a2c4498aa3a2d3fd3a81a67e547680abdd5f94ed","timestamp":"2026-09-09T07:07:43Z"}


### PR DESCRIPTION
## Summary
- Automated daily docs-freshness sync, scoped to 36 source files changed since the last anchor (`3e0bd47`).
- Fixed one genuinely stale reference: `docs/deploy-kubernetes.md`'s voice-values example pinned the Whisper ASR image at `v1.3.0`, but `charts/shipwright/values.yaml` was bumped to `v1.10.0`. Updated the doc to match.
- Everything else in the changed-file list was either test-only changes (no corresponding source diff), routine version/lockfile bumps with no doc citing the specific value, or source changes (the `PushService` refactor in `admin-ui.ts`/`push-service.ts`, and `check-helpers.ts`'s `redactBodySnippet`) that were already correctly reflected in `docs/agent-key-files.md` and `docs/observability.md` from a prior sync — no edit needed there.
- Filed one task-store task (`docs-freshness-cron` session) proposing a split of `docs/deploy-kubernetes.md` (1354 lines, well over the 200-line governance threshold) into a new `docs/deploy-kubernetes-providers.md` for the five per-cloud-provider sections — proposal only, not applied.
- Synced `state/docs-last-synced.json` to HEAD.

## Test plan
- [x] Doc-only change; no code paths affected.
- [x] Verified the corrected image tag (`v1.10.0`) matches `charts/shipwright/values.yaml`'s current default.