### PR TITLE
docs: regenerate MCP tool docs for /sessions routes

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -36,6 +36,24 @@ Update pull request fields
 - **Has body:** Yes
 - **Parameters:** `id` (path)
 
+## `sessions_get`
+
+Get a session by slug
+
+- **Method:** GET
+- **Path:** `/sessions/{slug}`
+- **Has body:** No
+- **Parameters:** `slug` (path)
+
+## `sessions_list`
+
+List sessions
+
+- **Method:** GET
+- **Path:** `/sessions`
+- **Has body:** No
+- **Parameters:** `state` (query), `sort` (query), `agentId` (query), `repo` (query), `q` (query), `limit` (query), `offset` (query)
+
 ## `tasks_bulk`
 
 Bulk insert tasks

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -1072,4 +1072,90 @@ export const generatedTools: GeneratedTool[] = [
     pathParams: ["id"],
     hasBody: false,
   },
+  {
+    name: "sessions_list",
+    description: "List sessions",
+    inputSchema: {
+      type: "object",
+      properties: {
+        state: {
+          type: "string",
+          enum: ["waiting", "active", "closed", "empty", "archived", "all"],
+          description:
+            "Omitted: archived===false AND state!=='closed'. A named state (waiting/active/closed/empty) matches rollup.state alone (not additionally archived-filtered). 'archived': archived===true (rollup state ignored). 'all': no filtering.",
+          example: "waiting",
+        },
+        sort: {
+          type: "string",
+          enum: ["waitingSince", "lastActivityAt"],
+          description:
+            "'waitingSince': waiting sessions first (oldest waitingSince first), then non-waiting sessions by lastActivityAt desc. Default (or 'lastActivityAt'): all sessions by lastActivityAt desc, nulls last.",
+          example: "waitingSince",
+        },
+        agentId: {
+          type: "string",
+          description:
+            "Only sessions whose rollup.agentIds includes this agent.",
+          example: "agent-id-123",
+        },
+        repo: {
+          anyOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          ],
+          description:
+            "Only sessions whose rollup.repos includes any of the given repo(s). Repeatable (?repo=a&repo=b).",
+          example: "org/repo",
+        },
+        q: {
+          type: "string",
+          description:
+            "Case-insensitive substring match against slug OR title.",
+          example: "launch",
+        },
+        limit: {
+          type: "string",
+          example: "50",
+        },
+        offset: {
+          type: "string",
+          example: "0",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/sessions",
+    queryParams: ["state", "sort", "agentId", "repo", "q", "limit", "offset"],
+    pathParams: [],
+    hasBody: false,
+  },
+  {
+    name: "sessions_get",
+    description: "Get a session by slug",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          example: "shipwright-may-launch",
+        },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    method: "GET",
+    pathTemplate: "/sessions/{slug}",
+    queryParams: [],
+    pathParams: ["slug"],
+    hasBody: false,
+  },
 ];

