### PR TITLE
fix: correct pillar-2 OpenHands claim on /compare to reflect Plan Mode

### DIFF
--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -182,10 +182,12 @@ const landscape = [
 // Factory's Missions overview states missions run user-facing QA testing as
 // they work and self-correct, so the pillar-1 body describes Factory's QA as
 // running-but-not-merge-blocking rather than as opt-in test generation.
-// Pillar 2's "primitives and no opinion" claim is sourced to OpenHands' own SDK
-// product page, which states verbatim: "OpenHands gives you primitives, not
-// prescriptions, so you can adapt agents to your codebase, tooling, and
-// governance needs."
+// Pillar 2's OpenHands claims are sourced to OpenHands' own blog and docs:
+// their trigger -> sandbox run -> PR flow (including Plan Mode, shipped
+// 2026-03-30) is documented on their workflow-automation blog post, and the
+// ephemeral, run-scoped nature of their TODO/plan tracking ("no tracking
+// across runs") is documented in their SDK's todo-management guide. Verified
+// 2026-09-06 — see MKT-PILLAR2-PRECISION-1.
 const pillars = [
   {
     title: "Tests are enforced, not offered",
@@ -199,10 +201,10 @@ const pillars = [
   },
   {
     title: "An opinionated loop you can take apart",
-    body: "OpenHands gives you primitives and no opinion: you assemble the pipeline yourself. Factory gives you an opinion you cannot open. Shipwright ships the loop already opinionated, then lets you disable phases, override the review principles per repo, and bolt on your own commands and scheduled jobs. Start on rails, then change the rails.",
+    body: "OpenHands will plan a task, run it, and open a PR for you to merge. What it does not keep is the middle: the plan is a markdown file, not tracked work, and nothing survives the run. Shipwright turns a plan into a durable backlog with dependency edges and a status lifecycle, and agents pull the next ready task on a schedule for days without anyone re-triggering them. Then you can disable phases, override the review principles per repo, and add your own commands. Their unit of work is a run. Ours is a backlog.",
     citations: [
-      { label: "OpenHands: primitives, not prescriptions", url: "https://www.openhands.dev/product/sdk" },
-      { label: "Factory Missions", url: "https://docs.factory.ai/features/missions/overview" },
+      { label: "OpenHands: trigger to PR workflow", url: "https://www.openhands.dev/blog/ai-agent-workflow-automation" },
+      { label: "OpenHands: ephemeral, no cross-run tracking", url: "https://docs.openhands.dev/sdk/guides/github-workflows/todo-management" },
     ],
   },
   {

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -407,20 +407,22 @@ test("each pillar cites the competitors its own body names", async ({
     await expect(testsPillar.locator(`a[href="${url}"]`)).toHaveCount(1);
   }
 
-  // Pillar 2 names both OpenHands ("primitives and no opinion") and Factory —
-  // both need a primary source on this card. The OpenHands source is the SDK
-  // product page ("primitives, not prescriptions"), not the QA-changes doc:
-  // this pillar is about architecture/extensibility, not testing, so the
-  // QA-is-CI's-job link belongs on pillar 1 and must not appear here.
+  // Pillar 2 names OpenHands' trigger-to-PR flow (Plan Mode included) and its
+  // ephemeral, run-scoped tracking — both need a primary source on this card.
+  // Factory is no longer named in this pillar's body (MKT-PILLAR2-PRECISION-1),
+  // so its citation must not appear here. This pillar is about
+  // architecture/extensibility, not testing, so the QA-is-CI's-job link
+  // belongs on pillar 1 and must not appear here either.
   const loopPillar = card("An opinionated loop you can take apart");
-  await expect(
-    loopPillar.locator(
-      'a[href="https://docs.openhands.dev/openhands/usage/use-cases/qa-changes"]',
-    ),
-  ).toHaveCount(0);
   for (const url of [
-    "https://www.openhands.dev/product/sdk",
+    "https://docs.openhands.dev/openhands/usage/use-cases/qa-changes",
     "https://docs.factory.ai/features/missions/overview",
+  ]) {
+    await expect(loopPillar.locator(`a[href="${url}"]`)).toHaveCount(0);
+  }
+  for (const url of [
+    "https://www.openhands.dev/blog/ai-agent-workflow-automation",
+    "https://docs.openhands.dev/sdk/guides/github-workflows/todo-management",
   ]) {
     await expect(loopPillar.locator(`a[href="${url}"]`)).toHaveCount(1);
   }
@@ -450,6 +452,35 @@ test("retired pillar copy no longer appears anywhere on /compare", async ({
   const text = (await page.locator("main").textContent()) ?? "";
   expect(text).not.toContain("Plan-approval by default");
   expect(text).not.toContain("Claude-native by design");
+});
+
+// MKT-PILLAR2-PRECISION-1: OpenHands ships an opinionated per-run flow
+// (Plan Mode, trigger -> sandbox -> PR) — the old "primitives and no opinion"
+// claim understated them. This phrase must not appear anywhere on the site.
+test("the retired 'primitives and no opinion' claim no longer appears anywhere on /compare", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  await expectBannedPhrasesAbsent(page, ["primitives and no opinion"]);
+});
+
+// The corrected pillar-2 claim: OpenHands' unit of work is a run, Shipwright's
+// is a durable backlog. Humans review gate for OpenHands stays "Optional" in
+// the landscape table (Plan Mode is opt-in, not a default gate) — unchanged
+// by this correction.
+test("pillar 2 states the run-vs-backlog distinction and leaves OpenHands' human review gate unchanged", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).toContain("Their unit of work is a run. Ours is a backlog.");
+  expect(text).toContain(
+    "the plan is a markdown file, not tracked work, and nothing survives the run",
+  );
+  const row = page.locator("table tr").filter({
+    has: page.locator("td").first().getByText("OpenHands", { exact: true }),
+  });
+  await expect(row).toContainText("Optional");
 });
 
 test("homepage differentiators bridge into /compare (competitor-free)", async ({


### PR DESCRIPTION
## Summary
- Replaced the pillar-2 "OpenHands gives you primitives and no opinion" claim on `/compare` — inaccurate, since OpenHands shipped an opinionated per-run flow (Plan Mode, trigger → sandbox → PR) in v1.6.0 beta (2026-03-30).
- New claim is the sharper, defensible one: OpenHands' unit of work is a run (plan lives in a markdown file, nothing survives the run); Shipwright's is a durable backlog (dependency edges, status lifecycle, no re-triggering needed).
- Added D10 primary-source citations for both new OpenHands claims and removed the stale Factory citation from this pillar (Factory is no longer named in the body).
- Re-read `/vs/openhands` and the rest of `/compare`'s OpenHands prose — no other copy implies OpenHands can't plan; `humanReviewGate` for OpenHands correctly stays "Optional" (Plan Mode is opt-in, not a default gate).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | compare.astro pillar 2 body replaced verbatim with the specified copy | MET |
| 2 | Pillar 2 title unchanged | MET |
| 3 | Both OpenHands claims in the new body carry the specified primary-source citations | MET |
| 4 | The phrase "primitives and no opinion" appears nowhere on the site | MET |
| 5 | OpenHands humanReviewGate cell remains "Optional" | MET |
| 6 | /vs/openhands and /compare OpenHands prose re-read; no copy implying OpenHands cannot plan | MET |
| 7 | Tests-first pillar unchanged | MET |
| 8 | No prices, tier names, or SWE-bench figures introduced | MET |
| 9 | site build passes (cd site && npm run build) | MET |
| 10 | compare.spec.ts updated to assert the corrected pillar-2 copy | MET |

## Test Plan
- `cd site && npm run build` — passes, 27 pages built.
- `npx playwright test tests/compare.spec.ts tests/vs-openhands.spec.ts` — 44/44 pass.
- `npx playwright test` (full site suite) — 305/305 pass.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
