### PR TITLE
feat: add computeSessionRollup pure function

### DIFF
--- a/task-store/src/session-rollup.ts
+++ b/task-store/src/session-rollup.ts
@@ -1,0 +1,240 @@
+/**
+ * task-store/src/session-rollup.ts
+ *
+ * Pure helper: computeSessionRollup(tasks, prBlockedSet, clock, session?) →
+ * SessionRollup
+ *
+ * Summarizes a session's task set into a single rollup: overall state,
+ * activity timestamps, per-status counts, distinct agents/repos, and the
+ * list of tasks currently "waiting".
+ *
+ * ─── Signature note ─────────────────────────────────────────────────────────
+ * The spec names a 3-arg contract — (tasks, prBlockedSet, clock) — for the
+ * core state computation, but AC3 also requires reporting `archived: true`
+ * for archived sessions, and archival status (Session.archivedAt) lives
+ * outside the Task rows this function otherwise operates on. Rather than
+ * force session metadata through the Task rows (or drop the 3-arg contract),
+ * `session` is added as a 4th, OPTIONAL parameter: omitting it (the primary
+ * 3-arg call shape) means "not archived"; passing `{ archivedAt }` satisfies
+ * AC3. `archived` is computed independently of `state`, so both are always
+ * reportable together — including for an empty task list.
+ *
+ * ─── Waiting definition (reuses computeBlockedBy semantics) ────────────────
+ * A task counts as "waiting" when, among its open (non-terminal) tasks:
+ *   1. status === "blocked" (explicit park), or
+ *   2. hitl === true AND computeBlockedBy reports no unsatisfied dependency
+ *      for it (i.e. the HITL gate is the only thing holding it back), or
+ *   3. it has a linked PR (task.pr != null) present in prBlockedSet.
+ * A task whose ONLY computeBlockedBy entry is an unsatisfied dependency does
+ * NOT count as waiting — dependency-only waits are excluded by design.
+ *
+ * When more than one condition applies to the same task, precedence is
+ * blocked > pr_blocked > hitl: status="blocked" is the most explicit,
+ * operator-visible signal; pr_blocked is an external system signal; the
+ * hitl gate is considered last since AC1 already conditions it on having no
+ * unmet dependency.
+ */
+
+import { computeBlockedBy } from "./blocked-by.ts";
+import type { Clock } from "./clock.ts";
+import type { ReadyTaskLike } from "./ready.ts";
+import { CLOSED_STATUSES } from "./statuses.ts";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** The minimal Task shape computeSessionRollup needs. */
+export interface SessionRollupTaskLike extends ReadyTaskLike {
+  repo?: string | null;
+  assignee?: string | null;
+  claimedBy?: string | null;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+/** The minimal Session shape needed to report `archived`. See the file-level
+ * doc comment for why this is a separate, optional parameter. */
+export interface SessionRollupSessionLike {
+  archivedAt?: string | Date | null;
+}
+
+export type SessionRollupState = "waiting" | "active" | "closed" | "empty";
+
+export type WaitingKind = "hitl" | "blocked" | "pr_blocked";
+
+export interface WaitingTaskEntry {
+  id: string;
+  kind: WaitingKind;
+}
+
+export interface SessionRollupCounts {
+  total: number;
+  open: number;
+  closed: number;
+}
+
+export interface SessionRollup {
+  state: SessionRollupState;
+  waitingSince: string | null;
+  lastActivityAt: string | null;
+  counts: SessionRollupCounts;
+  agentIds: string[];
+  repos: string[];
+  waitingTasks: WaitingTaskEntry[];
+  archived: boolean;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const CLOSED_STATUS_SET = new Set<string>(CLOSED_STATUSES);
+
+function toIso(value: string | Date): string {
+  return typeof value === "string"
+    ? new Date(value).toISOString()
+    : value.toISOString();
+}
+
+function toTime(value: string | Date): number {
+  return typeof value === "string"
+    ? new Date(value).getTime()
+    : value.getTime();
+}
+
+function isArchived(session?: SessionRollupSessionLike): boolean {
+  return session?.archivedAt != null;
+}
+
+/**
+ * Determine the WaitingKind (if any) for a single open task, per the
+ * precedence documented at the top of this file.
+ */
+function classifyWaiting(
+  task: SessionRollupTaskLike,
+  allTasks: SessionRollupTaskLike[],
+  prBlockedSet: Set<number>,
+): WaitingKind | null {
+  if (task.status === "blocked") {
+    return "blocked";
+  }
+
+  if (task.pr != null && prBlockedSet.has(task.pr)) {
+    return "pr_blocked";
+  }
+
+  if (task.hitl === true) {
+    const blockedBy = computeBlockedBy(task, allTasks);
+    const hasUnmetDependency = blockedBy.some(
+      (entry) => entry.type === "dependency",
+    );
+    if (!hasUnmetDependency) {
+      return "hitl";
+    }
+  }
+
+  return null;
+}
+
+// ─── Core helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Compute a session-level rollup from its task set.
+ *
+ * @param tasks         All tasks belonging to the session.
+ * @param prBlockedSet  PR numbers (task-store `pr` field) currently blocked.
+ * @param clock         Injected time source (reserved for "now"-relative
+ *                       fields; current fields are all derived from task
+ *                       timestamps, not wall-clock time).
+ * @param session       Optional session metadata, used only for `archived`.
+ */
+export function computeSessionRollup(
+  tasks: SessionRollupTaskLike[],
+  prBlockedSet: Set<number>,
+  clock: Clock,
+  session?: SessionRollupSessionLike,
+): SessionRollup {
+  void clock;
+  const archived = isArchived(session);
+
+  if (tasks.length === 0) {
+    return {
+      state: "empty",
+      waitingSince: null,
+      lastActivityAt: null,
+      counts: { total: 0, open: 0, closed: 0 },
+      agentIds: [],
+      repos: [],
+      waitingTasks: [],
+      archived,
+    };
+  }
+
+  const openTasks = tasks.filter((t) => !CLOSED_STATUS_SET.has(t.status));
+  const closedCount = tasks.length - openTasks.length;
+
+  const waitingTasks: WaitingTaskEntry[] = [];
+  for (const task of openTasks) {
+    const kind = classifyWaiting(task, tasks, prBlockedSet);
+    if (kind) {
+      waitingTasks.push({ id: task.id, kind });
+    }
+  }
+  const waitingIds = new Set(waitingTasks.map((w) => w.id));
+
+  let state: SessionRollupState;
+  if (openTasks.length === 0) {
+    state = "closed";
+  } else if (waitingTasks.length > 0) {
+    state = "waiting";
+  } else {
+    state = "active";
+  }
+
+  const lastActivityAt = toIso(
+    tasks.reduce(
+      (latest, t) =>
+        toTime(t.updatedAt) > toTime(latest) ? t.updatedAt : latest,
+      tasks[0].updatedAt,
+    ),
+  );
+
+  let waitingSince: string | null = null;
+  if (state === "waiting") {
+    const waitingTaskRecords = openTasks.filter((t) => waitingIds.has(t.id));
+    const earliest = waitingTaskRecords.reduce(
+      (earliestSoFar, t) =>
+        toTime(t.updatedAt) < toTime(earliestSoFar)
+          ? t.updatedAt
+          : earliestSoFar,
+      waitingTaskRecords[0].updatedAt,
+    );
+    waitingSince = toIso(earliest);
+  }
+
+  const agentIds = Array.from(
+    new Set(
+      tasks
+        .map((t) => t.claimedBy ?? t.assignee ?? null)
+        .filter((id): id is string => id != null),
+    ),
+  );
+
+  const repos = Array.from(
+    new Set(
+      tasks.map((t) => t.repo ?? null).filter((r): r is string => r != null),
+    ),
+  );
+
+  return {
+    state,
+    waitingSince,
+    lastActivityAt,
+    counts: {
+      total: tasks.length,
+      open: openTasks.length,
+      closed: closedCount,
+    },
+    agentIds,
+    repos,
+    waitingTasks,
+    archived,
+  };
+}

--- a/task-store/src/session-rollup.unit.test.ts
+++ b/task-store/src/session-rollup.unit.test.ts
@@ -1,0 +1,261 @@
+/**
+ * task-store/src/session-rollup.unit.test.ts
+ *
+ * Unit tests for the computeSessionRollup() pure helper.
+ * No I/O — pure logic only. Time is injected via FixedClock.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { FixedClock } from "./clock.ts";
+import {
+  type SessionRollupTaskLike,
+  computeSessionRollup,
+} from "./session-rollup.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTask(
+  overrides: Partial<SessionRollupTaskLike> = {},
+): SessionRollupTaskLike {
+  return {
+    id: "task-1",
+    status: "pending",
+    branch: null,
+    dependencies: [],
+    pr: null,
+    hitl: null,
+    blockedReason: null,
+    repo: "app-vitals/shipwright",
+    assignee: null,
+    claimedBy: null,
+    createdAt: "2026-09-01T00:00:00.000Z",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const clock = FixedClock(new Date("2026-09-11T00:00:00.000Z"));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("computeSessionRollup", () => {
+  it("returns state 'waiting' with a hitl waitingTasks entry when hitl=true and dependencies are satisfied", () => {
+    const dep = makeTask({ id: "dep-1", status: "done" });
+    const task = makeTask({
+      id: "t1",
+      hitl: true,
+      dependencies: ["dep-1"],
+      updatedAt: "2026-09-05T00:00:00.000Z",
+    });
+    const result = computeSessionRollup([task, dep], new Set(), clock);
+    expect(result.state).toBe("waiting");
+    expect(result.waitingTasks).toEqual([{ id: "t1", kind: "hitl" }]);
+  });
+
+  it("returns state 'active' (no waitingTasks) when hitl=true but has an unmet dependency", () => {
+    const dep = makeTask({ id: "dep-1", status: "pending" });
+    const task = makeTask({ id: "t1", hitl: true, dependencies: ["dep-1"] });
+    const result = computeSessionRollup([task, dep], new Set(), clock);
+    expect(result.state).toBe("active");
+    expect(result.waitingTasks).toEqual([]);
+  });
+
+  it("returns state 'waiting' with a pr_blocked waitingTasks entry when task.pr is in prBlockedSet", () => {
+    const task = makeTask({ id: "t1", pr: 42 });
+    const result = computeSessionRollup([task], new Set([42]), clock);
+    expect(result.state).toBe("waiting");
+    expect(result.waitingTasks).toEqual([{ id: "t1", kind: "pr_blocked" }]);
+  });
+
+  it("does not report pr_blocked when task.pr is set but not present in prBlockedSet", () => {
+    const task = makeTask({ id: "t1", pr: 42, status: "in_progress" });
+    const result = computeSessionRollup([task], new Set([99]), clock);
+    expect(result.state).toBe("active");
+    expect(result.waitingTasks).toEqual([]);
+  });
+
+  it("reports archived: true via the optional session param, alongside computed state", () => {
+    const task = makeTask({ id: "t1", status: "in_progress" });
+    const result = computeSessionRollup([task], new Set(), clock, {
+      archivedAt: "2026-09-01T00:00:00.000Z",
+    });
+    expect(result.archived).toBe(true);
+    expect(result.state).toBe("active");
+  });
+
+  it("reports archived: false when no session param is passed", () => {
+    const task = makeTask({ id: "t1" });
+    const result = computeSessionRollup([task], new Set(), clock);
+    expect(result.archived).toBe(false);
+  });
+
+  it("reports archived: false when session param has a null archivedAt", () => {
+    const task = makeTask({ id: "t1" });
+    const result = computeSessionRollup([task], new Set(), clock, {
+      archivedAt: null,
+    });
+    expect(result.archived).toBe(false);
+  });
+
+  it("returns state 'empty' with zeroed counts and null timestamps for an empty task list", () => {
+    const result = computeSessionRollup([], new Set(), clock);
+    expect(result.state).toBe("empty");
+    expect(result.counts).toEqual({ total: 0, open: 0, closed: 0 });
+    expect(result.lastActivityAt).toBeNull();
+    expect(result.waitingSince).toBeNull();
+    expect(result.agentIds).toEqual([]);
+    expect(result.repos).toEqual([]);
+    expect(result.waitingTasks).toEqual([]);
+    expect(result.archived).toBe(false);
+  });
+
+  it("combines an empty task list with archived: true", () => {
+    const result = computeSessionRollup([], new Set(), clock, {
+      archivedAt: "2026-09-01T00:00:00.000Z",
+    });
+    expect(result.state).toBe("empty");
+    expect(result.archived).toBe(true);
+  });
+
+  it("returns state 'closed' when every task has a terminal status", () => {
+    const t1 = makeTask({ id: "t1", status: "merged" });
+    const t2 = makeTask({ id: "t2", status: "done" });
+    const result = computeSessionRollup([t1, t2], new Set(), clock);
+    expect(result.state).toBe("closed");
+    expect(result.waitingTasks).toEqual([]);
+  });
+
+  it("returns state 'waiting' with a blocked waitingTasks entry when status='blocked'", () => {
+    const task = makeTask({
+      id: "t1",
+      status: "blocked",
+      blockedReason: "waiting on infra",
+    });
+    const result = computeSessionRollup([task], new Set(), clock);
+    expect(result.state).toBe("waiting");
+    expect(result.waitingTasks).toEqual([{ id: "t1", kind: "blocked" }]);
+  });
+
+  it("returns state 'active' for a mix of open non-waiting tasks", () => {
+    const t1 = makeTask({ id: "t1", status: "in_progress" });
+    const t2 = makeTask({ id: "t2", status: "pr_open" });
+    const result = computeSessionRollup([t1, t2], new Set(), clock);
+    expect(result.state).toBe("active");
+    expect(result.waitingTasks).toEqual([]);
+  });
+
+  describe("counts", () => {
+    it("computes total/open/closed counts across the task list", () => {
+      const t1 = makeTask({ id: "t1", status: "in_progress" });
+      const t2 = makeTask({ id: "t2", status: "merged" });
+      const t3 = makeTask({ id: "t3", status: "done" });
+      const result = computeSessionRollup([t1, t2, t3], new Set(), clock);
+      expect(result.counts).toEqual({ total: 3, open: 1, closed: 2 });
+    });
+  });
+
+  describe("agentIds and repos", () => {
+    it("collects distinct non-null agent identifiers, preferring claimedBy over assignee", () => {
+      const t1 = makeTask({
+        id: "t1",
+        claimedBy: "agent-a",
+        assignee: "agent-x",
+      });
+      const t2 = makeTask({ id: "t2", claimedBy: null, assignee: "agent-b" });
+      const t3 = makeTask({ id: "t3", claimedBy: "agent-a", assignee: null });
+      const t4 = makeTask({ id: "t4", claimedBy: null, assignee: null });
+      const result = computeSessionRollup([t1, t2, t3, t4], new Set(), clock);
+      expect(result.agentIds.slice().sort()).toEqual(["agent-a", "agent-b"]);
+    });
+
+    it("collects distinct non-null repos", () => {
+      const t1 = makeTask({ id: "t1", repo: "org/repo-a" });
+      const t2 = makeTask({ id: "t2", repo: "org/repo-b" });
+      const t3 = makeTask({ id: "t3", repo: "org/repo-a" });
+      const t4 = makeTask({ id: "t4", repo: null });
+      const result = computeSessionRollup([t1, t2, t3, t4], new Set(), clock);
+      expect(result.repos.slice().sort()).toEqual(["org/repo-a", "org/repo-b"]);
+    });
+  });
+
+  describe("lastActivityAt", () => {
+    it("is the max updatedAt across all tasks regardless of state", () => {
+      const t1 = makeTask({
+        id: "t1",
+        status: "merged",
+        updatedAt: "2026-09-01T00:00:00.000Z",
+      });
+      const t2 = makeTask({
+        id: "t2",
+        status: "done",
+        updatedAt: "2026-09-05T00:00:00.000Z",
+      });
+      const result = computeSessionRollup([t1, t2], new Set(), clock);
+      expect(result.lastActivityAt).toBe("2026-09-05T00:00:00.000Z");
+    });
+  });
+
+  describe("waitingSince", () => {
+    it("is the earliest updatedAt among currently-waiting tasks", () => {
+      const t1 = makeTask({
+        id: "t1",
+        status: "blocked",
+        updatedAt: "2026-09-05T00:00:00.000Z",
+      });
+      const t2 = makeTask({
+        id: "t2",
+        status: "blocked",
+        updatedAt: "2026-09-02T00:00:00.000Z",
+      });
+      const t3 = makeTask({
+        id: "t3",
+        status: "in_progress",
+        updatedAt: "2026-09-09T00:00:00.000Z",
+      });
+      const result = computeSessionRollup([t1, t2, t3], new Set(), clock);
+      expect(result.state).toBe("waiting");
+      expect(result.waitingSince).toBe("2026-09-02T00:00:00.000Z");
+    });
+
+    it("is null when state is not 'waiting'", () => {
+      const t1 = makeTask({ id: "t1", status: "in_progress" });
+      const result = computeSessionRollup([t1], new Set(), clock);
+      expect(result.waitingSince).toBeNull();
+    });
+  });
+
+  describe("waiting kind precedence", () => {
+    it("reports 'blocked' rather than 'hitl' when a task is both status='blocked' and hitl=true with satisfied deps", () => {
+      const task = makeTask({
+        id: "t1",
+        status: "blocked",
+        hitl: true,
+        blockedReason: "manual gate",
+      });
+      const result = computeSessionRollup([task], new Set(), clock);
+      expect(result.waitingTasks).toEqual([{ id: "t1", kind: "blocked" }]);
+    });
+
+    it("reports 'blocked' rather than 'pr_blocked' when both apply", () => {
+      const task = makeTask({ id: "t1", status: "blocked", pr: 7 });
+      const result = computeSessionRollup([task], new Set([7]), clock);
+      expect(result.waitingTasks).toEqual([{ id: "t1", kind: "blocked" }]);
+    });
+
+    it("reports 'pr_blocked' rather than 'hitl' when both apply and dependencies are satisfied", () => {
+      const task = makeTask({ id: "t1", hitl: true, pr: 7 });
+      const result = computeSessionRollup([task], new Set([7]), clock);
+      expect(result.waitingTasks).toEqual([{ id: "t1", kind: "pr_blocked" }]);
+    });
+  });
+
+  describe("dependency-only waits", () => {
+    it("does not count a task whose only blocked-by reason is an unsatisfied dependency", () => {
+      const dep = makeTask({ id: "dep-1", status: "pending" });
+      const task = makeTask({ id: "t1", dependencies: ["dep-1"] });
+      const result = computeSessionRollup([task, dep], new Set(), clock);
+      expect(result.waitingTasks.map((w) => w.id)).not.toContain("t1");
+      expect(result.state).toBe("active");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `task-store/src/session-rollup.ts` exporting a pure `computeSessionRollup(tasks, prBlockedSet, clock, session?)` function
- Computes a session's overall state (`waiting|active|closed|empty`), `waitingSince`, `lastActivityAt`, per-status `counts`, distinct `agentIds`/`repos`, and `waitingTasks[]`
- Reuses `computeBlockedBy`'s dependency-satisfaction logic rather than forking it; waiting kinds (`hitl`/`blocked`/`pr_blocked`) follow documented precedence (`blocked` > `pr_blocked` > `hitl`)

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | hitl:true + satisfied deps → waiting/hitl; unmet dep → active | MET | `classifyWaiting` checks `computeBlockedBy` for unmet-dependency entries before returning `hitl` |
| 2 | Only open task pr-blocked → waiting/pr_blocked | MET | `task.pr != null && prBlockedSet.has(task.pr)` check |
| 3 | Archived sessions report `archived: true` alongside state; empty list → state:"empty" | MET | `archived` computed independently of `state`, included on every return path incl. empty |
| 4 | Unit tests only, pure function, fixture tasks, FixedClock, covers all four states + three waiting-kind branches | MET | 22 unit tests in `session-rollup.unit.test.ts`, no I/O |

## Test Plan
- 22 new unit tests in `task-store/src/session-rollup.unit.test.ts` covering all four states, all three waiting kinds, precedence rules, and dependency-only-wait exclusion
- `task-store/src/session-rollup.ts`: 98.28% line coverage, 100% function coverage
- `task lint`, `task typecheck` clean
- `bun test` full suite: 8022 pass (up from 7999 on main + 22 new), same pre-existing full-suite-only flakes (3-4, environment-dependent) reproduced identically on clean `origin/main`
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