--- a/mcp-server/src/generated-tools.unit.test.ts
+++ b/mcp-server/src/generated-tools.unit.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "bun:test";
 import { generatedTools } from "./generated-tools.ts";
 
 describe("generatedTools", () => {
-  it("emits one tool per OpenAPI operation (32 total)", () => {
-    expect(generatedTools).toHaveLength(32);
+  it("emits one tool per OpenAPI operation (34 total)", () => {
+    // 32 pre-SESH-2.2 + sessions_list (GET /sessions) + sessions_get
+    // (GET /sessions/{slug}).
+    expect(generatedTools).toHaveLength(34);
   });
 
   it("has unique tool names", () => {

--- a/mcp-server/src/http-transport.smoke.test.ts
+++ b/mcp-server/src/http-transport.smoke.test.ts
@@ -26,6 +26,8 @@ const ALLOWED_TOOL_NAMES = [
   "prs_list",
   "prs_get",
   "prs_update",
+  "sessions_list",
+  "sessions_get",
 ] as const;
 
 interface JsonRpcResponse {
@@ -109,7 +111,7 @@ describe("MCP Streamable HTTP transport", () => {
     });
   });
 
-  it("tools/list over HTTP returns the same 9 allowlisted tools as stdio", async () => {
+  it("tools/list over HTTP returns the same 11 allowlisted tools as stdio", async () => {
     const { app } = buildApp();
     const { sessionId } = await initialize(app);
 
@@ -132,7 +134,7 @@ describe("MCP Streamable HTTP transport", () => {
     const tools = (body.result?.tools ?? []) as Array<{ name: string }>;
     const names = tools.map((t) => t.name);
 
-    expect(names).toHaveLength(9);
+    expect(names).toHaveLength(11);
     for (const name of ALLOWED_TOOL_NAMES) {
       expect(names).toContain(name);
     }

--- a/mcp-server/src/index.smoke.test.ts
+++ b/mcp-server/src/index.smoke.test.ts
@@ -12,6 +12,8 @@ const ALLOWED_TOOL_NAMES = [
   "prs_list",
   "prs_get",
   "prs_update",
+  "sessions_list",
+  "sessions_get",
 ] as const;
 
 const TEST_TOKEN = "test-mcp-server-token";
@@ -28,7 +30,7 @@ describe("mcp-server", () => {
     expect(res.status).toBe(200);
   });
 
-  it("GET /mcp/tools returns only the 9 allowed tools", async () => {
+  it("GET /mcp/tools returns only the 11 allowed tools", async () => {
     const res = await app.request("/mcp/tools", {
       headers: { Authorization: `Bearer ${TEST_TOKEN}` },
     });
@@ -37,8 +39,8 @@ describe("mcp-server", () => {
     const body = (await res.json()) as { tools: Array<{ name: string; description: string }> };
     const toolNames = body.tools.map((t) => t.name);
 
-    // Verify we have exactly 9 tools
-    expect(toolNames).toHaveLength(9);
+    // Verify we have exactly 11 tools
+    expect(toolNames).toHaveLength(11);
 
     // Verify all allowed tools are present
     for (const name of ALLOWED_TOOL_NAMES) {

--- a/mcp-server/src/mcp-server.smoke.test.ts
+++ b/mcp-server/src/mcp-server.smoke.test.ts
@@ -22,11 +22,13 @@ describe("MCP server tools/list", () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
 
-    // Only the 9 allowed tools are exposed; pipeline-internal ops are excluded.
-    expect(tools.length).toBe(9);
+    // Only the 11 allowed tools are exposed; pipeline-internal ops are excluded.
+    expect(tools.length).toBe(11);
     expect(names).toContain("tasks_list");
     expect(names).toContain("prs_list");
     expect(names).toContain("prs_update");
+    expect(names).toContain("sessions_list");
+    expect(names).toContain("sessions_get");
     expect(names).not.toContain("tasks_claim");
     expect(names).not.toContain("prs_claim");
 

--- a/mcp-server/src/tool-allowlist.ts
+++ b/mcp-server/src/tool-allowlist.ts
@@ -31,6 +31,20 @@ import type { GeneratedTool } from "./generated-tools.ts";
  * pipeline-internal category as the lifecycle routes above, and the two
  * `*_events` routes are audit-trail internals. Widening the public MCP
  * surface is a deliberate decision, not a side effect of regeneration.
+ *
+ * SESH-2.2 decision (regeneration that added GET /sessions and
+ * GET /sessions/{slug} to task-store/openapi.json): `sessions_list` and
+ * `sessions_get` are deliberately NOT added here — they stay on the public
+ * surface, bringing it to 11 tools. Reasoning: both are read-only GETs, and
+ * task-store/src/routes/sessions.ts always builds an `agentScope` for any
+ * token with a non-null `agentId` (an empty `repos` list degrades to
+ * assignee-only visibility inside SessionService's `hasQualifyingTask()`
+ * rather than to unrestricted access — fail-safe-restrictive, not
+ * fail-open). That's the same shape as the already-public `tasks_list` /
+ * `tasks_get` / `prs_list` / `prs_get` (agent-token-scoped reads), not the
+ * shape of what's excluded above: `prs_findings` is a write op, and
+ * `tasks_events` / `prs_events` are audit-trail internals unrelated to
+ * per-agent scoping. This is a considered inclusion, not an omission.
  */
 export const EXCLUDED_TOOLS: readonly string[] = [
   // tasks: pipeline-internal lifecycle
@@ -66,7 +80,8 @@ export const EXCLUDED_TOOLS: readonly string[] = [
 /**
  * Filter a generated tool list down to the agreed public surface.
  * Allowed tools: tasks_list, tasks_create, tasks_bulk, tasks_distinct,
- * tasks_get, tasks_update, prs_list, prs_get, prs_update (9 total).
+ * tasks_get, tasks_update, prs_list, prs_get, prs_update, sessions_list,
+ * sessions_get (11 total).
  */
 export function allowedTools(tools: GeneratedTool[]): GeneratedTool[] {
   const excluded = new Set<string>(EXCLUDED_TOOLS);

--- a/mcp-server/src/tool-allowlist.unit.test.ts
+++ b/mcp-server/src/tool-allowlist.unit.test.ts
@@ -15,12 +15,14 @@ const ALLOWED_TOOL_NAMES = [
   "prs_list",
   "prs_get",
   "prs_update",
+  "sessions_list",
+  "sessions_get",
 ] as const;
 
 describe("allowedTools", () => {
-  it("returns only the 9 agreed tools", () => {
+  it("returns only the 11 agreed tools", () => {
     const result = allowedTools(generatedTools);
-    expect(result).toHaveLength(9);
+    expect(result).toHaveLength(11);
   });
 
   it("excludes all EXCLUDED_TOOLS names", () => {
@@ -31,12 +33,12 @@ describe("allowedTools", () => {
     }
   });
 
-  it("stays stable across regeneration — given all 32 generatedTools, only 9 come back", () => {
+  it("stays stable across regeneration — given all 34 generatedTools, only 11 come back", () => {
     // This is the "across regeneration" invariant:
-    // even if generate:mcp-tools emits all 32 ops, only the 9 allowed ones are exposed.
-    expect(generatedTools).toHaveLength(32);
+    // even if generate:mcp-tools emits all 34 ops, only the 11 allowed ones are exposed.
+    expect(generatedTools).toHaveLength(34);
     const result = allowedTools(generatedTools);
-    expect(result).toHaveLength(9);
+    expect(result).toHaveLength(11);
     const resultNames = result.map((t) => t.name);
     for (const name of ALLOWED_TOOL_NAMES) {
       expect(resultNames).toContain(name);
@@ -51,7 +53,7 @@ describe("allowedTools", () => {
 });
 
 describe("createMcpServer lists only allowed tools", () => {
-  it("tools/list returns exactly 9 names and none are in EXCLUDED_TOOLS", async () => {
+  it("tools/list returns exactly 11 names and none are in EXCLUDED_TOOLS", async () => {
     const server = createMcpServer({
       config: { baseUrl: "http://localhost:3002", token: "test-token" },
     });
@@ -67,7 +69,7 @@ describe("createMcpServer lists only allowed tools", () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
 
-    expect(tools.length).toBe(9);
+    expect(tools.length).toBe(11);
     for (const excluded of EXCLUDED_TOOLS) {
       expect(names).not.toContain(excluded);
     }


### PR DESCRIPTION
## Summary
- Regenerated `mcp-server/src/generated-tools.ts` from the current `task-store/openapi.json`, which now includes `sessions_list` (`GET /sessions`) and `sessions_get` (`GET /sessions/{slug}`) — 32 → 34 tools
- Regenerated `docs/mcp-tools.md` via `bun run generate:mcp-docs` to reflect the current tool set
- Made an explicit allowlist decision in `mcp-server/src/tool-allowlist.ts`: `sessions_list`/`sessions_get` stay on the public MCP surface (9 → 11 tools), since both are read-only GETs scoped per-agent the same fail-safe-restrictive way as the already-public `tasks_list`/`tasks_get`/`prs_list`/`prs_get` — unlike the excluded write op `prs_findings` or the audit-trail `*_events` routes
- Updated hardcoded tool-count/name assertions in `generated-tools.unit.test.ts`, `tool-allowlist.unit.test.ts`, `http-transport.smoke.test.ts`, `index.smoke.test.ts`, and `mcp-server.smoke.test.ts` to match the new 34/11 totals

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `generated-tools.ts` regenerated, includes/excludes `sessions_list`/`sessions_get` via decision | MET |
| 2 | `docs/mcp-tools.md` regenerated via `bun run generate:mcp-docs`, reflects current tool set | MET |
| 3 | sessions surface not silently missing without explicit decision | MET |

## Test Plan
- `bun test mcp-server/src` — 45/45 pass, 100% line coverage on both touched source files
- `task lint` — clean
- `task typecheck` — clean across all workspaces
- Full `bun test` — 8110 pass, 2 pre-existing failures in `task-store/src/routes/prs.openapi.smoke.test.ts` (a `validateRepo` null/undefined-repos bug that predates this branch and is unrelated to this change — confirmed identical on `main`)
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
