### PR TITLE
feat: add GET /sessions and GET /sessions/:slug routes

### DIFF
--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -313,13 +313,16 @@ Query params:
 Returns `{ sessions: Session[], total: number, limit: number, offset: number }`. `total` is the
 count of all sessions matching the filters, independent of `limit`/`offset`.
 
-**Agent token visibility:** a repo-scoped agent token (`agentId` set, non-empty resolved repo scope
-— the same condition `/tasks` uses to decide whether to apply `agentScope`) only sees sessions where
-at least one of that session's own Task rows satisfies `task.assignee === agentId OR (task.repo !==
-null AND task.repo is in the agent's scope)`. A session with zero tasks can never satisfy this OR,
-so it is never visible under a scoped token, and a session none of whose tasks match is silently
-absent from the list (no error, no partial rollup). Admin tokens (`agentId === null`) — and agent
-tokens with no resolved repo scope — see every session matching the query filters, unrestricted.
+**Agent token visibility:** *every* agent token (`agentId` set) is scoped — the scope is applied
+whenever `agentId` is non-null, regardless of whether the token's resolved repo list is empty. A
+scoped token only sees sessions where at least one of that session's own Task rows satisfies
+`task.assignee === agentId OR (task.repo !== null AND task.repo is in the agent's resolved repo
+scope)`. A session with zero tasks can never satisfy this OR, so it is never visible under an agent
+token, and a session none of whose tasks match is silently absent from the list (no error, no
+partial rollup). An agent token with **no** resolved repo scope (empty repo list) degrades to
+assignee-only matching — the repo half of the OR can never match, so it sees only sessions
+containing a task assigned directly to it — it is **not** granted unrestricted visibility. Only
+admin tokens (`agentId === null`) see every session matching the query filters, unrestricted.
 
 #### Get session
 
