### PR TITLE
feat: dev-task guard (fallback safety net) for PRD-shaped tasks

### DIFF
--- a/plugins/shipwright/commands/dev-task.content.test.ts
+++ b/plugins/shipwright/commands/dev-task.content.test.ts
@@ -684,3 +684,80 @@ describe("dev-task.md Step 1 — repo-slug derivation for local paths (PRF-1.4)"
     );
   });
 });
+
+describe("dev-task.md Step 1 — PRD-shaped task guard (fallback safety net) (PDR-1.1)", () => {
+  const getGuardSection = () => {
+    const guardIdx = content.indexOf("### PRD-Shaped Task Guard");
+    expect(guardIdx).toBeGreaterThan(-1);
+    const dependencyCheckIdx = content.indexOf("### Dependency Check (pending tasks only)");
+    expect(dependencyCheckIdx).toBeGreaterThan(guardIdx);
+    return { guardIdx, dependencyCheckIdx, section: content.slice(guardIdx, dependencyCheckIdx) };
+  };
+
+  it("adds a PRD-Shaped Task Guard section in Step 1 after pending-status validation and before Dependency Check", () => {
+    const { guardIdx, dependencyCheckIdx } = getGuardSection();
+    const pendingBulletIdx = content.indexOf('**Found, `status == "pending"`**:');
+    expect(pendingBulletIdx).toBeGreaterThan(-1);
+    // Guard should be after the pending bullet and before Dependency Check
+    expect(pendingBulletIdx).toBeLessThan(guardIdx);
+    expect(guardIdx).toBeLessThan(dependencyCheckIdx);
+  });
+
+  it("detects task id prefix: task id matches ^prd-", () => {
+    const { section } = getGuardSection();
+    expect(section).toMatch(/task.{0,40}id.{0,40}(match|matches).{0,60}\^prd-/i);
+  });
+
+  it("detects description prefix: description opens with 'Commit as PRODUCT-SPEC.md and run /shipwright:plan-session'", () => {
+    const { section } = getGuardSection();
+    expect(section).toContain("Commit as PRODUCT-SPEC.md and run /shipwright:plan-session");
+  });
+
+  it("detects branch and criteria: branch === 'main' AND acceptanceCriteria is empty", () => {
+    const { section } = getGuardSection();
+    expect(section).toMatch(/branch.{0,60}main/i);
+    expect(section).toMatch(/acceptanceCriteria.{0,60}empty/i);
+  });
+
+  it("stops before the Dependency Check and before claiming (Step 2)", () => {
+    const { section } = getGuardSection();
+    const claimIdx = content.indexOf("/tasks/{id}/claim");
+    const guardIdx = content.indexOf("### PRD-Shaped Task Guard");
+    expect(guardIdx).toBeLessThan(claimIdx);
+  });
+
+  it("PATCHes the task with exact fields: status:blocked, hitl:true, blockedReason:misrouted_needs_plan_session_not_dev_task", () => {
+    const { section } = getGuardSection();
+    expect(section).toContain('"status": "blocked"');
+    expect(section).toContain('"hitl": true');
+    expect(section).toContain('"blockedReason": "misrouted_needs_plan_session_not_dev_task"');
+  });
+
+  it("uses curl -X PATCH with the standard Authorization header and Content-Type application/json", () => {
+    const { section } = getGuardSection();
+    expect(section).toContain("curl -sf -X PATCH");
+    expect(section).toContain("-H \"Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN\"");
+    expect(section).toContain('-H "Content-Type: application/json"');
+  });
+
+  it("includes the curl command targeting the task-store /tasks/{id} endpoint", () => {
+    const { section } = getGuardSection();
+    expect(section).toContain("$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}");
+  });
+
+  it("pipes the PATCH response through jq", () => {
+    const { section } = getGuardSection();
+    expect(section).toMatch(/\| jq \./);
+  });
+
+  it("prints a clear warning message when guard triggers", () => {
+    const { section } = getGuardSection();
+    expect(section).toMatch(/⚠.*PRD-shaped|Task.{0,40}looks PRD-shaped/i);
+    expect(section).toMatch(/blocked|blocked for human/i);
+  });
+
+  it("does NOT special-case autonomousPlanSession:true tasks (they are excluded upstream at ?ready=true level)", () => {
+    const { section } = getGuardSection();
+    expect(section).not.toContain("autonomousPlanSession");
+  });
+});

