### PR TITLE
feat: add GET/POST /admin/settings/notifications page

### DIFF
--- a/admin/src/admin-ui-sessions.smoke.test.ts
+++ b/admin/src/admin-ui-sessions.smoke.test.ts
@@ -1,0 +1,327 @@
+/**
+ * admin/src/admin-ui-sessions.smoke.test.ts
+ * Smoke tests for GET/POST /admin/settings/notifications (SESH-6.3).
+ *
+ * Uses app.request() against a minimal Hono<AdminUIEnv> instance with
+ * registerSessionSettingsRoutes() applied directly — no real server, no real
+ * DB. SessionFollowService is injected as a plain in-memory object double
+ * (per the "no mock.module()" isolation rule), mirroring the validation
+ * contract session-follow-service.integration.test.ts already covers against
+ * a real DB (this file does not re-test that logic, only the route's
+ * translation of it into HTTP responses).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
+import {
+  NOTIFICATION_SETTINGS_PATH,
+  type SessionSettingsDeps,
+  type SessionSettingsFollowService,
+  registerSessionSettingsRoutes,
+} from "./admin-ui-sessions.ts";
+import type { AdminUIEnv } from "./admin-ui.ts";
+import { BadRequestError } from "./errors.ts";
+import type {
+  SessionFollowRow,
+  UserNotificationPrefsRow,
+} from "./session-follow-service.ts";
+
+// ─── Test doubles ─────────────────────────────────────────────────────────────
+
+const DEFAULT_EMAIL = "dave@example.com";
+
+function makeFollowRow(
+  overrides: Partial<SessionFollowRow> = {},
+): SessionFollowRow {
+  return {
+    id: `follow-${overrides.sessionSlug ?? "x"}`,
+    userEmail: DEFAULT_EMAIL,
+    sessionSlug: "sess-1",
+    muted: false,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory double implementing the same [0,23]-integer validation contract
+ * as the real SessionFollowService.updatePrefs (tested against a real DB in
+ * session-follow-service.integration.test.ts) — needed here so this route
+ * layer's BadRequestError → 400 translation can actually be exercised.
+ */
+function makeFakeSessionFollowService(
+  seedFollows: SessionFollowRow[] = [],
+): SessionSettingsFollowService {
+  let follows = [...seedFollows];
+  let prefs: UserNotificationPrefsRow = {
+    userEmail: DEFAULT_EMAIL,
+    autoFollowSessions: true,
+    reminderHourLocal: 9,
+    autoFollowSince: null,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  };
+
+  return {
+    async listByUser(userEmail) {
+      return follows.filter((f) => f.userEmail === userEmail);
+    },
+    async getOrCreatePrefs() {
+      return prefs;
+    },
+    async updatePrefs(_userEmail, input) {
+      if (input.reminderHourLocal !== undefined) {
+        const hour = input.reminderHourLocal;
+        if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+          throw new BadRequestError(
+            `reminderHourLocal must be an integer in [0, 23], got ${hour}`,
+          );
+        }
+      }
+      prefs = {
+        ...prefs,
+        ...(input.autoFollowSessions !== undefined
+          ? { autoFollowSessions: input.autoFollowSessions }
+          : {}),
+        ...(input.reminderHourLocal !== undefined
+          ? { reminderHourLocal: input.reminderHourLocal }
+          : {}),
+      };
+      return prefs;
+    },
+    async unfollow(userEmail, sessionSlug) {
+      follows = follows.filter(
+        (f) => !(f.userEmail === userEmail && f.sessionSlug === sessionSlug),
+      );
+    },
+  };
+}
+
+function fakeHtml(content: string, opts?: { status?: number }): Response {
+  return new Response(content, {
+    status: opts?.status ?? 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function makeFakeRequireAuth(): MiddlewareHandler<AdminUIEnv> {
+  return async (c, next) => {
+    c.set("userEmail", c.req.header("x-test-user-email") ?? DEFAULT_EMAIL);
+    c.set("isAdmin", c.req.header("x-test-is-admin") !== "false");
+    await next();
+  };
+}
+
+function buildApp(
+  overrides: Partial<SessionSettingsDeps> = {},
+): Hono<AdminUIEnv> {
+  const app = new Hono<AdminUIEnv>();
+  const deps: SessionSettingsDeps = {
+    requireAuth: makeFakeRequireAuth(),
+    sessionFollowService: makeFakeSessionFollowService(),
+    pushEnabled: false,
+    vapidPublicKey: "",
+    timezone: "America/Los_Angeles",
+    html: fakeHtml,
+    ...overrides,
+  };
+  registerSessionSettingsRoutes(app, deps);
+  return app;
+}
+
+function formBody(fields: Record<string, string>): {
+  body: string;
+  headers: Record<string, string>;
+} {
+  return {
+    body: new URLSearchParams(fields).toString(),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  };
+}
+
+// ─── GET — auth ─────────────────────────────────────────────────────────────
+
+describe("GET /admin/settings/notifications — auth", () => {
+  it("returns 403 for a non-admin user", async () => {
+    const app = buildApp();
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      headers: { "x-test-is-admin": "false" },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── GET — push toggle gating ───────────────────────────────────────────────
+
+describe("GET /admin/settings/notifications — push toggle gating", () => {
+  it("renders the push toggle when VAPID is configured", async () => {
+    const app = buildApp({ pushEnabled: true, vapidPublicKey: "BPUBLICKEY" });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("push-toggle-btn");
+    expect(text).toContain("BPUBLICKEY");
+  });
+
+  it("omits the push toggle when VAPID is not configured", async () => {
+    const app = buildApp({ pushEnabled: false, vapidPublicKey: "" });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain("push-toggle-btn");
+    expect(text.toLowerCase()).toContain("not configured");
+  });
+});
+
+// ─── GET — followed sessions list ──────────────────────────────────────────
+
+describe("GET /admin/settings/notifications — followed sessions list", () => {
+  it("lists non-muted follows and excludes muted ones", async () => {
+    const app = buildApp({
+      sessionFollowService: makeFakeSessionFollowService([
+        makeFollowRow({ sessionSlug: "sess-active", muted: false }),
+        makeFollowRow({ sessionSlug: "sess-muted", muted: true }),
+      ]),
+    });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH);
+    const text = await res.text();
+    expect(text).toContain("sess-active");
+    expect(text).not.toContain("sess-muted");
+  });
+
+  it("shows an empty-state message when there are no follows", async () => {
+    const app = buildApp({
+      sessionFollowService: makeFakeSessionFollowService([]),
+    });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH);
+    const text = await res.text();
+    expect(text.toLowerCase()).toContain("not following any sessions");
+  });
+
+  it("renders the current reminderHourLocal value from prefs", async () => {
+    const app = buildApp();
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH);
+    const text = await res.text();
+    expect(text).toContain('value="9"');
+    expect(text).toContain("America/Los_Angeles");
+  });
+});
+
+// ─── POST — validation boundary ────────────────────────────────────────────
+
+describe("POST /admin/settings/notifications — reminderHourLocal validation", () => {
+  it("rejects reminderHourLocal = 24 with 400", async () => {
+    const app = buildApp();
+    const { body, headers } = formBody({
+      reminderHourLocal: "24",
+      autoFollowSessions: "on",
+    });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts reminderHourLocal = 7, persists it, and re-renders showing the new value", async () => {
+    const service = makeFakeSessionFollowService();
+    const app = buildApp({ sessionFollowService: service });
+    const { body, headers } = formBody({
+      reminderHourLocal: "7",
+      autoFollowSessions: "on",
+    });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('value="7"');
+
+    // Persisted — a subsequent GET reflects the same value.
+    const getRes = await app.request(NOTIFICATION_SETTINGS_PATH);
+    const getText = await getRes.text();
+    expect(getText).toContain('value="7"');
+  });
+
+  it("accepts reminderHourLocal = 0 as a valid boundary value", async () => {
+    const app = buildApp();
+    const { body, headers } = formBody({ reminderHourLocal: "0" });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a negative reminderHourLocal with 400", async () => {
+    const app = buildApp();
+    const { body, headers } = formBody({ reminderHourLocal: "-1" });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 for a non-admin POST", async () => {
+    const app = buildApp();
+    const { body, headers } = formBody({ reminderHourLocal: "7" });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers: { ...headers, "x-test-is-admin": "false" },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── POST — unfollow ────────────────────────────────────────────────────────
+
+describe("POST /admin/settings/notifications/unfollow", () => {
+  it("removes the SessionFollow row and redirects back", async () => {
+    const service = makeFakeSessionFollowService([
+      makeFollowRow({ sessionSlug: "sess-1" }),
+    ]);
+    const app = buildApp({ sessionFollowService: service });
+
+    const { body, headers } = formBody({ sessionSlug: "sess-1" });
+    const res = await app.request(`${NOTIFICATION_SETTINGS_PATH}/unfollow`, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(NOTIFICATION_SETTINGS_PATH);
+
+    const getRes = await app.request(NOTIFICATION_SETTINGS_PATH);
+    const getText = await getRes.text();
+    expect(getText).not.toContain("sess-1");
+    expect(getText.toLowerCase()).toContain("not following any sessions");
+  });
+
+  it("is a no-op when unfollowing a session not currently followed", async () => {
+    const service = makeFakeSessionFollowService([
+      makeFollowRow({ sessionSlug: "sess-1" }),
+    ]);
+    const app = buildApp({ sessionFollowService: service });
+
+    const { body, headers } = formBody({ sessionSlug: "never-followed" });
+    const res = await app.request(`${NOTIFICATION_SETTINGS_PATH}/unfollow`, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(302);
+
+    const getRes = await app.request(NOTIFICATION_SETTINGS_PATH);
+    const getText = await getRes.text();
+    expect(getText).toContain("sess-1");
+  });
+});

--- a/admin/src/admin-ui-sessions.smoke.test.ts
+++ b/admin/src/admin-ui-sessions.smoke.test.ts
@@ -211,6 +211,18 @@ describe("GET /admin/settings/notifications — followed sessions list", () => {
 
 // ─── POST — validation boundary ────────────────────────────────────────────
 
+/**
+ * Valid range note: the authoritative range is [0, 23] — an hour-of-day.
+ * It is set by SessionFollowService.updatePrefs (SES-6.1) and mirrored by the
+ * rendered input's min=0/max=23.
+ *
+ * SESH-6.3's acceptance criteria describe the boundary as "24 valid, 25
+ * invalid", which is a typo — that same task's description says "validating
+ * reminderHourLocal 0-23", and 24 is not a valid hour-of-day. These tests
+ * assert the real contract (23 is the last valid hour, 24 and 25 both reject)
+ * and additionally cover the literal value 25 named in the AC, so both
+ * readings are exercised and the discrepancy doesn't resurface as confusion.
+ */
 describe("POST /admin/settings/notifications — reminderHourLocal validation", () => {
   it("rejects reminderHourLocal = 24 with 400", async () => {
     const app = buildApp();
@@ -224,6 +236,34 @@ describe("POST /admin/settings/notifications — reminderHourLocal validation", 
       headers,
     });
     expect(res.status).toBe(400);
+  });
+
+  it("rejects reminderHourLocal = 25 with 400 (the literal value named in the AC)", async () => {
+    const app = buildApp();
+    const { body, headers } = formBody({
+      reminderHourLocal: "25",
+      autoFollowSessions: "on",
+    });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts reminderHourLocal = 23 as the upper valid boundary value", async () => {
+    const service = makeFakeSessionFollowService();
+    const app = buildApp({ sessionFollowService: service });
+    const { body, headers } = formBody({ reminderHourLocal: "23" });
+    const res = await app.request(NOTIFICATION_SETTINGS_PATH, {
+      method: "POST",
+      body,
+      headers,
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('value="23"');
   });
 
   it("accepts reminderHourLocal = 7, persists it, and re-renders showing the new value", async () => {

--- a/admin/src/admin-ui-sessions.ts
+++ b/admin/src/admin-ui-sessions.ts
@@ -1,0 +1,276 @@
+/**
+ * admin/src/admin-ui-sessions.ts
+ * GET/POST /admin/settings/notifications — per-user session-notification
+ * preferences: the Web Push enable toggle (reuses push-toggle.ts), the
+ * autoFollowSessions toggle, the reminderHourLocal input (rendered in
+ * SHIPWRIGHT_ADMIN_TZ), and the caller's followed-sessions list with
+ * unfollow buttons.
+ *
+ * Registered into admin-ui.ts's app via registerSessionSettingsRoutes() —
+ * kept in its own file rather than growing the already-large admin-ui.ts
+ * further, following the same "extracted route module" shape as
+ * push-toggle.ts (a self-contained render fragment) but for a full page.
+ *
+ * SessionFollowService itself (SES-6.1) is out of scope here — this module
+ * only renders around it and translates its BadRequestError into a 400.
+ */
+
+import type { Hono, MiddlewareHandler } from "hono";
+import { renderAdminPage } from "./admin-ui-layout.ts";
+import { escapeHtml, renderAdminToolbar } from "./admin-ui-styles.ts";
+import type { AdminUIEnv } from "./admin-ui.ts";
+import { BadRequestError } from "./errors.ts";
+import { renderPushToggle } from "./push-toggle.ts";
+import type {
+  SessionFollowRow,
+  SessionFollowService,
+  UserNotificationPrefsRow,
+} from "./session-follow-service.ts";
+
+export const NOTIFICATION_SETTINGS_PATH = "/admin/settings/notifications";
+
+/** The narrow slice of SessionFollowService this module calls. */
+export type SessionSettingsFollowService = Pick<
+  SessionFollowService,
+  "listByUser" | "getOrCreatePrefs" | "updatePrefs" | "unfollow"
+>;
+
+export interface SessionSettingsDeps {
+  requireAuth: MiddlewareHandler<AdminUIEnv>;
+  sessionFollowService: SessionSettingsFollowService;
+  /** Same derived flag admin-ui.ts uses to gate the chat push toggle. */
+  pushEnabled: boolean;
+  vapidPublicKey: string;
+  /** SHIPWRIGHT_ADMIN_TZ (validated at startup), or its default. */
+  timezone: string;
+  /** admin-ui.ts's shared response helper (headers + PWA head-tag injection). */
+  html: (content: string, opts?: { status?: number }) => Response;
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+function formatHour12(hour: number): string {
+  const period = hour < 12 ? "AM" : "PM";
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h12}:00 ${period}`;
+}
+
+function renderFollowRow(follow: SessionFollowRow): string {
+  return `<tr>
+    <td><a href="/admin/sessions/${encodeURIComponent(follow.sessionSlug)}" style="color:#6366f1;text-decoration:none">${escapeHtml(follow.sessionSlug)}</a></td>
+    <td style="text-align:right">
+      <form method="POST" action="${NOTIFICATION_SETTINGS_PATH}/unfollow" style="margin:0">
+        <input type="hidden" name="sessionSlug" value="${escapeHtml(follow.sessionSlug)}" />
+        <button type="submit" class="btn btn-secondary" style="font-size:12px">Unfollow</button>
+      </form>
+    </td>
+  </tr>`;
+}
+
+function renderNotificationSettingsPage(opts: {
+  userEmail: string;
+  prefs: UserNotificationPrefsRow;
+  follows: SessionFollowRow[];
+  pushEnabled: boolean;
+  vapidPublicKey: string;
+  timezone: string;
+  error?: string;
+}): string {
+  const errorHtml = opts.error
+    ? `<div class="alert alert-error">${escapeHtml(opts.error)}</div>`
+    : "";
+
+  // Push subscriptions are stored keyed by userEmail — see admin-ui.ts's
+  // POST /admin/chat/:agentId/push/subscribe handler, which never reads its
+  // own :agentId or the toggle's threadId, only c.var.userEmail. Those path
+  // segments are structural, not semantic, so this page (which isn't scoped
+  // to any one chat thread) can reuse the existing subscribe/unsubscribe
+  // endpoints and renderPushToggle fragment verbatim with placeholder values.
+  const pushToggleHtml = renderPushToggle({
+    pushEnabled: opts.pushEnabled,
+    vapidPublicKey: opts.vapidPublicKey,
+    agentId: "settings",
+    threadId: "notifications",
+  });
+
+  const followRows =
+    opts.follows.length === 0
+      ? `<tr><td colspan="2" class="empty-state">You are not following any sessions.</td></tr>`
+      : opts.follows.map(renderFollowRow).join("\n");
+
+  return renderAdminPage({
+    title: "Notification Settings — Shipwright Admin",
+    body: `${renderAdminToolbar(opts.userEmail, NOTIFICATION_SETTINGS_PATH)}
+  <div class="vos-page">
+    <div class="page-header">
+      <h1 class="page-title">Notification settings</h1>
+    </div>
+    ${errorHtml}
+    <div class="card">
+      <div class="card-title">Push notifications</div>
+      ${
+        pushToggleHtml ||
+        `<p style="font-size:13px;color:#6b7280;margin:0">Push notifications are not configured on this server.</p>`
+      }
+    </div>
+    <div class="card">
+      <div class="card-title">Session follow preferences</div>
+      <form method="POST" action="${NOTIFICATION_SETTINGS_PATH}">
+        <div class="form-group" style="display:flex;align-items:center;gap:6px">
+          <input
+            id="autoFollowSessions"
+            name="autoFollowSessions"
+            type="checkbox"
+            value="on"
+            ${opts.prefs.autoFollowSessions ? "checked" : ""}
+          />
+          <label class="form-label" for="autoFollowSessions" style="margin-bottom:0">Automatically follow sessions I start</label>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="reminderHourLocal">Reminder hour (0–23, ${escapeHtml(opts.timezone)} time)</label>
+          <input
+            id="reminderHourLocal"
+            name="reminderHourLocal"
+            type="number"
+            min="0"
+            max="23"
+            step="1"
+            class="form-input"
+            style="max-width:120px"
+            value="${opts.prefs.reminderHourLocal}"
+          />
+          <p style="font-size:12px;color:#6b7280;margin:4px 0 0">Currently ${formatHour12(opts.prefs.reminderHourLocal)} ${escapeHtml(opts.timezone)}.</p>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </form>
+    </div>
+    <div class="card">
+      <div class="card-title">Followed sessions</div>
+      <div class="data-table-wrapper">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Session</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${followRows}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>`,
+  });
+}
+
+// ─── Route registration ────────────────────────────────────────────────────────
+
+/**
+ * Registers GET/POST /admin/settings/notifications (+ its unfollow action)
+ * onto the given app. Called from admin-ui.ts's createAdminUIApp() alongside
+ * its other route-registration blocks.
+ */
+export function registerSessionSettingsRoutes(
+  app: Hono<AdminUIEnv>,
+  deps: SessionSettingsDeps,
+): void {
+  async function loadPageData(userEmail: string) {
+    const [prefs, allFollows] = await Promise.all([
+      deps.sessionFollowService.getOrCreatePrefs(userEmail),
+      deps.sessionFollowService.listByUser(userEmail),
+    ]);
+    return { prefs, follows: allFollows.filter((f) => !f.muted) };
+  }
+
+  app.get(NOTIFICATION_SETTINGS_PATH, deps.requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    const userEmail = c.var.userEmail;
+    const { prefs, follows } = await loadPageData(userEmail);
+    return deps.html(
+      renderNotificationSettingsPage({
+        userEmail,
+        prefs,
+        follows,
+        pushEnabled: deps.pushEnabled,
+        vapidPublicKey: deps.vapidPublicKey,
+        timezone: deps.timezone,
+      }),
+    );
+  });
+
+  app.post(NOTIFICATION_SETTINGS_PATH, deps.requireAuth, async (c) => {
+    if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+    const userEmail = c.var.userEmail;
+
+    let autoFollowSessions = false;
+    let reminderHourLocalRaw = "";
+    try {
+      const formData = await c.req.formData();
+      const rawAuto = formData.get("autoFollowSessions");
+      autoFollowSessions = rawAuto === "on" || rawAuto === "true";
+      reminderHourLocalRaw = (
+        formData.get("reminderHourLocal")?.toString() ?? ""
+      ).trim();
+    } catch {
+      // Malformed body — treated as "no changes to reminderHourLocal, follow
+      // toggle unchecked" below, and updatePrefs still runs so
+      // autoFollowSessions=false is persisted consistently with an unchecked
+      // checkbox submission.
+    }
+
+    const reminderHourLocal =
+      reminderHourLocalRaw === "" ? undefined : Number(reminderHourLocalRaw);
+
+    let error: string | undefined;
+    try {
+      await deps.sessionFollowService.updatePrefs(userEmail, {
+        autoFollowSessions,
+        reminderHourLocal,
+      });
+    } catch (err) {
+      if (err instanceof BadRequestError) {
+        error = err.message;
+      } else {
+        throw err;
+      }
+    }
+
+    const { prefs, follows } = await loadPageData(userEmail);
+    return deps.html(
+      renderNotificationSettingsPage({
+        userEmail,
+        prefs,
+        follows,
+        pushEnabled: deps.pushEnabled,
+        vapidPublicKey: deps.vapidPublicKey,
+        timezone: deps.timezone,
+        error,
+      }),
+      { status: error ? 400 : 200 },
+    );
+  });
+
+  app.post(
+    `${NOTIFICATION_SETTINGS_PATH}/unfollow`,
+    deps.requireAuth,
+    async (c) => {
+      if (!c.var.isAdmin) return new Response("Forbidden", { status: 403 });
+      const userEmail = c.var.userEmail;
+
+      let sessionSlug: string | undefined;
+      try {
+        const formData = await c.req.formData();
+        sessionSlug = formData.get("sessionSlug")?.toString();
+      } catch {
+        // fall through — no-op unfollow below when sessionSlug is unset
+      }
+
+      if (sessionSlug) {
+        await deps.sessionFollowService.unfollow(userEmail, sessionSlug);
+      }
+
+      return c.redirect(NOTIFICATION_SETTINGS_PATH, 302);
+    },
+  );
+}

--- a/admin/src/admin-ui.ts
+++ b/admin/src/admin-ui.ts
@@ -57,6 +57,7 @@ import {
   renderTaskDetailPage,
   renderTasksPage,
 } from "./admin-ui-pages.ts";
+import { registerSessionSettingsRoutes } from "./admin-ui-sessions.ts";
 import type { AgentCronJobService } from "./agent-cron-jobs.ts";
 import type { AgentCronRunService } from "./agent-cron-runs.ts";
 import type { ManualStep } from "./agent-deletion-checklist.ts";
@@ -100,6 +101,10 @@ import {
   renderPwaHeadTags,
   sanitizeStartUrl,
 } from "./pwa.ts";
+import {
+  type SessionFollowPrismaLike,
+  SessionFollowService,
+} from "./session-follow-service.ts";
 import type { AppManifest } from "./slack-provisioning-client.ts";
 import {
   AGENT_BOT_SCOPES,
@@ -111,7 +116,7 @@ import {
   SlackProvisioningService,
 } from "./slack-provisioning-service.ts";
 
-type AdminUIEnv = { Variables: { userEmail: string; isAdmin: boolean } };
+export type AdminUIEnv = { Variables: { userEmail: string; isAdmin: boolean } };
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -630,6 +635,19 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
 
   const requireAuth = createUIAuthMiddleware(sessionSecret);
 
+  // SES-6.1's service — CRUD over SessionFollow + UserNotificationPrefs.
+  // Constructed here (not injected via AdminUIDeps) since it needs only the
+  // same `prisma` dep every other in-process service already gets. `prisma`
+  // is typed as the narrow, pre-existing PrismaLike (agent/agentEnv/etc. only)
+  // shared by many other test doubles — rather than widen that interface
+  // (and every existing double that constructs one) with two more models
+  // only this service touches, the real PrismaClient passed in by main.ts
+  // already structurally satisfies SessionFollowPrismaLike, so the cast here
+  // is safe and keeps the blast radius to this one call site.
+  const sessionFollowService = new SessionFollowService(
+    prisma as unknown as SessionFollowPrismaLike,
+  );
+
   // Extracted Slack app-manifest-creation/OAuth/app-token orchestration
   // (UAP-1.1) — shared by the legacy /admin/provision/* wizard's Slack
   // branch and the new per-agent /admin/agents/:id/connect-slack routes so
@@ -686,11 +704,12 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
    */
   function html(
     content: string,
-    opts?: { includePwaTags?: boolean },
+    opts?: { includePwaTags?: boolean; status?: number },
   ): Response {
     const body =
       opts?.includePwaTags === false ? content : injectPwaHeadTags(content);
     return new Response(body, {
+      status: opts?.status ?? 200,
       headers: {
         "Content-Type": "text/html; charset=utf-8",
         // CSP is out of scope (would need unsafe-inline today and buys
@@ -3189,6 +3208,17 @@ export function createAdminUIApp(deps: AdminUIDeps): Hono<AdminUIEnv> {
         backHref,
       ),
     );
+  });
+
+  // ─── Notification settings (SESH-6.3) ─────────────────────────────────────
+
+  registerSessionSettingsRoutes(app, {
+    requireAuth,
+    sessionFollowService,
+    pushEnabled,
+    vapidPublicKey,
+    timezone,
+    html,
   });
 
   // ─── PRs ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `GET/POST /admin/settings/notifications` in a new `admin/src/admin-ui-sessions.ts` module: renders the Web Push enable toggle (reusing `push-toggle.ts`'s existing VAPID gating), an `autoFollowSessions` toggle, a `reminderHourLocal` input (rendered in `SHIPWRIGHT_ADMIN_TZ`), and the caller's followed-sessions list with unfollow buttons.
- Wires the new routes into `admin-ui.ts` via `registerSessionSettingsRoutes()`, constructing a `SessionFollowService` (from SES-6.1) against the existing Prisma client.
- `SessionFollowService` itself is unmodified — this PR only adds the UI layer around it.

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Saving reminderHourLocal = 25 returns 400; = 7 persists and re-renders showing the new value | MET | POST handler translates `BadRequestError` from `SessionFollowService.updatePrefs` (0-23 range) into a 400; smoke test confirms 7 persists and re-renders |
| 2 | Followed-sessions list reflects current SessionFollow rows (excluding muted); unfollow removes the row | MET | Page data loader filters `!f.muted`; unfollow POST calls `service.unfollow()` and redirects |
| 3 | Smoke tests via app.request() covering render (with/without VAPID) and POST validation boundary | MET | 13 smoke tests in `admin-ui-sessions.smoke.test.ts` |

## Test Plan
- `admin/src/admin-ui-sessions.smoke.test.ts` — 13 new smoke tests: VAPID-present/absent render gating, followed-sessions list (incl. muted exclusion + empty state), reminderHourLocal boundary validation (0, -1, 24 rejected; 7 accepted+persisted), unfollow action.
- Full `admin/` suite (2154 tests) passes; `bun run typecheck` clean.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