@@ -328,7 +331,7 @@ GET /sessions/:slug
 ```
 
 Returns the same flattened session+rollup shape as the list response. Returns `404` if the session
-doesn't exist, or if a repo-scoped agent token has no qualifying task in it (same visibility rule as
+doesn't exist, or if an agent token has no qualifying task in it (same visibility rule as
 the list route above) — the two cases are indistinguishable to the caller by design.
 
 ### Task status lifecycle

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -282,6 +282,55 @@ POST /tasks/:id/skip/reset
 
 Resets `skipCount` back to 0 and clears `lastSkippedAt`. Called after a human reviews and unblocks a task that was auto-blocked by skip threshold. Returns `200` with the updated task.
 
+### Sessions
+
+A `Session` row (`slug` is the primary key) is upserted automatically whenever a task write sets a
+non-blank `session` field — see `SessionService.upsert()`. These two read routes let a caller list
+and inspect sessions without re-deriving their rollup state client-side: each session's Task rows
+are summarized into a single rollup (`state`, `waitingSince`, `lastActivityAt`, per-status `counts`,
+distinct `agentIds`/`repos`, and the list of currently-`waitingTasks`) via `computeSessionRollup()`,
+then flattened together with the Session row's own fields (`slug`, `title`, `createdAt`, `updatedAt`,
+`archivedAt`, `archivedBy`) into one object — the rollup is never nested under a `rollup` key.
+
+#### List sessions
+
+```
+GET /sessions
+```
+
+Query params:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `state` | string | `waiting`, `active`, `closed`, `empty`, `archived`, or `all`. Omitted: only sessions where `archived === false` AND `rollup.state !== 'closed'` (the default view). A named state (`waiting`/`active`/`closed`/`empty`) matches `rollup.state` alone — it is **not** additionally filtered by `archived`, since an explicit state request overrides the default archived-exclusion. `archived` matches `archived === true` (rollup state is ignored). `all` applies no state/archived filtering at all. |
+| `sort` | string | `waitingSince` or `lastActivityAt` (default). `waitingSince`: sessions with `rollup.state === 'waiting'` come first, ordered by `waitingSince` ascending (oldest-waiting-first), followed by every non-waiting session ordered by `lastActivityAt` descending. Default (or explicit `lastActivityAt`): all sessions ordered by `lastActivityAt` descending, with `null` values (e.g. `empty` sessions) sorted last. |
+| `agentId` | string | Only sessions whose `rollup.agentIds` includes this agent. This is a caller-supplied narrowing filter, separate from the auth-scoping described below. |
+| `repo` | string, repeatable | Only sessions whose `rollup.repos` includes any of the given repo(s). Repeat the param to match several repos (e.g. `?repo=org/a&repo=org/b`). |
+| `q` | string | Case-insensitive substring match against `slug` OR `title`. |
+| `limit` | number | Page size. Defaults to `50` when omitted. |
+| `offset` | number | Page offset. Defaults to `0` when omitted. |
+
+Returns `{ sessions: Session[], total: number, limit: number, offset: number }`. `total` is the
+count of all sessions matching the filters, independent of `limit`/`offset`.
+
+**Agent token visibility:** a repo-scoped agent token (`agentId` set, non-empty resolved repo scope
+— the same condition `/tasks` uses to decide whether to apply `agentScope`) only sees sessions where
+at least one of that session's own Task rows satisfies `task.assignee === agentId OR (task.repo !==
+null AND task.repo is in the agent's scope)`. A session with zero tasks can never satisfy this OR,
+so it is never visible under a scoped token, and a session none of whose tasks match is silently
+absent from the list (no error, no partial rollup). Admin tokens (`agentId === null`) — and agent
+tokens with no resolved repo scope — see every session matching the query filters, unrestricted.
+
+#### Get session
+
+```
+GET /sessions/:slug
+```
+
+Returns the same flattened session+rollup shape as the list response. Returns `404` if the session
+doesn't exist, or if a repo-scoped agent token has no qualifying task in it (same visibility rule as
+the list route above) — the two cases are indistinguishable to the caller by design.
+
 ### Task status lifecycle
 
 ```

--- a/task-store/openapi.json
+++ b/task-store/openapi.json
@@ -2063,6 +2063,179 @@
           }
         }
       }
+    },
+    "/sessions": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "List sessions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "waiting",
+                "active",
+                "closed",
+                "empty",
+                "archived",
+                "all"
+              ],
+              "description": "Omitted: archived===false AND state!=='closed'. A named state (waiting/active/closed/empty) matches rollup.state alone (not additionally archived-filtered). 'archived': archived===true (rollup state ignored). 'all': no filtering.",
+              "example": "waiting"
+            },
+            "required": false,
+            "name": "state",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "waitingSince",
+                "lastActivityAt"
+              ],
+              "description": "'waitingSince': waiting sessions first (oldest waitingSince first), then non-waiting sessions by lastActivityAt desc. Default (or 'lastActivityAt'): all sessions by lastActivityAt desc, nulls last.",
+              "example": "waitingSince"
+            },
+            "required": false,
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Only sessions whose rollup.agentIds includes this agent.",
+              "example": "agent-id-123"
+            },
+            "required": false,
+            "name": "agentId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "description": "Only sessions whose rollup.repos includes any of the given repo(s). Repeatable (?repo=a&repo=b).",
+              "example": "org/repo"
+            },
+            "required": false,
+            "name": "repo",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Case-insensitive substring match against slug OR title.",
+              "example": "launch"
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "50"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "0"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sessions with total count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{slug}": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Get a session by slug",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "shipwright-may-launch"
+            },
+            "required": true,
+            "name": "slug",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3412,6 +3585,187 @@
         },
         "required": [
           "events",
+          "total",
+          "limit",
+          "offset"
+        ]
+      },
+      "Session": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "example": "shipwright-may-launch"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "May launch prep"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-01-01T00:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-01-06T12:00:00.000Z"
+          },
+          "archivedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": null
+          },
+          "archivedBy": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": null
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "waiting",
+              "active",
+              "closed",
+              "empty"
+            ],
+            "example": "active"
+          },
+          "waitingSince": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "2026-01-01T00:00:00.000Z"
+          },
+          "lastActivityAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "2026-01-06T12:00:00.000Z"
+          },
+          "counts": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer"
+              },
+              "open": {
+                "type": "integer"
+              },
+              "closed": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total",
+              "open",
+              "closed"
+            ],
+            "example": {
+              "total": 3,
+              "open": 2,
+              "closed": 1
+            }
+          },
+          "agentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "agent-1"
+            ]
+          },
+          "repos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "org/repo"
+            ]
+          },
+          "waitingTasks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "hitl",
+                    "blocked",
+                    "pr_blocked"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "kind"
+              ]
+            },
+            "example": [
+              {
+                "id": "task-1",
+                "kind": "hitl"
+              }
+            ]
+          },
+          "archived": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "slug",
+          "createdAt",
+          "updatedAt",
+          "state",
+          "waitingSince",
+          "lastActivityAt",
+          "counts",
+          "agentIds",
+          "repos",
+          "waitingTasks",
+          "archived"
+        ]
+      },
+      "SessionListResponse": {
+        "type": "object",
+        "properties": {
+          "sessions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Session"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "example": 10
+          },
+          "limit": {
+            "type": "integer",
+            "example": 50
+          },
+          "offset": {
+            "type": "integer",
+            "example": 0
+          }
+        },
+        "required": [
+          "sessions",
           "total",
           "limit",
           "offset"

--- a/task-store/src/api.integration.test.ts
+++ b/task-store/src/api.integration.test.ts
@@ -19,6 +19,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { PrismaClient } from "./index.ts";
+import { SessionService } from "./session-service.ts";
 import { TaskService } from "./task-service.ts";
 import { TaskTokenService } from "./token-service.ts";
 
@@ -44,10 +45,11 @@ describeOrSkip("task-store API (integration)", () => {
 
     const taskService = new TaskService(prisma);
     const tokenService = new TaskTokenService(prisma);
+    const sessionService = new SessionService(prisma);
     const created = await tokenService.create("integration");
     rawToken = created.rawToken;
 
-    app = createTaskStoreApp({ taskService, tokenService });
+    app = createTaskStoreApp({ taskService, tokenService, sessionService });
   });
 
   afterEach(async () => {
@@ -368,7 +370,10 @@ describeOrSkip("task-store API (integration)", () => {
 
     const res = await app.request("/tasks?ready=true", { headers: auth() });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { tasks: Array<{ id: string; title: string }>; total: number };
+    const body = (await res.json()) as {
+      tasks: Array<{ id: string; title: string }>;
+      total: number;
+    };
     const ids = body.tasks.map((t) => t.id);
     // ready task qualifies; blockingDep is pending with no deps → also ready.
     expect(ids).toContain(ready.id);

--- a/task-store/src/api.smoke.test.ts
+++ b/task-store/src/api.smoke.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import type { Task } from "./index.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type {
   TaskListFilters,
   TaskListResult,
@@ -23,6 +24,18 @@ import type {
   TaskWithBlockedBy,
 } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
+
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
 
 // ─── Distinct result shape ────────────────────────────────────────────────────
 
@@ -261,6 +274,7 @@ function makeApp(
   return createTaskStoreApp({
     taskService: deps.taskService ?? fakeTaskService(),
     tokenService: deps.tokenService ?? fakeTokenService(),
+    sessionService: fakeSessionService(),
     scopeResolver: deps.scopeResolver,
   });
 }

--- a/task-store/src/app.readiness.smoke.test.ts
+++ b/task-store/src/app.readiness.smoke.test.ts
@@ -13,8 +13,21 @@
 
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
+
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
 
 function fakeTaskService(): TaskServiceLike {
   return {
@@ -107,6 +120,7 @@ describe("GET /health/ready (smoke)", () => {
     const app = createTaskStoreApp({
       taskService: fakeTaskService(),
       tokenService: fakeTokenService(),
+      sessionService: fakeSessionService(),
     });
     const res = await app.request("/health/ready");
     expect(res.status).toBe(200);
@@ -118,6 +132,7 @@ describe("GET /health/ready (smoke)", () => {
     const app = createTaskStoreApp({
       taskService: fakeTaskService(),
       tokenService: fakeTokenService(),
+      sessionService: fakeSessionService(),
       checkDbReady: async () => false,
     });
     const res = await app.request("/health/ready");

--- a/task-store/src/app.sentry.smoke.test.ts
+++ b/task-store/src/app.sentry.smoke.test.ts
@@ -20,8 +20,21 @@ import { callerLabel } from "@shipwright/lib/request-context";
 import type { ErrorCapturingClient } from "@shipwright/lib/sentry";
 import { createTaskStoreApp } from "./app.ts";
 import { NotFoundError } from "./errors.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
+
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
 
 const VALID_TOKEN = "valid-token";
 const AGENT_TOKEN = "agent-token";
@@ -116,6 +129,7 @@ describe("onError — Sentry capture wiring", () => {
     const app = createTaskStoreApp({
       taskService: throwingTaskService(),
       tokenService: fakeTokenService(),
+      sessionService: fakeSessionService(),
       sentryClient,
     });
 
@@ -135,6 +149,7 @@ describe("onError — Sentry capture wiring", () => {
     const app = createTaskStoreApp({
       taskService: apiErrorTaskService(),
       tokenService: fakeTokenService(),
+      sessionService: fakeSessionService(),
       sentryClient,
     });
 
@@ -150,6 +165,7 @@ describe("onError — Sentry capture wiring", () => {
     const app = createTaskStoreApp({
       taskService: throwingTaskService(),
       tokenService: fakeTokenService(),
+      sessionService: fakeSessionService(),
     });
 
     const res = await app.request("/tasks/abc", {
@@ -166,6 +182,7 @@ describe("onError — malformed JSON request body", () => {
     const app = createTaskStoreApp({
       taskService: apiErrorTaskService(),
       tokenService: fakeTokenService(),
+      sessionService: fakeSessionService(),
       sentryClient,
     });
 
@@ -192,6 +209,7 @@ describe("onError — caller label logging (AOB-3.3)", () => {
       const app = createTaskStoreApp({
         taskService: throwingTaskService(),
         tokenService: fakeTokenServiceWithAgent(),
+        sessionService: fakeSessionService(),
       });
 
       const res = await app.request("/tasks/abc", {
@@ -215,6 +233,7 @@ describe("onError — caller label logging (AOB-3.3)", () => {
       const app = createTaskStoreApp({
         taskService: throwingTaskService(),
         tokenService: fakeTokenServiceWithAgent(),
+        sessionService: fakeSessionService(),
       });
 
       const res = await app.request("/tasks/abc", {

--- a/task-store/src/app.ts
+++ b/task-store/src/app.ts
@@ -29,8 +29,10 @@ import { type TaskStoreAuthEnv, createBearerAuthMiddleware } from "./auth.ts";
 import { ApiError } from "./errors.ts";
 import type { PullRequestServiceLike } from "./pull-request-service.ts";
 import { createPrsRoutes } from "./routes/prs.ts";
+import { createSessionsRoutes } from "./routes/sessions.ts";
 import { createTasksRoutes } from "./routes/tasks.ts";
 import { createTokensRoutes } from "./routes/tokens.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
@@ -75,11 +77,15 @@ const noopPrService: PullRequestServiceLike = {
   async getEvents(_prId, _opts?) {
     return { events: [], total: 0 };
   },
+  async lookupBlockedPrNumbers(_pairs) {
+    return new Set();
+  },
 };
 
 export interface TaskStoreDeps {
   taskService: TaskServiceLike;
   tokenService: TokenServiceLike;
+  sessionService: SessionServiceLike;
   pullRequestService?: PullRequestServiceLike;
   /** Optional scope resolver for agent tokens — returns repos from agents service. */
   scopeResolver?: (agentId: string) => Promise<string[]>;
@@ -170,6 +176,7 @@ export function createTaskStoreApp(
   app.route("/tasks", createTasksRoutes(deps.taskService));
   app.route("/tokens", createTokensRoutes(deps.tokenService));
   app.route("/prs", createPrsRoutes(deps.pullRequestService ?? noopPrService));
+  app.route("/sessions", createSessionsRoutes(deps.sessionService));
 
   return app;
 }

--- a/task-store/src/blocked-by.smoke.test.ts
+++ b/task-store/src/blocked-by.smoke.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import { computeBlockedBy } from "./blocked-by.ts";
 import type { Task } from "./index.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type {
   TaskListFilters,
   TaskListResult,
@@ -183,10 +184,23 @@ function fakeTaskService(
   };
 }
 
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
+
 function makeApp(taskService: TaskServiceLike) {
   return createTaskStoreApp({
     taskService,
     tokenService: fakeTokenService(),
+    sessionService: fakeSessionService(),
   });
 }
 

--- a/task-store/src/generate-spec.ts
+++ b/task-store/src/generate-spec.ts
@@ -6,17 +6,19 @@
  *   - scripts/generate-task-store-spec.ts (the CLI entry point)
  *   - task-store/src/generate-spec.unit.test.ts (for automated verification)
  *
- * Instantiates the tasks, tokens, and prs sub-apps with minimal stubs
- * (no real DB, no real services), calls getOpenAPI31Document() on each, and
- * merges the results into a single OpenAPI 3.1 document.
+ * Instantiates the tasks, tokens, prs, and sessions sub-apps with minimal
+ * stubs (no real DB, no real services), calls getOpenAPI31Document() on each,
+ * and merges the results into a single OpenAPI 3.1 document.
  */
 
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { PullRequestServiceLike } from "./pull-request-service.ts";
 import { createPrsRoutes } from "./routes/prs.ts";
+import { createSessionsRoutes } from "./routes/sessions.ts";
 import { createTasksRoutes } from "./routes/tasks.ts";
 import { createTokensRoutes } from "./routes/tokens.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
@@ -132,6 +134,18 @@ const stubPrService: PullRequestServiceLike = {
   async getEvents() {
     return { events: [], total: 0 };
   },
+  async lookupBlockedPrNumbers() {
+    return new Set();
+  },
+};
+
+const stubSessionService: SessionServiceLike = {
+  async list() {
+    return { sessions: [], total: 0, limit: 50, offset: 0 };
+  },
+  async get() {
+    return null;
+  },
 };
 
 // ─── Spec assembly ────────────────────────────────────────────────────────────
@@ -156,6 +170,7 @@ export function buildTaskStoreSpec(): Record<string, unknown> {
   const tasksApp = createTasksRoutes(stubTaskService);
   const tokensApp = createTokensRoutes(stubTokenService);
   const prsApp = createPrsRoutes(stubPrService);
+  const sessionsApp = createSessionsRoutes(stubSessionService);
 
   const innerDocInfo = {
     openapi: "3.1.0" as const,
@@ -165,6 +180,7 @@ export function buildTaskStoreSpec(): Record<string, unknown> {
   const tasksSpec = tasksApp.getOpenAPI31Document(innerDocInfo);
   const tokensSpec = tokensApp.getOpenAPI31Document(innerDocInfo);
   const prsSpec = prsApp.getOpenAPI31Document(innerDocInfo);
+  const sessionsSpec = sessionsApp.getOpenAPI31Document(innerDocInfo);
 
   const mergedPaths: Record<string, Record<string, unknown>> = {
     ...prefixPaths(
@@ -178,6 +194,10 @@ export function buildTaskStoreSpec(): Record<string, unknown> {
     ...prefixPaths(
       (prsSpec.paths ?? {}) as Record<string, Record<string, unknown>>,
       "/prs",
+    ),
+    ...prefixPaths(
+      (sessionsSpec.paths ?? {}) as Record<string, Record<string, unknown>>,
+      "/sessions",
     ),
   };
 
@@ -196,6 +216,7 @@ export function buildTaskStoreSpec(): Record<string, unknown> {
         ...(tasksSpec.components?.schemas ?? {}),
         ...(tokensSpec.components?.schemas ?? {}),
         ...(prsSpec.components?.schemas ?? {}),
+        ...(sessionsSpec.components?.schemas ?? {}),
       },
     },
   };

--- a/task-store/src/main.ts
+++ b/task-store/src/main.ts
@@ -20,6 +20,7 @@ import { createScopeResolver } from "./auth.ts";
 import { checkClaimTtlBuffer } from "./claim-ttl-buffer-check.ts";
 import { PrismaClient } from "./index.ts";
 import { PullRequestService } from "./pull-request-service.ts";
+import { SessionService } from "./session-service.ts";
 import { StaleClaimReaper } from "./stale-claim-reaper.ts";
 import { TaskService } from "./task-service.ts";
 import { TaskTokenService } from "./token-service.ts";
@@ -119,6 +120,9 @@ async function startServer(): Promise<void> {
   const taskService = new TaskService(prisma);
   const tokenService = new TaskTokenService(prisma);
   const pullRequestService = new PullRequestService(prisma);
+  const sessionService = new SessionService(prisma, undefined, (pairs) =>
+    pullRequestService.lookupBlockedPrNumbers(pairs),
+  );
 
   const seedToken = process.env.TASK_STORE_SEED_ADMIN_TOKEN;
   if (seedToken) {
@@ -152,6 +156,7 @@ async function startServer(): Promise<void> {
     taskService,
     tokenService,
     pullRequestService,
+    sessionService,
     scopeResolver,
     sentryClient: process.env.SENTRY_DSN ? Sentry : undefined,
     // Once a shutdown signal has been received, fail readiness immediately

--- a/task-store/src/openapi-schemas.ts
+++ b/task-store/src/openapi-schemas.ts
@@ -445,6 +445,119 @@ export const PullRequestSchema = z
 
 export type PullRequest = z.infer<typeof PullRequestSchema>;
 
+// ─── Session ──────────────────────────────────────────────────────────────────
+
+/**
+ * A Session row's own fields flattened together with its computed
+ * session-rollup (SESH-2.1's computeSessionRollup) fields — never nested
+ * under a `rollup` key. Mirrors SessionListItem in session-service.ts.
+ */
+export const SessionSchema = z
+  .object({
+    slug: z.string().openapi({ example: "shipwright-may-launch" }),
+    title: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({ example: "May launch prep" }),
+    createdAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
+    updatedAt: z
+      .string()
+      .datetime()
+      .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+    archivedAt: z.string().nullable().optional().openapi({ example: null }),
+    archivedBy: z.string().nullable().optional().openapi({ example: null }),
+    state: z
+      .enum(["waiting", "active", "closed", "empty"])
+      .openapi({ example: "active" }),
+    waitingSince: z
+      .string()
+      .nullable()
+      .openapi({ example: "2026-01-01T00:00:00.000Z" }),
+    lastActivityAt: z
+      .string()
+      .nullable()
+      .openapi({ example: "2026-01-06T12:00:00.000Z" }),
+    counts: z
+      .object({
+        total: z.number().int(),
+        open: z.number().int(),
+        closed: z.number().int(),
+      })
+      .openapi({ example: { total: 3, open: 2, closed: 1 } }),
+    agentIds: z.array(z.string()).openapi({ example: ["agent-1"] }),
+    repos: z.array(z.string()).openapi({ example: ["org/repo"] }),
+    waitingTasks: z
+      .array(
+        z.object({
+          id: z.string(),
+          kind: z.enum(["hitl", "blocked", "pr_blocked"]),
+        }),
+      )
+      .openapi({ example: [{ id: "task-1", kind: "hitl" }] }),
+    archived: z.boolean().openapi({ example: false }),
+  })
+  .openapi("Session");
+
+export type Session = z.infer<typeof SessionSchema>;
+
+/** Path param for GET /sessions/:slug */
+export const SessionSlugParamSchema = z
+  .object({
+    slug: z.string().openapi({ example: "shipwright-may-launch" }),
+  })
+  .openapi("SessionSlugParam");
+
+/** Query params for GET /sessions */
+export const SessionListQuerySchema = z
+  .object({
+    state: z
+      .enum(["waiting", "active", "closed", "empty", "archived", "all"])
+      .optional()
+      .openapi({
+        example: "waiting",
+        description:
+          "Omitted: archived===false AND state!=='closed'. A named state (waiting/active/closed/empty) matches rollup.state alone (not additionally archived-filtered). 'archived': archived===true (rollup state ignored). 'all': no filtering.",
+      }),
+    sort: z.enum(["waitingSince", "lastActivityAt"]).optional().openapi({
+      example: "waitingSince",
+      description:
+        "'waitingSince': waiting sessions first (oldest waitingSince first), then non-waiting sessions by lastActivityAt desc. Default (or 'lastActivityAt'): all sessions by lastActivityAt desc, nulls last.",
+    }),
+    agentId: z.string().optional().openapi({
+      example: "agent-id-123",
+      description: "Only sessions whose rollup.agentIds includes this agent.",
+    }),
+    repo: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .openapi({
+        example: "org/repo",
+        description:
+          "Only sessions whose rollup.repos includes any of the given repo(s). Repeatable (?repo=a&repo=b).",
+      }),
+    q: z.string().optional().openapi({
+      example: "launch",
+      description: "Case-insensitive substring match against slug OR title.",
+    }),
+    limit: z.string().optional().openapi({ example: "50" }),
+    offset: z.string().optional().openapi({ example: "0" }),
+  })
+  .openapi("SessionListQuery");
+
+/** Response for GET /sessions */
+export const SessionListResponseSchema = z
+  .object({
+    sessions: z.array(SessionSchema),
+    total: z.number().int().openapi({ example: 10 }),
+    limit: z.number().int().openapi({ example: 50 }),
+    offset: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("SessionListResponse");
+
 // ─── Task Token ───────────────────────────────────────────────────────────────
 
 /**

--- a/task-store/src/prs.smoke.test.ts
+++ b/task-store/src/prs.smoke.test.ts
@@ -35,8 +35,21 @@ import type {
   PullRequestListResult,
   PullRequestServiceLike,
 } from "./pull-request-service.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
+
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -460,6 +473,10 @@ function fakePrService(
       if (!store.has(prId)) throw new NotFoundError("pr not found");
       return { events: [], total: 0 };
     },
+
+    async lookupBlockedPrNumbers(): Promise<Set<number>> {
+      return new Set();
+    },
   };
 }
 
@@ -531,6 +548,7 @@ function makeApp(
     taskService: fakeTaskService(),
     tokenService: deps.tokenService ?? fakeAdminTokenService(),
     pullRequestService: deps.prService ?? fakePrService(),
+    sessionService: fakeSessionService(),
     scopeResolver: deps.scopeResolver,
   });
 }

--- a/task-store/src/pull-request-service.ts
+++ b/task-store/src/pull-request-service.ts
@@ -244,6 +244,9 @@ export interface PullRequestServiceLike {
     prId: string,
     opts?: { limit?: number; offset?: number },
   ): Promise<GetEventsResult>;
+  lookupBlockedPrNumbers(
+    pairs: { repo: string; prNumber: number }[],
+  ): Promise<Set<number>>;
 }
 
 export class PullRequestService implements PullRequestServiceLike {
@@ -1121,6 +1124,56 @@ export class PullRequestService implements PullRequestServiceLike {
     ]);
 
     return { events, total };
+  }
+
+  /**
+   * Given a batch of (repo, prNumber) pairs — typically every linked-PR
+   * reference across a set of tasks — return the subset of prNumbers whose
+   * PullRequest record has `blocked === true`, in ONE query. Built for
+   * SessionService.list()/get() (SESH-2.2): computeSessionRollup()'s
+   * `prBlockedSet` param needs exactly this signal, and batching the lookup
+   * across an entire session list avoids a per-session round trip.
+   *
+   * Deliberately narrower than the private isPrBlocked()/list({blocked:true})
+   * pair above: this does NOT also consult linked-task status. Callers here
+   * already have the full task set for their own use (SessionService reads
+   * every Task row for the sessions it's rolling up) and
+   * computeSessionRollup's classifyWaiting() independently checks
+   * `task.status === "blocked"` with higher precedence than pr_blocked — so
+   * re-deriving task-blocked-ness inside this helper would be redundant.
+   *
+   * Mirrors list()'s `{blocked:true}` branch: over-fetch on the repo ×
+   * prNumber cross-product (Prisma can't express "any of these (repo, pr)
+   * pairs" without an OR-per-pair query), then filter exact pairs in JS via
+   * the shared prKey() helper. Returns a Set of prNumbers ONLY (not repo+
+   * prNumber pairs) — matches computeSessionRollup's prBlockedSet shape,
+   * itself a pre-existing limitation carried over from SESH-2.1 (a task's pr
+   * field alone, without its repo, is what's compared against the set).
+   */
+  async lookupBlockedPrNumbers(
+    pairs: { repo: string; prNumber: number }[],
+  ): Promise<Set<number>> {
+    if (pairs.length === 0) return new Set();
+
+    const repos = [...new Set(pairs.map((p) => p.repo))];
+    const prNumbers = [...new Set(pairs.map((p) => p.prNumber))];
+    const rows = await this.prisma.pullRequest.findMany({
+      where: {
+        repo: { in: repos },
+        prNumber: { in: prNumbers },
+        blocked: true,
+      },
+      select: { repo: true, prNumber: true },
+    });
+
+    const exactPairs = new Set(pairs.map((p) => prKey(p.repo, p.prNumber)));
+    const result = new Set<number>();
+    for (const row of rows) {
+      if (exactPairs.has(prKey(row.repo, row.prNumber))) {
+        result.add(row.prNumber);
+      }
+    }
+    return result;
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -13,6 +13,7 @@ import { createTaskStoreApp } from "./app.ts";
 import { FixedClock } from "./clock.ts";
 import { ConflictError, NotFoundError } from "./errors.ts";
 import { PullRequestService } from "./pull-request-service.ts";
+import { SessionService } from "./session-service.ts";
 import { TaskService } from "./task-service.ts";
 import { TaskTokenService } from "./token-service.ts";
 
@@ -503,13 +504,7 @@ describeOrSkip("PullRequestService.claim() phase support (integration)", () => {
 
     let threw = false;
     try {
-      await service.claim(
-        repo,
-        prNumber,
-        commitSha,
-        "agent-y",
-        "patch",
-      );
+      await service.claim(repo, prNumber, commitSha, "agent-y", "patch");
     } catch (err) {
       threw = true;
       expect(err).toBeInstanceOf(ConflictError);
@@ -1809,6 +1804,7 @@ describeOrSkip(
         taskService: new TaskService(prisma),
         tokenService,
         pullRequestService: new PullRequestService(prisma),
+        sessionService: new SessionService(prisma),
       });
     });
 
@@ -2030,13 +2026,7 @@ describeOrSkip("PullRequestService.getEvents() (integration)", () => {
     // claim() (pending -> in_progress), complete() (in_progress -> posted),
     // patch() (posted -> pending) — three distinct auditable transitions.
     const svcClaim = new PullRequestService(prisma, FixedClock(times[0]));
-    await svcClaim.claim(
-      repo,
-      prNumber,
-      commitSha,
-      "agent-a",
-      "review",
-    );
+    await svcClaim.claim(repo, prNumber, commitSha, "agent-a", "review");
 
     const svcComplete = new PullRequestService(prisma, FixedClock(times[1]));
     await svcComplete.complete(seeded.id);

--- a/task-store/src/pull-request.integration.test.ts
+++ b/task-store/src/pull-request.integration.test.ts
@@ -1299,6 +1299,92 @@ describeOrSkip("PullRequestService.list() and get() (integration)", () => {
   });
 });
 
+// ─── lookupBlockedPrNumbers() — batched (repo, prNumber) blocked lookup (SESH-2.2) ──
+
+describeOrSkip("PullRequestService.lookupBlockedPrNumbers() (integration)", () => {
+  let prisma: PrismaClient;
+  let service: PullRequestService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    service = new PullRequestService(prisma);
+    await prisma.pullRequestEvent.deleteMany();
+    await prisma.pullRequest.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("returns the prNumber of a blocked PR matching (repo, prNumber)", async () => {
+    await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 2001,
+        blocked: true,
+      },
+    });
+
+    const result = await service.lookupBlockedPrNumbers([
+      { repo: "app-vitals/shipwright", prNumber: 2001 },
+    ]);
+    expect(result.has(2001)).toBe(true);
+  });
+
+  it("excludes a PR that is not blocked", async () => {
+    await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/shipwright",
+        prNumber: 2002,
+        blocked: false,
+      },
+    });
+
+    const result = await service.lookupBlockedPrNumbers([
+      { repo: "app-vitals/shipwright", prNumber: 2002 },
+    ]);
+    expect(result.has(2002)).toBe(false);
+  });
+
+  it("does not cross-match a blocked PR from an unrelated (repo, prNumber) pair (cross-product guard)", async () => {
+    // Same prNumber, different repo — blocked in a repo the caller didn't ask about.
+    await prisma.pullRequest.create({
+      data: {
+        repo: "app-vitals/other-repo",
+        prNumber: 2003,
+        blocked: true,
+      },
+    });
+
+    const result = await service.lookupBlockedPrNumbers([
+      { repo: "app-vitals/shipwright", prNumber: 2003 },
+    ]);
+    expect(result.has(2003)).toBe(false);
+  });
+
+  it("returns an empty set for an empty input array without querying the DB", async () => {
+    const result = await service.lookupBlockedPrNumbers([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("batches multiple (repo, prNumber) pairs in one call", async () => {
+    await prisma.pullRequest.createMany({
+      data: [
+        { repo: "app-vitals/shipwright", prNumber: 2010, blocked: true },
+        { repo: "app-vitals/shipwright", prNumber: 2011, blocked: false },
+        { repo: "app-vitals/other-repo", prNumber: 2012, blocked: true },
+      ],
+    });
+
+    const result = await service.lookupBlockedPrNumbers([
+      { repo: "app-vitals/shipwright", prNumber: 2010 },
+      { repo: "app-vitals/shipwright", prNumber: 2011 },
+      { repo: "app-vitals/other-repo", prNumber: 2012 },
+    ]);
+    expect(result).toEqual(new Set([2010, 2012]));
+  });
+});
+
 // ─── list({ blocked: true }) — joins linked-task status (HBV-2.1 / HSR-1.4) ──
 
 describeOrSkip(

--- a/task-store/src/routes/prs.openapi.smoke.test.ts
+++ b/task-store/src/routes/prs.openapi.smoke.test.ts
@@ -214,6 +214,10 @@ function fakePrService(
     async getEvents() {
       return { events: [], total: 0 };
     },
+
+    async lookupBlockedPrNumbers() {
+      return new Set();
+    },
   };
 }
 

--- a/task-store/src/routes/sessions.smoke.test.ts
+++ b/task-store/src/routes/sessions.smoke.test.ts
@@ -419,6 +419,26 @@ describe("GET /sessions (smoke)", () => {
     expect(body.sessions.map((s) => s.slug)).not.toContain("empty-1");
   });
 
+  it("agent token with an empty repo scope still sees sessions it is assigned to", async () => {
+    // repos: [] is "scoped-but-unknown" (auth.ts fail-safe restrictive) — it must
+    // degrade to assignee-only visibility, never to unrestricted admin visibility.
+    const parent = makeAgentParent(makeApp(), "agent-2", []);
+    const res = await parent.request("/?state=all");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["waiting-new"]);
+    expect(body.total).toBe(1);
+  });
+
+  it("agent token with an empty repo scope and no assigned task sees zero sessions", async () => {
+    const parent = makeAgentParent(makeApp(), "agent-unknown", []);
+    const res = await parent.request("/?state=all");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
   it("GET /sessions returns 401-shaped auth is enforced upstream — smoke here covers 200 shape: { sessions, total, limit, offset }", async () => {
     const parent = makeAdminParent(makeApp());
     const res = await parent.request("/");
@@ -466,5 +486,20 @@ describe("GET /sessions/:slug (smoke)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as SessionListItem;
     expect(body.slug).toBe("active-1");
+  });
+
+  it("returns 200 for an agent token with an empty repo scope assigned to a task in that session", async () => {
+    const parent = makeAgentParent(makeApp(), "agent-2", []);
+    const res = await parent.request("/waiting-new");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListItem;
+    expect(body.slug).toBe("waiting-new");
+  });
+
+  it("returns 404 for an agent token with an empty repo scope and no assigned task", async () => {
+    // Would be 200 (unrestricted) if an empty repo scope skipped agentScope.
+    const parent = makeAgentParent(makeApp(), "agent-unknown", []);
+    const res = await parent.request("/active-1");
+    expect(res.status).toBe(404);
   });
 });

--- a/task-store/src/routes/sessions.smoke.test.ts
+++ b/task-store/src/routes/sessions.smoke.test.ts
@@ -1,0 +1,470 @@
+/**
+ * task-store/src/routes/sessions.smoke.test.ts
+ *
+ * Smoke tests for the /sessions routes via in-process app.request(), mirroring
+ * routes/tasks.openapi.smoke.test.ts's pattern: createSessionsRoutes is
+ * exercised directly against an injected SessionServiceLike double (no real
+ * DB), wrapped in a minimal parent app that sets the auth context variables
+ * (agentId/repos) the way the real bearer-auth middleware would.
+ *
+ * Per SESH-2.2's test decision (AC5): smoke tests only. SessionService's real
+ * list()/get() logic is not under test here — the fake below implements the
+ * same filtering/sorting/visibility semantics purely so route-level wiring
+ * (query param parsing, agentScope construction, 404 mapping) can be
+ * exercised end to end.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { TaskStoreAuthEnv } from "../auth.ts";
+import { ApiError } from "../errors.ts";
+import type {
+  SessionListFilters,
+  SessionListItem,
+  SessionListResult,
+  SessionServiceLike,
+} from "../session-service.ts";
+import { createSessionsRoutes } from "./sessions.ts";
+
+// ─── Fake double ──────────────────────────────────────────────────────────────
+
+interface FakeSessionRecord extends SessionListItem {
+  /** Tasks used only by the fake's agentScope visibility check — not part of the real response shape. */
+  scopeTasks: { assignee: string | null; repo: string | null }[];
+}
+
+function activityTime(v: string | null): number {
+  return v === null ? Number.NEGATIVE_INFINITY : new Date(v).getTime();
+}
+
+function toItem(record: FakeSessionRecord): SessionListItem {
+  const { scopeTasks: _scopeTasks, ...item } = record;
+  return item;
+}
+
+function visible(
+  record: FakeSessionRecord,
+  agentScope?: { agentId: string; repos: string[] },
+): boolean {
+  if (!agentScope) return true;
+  return record.scopeTasks.some(
+    (t) =>
+      t.assignee === agentScope.agentId ||
+      (t.repo !== null && agentScope.repos.includes(t.repo)),
+  );
+}
+
+function fakeSessionService(records: FakeSessionRecord[]): SessionServiceLike {
+  return {
+    async list(filters: SessionListFilters = {}): Promise<SessionListResult> {
+      let items = records.filter((r) => visible(r, filters.agentScope));
+
+      if (filters.q) {
+        const needle = filters.q.toLowerCase();
+        items = items.filter(
+          (r) =>
+            r.slug.toLowerCase().includes(needle) ||
+            (r.title ?? "").toLowerCase().includes(needle),
+        );
+      }
+
+      if (filters.state === undefined) {
+        items = items.filter((r) => !r.archived && r.state !== "closed");
+      } else if (filters.state === "archived") {
+        items = items.filter((r) => r.archived);
+      } else if (filters.state !== "all") {
+        items = items.filter((r) => r.state === filters.state);
+      }
+
+      if (filters.agentId !== undefined) {
+        const agentId = filters.agentId;
+        items = items.filter((r) => r.agentIds.includes(agentId));
+      }
+
+      if (filters.repo !== undefined) {
+        const repoList = Array.isArray(filters.repo)
+          ? filters.repo
+          : [filters.repo];
+        items = items.filter((r) =>
+          r.repos.some((repo) => repoList.includes(repo)),
+        );
+      }
+
+      let sorted = [...items];
+      if (filters.sort === "waitingSince") {
+        const waiting = sorted.filter((r) => r.state === "waiting");
+        const nonWaiting = sorted.filter((r) => r.state !== "waiting");
+        waiting.sort(
+          (a, b) =>
+            new Date(a.waitingSince as string).getTime() -
+            new Date(b.waitingSince as string).getTime(),
+        );
+        nonWaiting.sort(
+          (a, b) =>
+            activityTime(b.lastActivityAt) - activityTime(a.lastActivityAt),
+        );
+        sorted = [...waiting, ...nonWaiting];
+      } else {
+        sorted.sort(
+          (a, b) =>
+            activityTime(b.lastActivityAt) - activityTime(a.lastActivityAt),
+        );
+      }
+
+      const total = sorted.length;
+      const limit = filters.limit ?? 50;
+      const offset = filters.offset ?? 0;
+      const paged = sorted.slice(offset, offset + limit).map(toItem);
+      return { sessions: paged, total, limit, offset };
+    },
+
+    async get(
+      slug: string,
+      agentScope?: { agentId: string; repos: string[] },
+    ): Promise<SessionListItem | null> {
+      const record = records.find((r) => r.slug === slug);
+      if (!record) return null;
+      if (!visible(record, agentScope)) return null;
+      return toItem(record);
+    },
+  };
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Partial<FakeSessionRecord>): FakeSessionRecord {
+  return {
+    slug: "session-1",
+    title: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    archivedAt: null,
+    archivedBy: null,
+    state: "active",
+    waitingSince: null,
+    lastActivityAt: "2026-01-01T00:00:00.000Z",
+    counts: { total: 1, open: 1, closed: 0 },
+    agentIds: [],
+    repos: [],
+    waitingTasks: [],
+    archived: false,
+    scopeTasks: [],
+    ...overrides,
+  } as FakeSessionRecord;
+}
+
+const FIXTURES: FakeSessionRecord[] = [
+  makeRecord({
+    slug: "waiting-old",
+    state: "waiting",
+    waitingSince: "2026-01-01T00:00:00.000Z",
+    lastActivityAt: "2026-01-01T00:00:00.000Z",
+    agentIds: ["agent-1"],
+    repos: ["org/a"],
+    waitingTasks: [{ id: "t-1", kind: "hitl" }],
+    scopeTasks: [{ assignee: "agent-1", repo: "org/a" }],
+  }),
+  makeRecord({
+    slug: "waiting-new",
+    state: "waiting",
+    waitingSince: "2026-01-05T00:00:00.000Z",
+    lastActivityAt: "2026-01-05T00:00:00.000Z",
+    agentIds: ["agent-2"],
+    repos: ["org/b"],
+    waitingTasks: [{ id: "t-2", kind: "blocked" }],
+    scopeTasks: [{ assignee: "agent-2", repo: "org/b" }],
+  }),
+  makeRecord({
+    slug: "active-1",
+    state: "active",
+    lastActivityAt: "2026-01-10T00:00:00.000Z",
+    agentIds: ["agent-1"],
+    repos: ["org/a"],
+    scopeTasks: [{ assignee: "agent-1", repo: "org/a" }],
+  }),
+  makeRecord({
+    slug: "active-2",
+    title: "Launch Prep",
+    state: "active",
+    lastActivityAt: "2026-01-08T00:00:00.000Z",
+    agentIds: [],
+    repos: ["org/c"],
+    scopeTasks: [{ assignee: null, repo: "org/c" }],
+  }),
+  makeRecord({
+    slug: "closed-1",
+    state: "closed",
+    lastActivityAt: "2025-12-01T00:00:00.000Z",
+    agentIds: ["agent-1"],
+    repos: ["org/a"],
+    scopeTasks: [{ assignee: "agent-1", repo: "org/a" }],
+  }),
+  makeRecord({
+    slug: "empty-1",
+    state: "empty",
+    lastActivityAt: null,
+    agentIds: [],
+    repos: [],
+    counts: { total: 0, open: 0, closed: 0 },
+    scopeTasks: [],
+  }),
+  makeRecord({
+    slug: "archived-1",
+    state: "active",
+    lastActivityAt: "2025-11-01T00:00:00.000Z",
+    archivedAt: new Date("2025-11-02T00:00:00.000Z"),
+    archivedBy: "dan",
+    archived: true,
+    agentIds: ["agent-1"],
+    repos: ["org/a"],
+    scopeTasks: [{ assignee: "agent-1", repo: "org/a" }],
+  }),
+  makeRecord({
+    slug: "no-scope",
+    state: "active",
+    lastActivityAt: "2026-01-09T00:00:00.000Z",
+    agentIds: ["agent-9"],
+    repos: ["org/z"],
+    scopeTasks: [{ assignee: "agent-9", repo: "org/z" }],
+  }),
+];
+
+// ─── Parent-app auth harness (mirrors tasks.openapi.smoke.test.ts) ────────────
+
+function makeParent(
+  app: OpenAPIHono<TaskStoreAuthEnv>,
+  agentId: string | null,
+  repos: string[] | null,
+) {
+  const parent = new OpenAPIHono<TaskStoreAuthEnv>();
+  parent.use("*", async (c, next) => {
+    c.set("agentId", agentId);
+    c.set("repos", repos);
+    c.set("scopeDegraded", false);
+    await next();
+  });
+  parent.onError((err, c) => {
+    if (err instanceof ApiError) {
+      return c.json({ error: err.message }, err.statusCode as 400);
+    }
+    return c.json({ error: "internal error" }, 500);
+  });
+  parent.route("/", app);
+  return parent;
+}
+
+function makeAdminParent(app: OpenAPIHono<TaskStoreAuthEnv>) {
+  return makeParent(app, null, null);
+}
+
+function makeAgentParent(
+  app: OpenAPIHono<TaskStoreAuthEnv>,
+  agentId: string,
+  repos: string[] = [],
+) {
+  return makeParent(app, agentId, repos);
+}
+
+function makeApp(records: FakeSessionRecord[] = FIXTURES) {
+  return createSessionsRoutes(fakeSessionService(records));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /sessions (smoke)", () => {
+  it("returns an OpenAPIHono instance", () => {
+    expect(makeApp()).toBeInstanceOf(OpenAPIHono);
+  });
+
+  it("admin token, ?state=all returns every session from the double", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=all");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.total).toBe(FIXTURES.length);
+    expect(body.sessions.map((s) => s.slug).sort()).toEqual(
+      FIXTURES.map((f) => f.slug).sort(),
+    );
+  });
+
+  it("default (no ?state=) excludes closed and archived sessions", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    const slugs = body.sessions.map((s) => s.slug);
+    expect(slugs).not.toContain("closed-1");
+    expect(slugs).not.toContain("archived-1");
+    expect(slugs).toContain("waiting-old");
+    expect(slugs).toContain("active-1");
+  });
+
+  it("?state=waiting returns only waiting sessions", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=waiting");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug).sort()).toEqual(
+      ["waiting-new", "waiting-old"].sort(),
+    );
+  });
+
+  it("?state=active returns only active sessions", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=active");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    // archived-1 has rollup.state==='active' too but is a separate axis —
+    // state=active does not additionally filter by archived (per spec).
+    expect(body.sessions.map((s) => s.slug).sort()).toEqual(
+      ["active-1", "active-2", "archived-1", "no-scope"].sort(),
+    );
+  });
+
+  it("?state=closed returns only closed sessions", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=closed");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["closed-1"]);
+  });
+
+  it("?state=empty returns only empty sessions", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=empty");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["empty-1"]);
+  });
+
+  it("?state=archived returns only archived sessions", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=archived");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["archived-1"]);
+  });
+
+  it("?sort=waitingSince orders oldest-waiting-first, non-waiting sessions after", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=all&sort=waitingSince");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    const slugs = body.sessions.map((s) => s.slug);
+    // Both waiting sessions come first, oldest waitingSince first.
+    expect(slugs.slice(0, 2)).toEqual(["waiting-old", "waiting-new"]);
+    // Non-waiting sessions follow, sorted by lastActivityAt desc (nulls last):
+    // active-1 (01-10) > no-scope (01-09) > active-2 (01-08) > closed-1
+    // (2025-12-01) > archived-1 (2025-11-01) > empty-1 (null, sorts last).
+    const rest = slugs.slice(2);
+    expect(rest.indexOf("active-1")).toBeLessThan(rest.indexOf("no-scope"));
+    expect(rest.indexOf("no-scope")).toBeLessThan(rest.indexOf("active-2"));
+    expect(rest.indexOf("active-2")).toBeLessThan(rest.indexOf("closed-1"));
+    expect(rest.indexOf("closed-1")).toBeLessThan(rest.indexOf("archived-1"));
+    expect(rest[rest.length - 1]).toBe("empty-1");
+  });
+
+  it("?agentId=agent-1 filters to sessions touching that agent", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=all&agentId=agent-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug).sort()).toEqual(
+      ["waiting-old", "active-1", "closed-1", "archived-1"].sort(),
+    );
+  });
+
+  it("?repo=org/b filters to sessions touching that repo", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=all&repo=org%2Fb");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["waiting-new"]);
+  });
+
+  it("?q=launch substring-matches title (case-insensitive)", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?q=launch");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["active-2"]);
+  });
+
+  it("?q= substring-matches slug", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/?state=all&q=archived");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).toEqual(["archived-1"]);
+  });
+
+  it("agent-scoped token only sees sessions with a qualifying task", async () => {
+    const parent = makeAgentParent(makeApp(), "agent-1", ["org/a"]);
+    const res = await parent.request("/?state=all");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    // agent-1 is assignee on waiting-old/active-1/closed-1/archived-1 (all repo org/a).
+    // waiting-new (agent-2/org/b), active-2 (repo org/c, no assignee match),
+    // no-scope (agent-9/org/z), and empty-1 (zero tasks) must all be excluded.
+    expect(body.sessions.map((s) => s.slug).sort()).toEqual(
+      ["waiting-old", "active-1", "closed-1", "archived-1"].sort(),
+    );
+  });
+
+  it("a session with zero qualifying tasks is absent from the scoped list", async () => {
+    const parent = makeAgentParent(makeApp(), "agent-1", ["org/a"]);
+    const res = await parent.request("/?state=all");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(body.sessions.map((s) => s.slug)).not.toContain("empty-1");
+  });
+
+  it("GET /sessions returns 401-shaped auth is enforced upstream — smoke here covers 200 shape: { sessions, total, limit, offset }", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListResult;
+    expect(Array.isArray(body.sessions)).toBe(true);
+    expect(typeof body.total).toBe("number");
+    expect(typeof body.limit).toBe("number");
+    expect(typeof body.offset).toBe("number");
+  });
+});
+
+describe("GET /sessions/:slug (smoke)", () => {
+  it("returns 200 with the flattened session+rollup shape for a visible session", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/waiting-old");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListItem;
+    expect(body.slug).toBe("waiting-old");
+    expect(body.state).toBe("waiting");
+    expect(body.waitingSince).toBe("2026-01-01T00:00:00.000Z");
+    expect(body.agentIds).toEqual(["agent-1"]);
+    expect(body.repos).toEqual(["org/a"]);
+    expect(body.waitingTasks).toEqual([{ id: "t-1", kind: "hitl" }]);
+    expect(body.archived).toBe(false);
+    // Flattened — no nested "rollup" key.
+    expect((body as unknown as { rollup?: unknown }).rollup).toBeUndefined();
+  });
+
+  it("returns 404 for a nonexistent slug", async () => {
+    const parent = makeAdminParent(makeApp());
+    const res = await parent.request("/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an agent-scoped token with no qualifying task in that session", async () => {
+    const parent = makeAgentParent(makeApp(), "agent-1", ["org/a"]);
+    const res = await parent.request("/waiting-new");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 for an agent-scoped token with a qualifying task in that session", async () => {
+    const parent = makeAgentParent(makeApp(), "agent-1", ["org/a"]);
+    const res = await parent.request("/active-1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SessionListItem;
+    expect(body.slug).toBe("active-1");
+  });
+});

--- a/task-store/src/routes/sessions.ts
+++ b/task-store/src/routes/sessions.ts
@@ -1,0 +1,144 @@
+/**
+ * task-store/src/routes/sessions.ts
+ * Session read routes (SESH-2.2) — mirrors routes/tasks.ts's createRoute +
+ * factory pattern.
+ *
+ * Returns an OpenAPIHono sub-app mounted at /sessions by app.ts. Auth is
+ * applied by the parent app, so these handlers assume the caller is already
+ * authenticated.
+ *
+ * Agent tokens are scoped the same way TaskService.list()'s `agentScope` and
+ * distinct() are: `agentScope` is built only when the token has a non-empty
+ * repo scope (`agentId !== null && repos !== null && repos.length > 0`,
+ * mirroring routes/tasks.ts's `useAgentScope`). Admin tokens (agentId null)
+ * are unrestricted.
+ *
+ * Routes:
+ *   GET /sessions        list (?state, ?sort, ?agentId, ?repo, ?q, ?limit, ?offset)
+ *                         returns { sessions, total, limit, offset }
+ *   GET /sessions/:slug   fetch one (404 when missing or out of agent scope)
+ */
+
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import type { TaskStoreAuthEnv } from "../auth.ts";
+import { NotFoundError } from "../errors.ts";
+import {
+  ErrorSchema,
+  SessionListQuerySchema,
+  SessionListResponseSchema,
+  SessionSchema,
+  SessionSlugParamSchema,
+} from "../openapi-schemas.ts";
+import type {
+  SessionListFilters,
+  SessionServiceLike,
+} from "../session-service.ts";
+
+// ─── Route definitions ────────────────────────────────────────────────────────
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["sessions"],
+  summary: "List sessions",
+  request: {
+    query: SessionListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List of sessions with total count",
+      content: { "application/json": { schema: SessionListResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+const getOneRoute = createRoute({
+  method: "get",
+  path: "/:slug",
+  tags: ["sessions"],
+  summary: "Get a session by slug",
+  request: {
+    params: SessionSlugParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Session",
+      content: { "application/json": { schema: SessionSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+export function createSessionsRoutes(
+  sessionService: SessionServiceLike,
+): OpenAPIHono<TaskStoreAuthEnv> {
+  const app = new OpenAPIHono<TaskStoreAuthEnv>();
+
+  // ─── List ──────────────────────────────────────────────────────────────────
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma-shaped types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(listRoute, async (c): Promise<any> => {
+    const agentId = c.get("agentId");
+    const repos = c.get("repos");
+
+    // Same useAgentScope condition as routes/tasks.ts's listRoute: only build
+    // an auth scope for agent tokens with a known, non-empty repo scope.
+    const useAgentScope =
+      agentId !== null && repos !== null && repos.length > 0;
+
+    const limitRaw = c.req.query("limit");
+    const offsetRaw = c.req.query("offset");
+
+    const filters: SessionListFilters = {
+      state: c.req.query("state") as SessionListFilters["state"],
+      sort: c.req.query("sort") as SessionListFilters["sort"],
+      agentId: c.req.query("agentId"),
+      repo: c.req.queries("repo"),
+      q: c.req.query("q"),
+      limit:
+        limitRaw !== undefined
+          ? Number.parseInt(limitRaw, 10) || undefined
+          : undefined,
+      offset:
+        offsetRaw !== undefined
+          ? Number.parseInt(offsetRaw, 10) || undefined
+          : undefined,
+      ...(useAgentScope
+        ? { agentScope: { agentId: agentId as string, repos } }
+        : {}),
+    };
+
+    const result = await sessionService.list(filters);
+    return c.json(result, 200);
+  });
+
+  // ─── Get one ───────────────────────────────────────────────────────────────
+  // biome-ignore lint/suspicious/noExplicitAny: service returns Prisma-shaped types; JSON serialization handles Date→string correctly at runtime
+  app.openapi(getOneRoute, async (c): Promise<any> => {
+    const agentId = c.get("agentId");
+    const repos = c.get("repos");
+    const useAgentScope =
+      agentId !== null && repos !== null && repos.length > 0;
+
+    const session = await sessionService.get(
+      c.req.param("slug"),
+      useAgentScope ? { agentId: agentId as string, repos } : undefined,
+    );
+    if (!session) throw new NotFoundError("session not found");
+    return c.json(session, 200);
+  });
+
+  return app;
+}

--- a/task-store/src/routes/sessions.ts
+++ b/task-store/src/routes/sessions.ts
@@ -7,11 +7,12 @@
  * applied by the parent app, so these handlers assume the caller is already
  * authenticated.
  *
- * Agent tokens are scoped the same way TaskService.list()'s `agentScope` and
- * distinct() are: `agentScope` is built only when the token has a non-empty
- * repo scope (`agentId !== null && repos !== null && repos.length > 0`,
- * mirroring routes/tasks.ts's `useAgentScope`). Admin tokens (agentId null)
- * are unrestricted.
+ * Agent tokens are ALWAYS scoped: `agentScope` is built for every token with a
+ * non-null `agentId`, regardless of whether its resolved `repos` list is empty.
+ * An empty `repos` (resolver failure or a legitimately zero-repo agent — see
+ * auth.ts's fail-safe-restrictive fallback) degrades naturally to assignee-only
+ * visibility inside SessionService's `hasQualifyingTask()`, rather than to
+ * unrestricted visibility. Only admin tokens (agentId null) are unrestricted.
  *
  * Routes:
  *   GET /sessions        list (?state, ?sort, ?agentId, ?repo, ?q, ?limit, ?offset)
@@ -93,10 +94,10 @@ export function createSessionsRoutes(
     const agentId = c.get("agentId");
     const repos = c.get("repos");
 
-    // Same useAgentScope condition as routes/tasks.ts's listRoute: only build
-    // an auth scope for agent tokens with a known, non-empty repo scope.
-    const useAgentScope =
-      agentId !== null && repos !== null && repos.length > 0;
+    // Every agent token gets an auth scope — an empty `repos` means
+    // "scoped-but-unknown" (fail-safe restrictive per auth.ts), not
+    // "unrestricted", and degrades to assignee-only matching in the service.
+    const useAgentScope = agentId !== null;
 
     const limitRaw = c.req.query("limit");
     const offsetRaw = c.req.query("offset");
@@ -116,7 +117,7 @@ export function createSessionsRoutes(
           ? Number.parseInt(offsetRaw, 10) || undefined
           : undefined,
       ...(useAgentScope
-        ? { agentScope: { agentId: agentId as string, repos } }
+        ? { agentScope: { agentId: agentId as string, repos: repos ?? [] } }
         : {}),
     };
 
@@ -129,12 +130,14 @@ export function createSessionsRoutes(
   app.openapi(getOneRoute, async (c): Promise<any> => {
     const agentId = c.get("agentId");
     const repos = c.get("repos");
-    const useAgentScope =
-      agentId !== null && repos !== null && repos.length > 0;
+    // Same always-scope-agent-tokens rule as the list route above.
+    const useAgentScope = agentId !== null;
 
     const session = await sessionService.get(
       c.req.param("slug"),
-      useAgentScope ? { agentId: agentId as string, repos } : undefined,
+      useAgentScope
+        ? { agentId: agentId as string, repos: repos ?? [] }
+        : undefined,
     );
     if (!session) throw new NotFoundError("session not found");
     return c.json(session, 200);

--- a/task-store/src/session-service.integration.test.ts
+++ b/task-store/src/session-service.integration.test.ts
@@ -18,6 +18,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { PrismaClient } from "../prisma/client/index.js";
+import { SessionService } from "./session-service.ts";
 import { TaskService } from "./task-service.ts";
 
 const TEST_DB = process.env.DATABASE_URL_SHIPWRIGHT_TASK_STORE_TEST;
@@ -295,3 +296,227 @@ describeOrSkip(
     });
   },
 );
+
+// ─── list() / get() (SESH-2.2) ─────────────────────────────────────────────────
+//
+// The smoke tests in routes/sessions.smoke.test.ts inject a hand-written
+// SessionServiceLike double — they verify the route's contract, but never
+// execute SessionService.list()/get()'s real Prisma-backed logic (state
+// filtering, agentScope visibility, sorting). Per data_layer_own_database,
+// that logic belongs here, against a real Postgres DB, not mocked.
+
+describeOrSkip("SessionService.list() / get() (integration)", () => {
+  let prisma: PrismaClient;
+  let taskService: TaskService;
+  let sessionService: SessionService;
+
+  beforeEach(async () => {
+    prisma = makePrisma();
+    taskService = new TaskService(prisma);
+    sessionService = new SessionService(prisma);
+    await prisma.taskEvent.deleteMany();
+    await prisma.task.deleteMany();
+    await prisma.session.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("list() with no filters excludes closed and archived sessions by default", async () => {
+    await taskService.create({
+      title: "active task",
+      status: "pending",
+      session: "active-session",
+    });
+    await taskService.create({
+      title: "closed task",
+      status: "done",
+      session: "closed-session",
+    });
+    await taskService.create({
+      title: "archived task",
+      status: "pending",
+      session: "archived-session",
+    });
+    await prisma.session.update({
+      where: { slug: "archived-session" },
+      data: { archivedAt: new Date() },
+    });
+
+    const result = await sessionService.list();
+    const slugs = result.sessions.map((s) => s.slug);
+    expect(slugs).toContain("active-session");
+    expect(slugs).not.toContain("closed-session");
+    expect(slugs).not.toContain("archived-session");
+  });
+
+  it("list({state:'archived'}) returns only archived sessions", async () => {
+    await taskService.create({
+      title: "active task",
+      status: "pending",
+      session: "active-session",
+    });
+    await taskService.create({
+      title: "archived task",
+      status: "pending",
+      session: "archived-session",
+    });
+    await prisma.session.update({
+      where: { slug: "archived-session" },
+      data: { archivedAt: new Date() },
+    });
+
+    const result = await sessionService.list({ state: "archived" });
+    const slugs = result.sessions.map((s) => s.slug);
+    expect(slugs).toEqual(["archived-session"]);
+  });
+
+  it("list({state:'closed'}) returns closed sessions even when archived", async () => {
+    await taskService.create({
+      title: "closed archived task",
+      status: "done",
+      session: "closed-archived-session",
+    });
+    await prisma.session.update({
+      where: { slug: "closed-archived-session" },
+      data: { archivedAt: new Date() },
+    });
+
+    const result = await sessionService.list({ state: "closed" });
+    const slugs = result.sessions.map((s) => s.slug);
+    expect(slugs).toEqual(["closed-archived-session"]);
+  });
+
+  it("list({sort:'waitingSince'}) places the oldest waiting session first, non-waiting after", async () => {
+    await taskService.create({
+      title: "older blocked task",
+      status: "blocked",
+      session: "wait-older",
+    });
+    // Real wall-clock gap so `updatedAt` (and thus waitingSince) differs.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await taskService.create({
+      title: "newer blocked task",
+      status: "blocked",
+      session: "wait-newer",
+    });
+    await taskService.create({
+      title: "active task",
+      status: "pending",
+      session: "not-waiting-older",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await taskService.create({
+      title: "more recently active task",
+      status: "pending",
+      session: "not-waiting-newer",
+    });
+
+    const result = await sessionService.list({
+      state: "all",
+      sort: "waitingSince",
+    });
+    const slugs = result.sessions.map((s) => s.slug);
+    const waitOlderIdx = slugs.indexOf("wait-older");
+    const waitNewerIdx = slugs.indexOf("wait-newer");
+    const notWaitingOlderIdx = slugs.indexOf("not-waiting-older");
+    const notWaitingNewerIdx = slugs.indexOf("not-waiting-newer");
+    expect(waitOlderIdx).toBeGreaterThanOrEqual(0);
+    expect(waitOlderIdx).toBeLessThan(waitNewerIdx);
+    expect(waitNewerIdx).toBeLessThan(notWaitingNewerIdx);
+    expect(waitNewerIdx).toBeLessThan(notWaitingOlderIdx);
+    // Non-waiting sessions are sorted by lastActivityAt descending (most
+    // recently active first) among themselves.
+    expect(notWaitingNewerIdx).toBeLessThan(notWaitingOlderIdx);
+  });
+
+  it("list({repo}) only returns sessions whose rollup.repos includes any of the given repo(s)", async () => {
+    await taskService.create({
+      title: "in target repo",
+      status: "pending",
+      session: "repo-match",
+      repo: "org/target-repo",
+    });
+    await taskService.create({
+      title: "in other repo",
+      status: "pending",
+      session: "repo-no-match",
+      repo: "org/other-repo",
+    });
+
+    const result = await sessionService.list({
+      state: "all",
+      repo: "org/target-repo",
+    });
+    const slugs = result.sessions.map((s) => s.slug);
+    expect(slugs).toContain("repo-match");
+    expect(slugs).not.toContain("repo-no-match");
+  });
+
+  it("list({agentScope}) only returns sessions with a task assigned to the agent or in its repo scope", async () => {
+    await taskService.create({
+      title: "assigned to agent",
+      status: "pending",
+      session: "scoped-by-assignee",
+      assignee: "agent-1",
+    });
+    await taskService.create({
+      title: "in scoped repo",
+      status: "pending",
+      session: "scoped-by-repo",
+      repo: "org/scoped-repo",
+    });
+    await taskService.create({
+      title: "unrelated",
+      status: "pending",
+      session: "scoped-hidden",
+      repo: "org/other-repo",
+    });
+
+    const result = await sessionService.list({
+      state: "all",
+      agentScope: { agentId: "agent-1", repos: ["org/scoped-repo"] },
+    });
+    const slugs = result.sessions.map((s) => s.slug);
+    expect(slugs).toContain("scoped-by-assignee");
+    expect(slugs).toContain("scoped-by-repo");
+    expect(slugs).not.toContain("scoped-hidden");
+  });
+
+  it("get() returns null for a slug with no Session row", async () => {
+    const result = await sessionService.get("does-not-exist");
+    expect(result).toBeNull();
+  });
+
+  it("get() returns null when agentScope has no qualifying task in an existing session", async () => {
+    await taskService.create({
+      title: "unrelated",
+      status: "pending",
+      session: "not-mine",
+      repo: "org/other-repo",
+    });
+
+    const result = await sessionService.get("not-mine", {
+      agentId: "agent-1",
+      repos: ["org/scoped-repo"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("get() returns the flattened session+rollup shape for a visible session", async () => {
+    await taskService.create({
+      title: "a task",
+      status: "pending",
+      session: "flat-session",
+    });
+
+    const result = await sessionService.get("flat-session");
+    expect(result).not.toBeNull();
+    expect(result?.slug).toBe("flat-session");
+    expect(result?.state).toBe("active");
+    expect(result?.counts).toEqual({ total: 1, open: 1, closed: 0 });
+    expect(result?.archived).toBe(false);
+    expect(Array.isArray(result?.waitingTasks)).toBe(true);
+  });
+});

--- a/task-store/src/session-service.ts
+++ b/task-store/src/session-service.ts
@@ -17,7 +17,13 @@
 
 import type { Clock } from "./clock.ts";
 import { SystemClock } from "./clock.ts";
-import type { Prisma, PrismaClient } from "./index.ts";
+import type { Prisma, PrismaClient, Task } from "./index.ts";
+import {
+  type SessionRollupCounts,
+  type SessionRollupState,
+  type WaitingTaskEntry,
+  computeSessionRollup,
+} from "./session-rollup.ts";
 
 /**
  * The Prisma client surface shared by the top-level client and a
@@ -27,6 +33,104 @@ import type { Prisma, PrismaClient } from "./index.ts";
  * the same `tx` the paired task write ran on.
  */
 export type PrismaTxClient = Pick<Prisma.TransactionClient, "session">;
+
+/**
+ * Batched (repo, prNumber) → blocked-prNumbers lookup, mirroring
+ * PullRequestService.lookupBlockedPrNumbers()'s signature exactly (SESH-2.2).
+ * Injected as a plain function (rather than a PullRequestServiceLike
+ * dependency) to keep SessionService decoupled from pull-request-service.ts —
+ * main.ts wires the real implementation in; the default below is a no-op so
+ * every existing caller of `new SessionService(prisma, clock)` (TaskService)
+ * is unaffected.
+ */
+export type LookupBlockedPrNumbers = (
+  pairs: { repo: string; prNumber: number }[],
+) => Promise<Set<number>>;
+
+/**
+ * Filters accepted by SessionService.list(). `agentScope` (auth) is distinct
+ * from `agentId` (a caller-supplied narrowing filter) — see list()'s doc
+ * comment.
+ */
+export interface SessionListFilters {
+  state?: "waiting" | "active" | "closed" | "empty" | "archived" | "all";
+  /** Order results. Defaults to "lastActivityAt" desc (nulls last). */
+  sort?: "waitingSince" | "lastActivityAt";
+  /** Caller filter: only sessions whose rollup.agentIds includes this agent. */
+  agentId?: string;
+  /** Caller filter: only sessions whose rollup.repos includes any of these repos. */
+  repo?: string | string[];
+  /** Case-insensitive substring match against slug OR title. */
+  q?: string;
+  limit?: number;
+  offset?: number;
+  /**
+   * AUTH scope for agent tokens — separate from the `agentId` filter above.
+   * When set, a session is visible only if at least one of its tasks
+   * satisfies `task.assignee === agentScope.agentId OR (task.repo !== null &&
+   * agentScope.repos.includes(task.repo))`. Undefined (admin tokens) sees
+   * every session unconditionally.
+   */
+  agentScope?: { agentId: string; repos: string[] };
+}
+
+/**
+ * A Session row's own fields flattened together with its computed rollup
+ * (SESH-2.1's computeSessionRollup) into one flat object — never nested under
+ * a `rollup` key.
+ */
+export interface SessionListItem {
+  slug: string;
+  title: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+  archivedBy: string | null;
+  state: SessionRollupState;
+  waitingSince: string | null;
+  lastActivityAt: string | null;
+  counts: SessionRollupCounts;
+  agentIds: string[];
+  repos: string[];
+  waitingTasks: WaitingTaskEntry[];
+  archived: boolean;
+}
+
+/** Paginated list result from SessionService.list. */
+export interface SessionListResult {
+  sessions: SessionListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/** The subset of SessionService the routes depend on. */
+export interface SessionServiceLike {
+  list(filters?: SessionListFilters): Promise<SessionListResult>;
+  get(
+    slug: string,
+    agentScope?: { agentId: string; repos: string[] },
+  ): Promise<SessionListItem | null>;
+}
+
+/** True when at least one task satisfies the agentScope OR-visibility rule
+ * shared by list() and get() — assignee match OR repo-scope match. Mirrors
+ * TaskService's agentScope OR shape exactly (assignee only, not claimedBy). */
+function hasQualifyingTask(
+  tasks: Pick<Task, "assignee" | "repo">[],
+  agentScope: { agentId: string; repos: string[] },
+): boolean {
+  return tasks.some(
+    (t) =>
+      t.assignee === agentScope.agentId ||
+      (t.repo !== null && agentScope.repos.includes(t.repo)),
+  );
+}
+
+/** -Infinity for null (sorts last in a descending sort); otherwise epoch ms. */
+function activityTime(value: string | null): number {
+  return value === null ? Number.NEGATIVE_INFINITY : new Date(value).getTime();
+}
 
 /**
  * True when `session` should be treated as absent for the purposes of the
@@ -41,11 +145,166 @@ export function isBlankSession(session: string | null | undefined): boolean {
   );
 }
 
-export class SessionService {
+export class SessionService implements SessionServiceLike {
   constructor(
     private prisma: PrismaClient,
     private clock: Clock = SystemClock(),
+    private lookupBlockedPrNumbers: LookupBlockedPrNumbers = async () =>
+      new Set<number>(),
   ) {}
+
+  // ─── Reads (SESH-2.2) ────────────────────────────────────────────────────────
+
+  /**
+   * List sessions, each flattened with its computeSessionRollup() result.
+   *
+   * `state` semantics (see SessionListFilters):
+   *   - omitted: archived===false AND rollup.state !== "closed"
+   *   - "waiting"|"active"|"closed"|"empty": rollup.state === value (NOT
+   *     additionally archived-filtered — an explicit state request overrides
+   *     the default archived-exclusion)
+   *   - "archived": archived === true (rollup state ignored)
+   *   - "all": no state/archived filtering at all
+   *
+   * `agentScope` (auth) is applied before every other filter — a session
+   * with zero tasks is never visible under a scoped token. `agentId`/`repo`
+   * are separate, caller-supplied narrowing filters applied afterward.
+   */
+  async list(filters: SessionListFilters = {}): Promise<SessionListResult> {
+    const where: Prisma.SessionWhereInput = {};
+    if (filters.q) {
+      where.OR = [
+        { slug: { contains: filters.q, mode: "insensitive" } },
+        { title: { contains: filters.q, mode: "insensitive" } },
+      ];
+    }
+
+    const sessionRows = await this.prisma.session.findMany({ where });
+    const slugs = sessionRows.map((s) => s.slug);
+    const tasks = slugs.length
+      ? await this.prisma.task.findMany({ where: { session: { in: slugs } } })
+      : [];
+
+    const tasksBySlug = new Map<string, Task[]>();
+    for (const task of tasks) {
+      if (task.session === null) continue;
+      const bucket = tasksBySlug.get(task.session);
+      if (bucket) bucket.push(task);
+      else tasksBySlug.set(task.session, [task]);
+    }
+
+    const prBlockedSet = await this.lookupBlockedPrNumbers(
+      tasks
+        .filter(
+          (t): t is Task & { repo: string; pr: number } =>
+            t.repo !== null && t.pr !== null,
+        )
+        .map((t) => ({ repo: t.repo, prNumber: t.pr })),
+    );
+
+    let items: SessionListItem[] = sessionRows.map((session) => {
+      const sessionTasks = tasksBySlug.get(session.slug) ?? [];
+      const rollup = computeSessionRollup(
+        sessionTasks,
+        prBlockedSet,
+        this.clock,
+        { archivedAt: session.archivedAt },
+      );
+      return { ...session, ...rollup };
+    });
+
+    if (filters.agentScope) {
+      const agentScope = filters.agentScope;
+      items = items.filter((item) =>
+        hasQualifyingTask(tasksBySlug.get(item.slug) ?? [], agentScope),
+      );
+    }
+
+    if (filters.state === undefined) {
+      items = items.filter((item) => !item.archived && item.state !== "closed");
+    } else if (filters.state === "archived") {
+      items = items.filter((item) => item.archived);
+    } else if (filters.state !== "all") {
+      const state = filters.state;
+      items = items.filter((item) => item.state === state);
+    }
+
+    if (filters.agentId !== undefined) {
+      const agentId = filters.agentId;
+      items = items.filter((item) => item.agentIds.includes(agentId));
+    }
+
+    if (filters.repo !== undefined) {
+      const repoList = Array.isArray(filters.repo)
+        ? filters.repo
+        : [filters.repo];
+      items = items.filter((item) =>
+        item.repos.some((repo) => repoList.includes(repo)),
+      );
+    }
+
+    if (filters.sort === "waitingSince") {
+      const waiting = items.filter((item) => item.state === "waiting");
+      const nonWaiting = items.filter((item) => item.state !== "waiting");
+      waiting.sort(
+        (a, b) =>
+          new Date(a.waitingSince as string).getTime() -
+          new Date(b.waitingSince as string).getTime(),
+      );
+      nonWaiting.sort(
+        (a, b) =>
+          activityTime(b.lastActivityAt) - activityTime(a.lastActivityAt),
+      );
+      items = [...waiting, ...nonWaiting];
+    } else {
+      items = [...items].sort(
+        (a, b) =>
+          activityTime(b.lastActivityAt) - activityTime(a.lastActivityAt),
+      );
+    }
+
+    const total = items.length;
+    const limit = filters.limit ?? 50;
+    const offset = filters.offset ?? 0;
+    const sessions = items.slice(offset, offset + limit);
+
+    return { sessions, total, limit, offset };
+  }
+
+  /**
+   * Fetch a single session by slug, flattened with its rollup. Returns null
+   * when missing OR when an agentScope is set and no task in the session
+   * qualifies (mirrors list()'s visibility rule) — both map to a route-level
+   * 404, indistinguishable to the caller by design.
+   */
+  async get(
+    slug: string,
+    agentScope?: { agentId: string; repos: string[] },
+  ): Promise<SessionListItem | null> {
+    const session = await this.prisma.session.findUnique({ where: { slug } });
+    if (!session) return null;
+
+    const tasks = await this.prisma.task.findMany({ where: { session: slug } });
+
+    if (agentScope && !hasQualifyingTask(tasks, agentScope)) {
+      return null;
+    }
+
+    const prBlockedSet = await this.lookupBlockedPrNumbers(
+      tasks
+        .filter(
+          (t): t is Task & { repo: string; pr: number } =>
+            t.repo !== null && t.pr !== null,
+        )
+        .map((t) => ({ repo: t.repo, prNumber: t.pr })),
+    );
+
+    const rollup = computeSessionRollup(tasks, prBlockedSet, this.clock, {
+      archivedAt: session.archivedAt,
+    });
+
+    return { ...session, ...rollup };
+  }
 
   /**
    * Upsert the Session row implied by a task write's `session` value.

--- a/task-store/src/session-service.ts
+++ b/task-store/src/session-service.ts
@@ -132,6 +132,19 @@ function activityTime(value: string | null): number {
   return value === null ? Number.NEGATIVE_INFINITY : new Date(value).getTime();
 }
 
+/** Extract the (repo, prNumber) pairs lookupBlockedPrNumbers() needs from a
+ * task set — only tasks with both fields set can ever be "pr_blocked". */
+function toBlockedLookupKeys(
+  tasks: Task[],
+): { repo: string; prNumber: number }[] {
+  return tasks
+    .filter(
+      (t): t is Task & { repo: string; pr: number } =>
+        t.repo !== null && t.pr !== null,
+    )
+    .map((t) => ({ repo: t.repo, prNumber: t.pr }));
+}
+
 /**
  * True when `session` should be treated as absent for the purposes of the
  * Session upsert hook: null, undefined, or a string that is empty or
@@ -194,12 +207,7 @@ export class SessionService implements SessionServiceLike {
     }
 
     const prBlockedSet = await this.lookupBlockedPrNumbers(
-      tasks
-        .filter(
-          (t): t is Task & { repo: string; pr: number } =>
-            t.repo !== null && t.pr !== null,
-        )
-        .map((t) => ({ repo: t.repo, prNumber: t.pr })),
+      toBlockedLookupKeys(tasks),
     );
 
     let items: SessionListItem[] = sessionRows.map((session) => {
@@ -291,12 +299,7 @@ export class SessionService implements SessionServiceLike {
     }
 
     const prBlockedSet = await this.lookupBlockedPrNumbers(
-      tasks
-        .filter(
-          (t): t is Task & { repo: string; pr: number } =>
-            t.repo !== null && t.pr !== null,
-        )
-        .map((t) => ({ repo: t.repo, prNumber: t.pr })),
+      toBlockedLookupKeys(tasks),
     );
 
     const rollup = computeSessionRollup(tasks, prBlockedSet, this.clock, {

--- a/task-store/src/state-filter.smoke.test.ts
+++ b/task-store/src/state-filter.smoke.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import type { Task } from "./index.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type {
   TaskListFilters,
   TaskListResult,
@@ -187,10 +188,23 @@ function fakeTaskService(opts: {
   };
 }
 
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
+
 function makeApp(taskService: TaskServiceLike) {
   return createTaskStoreApp({
     taskService,
     tokenService: fakeTokenService(),
+    sessionService: fakeSessionService(),
   });
 }
 

--- a/task-store/src/tasks.execution-fields.smoke.test.ts
+++ b/task-store/src/tasks.execution-fields.smoke.test.ts
@@ -8,8 +8,21 @@
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import type { Task } from "./index.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
+
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
 
 const ADMIN_TOKEN = "admin-token";
 
@@ -225,6 +238,7 @@ describe("Execution data columns — PATCH and GET round-trip", () => {
     const app = createTaskStoreApp({
       taskService,
       tokenService: fakeAdminTokenService(),
+      sessionService: fakeSessionService(),
     });
 
     // 1. Create a task
@@ -318,6 +332,7 @@ describe("Execution data columns — PATCH and GET round-trip", () => {
     const app = createTaskStoreApp({
       taskService,
       tokenService: fakeAdminTokenService(),
+      sessionService: fakeSessionService(),
     });
 
     // Create a task without execution fields (all null)

--- a/task-store/src/tasks.status-validation.smoke.test.ts
+++ b/task-store/src/tasks.status-validation.smoke.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import type { Task } from "./index.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskListFilters, TaskServiceLike } from "./task-service.ts";
 import type { TokenServiceLike } from "./token-service.ts";
 
@@ -101,10 +102,12 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-function fakeTaskService(opts: {
-  listResult?: Task[];
-  capturedListFilters?: TaskListFilters[];
-} = {}): TaskServiceLike {
+function fakeTaskService(
+  opts: {
+    listResult?: Task[];
+    capturedListFilters?: TaskListFilters[];
+  } = {},
+): TaskServiceLike {
   return {
     async list(filters?: TaskListFilters) {
       if (opts.capturedListFilters && filters) {
@@ -172,10 +175,23 @@ function fakeTaskService(opts: {
   };
 }
 
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
+
 function makeApp(taskService: TaskServiceLike) {
   return createTaskStoreApp({
     taskService,
     tokenService: fakeTokenService(),
+    sessionService: fakeSessionService(),
   });
 }
 

--- a/task-store/src/tokens.smoke.test.ts
+++ b/task-store/src/tokens.smoke.test.ts
@@ -14,12 +14,25 @@
  *   - 400 when updating a revoked token
  */
 
-import { OpenAPIHono } from "@hono/zod-openapi";
 import { describe, expect, it } from "bun:test";
+import { OpenAPIHono } from "@hono/zod-openapi";
 import { createTaskStoreApp } from "./app.ts";
 import { createTokensRoutes } from "./routes/tokens.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type { TaskServiceLike } from "./task-service.ts";
 import type { TaskToken, TokenServiceLike } from "./token-service.ts";
+
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -197,6 +210,7 @@ function makeApp(opts: { tokenService?: TokenServiceLike } = {}) {
   return createTaskStoreApp({
     taskService: fakeTaskService(),
     tokenService: opts.tokenService ?? fakeAdminTokenService(),
+    sessionService: fakeSessionService(),
   });
 }
 

--- a/task-store/src/validate.smoke.test.ts
+++ b/task-store/src/validate.smoke.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { createTaskStoreApp } from "./app.ts";
 import type { Task } from "./index.ts";
+import type { SessionServiceLike } from "./session-service.ts";
 import type {
   TaskListFilters,
   TaskListResult,
@@ -201,11 +202,24 @@ function agentAuth(): Record<string, string> {
   return { Authorization: `Bearer ${AGENT_TOKEN}` };
 }
 
+/** No-op SessionService double — session routes aren't under test here. */
+function fakeSessionService(): SessionServiceLike {
+  return {
+    async list() {
+      return { sessions: [], total: 0, limit: 50, offset: 0 };
+    },
+    async get() {
+      return null;
+    },
+  };
+}
+
 /** Build app with admin token and optional scope resolver for the agent token. */
 function makeAdminApp(deps: { taskService?: TaskServiceLike } = {}) {
   return createTaskStoreApp({
     taskService: deps.taskService ?? fakeTaskService(),
     tokenService: fakeAdminTokenService(),
+    sessionService: fakeSessionService(),
   });
 }
 
@@ -218,6 +232,7 @@ function makeAgentApp(
   return createTaskStoreApp({
     taskService: deps.taskService ?? fakeTaskService(),
     tokenService,
+    sessionService: fakeSessionService(),
     // Scope resolver returns the repos the agent was configured with.
     scopeResolver: async (_agentId: string) => scopedRepos,
   });


### PR DESCRIPTION
## Summary
- Add `GET /sessions` and `GET /sessions/:slug` read routes to the task-store service, mirroring `routes/tasks.ts`'s `createRoute` + Zod schema pattern
- Add `SessionService.list()`/`get()` — thin Prisma reads flattened with `computeSessionRollup()` output, scoped by agent token the same way `TaskService.distinct()` scopes (admin unrestricted; agent tokens limited to tasks assigned to them or in their repo scope)
- Add `PullRequestService.lookupBlockedPrNumbers()` — a single-query batched (repo, prNumber) → blocked-flag lookup feeding `computeSessionRollup()`'s `prBlockedSet`
- Add `SessionSchema`/`SessionListQuerySchema`/`SessionListResponseSchema`/`SessionSlugParamSchema` to `openapi-schemas.ts`, regenerate `task-store/openapi.json`, and document both routes in `docs/task-store.md`

## Acceptance Criteria
| Criterion | Status |
|---|---|
| GET /sessions returns 200 with `{ sessions, total, limit, offset }`; default state filter excludes closed and archived | MET |
| `sort=waitingSince` places the oldest waiting session first, non-waiting sessions after | MET |
| Agent-scoped token can't see a session with no task in its repos or assigned to it — 404 on `/sessions/:slug`, absent from the list | MET |
| `bun run generate:task-store-spec` output committed; docs document every `/sessions` route | MET |
| Smoke tests (injected `SessionServiceLike` double) cover scoping/filtering/sorting | MET |

## Test Plan
- `routes/sessions.smoke.test.ts` (new): route-contract coverage via an injected `SessionServiceLike` double — state variants, `sort=waitingSince`, `agentId`/`repo`/`q` filters, agent-token scoping, 200/404 on `GET /:slug`
- `session-service.integration.test.ts`: added real-DB coverage for `SessionService.list()`/`get()` (state filtering, `waitingSince` sort, agentScope visibility, `repo` filter, flattened shape) — closes a gap where the smoke tests' double never executed the real Prisma-backed logic
- `pull-request.integration.test.ts`: added real-DB coverage for `PullRequestService.lookupBlockedPrNumbers()` (blocked match, non-blocked exclusion, cross-product/repo-mismatch guard, batching, empty input)
- Verified against a real local Postgres instance: `task-store/src/session-service.ts`, `routes/sessions.ts`, and the new `lookupBlockedPrNumbers()` helper all sit at 100% line coverage
- [x] `task lint` / `task typecheck` / `task check-strings` all clean
- [x] Full task-store suite green (923 pass, 0 fail, against a real DB)
- [x] Repo-wide `bun run --filter='*' --sequential typecheck` clean across all 7 workspaces

Generated with [Claude Code](https://claude.com/claude-code)
