### PR TITLE
fix: set branch field when research-docs auto mode files bulk tasks

### DIFF
--- a/plugins/shipwright/commands/research-docs.md
+++ b/plugins/shipwright/commands/research-docs.md
@@ -115,7 +115,7 @@ Task titles, one shape per check, each paired with a `branch` slug derived the s
 - 6.5b hit → `title: "Review {doc} for literal/prose mismatch"`, `branch: "docs/review-{doc-slug}-literal-prose-mismatch"`
 - 6.5c hit → `title: "Review {doc} for convention missing named mechanism"`, `branch: "docs/review-{doc-slug}-missing-mechanism"`
 
-Each task: `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch` as derived above. **The `branch` field is required** — `/shipwright:dev-task` refuses to proceed on any task with no `branch` set (it can't create a worktree) and blocks it with `status: "blocked"` instead, so a task filed here without one silently stalls until a human notices and backfills it by hand.
+Each task: `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{doc-slug}-{YYYYMMDD}"` — `{doc-slug}` is the doc's path/basename minus extension, kebab-cased (e.g. `docs/api-billing.md` → `api-billing`), and `{YYYYMMDD}` is the current run's UTC date (`date -u +%Y%m%d`), so e.g. `docs/api-billing-20260909`. Compute this once per doc and reuse it for every hit filed against that doc in this run. **The `branch` field is required** — `/shipwright:dev-task` refuses to proceed on any task with no `branch` set (it can't create a worktree) and blocks it with `status: "blocked"` instead, so a task filed here without one silently stalls until a human notices and backfills it by hand. The `{YYYYMMDD}` suffix also keeps re-runs collision-free: without it, a doc flagged again on a later cron run would reuse the exact same branch name as a prior run, which can 409 on worktree creation or silently reuse a stale branch.
 
 Track a running count of tasks filed this way for the current repo — this becomes the `Quality flags tasked` figure in Step A9's per-repo summary.
 
@@ -125,7 +125,7 @@ Over 200 lines: file **one** task-store task via the same `/tasks/bulk` mechanis
 
 - `title: "Split {doc} — exceeds {N} lines"`
 - `description`: a best-effort section-grouping suggestion — which `##`/`###` sections would move to a new sub-topic doc, grouped by topic, following the same grouping approach as Step 6.6
-- `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/split-{doc-slug}"` (same kebab-case-path-minus-extension slug as Step A5.5's checks — **required**, see that step's note on why an unbranched task stalls silently)
+- `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{doc-slug}-{YYYYMMDD}"` — same doc-slug/date computation as the quality-pass tasks above, for the doc being split (**required**, see that step's note on why an unbranched task stalls silently)
 
 Track a running count of split-proposal tasks filed this way for the current repo — this becomes the `Split proposals tasked` figure in Step A9's per-repo summary.
 
@@ -153,9 +153,9 @@ curl -sf -X POST \
   --data-binary @/tmp/missing-docs-tasks.json | jq .
 ```
 
-Each missing module produces one task with: `title: "Document {module} module"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/document-{module-slug}-module"` (kebab-case the module name). **The `branch` field is required** — see Step A5.5's note on why an unbranched task stalls silently on `/shipwright:dev-task`.
+Each missing module produces one task with: `title: "Document {module} module"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{module-slug}-{YYYYMMDD}"` — `{module-slug}` is the module name kebab-cased, and `{YYYYMMDD}` is the run's UTC date (`date -u +%Y%m%d`), same computation Step A5.5 uses. **The `branch` field is required** — see Step A5.5's note on why an unbranched task stalls silently on `/shipwright:dev-task`.
 
-Additionally, run the Step 3a cross-cutting concerns checklist (same seven categories, same material-presence verification procedure), scoped to `CHANGED_FILES` — the same scoping A7's structural check above already uses. For each concern category verified materially present in `CHANGED_FILES` with no matching doc, union one more task into the same `/tmp/missing-docs-tasks.json` payload before it's posted: `title: "Document {concern} conventions"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/document-{concern-slug}-conventions"` (kebab-case the concern category name — e.g. `secrets/credential rotation` → `secrets-credential-rotation`) — same session as the structural tasks above, so both are queryable together by downstream tooling. The `"Document {concern} conventions"` title distinguishes concern-based tasks from the structural `"Document {module} module"` tasks in the same payload. If no concern qualifies, the payload is unchanged from the structural-only set.
+Additionally, run the Step 3a cross-cutting concerns checklist (same seven categories, same material-presence verification procedure), scoped to `CHANGED_FILES` — the same scoping A7's structural check above already uses. For each concern category verified materially present in `CHANGED_FILES` with no matching doc, union one more task into the same `/tmp/missing-docs-tasks.json` payload before it's posted: `title: "Document {concern} conventions"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{concern-slug}-{YYYYMMDD}"` — `{concern-slug}` is the concern category name kebab-cased, same UTC-date computation as above — same session as the structural tasks above, so both are queryable together by downstream tooling. The `"Document {concern} conventions"` title distinguishes concern-based tasks from the structural `"Document {module} module"` tasks in the same payload. If no concern qualifies, the payload is unchanged from the structural-only set.
 
 ### Step A8: Write Sync Anchor
 

--- a/plugins/shipwright/commands/research-docs.md
+++ b/plugins/shipwright/commands/research-docs.md
@@ -109,11 +109,11 @@ curl -sf -X POST \
   --data-binary @/tmp/quality-pass-tasks.json | jq .
 ```
 
-Task titles, one shape per check, each paired with a `branch` slug derived the same way (kebab-case the doc's path minus extension, prefixed `docs/`):
+Task titles, one shape per check:
 
-- 6.5a hit → `title: "Review {doc} for canonical-source duplication"`, `branch: "docs/review-{doc-slug}-canonical-source"`
-- 6.5b hit → `title: "Review {doc} for literal/prose mismatch"`, `branch: "docs/review-{doc-slug}-literal-prose-mismatch"`
-- 6.5c hit → `title: "Review {doc} for convention missing named mechanism"`, `branch: "docs/review-{doc-slug}-missing-mechanism"`
+- 6.5a hit → `title: "Review {doc} for canonical-source duplication"`
+- 6.5b hit → `title: "Review {doc} for literal/prose mismatch"`
+- 6.5c hit → `title: "Review {doc} for convention missing named mechanism"`
 
 Each task: `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{doc-slug}-{YYYYMMDD}"` — `{doc-slug}` is the doc's path/basename minus extension, kebab-cased (e.g. `docs/api-billing.md` → `api-billing`), and `{YYYYMMDD}` is the current run's UTC date (`date -u +%Y%m%d`), so e.g. `docs/api-billing-20260909`. Compute this once per doc and reuse it for every hit filed against that doc in this run. **The `branch` field is required** — `/shipwright:dev-task` refuses to proceed on any task with no `branch` set (it can't create a worktree) and blocks it with `status: "blocked"` instead, so a task filed here without one silently stalls until a human notices and backfills it by hand. The `{YYYYMMDD}` suffix also keeps re-runs collision-free: without it, a doc flagged again on a later cron run would reuse the exact same branch name as a prior run, which can 409 on worktree creation or silently reuse a stale branch.
 
@@ -153,9 +153,9 @@ curl -sf -X POST \
   --data-binary @/tmp/missing-docs-tasks.json | jq .
 ```
 
-Each missing module produces one task with: `title: "Document {module} module"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{module-slug}-{YYYYMMDD}"` — `{module-slug}` is the module name kebab-cased, and `{YYYYMMDD}` is the run's UTC date (`date -u +%Y%m%d`), same computation Step A5.5 uses. **The `branch` field is required** — see Step A5.5's note on why an unbranched task stalls silently on `/shipwright:dev-task`.
+Each missing module produces one task with: `title: "Document {module} module"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{module-slug}-{YYYYMMDD}"` — `{module-slug}` is the module name kebab-cased: lowercased, with every `/` and run of whitespace collapsed to a single `-`, so the slug is always one flat segment and never a nested git ref (e.g. `api/billing` → `api-billing`, giving `docs/api-billing-20260909`). `{YYYYMMDD}` is the run's UTC date (`date -u +%Y%m%d`), same computation Step A5.5 uses. **The `branch` field is required** — see Step A5.5's note on why an unbranched task stalls silently on `/shipwright:dev-task`.
 
-Additionally, run the Step 3a cross-cutting concerns checklist (same seven categories, same material-presence verification procedure), scoped to `CHANGED_FILES` — the same scoping A7's structural check above already uses. For each concern category verified materially present in `CHANGED_FILES` with no matching doc, union one more task into the same `/tmp/missing-docs-tasks.json` payload before it's posted: `title: "Document {concern} conventions"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{concern-slug}-{YYYYMMDD}"` — `{concern-slug}` is the concern category name kebab-cased, same UTC-date computation as above — same session as the structural tasks above, so both are queryable together by downstream tooling. The `"Document {concern} conventions"` title distinguishes concern-based tasks from the structural `"Document {module} module"` tasks in the same payload. If no concern qualifies, the payload is unchanged from the structural-only set.
+Additionally, run the Step 3a cross-cutting concerns checklist (same seven categories, same material-presence verification procedure), scoped to `CHANGED_FILES` — the same scoping A7's structural check above already uses. For each concern category verified materially present in `CHANGED_FILES` with no matching doc, union one more task into the same `/tmp/missing-docs-tasks.json` payload before it's posted: `title: "Document {concern} conventions"`, `layer: "CLI"`, `session: "docs-freshness-cron"`, `branch: "docs/{concern-slug}-{YYYYMMDD}"` — `{concern-slug}` is the concern category name kebab-cased by the same rule as `{module-slug}` above: every `/` and run of whitespace collapses to a single `-`, producing one flat segment rather than a nested git ref (e.g. `authorization/access-control` → `authorization-access-control`, and `secrets/credential rotation` → `secrets-credential-rotation`, giving `docs/secrets-credential-rotation-20260909`), same UTC-date computation as above — same session as the structural tasks above, so both are queryable together by downstream tooling. The `"Document {concern} conventions"` title distinguishes concern-based tasks from the structural `"Document {module} module"` tasks in the same payload. If no concern qualifies, the payload is unchanged from the structural-only set.
 
 ### Step A8: Write Sync Anchor
 

--- a/plugins/shipwright/commands/research-docs.unit.test.ts
+++ b/plugins/shipwright/commands/research-docs.unit.test.ts
@@ -486,3 +486,86 @@ describe("research-docs.md — size governance", () => {
     expect(splitIdx).toBeGreaterThan(qualityIdx);
   });
 });
+
+describe("research-docs.md — branch field on auto-mode bulk task payloads", () => {
+  it("Step A5.5's quality-pass task payload computes a docs/{doc-slug}-{YYYYMMDD} branch", () => {
+    const stepA5_5Idx = content.indexOf("### Step A5.5: Auto Mode Quality Pass");
+    const stepA6Idx = content.indexOf("### Step A6: Update CLAUDE.md References");
+    expect(stepA5_5Idx).toBeGreaterThan(-1);
+    expect(stepA6Idx).toBeGreaterThan(stepA5_5Idx);
+    const section = content.slice(stepA5_5Idx, stepA6Idx);
+
+    // Must appear before the split-proposal task block so it covers the
+    // quality-pass hit payload specifically, not just anywhere in A5.5.
+    const splitTitleIdx = section.indexOf("Split {doc} — exceeds");
+    expect(splitTitleIdx).toBeGreaterThan(-1);
+    const qualityPassSlice = section.slice(0, splitTitleIdx);
+
+    expect(qualityPassSlice).toContain("branch:");
+    expect(qualityPassSlice).toContain("docs/{doc-slug}-{YYYYMMDD}");
+    expect(qualityPassSlice.toLowerCase()).toContain("kebab");
+    expect(qualityPassSlice).toContain("UTC");
+  });
+
+  it("Step A5.5's split-proposal task payload computes a docs/{doc-slug}-{YYYYMMDD} branch", () => {
+    const stepA5_5Idx = content.indexOf("### Step A5.5: Auto Mode Quality Pass");
+    const stepA6Idx = content.indexOf("### Step A6: Update CLAUDE.md References");
+    const section = content.slice(stepA5_5Idx, stepA6Idx);
+
+    const splitTitleIdx = section.indexOf("Split {doc} — exceeds");
+    expect(splitTitleIdx).toBeGreaterThan(-1);
+    const splitSlice = section.slice(splitTitleIdx);
+
+    expect(splitSlice).toContain("branch:");
+    expect(splitSlice).toContain("docs/{doc-slug}-{YYYYMMDD}");
+  });
+
+  it("Step A7's missing-doc-module task payload computes a docs/{module-slug}-{YYYYMMDD} branch", () => {
+    const stepA7Idx = content.indexOf("### Step A7: Task Out Missing Docs");
+    const stepA8Idx = content.indexOf("### Step A8: Write Sync Anchor");
+    expect(stepA7Idx).toBeGreaterThan(-1);
+    expect(stepA8Idx).toBeGreaterThan(stepA7Idx);
+    const section = content.slice(stepA7Idx, stepA8Idx);
+
+    const concernTitleIdx = section.indexOf(
+      "Document {concern} conventions",
+    );
+    expect(concernTitleIdx).toBeGreaterThan(-1);
+    const moduleSlice = section.slice(0, concernTitleIdx);
+
+    expect(moduleSlice).toContain("branch:");
+    expect(moduleSlice).toContain("docs/{module-slug}-{YYYYMMDD}");
+    expect(moduleSlice.toLowerCase()).toContain("kebab");
+  });
+
+  it("Step A7's concern-based task payload computes a docs/{concern-slug}-{YYYYMMDD} branch", () => {
+    const stepA7Idx = content.indexOf("### Step A7: Task Out Missing Docs");
+    const stepA8Idx = content.indexOf("### Step A8: Write Sync Anchor");
+    const section = content.slice(stepA7Idx, stepA8Idx);
+
+    const concernTitleIdx = section.indexOf(
+      "Document {concern} conventions",
+    );
+    expect(concernTitleIdx).toBeGreaterThan(-1);
+    const concernSlice = section.slice(concernTitleIdx);
+
+    expect(concernSlice).toContain("branch:");
+    expect(concernSlice).toContain("docs/{concern-slug}-{YYYYMMDD}");
+  });
+
+  it("does not change staleness detection, candidate scoping, or task titles — additive field only", () => {
+    // Task titles from before this change must remain byte-identical.
+    expect(content).toContain(
+      'title: "Review {doc} for canonical-source duplication"',
+    );
+    expect(content).toContain(
+      'title: "Review {doc} for literal/prose mismatch"',
+    );
+    expect(content).toContain(
+      'title: "Review {doc} for convention missing named mechanism"',
+    );
+    expect(content).toContain("Split {doc} — exceeds {N} lines");
+    expect(content).toContain('title: "Document {module} module"');
+    expect(content).toContain("Document {concern} conventions");
+  });
+});

--- a/plugins/shipwright/commands/research-docs.unit.test.ts
+++ b/plugins/shipwright/commands/research-docs.unit.test.ts
@@ -536,6 +536,10 @@ describe("research-docs.md — branch field on auto-mode bulk task payloads", ()
     expect(moduleSlice).toContain("branch:");
     expect(moduleSlice).toContain("docs/{module-slug}-{YYYYMMDD}");
     expect(moduleSlice.toLowerCase()).toContain("kebab");
+
+    // A worked example must disambiguate slash-containing input: `/` collapses
+    // to `-` so the branch stays a single segment, not a nested git ref.
+    expect(moduleSlice).toContain("api/billing` → `api-billing");
   });
 
   it("Step A7's concern-based task payload computes a docs/{concern-slug}-{YYYYMMDD} branch", () => {
@@ -551,6 +555,16 @@ describe("research-docs.md — branch field on auto-mode bulk task payloads", ()
 
     expect(concernSlice).toContain("branch:");
     expect(concernSlice).toContain("docs/{concern-slug}-{YYYYMMDD}");
+
+    // Five of Step 3a's seven concern categories contain `/` (and two of those
+    // also contain a space), so the slug rule needs a worked example proving
+    // both collapse to `-` rather than producing a nested `docs/a/b-DATE` ref.
+    expect(concernSlice).toContain(
+      "authorization/access-control` → `authorization-access-control",
+    );
+    expect(concernSlice).toContain(
+      "secrets/credential rotation` → `secrets-credential-rotation",
+    );
   });
 
   it("does not change staleness detection, candidate scoping, or task titles — additive field only", () => {


### PR DESCRIPTION
## Summary
- `research-docs.md`'s auto-mode task-filing steps (A5.5 quality-pass hits + split-proposal, A7 missing-doc-module + concern-based) POST `/tasks/bulk` with only `title`/`layer`/`session` — no `branch` field.
- `/shipwright:dev-task`'s required-field guard refuses any task with no `branch` and self-blocks it, which is why `docs-freshness-cron` tasks keep getting stuck (5+ confirmed occurrences across shipwright and squadron, 2026-09-03 through 2026-09-06).
- Adds a computed `branch: "docs/{slug}-{YYYYMMDD}"` field to all four task shapes filed by A5.5 and A7 (kebab-cased doc/module/concern name + the run's UTC date), matching the `{type}/...` branch-prefix convention every other bulk-task producer already follows.
- Additive only — no changes to staleness detection, candidate scoping, or task titles.

## Note for reviewers
PR #3292 (`fix/docs-freshness-cron-missing-branch-field`) makes an overlapping edit to the same file/sections but uses a different branch format (no `-{YYYYMMDD}` date suffix) and adds no test coverage. It isn't linked to any task-store record. This PR implements the acceptance criteria as specified (date-suffixed format + test coverage) — a human should reconcile/close the other PR to avoid a merge conflict.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Step A5.5's quality-pass and split-proposal payloads each include `branch: "docs/{doc-slug}-{YYYYMMDD}"` | MET |
| 2 | Step A7's missing-doc-module and concern-based payloads each include `branch: "docs/{module-or-concern-slug}-{YYYYMMDD}"` | MET |
| 3 | New content assertions added to `research-docs.unit.test.ts` covering all 4 payload locations, no existing tests removed | MET |
| 4 | No change to staleness detection, candidate scoping, or task titles — additive field only | MET |

## Test Plan
- [x] `bun test plugins/shipwright/commands/research-docs.unit.test.ts` — 51 pass (5 new)
- [x] `task lint`, `task typecheck`, `task check-config-docs`, `task check-version-sync`, `task check-strings` — all pass
- [x] `task test:coverage` has 2 pre-existing, unrelated failures (`task-store/src/routes/prs.openapi.smoke.test.ts` — `validateRepo` null-repos `TypeError`), confirmed present on `main` HEAD and untouched by this diff

Generated with [Claude Code](https://claude.com/claude-code)