--- a/plugins/shipwright/commands/dev-task.md
+++ b/plugins/shipwright/commands/dev-task.md
@@ -65,6 +65,36 @@ API calls — e.g. the Same-Branch Sibling Check's `?repo=` filter below.
 - **Found, any other status** (e.g. `pr_open`, `blocked`, `merged`): not workable. Print
   `⚠ Task {task-id} has status "{status}" — nothing to do.` and stop.
 
+### PRD-Shaped Task Guard (fallback safety net)
+
+Before proceeding with a pending task, detect and block tasks that are PRD-shaped and
+misrouted to dev-task. This is a fallback safety net for legacy PRD tasks (e.g.
+pre-existing `prd-*` tasks) and any trusted source that forgets to set the appropriate
+routing flag.
+
+A task is PRD-shaped if ANY of the following is true:
+
+1. Task id matches the pattern `^prd-` (case-sensitive, e.g. `prd-abc123`)
+2. Task description opens with `"Commit as PRODUCT-SPEC.md and run /shipwright:plan-session"`
+3. Task's `branch` field is exactly `"main"` AND its `acceptanceCriteria` array is empty
+
+When any condition matches, the task is blocked immediately:
+
+```bash
+curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{id}" \
+  -d '{"status": "blocked", "hitl": true, "blockedReason": "misrouted_needs_plan_session_not_dev_task"}' | jq .
+```
+
+Print:
+
+```
+⚠ Task {id} looks PRD-shaped, not dev-task-shaped — blocked for human triage (misrouted_needs_plan_session_not_dev_task).
+```
+
+Stop immediately. Do not proceed to Dependency Check, do not claim (Step 2), do not build.
+
 ### Dependency Check (pending tasks only)
 
 An explicit task id is an instruction to work this task now, but it must still be


### PR DESCRIPTION
## Summary
- Adds a "PRD-Shaped Task Guard" to `dev-task.md`'s Step 1: detects tasks that are actually PRD-shaped (misrouted to `dev-task` instead of `plan-session`) via three heuristics — task id prefix `prd-`, description opening with the known plan-session handoff marker, or an empty-acceptance-criteria task on `main`.
- On match, PATCHes the task to `status: blocked`, `hitl: true`, `blockedReason: "misrouted_needs_plan_session_not_dev_task"` and stops before Step 2's claim — mirroring the existing "no branch field" guard's PATCH-then-stop pattern.
- This is a fallback safety net for legacy/unflagged PRD tasks; once PDR-2.1/PDR-2.2 ship, properly-flagged `autonomousPlanSession:true` tasks are excluded upstream at the `?ready=true` filter and never reach this guard — no special-casing of that flag was added here.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Detection check added right after the status == "pending" validation in dev-task.md Step 1, before Dependency Check/claim | MET |
| 2 | On match: PATCH sets status: "blocked", hitl: true, blockedReason: "misrouted_needs_plan_session_not_dev_task"; command stops, no claim, no build attempted | MET |
| 3 | A properly-flagged autonomousPlanSession: true task is never reached by this guard once PDR-2.2 ships -- no special-case needed here | MET |
| 4 | Test: extend dev-task.content.test.ts pinning the detection heuristic and exact blockedReason string (content layer, matching this file's existing convention) | MET |

## Test Plan
- Added 11 content-layer tests to `dev-task.content.test.ts` pinning: section placement, all three detection conditions, the exact PATCH body fields, curl shape, and the printed warning message.
- `bun test plugins/shipwright/commands/dev-task.content.test.ts` — 85/85 pass.
- `task lint`, `task typecheck`, `task check-config-docs`, `task check-version-sync` all pass.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
