### PR TITLE
fix: add autonomousPlanSession to tasks_list MCP tool

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -97,7 +97,7 @@ List tasks
 - **Method:** GET
 - **Path:** `/tasks`
 - **Has body:** No
-- **Parameters:** `status` (query), `state` (query), `source` (query), `session` (query), `repo` (query), `org` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `hitl` (query), `sort` (query), `updatedSince` (query)
+- **Parameters:** `status` (query), `state` (query), `source` (query), `session` (query), `repo` (query), `org` (query), `assignee` (query), `claimedBy` (query), `branch` (query), `pr` (query), `limit` (query), `offset` (query), `ready` (query), `hitl` (query), `autonomousPlanSession` (query), `sort` (query), `updatedSince` (query)
 
 ## `tasks_update`
 

--- a/mcp-server/src/generated-tools.ts
+++ b/mcp-server/src/generated-tools.ts
@@ -121,6 +121,11 @@ export const generatedTools: GeneratedTool[] = [
           enum: ["true", "false"],
           example: "true",
         },
+        autonomousPlanSession: {
+          type: "string",
+          enum: ["true", "false"],
+          example: "true",
+        },
         sort: {
           type: "string",
           enum: ["asc", "desc"],
@@ -153,6 +158,7 @@ export const generatedTools: GeneratedTool[] = [
       "offset",
       "ready",
       "hitl",
+      "autonomousPlanSession",
       "sort",
       "updatedSince",
     ],
@@ -1157,5 +1163,37 @@ export const generatedTools: GeneratedTool[] = [
     queryParams: [],
     pathParams: ["slug"],
     hasBody: false,
+  },
+  {
+    name: "sessions_update",
+    description: "Rename/archive a session — admin-only",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          example: "shipwright-may-launch",
+        },
+        title: {
+          type: ["string", "null"],
+          description:
+            "Omitted: title untouched. A string: set. null: clears the title.",
+          example: "May launch prep",
+        },
+        archived: {
+          type: "boolean",
+          description:
+            "Omitted: archive fields untouched. true: stamps archivedAt/archivedBy. false: clears both.",
+          example: true,
+        },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    method: "PATCH",
+    pathTemplate: "/sessions/{slug}",
+    queryParams: [],
+    pathParams: ["slug"],
+    hasBody: true,
   },
 ];

--- a/mcp-server/src/generated-tools.unit.test.ts
+++ b/mcp-server/src/generated-tools.unit.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "bun:test";
 import { generatedTools } from "./generated-tools.ts";
 
 describe("generatedTools", () => {
-  it("emits one tool per OpenAPI operation (34 total)", () => {
+  it("emits one tool per OpenAPI operation (35 total)", () => {
     // 32 pre-SESH-2.2 + sessions_list (GET /sessions) + sessions_get
-    // (GET /sessions/{slug}).
-    expect(generatedTools).toHaveLength(34);
+    // (GET /sessions/{slug}) + sessions_update (PATCH /sessions/{slug}, SESH-3.1).
+    expect(generatedTools).toHaveLength(35);
   });
 
   it("has unique tool names", () => {

--- a/mcp-server/src/tool-allowlist.ts
+++ b/mcp-server/src/tool-allowlist.ts
@@ -45,6 +45,14 @@ import type { GeneratedTool } from "./generated-tools.ts";
  * shape of what's excluded above: `prs_findings` is a write op, and
  * `tasks_events` / `prs_events` are audit-trail internals unrelated to
  * per-agent scoping. This is a considered inclusion, not an omission.
+ *
+ * `sessions_update` (PATCH /sessions/{slug}, added to task-store/openapi.json
+ * for SESH-3.1) surfaced when this file was next regenerated: it's excluded
+ * here, not added to the public surface. Unlike `sessions_list`/`sessions_get`
+ * above, the route itself is admin-only (`session updates are admin-only` —
+ * task-store/src/routes/sessions.ts throws `ForbiddenError` for any non-admin
+ * token), so it's in the same "write op outside the agreed edit surface"
+ * category as `prs_findings`, not the "agent-token-scoped read" category.
  */
 export const EXCLUDED_TOOLS: readonly string[] = [
   // tasks: pipeline-internal lifecycle
@@ -75,6 +83,8 @@ export const EXCLUDED_TOOLS: readonly string[] = [
   "tasks_events",
   "prs_events",
   "prs_findings",
+  // sessions: admin-only write op
+  "sessions_update",
 ] as const;
 
 /**

--- a/mcp-server/src/tool-allowlist.unit.test.ts
+++ b/mcp-server/src/tool-allowlist.unit.test.ts
@@ -33,10 +33,10 @@ describe("allowedTools", () => {
     }
   });
 
-  it("stays stable across regeneration — given all 34 generatedTools, only 11 come back", () => {
+  it("stays stable across regeneration — given all 35 generatedTools, only 11 come back", () => {
     // This is the "across regeneration" invariant:
-    // even if generate:mcp-tools emits all 34 ops, only the 11 allowed ones are exposed.
-    expect(generatedTools).toHaveLength(34);
+    // even if generate:mcp-tools emits all 35 ops, only the 11 allowed ones are exposed.
+    expect(generatedTools).toHaveLength(35);
     const result = allowedTools(generatedTools);
     expect(result).toHaveLength(11);
     const resultNames = result.map((t) => t.name);


### PR DESCRIPTION
## Summary
- Regenerates `mcp-server/src/generated-tools.ts` from `task-store/openapi.json` so the `tasks_list` MCP tool picks up the `autonomousPlanSession` query param (added alongside PDR-4.1's autonomous plan-session loop phase), and regenerates `docs/mcp-tools.md` to match.
- Regeneration also surfaced pre-existing drift: `sessions_update` (`PATCH /sessions/{slug}`, SESH-3.1) was missing from the generated tool set. Since that route is admin-only (`ForbiddenError` for non-admin tokens — `task-store/src/routes/sessions.ts`), it's excluded from the public MCP surface in `mcp-server/src/tool-allowlist.ts`, following the same precedent already documented there for PTL-3.1/SESH-2.2.
- Updates the two hardcoded tool-count assertions in `generated-tools.unit.test.ts` / `tool-allowlist.unit.test.ts` (generated: 34 → 35; public/allowed stays 11).

## Acceptance Criteria
None specified on the source task — this is a mechanical docs/codegen-drift fix.

## Test Plan
- [x] `bun test mcp-server/` — 45 pass, 0 fail
- [x] `task lint` — clean
- [x] `task typecheck` — clean across all workspaces
- [x] Full `bun test` run — 3 pre-existing failures (`check-downstream-compat.sh` allowlist cases, `extraAllowedTools`), all reproduce identically on `origin/main` and pass in isolation; unrelated to this diff
- [x] Verified `docs/mcp-tools.md`'s `tasks_list` parameter list now includes `autonomousPlanSession`

Generated with [Claude Code](https://claude.com/claude-code)
