### PR TITLE
docs: document sessions, follow/push, and archive retention (SESH-9.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,12 @@ pending → in_progress → pr_open → merged → deployed → done
 ```
 plus `approved`, `blocked`, `cancelled`.
 
+Tasks sharing a non-blank `session` field (set only by `/shipwright:plan-session`) roll up into a
+**Session** — browsable in the admin UI's Sessions tab (`/admin/sessions`), which shows per-session
+task status and follow/notification controls. A background alert sweeper pushes "waiting" / reminder /
+"completed" notifications to session followers; see [`docs/task-store.md`](./docs/task-store.md#sessions)
+and [`docs/agent.md`](./docs/agent.md) for the full model.
+
 ### Execution loop
 
 1. Pick a `pending` task whose every `dependencies` entry is done.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -95,6 +95,8 @@ Mounted at `/admin/sessions*`. **Requires authentication** — session cookie or
 | POST | `/admin/sessions/:slug/archive` | admin-only | Archive a session (SESH-5.2). Body: empty form. Admin-only: returns `403` for non-admin callers. Calls task-store `PATCH /sessions/:slug` with `{ archived: true }` (idempotent re-stamp when already archived). On success, redirects to `/admin/sessions/:slug?success=archived` (302); on task-store error or missing dependency, redirects to `/admin/sessions/:slug?error=archive_failed` (302). Errors are logged for operator visibility. |
 | POST | `/admin/sessions/:slug/unarchive` | admin-only | Unarchive a session (SESH-5.2). Body: empty form. Admin-only: returns `403` for non-admin callers. Calls task-store `PATCH /sessions/:slug` with `{ archived: false }` (idempotent re-stamp when already unarchived). On success, redirects to `/admin/sessions/:slug?success=unarchived` (302); on task-store error or missing dependency, redirects to `/admin/sessions/:slug?error=unarchive_failed` (302). Errors are logged for operator visibility. |
 | POST | `/admin/sessions/:slug/rename` | admin-only | Rename a session (SESH-5.2). Body: form-encoded `newTitle` (optional string; empty value sends `null` to clear the title). Admin-only: returns `403` for non-admin callers. Calls task-store `PATCH /sessions/:slug` with `{ title: <value> }` or `{ title: null }` when blank. On success, redirects to `/admin/sessions/:slug?success=renamed` (302); on task-store error or missing dependency, redirects to `/admin/sessions/:slug?error=rename_failed` (302). Errors are logged for operator visibility. |
+| POST | `/admin/sessions/:slug/follow` | admin or member | Follow a session (SESH-6.2), registered by `admin-ui-session-follow.ts`. Body: none (JSON response, not a form post — distinct from the archive/unarchive/rename routes above). Admins always pass; a non-admin member must additionally satisfy the same visibility check as the detail page (`memberCanSeeSession()`, fail-closed — no `fetchTaskStoreSession` dependency or a lookup error yields `404` rather than a false allow). Calls `SessionFollowService.follow()` (upsert, idempotent). Returns `200` with `{ sessionSlug, following: true }`; `404` if the session isn't visible to the caller. |
+| POST | `/admin/sessions/:slug/unfollow` | admin or member | Unfollow a session (SESH-6.2), registered by `admin-ui-session-follow.ts`. Body: none. No visibility re-check — removing your own follow state never requires re-proving visibility (mirrors `POST /admin/settings/notifications/unfollow`'s same skip). Calls `SessionFollowService.unfollow()` (delete, idempotent). Returns `200` with `{ sessionSlug, following: false }`. |
 
 **Visibility scoping (SESH-4.1):** The sessions list and detail routes use the same visibility logic. An admin sees all sessions. A non-admin member's view is scoped to their `AgentMember` rows: they see only sessions with tasks assigned/claimed by their agents, or in their agents' repositories. A member with zero memberships sees an empty sessions list and receives `404` for any detail route. The visibility scope is computed once per request via `resolveVisibilityScope()` (in `admin-ui-sessions-list.ts`) and applied identically to both list and detail routes. The list route checks against the task store's own session rollup; the detail route derives the equivalent shape from the session's tasks via `deriveSessionVisibilityFromTasks()` (in `session-scope.ts`), which uses the same `claimedBy ?? assignee` precedence as `task-store/src/session-rollup.ts` — so a reassigned task's former assignee loses detail access at the same moment the session disappears from their list.
 
@@ -103,6 +105,24 @@ Mounted at `/admin/sessions*`. **Requires authentication** — session cookie or
 **Configuration:**
 
 - Task-store connection is inherited from the agent's main config (`SHIPWRIGHT_TASK_STORE_URL` and `SHIPWRIGHT_TASK_STORE_TOKEN`). No additional env vars required for this route.
+
+### Session alert sweeper (`session-alert-sweeper.ts`) — background job
+
+`SessionAlertSweeper` is the admin service's first (and, as of SESH-7.4, only) background loop — registered via `setInterval` in `main.ts`, never inside `createAdminUIApp()`, which must stay side-effect-free. Every tick it:
+
+1. Fetches the task-store's `waiting` and `closed` sessions (`GET /sessions?state=waiting`/`?state=closed`, admin token, `limit=500`).
+2. Materializes auto-follows: for each user with `UserNotificationPrefs.autoFollowSessions = true` who can already see a waiting session, has no existing `SessionFollow` row, and whose auto-follow boundary (`autoFollowSince`, else the prefs row's `createdAt`) predates the session, upserts a `SessionFollow` row.
+3. Sends one `immediate` push the first time a follower is alerted about a waiting session, and at most one `reminder` per later local day once that user's `reminderHourLocal` has passed — derived entirely from `SessionAlertState.lastAlertedAt` (the schema stores no "kind" column).
+4. Sends one `completed` push per follower of a closed session, then deletes that pair's `SessionFollow` + `SessionAlertState` rows so it never fires again.
+5. Prunes the `SessionAlertState` row of any follower who has lost visibility of the session (membership revoked / repo removed), sending them nothing.
+
+Pushes reuse `PushService.notifySession()` — the same Web Push delivery path as the chat-reply notifier (`POST /admin/push/notify`) — so they share the same VAPID configuration and the same `SHIPWRIGHT_ADMIN_PUSH_MAX_DETAIL` operator ceiling. Not re-entrant: an in-flight guard makes an overlapping tick (a slow task-store fetch under a short interval) return an all-zero result rather than racing the sweep already running; this guard is per-process, so running more than one admin replica needs a shared lock not introduced by this task.
+
+**Configuration:**
+
+- The sweeper only starts when Web Push is fully configured (`SHIPWRIGHT_ADMIN_VAPID_PUBLIC_KEY` + `SHIPWRIGHT_ADMIN_VAPID_PRIVATE_KEY` + `SHIPWRIGHT_ADMIN_VAPID_SUBJECT`) **and** `SHIPWRIGHT_TASK_STORE_URL` + `SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN` are set — otherwise it is never registered (not degraded-mode; simply absent).
+- `SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS` (optional, default `60000`) — tick cadence in ms. Blank, non-numeric, zero, or negative values fall back to the default.
+- See [`configuration.md`](./configuration.md#metrics--admin--chat--task-store-services) for the full env var reference.
 
 ### Public read-only task board (`admin-ui.ts`) — unauthenticated
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -484,6 +484,54 @@ and the chat service presents a bearer value that doesn't match it.
 See [`configuration.md`](./configuration.md#metrics--admin--chat--task-store-services)
 for the full list of Web Push env vars and their defaults.
 
+### Session alerts (waiting / reminder / completed)
+
+The same VAPID configuration above also powers a second, independent notification type:
+the **session alert sweeper** (`session-alert-sweeper.ts`), a background loop that pushes
+"session is waiting" / daily-reminder / "session completed" notifications to session
+followers — distinct from the chat-reply notifier's webhook-triggered push above, this one
+runs on its own interval and reads sessions directly from the task-store.
+
+No extra VAPID setup is needed — the sweeper only starts once the VAPID env vars above are
+configured, **and** the admin service can reach the task-store as an admin caller:
+
+```yaml
+admin:
+  extraEnv:
+    - name: SHIPWRIGHT_TASK_STORE_URL
+      value: "http://task-store:3000"
+    - name: SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: shipwright-secrets
+          key: shipwright-task-store-admin-token
+    - name: SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS
+      value: "60000"                          # optional — tick cadence in ms (default: 60000)
+```
+
+If either the task-store connection or a VAPID var is missing, the sweeper is simply never
+registered (no error, no degraded-mode banner — it's absent).
+
+Retention for these same sessions is a separate, task-store-side concern — set on `taskStore.extraEnv`,
+not `admin.extraEnv`:
+
+```yaml
+taskStore:
+  extraEnv:
+    - name: SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS
+      value: "30"                             # optional — days of inactivity before archiving (default: 30; 0 disables the sweep)
+```
+
+Archiving is non-destructive (it only hides a session from the default list view) and reversible
+(any new task written into an archived session un-archives it automatically) — see
+[`task-store.md`](./task-store.md#session-archive-sweep) for the full sweep rules. There is no
+purge/delete endpoint anywhere in this pipeline; nothing this chart configures ever deletes a
+session or its tasks.
+
+See [`configuration.md`](./configuration.md#metrics--admin--chat--task-store-services)
+for the full env var reference (`SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS`,
+`SHIPWRIGHT_TASK_STORE_ADMIN_TOKEN`, `SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS`).
+
 ---
 
 ## Authentication modes

--- a/docs/task-store.md
+++ b/docs/task-store.md
@@ -292,6 +292,13 @@ distinct `agentIds`/`repos`, and the list of currently-`waitingTasks`) via `comp
 then flattened together with the Session row's own fields (`slug`, `title`, `createdAt`, `updatedAt`,
 `archivedAt`, `archivedBy`) into one object — the rollup is never nested under a `rollup` key.
 
