### PR TITLE
feat: helm chart extraEnv examples + patch version bump (SESH-9.2)

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.20.25] - 2026-09-11
+
+### Added
+
+- document `SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS` and `SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS` as commented extraEnv examples under `admin.extraEnv` and `taskStore.extraEnv` (SESH-9.2). Both env vars already have code-level defaults (60000ms and 30 days respectively), so no new required Helm value.
+
 ## [1.20.24] - 2026-09-11
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.20.24
+version: 1.20.25
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -29,10 +29,8 @@ annotations:
   # Artifact Hub change log for this release. Must mirror the matching version
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
-    - kind: changed
-      description: "auto-bump to chart v1.20.24 triggered by release tag admin-v1.166.0"
-    - kind: changed
-      description: "auto-bump to chart v1.20.24 triggered by release tag admin-v1.167.0"
+    - kind: added
+      description: "document SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS and SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS as commented extraEnv examples (SESH-9.2)"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -271,7 +271,12 @@ admin:
   appBaseUrl: ""
   # -- Extra environment variables injected into the admin container.
   # List of Kubernetes envVar objects (name/value or name/valueFrom). Use for
-  # env vars not otherwise covered by chart values.
+  # env vars not otherwise covered by chart values. Example (commented out —
+  # the sweeper's own default of 60000ms applies when unset; see
+  # docs/configuration.md for the session-alert sweeper):
+  #   extraEnv:
+  #     - name: SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS
+  #       value: "60000"
   extraEnv: []
   # -- Optional Sentry error reporting for the admin service. Leave
   # dsn.existingSecret empty to disable (no Sentry init, no middleware mounted).
@@ -863,6 +868,10 @@ taskStore:
   # SHIPWRIGHT_TASK_STORE_AGENTS_URL / AGENTS_API_KEY scope-resolver wiring
   # named above), upgrading to this default will silently drop this
   # SHIPWRIGHT_CLAUDE_TIMEOUT_MS entry — re-add it to your own override list.
+  # Another example (commented out — code-level default is 30 days; see
+  # docs/configuration.md for the session-retention reaper):
+  #   - name: SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS
+  #     value: "30"
   extraEnv:
     - name: SHIPWRIGHT_CLAUDE_TIMEOUT_MS
       value: "3600000"


### PR DESCRIPTION
## Summary
- Add commented `extraEnv` examples for `SHIPWRIGHT_ADMIN_SESSION_ALERT_INTERVAL_MS` (admin, SESH-7.4) and `SHIPWRIGHT_TASK_STORE_SESSION_ARCHIVE_AFTER_DAYS` (task-store, SESH-8.1) under `charts/shipwright/values.yaml`'s existing `admin.extraEnv` / `taskStore.extraEnv` blocks
- Bump chart patch version 1.20.24 → 1.20.25 per `docs/helm-repo.md` (`ct lint --check-version-increment` requires a bump on any chart content change), with matching `CHANGELOG.md` entry and `artifacthub.io/changes` annotation

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | No new required Helm values (all new env vars have code-level defaults) | MET | Both examples are commented out; `admin.extraEnv` stays `[]`, `taskStore.extraEnv` keeps only its pre-existing active entry. Both env vars already default in code (60000ms admin sweeper interval, 30-day task-store archive) |
| 2 | helm lint (task helm:check) passes | MET | `task helm:check` (lint → unittest → validate) is fully green: 1 chart linted/0 failed, 507/507 unittest cases passed, kubeconform validated all 3 rendered profiles with 0 invalid/errors |
| 3 | Test decision: content/CI-gate layer only — no unit/integration test applies | MET | No test files touched; verification relies solely on `task helm:check` |

## Test Plan
- [x] `task helm:check` (lint + unittest + validate) — all green
- [x] `task ci` — passes aside from a pre-existing, unrelated `task-store/src/routes/prs.openapi.smoke.test.ts` failure (`validateRepo` null-repos guard bug on `main`, not touched by this diff)

Generated with [Claude Code](https://claude.com/claude-code)
