### PR TITLE
feat: SessionService upsert + wrap Task.create/bulk in transaction

### DIFF
--- a/task-store/src/session-migration.integration.test.ts
+++ b/task-store/src/session-migration.integration.test.ts
@@ -12,7 +12,14 @@
  * Requires DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST to be set; skips otherwise.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { PrismaClient } from "../prisma/client/index.js";
@@ -89,9 +96,7 @@ async function hasSessionColumn(
 /**
  * Get column info for the Session table (type, nullable, defaults).
  */
-async function getSessionColumnInfo(
-  prisma: PrismaClient,
-): Promise<
+async function getSessionColumnInfo(prisma: PrismaClient): Promise<
   Array<{
     column_name: string;
     data_type: string;
@@ -133,6 +138,30 @@ describeOrSkip("add Session model migration (integration)", () => {
   afterEach(async () => {
     await dropSessionTable(prisma);
     await prisma.$disconnect();
+  });
+
+  // The suite's own migrations already applied this migration once (via
+  // `prisma migrate deploy`) before any test file ran, so the Session table
+  // is expected to exist for every OTHER test file/suite that depends on it
+  // (e.g. session-service.integration.test.ts) — this file just re-applies
+  // and re-drops it per-test to exercise the migration.sql in isolation.
+  // Without restoring it here, this file's last afterEach leaves the table
+  // dropped for the remainder of the `bun test` run (file execution order is
+  // alphabetical, so session-migration runs before session-service),
+  // breaking every later suite that assumes Session already exists. Re-run
+  // the migration statements one more time after all of this file's tests
+  // finish so the table is left in the same state this file found it in.
+  afterAll(async () => {
+    const restore = makePrisma();
+    try {
+      if (!(await hasSessionTable(restore))) {
+        for (const statement of migrationStatements()) {
+          await restore.$executeRawUnsafe(statement);
+        }
+      }
+    } finally {
+      await restore.$disconnect();
+    }
   });
 
   it("creates the Session table", async () => {
@@ -261,9 +290,7 @@ describeOrSkip("add Session model migration (integration)", () => {
     // Verify we can query it back
     const sessions = await prisma.$queryRawUnsafe<
       Array<{ slug: string; title: string | null }>
-    >(
-      `SELECT "slug", "title" FROM "Session" WHERE "slug" = 'test-session-1';`,
-    );
+    >(`SELECT "slug", "title" FROM "Session" WHERE "slug" = 'test-session-1';`);
 
     expect(sessions).toHaveLength(1);
     expect(sessions[0]?.slug).toBe("test-session-1");

--- a/task-store/src/session-service.integration.test.ts
+++ b/task-store/src/session-service.integration.test.ts
@@ -205,6 +205,48 @@ describeOrSkip(
       expect(fine).not.toBeNull();
     });
 
+    // ─── concurrency ────────────────────────────────────────────────────────
+
+    it("two concurrent create()s into the same brand-new session both succeed and leave exactly one Session row", async () => {
+      // Regression guard: upsert() used to do a plain findUnique-then-create,
+      // which isn't atomic — two overlapping transactions writing into the
+      // same brand-new slug could both observe "no row yet", then race on
+      // session.create(). A caught P2002 from inside a Prisma interactive
+      // transaction doesn't actually recover it either: Postgres marks the
+      // whole transaction aborted after any failed statement, so the
+      // subsequent COMMIT silently discards it (including the
+      // already-successful Task insert) without Prisma surfacing an error —
+      // the promise resolves "fulfilled" with data that was never actually
+      // persisted. upsert() now issues a single atomic
+      // `INSERT ... ON CONFLICT (slug) DO UPDATE` via Prisma's native
+      // session.upsert(), which has no such race window.
+      const results = await Promise.allSettled([
+        service.create({
+          title: "racer a",
+          status: "pending",
+          session: "fresh-race-slug",
+        }),
+        service.create({
+          title: "racer b",
+          status: "pending",
+          session: "fresh-race-slug",
+        }),
+      ]);
+
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(rejected).toEqual([]);
+
+      const rows = await prisma.session.findMany({
+        where: { slug: "fresh-race-slug" },
+      });
+      expect(rows).toHaveLength(1);
+
+      const tasks = await prisma.task.findMany({
+        where: { session: "fresh-race-slug" },
+      });
+      expect(tasks).toHaveLength(2);
+    });
+
     // ─── no-op for blank session ───────────────────────────────────────────────
 
     it("create() with session: null creates no Session row", async () => {

--- a/task-store/src/session-service.integration.test.ts
+++ b/task-store/src/session-service.integration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * task-store/src/session-service.integration.test.ts
+ *
+ * Integration tests for SessionService.upsert() and its wiring into
+ * TaskService.create()/bulk() (SESH-1.2), against a real Postgres DB.
+ *
+ * Covers:
+ *   - a task write with a non-blank session creates the Session row
+ *   - a second write to the same session does not change createdAt or
+ *     overwrite an existing title
+ *   - bulk() upserts the Session row the same way as create()
+ *   - writing into an archived session clears archivedAt (un-archive)
+ *   - session: null / "" / "   " create no Session row at all, and
+ *     create()/bulk() still work unchanged for those tasks
+ *
+ * Requires DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST to be set; skips otherwise.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { PrismaClient } from "../prisma/client/index.js";
+import { TaskService } from "./task-service.ts";
+
+const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
+
+const describeOrSkip = TEST_DB ? describe : describe.skip;
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient({
+    // TEST_DB is guaranteed set — the describe block is skipped otherwise.
+    datasources: { db: { url: TEST_DB as string } },
+  });
+}
+
+describeOrSkip(
+  "SessionService upsert via TaskService.create()/bulk() (integration)",
+  () => {
+    let prisma: PrismaClient;
+    let service: TaskService;
+
+    beforeEach(async () => {
+      prisma = makePrisma();
+      service = new TaskService(prisma);
+      // TaskEvent's FK is ON DELETE RESTRICT (TCS-1.1) — clear event rows
+      // before their parent Task rows.
+      await prisma.taskEvent.deleteMany();
+      await prisma.task.deleteMany();
+      await prisma.session.deleteMany();
+    });
+
+    afterEach(async () => {
+      await prisma.$disconnect();
+    });
+
+    // ─── create() ────────────────────────────────────────────────────────────
+
+    it("create() with session: 'x' creates a Session row with slug 'x'", async () => {
+      const task = await service.create({
+        title: "task with session",
+        status: "pending",
+        session: "x",
+      });
+      expect(task.session).toBe("x");
+
+      const row = await prisma.session.findUnique({ where: { slug: "x" } });
+      expect(row).not.toBeNull();
+      expect(row?.slug).toBe("x");
+      expect(row?.title).toBeNull();
+      expect(row?.archivedAt).toBeNull();
+    });
+
+    it("a second create() into the same session does not change createdAt or overwrite an existing title", async () => {
+      // Seed a Session with a title directly — create() has no way to set a
+      // title itself, so this simulates a row that was titled some other way.
+      const seeded = await prisma.session.create({
+        data: { slug: "x", title: "My Session Title" },
+      });
+
+      await service.create({
+        title: "first task",
+        status: "pending",
+        session: "x",
+      });
+      const afterFirst = await prisma.session.findUnique({
+        where: { slug: "x" },
+      });
+      expect(afterFirst?.title).toBe("My Session Title");
+      expect(afterFirst?.createdAt.getTime()).toBe(seeded.createdAt.getTime());
+
+      // A second write to the same session must not change createdAt or wipe
+      // the title.
+      await service.create({
+        title: "second task",
+        status: "pending",
+        session: "x",
+      });
+      const afterSecond = await prisma.session.findUnique({
+        where: { slug: "x" },
+      });
+      expect(afterSecond?.title).toBe("My Session Title");
+      expect(afterSecond?.createdAt.getTime()).toBe(seeded.createdAt.getTime());
+
+      // Exactly one Session row exists for the slug — no duplicate created.
+      const count = await prisma.session.count({ where: { slug: "x" } });
+      expect(count).toBe(1);
+    });
+
+    it("writing a task into an archived session clears archivedAt (un-archive)", async () => {
+      const archivedAt = new Date("2026-01-01T00:00:00.000Z");
+      await prisma.session.create({
+        data: {
+          slug: "archived-session",
+          archivedAt,
+          archivedBy: "someone",
+        },
+      });
+
+      await service.create({
+        title: "revives the session",
+        status: "pending",
+        session: "archived-session",
+      });
+
+      const row = await prisma.session.findUnique({
+        where: { slug: "archived-session" },
+      });
+      expect(row?.archivedAt).toBeNull();
+      // archivedBy is untouched by the upsert hook — out of scope for v1.
+      expect(row?.archivedBy).toBe("someone");
+    });
+
+    // ─── bulk() ───────────────────────────────────────────────────────────────
+
+    it("bulk() with session: 'x' on one or more tasks upserts the Session row", async () => {
+      const result = await service.bulk([
+        { title: "bulk task 1", status: "pending", session: "bulk-x" },
+        { title: "bulk task 2", status: "pending", session: "bulk-x" },
+        { title: "bulk task 3", status: "pending", session: "bulk-y" },
+      ]);
+      expect(result.inserted).toBe(3);
+      expect(result.skipped).toEqual([]);
+
+      const rowX = await prisma.session.findUnique({
+        where: { slug: "bulk-x" },
+      });
+      expect(rowX).not.toBeNull();
+      const rowY = await prisma.session.findUnique({
+        where: { slug: "bulk-y" },
+      });
+      expect(rowY).not.toBeNull();
+
+      // Only one Session row for "bulk-x" despite two tasks writing into it.
+      const countX = await prisma.session.count({
+        where: { slug: "bulk-x" },
+      });
+      expect(countX).toBe(1);
+    });
+
+    it("bulk() writing into an archived session clears archivedAt", async () => {
+      await prisma.session.create({
+        data: { slug: "bulk-archived", archivedAt: new Date() },
+      });
+
+      const result = await service.bulk([
+        { title: "bulk revive", status: "pending", session: "bulk-archived" },
+      ]);
+      expect(result.inserted).toBe(1);
+
+      const row = await prisma.session.findUnique({
+        where: { slug: "bulk-archived" },
+      });
+      expect(row?.archivedAt).toBeNull();
+    });
+
+    it("bulk()'s per-item P2002 skip semantics are preserved alongside the session upsert", async () => {
+      const existing = await service.create({
+        id: "dup-id",
+        title: "existing task",
+        status: "pending",
+      });
+      expect(existing.id).toBe("dup-id");
+
+      const result = await service.bulk([
+        {
+          id: "dup-id",
+          title: "colliding task",
+          status: "pending",
+          session: "should-not-exist",
+        },
+        { title: "fine task", status: "pending", session: "bulk-ok" },
+      ]);
+      expect(result.inserted).toBe(1);
+      expect(result.skipped).toEqual(["dup-id"]);
+
+      // The colliding task's session upsert must not have run (its create()
+      // never committed — same transaction as the failed task create()).
+      const shouldNotExist = await prisma.session.findUnique({
+        where: { slug: "should-not-exist" },
+      });
+      expect(shouldNotExist).toBeNull();
+
+      // The non-colliding task's session upsert still landed.
+      const fine = await prisma.session.findUnique({
+        where: { slug: "bulk-ok" },
+      });
+      expect(fine).not.toBeNull();
+    });
+
+    // ─── no-op for blank session ───────────────────────────────────────────────
+
+    it("create() with session: null creates no Session row", async () => {
+      const task = await service.create({
+        title: "no session",
+        status: "pending",
+        session: null,
+      });
+      expect(task.session).toBeNull();
+      const count = await prisma.session.count();
+      expect(count).toBe(0);
+    });
+
+    it("create() with session: '' creates no Session row", async () => {
+      const task = await service.create({
+        title: "empty session",
+        status: "pending",
+        session: "",
+      });
+      expect(task.session).toBe("");
+      const count = await prisma.session.count();
+      expect(count).toBe(0);
+    });
+
+    it("create() with session: '   ' (whitespace-only) creates no Session row", async () => {
+      const task = await service.create({
+        title: "whitespace session",
+        status: "pending",
+        session: "   ",
+      });
+      expect(task.session).toBe("   ");
+      const count = await prisma.session.count();
+      expect(count).toBe(0);
+    });
+
+    it("bulk() with session: null/''/'   ' creates no Session rows and tasks still insert", async () => {
+      const result = await service.bulk([
+        { title: "bulk null", status: "pending", session: null },
+        { title: "bulk empty", status: "pending", session: "" },
+        { title: "bulk whitespace", status: "pending", session: "   " },
+      ]);
+      expect(result.inserted).toBe(3);
+      expect(result.skipped).toEqual([]);
+      const count = await prisma.session.count();
+      expect(count).toBe(0);
+    });
+  },
+);

--- a/task-store/src/session-service.ts
+++ b/task-store/src/session-service.ts
@@ -52,15 +52,33 @@ export class SessionService {
    *
    * - Blank (see isBlankSession): a pure no-op — does not touch the DB at
    *   all, so tasks with session: null/""/"   " never create a Session row.
-   * - No existing row for the slug: created with just `slug` set — this call
-   *   site has no title to provide, so `title` is left null and
-   *   createdAt/updatedAt fall back to their schema defaults.
-   * - Existing row: `title` and `createdAt` are never part of the update
-   *   payload, so a second write into the same session can't overwrite an
-   *   already-set title or reset createdAt. If the row is currently archived
-   *   (archivedAt !== null), the write un-archives it (archivedAt: null) and
-   *   logs the transition, mirroring StaleClaimReaper's console.log
-   *   convention — no TaskEvent-style audit row for v1.
+   * - The actual write is Prisma's native `upsert()` — a single atomic
+   *   `INSERT ... ON CONFLICT (slug) DO UPDATE` statement, not a separate
+   *   findUnique-then-create/update. That matters under concurrency: two
+   *   overlapping task writes into the same brand-new slug both running a
+   *   plain findUnique-then-create would race on the create(), and a caught
+   *   P2002 from *inside* a Prisma interactive transaction doesn't actually
+   *   recover it — Postgres marks the whole transaction aborted after any
+   *   failed statement, so a subsequent COMMIT silently discards it
+   *   (including the already-successful Task insert) without Prisma
+   *   surfacing an error. A single-statement ON CONFLICT upsert has no such
+   *   window: it always cleanly creates-or-updates, never errors on a
+   *   concurrent slug collision.
+   * - `create` sets only `slug` — this call site has no title to provide, so
+   *   `title` is left null and `createdAt`/`updatedAt` fall back to their
+   *   schema defaults.
+   * - `update` sets only `archivedAt: null` — `title` and `createdAt` are
+   *   never part of the update payload, so a second write into the same
+   *   session can't overwrite an already-set title or reset createdAt.
+   *   Setting `archivedAt: null` un-archives a currently-archived row; it's
+   *   a harmless no-op value-wise when the row is already un-archived
+   *   (though Prisma still issues the UPDATE, bumping `updatedAt`).
+   *
+   * The pre-write `findUnique` read below exists solely to decide whether to
+   * log an un-archive transition (mirroring StaleClaimReaper's console.log
+   * convention — no TaskEvent-style audit row for v1); it never gates the
+   * write's correctness, so a stale read under concurrency can at worst
+   * suppress or emit one log line, never corrupt data.
    */
   async upsert(
     client: PrismaTxClient,
@@ -72,21 +90,16 @@ export class SessionService {
 
     const existing = await client.session.findUnique({ where: { slug } });
 
-    if (!existing) {
-      await client.session.create({ data: { slug } });
-      return;
-    }
+    await client.session.upsert({
+      where: { slug },
+      create: { slug },
+      update: { archivedAt: null },
+    });
 
-    if (existing.archivedAt !== null) {
-      await client.session.update({
-        where: { slug },
-        data: { archivedAt: null },
-      });
+    if (existing?.archivedAt) {
       console.log(
         `[session-service] un-archived session "${slug}" on task write at ${this.clock.now().toISOString()}`,
       );
     }
-    // Row exists and isn't archived: nothing to change — title/createdAt are
-    // deliberately left untouched by a task write.
   }
 }

--- a/task-store/src/session-service.ts
+++ b/task-store/src/session-service.ts
@@ -1,0 +1,92 @@
+/**
+ * task-store/src/session-service.ts
+ * SessionService — upserts Session rows in lockstep with Task writes.
+ *
+ * v1 scope (SESH-1.2): upsert only. get/list/update/purge land in later
+ * tasks. Task.session (String?) is a free-text field that maps 1:1 to
+ * Session.slug whenever it's non-blank — a task write with a blank/absent
+ * session performs no Session write at all (see isBlankSession below).
+ *
+ * upsert() is designed to run inside the SAME transaction as the Task write
+ * that triggers it: it accepts an explicit tx-compatible client
+ * (PrismaTxClient, mirrors the identically-named alias in task-service.ts /
+ * pull-request-service.ts) rather than always reaching for `this.prisma`, so
+ * TaskService.create()/bulk() can hand it the same `tx` their task write ran
+ * on and get one atomic write across both tables.
+ */
+
+import type { Clock } from "./clock.ts";
+import { SystemClock } from "./clock.ts";
+import type { Prisma, PrismaClient } from "./index.ts";
+
+/**
+ * The Prisma client surface shared by the top-level client and a
+ * $transaction callback's `tx`. Mirrors PrismaTxClient in task-service.ts /
+ * pull-request-service.ts — upsert() accepts this so it can run against
+ * either, though in practice its only caller (TaskService) always hands it
+ * the same `tx` the paired task write ran on.
+ */
+export type PrismaTxClient = Pick<Prisma.TransactionClient, "session">;
+
+/**
+ * True when `session` should be treated as absent for the purposes of the
+ * Session upsert hook: null, undefined, or a string that is empty or
+ * whitespace-only. Pure logic, no I/O — kept as a standalone export so it
+ * has its own fast unit test (session-service.unit.test.ts) distinct from
+ * the DB-backed integration coverage of upsert() itself.
+ */
+export function isBlankSession(session: string | null | undefined): boolean {
+  return (
+    session === null || session === undefined || session.trim().length === 0
+  );
+}
+
+export class SessionService {
+  constructor(
+    private prisma: PrismaClient,
+    private clock: Clock = SystemClock(),
+  ) {}
+
+  /**
+   * Upsert the Session row implied by a task write's `session` value.
+   *
+   * - Blank (see isBlankSession): a pure no-op — does not touch the DB at
+   *   all, so tasks with session: null/""/"   " never create a Session row.
+   * - No existing row for the slug: created with just `slug` set — this call
+   *   site has no title to provide, so `title` is left null and
+   *   createdAt/updatedAt fall back to their schema defaults.
+   * - Existing row: `title` and `createdAt` are never part of the update
+   *   payload, so a second write into the same session can't overwrite an
+   *   already-set title or reset createdAt. If the row is currently archived
+   *   (archivedAt !== null), the write un-archives it (archivedAt: null) and
+   *   logs the transition, mirroring StaleClaimReaper's console.log
+   *   convention — no TaskEvent-style audit row for v1.
+   */
+  async upsert(
+    client: PrismaTxClient,
+    session: string | null | undefined,
+  ): Promise<void> {
+    if (isBlankSession(session)) return;
+    // Non-null/undefined per isBlankSession's guard above.
+    const slug = session as string;
+
+    const existing = await client.session.findUnique({ where: { slug } });
+
+    if (!existing) {
+      await client.session.create({ data: { slug } });
+      return;
+    }
+
+    if (existing.archivedAt !== null) {
+      await client.session.update({
+        where: { slug },
+        data: { archivedAt: null },
+      });
+      console.log(
+        `[session-service] un-archived session "${slug}" on task write at ${this.clock.now().toISOString()}`,
+      );
+    }
+    // Row exists and isn't archived: nothing to change — title/createdAt are
+    // deliberately left untouched by a task write.
+  }
+}

--- a/task-store/src/session-service.unit.test.ts
+++ b/task-store/src/session-service.unit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * task-store/src/session-service.unit.test.ts
+ *
+ * Pure-logic unit coverage for isBlankSession() — the "is this task.session
+ * value absent for the purposes of the Session upsert hook" predicate used
+ * by SessionService.upsert(). No I/O; the DB-backed upsert()
+ * create/un-archive/no-overwrite behavior is covered by
+ * session-service.integration.test.ts.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isBlankSession } from "./session-service.ts";
+
+describe("isBlankSession (unit)", () => {
+  it("treats null as blank", () => {
+    expect(isBlankSession(null)).toBe(true);
+  });
+
+  it("treats undefined as blank", () => {
+    expect(isBlankSession(undefined)).toBe(true);
+  });
+
+  it("treats an empty string as blank", () => {
+    expect(isBlankSession("")).toBe(true);
+  });
+
+  it("treats a whitespace-only string as blank", () => {
+    expect(isBlankSession("   ")).toBe(true);
+  });
+
+  it("treats a tab/newline-only string as blank", () => {
+    expect(isBlankSession("\t\n  ")).toBe(true);
+  });
+
+  it("treats a non-blank string as present", () => {
+    expect(isBlankSession("x")).toBe(false);
+  });
+
+  it("treats a string with meaningful whitespace around real content as present", () => {
+    expect(isBlankSession("  x  ")).toBe(false);
+  });
+});

--- a/task-store/src/task-service.ts
+++ b/task-store/src/task-service.ts
@@ -18,6 +18,7 @@ import { BadRequestError, ConflictError, NotFoundError } from "./errors.ts";
 import type { Prisma, PrismaClient, Task, TaskEvent } from "./index.ts";
 import { buildRepoOrgWhere } from "./lib/repo-org-filter.ts";
 import { resolveReadyTasks } from "./ready.ts";
+import { SessionService } from "./session-service.ts";
 import { CLOSED_STATUSES, OPEN_STATUSES } from "./statuses.ts";
 import { writeTaskEvents } from "./task-transition-diff.ts";
 
@@ -286,10 +287,14 @@ export interface TaskServiceLike {
 }
 
 export class TaskService implements TaskServiceLike {
+  private sessionService: SessionService;
+
   constructor(
     private prisma: PrismaClient,
     private clock: Clock = SystemClock(),
-  ) {}
+  ) {
+    this.sessionService = new SessionService(prisma, clock);
+  }
 
   // ─── Reads ─────────────────────────────────────────────────────────────────
 
@@ -559,10 +564,29 @@ export class TaskService implements TaskServiceLike {
 
   // ─── Writes ────────────────────────────────────────────────────────────────
 
+  /**
+   * Wrapped in a $transaction so a non-blank `data.session` upserts the
+   * corresponding Session row (create-if-missing, un-archive-on-write —
+   * see SessionService.upsert()) atomically with the task create. A blank
+   * session (null/undefined/whitespace-only) is a no-op for the Session
+   * table, so this is functionally unchanged for callers not using session.
+   */
   async create(data: Prisma.TaskCreateInput): Promise<Task> {
-    return this.prisma.task.create({ data });
+    return this.prisma.$transaction(async (tx) => {
+      const task = await tx.task.create({ data });
+      await this.sessionService.upsert(tx, task.session);
+      return task;
+    });
   }
 
+  /**
+   * Each task's create + its Session upsert run inside one $transaction per
+   * loop iteration (not one transaction for the whole bulk call) — this
+   * preserves the pre-existing partial-success semantics: one task's P2002
+   * collision (caught below) doesn't roll back tasks already inserted
+   * earlier in the same bulk() call, matching the try/catch-per-item
+   * behavior this had before session support was added.
+   */
   async bulk(
     tasks: Prisma.TaskCreateInput[],
   ): Promise<{ inserted: number; updated: number; skipped: string[] }> {
@@ -570,7 +594,10 @@ export class TaskService implements TaskServiceLike {
     const skipped: string[] = [];
     for (const task of tasks) {
       try {
-        await this.prisma.task.create({ data: task });
+        await this.prisma.$transaction(async (tx) => {
+          const created = await tx.task.create({ data: task });
+          await this.sessionService.upsert(tx, created.session);
+        });
         inserted++;
       } catch (err: unknown) {
         // P2002 = unique constraint violation (id already exists) — skip, but

--- a/task-store/src/task-service.unit.test.ts
+++ b/task-store/src/task-service.unit.test.ts
@@ -474,7 +474,7 @@ describe("TaskService.bulk (unit)", () => {
         create: async ({
           data,
         }: {
-          data: { id?: string };
+          data: { id?: string; session?: string | null };
         }) => {
           if (data.id === "dup-task") {
             throw { code: "P2002" };
@@ -483,6 +483,13 @@ describe("TaskService.bulk (unit)", () => {
           return { ...data };
         },
       },
+      // bulk() now wraps each task's create + session upsert in one
+      // $transaction per item — hand the callback a `tx` that's just this
+      // same fake client. Neither test task sets `session`, so
+      // SessionService.upsert() short-circuits as a no-op and never reaches
+      // for `tx.session`.
+      $transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn(fakePrisma),
     } as unknown as PrismaClient;
 
     const service = new TaskService(fakePrisma);
@@ -1118,9 +1125,7 @@ describe("TaskService.claim() defense-in-depth claimedBy guard (unit)", () => {
       () => {},
     );
     try {
-      await expect(
-        service.claim("task-1", "agent-1"),
-      ).rejects.toThrow(dbError);
+      await expect(service.claim("task-1", "agent-1")).rejects.toThrow(dbError);
 
       expect(consoleErrorSpy).toHaveBeenCalled();
       const loggedArgs = consoleErrorSpy.mock.calls.flat().join(" ");


### PR DESCRIPTION
## Summary
- Add `task-store/src/session-service.ts` with `SessionService.upsert()` — v1 scope, upsert only (get/list/update/purge land in later tasks)
- Wrap `TaskService.create()`/`bulk()` in `$transaction` so a non-blank `session` on a task write atomically upserts the corresponding `Session` row (create-if-missing, never overwrite `title`/`createdAt`)
- Writing into an archived session clears `archivedAt` (un-archive), logged via `console.log` per the reaper convention
- `isBlankSession()` treats `null`, `undefined`, and empty/whitespace-only strings alike as "no session" — a pure no-op, no DB write
- The upsert is implemented as a single atomic `INSERT ... ON CONFLICT (slug) DO UPDATE` (Prisma's native `session.upsert()`) rather than a `findUnique`-then-`create`/`update`, closing a race window where two concurrent writes into the same brand-new session slug could otherwise collide

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `POST /tasks` and `POST /tasks/bulk` with `session: "x"` result in a Session row `x` existing; a second write does not change `createdAt` or overwrite an existing title | MET |
| 2 | The upsert hook treats `session` as absent for `null`, `undefined`, and empty/whitespace-only string alike | MET |
| 3 | Writing a task into an archived session clears `archivedAt` | MET |
| 4 | `Task.create()`/`bulk()` remain functionally unchanged for tasks with `session: null` or empty-string session | MET |
| 5 | Integration tests (real Postgres) covering upsert-on-create, upsert-on-bulk, un-archive-on-write, and no-op for both `session: null` and `session: ""`; >=90% line coverage on `session-service.ts` and touched `task-service.ts` paths | MET |

## Test Plan
- `session-service.unit.test.ts` — `isBlankSession()` pure-logic coverage (null/undefined/empty/whitespace/non-blank)
- `session-service.integration.test.ts` (real Postgres, `DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST`) — upsert-on-create, no-overwrite of title/createdAt, un-archive-on-write, bulk() parity, per-item P2002 skip semantics preserved, blank-session no-op (`null`/`""`/`"   "`), and a concurrency regression test racing two `create()` calls into a fresh slug
- `task-service.unit.test.ts` — updated `bulk()` mock to supply `$transaction`
- Verified locally against a real local Postgres instance: full `bun test` suite 867 pass / 0 fail; coverage on `session-service.ts` 26/26 lines (100%), and every touched line in `task-service.ts`'s `create()`/`bulk()` is hit (470/503 file-wide, 93.4%)
- `task typecheck` / `task lint` clean
- Repo-wide `task ci` coverage gate (85.25%/85.91%) is below the 90%/89% threshold, but this is a pre-existing gap — confirmed against `origin/main` baseline (85.06%/85.69%, also failing); this branch is not a regression
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
