### PR TITLE
fix: scope /compare's pipeline claims to the cohort, add ownable-queue point

### DIFF
--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -201,10 +201,14 @@ const pillars = [
   },
   {
     title: "An opinionated loop you can take apart",
-    body: "OpenHands will plan a task, run it, and open a PR for you to merge. What it does not keep is the middle: the plan is a markdown file, not tracked work, and nothing survives the run. Shipwright turns a plan into a durable backlog with dependency edges and a status lifecycle, and agents pull the next ready task on a schedule for days without anyone re-triggering them. Then you can disable phases, override the review principles per repo, and add your own commands. Their unit of work is a run. Ours is a backlog.",
+    body: "OpenHands will plan a task, run it, and open a PR for you to merge. What it does not keep is the middle: the plan is a markdown file, not tracked work, and nothing survives the run. Shipwright turns a plan into a durable backlog with dependency edges and a status lifecycle, and agents pull the next ready task on a schedule for days without anyone re-triggering them. Then you can disable phases, override the review principles per repo, and add your own commands. Their unit of work is a run. Ours is a backlog. The backlog itself is the wider point: Devin's automation triggers start it on a matching Jira or GitHub ticket with no manual assignment, Augment plans against tickets pulled from Jira, Linear, or Slack, and GitHub's coding agent works GitHub Issues as its backlog directly. In every case the queue lives in someone else's SaaS. Shipwright's task store runs on infrastructure you operate, in the repo you forked.",
     citations: [
       { label: "OpenHands: trigger to PR workflow", url: "https://www.openhands.dev/blog/ai-agent-workflow-automation" },
       { label: "OpenHands: ephemeral, no cross-run tracking", url: "https://docs.openhands.dev/sdk/guides/github-workflows/todo-management" },
+      { label: "Devin: 2026 release notes", url: "https://docs.devin.ai/release-notes/2026" },
+      { label: "Devin: Jira integration", url: "https://docs.devin.ai/integrations/jira" },
+      { label: "Augment: Remote Agent", url: "https://www.augmentcode.com/blog/introducing-remote-agent" },
+      { label: "GitHub Copilot: coding agent", url: "https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent" },
     ],
   },
   {
@@ -359,10 +363,22 @@ const landscapeRows = landscape.map((row) => {
       Commercial-tier agents in mid-2026 — the tools teams actually evaluate
       when choosing an AI delivery layer. MIT / own-it / self-hosted is
       table-stakes on the open-source side — every serious open-source tool
-      runs on your infra, so it earns parity, not separation. The delivery-pipeline
-      layer is already contested: OpenHands runs it today, Augment Code's Remote
-      Agents pull from a background task queue and land review-ready PRs, and the
-      commercial tier is moving fast.
+      runs on your infra, so it earns parity, not separation. The
+      delivery-pipeline layer is no longer merely contested — most of this
+      cohort now plans a change and works it from a queue without a human
+      assigning the ticket: Devin's{" "}
+      <a href="https://docs.devin.ai/release-notes/2026">automation triggers</a>{" "}
+      start it on a matching Jira or GitHub ticket with no manual assignment,
+      Augment's{" "}
+      <a href="https://www.augmentcode.com/blog/introducing-remote-agent">Remote
+      Agent</a> picks up tickets from Jira, Linear, or Slack and opens a PR
+      that has already been through review, GitHub's{" "}
+      <a href="https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent">coding
+      agent</a> works GitHub Issues as its backlog directly, and{" "}
+      <a href="https://docs.factory.ai/features/missions/overview">Factory's
+      Missions</a> decompose a plan into milestones behind an approval gate.
+      Being first to say so plainly is more credible than being caught
+      understating it.
     </p>
     <p class="mt-4 text-sm" style="color: var(--sw-color-text-muted);">
       Facts verified as of {verifiedDate}, from each vendor's own primary
@@ -405,6 +421,12 @@ const landscapeRows = landscape.map((row) => {
         </div>
       ))}
     </div>
+    <p class="mt-8 max-w-2xl sw-editorial">
+      Most of this cohort will plan a change and work it from a queue now.
+      None of them will refuse to merge code that has no test written first,
+      and none of them will let you own the whole pipeline — queue included —
+      on infrastructure you run.
+    </p>
     <div class="sw-callout mt-8 max-w-3xl">
       <p>
         <strong>On "own-it":</strong> running on your own infra is necessary, not

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -371,8 +371,8 @@ const landscapeRows = landscape.map((row) => {
       start it on a matching Jira or GitHub ticket with no manual assignment,
       Augment's{" "}
       <a href="https://www.augmentcode.com/blog/introducing-remote-agent">Remote
-      Agent</a> picks up tickets from Jira, Linear, or Slack and opens a PR
-      that has already been through review, GitHub's{" "}
+      Agent</a> picks up tickets from Jira, Linear, or Slack and lands
+      review-ready PRs, GitHub's{" "}
       <a href="https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent">coding
       agent</a> works GitHub Issues as its backlog directly, and{" "}
       <a href="https://docs.factory.ai/features/missions/overview">Factory's

--- a/site/tests/compare.spec.ts
+++ b/site/tests/compare.spec.ts
@@ -408,8 +408,9 @@ test("each pillar cites the competitors its own body names", async ({
   }
 
   // Pillar 2 names OpenHands' trigger-to-PR flow (Plan Mode included) and its
-  // ephemeral, run-scoped tracking — both need a primary source on this card.
-  // Factory is no longer named in this pillar's body (MKT-PILLAR2-PRECISION-1),
+  // ephemeral, run-scoped tracking, plus the ownable-queue point naming
+  // Devin, Augment, and GitHub Copilot (MKT-PIPELINE-PARITY-1) — all need a
+  // primary source on this card. Factory is not named in this pillar's body,
   // so its citation must not appear here. This pillar is about
   // architecture/extensibility, not testing, so the QA-is-CI's-job link
   // belongs on pillar 1 and must not appear here either.
@@ -423,6 +424,10 @@ test("each pillar cites the competitors its own body names", async ({
   for (const url of [
     "https://www.openhands.dev/blog/ai-agent-workflow-automation",
     "https://docs.openhands.dev/sdk/guides/github-workflows/todo-management",
+    "https://docs.devin.ai/release-notes/2026",
+    "https://docs.devin.ai/integrations/jira",
+    "https://www.augmentcode.com/blog/introducing-remote-agent",
+    "https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent",
   ]) {
     await expect(loopPillar.locator(`a[href="${url}"]`)).toHaveCount(1);
   }
@@ -481,6 +486,66 @@ test("pillar 2 states the run-vs-backlog distinction and leaves OpenHands' human
     has: page.locator("td").first().getByText("OpenHands", { exact: true }),
   });
   await expect(row).toContainText("Optional");
+});
+
+// MKT-PIPELINE-PARITY-1: pillar 2 must state the ownable-queue point — their
+// backlog lives in a third-party SaaS (Jira/Linear/GitHub Issues), ours runs
+// on infrastructure the reader operates.
+test("pillar 2 states the ownable-queue point", async ({ page }) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).toContain(
+    "In every case the queue lives in someone else's SaaS.",
+  );
+  expect(text).toContain(
+    "Shipwright's task store runs on infrastructure you operate, in the repo you forked.",
+  );
+});
+
+// MKT-PIPELINE-PARITY-1: the landscape intro no longer merely says
+// "contested" — it names the specific cohort-wide claim (most competitors
+// now plan + queue + ship) with a primary source per vendor.
+test("landscape intro strengthens the contested claim with per-vendor citations", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const heading = page.getByRole("heading", { name: /^The landscape$/i });
+  const section = page.locator("section").filter({ has: heading });
+  const text = (await section.textContent()) ?? "";
+  expect(text).toContain("no longer merely contested");
+  // Devin, GitHub Copilot, and Factory's citation URLs are also already used
+  // by their own landscape-table row (same section) — assert "at least one",
+  // not an exact count, so a legitimate shared citation isn't flagged.
+  // Augment's Remote Agent URL is new to this section, so it gets an exact
+  // count of 1.
+  for (const url of [
+    "https://docs.devin.ai/release-notes/2026",
+    "https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent",
+    "https://docs.factory.ai/features/missions/overview",
+  ]) {
+    const count = await section.locator(`a[href="${url}"]`).count();
+    expect(count).toBeGreaterThan(0);
+  }
+  await expect(
+    section.locator(
+      'a[href="https://www.augmentcode.com/blog/introducing-remote-agent"]',
+    ),
+  ).toHaveCount(1);
+});
+
+// MKT-PIPELINE-PARITY-1 AC: the honest summary line must close out "What
+// actually makes Shipwright different", adapted to page voice.
+test("the honest summary line closes the pillars section", async ({
+  page,
+}) => {
+  await page.goto("/compare");
+  const text = (await page.locator("main").textContent()) ?? "";
+  expect(text).toContain(
+    "Most of this cohort will plan a change and work it from a queue now.",
+  );
+  expect(text).toContain(
+    "none of them will let you own the whole pipeline — queue included — on infrastructure you run.",
+  );
 });
 
 test("homepage differentiators bridge into /compare (competitor-free)", async ({


### PR DESCRIPTION
## Summary
- Strengthens `/compare`'s landscape intro from "already contested" to explicitly naming that most of the commercial-tier cohort (Devin, Augment, GitHub Copilot, Factory) now plans, queues, and ships autonomously — each claim cited to its primary source.
- Adds the genuinely cohort-wide differentiator to pillar 2: competitors' backlogs live in a third-party SaaS (Jira/Linear/GitHub Issues); Shipwright's task store runs on infrastructure you own.
- Closes "What actually makes Shipwright different" with an honest summary line, adapted to page voice.
- Landscape table cell values, the tests-first pillar, and index.astro are all left untouched.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | No copy implies planning/queue/backlog unique to Shipwright | MET |
| 2 | Pillar 2 explicitly scoped to competitors it names | MET |
| 3 | Ownable-queue point present with citations | MET |
| 4 | Honest summary line present, adapted to page voice | MET |
| 5 | Every added competitor claim carries a primary-source citation | MET |
| 6 | Landscape table cell values unchanged | MET |
| 7 | Tests-first pillar unchanged, still lead pillar | MET |
| 8 | No competitor names added to index.astro | MET |
| 9 | No prices, tier names, or SWE-bench figures | MET |
| 10 | site build passes | MET |
| 11 | compare.spec.ts updated to cover the new summary line | MET |

## Test Plan
- `bun install && bunx astro build` — 27 pages built, including `/compare`
- `npm run brand-lint` — all pages on-brand
- `bunx playwright test tests/compare.spec.ts` — 34/34 passing (3 new tests added)
- `bunx playwright test tests/home.spec.ts` — 41/41 passing (no regression, index.astro untouched)
- `task check-strings` — no banned strings
- `bunx biome lint` on changed files — clean
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