+**Out of session scope by decision, not oversight:** only `/shipwright:plan-session` ever writes a
+non-blank `session` field onto a task — the `*-fix` patrol skills (`entropy-fix`, `security-fix`,
+`error-fix`, `consolidation-fix`, `test-fix`) never set it on the tasks they queue, and an
+externally-opened PR not linked to any task (e.g. a Renovate dependency-bump PR) has no task at all
+to carry one. Neither surfaces in `/sessions` — this is a deliberate scoping choice (sessions model
+planning-session groupings, not every automated queue or inbound PR), not a gap to be closed.
+
 #### List sessions
 
 ```
@@ -397,6 +404,11 @@ A session is archived (`archivedAt` set, `archivedBy = "system"`) when **all** o
 4. its last task activity is older than `SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS` days (default `30`; see [`docs/configuration.md`](./configuration.md) — set to `0` to disable the sweep).
 
 Archiving is **non-destructive and reversible**: it only removes the session from the default list view. Nothing is deleted, and writing any new task into an archived session automatically un-archives it (`SessionService.upsert()`, SES-1.2) — the next sweep will not re-archive it while that task remains open.
+
+**Retention is archive-only.** There is no purge/delete endpoint for sessions (or for the tasks
+within them) — `SessionRetentionReaper` only ever sets `archivedAt`/`archivedBy`, and no route under
+`/sessions` accepts a `DELETE`. A session's rows, and every task that ever belonged to it, persist
+indefinitely; "retention" here means "stop showing it by default," never "remove it."
 
 ### PR tracking
 


### PR DESCRIPTION
## Summary
- Documents the Sessions feature surface shipped by SESH-5.3 (follow), SESH-6.3 (notification prefs), SESH-7.4 (alert sweeper), and SESH-8.1 (retention reaper): adds the `/admin/sessions/:slug/follow` and `/unfollow` routes to `docs/agent.md`, plus a new "Session alert sweeper" subsection describing its tick behavior, re-entrancy guard, and shared VAPID config.
- `docs/task-store.md`: adds an explicit "archive-only, no purge/delete endpoint" statement to the Session archive sweep section, and a new "out of session scope by decision, not oversight" note confirming the `*-fix` patrol skills and externally-opened PRs (e.g. Renovate) never populate the `session` field.
- `docs/deploy-kubernetes.md`: adds a "Session alerts (waiting / reminder / completed)" subsection showing `admin.extraEnv`/`taskStore.extraEnv` Helm wiring for the sweeper interval and archive-retention env vars.
- `CLAUDE.md`: adds a short pointer from "How work is tracked" to the Sessions tab and alert sweeper.
- `docs/configuration.md` and `docs/agent-api.md` needed no changes — all relevant env vars were already documented from prior PRs, and `agent-api.md`'s scope is strictly the `/agents` CRUD API (admin-UI session routes correctly live in `agent.md`, matching the existing convention for the pre-existing archive/unarchive/rename routes).

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `task check-config-docs` and `task check-version-sync` pass | MET |
| 2 | `docs/task-store.md` lists every `/sessions` route w/ method, query params, auth; documents archive-only retention | MET |
| 3 | Docs explicitly state `*-fix` skills and non-task-linked PRs are out of session scope | MET |
| 4 | Test decision: content layer (check-config-docs gate + doc-freshness checks); no code tests | MET |

## Test Plan
- [x] `task check-config-docs` — all 40 env vars documented
- [x] `task check-version-sync` — passes
- [x] `task lint` — clean
- [x] `task check-strings` — clean
- [x] Docs-only diff verified (`git diff main...HEAD --stat`) — zero code/test files touched
- [x] Full-suite `task ci` run reviewed: 3 failures (`errors.unit.test.ts`, `prs.openapi.smoke.test.ts`, `task-store-provider.integration.test.ts`) confirmed pre-existing full-suite-only flakes — each passes in isolation on clean `main`, unrelated to this diff

Generated with [Claude Code](https://claude.com/claude-code)
