### PR TITLE
chore(chart): bump chart version to 1.20.28

### DIFF
--- a/charts/shipwright/CHANGELOG.md
+++ b/charts/shipwright/CHANGELOG.md
@@ -10,6 +10,12 @@ independent of `appVersion`. CI enforces this with
 `ct lint --check-version-increment`. Each release here must mirror the
 `artifacthub.io/changes` annotation in `Chart.yaml`.
 
+## [1.20.28] - 2026-09-11
+
+### Changed
+
+- auto-bump to chart v1.20.28 triggered by release tag(s): `admin-v1.168.0`, `chat-v1.88.0`, `metrics-v1.91.0`, `task-store-v1.121.0`
+
 ## [1.20.27] - 2026-09-11
 
 ### Changed

--- a/charts/shipwright/Chart.yaml
+++ b/charts/shipwright/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # Chart version (SemVer). Bump on every chart change, independent of appVersion.
 # See CHANGELOG.md and the README "Versioning" section — CI enforces this bump
 # via `ct lint --check-version-increment`.
-version: 1.20.27
+version: 1.20.28
 # Version of the Shipwright application this chart deploys by default.
 appVersion: "0.1.0"
 home: https://shipwrightharness.com
@@ -30,7 +30,13 @@ annotations:
   # entry in CHANGELOG.md (keep the two in sync on every bump).
   artifacthub.io/changes: |
     - kind: changed
-      description: "auto-bump to chart v1.20.27 triggered by release tag agent-v1.264.0"
+      description: "auto-bump to chart v1.20.28 triggered by release tag admin-v1.168.0"
+    - kind: changed
+      description: "auto-bump to chart v1.20.28 triggered by release tag chat-v1.88.0"
+    - kind: changed
+      description: "auto-bump to chart v1.20.28 triggered by release tag metrics-v1.91.0"
+    - kind: changed
+      description: "auto-bump to chart v1.20.28 triggered by release tag task-store-v1.121.0"
 dependencies:
   # Bitnami PostgreSQL subchart. Pinned to a chart version whose default image tag
   # is concrete (NOT `latest`), because Bitnami's 2025 catalog change moved newer

--- a/charts/shipwright/values.yaml
+++ b/charts/shipwright/values.yaml
@@ -223,7 +223,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-admin
-    tag: admin-v1.167.0
+    tag: admin-v1.168.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the admin service. ClusterIP is Minikube-friendly.
@@ -317,7 +317,7 @@ metrics:
   enabled: true
   image:
     repository: ghcr.io/app-vitals/shipwright-metrics
-    tag: metrics-v1.90.0
+    tag: metrics-v1.91.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the metrics service. ClusterIP is Minikube-friendly.
@@ -806,7 +806,7 @@ taskStore:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-task-store
-    tag: task-store-v1.120.0
+    tag: task-store-v1.121.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the task-store service. ClusterIP is Minikube-friendly.
@@ -983,7 +983,7 @@ chat:
   enabled: false
   image:
     repository: ghcr.io/app-vitals/shipwright-chat
-    tag: chat-v1.87.0
+    tag: chat-v1.88.0
     pullPolicy: ""    # defaults to top-level imagePullPolicy when empty
   service:
     # -- Service type for the chat service. ClusterIP is Minikube-friendly.


### PR DESCRIPTION
## Chart version bump: 1.20.27 → 1.20.28

**Triggering tags:**
- `admin-v1.168.0`
- `chat-v1.88.0`
- `metrics-v1.91.0`
- `task-store-v1.121.0`

**New chart version:** `1.20.28`

**Pinned in values.yaml:**
- `admin.image.tag`: `admin-v1.168.0`
- `chat.image.tag`: `chat-v1.88.0`
- `metrics.image.tag`: `metrics-v1.91.0`
- `taskStore.image.tag`: `task-store-v1.121.0`


### What happens next

1. This PR is auto-merged (squash) once CI passes.
2. The merge triggers `chart-release.yml`, which packages and publishes
   chart v1.20.28 to the Helm repository.

---
_Auto-generated by `.github/workflows/auto-bump-chart.yml`._