### PR TITLE
chore: sync docs freshness anchor to e18252f8

### DIFF
--- a/state/docs-last-synced.json
+++ b/state/docs-last-synced.json
@@ -1,1 +1,1 @@
-{"sha":"a2c4498aa3a2d3fd3a81a67e547680abdd5f94ed","timestamp":"2026-09-09T07:07:43Z"}
+{"sha":"e18252f84939b8d66de93dbbd216be26e4d3c1a6","timestamp":"2026-09-10T07:07:20Z"}


### PR DESCRIPTION
## Summary
- Automated daily docs-freshness sync, scoped to 85 source files changed since the last anchor (`a2c4498a`).
- No genuinely stale references found. Broken-reference checks (removed exports, moved file paths, renamed symbols) came up clean across all 21 `docs/*.md` files — the only removed export in the diff, `AGENT_CONTAINER_RESOURCES` → `resolveAgentContainerResources()` (admin/src/agent-manifest.ts), plus the new `loopEnabled` gating in `agent-work-queue-merge.ts`/`admin-ui.ts` and the new `lib/graceful-shutdown.ts` wiring in `admin`/`task-store`/`chat`, were all already correctly reflected in `docs/agent-key-files.md` from a prior per-PR sync.
- The remaining changed files were either test-only diffs, routine version/lockfile/chart-version bumps, marketing site pages (`site/`, out of `docs/` scope), or infra additions (new Helm PodDisruptionBudget templates) with no existing enumeration in `docs/deploy-kubernetes.md` for them to break.
- Cross-cutting checklist found one concrete, undocumented convention: `reportClaudeError()` (added to `agent/src/claude.ts`, VITALS-OS-46) now governs how every Claude-error Sentry call site (`cron-failure-reporter.ts`, `health.ts`, `loop-orchestrator.ts`, `slack.ts`) classifies a `ClaudeTimeoutError` — downgraded to `captureMessage` for the expected ceiling case, `captureException` otherwise — with no mention in `docs/observability.md`. Filed a task-store task (`docs-freshness-cron` session, `docs/observability-20260910` branch) rather than auto-editing, since this is new/missing coverage, not a broken reference.
- Synced `state/docs-last-synced.json` to HEAD (`e18252f8`).

## Test plan
- [x] Anchor-only change (plus one filed task-store task); no docs or code paths edited, nothing to run.