### PR TITLE
feat: add session-scope.ts visibility helper

### DIFF
--- a/admin/src/session-scope.ts
+++ b/admin/src/session-scope.ts
@@ -1,0 +1,121 @@
+/**
+ * admin/src/session-scope.ts
+ *
+ * Pure, no-I/O helpers deciding which sessions a caller is allowed to see:
+ *
+ *   1. visibleAgentIdsFor(isAdmin, memberships) — resolves the caller's
+ *      accessible-agent-ids scope: "all" for an admin, or the list of agent
+ *      ids the caller has a membership row for (possibly empty).
+ *
+ *   2. isSessionVisible(session, scope) — given a session-like value and a
+ *      VisibilityScope, decides whether that session is visible: always true
+ *      under the "all" scope, otherwise true iff the session's agentIds or
+ *      repos intersects the scope's.
+ *
+ * Deliberately does not accept an email string or call
+ * AgentMemberService.listByEmail() itself, even though the brief describes
+ * visibleAgentIdsFor in terms of an email lookup. Doing that I/O here would
+ * make this module untestable with plain fixtures (AC4 requires unit tests
+ * with no I/O boundary). Real callers — the session list page, detail page,
+ * follow routes, and the sweeper (none built yet) — already have `isAdmin`
+ * from their own auth context (see admin/src/api-auth.ts's
+ * createAdminAuthMiddleware) and can call
+ * `agentMemberService.listByEmail(email)` themselves before invoking this
+ * pure function. This mirrors the established pattern in
+ * admin/src/agent-work-queue-merge.ts, which similarly takes
+ * already-resolved data rather than performing its own I/O.
+ *
+ * Also deliberately does not import Session (task-store/src/session-rollup.ts)
+ * or AgentMember (admin/src/agent-members.ts) directly — those types are
+ * owned elsewhere. Instead this module declares narrow local structural
+ * interfaces containing only the fields it needs, so it stays decoupled and
+ * trivially testable against plain object fixtures.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal session shape the visibility check needs — a subset of
+ * SessionRollup (task-store/src/session-rollup.ts), whose `agentIds` and
+ * `repos` fields are always arrays (never undefined), deduped, and possibly
+ * empty.
+ */
+export interface SessionForVisibility {
+  agentIds: string[];
+  repos: string[];
+}
+
+/**
+ * Minimal membership shape visibleAgentIdsFor needs — a subset of
+ * AgentMember (admin/src/agent-members.ts).
+ */
+export interface MembershipForScope {
+  agentId: string;
+}
+
+/**
+ * The caller's accessible-agent-ids scope: "all" for an admin (bypasses
+ * every check), or the specific list of agent ids a member belongs to
+ * (possibly empty — a member with zero memberships resolves to []).
+ */
+export type AgentIdScope = "all" | string[];
+
+/**
+ * The full visibility scope consumed by isSessionVisible(): the caller's
+ * accessible agent ids (or "all") plus the repos they can see. `repos` is
+ * resolved by the caller from the accessible agents' own `repos[]` fields
+ * (admin/prisma/schema.prisma's Agent model) — this module has no access to
+ * Agent data and does not compute it. Shared by the session list page,
+ * detail page, follow routes, and the sweeper so they all apply the same
+ * visibility rule.
+ */
+export interface VisibilityScope {
+  agentIds: AgentIdScope;
+  repos: string[];
+}
+
+// ─── Scope resolution ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the caller's accessible-agent-ids scope. An admin sees every
+ * agent ("all"), regardless of what memberships were passed in. A non-admin
+ * (member) sees exactly the agent ids they hold a membership row for — []
+ * for a member with zero memberships (AC3), not an error.
+ */
+export function visibleAgentIdsFor(
+  isAdmin: boolean,
+  memberships: MembershipForScope[],
+): AgentIdScope {
+  if (isAdmin) return "all";
+  return memberships.map((membership) => membership.agentId);
+}
+
+// ─── Visibility check ───────────────────────────────────────────────────────
+
+/**
+ * Decide whether a session is visible under the given scope.
+ *
+ * - "all" scope (admin): always visible (AC1), regardless of the session's
+ *   agentIds/repos.
+ * - Member scope: visible iff the session's agentIds intersects the scope's
+ *   agentIds, OR the session's repos intersects the scope's repos (AC2). A
+ *   scope built from zero memberships has empty agentIds/repos, so every
+ *   session is correctly invisible (AC3) — no throw, just false.
+ */
+export function isSessionVisible(
+  session: SessionForVisibility,
+  scope: VisibilityScope,
+): boolean {
+  if (scope.agentIds === "all") return true;
+
+  return (
+    intersects(session.agentIds, scope.agentIds) ||
+    intersects(session.repos, scope.repos)
+  );
+}
+
+function intersects(a: string[], b: string[]): boolean {
+  if (a.length === 0 || b.length === 0) return false;
+  const set = new Set(b);
+  return a.some((value) => set.has(value));
+}

