### PR TITLE
fix: await stub server stop and use ephemeral ports in test teardown

### DIFF
--- a/agent/src/chat-token-reporter.integration.test.ts
+++ b/agent/src/chat-token-reporter.integration.test.ts
@@ -95,8 +95,7 @@ describe("HttpChatTokenReporter", () => {
   // biome-ignore lint/suspicious/noExplicitAny: Server type param varies by bun version
   let server: ReturnType<typeof Bun.serve<any>>;
   let state: StubState;
-  const PORT = 19961;
-  const BASE_URL = `http://localhost:${PORT}`;
+  let baseUrl: string;
   const AGENT_ID = "agent-abc";
   const API_KEY = "test-api-key";
   const CLOCK = FixedClock(new Date("2026-01-15T12:00:00.000Z"));
@@ -104,7 +103,8 @@ describe("HttpChatTokenReporter", () => {
 
   beforeEach(() => {
     state = { captured: [], statusToReturn: 200 };
-    server = startStubServer(PORT, state);
+    server = startStubServer(0, state);
+    baseUrl = `http://localhost:${server.port}`;
     // liveClaudeConfig is a shared mutable module singleton (see claude.ts) —
     // tests must not depend on the ambient ANTHROPIC_MODEL env var. Inject a
     // model guaranteed to be present in pricing.ts's RATES table with a
@@ -115,14 +115,14 @@ describe("HttpChatTokenReporter", () => {
     setLiveClaudeConfig({ model: "claude-sonnet-4-6" });
   });
 
-  afterEach(() => {
-    server.stop(true);
+  afterEach(async () => {
+    await server.stop(true);
     setLiveClaudeConfig({ model: originalModel });
   });
 
   function makeReporter() {
     return new HttpChatTokenReporter({
-      apiUrl: BASE_URL,
+      apiUrl: baseUrl,
       agentId: AGENT_ID,
       apiKey: API_KEY,
       clock: CLOCK,

--- a/agent/src/cron-handler.smoke.test.ts
+++ b/agent/src/cron-handler.smoke.test.ts
@@ -598,14 +598,12 @@ describe("handleCronRequest — CronRunReporter", () => {
   // biome-ignore lint/suspicious/noExplicitAny: Server type param varies by bun version
   let reporterServer: ReturnType<typeof Bun.serve<any>> | undefined;
   let reporterState: ReporterStubState;
-
-  const REPORTER_PORT = 19965;
-  const REPORTER_BASE_URL = `http://localhost:${REPORTER_PORT}`;
+  let reporterBaseUrl: string;
   const AGENT_ID = "test-agent-id";
 
   function makeHttpReporter() {
     return new HttpCronRunReporter({
-      apiUrl: REPORTER_BASE_URL,
+      apiUrl: reporterBaseUrl,
       agentId: AGENT_ID,
       apiKey: "test-key",
     });
@@ -615,11 +613,12 @@ describe("handleCronRequest — CronRunReporter", () => {
     tmpDir = mkdtempSync(join(tmpdir(), "cron-reporter-test-"));
     mkdirSync(join(tmpDir, "shipwright", "scripts"), { recursive: true });
     reporterState = { requests: [], runIdToReturn: "run-test-1" };
-    reporterServer = startReporterStub(REPORTER_PORT, reporterState);
+    reporterServer = startReporterStub(0, reporterState);
+    reporterBaseUrl = `http://localhost:${reporterServer.port}`;
   });
 
-  afterEach(() => {
-    reporterServer?.stop(true);
+  afterEach(async () => {
+    await reporterServer?.stop(true);
     reporterServer = undefined;
   });
 
@@ -1124,25 +1123,24 @@ describe("POST /cron HTTP endpoint", () => {
   const servers: Server<any>[] = [];
 
   function serve(
-    port: number,
     sentryClient?: ErrorCapturingClient,
     // biome-ignore lint/suspicious/noExplicitAny: Server type param varies by bun version
   ): Server<any> {
-    const s = startHealthServer(port, deps, undefined, undefined, sentryClient);
+    const s = startHealthServer(0, deps, undefined, undefined, sentryClient);
     servers.push(s);
     return s;
   }
 
-  afterEach(() => {
-    for (const s of servers) s.stop(true);
+  afterEach(async () => {
+    for (const s of servers) await s.stop(true);
     servers.length = 0;
   });
 
   test("200 on valid channel request", async () => {
     mockRunner.mockResolvedValueOnce({ result: "ok", sessionId: "s" });
-    serve(19920);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19920/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j1", prompt: "hello", channel: "C-X" }),
@@ -1155,9 +1153,9 @@ describe("POST /cron HTTP endpoint", () => {
 
   test("200 on valid user DM request", async () => {
     mockRunner.mockResolvedValueOnce({ result: "dm reply", sessionId: "s" });
-    serve(19921);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19921/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j2", prompt: "daily", user: "U-DAN" }),
@@ -1167,9 +1165,9 @@ describe("POST /cron HTTP endpoint", () => {
   });
 
   test("400 for missing prompt", async () => {
-    serve(19922);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19922/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j3" }),
@@ -1178,9 +1176,9 @@ describe("POST /cron HTTP endpoint", () => {
   });
 
   test("422 when neither channel nor user and not silent", async () => {
-    serve(19923);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19923/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j4", prompt: "hello" }),
@@ -1191,9 +1189,9 @@ describe("POST /cron HTTP endpoint", () => {
   });
 
   test("400 for invalid JSON body", async () => {
-    serve(19924);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19924/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: "not json {{",
@@ -1202,9 +1200,9 @@ describe("POST /cron HTTP endpoint", () => {
   });
 
   test("400 for missing jobId in body", async () => {
-    serve(19925);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19925/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: "hello", channel: "C-X" }),
@@ -1214,9 +1212,9 @@ describe("POST /cron HTTP endpoint", () => {
 
   test("500 when Claude runner throws", async () => {
     mockRunner.mockRejectedValueOnce(new Error("claude down"));
-    serve(19926);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19926/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j5", prompt: "run", channel: "C-X" }),
@@ -1234,9 +1232,9 @@ describe("POST /cron HTTP endpoint", () => {
         capturedErrors.push(err);
       },
     };
-    serve(19930, fakeSentryClient);
+    const server = serve(fakeSentryClient);
 
-    const res = await fetch("http://localhost:19930/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j8", prompt: "run", channel: "C-X" }),
@@ -1263,9 +1261,9 @@ describe("POST /cron HTTP endpoint", () => {
         capturedMessages.push(message);
       },
     };
-    serve(19933, fakeSentryClient);
+    const server = serve(fakeSentryClient);
 
-    const res = await fetch("http://localhost:19933/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j9", prompt: "run", channel: "C-X" }),
@@ -1291,9 +1289,9 @@ describe("POST /cron HTTP endpoint", () => {
         capturedMessages.push(message);
       },
     };
-    serve(19934, fakeSentryClient);
+    const server = serve(fakeSentryClient);
 
-    const res = await fetch("http://localhost:19934/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j10", prompt: "run", channel: "C-X" }),
@@ -1312,9 +1310,9 @@ describe("POST /cron HTTP endpoint", () => {
         capturedErrors.push(err);
       },
     };
-    serve(19931, fakeSentryClient);
+    const server = serve(fakeSentryClient);
 
-    const res = await fetch("http://localhost:19931/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j9", prompt: "hello" }),
@@ -1326,9 +1324,9 @@ describe("POST /cron HTTP endpoint", () => {
 
   test("500 with no sentryClient wired — behaves exactly as before (no throw, same response)", async () => {
     mockRunner.mockRejectedValueOnce(new Error("claude down"));
-    serve(19932);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19932/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j10", prompt: "run", channel: "C-X" }),
@@ -1341,9 +1339,9 @@ describe("POST /cron HTTP endpoint", () => {
 
   test("200 with silent=true — no Slack post", async () => {
     mockRunner.mockResolvedValueOnce({ result: "done", sessionId: "s" });
-    serve(19927);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19927/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j6", prompt: "run", silent: true }),
@@ -1353,10 +1351,10 @@ describe("POST /cron HTTP endpoint", () => {
   });
 
   test("503 when cronDeps not configured", async () => {
-    const s = startHealthServer(19928);
+    const s = startHealthServer(0);
     servers.push(s);
 
-    const res = await fetch("http://localhost:19928/cron", {
+    const res = await fetch(`http://localhost:${s.port}/cron`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jobId: "j7", prompt: "run", channel: "C-X" }),
@@ -1365,9 +1363,9 @@ describe("POST /cron HTTP endpoint", () => {
   });
 
   test("405 on GET /cron", async () => {
-    serve(19929);
+    const server = serve();
 
-    const res = await fetch("http://localhost:19929/cron", {
+    const res = await fetch(`http://localhost:${server.port}/cron`, {
       method: "GET",
     });
     expect(res.status).toBe(405);

--- a/agent/src/cron-run-reporter.integration.test.ts
+++ b/agent/src/cron-run-reporter.integration.test.ts
@@ -77,8 +77,7 @@ describe("HttpCronRunReporter", () => {
   // biome-ignore lint/suspicious/noExplicitAny: Server type param varies by bun version
   let server: ReturnType<typeof Bun.serve<any>>;
   let state: StubState;
-  const PORT = 19960;
-  const BASE_URL = `http://localhost:${PORT}`;
+  let baseUrl: string;
   const AGENT_ID = "agent-abc";
   const API_KEY = "test-api-key";
 
@@ -88,16 +87,17 @@ describe("HttpCronRunReporter", () => {
       postStatusToReturn: 201,
       patchStatusToReturn: 200,
     };
-    server = startStubServer(PORT, state);
+    server = startStubServer(0, state);
+    baseUrl = `http://localhost:${server.port}`;
   });
 
-  afterEach(() => {
-    server.stop(true);
+  afterEach(async () => {
+    await server.stop(true);
   });
 
   function makeReporter() {
     return new HttpCronRunReporter({
-      apiUrl: BASE_URL,
+      apiUrl: baseUrl,
       agentId: AGENT_ID,
       apiKey: API_KEY,
     });

--- a/agent/src/loop-orchestrator.integration.test.ts
+++ b/agent/src/loop-orchestrator.integration.test.ts
@@ -82,7 +82,6 @@ function pr(
 describe("loop-orchestrator + real task-store claim client (CBD-2.1)", () => {
   // biome-ignore lint/suspicious/noExplicitAny: Server type param varies by bun version
   let server: ReturnType<typeof Bun.serve<any>>;
-  const PORT = 19962;
   let claimStatusByTaskId: Record<string, number>;
   let claimRequests: string[];
   let savedEnv: { url?: string; token?: string };
@@ -91,7 +90,7 @@ describe("loop-orchestrator + real task-store claim client (CBD-2.1)", () => {
     claimStatusByTaskId = {};
     claimRequests = [];
     server = Bun.serve({
-      port: PORT,
+      port: 0,
       fetch: (req) => {
         const match = new URL(req.url).pathname.match(
           /^\/tasks\/([^/]+)\/claim$/,
@@ -119,12 +118,12 @@ describe("loop-orchestrator + real task-store claim client (CBD-2.1)", () => {
       url: process.env.SHIPWRIGHT_TASK_STORE_URL,
       token: process.env.SHIPWRIGHT_TASK_STORE_TOKEN,
     };
-    process.env.SHIPWRIGHT_TASK_STORE_URL = `http://localhost:${PORT}`;
+    process.env.SHIPWRIGHT_TASK_STORE_URL = `http://localhost:${server.port}`;
     process.env.SHIPWRIGHT_TASK_STORE_TOKEN = "test-token";
   });
 
-  afterEach(() => {
-    server.stop(true);
+  afterEach(async () => {
+    await server.stop(true);
     if (savedEnv.url !== undefined) {
       process.env.SHIPWRIGHT_TASK_STORE_URL = savedEnv.url;
     } else {


### PR DESCRIPTION
## Summary
- Fixes a stub-server port race in `agent/src/cron-run-reporter.integration.test.ts`, `chat-token-reporter.integration.test.ts`, `loop-orchestrator.integration.test.ts`, and `cron-handler.smoke.test.ts`
- `afterEach` hooks now `await server.stop(true)` instead of firing-and-forgetting it, so the socket is fully released before the next test's `beforeEach` runs
- All four files switched from hardcoded fixed ports (19960/19961/19962/19965, plus a second hardcoded block in `cron-handler.smoke.test.ts`) to OS-assigned ephemeral ports (`port: 0`), deriving each test's base URL from the server's actual bound `server.port`
- Test-infrastructure-only change — no production code touched, no new tests added

## Acceptance Criteria
| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | afterEach in all four files awaits server.stop(true) | MET | All 4 files' afterEach hooks are now async and await stop() |
| 2 | All four files use port:0, derive base URL from server.port | MET | Hardcoded PORT/REPORTER_PORT constants removed; base URL derived from `server.port` after bind |
| 3 | No new tests added, existing assertions unmodified | MET | Diff is setup/teardown only — no new test() blocks, all expect() assertions unchanged |
| 4 | Full bun test suite run ≥3x to build confidence | MET | Full suite run 3x: 8001 pass / 506 skip / 2 pre-existing unrelated fails, consistent all 3 runs |

## Test Plan
- Ran the four target test files individually — 114/114 pass
- Ran the full `bun test` suite 3 consecutive times — 8001 pass / 506 skip each run, no flake in the touched files
- `task lint` and `task typecheck` pass clean
- The only 2 failures seen under `task ci` (`test-store/src/routes/prs.openapi.smoke.test.ts`) are a known pre-existing bug (`validateRepo` treats `undefined` repos differently than `null`) unrelated to this change — confirmed unaffected by this diff and pre-existing on main
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
