### PR TITLE
feat: add --autonomous mode to plan-session Steps 4/5/6

### DIFF
--- a/plugins/shipwright/commands/plan-session.content.test.ts
+++ b/plugins/shipwright/commands/plan-session.content.test.ts
@@ -162,6 +162,159 @@ describe("plan-session.md — repo auto-detect preserves org/repo format (PRF-1.
   });
 });
 
+describe("plan-session.md — Step 4 `--autonomous` mode (PDR-3.1)", () => {
+  function extractStep4Section(md: string): string {
+    const match = md.match(/## Step 4: Propose a Design[\s\S]*?(?=\n## Step 5: Task Breakdown)/);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  function extractAutonomousSubsection(section: string): string {
+    const idx = section.indexOf("### `--autonomous` Mode");
+    expect(idx).toBeGreaterThan(-1);
+    return section.slice(idx);
+  }
+
+  it("adds a distinct `--autonomous` Mode subsection to Step 4", () => {
+    const section = extractStep4Section(content);
+    expect(section).toContain("### `--autonomous` Mode");
+  });
+
+  it("states autonomous mode replaces iterate-until-approved with accept-first-pass", () => {
+    const autoSection = extractAutonomousSubsection(extractStep4Section(content));
+    const lower = autoSection.toLowerCase();
+    expect(lower).toMatch(/accept.first.pass/);
+    expect(lower).toContain("iterate-until-approved");
+    expect(lower).toContain("trusted");
+  });
+
+  it("defines the loose ambiguity bar with Soft ambiguity and Hard contradiction cases", () => {
+    const autoSection = extractAutonomousSubsection(extractStep4Section(content));
+    expect(autoSection).toContain("Soft ambiguity");
+    expect(autoSection).toContain("Hard contradiction");
+    expect(autoSection).toContain("sensible default");
+  });
+
+  it("soft ambiguity applies the default and logs it instead of stalling or asking", () => {
+    const autoSection = extractAutonomousSubsection(extractStep4Section(content));
+    const softIdx = autoSection.indexOf("Soft ambiguity");
+    const hardIdx = autoSection.indexOf("Hard contradiction");
+    const softSection = autoSection.slice(softIdx, hardIdx);
+    const lower = softSection.toLowerCase();
+    expect(lower).toContain("apply the default");
+    expect(lower).toMatch(/do not stall|not.*ask a clarifying question/);
+    expect(lower).not.toContain("blockedreason");
+    expect(lower).not.toContain("patch");
+  });
+
+  it("hard contradiction escapes via PATCH to blocked with hitl:true and blockedReason, then stops before Step 5", () => {
+    const autoSection = extractAutonomousSubsection(extractStep4Section(content));
+    expect(autoSection).toContain('"status": "blocked"');
+    expect(autoSection).toContain('"hitl": true');
+    expect(autoSection).toContain("blockedReason");
+    expect(autoSection).toContain("plan_session_autonomous_hard_contradiction");
+    expect(autoSection.toLowerCase()).toContain("do not proceed to step 5");
+    expect(autoSection.toLowerCase()).toMatch(/do not fabricate|not fabricate an answer/);
+  });
+
+  it("records every accepted default in a Decision Log that carries through to PLAN.md", () => {
+    const autoSection = extractAutonomousSubsection(extractStep4Section(content));
+    expect(autoSection).toContain("## Decision Log");
+    expect(autoSection.toLowerCase()).toContain("plan.md");
+  });
+});
+
+describe("plan-session.md — Step 5 `--autonomous` mode (PDR-3.1)", () => {
+  function extractStep5FullSection(md: string): string {
+    const match = md.match(/## Step 5: Task Breakdown[\s\S]*?(?=\n## Step 5\.5: HITL Detection)/);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  function extractAutonomousSubsection(section: string): string {
+    const idx = section.indexOf("### `--autonomous` Mode");
+    expect(idx).toBeGreaterThan(-1);
+    return section.slice(idx);
+  }
+
+  it("adds a distinct `--autonomous` Mode subsection to Step 5", () => {
+    const section = extractStep5FullSection(content);
+    expect(section).toContain("### `--autonomous` Mode");
+  });
+
+  it("applies the same loose ambiguity bar to breakdown-level decisions", () => {
+    const autoSection = extractAutonomousSubsection(extractStep5FullSection(content));
+    expect(autoSection).toContain("Soft ambiguity");
+    expect(autoSection).toContain("Hard contradiction");
+    expect(autoSection).toContain("sensible default");
+  });
+
+  it("hard contradiction escapes via the same PATCH-to-blocked pattern, stopping before Step 5.5", () => {
+    const autoSection = extractAutonomousSubsection(extractStep5FullSection(content));
+    expect(autoSection).toContain('"status": "blocked"');
+    expect(autoSection).toContain('"hitl": true');
+    expect(autoSection).toContain("blockedReason");
+    expect(autoSection.toLowerCase()).toContain("do not proceed to step 5.5");
+  });
+
+  it("skips the iterate-until-approved loop and proceeds directly to Step 5.5", () => {
+    const autoSection = extractAutonomousSubsection(extractStep5FullSection(content));
+    expect(autoSection.toLowerCase()).toContain("skip");
+    expect(autoSection).toContain("Step 5.5");
+  });
+
+  it("soft ambiguity defaults append to the same Decision Log started in Step 4", () => {
+    const autoSection = extractAutonomousSubsection(extractStep5FullSection(content));
+    expect(autoSection).toContain("Decision Log");
+    expect(autoSection.toLowerCase()).toContain("step 4");
+  });
+});
+
+describe("plan-session.md — `--autonomous {task-id}` argument parsing (PDR-3.1)", () => {
+  function extractArgsAndAutoDetectSection(md: string): string {
+    const match = md.match(/^---[\s\S]*?Wait for user confirmation before continuing to Step 1\./);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
+  it("documents the --autonomous {task-id} optional token alongside repo/session", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    expect(section).toContain("--autonomous");
+    expect(section).toContain("{task-id}");
+    expect(section.toLowerCase()).toContain("autonomousplansession");
+  });
+
+  it("states repo/session are always passed explicitly and the auto-detect confirmation flow does not apply", () => {
+    const section = extractArgsAndAutoDetectSection(content);
+    const autonomousIdx = section.indexOf("--autonomous");
+    expect(autonomousIdx).toBeGreaterThan(-1);
+    const autonomousSection = section.slice(autonomousIdx);
+    const lower = autonomousSection.toLowerCase();
+    expect(lower).toContain("does not apply");
+    expect(lower).toContain("explicitly");
+  });
+});
+
+describe("plan-session.md — Step 6c autonomous close-out (PDR-3.1)", () => {
+  it("Step 6b section includes a Step 6c gated on --autonomous that PATCHes status:done and source to PLAN.md", () => {
+    const section = extractStep6bSection(content);
+    expect(section).toContain("Step 6c");
+    expect(section).toContain("--autonomous");
+    expect(section).toContain('\\"status\\": \\"done\\"');
+    expect(section).toContain('\\"source\\"');
+    expect(section.toLowerCase()).toContain("plan.md");
+  });
+
+  it("only runs Step 6c after the bulk write succeeds", () => {
+    const section = extractStep6bSection(content);
+    const idx = section.indexOf("Step 6c");
+    expect(idx).toBeGreaterThan(-1);
+    const step6cSection = section.slice(idx);
+    expect(step6cSection.toLowerCase()).toMatch(/only run this after|once step 6b.*succeeds/);
+    expect(step6cSection.toLowerCase()).toContain("must not mark the originating task done");
+  });
+});
+
 describe("plan-session.md — Step 5 principles override check + security domain (PCO-1.1)", () => {
   function extractStep5Section(md: string): string {
     const match = md.match(/## Step 5: Task Breakdown[\s\S]*?(?=\n### Complexity and Model Scoring)/);

--- a/plugins/shipwright/commands/plan-session.md
+++ b/plugins/shipwright/commands/plan-session.md
@@ -16,8 +16,9 @@ arguments:
 Parse `$ARGUMENTS` to extract:
 - **repo**: first argument
 - **session**: second argument
+- **`--autonomous {task-id}`** (optional): the id of the originating PRD task in the task store — the one flagged `autonomousPlanSession: true`. `{task-id}` is used by Step 4 and Step 5 for the hard-contradiction PATCH-to-blocked escape hatch, and by Step 6 for the on-success PATCH-to-done. **When `--autonomous` is present, `repo` and `session` are always passed explicitly by the machine dispatcher invoking this mode** — the single-argument auto-detect-and-confirm flow below does not apply and must not run in this mode.
 
-**If only one argument is provided**, treat it as `session` and auto-detect `repo`:
+**If only one argument is provided** (and `--autonomous` was not passed), treat it as `session` and auto-detect `repo`:
 1. `git remote get-url origin` → parse the `org/repo` value, stripping trailing `.git`. Preserve the full owner/repo value — do not strip it down to just the repo segment. This is the `repo` value used for the task-store `repo` field.
 2. Fallback (only when the remote parse fails): `basename $(git rev-parse --show-toplevel)`. In this fallback case there is no owner segment, so `repo` and `repo-slug` end up the same bare value.
 3. Derive `repo-slug` from `repo`: the last path segment, lowercased — e.g. `app-vitals/shipwright` → `shipwright`. Use `repo-slug` for all local filesystem path references.
@@ -162,6 +163,24 @@ If the spec is ambiguous or silent on a decision that affects the design, state 
 
 Iterate on feedback. Do not move to task breakdown until the design is approved.
 
+### `--autonomous` Mode
+
+When `--autonomous {task-id}` was passed, this replaces the iterate-until-approved loop above with accept-first-pass: a flagged PRD is already trusted/complete — not a first-draft ambiguous spec — so there is no human in this loop to iterate with.
+
+Apply a loose ambiguity bar with exactly two cases:
+
+- **Soft ambiguity** — the spec is silent, vague, or offers multiple reasonable readings on a design decision, but a sensible default exists. Apply the default. Do not stall or ask a clarifying question — log it (see Decision Log below) instead of flagging for human confirmation.
+- **Hard contradiction** — the spec's own requirements conflict with each other, or with a hard codebase constraint, in a way no default can resolve without guessing. Do NOT fabricate an answer or silently pick a side. Stop immediately:
+  ```bash
+  curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/{task-id}" \
+    -d '{"status": "blocked", "hitl": true, "blockedReason": "plan_session_autonomous_hard_contradiction: {one-line description}"}' | jq .
+  ```
+  Then stop the command entirely — do not proceed to Step 5.
+
+**Decision Log:** every default applied under the loose ambiguity bar above is recorded as a bullet under a `## Decision Log` section appended to the design writeup, in the form `- {decision point}: defaulted to {choice} — {one-line reason}`. This log carries through into `planning/{session}/PLAN.md` when Step 6a writes the plan to disk — this is what satisfies "every auto-approval decision recorded in the PLAN.md artifact."
+
 ---
 
 ## Step 5: Task Breakdown
@@ -263,6 +282,20 @@ A task that drops or renames something while a later task updates the consumers 
 If a task has no renames, removals, or constraint additions, mark it: `Safe to deploy standalone: yes`.
 
 Present the task list and dependency map as a first pass. The engineer reviews and iterates — they may catch implementation details, missing edge cases, or better task splits. Iterate until approved.
+
+### `--autonomous` Mode
+
+When `--autonomous {task-id}` was passed, apply the same loose ambiguity bar from Step 4 to breakdown-level decisions (how finely to split a task, which layer a cross-cutting task belongs to, complexity/model scoring judgment calls) — skip the "iterate until approved" loop above and proceed directly to Step 5.5 once the first-pass breakdown is accepted.
+
+- **Soft ambiguity** — the breakdown is silent, vague, or offers multiple reasonable readings on a breakdown-level decision, but a sensible default exists. Apply the default and append it to the same `## Decision Log` section started in Step 4 — do not stall or ask a clarifying question.
+- **Hard contradiction** — e.g. a task can't be made to satisfy Breaking Change Safety, or its acceptance criteria can't be made testable. Do NOT fabricate an answer or silently pick a side. Stop immediately using the same escape hatch as Step 4:
+  ```bash
+  curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$SHIPWRIGHT_TASK_STORE_URL/tasks/{task-id}" \
+    -d '{"status": "blocked", "hitl": true, "blockedReason": "plan_session_autonomous_hard_contradiction: {one-line description}"}' | jq .
+  ```
+  Then stop the command entirely — do not proceed to Step 5.5.
 
 ---
 
@@ -420,6 +453,19 @@ curl -sf -X POST \
   "$SHIPWRIGHT_TASK_STORE_URL/tasks/bulk" \
   --data-binary @/tmp/new-tasks-{session}.json | jq .
 ```
+
+**Step 6c — Autonomous mode: close out the originating PRD task** (only when `--autonomous {task-id}` was passed):
+
+Once Step 6b's bulk POST succeeds (real tasks are in the queue), transition the originating PRD task to `done` and point its `source` at the plan just written:
+
+```bash
+curl -sf -X PATCH -H "Authorization: Bearer $SHIPWRIGHT_TASK_STORE_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$SHIPWRIGHT_TASK_STORE_URL/tasks/{task-id}" \
+  -d "{\"status\": \"done\", \"source\": \"planning/{session}/PLAN.md\"}" | jq .
+```
+
+Only run this after the bulk write succeeds — a failed or partial `tasks/bulk` POST must not mark the originating task done.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a `--autonomous {task-id}` mode to `plan-session.md`'s Steps 4 and 5, replacing the interactive iterate-until-approved loop with accept-first-pass-and-log for flagged, machine-submitted PRDs.
- Defines a loose ambiguity bar: soft ambiguity gets a sensible default applied and logged to a `## Decision Log` (which carries into `PLAN.md`); a hard contradiction PATCHes the originating task to `blocked`/`hitl: true` with a clear `blockedReason` and stops the run — no fabricated answers.
- Adds Step 6c: on success, once real tasks are written (Step 6b), the originating PRD task is PATCHed to `status: "done"` with `source` pointing at the generated `planning/{session}/PLAN.md`.

## Acceptance Criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | `--autonomous` mode section added to Step 4 and Step 5, distinct from the interactive default | MET |
| 2 | Soft ambiguity → default applied+logged; hard contradiction → blocked/hitl:true/blockedReason, no fabrication | MET |
| 3 | On success, originating PRD task → status:"done", source → planning/{session}/PLAN.md | MET |
| 4 | Every auto-approval decision recorded in session's PLAN.md | MET |
| 5 | Test extends plan-session.content.test.ts pinning autonomous-mode wording in Step 4 and Step 5 | MET |

## Test Plan
- `bun test plugins/shipwright/commands/plan-session.content.test.ts` — 36 pass, 0 fail (15 new tests added).
- `task lint`, `task typecheck`, `task check-config-docs`, `task check-version-sync`, `task check-strings` — all clean.
- `task ci` shows 3 pre-existing failures in unrelated files (`metrics/src/lib/errors.unit.test.ts`, `task-store/src/routes/prs.openapi.smoke.test.ts`) — verified these reproduce identically on clean `origin/main`.
- [x] Pre-commit checks passing

Generated with [Claude Code](https://claude.com/claude-code)