--- a/admin/src/session-scope.unit.test.ts
+++ b/admin/src/session-scope.unit.test.ts
@@ -1,0 +1,141 @@
+/**
+ * admin/src/session-scope.unit.test.ts
+ *
+ * Unit tests for the pure session-visibility helpers in session-scope.ts.
+ * No I/O — pure logic only, over fixture Session/scope objects.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  isSessionVisible,
+  type MembershipForScope,
+  type SessionForVisibility,
+  type VisibilityScope,
+  visibleAgentIdsFor,
+} from "./session-scope.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSession(
+  overrides: Partial<SessionForVisibility> = {},
+): SessionForVisibility {
+  return {
+    agentIds: [],
+    repos: [],
+    ...overrides,
+  };
+}
+
+function makeMembership(
+  overrides: Partial<MembershipForScope> = {},
+): MembershipForScope {
+  return {
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+function makeScope(overrides: Partial<VisibilityScope> = {}): VisibilityScope {
+  return {
+    agentIds: [],
+    repos: [],
+    ...overrides,
+  };
+}
+
+// ─── visibleAgentIdsFor ─────────────────────────────────────────────────────
+
+describe("visibleAgentIdsFor", () => {
+  it("returns the 'all' sentinel when isAdmin is true, regardless of memberships passed", () => {
+    expect(visibleAgentIdsFor(true, [])).toBe("all");
+    expect(
+      visibleAgentIdsFor(true, [
+        makeMembership({ agentId: "agent-a" }),
+        makeMembership({ agentId: "agent-b" }),
+      ]),
+    ).toBe("all");
+  });
+
+  it("returns the agent ids resolved from memberships when isAdmin is false", () => {
+    const result = visibleAgentIdsFor(false, [
+      makeMembership({ agentId: "agent-a" }),
+      makeMembership({ agentId: "agent-b" }),
+    ]);
+    expect(result).toEqual(["agent-a", "agent-b"]);
+  });
+
+  it("returns an empty array (not an error) for a member with zero memberships", () => {
+    expect(visibleAgentIdsFor(false, [])).toEqual([]);
+  });
+});
+
+// ─── isSessionVisible ───────────────────────────────────────────────────────
+
+describe("isSessionVisible", () => {
+  it("AC1: admin scope sees a session with empty agentIds/repos", () => {
+    const session = makeSession({ agentIds: [], repos: [] });
+    const scope = makeScope({ agentIds: "all" });
+    expect(isSessionVisible(session, scope)).toBe(true);
+  });
+
+  it("AC1: admin scope sees a session with populated but unrelated agentIds/repos", () => {
+    const session = makeSession({
+      agentIds: ["agent-x", "agent-y"],
+      repos: ["org/repo-x"],
+    });
+    const scope = makeScope({ agentIds: "all" });
+    expect(isSessionVisible(session, scope)).toBe(true);
+  });
+
+  it("AC2: member scope sees a session when agentIds intersects", () => {
+    const session = makeSession({ agentIds: ["agent-a"], repos: [] });
+    const scope = makeScope({ agentIds: ["agent-a", "agent-b"], repos: [] });
+    expect(isSessionVisible(session, scope)).toBe(true);
+  });
+
+  it("AC2: member scope sees a session via repos intersection even when agentIds does not intersect", () => {
+    const session = makeSession({
+      agentIds: ["agent-z"],
+      repos: ["org/repo-1"],
+    });
+    const scope = makeScope({
+      agentIds: ["agent-a", "agent-b"],
+      repos: ["org/repo-1"],
+    });
+    expect(isSessionVisible(session, scope)).toBe(true);
+  });
+
+  it("AC2: member scope does NOT see a session when neither agentIds nor repos intersects", () => {
+    const session = makeSession({
+      agentIds: ["agent-z"],
+      repos: ["org/repo-9"],
+    });
+    const scope = makeScope({
+      agentIds: ["agent-a", "agent-b"],
+      repos: ["org/repo-1"],
+    });
+    expect(isSessionVisible(session, scope)).toBe(false);
+  });
+
+  it("AC3: member with zero memberships (empty scope) sees nothing, not an error", () => {
+    const scope = makeScope({
+      agentIds: visibleAgentIdsFor(false, []),
+      repos: [],
+    });
+    expect(isSessionVisible(makeSession({ agentIds: [], repos: [] }), scope)).toBe(
+      false,
+    );
+    expect(
+      isSessionVisible(
+        makeSession({ agentIds: ["agent-a"], repos: ["org/repo-1"] }),
+        scope,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for a session with empty agentIds/repos under a non-empty member scope", () => {
+    const session = makeSession({ agentIds: [], repos: [] });
+    const scope = makeScope({ agentIds: ["agent-a"], repos: ["org/repo-1"] });
+    expect(isSessionVisible(session, scope)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `admin/src/session-scope.ts`, a pure no-I/O module deciding which sessions a caller can see: `visibleAgentIdsFor(isAdmin, memberships)` resolves the caller's accessible-agent-ids scope (`"all"` for an admin, or the agent ids from their memberships), and `isSessionVisible(session, scope)` checks whether a session's `agentIds`/`repos` intersect that scope.
- Deliberately deviates from the brief's literal `visibleAgentIdsFor(email)` signature: that phrasing implies an I/O call to `agentMemberService.listByEmail()` inside this module, which conflicts with AC4's "no I/O boundary" requirement. Instead the function takes already-resolved `isAdmin`/`memberships` data — future callers (list page, detail page, follow routes, sweeper — none built yet) will resolve `isAdmin` from their auth context and call `agentMemberService.listByEmail(email)` themselves before invoking this pure function. Mirrors the existing `admin/src/agent-work-queue-merge.ts` pattern of narrow local structural types over imported Prisma/owning-module types.
- 100% line/function coverage on the new module.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Admin scope makes every session visible regardless of agentIds/repos | MET |
| 2 | A member sees a session only if its agentIds includes an agent they belong to, or its repos intersects that agent's repos | MET |
| 3 | A member with zero memberships sees nothing (empty scope, not an error) | MET |
| 4 | Test decision: unit tests only (pure function over fixture Session/scope objects) -- no I/O boundary in this module | MET |

## Test Plan
- `admin/src/session-scope.unit.test.ts` — 10 unit tests covering admin visibility, agentIds-intersection, repos-intersection, non-intersection, and the zero-membership empty-scope case.
- `bun test admin/src/session-scope.unit.test.ts` — 10/10 pass, 100% coverage.
- `task lint` / `task typecheck` — clean.
- `task ci` — 2 pre-existing failures in `task-store/src/routes/prs.openapi.smoke.test.ts` (unrelated `validateRepo` null-vs-undefined bug, reproduced on `main` HEAD prior to this change) — not touched by this diff.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
